### PR TITLE
feat(metrics): include promo code for cancel sub events

### DIFF
--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -40,6 +40,7 @@ export type EventProperties = GlobalEventProperties & {
   productId?: string;
   product_id?: string;
   paymentProvider?: PaymentProvider;
+  promotionCode?: string;
   error?: Error;
   checkoutType?: string;
   utm_campaign?: string;

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -285,11 +285,13 @@ describe('API requests', () => {
       planId: 'plan_2345',
       productId: 'prod_4567',
       paymentProvider: 'paypal' as PaymentProvider,
+      promotionCode: 'freecats',
     };
     const metricsOptions = {
       planId: params.planId,
       productId: params.productId,
       paymentProvider: params.paymentProvider,
+      promotionCode: params.promotionCode,
     };
 
     it('DELETE {auth-server}/v1/oauth/subscriptions/active/', async () => {

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -179,12 +179,15 @@ export async function apiCancelSubscription(params: {
   planId: string;
   productId: string;
   paymentProvider: PaymentProvider | undefined;
+  promotionCode: string | undefined;
 }) {
-  const { subscriptionId, planId, productId, paymentProvider } = params;
+  const { subscriptionId, planId, productId, paymentProvider, promotionCode } =
+    params;
   const metricsOptions = {
     planId,
     productId,
     paymentProvider,
+    promotionCode,
   };
   try {
     Amplitude.cancelSubscription_PENDING(metricsOptions);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -219,11 +219,24 @@ describe('CancelSubscriptionPanel', () => {
       (Amplitude.cancelSubscriptionMounted as jest.Mock).mockClear();
       (Amplitude.cancelSubscriptionEngaged as jest.Mock).mockClear();
       const plan = findMockPlan('plan_daily');
-      render(<CancelSubscriptionPanel {...baseProps} plan={plan} />);
+      render(
+        <CancelSubscriptionPanel
+          {...baseProps}
+          plan={plan}
+          paymentProvider="stripe"
+          promotionCode="gogogo"
+        />
+      );
       fireEvent.click(getByTestId('reveal-cancel-subscription-button'));
-      expect(Amplitude.cancelSubscriptionMounted).toHaveBeenCalledTimes(1);
+      expect(Amplitude.cancelSubscriptionMounted).toHaveBeenCalledWith({
+        ...plan,
+        promotionCode: 'gogogo',
+      });
       fireEvent.click(getByTestId('confirm-cancel-subscription-checkbox'));
-      expect(Amplitude.cancelSubscriptionEngaged).toHaveBeenCalledTimes(1);
+      expect(Amplitude.cancelSubscriptionEngaged).toHaveBeenCalledWith({
+        ...plan,
+        promotionCode: 'gogogo',
+      });
     });
   });
 });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -26,6 +26,7 @@ export type CancelSubscriptionPanelProps = {
   customerSubscription: WebSubscription;
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
   paymentProvider: PaymentProvider | undefined;
+  promotionCode: string | undefined;
 };
 
 const CancelSubscriptionPanel = ({
@@ -34,6 +35,7 @@ const CancelSubscriptionPanel = ({
   customerSubscription: { subscription_id, current_period_end },
   cancelSubscriptionStatus,
   paymentProvider,
+  promotionCode,
 }: CancelSubscriptionPanelProps) => {
   const [cancelRevealed, revealCancel, hideCancel] = useBooleanState();
   const [confirmationChecked, onConfirmationChanged] = useCheckboxState();
@@ -46,29 +48,40 @@ const CancelSubscriptionPanel = ({
   const confirmCancellation = useCallback(async () => {
     setIsLocalCancellation();
     try {
-      await cancelSubscription(subscription_id, plan, paymentProvider);
+      await cancelSubscription(
+        subscription_id,
+        plan,
+        paymentProvider,
+        promotionCode
+      );
     } catch (err) {
       // no-op, error is displayed in the Subscriptions route parent
     }
     resetIsLocalCancellation();
-  }, [cancelSubscription, subscription_id, plan, paymentProvider]);
+  }, [
+    cancelSubscription,
+    subscription_id,
+    plan,
+    paymentProvider,
+    promotionCode,
+  ]);
 
   const viewed = useRef(false);
   const engaged = useRef(false);
 
   useEffect(() => {
     if (!viewed.current && cancelRevealed) {
-      Amplitude.cancelSubscriptionMounted(plan);
+      Amplitude.cancelSubscriptionMounted({ ...plan, promotionCode });
       viewed.current = true;
     }
-  }, [cancelRevealed, viewed, plan]);
+  }, [cancelRevealed, viewed, plan, promotionCode]);
 
   const engage = useCallback(() => {
     if (!engaged.current) {
-      Amplitude.cancelSubscriptionEngaged(plan);
+      Amplitude.cancelSubscriptionEngaged({ ...plan, promotionCode });
       engaged.current = true;
     }
-  }, [engaged, plan]);
+  }, [engaged, plan, promotionCode]);
 
   const engagedOnHideCancel = useCallback(
     (evt) => {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -38,6 +38,7 @@ export const SubscriptionItem = ({
 
   const paymentProvider: PaymentProvider | undefined =
     customer?.payment_provider;
+  const promotionCode = customerSubscription.promotion_code;
 
   if (!plan) {
     // TODO: This really shouldn't happen, would mean the user has a
@@ -69,6 +70,7 @@ export const SubscriptionItem = ({
               customerSubscription,
               plan,
               paymentProvider,
+              promotionCode,
             }}
           />
         ) : (

--- a/packages/fxa-payments-server/src/store/actions/api.ts
+++ b/packages/fxa-payments-server/src/store/actions/api.ts
@@ -43,7 +43,8 @@ export default {
   cancelSubscription: (
     subscriptionId: string,
     plan: Plan,
-    paymentProvider: PaymentProvider | undefined
+    paymentProvider: PaymentProvider | undefined,
+    promotionCode: string | undefined
   ) =>
     ({
       type: 'cancelSubscription',
@@ -54,6 +55,7 @@ export default {
           planId: plan.plan_id,
           productId: plan.product_id,
           paymentProvider,
+          promotionCode,
         });
         // Cancellation response does not include subscriptionId, but we want it.
         return { ...result, subscriptionId };

--- a/packages/fxa-payments-server/src/store/sequences.test.ts
+++ b/packages/fxa-payments-server/src/store/sequences.test.ts
@@ -9,6 +9,9 @@ jest.mock('./actions', () => ({
     updateSubscriptionPlan: jest
       .fn()
       .mockReturnValue({ type: 'updateSubscriptionPlan' }),
+    cancelSubscription: jest
+      .fn()
+      .mockReturnValue({ type: 'updateSubscriptionPlan' }),
     fetchCustomer: jest.fn().mockReturnValue({ type: 'fetchCustomer' }),
     fetchSubscriptions: jest
       .fn()
@@ -68,6 +71,35 @@ describe('updateSubscriptionPlanAndRefresh', () => {
       subscriptionId,
       plan,
       paymentProvider
+    );
+    expect(actions.fetchCustomer).toBeCalled();
+  });
+});
+
+describe('cancelSubscriptionAndRefresh', () => {
+  const plan = MOCK_PLANS[0];
+  const subscriptionId = 'sub-8675309';
+  const paymentProvider = 'paypal';
+  const promotionCode = 'takemymoney';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls actions as expected', async () => {
+    await sequences.cancelSubscriptionAndRefresh(
+      subscriptionId,
+      plan,
+      paymentProvider,
+      promotionCode
+    )(dispatch);
+
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    expect(actions.cancelSubscription).toHaveBeenCalledWith(
+      subscriptionId,
+      plan,
+      paymentProvider,
+      promotionCode
     );
     expect(actions.fetchCustomer).toBeCalled();
   });

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -74,11 +74,14 @@ export const cancelSubscriptionAndRefresh =
   (
     subscriptionId: string,
     plan: Plan,
-    paymentProvider: PaymentProvider | undefined
+    paymentProvider: PaymentProvider | undefined,
+    promotionCode: string | undefined
   ) =>
-  async (dispatch: Function, getState: Function) => {
+  async (dispatch: Function) => {
     try {
-      await dispatch(cancelSubscription(subscriptionId, plan, paymentProvider));
+      await dispatch(
+        cancelSubscription(subscriptionId, plan, paymentProvider, promotionCode)
+      );
       await dispatch(fetchCustomerAndSubscriptions());
     } catch (err) {
       handleThunkError(err);


### PR DESCRIPTION
Because:
 - we need to include a subscription's promotion code in the
   subscription cancellation metrics events

This commit:
 - add the subscription's promotion code as an event property to the
   cancellation events

## Issue that this pull request solves

Closes: #11378
