### PR TITLE
feat(auth-server): convert `subscriptionRenewalReminder`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -476,6 +476,7 @@
       "subscriptionPaymentFailed",
       "subscriptionPaymentProviderCancelled",
       "subscriptionReactivation",
+      "subscriptionRenewalReminder",
       "subscriptionsPaymentProviderCancelled",
       "subscriptionSubsequentInvoice",
       "subscriptionUpgrade"

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportContact/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportContact/en.ftl
@@ -1,0 +1,5 @@
+# Variables
+#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionSupportContact = Thank you for subscribing to { $productName }. If you have any questions about your subscription or need more information about { $productName }, please <a data-l10n-name="subscriptionSupportUrl">contact us</a>.
+# After the colon, there's a link to https://accounts.firefox.com/support
+subscriptionSupportContact-plaintext = Thank you for subscribing to { $productName }. If you have any questions about your subscription or need more information about { $productName }, please contact us:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportContact/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportContact/index.mjml
@@ -1,0 +1,9 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-text css-class="text-body">
+  <span data-l10n-id="subscriptionSupportContact" data-l10n-args="<%= JSON.stringify({productName}) %>">
+    Thank you for subscribing to <%- productName %>. If you have any questions about your subscription or need more information about <%- productName %>, please <a data-l10n-name="subscriptionSupportUrl" href="<%- subscriptionSupportUrl %>">contact us</a>.
+  </span>
+</mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportContact/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportContact/index.txt
@@ -1,0 +1,2 @@
+subscriptionSupportContact-plaintext = "Thank you for subscribing to <%- productName %>. If you have any questions about your subscription or need more information about <%- productName %>, please contact us:"
+<%- subscriptionSupportUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingEnsure/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingEnsure/en.ftl
@@ -1,0 +1,3 @@
+subscriptionUpdateBillingEnsure = You can ensure that your payment method and account information are up to date <a data-l10n-name="updateBillingUrl">here</a>.
+# After the colon, there's a link to https://accounts.firefox.com/subscriptions
+subscriptionUpdateBillingEnsure-plaintext = You can ensure that your payment method and account information are up to date here:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingEnsure/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingEnsure/index.mjml
@@ -1,0 +1,9 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-text css-class="text-body">
+  <span data-l10n-id="subscriptionUpdateBillingEnsure">
+    You can ensure that your payment method and account information are up to date <a data-l10n-name="updateBillingUrl" href="<%- locals.updateBillingUrl %>">here</a>.
+  </span>
+</mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingEnsure/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingEnsure/index.txt
@@ -1,0 +1,2 @@
+subscriptionUpdateBillingEnsure-plaintext = "You can ensure that your payment method and account information are up to date here:"
+<%- updateBillingUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingTry/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingTry/en.ftl
@@ -1,0 +1,3 @@
+subscriptionUpdateBillingTry = We’ll try your payment again over the next few days, but you may need to help us fix it by <a data-l10n-name="updateBillingUrl">updating your payment information</a>.
+# After the colon, there's a link to https://accounts.firefox.com/subscriptions
+subscriptionUpdateBillingTry-plaintext = We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingTry/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingTry/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="updateBilling">
+      <span data-l10n-id="subscriptionUpdateBillingTry">
         We’ll try your payment again over the next few days, but you may need to help us fix it by <a data-l10n-name="updateBillingUrl" href="<%- updateBillingUrl %>">updating your payment information</a>.
       </span>
     </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingTry/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionUpdateBillingTry/index.txt
@@ -1,0 +1,2 @@
+subscriptionUpdateBillingTry-plaintext = "We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:"
+<%- updateBillingUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/en.ftl
@@ -1,3 +1,0 @@
-updateBilling = We’ll try your payment again over the next few days, but you may need to help us fix it by <a data-l10n-name="updateBillingUrl">updating your payment information</a>.
-# After the colon, there's a link to https://accounts.firefox.com/subscriptions
-updateBilling-plaintext = We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/index.txt
@@ -1,2 +1,0 @@
-updateBilling-plaintext = "We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:"
-<%- updateBillingUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.mjml
@@ -28,5 +28,5 @@
   </mj-column>
 </mj-section>
 
-<%- include ('/partials/updateBilling/index.mjml') %>
+<%- include ('/partials/subscriptionUpdateBillingTry/index.mjml') %>
 <%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.txt
@@ -6,5 +6,5 @@ subscriptionPaymentFailed-content-problem = "We had a problem with your latest p
 
 subscriptionPaymentFailed-content-outdated = "It may be that your credit card has expired, or your current payment method is out of date."
 
-<%- include ('/partials/updateBilling/index.txt') %>
+<%- include ('/partials/subscriptionUpdateBillingTry/index.txt') %>
 <%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
@@ -1,0 +1,17 @@
+# Variables
+#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionRenewalReminder-subject = { $productName } automatic renewal notice
+subscriptionRenewalReminder-title = Your subscription will be renewed soon
+# Variables
+#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionRenewalReminder-content-greeting = Dear { $productName } customer,
+# Variables
+#   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+#   $planIntervalCount (String) - The interval count of subscription plan, e.g. 2
+#   $planInterval (String) - The interval of time of the subscription plan, e.g. week
+#   $reminderLength (String) - The number of days until the current subscription is set to automatically renew, e.g. 14
+subscriptionRenewalReminder-content-current = Your current subscription is set to automatically renew in { $reminderLength } days. At that time, { -brand-mozilla } will renew your { $planIntervalCount} { $planInterval} subscription and a charge of { $invoiceTotal} will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-closing = Sincerely,
+# Variables
+#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionRenewalReminder-content-signature = The { $productName } team

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.mjml
@@ -1,0 +1,32 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionRenewalReminder-title">Your subscription will be renewed soon</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionRenewalReminder-content-greeting" data-l10n-args="<%= JSON.stringify({productName}) %>">Dear <%- productName %> customer,</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionRenewalReminder-content-current" data-l10n-args="<%= JSON.stringify({invoiceTotal, planInterval, planIntervalCount, reminderLength}) %>">
+        Your current subscription is set to automatically renew in <%- reminderLength %> days. At that time, Mozilla will renew your <%- planIntervalCount%> <%- planInterval%> subscription and a charge of <%- invoiceTotal%> will be applied to the payment method on your account.
+      </span>
+    </mj-text>
+
+    <%- include ('/partials/subscriptionUpdateBillingEnsure/index.mjml') %>
+    <%- include ('/partials/subscriptionSupportContact/index.mjml') %>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionRenewalReminder-content-closing">Sincerely,</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionRenewalReminder-content-signature" data-l10n-args="<%= JSON.stringify({productName}) %>">The <%- productName %> team</span>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionRenewalReminder',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionRenewalReminder',
+  'Sent when a user remind them to renew their subscription.',
+  {
+    productName: 'Firefox Fortress',
+    invoiceTotal: '$20.00',
+    planInterval: 'week',
+    planIntervalCount: '2',
+    reminderLength: '14',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+    updateBillingUrl: 'http://localhost:3030/subscriptions',
+  }
+);
+
+export const SubscriptionReactivation = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
@@ -11,7 +11,7 @@ export default {
 
 const createStory = subplatStoryWithProps(
   'subscriptionRenewalReminder',
-  'Sent when a user remind them to renew their subscription.',
+  'Sent to remind a user of an upcoming automatic subscription renewal X days out from charge (X being what is set in the Stripe dashboard)',
   {
     productName: 'Firefox Fortress',
     invoiceTotal: '$20.00',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.txt
@@ -1,0 +1,15 @@
+subscriptionRenewalReminder-subject = "<%- productName %> automatic renewal notice"
+
+subscriptionRenewalReminder-title = "Your subscription will be renewed soon"
+
+subscriptionRenewalReminder-content-greeting = "Dear <%- productName %> customer,"
+
+subscriptionRenewalReminder-content-current = "Your current subscription is set to automatically renew in <%- reminderLength %> days. At that time, Mozilla will renew your <%- planIntervalCount%> <%- planInterval%> subscription and a charge of <%- invoiceTotal%> will be applied to the payment method on your account."
+
+<%- include ('/partials/subscriptionUpdateBillingEnsure/index.txt') %>
+
+<%- include ('/partials/subscriptionSupportContact/index.txt') %>
+
+subscriptionRenewalReminder-content-closing = "Sincerely,"
+
+subscriptionRenewalReminder-content-signature = "The <%- productName %> team"

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -88,12 +88,15 @@ const MESSAGE = {
   paymentProratedCurrency: 'usd',
   payment_provider: 'stripe',
   planId: 'plan-example',
+  planInterval: 'day',
+  planIntervalCount: 2,
   productId: 'wibble',
   productMetadata,
   productName: 'Firefox Fortress',
   productNameOld: 'Product A',
   productNameNew: 'Product B',
   productPaymentCycle: 'month',
+  reminderLength: 14,
   serviceLastActiveDate: new Date(1587339098816),
   subscription: {
     productName: 'Cooking with Foxkeh',
@@ -1247,6 +1250,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
+
   ['subscriptionPaymentProviderCancelledEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `Payment information update required for ${MESSAGE.productName}` }],
     ['headers', new Map([
@@ -1305,6 +1309,33 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
     ['text', [
       { test: 'include', expected: `reactivating your ${MESSAGE.productName} subscription` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
+  ['subscriptionRenewalReminderEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.subscription.productName} automatic renewal notice` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionRenewalReminder') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionRenewalReminder' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionRenewalReminder }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-renewal-reminder', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-renewal-reminder', 'update-billing', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-renewal-reminder', 'subscription-support')) },
+      { test: 'include', expected: `Dear ${MESSAGE.subscription.productName} customer` },
+      { test: 'include', expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days. At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.` },
+      { test: 'include', expected: "Sincerely," },
+      { test: 'include', expected: `The ${MESSAGE.subscription.productName} team` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.subscription.productName} automatic renewal notice` },
+      { test: 'include', expected: `Dear ${MESSAGE.subscription.productName} customer` },
+      { test: 'include', expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days. At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.` },
+      { test: 'include', expected: "Sincerely," },
+      { test: 'include', expected: `The ${MESSAGE.subscription.productName} team` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionRenewalReminder` subscription platform email to the new stack.

Closes #10227

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="657" alt="Screen Shot 2021-12-21 at 10 00 12 AM" src="https://user-images.githubusercontent.com/28129806/146951250-0eff8a84-4d1e-4700-bc54-2632b102659b.png">

New template
<img width="659" alt="Screen Shot 2021-12-21 at 9 59 58 AM" src="https://user-images.githubusercontent.com/28129806/146951306-d15ea47a-9a40-41ca-95ca-41cc08529091.png">

## Other information (Optional)
Added `subscriptionSupportContact` partial:
* `emails/partials/subscriptionSupportContact/en.ftl`
* `emails/partials/subscriptionSupportContact/index.mjml`
* `emails/partials/subscriptionSupportContact/index.txt`

Added `subscriptionUpdateBillingEnsure` partial:
* `emails/partials/subscriptionUpdateBillingEnsure/en.ftl`
* `emails/partials/subscriptionUpdateBillingEnsure/index.mjml`
* `emails/partials/subscriptionUpdateBillingEnsure/index.txt `

Revised `updateBilling` partial to `subscriptionUpdateBillingTry` to avoid confusion:
* `emails/partials/subscriptionUpdateBillingTry/en.ftl`
* `emails/partials/subscriptionUpdateBillingTry/index.mjml`
* `emails/partials/subscriptionUpdateBillingTry/index.txt`

Updated emails using `updateBilling` partial:
* `emails/templates/subscriptionPaymentFailed/index.mjml `
* `emails/templates/subscriptionPaymentFailed/index.mjml`