### PR TITLE
fix(subscriptions): update a payment method webhook event type

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2730,7 +2730,8 @@ export class StripeHelper {
           await this.processSubscriptionEventToFirestore(event);
           break;
         case 'payment_method.attached':
-        case 'payment_method.automatically_updated':
+        // @ts-ignore
+        case 'payment_method.card_automatically_updated':
         case 'payment_method.updated':
           await this.processPaymentMethodEventToFirestore(event);
           break;

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4185,7 +4185,7 @@ describe('StripeHelper', () => {
 
     for (const type of [
       'payment_method.attached',
-      'payment_method.automatically_updated',
+      'payment_method.card_automatically_updated',
       'payment_method.updated',
     ]) {
       it(`handles ${type} operations`, async () => {


### PR DESCRIPTION
Because:
 - there's a mismatch between an event type in Stripe's SDK types and
   docs and what's actually sent

This commit:
 - update the type to the one that's actually in the payload

## Issue that this pull request solves

Closes: #11335
