### PR TITLE
fix(scripts): add new deps to delete acct script

### DIFF
--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -83,6 +83,16 @@ DB.connect(config).then(async (db) => {
     log,
     config
   );
+  const subscriptionAccountReminders =
+    require('../lib/subscription-account-reminders')(log, config);
+  const signupUtils = require('../lib/routes/utils/signup')(
+    log,
+    db,
+    mailer,
+    push,
+    verificationReminders
+  );
+
   /** @type {undefined | import('../lib/payments/stripe').StripeHelper} */
   let stripeHelper = undefined;
   if (config.subscriptions && config.subscriptions.stripeApiKey) {
@@ -113,8 +123,10 @@ DB.connect(config).then(async (db) => {
       config,
       mockCustoms,
       signinUtils,
+      signupUtils,
       push,
       verificationReminders,
+      subscriptionAccountReminders,
       oauthDB,
       stripeHelper
     )


### PR DESCRIPTION
## Because

* The accountRoutes function has some new args that need to be added to
  the delete account script.

## This pull request

* Adds the missing deps to the account script.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
