### PR TITLE
bug(auth): button text is "Click here" in all emails 

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .yarn
+*.mjml

--- a/packages/fxa-auth-server/lib/senders/emails/partials/test/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/test/index.mjml
@@ -1,0 +1,21 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="<%- template %>-title" >Not Localized - Test Render <%- testTerm %> </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="<%- template %>-description" >Not Loclalized - A test to validate edge cases in mjml rendering and fluent localization. <%- testTerm %></span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/test/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/test/index.txt
@@ -1,0 +1,4 @@
+<%- template %>-title = "Not Localized - Render - <%- template %> - <%- testTerm %> "
+
+<%- template %>-description = "Not Loclalized - A test to validate edge cases in mjml rendering and fluent localization. - <%- template %> - <%- testTerm %>"
+<%- link %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test1/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test1/en.ftl
@@ -1,0 +1,4 @@
+test1-subject = Render - test1 - { $testTerm }
+test1-title = Render - test1 - { $testTerm }
+test1-action = Click Here - test1 - { $testTerm }
+test1-description = A test to validate edge cases in mjml rendering and fluent localization. - test1 - { $testTerm }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test1/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test1/index.mjml
@@ -1,0 +1,1 @@
+<%- include('/partials/test/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test1/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test1/index.txt
@@ -1,0 +1,1 @@
+<%- include('/partials/test/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test2/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test2/en.ftl
@@ -1,0 +1,4 @@
+test2-subject = Render - test2 - { $testTerm }
+test2-title = Render - test2 - { $testTerm }
+test2-action = Click Here - test2 - { $testTerm }
+test2-description = A test to validate edge cases in mjml rendering and fluent localization. - test2 - { $testTerm }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test2/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test2/index.mjml
@@ -1,0 +1,1 @@
+<%- include('/partials/test/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test2/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test2/index.txt
@@ -1,0 +1,1 @@
+<%- include('/partials/test/index.txt') %>

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -23,6 +23,7 @@
     "test-e2e": "NODE_ENV=dev mocha -r esbuild-register test/e2e",
     "test-scripts": "NODE_ENV=dev mocha -r esbuild-register test/scripts --exit",
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha -r esbuild-register --timeout=300000 test/remote",
+    "test-mjml": "grunt merge-ftl && NODE_ENV=dev mocha -r esbuild-register test/mjml --exit",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "gen-keys": "node -r esbuild-register ./scripts/gen_keys.js; node -r esbuild-register ./scripts/oauth_gen_keys.js; node -r esbuild-register ./scripts/gen_vapid_keys.js",
     "write-emails": "npm run emails-scss && node -r esbuild-register ./scripts/write-emails-to-disk.js",

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -44,6 +44,7 @@ const productMetadata = {
 const MESSAGE = {
   // Note: acceptLanguage is not just a single locale
   acceptLanguage: 'en;q=0.8,en-US;q=0.5,en;q=0.3"',
+  androidLink: 'https://example.com/play-store',
   appStoreLink: 'https://example.com/app-store',
   code: 'abc123',
   date: 'Wednesday, Apr 7, 2021',
@@ -78,6 +79,7 @@ const MESSAGE = {
   invoiceNumber: '8675309',
   invoiceTotalInCents: 999999.9,
   invoiceTotalCurrency: 'eur',
+  iosLink: 'https://example.com/app-store',
   lastFour: '5309',
   nextInvoiceDate: new Date(1587339098816),
   paymentAmountOldInCents: 9999099.9,

--- a/packages/fxa-auth-server/test/mjml/mjml-templates.test.ts
+++ b/packages/fxa-auth-server/test/mjml/mjml-templates.test.ts
@@ -1,0 +1,114 @@
+import { assert } from 'chai';
+import FluentLocalizer, {
+  splitPlainTextLine,
+} from '../../lib/senders/emails/fluent-localizer';
+import { TemplateContext } from '../../lib/senders/emails/renderer';
+
+describe('mjml rendering', () => {
+  describe.only('line splitter', () => {
+    const pair = {
+      key: 'foo_2-Bar',
+      val: 'foo - bar',
+    };
+
+    it('splits default format', () => {
+      const { key, val } = splitPlainTextLine(`${pair.key} = "${pair.val}"`);
+
+      assert.equal(key, pair.key);
+      assert.equal(val, pair.val);
+    });
+
+    it('handles trailing extra whitespace', () => {
+      const { key, val } = splitPlainTextLine(
+        `  ${pair.key}  =  "${pair.val}"  `
+      );
+      assert.equal(key, pair.key);
+      assert.equal(val, pair.val);
+    });
+
+    it('handles compact format', () => {
+      const { key, val } = splitPlainTextLine(`${pair.key}="${pair.val}"`);
+      assert.equal(key, pair.key);
+      assert.equal(val, pair.val);
+    });
+
+    it('handles escaped quote format', () => {
+      const { key, val } = splitPlainTextLine(
+        `${pair.key}="${pair.val} \"baz\" "`
+      );
+      assert.equal(key, pair.key);
+      assert.equal(val, pair.val + ' "baz" ');
+    });
+
+    it('requires quoted string', () => {
+      const { key, val } = splitPlainTextLine(`${pair.key} = ${pair.val}`);
+      assert.notExists(key);
+      assert.notExists(val);
+    });
+  });
+
+  describe.only('fluent-localizer', () => {
+    const localizer = new FluentLocalizer();
+
+    it('creates localizes', async () => {
+      assert.exists(localizer);
+    });
+
+    // Here we test two folders bot of which reference the partials/test.
+    // There have been several bugs were when two diffferent template folders
+    // referencing the same partial would give language translation issues.
+    for (const test of ['test1', 'test2']) {
+      describe(`localizes ${test}`, () => {
+        const template: TemplateContext = {
+          acceptLanguage: 'en',
+          template: test,
+          layout: 'fxa',
+          link: 'xyz',
+          subject: `Render - ${test} - { $testTerm }`,
+          testTerm: `foobar${test}`,
+          privacyUrl: 'xyz',
+        };
+
+        let result: any = {};
+        before(async () => {
+          result = await localizer.localizeEmail(template);
+        });
+
+        it('rendered', () => {
+          assert.exists(result);
+
+          assert.exists(result.subject);
+          assert.exists(result.text);
+          assert.exists(result.html);
+        });
+
+        it('localized subject', () => {
+          assert.isFalse(/Not Localized/.test(result.subject));
+        });
+
+        it('localized text', () => {
+          assert.isFalse(/Not Localized/.test(result.text));
+        });
+
+        it('localized html', () => {
+          assert.isFalse(/Not Localized/.test(result.html));
+        });
+
+        it('applied props', () => {
+          const reTestTerm = new RegExp(template.testTerm);
+          assert.isTrue(reTestTerm.test(result.subject));
+          assert.isTrue(reTestTerm.test(result.text));
+          assert.isTrue(reTestTerm.test(result.html));
+        });
+
+        it('localized dynamic l10n', () => {
+          assert.isTrue(
+            new RegExp(`Click Here - ${test} - ${template.testTerm}`).test(
+              result.html
+            )
+          );
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Because

- Translated text in partials was difficult to control and would often fallback to the default value.

## This pull request

- Automatically decorates DOM elements having data-l10n-id attributes with context.
- Adds test around the FluentLocalizer class

## Issue that this pull request solves

Closes: #10586

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
