### PR TITLE
fix(subscriptions): use ip only customs check on invoicePreview

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -397,7 +397,7 @@ export class StripeHandler {
     request: AuthRequest
   ): Promise<invoiceDTO.invoicePreviewSchema> {
     this.log.begin('subscriptions.previewInvoice', request);
-    await this.customs.check(request, 'previewInvoice');
+    await this.customs.checkIpOnly(request, 'previewInvoice');
 
     const { promotionCode, priceId } = request.payload as Record<
       string,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -567,9 +567,13 @@ describe('DirectStripeRoutes', () => {
         priceId: 'priceId',
       };
       VALID_REQUEST.app.geo = {};
-
       const actual = await directStripeRoutesInstance.previewInvoice(
         VALID_REQUEST
+      );
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.customs.checkIpOnly,
+        VALID_REQUEST,
+        'previewInvoice'
       );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.previewInvoice,


### PR DESCRIPTION
Because:
 - there's no email in the request

This commit:
 - switch to use ip only check with customs
