### PR TITLE
bug(auth) - Fix issue with second email verification reminder

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
@@ -2,4 +2,24 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<%- include('/partials/verificationReminder/index.mjml') %>
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="verificationReminderSecond-title">Still there?</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="verificationReminderSecond-description">Almost a week ago you created a { -product-firefox-account } but never verified it. We’re worried about you.</span>
+    </mj-text>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verificationReminderSecond-sub-description">Confirm this email address to activate your account and let us know you’re okay.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>


### PR DESCRIPTION
 Because:
 
  - Second verification reminder produced the wrong email.

This commit:

   - Reverts the use of the partials/verificationReminder/index.mjml template.
   - This is not a long term fix. It appears there maybe another underlying issue.

Closes: #11246

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note: The issue could not be reproduced locally. At best this is a quick fix and at worst it's a good sanity check. Both story book and manual testing generated the correct email body; however, testing on stage reproduces the issue. There will be another bug filed documenting this problem, as it seems like this is not an isolated incident and there are other templates which reference partials that have similar issues.
