### PR TITLE
chore(auth-server): Add 'merge-ftl' to 'storybook-mjml' command

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -33,7 +33,7 @@
     "emails-scss": "node -r esbuild-register ./lib/senders/emails/sass-compile-files.ts",
     "start-mjml": "NODE_ENV=dev node -r esbuild-register ./bin/mjml-server.ts",
     "storybook": "npm run emails-scss && start-storybook -p 6010 --no-version-updates",
-    "storybook-mjml": "nodemon -e scss,ts  --exec \"npm-run-all -p watch-ftl start-mjml storybook\"",
+    "storybook-mjml": "nodemon -e scss,ts  --exec \"grunt merge-ftl && npm-run-all -p watch-ftl start-mjml storybook\"",
     "watch-ftl": "yarn grunt watch-ftl"
   },
   "repository": {


### PR DESCRIPTION
Because:
* When you check into a branch with new or updated FTL strings and you run storybook-mjml, strings will be missing since the file hasn't been concatenated locally yet

This commit:
* Adds 'grunt merge-ftl' to the start of 'storybook-mjml' script