### PR TITLE
feat(auth): add ip geo data when it matches billing country for paypal

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -160,7 +160,12 @@ export class PayPalHandler extends StripeWebhookHandler {
       await this.extractPromotionCode(promotionCodeFromRequest, priceId);
     const currency = (await this.stripeHelper.findPlanById(priceId)).currency;
     const { agreementId, agreementDetails } =
-      await this.createAndVerifyBillingAgreement({ uid, token, currency });
+      await this.createAndVerifyBillingAgreement({
+        uid,
+        token,
+        currency,
+        location: request.app.geo.location,
+      });
 
     const taxRate = await this.stripeHelper.taxRateByCountryCode(
       agreementDetails.countryCode
@@ -305,6 +310,7 @@ export class PayPalHandler extends StripeWebhookHandler {
       uid,
       token,
       currency: customer.currency,
+      location: request.app.geo.location,
     });
 
     await this.stripeHelper.updateCustomerPaypalAgreement(
@@ -365,6 +371,12 @@ export class PayPalHandler extends StripeWebhookHandler {
     uid: string;
     token: string;
     currency: string;
+    location?: {
+      city: string;
+      state: string;
+      country: string;
+      countryCode: string;
+    };
   }) {
     const { uid, token, currency } = options;
     // Create PayPal billing agreement
@@ -379,6 +391,11 @@ export class PayPalHandler extends StripeWebhookHandler {
     // copy bill to address information to Customer
     const accountCustomer = await getAccountCustomerByUid(uid);
     if (accountCustomer.stripeCustomerId) {
+      let locationDetails = {} as any;
+      if (agreementDetails.countryCode === options.location?.countryCode) {
+        locationDetails.city = options.location?.city;
+        locationDetails.state = options.location?.state;
+      }
       this.stripeHelper.updateCustomerBillingAddress(
         accountCustomer.stripeCustomerId,
         {
@@ -388,6 +405,7 @@ export class PayPalHandler extends StripeWebhookHandler {
           line2: agreementDetails.street2,
           postalCode: agreementDetails.zip,
           state: agreementDetails.state,
+          ...locationDetails,
         }
       );
     }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -276,8 +276,16 @@ describe('subscriptions payPalRoutes', () => {
       });
 
       it('should run a charge successfully', async () => {
+        const requestOptions = deepCopy(defaultRequestOptions);
+        requestOptions.geo = {
+          location: {
+            countryCode: 'CA',
+            city: 'Toronto',
+            state: 'Ontario',
+          },
+        };
         const actual = await runTest('/oauth/subscriptions/active/new-paypal', {
-          ...defaultRequestOptions,
+          ...requestOptions,
           payload: { token },
         });
         assert.deepEqual(actual, {
@@ -312,12 +320,12 @@ describe('subscriptions payPalRoutes', () => {
           stripeHelper.updateCustomerBillingAddress,
           accountCustomer.stripeCustomerId,
           {
-            city: undefined,
+            city: 'Toronto',
             country: 'CA',
             line1: undefined,
             line2: undefined,
             postalCode: undefined,
-            state: undefined,
+            state: 'Ontario',
           }
         );
       });
@@ -688,11 +696,19 @@ describe('subscriptions payPalRoutes', () => {
     });
 
     it('should update the billing agreement and process invoice', async () => {
+      const requestOptions = deepCopy(defaultRequestOptions);
+      requestOptions.geo = {
+        location: {
+          countryCode: 'CA',
+          city: 'Toronto',
+          state: 'Ontario',
+        },
+      };
       invoices.push(subscription.latest_invoice);
       subscription.latest_invoice.subscription = subscription;
       const actual = await runTest(
         '/oauth/subscriptions/paymentmethod/billing-agreement',
-        defaultRequestOptions
+        requestOptions
       );
       assert.deepEqual(actual, filterCustomer(customer));
       sinon.assert.calledOnce(stripeHelper.fetchCustomer);
@@ -702,6 +718,18 @@ describe('subscriptions payPalRoutes', () => {
       sinon.assert.calledOnce(stripeHelper.fetchOpenInvoices);
       sinon.assert.calledOnce(stripeHelper.getCustomerPaypalAgreement);
       sinon.assert.calledOnce(payPalHelper.processInvoice);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.updateCustomerBillingAddress,
+        accountCustomer.stripeCustomerId,
+        {
+          city: 'Toronto',
+          country: 'CA',
+          line1: undefined,
+          line2: undefined,
+          postalCode: undefined,
+          state: 'Ontario',
+        }
+      );
     });
 
     it('should update the billing agreement and process zero invoice', async () => {


### PR DESCRIPTION
Because:

* We want to capture additional billing details for PayPal users based
  on their IP for tax compliance.

This commit:

* Captures the general location via the IP on the request and adds it to
  the Stripe customer record.

Closes #11068

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
