### PR TITLE
 fix(scripts): add deps and fix route init for delete acct script

### DIFF
--- a/packages/fxa-auth-server/test/scripts/delete-account.js
+++ b/packages/fxa-auth-server/test/scripts/delete-account.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const cp = require('child_process');
+const util = require('util');
+const path = require('path');
+
+const execAsync = util.promisify(cp.exec);
+
+const cwd = path.resolve(__dirname, ROOT_DIR);
+const execOptions = {
+  cwd,
+  env: {
+    NODE_ENV: 'dev',
+    LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
+  },
+};
+
+describe('scripts/delete-account:', () => {
+  it('does not fail', () => {
+    return execAsync(
+      'node -r esbuild-register scripts/delete-account',
+      execOptions
+    );
+  });
+});


### PR DESCRIPTION
Because:
 - the script was erroring due to
   - missing dependencies
   - change in the account routes export

This commit:
 - add the ProfileClient Firestore deps to the Container
 - fix account routes init
 - add a test