### PR TITLE
fix(coupon): plan total price interval translation

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -208,7 +208,7 @@ describe('PlanDetails', () => {
       const testInstance = testRenderer.root;
 
       const planPriceComponent = testInstance.findByProps({
-        id: 'total-price',
+        'data-testid': `plan-price-total`,
       });
 
       const expectedAmount = getLocalizedCurrency(

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -167,6 +167,7 @@ export const PlanDetails = ({
                   </Localized>
                   <Localized
                     id={`plan-price-${interval}`}
+                    data-testid="plan-price-total"
                     attrs={{ title: true }}
                     vars={{
                       amount:

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useContext } from 'react';
 import { Localized } from '@fluent/react';
-import { getLocalizedCurrency, formatPlanPricing, getLocalizedCurrencyString } from '../../lib/formats';
+import {
+  getLocalizedCurrency,
+  formatPlanPricing,
+  getLocalizedCurrencyString,
+} from '../../lib/formats';
 import {
   metadataFromPlan,
   productDetailsFromPlan,
@@ -46,7 +50,10 @@ export const PlanDetails = ({
     ? { background: webIconBackground }
     : '';
 
-  const discountAmount = coupon && amount && config.featureFlags.subscriptionCoupons ? amount - coupon.amount : amount;
+  const discountAmount =
+    coupon && amount && config.featureFlags.subscriptionCoupons
+      ? amount - coupon.amount
+      : amount;
   const planPrice = formatPlanPricing(
     discountAmount,
     currency,
@@ -126,7 +133,9 @@ export const PlanDetails = ({
                             amount: getLocalizedCurrency(amount, currency),
                             intervalCount: interval_count,
                           }}
-                        >{getLocalizedCurrencyString(amount, currency)}</Localized>
+                        >
+                          {getLocalizedCurrencyString(amount, currency)}
+                        </Localized>
                       </div>
                     </div>
                     <div className="plan-details-total-inner">
@@ -157,7 +166,7 @@ export const PlanDetails = ({
                     <p className="label">Total</p>
                   </Localized>
                   <Localized
-                    id={`total-price`}
+                    id={`plan-price-${interval}`}
                     attrs={{ title: true }}
                     vars={{
                       amount:


### PR DESCRIPTION
## Because

* Plan total price interval is not being translated.

## This pull request

* Reverts localized id to previous value so that it uses existing
  translations

## Issue that this pull request solves

Closes: #11493 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before the change (Notice total price interval didn't translate and reads  "Gesamt $1.00 daily")
![image](https://user-images.githubusercontent.com/10620585/147709690-eeea7136-0ffd-402c-86d7-73b6d3589c51.png)

After fix (The interval is now translated as expected. In this case "pro Woche")
![image](https://user-images.githubusercontent.com/10620585/147709745-4b37b6b7-d325-4e9e-84fa-fd09c2e5e84c.png)
