### PR TITLE
fix(auth-server): revised strings for brand names

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/auth.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/auth.ftl
@@ -21,6 +21,6 @@
 -product-firefox-cloud = Firefox Cloud
 
 # Other brands
--paypal = PayPal
+-brand-paypal = PayPal
 
 ## Email content

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,6 +1,6 @@
 # After the colon is how the user paid, e.g. PayPal or credit card
 payment-method = Payment Method:
-payment-provider-paypal-plaintext = { payment-method } { -paypal }
+payment-provider-paypal-plaintext = { payment-method } { -brand-paypal }
 # Variables:
 #  $cardType (String) - The type of the credit card, e.g. Visa
 #  $lastFour (String) - The last four digits of the credit card, e.g. 5309

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/en.ftl
@@ -1,4 +1,4 @@
-subscriptionsPaymentProviderCancelled-subject = Payment information update required for Mozilla subscriptions
+subscriptionsPaymentProviderCancelled-subject = Payment information update required for { -brand-mozilla } subscriptions
 subscriptionsPaymentProviderCancelled-title = Sorry, we’re having trouble with your payment method
 subscriptionsPaymentProviderCancelled-content-detected = We have detected a problem with your payment method for the following subscriptions.
 subscriptionsPaymentProviderCancelled-content-payment = It may be that your credit card has expired, or your current payment method is out of date.


### PR DESCRIPTION
Fixes strings mentioned in [merge strings for train 36061](https://github.com/mozilla/fxa-content-server-l10n/pull/541)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
