### PR TITLE
fix(auth-server): text in plain version of postVerifySecondary template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
@@ -1,6 +1,6 @@
 postVerifySecondary-title = "Secondary email added"
 
-postVerifySecondary-description = "You have successfully added <%- secondaryEmail %> as a secondary email from your Firefox account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
+postVerifySecondary-description = "You have successfully verified <%- secondaryEmail %> as a secondary email from your Firefox account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
 
 <%- include('/partials/manageAccount/index.txt') %>
 


### PR DESCRIPTION
Because:

* Text in plain version of postVerifySecondary template was different than HTML version and old template

This commit:

* Revises the plain text to reflect correct wording

Closes: #11350

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).