### PR TITLE
fix(auth-server): Text difference in postVerifySecondary template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en.ftl
@@ -2,5 +2,5 @@ postVerifySecondary-subject = Secondary email added
 postVerifySecondary-title = Secondary email added
 # Variables:
 #  $secondaryEmail (String) - A user's secondary email address
-postVerifySecondary-description = You have successfully verified { $secondaryEmail } as a secondary email from your { -product-firefox-account }. Security notifications and sign-in confirmations will now be delivered to both email addresses.
+postVerifySecondary-content = You have successfully verified { $secondaryEmail } as a secondary email for your { -product-firefox-account }. Security notifications and sign-in confirmations will now be delivered to both email addresses.
 postVerifySecondary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.mjml
@@ -16,7 +16,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span
-        data-l10n-id="postVerifySecondary-description"
+        data-l10n-id="postVerifySecondary-content"
         data-l10n-args="<%= JSON.stringify({secondaryEmail}) %>">
         You have successfully verified <%- secondaryEmail %> as a secondary
         email for your Firefox account. Security notifications and sign-in

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
@@ -1,6 +1,6 @@
 postVerifySecondary-title = "Secondary email added"
 
-postVerifySecondary-description = "You have successfully verified <%- secondaryEmail %> as a secondary email from your Firefox account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
+postVerifySecondary-content = "You have successfully verified <%- secondaryEmail %> as a secondary email for your Firefox account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
 
 <%- include('/partials/manageAccount/index.txt') %>
 


### PR DESCRIPTION
The old template reflects the word as 'for' instead of 'from'.

Note: this fix creates a new ftl ID, `postVerifySecondary-content`.

Closes: #11513

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
