### PR TITLE
feat(auth-server): convert `subscriptionAccountReminderSecond`

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/en.ftl
@@ -1,0 +1,6 @@
+subscriptionAccountReminderSecond-subject = Final reminder: Setup your account
+subscriptionAccountReminderSecond-title = Welcome to { -brand-firefox }!
+subscriptionAccountReminderSecond-content-info = A few days ago you created a { -product-firefox-account } but never verified it. We hope you’ll finish setting up your account, so you can use your new subscription.
+subscriptionAccountReminderSecond-content-select = Select “Create Password” to set up a new password and finish verifying your account.
+subscriptionAccountReminderSecond-action = Create Password
+subscriptionAccountReminderSecond-action-plaintext = { subscriptionAccountReminderSecond-action }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.mjml
@@ -1,0 +1,27 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionAccountReminderSecond-title">Welcome to Firefox!</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionAccountReminderSecond-content-info">
+        A few days ago you created a Firefox account but never verified it. We hope you’ll finish setting up your account, so you can use your new subscription.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionAccountReminderSecond-content-select">
+        Select “Create Password” to set up a new password and finish verifying your account.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/button/index.mjml', { cssClass: 'mb-8' }) %>
+<%- include ('/partials/subscriptionSupport/index.mjml') %>
+<%- include ('/partials/automatedEmailResetPassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionAccountReminderSecond',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionAccountReminderSecond',
+  'Sent as a final reminder to a user to remind them to finish setting up a Firefox account as they signed up through the password-less flow without an existing account.',
+  {
+    link: 'http://localhost:3030/post_verify/finish_account_setup/set_password',
+    reminderShortForm: true,
+    resetLink: 'http://localhost:3030/settings/change_password',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionAccountReminderSecond = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.txt
@@ -1,0 +1,14 @@
+subscriptionAccountReminderSecond-subject = "Final reminder: Setup your account"
+
+subscriptionAccountReminderSecond-title = "Welcome to Firefox!"
+
+subscriptionAccountReminderSecond-content-info = "A few days ago you created a Firefox account but never verified it. We hope you’ll finish setting up your account, so you can use your new subscription."
+
+subscriptionAccountReminderSecond-content-select = "Select “Create Password” to set up a new password and finish verifying your account."
+
+subscriptionAccountReminderSecond-action-plaintext = "Create Password:"
+<%- link %>
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>
+
+<%- include ('/partials/automatedEmailResetPassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1104,6 +1104,26 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
   ])],
 
+  ['subscriptionAccountReminderSecondEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Final reminder: Setup your account' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountFinishSetupUrl', 'second-subscription-account-reminder', 'subscription-account-create-email', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionAccountReminderSecond') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionAccountReminderSecond' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountReminderSecond }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'second-subscription-account-reminder', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'second-subscription-account-reminder', 'support')) },
+      { test: 'include', expected: decodeUrl(configHref('accountFinishSetupUrl', 'second-subscription-account-reminder', 'subscription-account-create-email', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Create Password:\n${configUrl('accountFinishSetupUrl', 'second-subscription-account-reminder', 'subscription-account-create-email', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
   ['subscriptionDowngradeEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `You have switched to ${MESSAGE.productNameNew}` }],
     ['headers', new Map([


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionAccountReminderSecond` subscription platform email to the new stack.

Closes: #10911

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="654" alt="Screen Shot 2021-12-21 at 10 27 23 AM" src="https://user-images.githubusercontent.com/28129806/146956033-c7bfca21-fb21-4e20-83bd-7abb6b638111.png">

New template
<img width="667" alt="Screen Shot 2021-12-21 at 10 27 12 AM" src="https://user-images.githubusercontent.com/28129806/146956070-2c0ff624-e618-492f-8241-6e260a4f5684.png">

## Other information (Optional)
Note, `subscriptionAccountReminderSecond` is already included in `dev.json`

I have added the update of the button from "Create a password" to "Create Password" to the Confirmation Needed doc.
