### PR TITLE
bug(settings): Remove firefox lockwise from Delete Account page

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -9,13 +9,7 @@ import { useAccount, useAlertBar } from '../../models';
 import InputPassword from '../InputPassword';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
-import {
-  HomePath,
-  LockwiseLink,
-  MonitorLink,
-  ROOTPATH,
-  VPNLink,
-} from '../../constants';
+import { HomePath, MonitorLink, ROOTPATH, VPNLink } from '../../constants';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { Checkbox } from '../Checkbox';
 import { useLocalization } from '@fluent/react';
@@ -96,18 +90,17 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
     [account, l10n, setErrorText, setValue, alertBar]
   );
 
-  const handleConfirmChange = (labelText: string) => (
-    event: ChangeEvent<HTMLInputElement>
-  ) => {
-    event.persist();
-    setCheckedBoxes((existing) => {
-      if (event.target.checked) {
-        return [...existing, labelText];
-      } else {
-        return [...existing.filter((text) => text !== labelText)];
-      }
-    });
-  };
+  const handleConfirmChange =
+    (labelText: string) => (event: ChangeEvent<HTMLInputElement>) => {
+      event.persist();
+      setCheckedBoxes((existing) => {
+        if (event.target.checked) {
+          return [...existing, labelText];
+        } else {
+          return [...existing.filter((text) => text !== labelText)];
+        }
+      });
+    };
 
   const onFormSubmit = ({ password }: FormData) => {
     deleteAccount(password);

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -133,13 +133,6 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                   </a>
                 </li>
                 <li className="list-disc">
-                  <a className="link-blue" href={LockwiseLink}>
-                    <Localized id="firefox-lockwise">
-                      Firefox Lockwise
-                    </Localized>
-                  </a>
-                </li>
-                <li className="list-disc">
                   <a className="link-blue" href={MonitorLink}>
                     <Localized id="product-firefox-monitor">
                       Firefox Monitor

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -6,5 +6,4 @@ export const ROOTPATH = '/';
 export const HomePath = '/settings';
 export const DeleteAccountPath = '/settings/delete_account';
 export const VPNLink = 'https://vpn.mozilla.org/';
-export const LockwiseLink = 'https://lockwise.firefox.com/';
 export const MonitorLink = 'https://monitor.firefox.com/';


### PR DESCRIPTION
## Because
- Firefox lockwise is no longer valid.

## This pull request
- Removes the link for firefox lockwise on the Delete Account page

Closes: #11421

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
