### PR TITLE
feat(subscriptions): create subs with promo codes

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -83,7 +83,8 @@ export class StripeFirestore {
     } catch (err) {
       if (err.name === FirestoreStripeError.FIRESTORE_SUBSCRIPTION_NOT_FOUND) {
         const subscription = await this.stripe.subscriptions.retrieve(
-          subscriptionId
+          subscriptionId,
+          { expand: ['discount.promotion_code'] }
         );
         await this.fetchAndInsertCustomer(subscription.customer as string);
         return subscription;
@@ -102,7 +103,10 @@ export class StripeFirestore {
     const [customer, subscriptions] = await Promise.all([
       this.stripe.customers.retrieve(customerId),
       this.stripe.subscriptions
-        .list({ customer: customerId })
+        .list({
+          customer: customerId,
+          expand: ['data.discount.promotion_code'],
+        })
         .autoPagingToArray({ limit: 100 }),
     ]);
     if (customer.deleted) {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -180,7 +180,7 @@ export class PayPalHandler extends StripeWebhookHandler {
       this.stripeHelper.createSubscriptionWithPaypal({
         customer,
         priceId,
-        couponId: promotionCode?.coupon.id,
+        promotionCode,
         subIdempotencyKey: idempotencyKey,
         taxRateId: taxRate?.id,
       }),
@@ -241,7 +241,7 @@ export class PayPalHandler extends StripeWebhookHandler {
     const subscription = await this.stripeHelper.createSubscriptionWithPaypal({
       customer,
       priceId,
-      couponId: promotionCode?.coupon.id,
+      promotionCode: promotionCode,
       subIdempotencyKey: idempotencyKey,
       taxRateId: taxRate?.id,
     });

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -475,7 +475,7 @@ export class StripeHandler {
         customerId: customer.id,
         priceId,
         paymentMethodId,
-        couponId: promotionCode?.coupon.id,
+        promotionCode: promotionCode,
         subIdempotencyKey,
         taxRateId,
       }

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -365,7 +365,6 @@ module.exports.subscriptionsInvoicePIExpandedValidator = isA
   })
   .unknown(true);
 
-// This is subhub's perspective on an active subscription
 module.exports.subscriptionsSubscriptionValidator = isA.object({
   _subscription_type: MozillaSubscriptionTypes.WEB,
   created: isA.number().required(),
@@ -381,6 +380,7 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
   product_name: isA.string().required(),
   status: isA.string().required(),
   subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+  promotion_code: isA.string().optional().allow(null),
 });
 
 // This is support-panel's perspective on a subscription

--- a/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
@@ -135,6 +135,11 @@ describe('StripeFirestore', () => {
       assert.deepEqual(result, subscription);
       assert.calledOnce(stripeFirestore.retrieveSubscription);
       assert.calledOnce(stripeFirestore.fetchAndInsertCustomer);
+      assert.calledOnceWithExactly(
+        stripe.subscriptions.retrieve,
+        subscription.id,
+        { expand: ['discount.promotion_code'] }
+      );
     });
 
     it('errors otherwise', async () => {
@@ -177,7 +182,10 @@ describe('StripeFirestore', () => {
       const result = await stripeFirestore.fetchAndInsertCustomer(customer.id);
       assert.deepEqual(result, customer);
       assert.calledOnce(stripe.customers.retrieve);
-      assert.calledOnce(stripe.subscriptions.list);
+      assert.calledOnceWithExactly(stripe.subscriptions.list, {
+        customer: customer.id,
+        expand: ['data.discount.promotion_code'],
+      });
       assert.calledOnce(stripeFirestore.insertCustomerRecord);
       assert.calledOnce(customerCollectionDbRef.doc);
     });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -307,7 +307,7 @@ describe('subscriptions payPalRoutes', () => {
           {
             customer,
             priceId: undefined,
-            couponId: undefined,
+            promotionCode: undefined,
             subIdempotencyKey: undefined,
             taxRateId: 'tr-1234',
           }
@@ -358,7 +358,7 @@ describe('subscriptions payPalRoutes', () => {
           {
             customer,
             priceId: undefined,
-            couponId: 'test-coupon',
+            promotionCode: promoCode,
             subIdempotencyKey: undefined,
             taxRateId: 'tr-1234',
           }
@@ -566,7 +566,7 @@ describe('subscriptions payPalRoutes', () => {
               },
             },
             priceId: undefined,
-            couponId: undefined,
+            promotionCode: undefined,
             subIdempotencyKey: undefined,
             taxRateId: 'tr-1234',
           }
@@ -615,7 +615,7 @@ describe('subscriptions payPalRoutes', () => {
               },
             },
             priceId: undefined,
-            couponId: 'test-coupon',
+            promotionCode: promoCode,
             subIdempotencyKey: undefined,
             taxRateId: 'tr-1234',
           }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -701,7 +701,9 @@ describe('DirectStripeRoutes', () => {
           customerId: 'cus_new',
           priceId: 'Jane Doe',
           paymentMethodId: 'pm_asdf',
-          couponId: 'couponId',
+          promotionCode: {
+            coupon: { id: 'couponId' },
+          },
           subIdempotencyKey: `${VALID_REQUEST.payload.idempotencyKey}-createSub`,
           taxRateId: undefined,
         }
@@ -807,7 +809,7 @@ describe('DirectStripeRoutes', () => {
         {
           customerId: customer.id,
           priceId: 'quux',
-          couponId: undefined,
+          promotionCode: undefined,
           paymentMethodId: undefined,
           subIdempotencyKey: `${idempotencyKey}-createSub`,
           taxRateId: undefined,

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -706,6 +706,7 @@ describe('lib/routes/validators:', () => {
       plan_id: 'plan_G93lTs8hfK7NNG',
       product_id: 'prod_G93l8Yn7XJHYUs',
       product_name: 'testo',
+      promotion_code: 'testo',
       status: 'active',
       subscription_id: 'sub_xyz',
     };

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -115,6 +115,7 @@ export type WebSubscription = Pick<
       'incomplete' | 'incomplete_expired'
     >;
     subscription_id: Stripe.Subscription['id'];
+    promotion_code?: string;
   };
 
 export interface AbbrevPlayPurchase {


### PR DESCRIPTION
Because:
 - the payments frontend need to know, for metrics, the promo code value
   a subscription with which it was created

This commit:
 - switch the subscription creation to use a promotion code instead of a
   coupon so that the promotion code is associated with the
   subscription's discount
   - there is a one to many relationship from a coupon to promotion
     codes, so if we create a subscription with a coupon looked up by a
     promotion code, we wouldn't know which promotion code was
     originally used
 - include the promotion code value in the subscriptions list for the
   frontend

## Issue that this pull request solves

Closes: #11376 
