### PR TITLE
fix(auth-server): subject for 2FA email template is different

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1597,7 +1597,7 @@ module.exports = function (log, config, bounces) {
 
     const templateName = 'postAddTwoStepAuthentication';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Two-step verification enabled');
+    const subject = gettext('Two-step authentication enabled');
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
@@ -1644,7 +1644,7 @@ module.exports = function (log, config, bounces) {
 
     const templateName = 'postRemoveTwoStepAuthentication';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Two-step verification is off');
+    const subject = gettext('Two-step authentication is off');
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,

--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -86,7 +86,17 @@ class FluentLocalizer {
 
     context = { ...context, ...context.templateValues };
     if (template !== '_storybook') {
-      context.subject = await l10n.formatValue(`${template}-subject`, context);
+      if (template === 'postRemoveTwoStepAuthentication') {
+        context.subject = await l10n.formatValue(
+          `${template}-subject-line`,
+          context
+        );
+      } else {
+        context.subject = await l10n.formatValue(
+          `${template}-subject`,
+          context
+        );
+      }
     }
 
     // metadata.mjml needs a localized version of `action`,

--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -86,6 +86,7 @@ class FluentLocalizer {
 
     context = { ...context, ...context.templateValues };
     if (template !== '_storybook') {
+      // TODO: #11471 Improve dynamically rendered actions & subjects in email.js, etc.
       if (template === 'postRemoveTwoStepAuthentication') {
         context.subject = await l10n.formatValue(
           `${template}-subject-line`,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en.ftl
@@ -1,4 +1,4 @@
-postRemoveTwoStepAuthentication-subject = Two-step verification is off
+postRemoveTwoStepAuthentication-subject-line = Two-step authentication is off
 postRemoveTwoStepAuthentication-title = Two-step authentication disabled
 postRemoveTwoStepAuthentication-description = You have successfully disabled two-step authentication on your { -product-firefox-account } from the following device:
 postRemoveTwoStepAuthentication-description-plaintext = You have successfully disabled two-step authentication on your { -product-firefox-account }. Security codes will no longer be required at each sign-in.

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -757,7 +757,7 @@ const TESTS = [
     ]],
   ])],
   ['postAddTwoStepAuthenticationEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Two-step verification enabled' }],
+    ['subject', { test: 'equal', expected: 'Two-step authentication enabled' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddTwoStepAuthentication') }],
@@ -933,7 +933,7 @@ const TESTS = [
     ]],
   ])],
   ['postRemoveTwoStepAuthenticationEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Two-step verification is off' }],
+    ['subject', { test: 'equal', expected: 'Two-step authentication is off' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveTwoStepAuthentication') }],

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -836,7 +836,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postRemoveTwoStepAuthenticationEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Two-step verification is off' }],
+    ['subject', { test: 'equal', expected: 'Two-step authentication is off' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveTwoStepAuthentication') }],


### PR DESCRIPTION
Closes: #11263

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
