### PR TITLE
feat(auth): convert subscriptionFailedPaymentsCancellation email templates

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -472,6 +472,7 @@
       "subscriptionAccountReminderSecond",
       "subscriptionCancellation",
       "subscriptionDowngrade",
+      "subscriptionFailedPaymentsCancellation",
       "subscriptionFirstInvoice",
       "subscriptionPaymentFailed",
       "subscriptionPaymentProviderCancelled",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/en.ftl
@@ -1,0 +1,7 @@
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFailedPaymentsCancellation-subject = Your { $productName } subscription has been cancelled
+subscriptionFailedPaymentsCancellation-title = Your subscription has been cancelled
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFailedPaymentsCancellation-content = We’ve cancelled your { $productName } subscription because multiple payment attempts failed. To get access again, start a new subscription with an updated payment method.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/index.mjml
@@ -1,0 +1,23 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionFailedPaymentsCancellation-title">Your subscription has been cancelled</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFailedPaymentsCancellation-content" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        We’ve cancelled your <%- productName %> subscription because multiple payment attempts failed. To get access again, start a new subscription with an updated payment method.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/cancellationSurvey/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionFailedPaymentsCancellation',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionFailedPaymentsCancellation',
+  'Sent when failed payments result in cancellation of user subscription.',
+  {
+    productName: 'Firefox Fortress',
+    isCancellationEmail: true,
+    cancellationSurveryUrl:
+      'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+  }
+);
+
+export const subscriptionFailedPaymentsCancellation = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/index.txt
@@ -1,0 +1,7 @@
+subscriptionFailedPaymentsCancellation-subject = "Your <%- productName %> subscription has been cancelled"
+
+subscriptionFailedPaymentsCancellation-title = "Your subscription has been cancelled"
+
+subscriptionFailedPaymentsCancellation-content = "We’ve cancelled your <%- productName %> subscription because multiple payment attempts failed. To get access again, start a new subscription with an updated payment method."
+
+<%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1133,6 +1133,25 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]]
   ])],
 
+  ['subscriptionFailedPaymentsCancellationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionFailedPaymentsCancellation') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionFailedPaymentsCancellation' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionFailedPaymentsCancellation }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-failed-payments-cancellation', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-failed-payments-cancellation', 'update-billing', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: `We’ve cancelled your ${MESSAGE.productName} subscription because multiple payment attempts failed. To get access again, start a new subscription with an updated payment method.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `We’ve cancelled your ${MESSAGE.productName} subscription because multiple payment attempts failed. To get access again, start a new subscription with an updated payment method.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
   ['subscriptionFirstInvoiceEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
     ['headers', new Map([


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionFailedPaymentsCancellation` subscription platform email to the new stack.

Closes: #10226 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

New Template:
![image](https://user-images.githubusercontent.com/94418270/146805686-e7714505-d8d5-4222-b745-fbb727bf34e5.png)


Old Template:
![image](https://user-images.githubusercontent.com/94418270/146624997-21e06c39-2454-4171-a858-8e154154629c.png)



