### PR TITLE
feat(coupons): add discount to 1st invoice email

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2071,6 +2071,7 @@ export class StripeHelper {
 
     const invoiceDiscountAmountInCents =
       (invoice.total_discount_amounts &&
+        invoice.total_discount_amounts.length &&
         invoice.total_discount_amounts[0].amount) ||
       null;
 

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -52,7 +52,6 @@ import { AuthFirestore } from '../types';
 import { CurrencyHelper } from './currencies';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
 import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
-import { stripeInvoiceToInvoicePreviewDTO } from './stripe-formatter';
 
 export const CUSTOMER_RESOURCE = 'customers';
 export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
@@ -2009,7 +2008,6 @@ export class StripeHelper {
    *   - No email on the customer object.
    */
   async extractInvoiceDetailsForEmail(invoice: Stripe.Invoice) {
-    console.log('Reino ----- Email should get here right?');
     const customer = await this.expandResource(
       invoice.customer,
       CUSTOMER_RESOURCE
@@ -2060,6 +2058,7 @@ export class StripeHelper {
       created: invoiceDate,
       currency: invoiceTotalCurrency,
       total: invoiceTotalInCents,
+      subtotal: invoiceSubTotalInCents,
       hosted_invoice_url: invoiceLink,
       lines: {
         data: [
@@ -2069,6 +2068,12 @@ export class StripeHelper {
         ],
       },
     } = invoice;
+
+    const invoiceDiscountAmountInCents =
+      (invoice.total_discount_amounts &&
+        invoice.total_discount_amounts[0].amount) ||
+      null;
+
     const { id: planId, nickname: planName } = plan;
     const productMetadata = this.mergeMetadata(plan, abbrevProduct);
     const {
@@ -2082,12 +2087,6 @@ export class StripeHelper {
 
     const payment_provider = this.getPaymentProvider(customer);
 
-    const { discount } = stripeInvoiceToInvoicePreviewDTO(invoice);
-
-    console.log('Reino - Here is where the log for this begins!!!');
-    console.log(discount);
-    console.log(invoice);
-
     return {
       uid,
       email,
@@ -2098,8 +2097,8 @@ export class StripeHelper {
       invoiceNumber,
       invoiceTotalInCents,
       invoiceTotalCurrency,
-      subtotal: invoice.subtotal,
-      discountAmount: discount?.amount,
+      invoiceSubTotalInCents,
+      invoiceDiscountAmountInCents,
       invoiceDate: new Date(invoiceDate * 1000),
       nextInvoiceDate: new Date(nextInvoiceDate * 1000),
       productId,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -52,6 +52,7 @@ import { AuthFirestore } from '../types';
 import { CurrencyHelper } from './currencies';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
 import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
+import { stripeInvoiceToInvoicePreviewDTO } from './stripe-formatter';
 
 export const CUSTOMER_RESOURCE = 'customers';
 export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
@@ -2008,6 +2009,7 @@ export class StripeHelper {
    *   - No email on the customer object.
    */
   async extractInvoiceDetailsForEmail(invoice: Stripe.Invoice) {
+    console.log('Reino ----- Email should get here right?');
     const customer = await this.expandResource(
       invoice.customer,
       CUSTOMER_RESOURCE
@@ -2080,6 +2082,12 @@ export class StripeHelper {
 
     const payment_provider = this.getPaymentProvider(customer);
 
+    const { discount } = stripeInvoiceToInvoicePreviewDTO(invoice);
+
+    console.log('Reino - Here is where the log for this begins!!!');
+    console.log(discount);
+    console.log(invoice);
+
     return {
       uid,
       email,
@@ -2090,6 +2098,8 @@ export class StripeHelper {
       invoiceNumber,
       invoiceTotalInCents,
       invoiceTotalCurrency,
+      subtotal: invoice.subtotal,
+      discountAmount: discount?.amount,
       invoiceDate: new Date(invoiceDate * 1000),
       nextInvoiceDate: new Date(nextInvoiceDate * 1000),
       productId,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2058,7 +2058,7 @@ export class StripeHelper {
       created: invoiceDate,
       currency: invoiceTotalCurrency,
       total: invoiceTotalInCents,
-      subtotal: invoiceSubTotalInCents,
+      subtotal: invoiceSubtotalInCents,
       hosted_invoice_url: invoiceLink,
       lines: {
         data: [
@@ -2097,7 +2097,7 @@ export class StripeHelper {
       invoiceNumber,
       invoiceTotalInCents,
       invoiceTotalCurrency,
-      invoiceSubTotalInCents,
+      invoiceSubtotalInCents,
       invoiceDiscountAmountInCents,
       invoiceDate: new Date(invoiceDate * 1000),
       nextInvoiceDate: new Date(nextInvoiceDate * 1000),

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -541,7 +541,7 @@ export class StripeWebhookHandler extends StripeHandler {
   async sendSubscriptionInvoiceEmail(invoice: Stripe.Invoice) {
     const invoiceDetails =
       await this.stripeHelper.extractInvoiceDetailsForEmail(invoice);
-    const { uid, invoiceSubTotalInCents, invoiceDiscountAmountInCents } =
+    const { uid, invoiceSubtotalInCents, invoiceDiscountAmountInCents } =
       invoiceDetails;
     const account = await this.db.account(uid);
     const mailParams = [
@@ -554,7 +554,7 @@ export class StripeWebhookHandler extends StripeHandler {
     ];
     switch (invoice.billing_reason) {
       case 'subscription_create':
-        if (invoiceSubTotalInCents && invoiceDiscountAmountInCents) {
+        if (invoiceSubtotalInCents && invoiceDiscountAmountInCents) {
           await this.mailer.sendSubscriptionFirstInvoiceDiscountEmail(
             ...mailParams
           );

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -553,7 +553,13 @@ export class StripeWebhookHandler extends StripeHandler {
     ];
     switch (invoice.billing_reason) {
       case 'subscription_create':
-        await this.mailer.sendSubscriptionFirstInvoiceEmail(...mailParams);
+        if (invoiceDetails.subtotal && invoiceDetails.discountAmount) {
+          await this.mailer.sendSubscriptionFirstInvoiceDiscountEmail(
+            ...mailParams
+          );
+        } else {
+          await this.mailer.sendSubscriptionFirstInvoiceEmail(...mailParams);
+        }
 
         // To not overwhelm users with emails, we only send download subscription email
         // for existing accounts. Passwordless accounts get their own email.

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -541,7 +541,8 @@ export class StripeWebhookHandler extends StripeHandler {
   async sendSubscriptionInvoiceEmail(invoice: Stripe.Invoice) {
     const invoiceDetails =
       await this.stripeHelper.extractInvoiceDetailsForEmail(invoice);
-    const { uid } = invoiceDetails;
+    const { uid, invoiceSubTotalInCents, invoiceDiscountAmountInCents } =
+      invoiceDetails;
     const account = await this.db.account(uid);
     const mailParams = [
       account.emails,
@@ -553,7 +554,7 @@ export class StripeWebhookHandler extends StripeHandler {
     ];
     switch (invoice.billing_reason) {
       case 'subscription_create':
-        if (invoiceDetails.subtotal && invoiceDetails.discountAmount) {
+        if (invoiceSubTotalInCents && invoiceDiscountAmountInCents) {
           await this.mailer.sendSubscriptionFirstInvoiceDiscountEmail(
             ...mailParams
           );

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2901,8 +2901,8 @@ module.exports = function (log, config, bounces) {
       invoiceLink,
       invoiceTotalInCents,
       invoiceTotalCurrency,
-      subtotal,
-      discountAmount,
+      invoiceSubtotalInCents,
+      invoiceDiscountAmountInCents,
       payment_provider,
       cardType,
       lastFour,
@@ -2961,16 +2961,16 @@ module.exports = function (log, config, bounces) {
           invoiceTotalCurrency,
           message.acceptLanguage
         ),
-        subtotal: this._getLocalizedCurrencyString(
-          subtotal,
+        invoiceSubtotal: this._getLocalizedCurrencyString(
+          invoiceSubtotalInCents,
           invoiceTotalCurrency,
           message.acceptLanguage
         ),
-        discountAmount: `-${this._getLocalizedCurrencyString(
-          discountAmount,
+        invoiceDiscountAmount: this._getLocalizedCurrencyString(
+          invoiceDiscountAmountInCents,
           invoiceTotalCurrency,
           message.acceptLanguage
-        )}`,
+        ),
         payment_provider,
         cardType: cardTypeToText(cardType),
         lastFour,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
@@ -16,11 +16,11 @@ subscriptionFirstInvoiceDiscount-content-invoice-number = Invoice Number: <b>{ $
 #  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
 subscriptionFirstInvoiceDiscount-content-invoice-number-plaintext = Invoice Number: { $invoiceNumber }
 # Variables:
-#  $subtotal (String) - The amount, before discount, of the subscription invoice, including currency, e.g. $10.00
-subscriptionFirstInvoiceDiscount-content-subtotal = Subtotal: { $subtotal }
+#  $invoiceSubtotal (String) - The amount, before discount, of the subscription invoice, including currency, e.g. $10.00
+subscriptionFirstInvoiceDiscount-content-subtotal = Subtotal: { $invoiceSubtotal }
 # Variables:
-#  $discountAmount (String) - The amount of the discount of the subscription invoice, including currency and negative sign, e.g. -$2.00
-subscriptionFirstInvoiceDiscount-content-onetime-discount = One-time discount: { $discountAmount }
+#  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
+subscriptionFirstInvoiceDiscount-content-onetime-discount = One-time discount: -{ $invoiceDiscountAmount }
 # Variables:
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
 #  $invoiceTotal (String) - The amount, after discount, of the subscription invoice, including currency, e.g. $8.00

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
@@ -1,0 +1,30 @@
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFirstInvoiceDiscount-subject = { $productName } payment confirmed
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFirstInvoiceDiscount-title = Thank you for subscribing to { $productName }
+subscriptionFirstInvoiceDiscount-content-processing = Your payment is currently processing and may take up to four business days to complete.
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFirstInvoiceDiscount-content-install = You will receive a separate email with download instructions on how to start using { $productName }.
+subscriptionFirstInvoiceDiscount-content-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.
+# Variables:
+#  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
+subscriptionFirstInvoiceDiscount-content-invoice-number = Invoice Number: <b>{ $invoiceNumber }</b>
+# Variables:
+#  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
+subscriptionFirstInvoiceDiscount-content-invoice-number-plaintext = Invoice Number: { $invoiceNumber }
+# Variables:
+#  $subtotal (String) - The amount, before discount, of the subscription invoice, including currency, e.g. $10.00
+subscriptionFirstInvoiceDiscount-content-subtotal = Subtotal: { $subtotal }
+# Variables:
+#  $discountAmount (String) - The amount of the discount of the subscription invoice, including currency and negative sign, e.g. -$2.00
+subscriptionFirstInvoiceDiscount-content-onetime-discount = One-time discount: { $discountAmount }
+# Variables:
+#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+#  $invoiceTotal (String) - The amount, after discount, of the subscription invoice, including currency, e.g. $8.00
+subscriptionFirstInvoiceDiscount-content-charge = Charged { $invoiceTotal } on { $invoiceDateOnly }
+# Variables:
+#  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+subscriptionFirstInvoiceDiscount-content-next-invoice = Next Invoice: { $nextInvoiceDateOnly }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
@@ -1,0 +1,90 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public #
+License, v. 2.0. If a copy of the MPL was not distributed with this # file, You
+can obtain one at http://mozilla.org/MPL/2.0/. %> <%- include
+('/partials/icon/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-title"
+        data-l10n-args="<%= JSON.stringify({productName}) %>"
+        >Thank you for subscribing to <%- productName %></span
+      >
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-processing">
+        Your payment is currently processing and may take up to four business
+        days to complete.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-install"
+        data-l10n-args="<%= JSON.stringify({productName}) %>"
+      >
+        You will receive a separate email with download instructions on how to
+        start using <%- productName %>.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-auto-renew">
+        Your subscription will automatically renew each billing period unless
+        you choose to cancel.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-invoice-number"
+        data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>"
+      >
+        Invoice Number: <b><%- invoiceNumber %></b>
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-subtotal"
+        data-l10n-args="<%= JSON.stringify({subtotal}) %>"
+      >
+        Subtotal: <%- subtotal %>
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-onetime-discount"
+        data-l10n-args="<%= JSON.stringify({discountAmount}) %>"
+      >
+        One-time discount: <%- discountAmount %>
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-charge"
+        data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>"
+      >
+        Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>
+      </span>
+    </mj-text>
+
+    <%- include ('/partials/viewInvoice/index.mjml') %> <%- include
+    ('/partials/paymentProvider/index.mjml') %>
+
+    <mj-text css-class="text-body">
+      <span
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-next-invoice"
+        data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>"
+      >
+        Next Invoice: <%- nextInvoiceDateOnly %>
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
@@ -49,18 +49,18 @@ can obtain one at http://mozilla.org/MPL/2.0/. %> <%- include
     <mj-text css-class="text-body-no-bottom-margin">
       <span
         data-l10n-id="subscriptionFirstInvoiceDiscount-content-subtotal"
-        data-l10n-args="<%= JSON.stringify({subtotal}) %>"
+        data-l10n-args="<%= JSON.stringify({invoiceSubtotal}) %>"
       >
-        Subtotal: <%- subtotal %>
+        Subtotal: <%- invoiceSubtotal %>
       </span>
     </mj-text>
 
     <mj-text css-class="text-body-no-bottom-margin">
       <span
         data-l10n-id="subscriptionFirstInvoiceDiscount-content-onetime-discount"
-        data-l10n-args="<%= JSON.stringify({discountAmount}) %>"
+        data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount}) %>"
       >
-        One-time discount: <%- discountAmount %>
+        One-time discount: -<%- invoiceDiscountAmount %>
       </span>
     </mj-text>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionFirstInvoiceDiscount',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionFirstInvoice',
+  'Sent to inform a user that their first payment is currently being processed.',
+  {
+    productName: 'Firefox Fortress',
+    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    invoiceDateOnly: '10/13/2021',
+    invoiceLink:
+      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$18.00',
+    subtotal: '$20.00',
+    discountAmount: '-$2.00',
+    nextInvoiceDateOnly: '11/13/2021',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionFirstInvoiceWithPayPal = createStory(
+  {
+    payment_provider: 'paypal',
+  },
+  'Payment method - PayPal'
+);
+
+export const SubscriptionFirstInvoiceWithStripe = createStory(
+  {
+    cardType: 'MasterCard',
+    lastFour: '5309',
+    payment_provider: 'stripe',
+  },
+  'Payment method - Stripe'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
@@ -1,0 +1,20 @@
+subscriptionFirstInvoiceDiscount-subject = "<%- productName %> payment confirmed"
+
+subscriptionFirstInvoiceDiscount-title = "Thank you for subscribing to <%- productName%>"
+
+subscriptionFirstInvoiceDiscount-content-processing = "Your payment is currently processing and may take up to four business days to complete."
+
+subscriptionFirstInvoiceDiscount-content-install = "You will receive a separate email with download instructions on how to start using <%- productName %>."
+
+subscriptionFirstInvoiceDiscount-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
+
+subscriptionFirstInvoiceDiscount-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
+subscriptionFirstInvoiceDiscount-content-subtotal = "Subtotal: <%- subtotal %>"
+subscriptionFirstInvoiceDiscount-content-onetime-discount = "One-time discount: <%- discountAmount %>"
+subscriptionFirstInvoiceDiscount-content-charge = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
+<%- include ('/partials/viewInvoice/index.txt') %>
+<%- include ('/partials/paymentProvider/index.txt') %>
+
+subscriptionFirstInvoiceDiscount-content-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
@@ -9,8 +9,8 @@ subscriptionFirstInvoiceDiscount-content-install = "You will receive a separate 
 subscriptionFirstInvoiceDiscount-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
 
 subscriptionFirstInvoiceDiscount-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
-subscriptionFirstInvoiceDiscount-content-subtotal = "Subtotal: <%- subtotal %>"
-subscriptionFirstInvoiceDiscount-content-onetime-discount = "One-time discount: <%- discountAmount %>"
+subscriptionFirstInvoiceDiscount-content-subtotal = "Subtotal: <%- invoiceSubtotal %>"
+subscriptionFirstInvoiceDiscount-content-onetime-discount = "One-time discount: -<%- invoiceDiscountAmount %>"
 subscriptionFirstInvoiceDiscount-content-charge = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
 <%- include ('/partials/viewInvoice/index.txt') %>
 <%- include ('/partials/paymentProvider/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.html
@@ -11,9 +11,9 @@
   <br><br>
   {{{t "Invoice Number: <b>%(invoiceNumber)s</b>" }}}
   <br>
-  {{{t "Subtotal: %(subtotal)s" }}}
+  {{{t "Subtotal: %(invoiceSubtotal)s" }}}
   <br>
-  {{{t "One-time discount: %(discountAmount)s" }}}
+  {{{t "One-time discount: -%(invoiceDiscountAmount)s" }}}
   <br>
   {{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}
   <br>

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.html
@@ -1,0 +1,28 @@
+{{#*inline "title"}}
+  {{t "Thank you for subscribing to %(productName)s" }}
+{{/inline}}
+
+{{#*inline "content"}}
+  {{t "Your payment is currently processing and may take up to four business days to complete." }}
+  <br><br>
+  {{t "You will receive a separate email with download instructions on how to start using %(productName)s." }}
+  <br><br>
+  {{t "Your subscription will automatically renew each billing period unless you choose to cancel." }}
+  <br><br>
+  {{{t "Invoice Number: <b>%(invoiceNumber)s</b>" }}}
+  <br>
+  {{{t "Subtotal: %(subtotal)s" }}}
+  <br>
+  {{{t "One-time discount: %(discountAmount)s" }}}
+  <br>
+  {{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}
+  <br>
+  {{{t "<a href=\"%(invoiceLink)s\">View your invoice</a>." }}}
+  {{> paymentProvider }}
+  <br><br>
+  {{t "Next Invoice: %(nextInvoiceDateOnly)s" }}
+  <br><br>
+  {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
+{{/inline}}
+
+{{> subscriptionEmail}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.txt
@@ -8,9 +8,9 @@
 
 {{{t "Invoice Number: %(invoiceNumber)s" }}}
 
-{{{t "Subtotal: %(subtotal)s" }}}
+{{{t "Subtotal: %(invoiceSubtotal)s" }}}
 
-{{{t "One-time discount: %(discountAmount)s" }}}
+{{{t "One-time discount: -%(invoiceDiscountAmount)s" }}}
 
 {{{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}}
 

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoiceDiscount.txt
@@ -1,0 +1,25 @@
+{{{subject}}}
+
+{{{t "Your payment is currently processing and may take up to four business days to complete." }}}
+
+{{{t "You will receive a separate email with download instructions on how to start using %(productName)s." }}}
+
+{{{t "Your subscription will automatically renew each billing period unless you choose to cancel." }}}
+
+{{{t "Invoice Number: %(invoiceNumber)s" }}}
+
+{{{t "Subtotal: %(subtotal)s" }}}
+
+{{{t "One-time discount: %(discountAmount)s" }}}
+
+{{{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}}
+
+{{{t "View Invoice: %(invoiceLink)s" }}}
+
+{{> paymentProvider }}
+
+{{{t "Next Invoice: %(nextInvoiceDateOnly)s" }}}
+
+{{{t "Questions about your subscription? Our support team is here to help you:" }}}
+
+{{{subscriptionSupportUrl}}}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid_subscription_create_discount.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid_subscription_create_discount.json
@@ -1,0 +1,200 @@
+{
+  "id": "in_1KEJVVBVqmGyQTMaBCtaciEj",
+  "object": "invoice",
+  "account_country": "US",
+  "account_name": "Mozilla Corporation",
+  "account_tax_ids": null,
+  "amount_due": 450,
+  "amount_paid": 450,
+  "amount_remaining": 0,
+  "application_fee_amount": null,
+  "attempt_count": 1,
+  "attempted": true,
+  "auto_advance": false,
+  "automatic_tax": {
+    "enabled": false,
+    "status": null
+  },
+  "billing_reason": "subscription_create",
+  "charge": "ch_3KEJVVBVqmGyQTMa1jHz30rE",
+  "collection_method": "charge_automatically",
+  "created": 1585088620,
+  "currency": "usd",
+  "custom_fields": null,
+  "customer": "cus_Ku7kUUAPxDG3WU",
+  "customer_address": null,
+  "customer_email": "ray1@example.com",
+  "customer_name": "Ray",
+  "customer_phone": null,
+  "customer_shipping": null,
+  "customer_tax_exempt": "none",
+  "customer_tax_ids": [],
+  "default_payment_method": null,
+  "default_source": null,
+  "default_tax_rates": [],
+  "description": null,
+  "discount": {
+    "id": "di_1KEJVVBVqmGyQTMay9usx63n",
+    "object": "discount",
+    "checkout_session": null,
+    "coupon": {
+      "id": "jeVw0xYj",
+      "object": "coupon",
+      "amount_off": null,
+      "created": 1640198196,
+      "currency": null,
+      "duration": "forever",
+      "duration_in_months": null,
+      "livemode": false,
+      "max_redemptions": null,
+      "metadata": {},
+      "name": "Percentage small",
+      "percent_off": 10,
+      "redeem_by": null,
+      "times_redeemed": 1,
+      "valid": true
+    },
+    "customer": "cus_Ku7kUUAPxDG3WU",
+    "end": null,
+    "invoice": null,
+    "invoice_item": null,
+    "promotion_code": null,
+    "start": 1585088620,
+    "subscription": "sub_1KEJVVBVqmGyQTMakN6U7sPU"
+  },
+  "discounts": ["di_1KEJVVBVqmGyQTMay9usx63n"],
+  "due_date": null,
+  "ending_balance": 0,
+  "footer": null,
+  "hosted_invoice_url": "https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp",
+  "invoice_pdf": "https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp/pdf",
+  "last_finalization_error": null,
+  "lines": {
+    "object": "list",
+    "data": [
+      {
+        "id": "il_1KEJVVBVqmGyQTMa0NwGdfWK",
+        "object": "line_item",
+        "amount": 500,
+        "currency": "usd",
+        "description": "1 × 123Done Pro (at $5.00 / month)",
+        "discount_amounts": [
+          {
+            "amount": 50,
+            "discount": "di_1KEJVVBVqmGyQTMay9usx63n"
+          }
+        ],
+        "discountable": true,
+        "discounts": [],
+        "livemode": false,
+        "metadata": {},
+        "period": {
+          "end": 1587767020,
+          "start": 1585088620
+        },
+        "plan": {
+          "id": "plan_GqM9N6qyhvxaVk",
+          "object": "plan",
+          "active": true,
+          "aggregate_usage": null,
+          "amount": 500,
+          "amount_decimal": "500",
+          "billing_scheme": "per_unit",
+          "created": 1583259953,
+          "currency": "usd",
+          "interval": "month",
+          "interval_count": 1,
+          "livemode": false,
+          "metadata": {
+            "promotionCodes": "FRIEND20,ASJQLIUQ,FRIENDS10,FRIENDS1,FRIENDS15,ANOTHER"
+          },
+          "nickname": "123Done Pro Monthly",
+          "product": "prod_GqM9ToKK62qjkK",
+          "tiers": null,
+          "tiers_mode": null,
+          "transform_usage": null,
+          "trial_period_days": null,
+          "usage_type": "licensed"
+        },
+        "price": {
+          "id": "plan_GqM9N6qyhvxaVk",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1583259953,
+          "currency": "usd",
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {
+            "promotionCodes": "FRIEND20,ASJQLIUQ,FRIENDS10,FRIENDS1,FRIENDS15,ANOTHER"
+          },
+          "nickname": "123Done Pro Monthly",
+          "product": "prod_GqM9ToKK62qjkK",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "unspecified",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 500,
+          "unit_amount_decimal": "500"
+        },
+        "proration": false,
+        "quantity": 1,
+        "subscription": "sub_1KEJVVBVqmGyQTMakN6U7sPU",
+        "subscription_item": "si_Ku7lBbLQOjx5ry",
+        "tax_amounts": [],
+        "tax_rates": [],
+        "type": "subscription"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/invoices/in_1KEJVVBVqmGyQTMaBCtaciEj/lines"
+  },
+  "livemode": false,
+  "metadata": {},
+  "next_payment_attempt": null,
+  "number": "3432720C-0001",
+  "on_behalf_of": null,
+  "paid": true,
+  "payment_intent": "pi_3KEJVVBVqmGyQTMa1MfskC2I",
+  "payment_settings": {
+    "payment_method_options": null,
+    "payment_method_types": null
+  },
+  "period_end": 1585088620,
+  "period_start": 1585088620,
+  "post_payment_credit_notes_amount": 0,
+  "pre_payment_credit_notes_amount": 0,
+  "quote": null,
+  "receipt_number": null,
+  "starting_balance": 0,
+  "statement_descriptor": null,
+  "status": "paid",
+  "status_transitions": {
+    "finalized_at": 1585088620,
+    "marked_uncollectible_at": null,
+    "paid_at": 1585088620,
+    "voided_at": null
+  },
+  "subscription": "sub_1KEJVVBVqmGyQTMakN6U7sPU",
+  "subtotal": 500,
+  "tax": null,
+  "tax_percent": null,
+  "total": 450,
+  "total_discount_amounts": [
+    {
+      "amount": 50,
+      "discount": "di_1KEJVVBVqmGyQTMay9usx63n"
+    }
+  ],
+  "total_tax_amounts": [],
+  "transfer_data": null,
+  "webhooks_delivered_at": null
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3437,7 +3437,7 @@ describe('StripeHelper', () => {
         invoiceNumber: 'AAF2CECC-0001',
         invoiceTotalCurrency: 'usd',
         invoiceTotalInCents: 500,
-        invoiceSubTotalInCents: 500,
+        invoiceSubtotalInCents: 500,
         invoiceDiscountAmountInCents: null,
         invoiceDate: new Date('2020-03-24T22:23:40.000Z'),
         nextInvoiceDate: new Date('2020-04-24T22:23:40.000Z'),
@@ -3460,7 +3460,7 @@ describe('StripeHelper', () => {
         ...expected,
         invoiceNumber: '3432720C-0001',
         invoiceTotalInCents: 450,
-        invoiceSubTotalInCents: 500,
+        invoiceSubtotalInCents: 500,
         invoiceDiscountAmountInCents: 50,
       };
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -1256,7 +1256,7 @@ describe('StripeWebhookHandler', () => {
         if (
           expectedMethodName === 'sendSubscriptionFirstInvoiceDiscountEmail'
         ) {
-          mockInvoiceDetails.invoiceSubTotalInCents = 12;
+          mockInvoiceDetails.invoiceSubtotalInCents = 12;
           mockInvoiceDetails.invoiceDiscountAmountInCents = 34;
         }
         StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.resolves(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -29,6 +29,7 @@ const subscriptionUpdated = require('../../payments/fixtures/stripe/subscription
 const subscriptionUpdatedFromIncomplete = require('../../payments/fixtures/stripe/subscription_updated_from_incomplete.json');
 const eventInvoiceCreated = require('../../payments/fixtures/stripe/event_invoice_created.json');
 const eventInvoicePaid = require('../../payments/fixtures/stripe/event_invoice_paid.json');
+const eventInvoicePaidDiscount = require('../../payments/fixtures/stripe/invoice_paid_subscription_create_discount.json');
 const eventInvoicePaymentFailed = require('../../payments/fixtures/stripe/event_invoice_payment_failed.json');
 const eventCustomerUpdated = require('../../payments/fixtures/stripe/event_customer_updated.json');
 const eventCustomerSubscriptionUpdated = require('../../payments/fixtures/stripe/event_customer_subscription_updated.json');
@@ -1244,10 +1245,20 @@ describe('StripeWebhookHandler', () => {
     const commonSendSubscriptionInvoiceEmailTest =
       (expectedMethodName, billingReason, verifierSetAt = Date.now()) =>
       async () => {
-        const invoice = deepCopy(eventInvoicePaid.data.object);
+        const invoice =
+          expectedMethodName === 'sendSubscriptionFirstInvoiceDiscountEmail'
+            ? deepCopy(eventInvoicePaidDiscount)
+            : deepCopy(eventInvoicePaid.data.object);
+
         invoice.billing_reason = billingReason;
 
         const mockInvoiceDetails = { uid: '1234', test: 'fake' };
+        if (
+          expectedMethodName === 'sendSubscriptionFirstInvoiceDiscountEmail'
+        ) {
+          mockInvoiceDetails.invoiceSubTotalInCents = 12;
+          mockInvoiceDetails.invoiceDiscountAmountInCents = 34;
+        }
         StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.resolves(
           mockInvoiceDetails
         );
@@ -1273,7 +1284,12 @@ describe('StripeWebhookHandler', () => {
             ...mockInvoiceDetails,
           }
         );
-        if (expectedMethodName === 'sendSubscriptionFirstInvoiceEmail') {
+        if (
+          [
+            'sendSubscriptionFirstInvoiceDiscountEmail',
+            'sendSubscriptionFirstInvoiceDiscountEmail',
+          ].includes(expectedMethodName)
+        ) {
           if (verifierSetAt) {
             assert.calledWith(
               StripeWebhookHandlerInstance.mailer.sendDownloadSubscriptionEmail,
@@ -1303,9 +1319,27 @@ describe('StripeWebhookHandler', () => {
     );
 
     it(
+      'sends the initial invoice email for a newly created subscription with a discount',
+      commonSendSubscriptionInvoiceEmailTest(
+        'sendSubscriptionFirstInvoiceDiscountEmail',
+        'subscription_create',
+        1
+      )
+    );
+
+    it(
       'sends the initial invoice email for a newly created subscription with passwordless account',
       commonSendSubscriptionInvoiceEmailTest(
         'sendSubscriptionFirstInvoiceEmail',
+        'subscription_create',
+        0
+      )
+    );
+
+    it(
+      'sends the initial invoice email for a newly created subscription with passwordless account and a discount',
+      commonSendSubscriptionInvoiceEmailTest(
+        'sendSubscriptionFirstInvoiceDiscountEmail',
         'subscription_create',
         0
       )

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -133,6 +133,7 @@ const MAILER_METHOD_NAMES = [
   'sendSubscriptionReactivationEmail',
   'sendSubscriptionSubsequentInvoiceEmail',
   'sendSubscriptionFirstInvoiceEmail',
+  'sendSubscriptionFirstInvoiceDiscountEmail',
   'sendDownloadSubscriptionEmail',
   'sendLowRecoveryCodesEmail',
   'sendNewDeviceLoginEmail',


### PR DESCRIPTION
## Because

- The discount amount and original price needs to be included in the
  first invoice email.

## This pull request

- Adds Subtotal and One-time discount fields to the first invoice email.

## Issue that this pull request solves

Closes: #11341 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Existing account - first invoice
![image](https://user-images.githubusercontent.com/10620585/148128199-f525808a-0c37-49d8-94e4-811f88faed91.png)


Passwordless flow - first invoice
![image](https://user-images.githubusercontent.com/10620585/148128109-750d72c5-f291-4523-ba09-7dd14d5ac144.png)


Passwordless flow - initial email (no changes made to this)
![image](https://user-images.githubusercontent.com/10620585/148127981-8d64de22-7691-4125-be49-d94028c9609e.png)

