### PR TITLE
fix(payments): remove hard-coded test coupon code

### DIFF
--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -8,25 +8,23 @@ import { Coupon } from '../../lib/Coupon';
 import sentry from '../../lib/sentry';
 
 /*
-* Check if the coupon promotion code provided by the user is valid.
-* If it is valid, return the discounted amount in cents.
-*/
+ * Check if the coupon promotion code provided by the user is valid.
+ * If it is valid, return the discounted amount in cents.
+ */
 const checkPromotionCode = async (planId: string, promotionCode: string) => {
   try {
     const { discount } = await apiInvoicePreview({
       priceId: planId,
-      promotionCode
+      promotionCode,
     });
 
-    if(!discount)
-      throw new Error('No discount for coupon');
+    if (!discount) throw new Error('No discount for coupon');
     return discount.amount;
   } catch (err) {
-    if (err instanceof APIError)
-      sentry.captureException(err);
+    if (err instanceof APIError) sentry.captureException(err);
     throw err;
   }
-}
+};
 
 type CouponFormProps = {
   planId: string;
@@ -36,7 +34,7 @@ type CouponFormProps = {
 
 export const CouponForm = ({ planId, coupon, setCoupon }: CouponFormProps) => {
   const [hasCoupon, setHasCoupon] = useState(coupon ? true : false);
-  const [couponCode, setCouponCode] = useState(coupon ? 'test' : '');
+  const [couponCode, setCouponCode] = useState(coupon ? coupon.couponCode : '');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -122,7 +120,12 @@ export const CouponForm = ({ planId, coupon, setCoupon }: CouponFormProps) => {
               </Localized>
             </div>
 
-            <button name="apply" type="submit" data-testid="coupon-button" disabled={loading}>
+            <button
+              name="apply"
+              type="submit"
+              data-testid="coupon-button"
+              disabled={loading}
+            >
               <Localized id="coupon-submit">
                 <span>Apply</span>
               </Localized>

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -18,10 +18,14 @@ const checkPromotionCode = async (planId: string, promotionCode: string) => {
       promotionCode,
     });
 
-    if (!discount) throw new Error('No discount for coupon');
+    if (!discount) {
+      throw new Error('No discount for coupon');
+    }
     return discount.amount;
   } catch (err) {
-    if (err instanceof APIError) sentry.captureException(err);
+    if (err instanceof APIError) {
+      sentry.captureException(err);
+    }
     throw err;
   }
 };


### PR DESCRIPTION
Because:

* We dont want to display the hard-coded test code if a coupon is present on page load

This commit:

* Uses the couponCode property of the coupon for display purposes

Closes #11426

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
