### PR TITLE
feat(auth-server): convert `subscriptionAccountFinishSetup`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -467,6 +467,7 @@
       "subscriptionPaymentExpired",
       "subscriptionsPaymentExpired",
       "subscriptionAccountDeletion",
+      "subscriptionAccountFinishSetup",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
       "subscriptionCancellation",

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -45,7 +45,7 @@ $s-10: 40px;
     font-size: 20px !important;
     line-height: 28px !important;
   }
-  &-1xl {
+  &-2xl {
     font-size: 22px !important;
     line-height: 30px !important;
   }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
@@ -11,7 +11,7 @@
 
 .text-header div {
   @extend %text-header-common;
-  @extend .text-1xl;
+  @extend .text-2xl;
   @extend .mb-4;
   font-weight: 700;
   color: global.$grey-600 !important;

--- a/packages/fxa-auth-server/lib/senders/emails/partials/button/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/button/index.mjml
@@ -5,7 +5,7 @@
 <mj-include path="./css/button/index.css" type="css" css-inline="inline" />
 
 <mj-section>
-  <mj-column>
+  <mj-column css-class="<%= locals.cssClass || undefined %>">
     <mj-button css-class="primary-button" href="<%- link %>">
       <span data-l10n-id="<%- template %>-action">Click here</span>
     </mj-button>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/button/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/button/index.scss
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @use '../../global.scss';
-@use '../../layouts/fxa/index.scss';
 
 .primary-button {
   height: 56px !important;

--- a/packages/fxa-auth-server/lib/senders/emails/partials/icon/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/icon/index.mjml
@@ -1,3 +1,7 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
 <mj-section css-class="mb-8">
   <% if (locals.productIconURLOld && locals.productIconURLNew) { %>
     <mj-group>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/icon/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/icon/index.mjml
@@ -1,0 +1,18 @@
+<mj-section css-class="mb-8">
+  <% if (locals.productIconURLOld && locals.productIconURLNew) { %>
+    <mj-group>
+      <mj-column>
+        <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
+        </mj-image>
+      </mj-column>
+      <mj-column>
+        <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
+        </mj-image>
+      </mj-column>
+    </mj-group>
+  <% } else { %>
+    <mj-column>
+      <mj-image src="<%- icon %>" alt="<%- productName %>" title="<%- productName %>" css-class="product-icon"></mj-image>
+    </mj-column>
+  <% } %>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
@@ -1,4 +1,3 @@
-payment-plan-product-name = { $productName }
 payment-plan-invoice-number = Invoice Number: { $invoiceNumber }
 payment-plan-charged = Charged: { $invoiceTotal } on { $invoiceDateOnly }
 payment-plan-next-invoice = Next Invoice: { $nextInvoiceDateOnly }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
@@ -1,3 +1,10 @@
+# Variables:
+#  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
 payment-plan-invoice-number = Invoice Number: { $invoiceNumber }
+# Variables:
+#  $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
+#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 payment-plan-charged = Charged: { $invoiceTotal } on { $invoiceDateOnly }
+# Variables
+#  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
 payment-plan-next-invoice = Next Invoice: { $nextInvoiceDateOnly }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
@@ -1,0 +1,4 @@
+payment-plan-product-name = { $productName }
+payment-plan-invoice-number = Invoice Number: { $invoiceNumber }
+payment-plan-charged = Charged: { $invoiceTotal } on { $invoiceDateOnly }
+payment-plan-next-invoice = Next Invoice: { $nextInvoiceDateOnly }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.mjml
@@ -3,27 +3,27 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
 <mj-text css-class="text-body">
-  <span><b data-l10n-id="payment-details">Payment details:</b></span>
+  <b data-l10n-id="payment-details">Payment details:</b>
   <ul>
-    <% if (productName) { %>
-      <li data-l10n-id="payment-plan-product-name" data-l10n-args="<%= JSON.stringify({productName}) %>">
+    <% if (locals.productName) { %>
+      <li data-l10n-args="<%= JSON.stringify({productName}) %>">
         <%- productName %>
       </li>
     <% } %>
 
-    <% if (invoiceNumber) { %>
+    <% if (locals.invoiceNumber) { %>
       <li data-l10n-id="payment-plan-invoice-number" data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>">
         Invoice Number: <%- invoiceNumber %>
       </li>
     <% } %>
 
-    <% if (invoiceTotal) { %>
+    <% if (locals.invoiceTotal) { %>
       <li data-l10n-id="payment-plan-charged" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">
         Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>
       </li>
     <% } %>
 
-    <% if (nextInvoiceDateOnly) { %>
+    <% if (locals.nextInvoiceDateOnly) { %>
       <li data-l10n-id="payment-plan-next-invoice" data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>">
         Next Invoice: <%- nextInvoiceDateOnly %>
       </li>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.mjml
@@ -1,0 +1,32 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-text css-class="text-body">
+  <span><b data-l10n-id="payment-details">Payment details:</b></span>
+  <ul>
+    <% if (productName) { %>
+      <li data-l10n-id="payment-plan-product-name" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        <%- productName %>
+      </li>
+    <% } %>
+
+    <% if (invoiceNumber) { %>
+      <li data-l10n-id="payment-plan-invoice-number" data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>">
+        Invoice Number: <%- invoiceNumber %>
+      </li>
+    <% } %>
+
+    <% if (invoiceTotal) { %>
+      <li data-l10n-id="payment-plan-charged" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">
+        Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>
+      </li>
+    <% } %>
+
+    <% if (nextInvoiceDateOnly) { %>
+      <li data-l10n-id="payment-plan-next-invoice" data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>">
+        Next Invoice: <%- nextInvoiceDateOnly %>
+      </li>
+    <% } %>
+  </ul>
+</mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.mjml
@@ -5,11 +5,9 @@
 <mj-text css-class="text-body">
   <b data-l10n-id="payment-details">Payment details:</b>
   <ul>
-    <% if (locals.productName) { %>
-      <li data-l10n-args="<%= JSON.stringify({productName}) %>">
-        <%- productName %>
-      </li>
-    <% } %>
+    <li data-l10n-args="<%= JSON.stringify({productName}) %>">
+      <%- productName %>
+    </li>
 
     <% if (locals.invoiceNumber) { %>
       <li data-l10n-id="payment-plan-invoice-number" data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>">
@@ -17,7 +15,7 @@
       </li>
     <% } %>
 
-    <% if (locals.invoiceTotal) { %>
+    <% if (locals.invoiceDateOnly && locals.invoiceTotal) { %>
       <li data-l10n-id="payment-plan-charged" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">
         Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>
       </li>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
@@ -1,0 +1,15 @@
+<% if (productName) { %>
+payment-plan-product-name = "<%- productName %>"
+<% } %>
+
+<% if (invoiceNumber) { %>
+payment-plan-invoice-number = "Invoice Number: <%- invoiceNumber %>"
+<% } %>
+
+<% if (invoiceTotal) { %>
+payment-plan-charged = "Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>"
+<% } %>
+
+<% if (nextInvoiceDateOnly) { %>
+payment-plan-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
+<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
@@ -6,7 +6,7 @@
 payment-plan-invoice-number = "Invoice Number: <%- invoiceNumber %>"
 <% } %>
 
-<% if (locals.invoiceTotal) { %>
+<% if (locals.invoiceDateOnly && locals.invoiceTotal) { %>
 payment-plan-charged = "Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>"
 <% } %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
@@ -1,15 +1,15 @@
-<% if (productName) { %>
-payment-plan-product-name = "<%- productName %>"
+<% if (locals.productName) { %>
+<%- productName %>
 <% } %>
 
-<% if (invoiceNumber) { %>
+<% if (locals.invoiceNumber) { %>
 payment-plan-invoice-number = "Invoice Number: <%- invoiceNumber %>"
 <% } %>
 
-<% if (invoiceTotal) { %>
+<% if (locals.invoiceTotal) { %>
 payment-plan-charged = "Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>"
 <% } %>
 
-<% if (nextInvoiceDateOnly) { %>
+<% if (locals.nextInvoiceDateOnly) { %>
 payment-plan-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
 <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
@@ -1,0 +1,13 @@
+# COMMENT ABOUT After the colon,
+payment-details = Payment details:
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionAccountFinishSetup-subject = Welcome to { $productName }: Please set your password.
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionAccountFinishSetup-title = Welcome to { $productName }
+subscriptionAccountFinishSetup-content-processing = Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel.
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionAccountFinishSetup-content-create = Next, you’ll create a Firefox account password and download { $productName }.
+subscriptionAccountFinishSetup-action = Create a password

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.mjml
@@ -1,0 +1,34 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section css-class="mb-6">
+  <mj-column>
+    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionAccountFinishSetup-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Welcome to <%- productName %></span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionAccountFinishSetup-content-processing">
+        Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel.
+      </span>
+    </mj-text>
+
+    <%- include ('/partials/paymentPlanDetails/index.mjml') %>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionAccountFinishSetup-content-create" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        Next, you’ll create a Firefox account password and download <%- productName %>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/button/index.mjml', { cssClass: 'mb-8'}) %>
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.mjml
@@ -2,11 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-column>
-    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
-  </mj-column>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
@@ -39,7 +39,7 @@ export const SubscriptionFirstInvoiceNextOnly = createStory(
   {
     nextInvoiceDateOnly: '11/13/2021',
   },
-  'Missing Details - Invoice Total Only'
+  'Missing Details - Next Invoice Only'
 );
 
 export const SubscriptionAccountFinishSetupFullDetails = createStory(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
@@ -20,13 +20,26 @@ const createStory = subplatStoryWithProps(
   }
 );
 
-export const SubscriptionFirstInvoiceMissingDetails = createStory(
+export const SubscriptionFirstInvoiceNumberOnly = createStory(
+  {
+    invoiceNumber: '8675309',
+  },
+  'Missing Details - Invoice Number Only'
+);
+
+export const SubscriptionFirstInvoiceTotalOnly = createStory(
   {
     invoiceDateOnly: '10/13/2021',
-    invoiceNumber: '8675309',
     invoiceTotal: '$20.00',
   },
-  'Missing Details'
+  'Missing Details - Invoice Date & Total Only'
+);
+
+export const SubscriptionFirstInvoiceNextOnly = createStory(
+  {
+    nextInvoiceDateOnly: '11/13/2021',
+  },
+  'Missing Details - Invoice Total Only'
 );
 
 export const SubscriptionAccountFinishSetupFullDetails = createStory(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
@@ -11,17 +11,30 @@ export default {
 
 const createStory = subplatStoryWithProps(
   'subscriptionAccountFinishSetup',
-  'Sent to a user to inform them that their payment is processing and prompt them to create a password and download subscription.',
+  'Sent to a user after they purchased the product through the password-less flow without an existing Firefox account.',
   {
     productName: 'Firefox Fortress',
-    invoiceDateOnly: '10/13/2021',
-    invoiceNumber: '8675309',
-    invoiceTotal: '$20.00',
-    nextInvoiceDateOnly: '11/13/2021',
     icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     link: 'http://localhost:3030/post_verify/finish_account_setup/set_password',
     subscriptionSupportUrl: 'http://localhost:3030/support',
   }
 );
 
-export const SubscriptionAccountFinishSetup = createStory();
+export const SubscriptionFirstInvoiceMissingDetails = createStory(
+  {
+    invoiceDateOnly: '10/13/2021',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$20.00',
+  },
+  'Missing Details'
+);
+
+export const SubscriptionAccountFinishSetupFullDetails = createStory(
+  {
+    invoiceDateOnly: '10/13/2021',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$20.00',
+    nextInvoiceDateOnly: '11/13/2021',
+  },
+  'Full Details'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionAccountFinishSetup',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionAccountFinishSetup',
+  'Sent to a user to inform them that their payment is processing and prompt them to create a password and download subscription.',
+  {
+    productName: 'Firefox Fortress',
+    invoiceDateOnly: '10/13/2021',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$20.00',
+    nextInvoiceDateOnly: '11/13/2021',
+    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    link: 'http://localhost:3030/post_verify/finish_account_setup/set_password',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionAccountFinishSetup = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.txt
@@ -1,0 +1,13 @@
+subscriptionAccountFinishSetup-subject = "Welcome to <%- productName %>: Please set your password."
+
+subscriptionAccountFinishSetup-title = "Welcome to <%- productName %>"
+
+subscriptionAccountFinishSetup-content-processing = "Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel."
+
+<%- include ('/partials/paymentPlanDetails/index.txt') %>
+
+subscriptionAccountFinishSetup-content-create = "Next, you’ll create a Firefox account password and download <%- productName %>."
+
+<%- link %>
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.mjml
@@ -2,18 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-group>
-    <mj-column>
-      <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
-      </mj-image>
-    </mj-column>
-    <mj-column>
-      <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
-      </mj-image>
-    </mj-column>
-  </mj-group>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
@@ -2,11 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-column>
-    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
-  </mj-column>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.mjml
@@ -2,11 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-column>
-    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
-  </mj-column>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
@@ -2,11 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-column>
-    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
-  </mj-column>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.mjml
@@ -2,11 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-column>
-    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
-  </mj-column>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
+
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -2,18 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-section css-class="mb-6">
-  <mj-group>
-    <mj-column>
-      <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
-      </mj-image>
-    </mj-column>
-    <mj-column>
-      <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
-      </mj-image>
-    </mj-column>
-  </mj-group>
-</mj-section>
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionAccountFinishSetup.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionAccountFinishSetup.txt
@@ -4,7 +4,7 @@
 
 {{{t "Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel." }}}
 
-{{#if productPlan }}{{ productPlan }}{{/if}}
+{{#if productName }}{{ productName }}{{/if}}
 {{#if invoiceNumber }}{{{t "Invoice number: %(invoiceNumber)s" }}}{{/if}}
 {{#if invoiceTotal }}{{{t "Charged: %(invoiceTotal)s on %(invoiceDateOnly)s" }}}{{/if}}
 {{#if nextInvoiceDateOnly }}{{{t "Next invoice: %(nextInvoiceDateOnly)s" }}}{{/if}}

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -117,12 +117,17 @@ const MESSAGE_FORMATTED = {
 // key = query param name, value = MESSAGE property name
 const MESSAGE_PARAMS = new Map([
   ['code', 'code'],
+  ['deviceId', 'deviceId'],
   ['email', 'email'],
+  ['flowBeginTime', 'flowBeginTime'],
+  ['flowId', 'flowId'],
   ['primary_email_verified', 'email'],
-  ['product_id', 'productId'],
   ['plan_id', 'planId'],
+  ['product_id', 'productId'],
+  ['product_name', 'productName'],
   ['secondary_email_verified', 'email'],
   ['service', 'service'],
+  ['token', 'token'],
   ['uid', 'uid'],
   ['unblockCode', 'unblockCode'],
 ]);
@@ -1046,6 +1051,35 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
       { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
       { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
+  ['subscriptionAccountFinishSetupEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}: Please set your password.` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionAccountFinishSetup') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionAccountFinishSetup' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountFinishSetup }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId')) },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support')) },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `create a Firefox account password and download ${MESSAGE.productName}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: configUrl('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId') },
+      { test: 'include', expected: configUrl('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support') },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `create a Firefox account password and download ${MESSAGE.productName}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionAccountFinishSetup` subscription platform email to the new stack.

Closes: #10225

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="662" alt="Screen Shot 2021-12-16 at 3 38 59 PM" src="https://user-images.githubusercontent.com/28129806/146445961-bc4f0013-cfaf-40b9-b205-fef0169a8b63.png">

New template - Full details
<img width="663" alt="Screen Shot 2021-12-16 at 3 39 17 PM" src="https://user-images.githubusercontent.com/28129806/146445981-42ac8d23-df82-4cc6-9841-b03e5549d809.png">

New template - Invoice Number
<img width="657" alt="Screen Shot 2021-12-20 at 7 30 44 PM" src="https://user-images.githubusercontent.com/28129806/146851075-8eaee0d2-8621-4f2d-bfdb-8fd23ca0559a.png">

New template - Invoice Date & Invoice Total
<img width="659" alt="Screen Shot 2021-12-20 at 7 30 52 PM" src="https://user-images.githubusercontent.com/28129806/146851061-84830706-9acd-4a27-b321-c22f894495b6.png">

New template - Next Invoice
<img width="659" alt="Screen Shot 2021-12-20 at 7 30 59 PM" src="https://user-images.githubusercontent.com/28129806/146851052-a8ea5eac-bdee-4f7e-9d09-b14307c4ebaf.png">

## Other information (Optional)
Per @LZoog 's request, update `1xl` to `2xl` in the following files:
* `emails/global.scss`
* `emails/layouts/subscription/index.scss`

Revisions to button partial - do not affect FxA email templates
* `emails/partials/button/index.mjml`: Added conditional `className` to button
* `emails/partials/button/index.scss`: Removed unnecessary import that affected the format of entire email

Added `icon` partial:
* `emails/partials/icon/index.mjml`

Updated emails to reflect icon partial
* `emails/templates/subscriptionDowngrade/index.mjml`
* `emails/templates/subscriptionFirstInvoice/index.mjml`
* `emails/templates/subscriptionPaymentFailed/index.mjml`
* `emails/templates/subscriptionReactivation/index.mjml`
* `emails/templates/subscriptionSubsequentInvoice/index.mjml`
* `emails/templates/subscriptionUpgrade/index.mjml`

Added `paymentPlanDetails` partial:
* `emails/partials/paymentPlanDetails/en.ftl`
* `emails/partials/paymentPlanDetails/index.mjml `
* `emails/partials/paymentPlanDetails/index.txt `

Possible fix:
* `templates/subscriptionAccountFinishSetup.txt` - I believe `productPlan` should be `productName`? The HTML and plaintext of the older template did not match as the product name was missing from the .txt file as `productPlan` was in place of where `productName` should be. I have added this to the "Confirmation needed" doc.