### PR TITLE
bug(auth): Less brittle partials

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/button/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/button/index.mjml
@@ -7,7 +7,7 @@
 <mj-section>
   <mj-column css-class="<%= locals.cssClass || undefined %>">
     <mj-button css-class="primary-button" href="<%- link %>">
-      <span data-l10n-id="<%- template %>-action">Click here</span>
+      <span data-l10n-id="<%- locals.l10nTemplateId || "" %>", data-l10n-args="<%= JSON.stringify(locals.l10nArgs) || "" %>" ><%- locals.action || "Click here" %></span>
     </mj-button>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/test/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/test/index.mjml
@@ -1,0 +1,21 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="<%- template %>-title" data-l10n-args="<%= JSON.stringify({testTerm}) %>" >Not Localized - Test Render <%- testTerm %> </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="<%- template %>-description" data-l10n-args="<%= JSON.stringify({testTerm}) %>">Not Loclalized - A test to validate edge cases in mjml rendering and fluent localization. <%- testTerm %></span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml', { l10nTemplateId: 'test-action', l10nArgs: {testTerm} }) %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/test/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/test/index.txt
@@ -1,0 +1,6 @@
+<%- template %>-title = "Not Localized - Test Render <%- testTerm %> "
+
+<%- template %>-description = "Not Loclalized - A test to validate edge cases in mjml rendering and fluent localization. <%- testTerm %> "
+
+<%- link %>
+

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test/en.ftl
@@ -1,0 +1,4 @@
+test-subject = Render Test - { $testTerm }
+test-title = Render Test - { $testTerm }
+test-action = foo - Click Here - { $testTerm } - bar
+test-description = A test to validate edge cases in mjml rendering and fluent localization. - { $testTerm }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test/index.mjml
@@ -1,0 +1,1 @@
+<%- include('/partials/test/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/test/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/test/index.txt
@@ -1,0 +1,1 @@
+<%- include('/partials/test/index.txt') %>

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -23,6 +23,7 @@
     "test-e2e": "NODE_ENV=dev mocha -r esbuild-register test/e2e",
     "test-scripts": "NODE_ENV=dev mocha -r esbuild-register test/scripts --exit",
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha -r esbuild-register --timeout=300000 test/remote",
+    "test-mjml": "NODE_ENV=dev mocha -r esbuild-register test/mjml --exit",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "gen-keys": "node -r esbuild-register ./scripts/gen_keys.js; node -r esbuild-register ./scripts/oauth_gen_keys.js; node -r esbuild-register ./scripts/gen_vapid_keys.js",
     "write-emails": "npm run emails-scss && node -r esbuild-register ./scripts/write-emails-to-disk.js",

--- a/packages/fxa-auth-server/test/mjml/mjml-templates.test.ts
+++ b/packages/fxa-auth-server/test/mjml/mjml-templates.test.ts
@@ -1,0 +1,63 @@
+import { string } from '@hapi/joi';
+import { assert } from 'chai';
+import { Recoverable } from 'repl';
+import FluentLocalizer from '../../lib/senders/emails/fluent-localizer';
+import { render, TemplateContext } from '../../lib/senders/emails/renderer';
+
+describe('fluent-localizer', () => {
+  const localizer = new FluentLocalizer();
+
+  it('creates localizes', async () => {
+    assert.exists(localizer);
+  });
+
+  describe('localizes', () => {
+    const template: TemplateContext = {
+      acceptLanguage: 'en-US',
+      template: 'test',
+      layout: 'fxa',
+      link: 'xyz',
+      subject: 'Render test - { $testTerm }',
+      testTerm: 'foobarbaz',
+      privacyUrl: 'xyz',
+    };
+
+    let result: any = {};
+    before(async () => {
+      result = await localizer.localizeEmail(template);
+    });
+
+    it('rendered', () => {
+      assert.exists(result);
+
+      assert.exists(result.subject);
+      assert.exists(result.text);
+      assert.exists(result.html);
+    });
+
+    it('localized subject', () => {
+      assert.isFalse(/Not Localized/.test(result.subject));
+    });
+
+    it('localized text', () => {
+      assert.isFalse(/Not Localized/.test(result.text));
+    });
+
+    it('localized html', () => {
+      assert.isFalse(/Not Localized/.test(result.html));
+    });
+
+    it('applied props', () => {
+      const reTestTerm = new RegExp(template.testTerm);
+      assert.isTrue(reTestTerm.test(result.subject));
+      assert.isTrue(reTestTerm.test(result.text));
+      assert.isTrue(reTestTerm.test(result.html));
+    });
+
+    it('localized dynamic l10n', () => {
+      assert.isTrue(
+        new RegExp(`Click Here - ${template.testTerm}`).test(result.html)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Because

- Translated text in partials was difficult to control and would often fallback to the default value.

## This pull request

- Changes the button partial so that text and l10n id & args can be passed into template
- Adds tests validating this works.

## Issue that this pull request solves

Closes: #10586

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
