### PR TITLE
 feat(Coupon): add backend call to coupon apply btn 

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
+
 
 const fs = require('fs');
 const path = require('path');

--- a/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
@@ -1,14 +1,17 @@
-import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
+import React, { useState } from 'react';
+
+import CouponForm from '.';
 import MockApp from '../../../.storybook/components/MockApp';
-import CouponForm from './index';
 import { Coupon } from '../../lib/Coupon';
+import { SELECTED_PLAN } from '../../lib/mock-data';
 
 storiesOf('components/Coupon', module).add('default', () => {
   const [coupon, setCoupon] = useState<Coupon>();
+
   return (
     <MockApp>
-      <CouponForm coupon={coupon} setCoupon={setCoupon} />
+      <CouponForm planId={SELECTED_PLAN.plan_id} coupon={coupon} setCoupon={setCoupon} />
     </MockApp>
   );
 });

--- a/packages/fxa-payments-server/src/components/CouponForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.test.tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import CouponForm from './index';
 import { Coupon } from '../../lib/Coupon';
+import { SELECTED_PLAN } from '../../lib/mock-data';
+import waitForExpect from 'wait-for-expect';
 
 afterEach(cleanup);
 
 describe('CouponForm', () => {
   it('renders as expected', () => {
     const subject = () => {
-      return render(<CouponForm coupon={undefined} setCoupon={() => {}} />);
+      return render(<CouponForm planId={SELECTED_PLAN.plan_id} coupon={undefined} setCoupon={() => {}} />);
     };
 
     const { queryByTestId } = subject();
@@ -19,16 +21,16 @@ describe('CouponForm', () => {
     expect(couponButton).toBeInTheDocument();
   });
 
-  it('shows an error message when invalid coupon code is used', () => {
+  it('shows an error message when invalid coupon code is used', async () => {
     const subject = () => {
-      return render(<CouponForm coupon={undefined} setCoupon={() => {}} />);
+      return render(<CouponForm planId={SELECTED_PLAN.plan_id} coupon={undefined} setCoupon={() => {}} />);
     };
 
     const { queryByTestId, getByTestId } = subject();
     fireEvent.change(getByTestId('coupon-input'), { target: { value: 'a' } });
     fireEvent.click(getByTestId('coupon-button'));
 
-    expect(queryByTestId('coupon-error')).toBeInTheDocument();
+    await waitForExpect(() => expect(queryByTestId('coupon-error')).toBeInTheDocument());
   });
 
   it('shows the coupon code and hides the input when a coupon is used', () => {
@@ -37,7 +39,7 @@ describe('CouponForm', () => {
       couponCode: '',
     };
     const subject = () => {
-      return render(<CouponForm coupon={coupon} setCoupon={(coupon) => {}} />);
+      return render(<CouponForm planId={SELECTED_PLAN.plan_id} coupon={coupon} setCoupon={(coupon) => {}} />);
     };
 
     const { queryByTestId } = subject();

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -22,8 +22,6 @@ const checkPromotionCode = async (planId: string, promotionCode: string) => {
       throw new Error('No discount for coupon');
     return discount.amount;
   } catch (err) {
-    console.log('erererererere');
-    console.log(err);
     if (err instanceof APIError)
       sentry.captureException(err);
     throw err;

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -22,6 +22,8 @@ const checkPromotionCode = async (planId: string, promotionCode: string) => {
       throw new Error('No discount for coupon');
     return discount.amount;
   } catch (err) {
+    console.log('erererererere');
+    console.log(err);
     if (err instanceof APIError)
       sentry.captureException(err);
     throw err;
@@ -132,7 +134,7 @@ export const CouponForm = ({ planId, coupon, setCoupon }: CouponFormProps) => {
         {error ? (
           <Localized id="coupon-error">
             <div className="coupon-error" data-testid="coupon-error">
-              The code you entered is invalid or expired.
+              {error}
             </div>
           </Localized>
         ) : null}

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { Localized } from '@fluent/react';
-import { getLocalizedCurrency, formatPlanPricing } from '../../lib/formats';
+import { getLocalizedCurrency, formatPlanPricing, getLocalizedCurrencyString } from '../../lib/formats';
 import {
   metadataFromPlan,
   productDetailsFromPlan,
@@ -51,6 +51,8 @@ export const PlanDetails = ({
     interval,
     interval_count
   );
+
+  console.log(config.featureFlags.subscriptionCoupons)
 
   return (
     <section
@@ -124,7 +126,7 @@ export const PlanDetails = ({
                             amount: getLocalizedCurrency(amount, currency),
                             intervalCount: interval_count,
                           }}
-                        ></Localized>
+                        >{getLocalizedCurrencyString(amount, currency)}</Localized>
                       </div>
                     </div>
                     <div className="plan-details-total-inner">
@@ -142,7 +144,10 @@ export const PlanDetails = ({
                             ),
                             intervalCount: interval_count,
                           }}
-                        ></Localized>
+                        >{getLocalizedCurrencyString(
+                          coupon.amount,
+                          currency
+                        )}</Localized>
                       </div>
                     </div>
                   </div>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -52,8 +52,6 @@ export const PlanDetails = ({
     interval_count
   );
 
-  console.log(config.featureFlags.subscriptionCoupons)
-
   return (
     <section
       className={`plan-details-component ${className}`}

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -45,8 +45,10 @@ export const PlanDetails = ({
   const setWebIconBackground = webIconBackground
     ? { background: webIconBackground }
     : '';
+
+  const discountAmount = coupon && amount && config.featureFlags.subscriptionCoupons ? amount - coupon.amount : amount;
   const planPrice = formatPlanPricing(
-    amount,
+    discountAmount,
     currency,
     interval,
     interval_count
@@ -142,10 +144,10 @@ export const PlanDetails = ({
                             ),
                             intervalCount: interval_count,
                           }}
-                        >{getLocalizedCurrencyString(
+                        >{`- ${getLocalizedCurrencyString(
                           coupon.amount,
                           currency
-                        )}</Localized>
+                        )}`}</Localized>
                       </div>
                     </div>
                   </div>

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -4,6 +4,7 @@ import * as Amplitude from './amplitude';
 import { getFlowData } from './flow-event';
 import { PaymentMethod } from '@stripe/stripe-js';
 import { PaymentProvider } from './PaymentProvider';
+import { InvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 // TODO: Use a better type here
 export interface APIFetchOptions {
@@ -369,6 +370,17 @@ export async function apiRetryInvoice(params: {
   return apiFetch(
     'POST',
     `${config.servers.auth.url}/v1/oauth/subscriptions/invoice/retry`,
+    { body: JSON.stringify(params) }
+  );
+}
+
+export async function apiInvoicePreview(params: {
+  priceId: string;
+  promotionCode: string;
+}): Promise<InvoicePreview> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/invoice/preview`,
     { body: JSON.stringify(params) }
   );
 }

--- a/packages/fxa-payments-server/src/routes/Checkout/index.scss
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.scss
@@ -1,7 +1,6 @@
 @import '../../../../fxa-content-server/app/styles/variables';
 @import '../../../../fxa-content-server/app/styles/breakpoints';
 
-
 .subscription-title {
   padding-top: 20px;
 }
@@ -37,7 +36,7 @@
 .subscription-title + .product-payment {
   grid-row: 2/3;
 
-  @include max-width('tablet'){
+  @include max-width('tablet') {
     grid-row: 4/5;
   }
 
@@ -54,13 +53,13 @@
   color: rgba(12, 12, 13, 0.8);
   padding: 16px 16px 60px;
 
-  @include max-width('tablet'){
+  @include max-width('tablet') {
     grid-row: 4/5;
     margin: 24px 16px;
     min-height: 100%;
   }
 
-  @media (orientation: landscape) and (max-width: 844px)  {
+  @media (orientation: landscape) and (max-width: 844px) {
     grid-row: 4/5;
     margin: 24px 16px;
     min-height: 100%;

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 import { AppContext } from '../../lib/AppContext';
 import { useMatchMedia, useNonce, usePaypalButtonSetup } from '../../lib/hooks';
 import { getSelectedPlan } from '../../lib/plan';
-import useValidatorState, {
+import {
   State as ValidatorState,
 } from '../../lib/validator';
 
@@ -23,13 +23,11 @@ import NewUserEmailForm, {
   checkAccountExists,
 } from '../../components/NewUserEmailForm';
 import Header from '../../components/Header';
-import { Form } from '../../components/fields';
 import PaymentProcessing from '../../components/PaymentProcessing';
 import SubscriptionTitle from '../../components/SubscriptionTitle';
 import PlanDetails from '../../components/PlanDetails';
 import TermsAndPrivacy from '../../components/TermsAndPrivacy';
 import PaymentLegalBlurb from '../../components/PaymentLegalBlurb';
-import { PaymentConsentCheckbox } from '../../components/PaymentConsentCheckbox';
 
 import { State } from '../../store/state';
 import { sequences, SequenceFunctions } from '../../store/sequences';
@@ -435,11 +433,11 @@ export const Checkout = ({
             selectedPlan,
             isMobile,
             showExpandButton: isMobile,
-            coupon: coupon,
+            coupon,
           }}
         />
         {config.featureFlags.subscriptionCoupons ? (
-          <CouponForm {...{ coupon, setCoupon }} />
+          <CouponForm {...{ planId: selectedPlan.plan_id, coupon, setCoupon }} />
         ) : null}
       </div>
     </>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
@@ -12,8 +12,6 @@
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
   }
-
-
 }
 
 .subscription-title + .product-payment {
@@ -43,7 +41,7 @@
     min-height: 100%;
   }
 
-  @media (orientation: landscape) and (max-width: 844px)  {
+  @media (orientation: landscape) and (max-width: 844px) {
     grid-row: 4/5;
     margin: 24px 16px;
     min-height: 100%;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -333,7 +333,7 @@ export const SubscriptionCreate = ({
           }}
         />
         {config.featureFlags.subscriptionCoupons ? (
-          <CouponForm {...{ coupon, setCoupon }} />
+          <CouponForm {...{ planId: selectedPlan.plan_id, coupon, setCoupon }} />
         ) : null}
       </div>
     </>


### PR DESCRIPTION
## Because

- The apply button should validate the coupon entered by the user

## This pull request

- Calls the invoice preview endpoint with the priceId and coupon code
  when the Apply button is pressed.

## Issue that this pull request solves

Closes: #10850

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
