### PR TITLE
fix(auth): setup appconfig where needed for scripts

### DIFF
--- a/packages/fxa-auth-server/bin/email_notifications.js
+++ b/packages/fxa-auth-server/bin/email_notifications.js
@@ -9,14 +9,17 @@ const StatsD = require('hot-shots');
 const { CurrencyHelper } = require('../lib/payments/currencies');
 
 const { Container } = require('typedi');
-const { AuthFirestore } = require('../lib/types');
+const { AuthFirestore, AppConfig } = require('../lib/types');
 const { StripeHelper } = require('../lib/payments/stripe');
 const { setupFirestore } = require('../lib/firestore-db');
+
 const statsd = new StatsD(config.statsd);
 Container.set(StatsD, statsd);
 const log = require('../lib/log')(config.log.level, 'fxa-email-bouncer', {
   statsd,
 });
+
+Container.set(AppConfig, config);
 
 // Set currencyHelper before stripe and paypal helpers, so they can use it.
 try {

--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -8,7 +8,7 @@ import Container from 'typedi';
 import { setupFirestore } from '../firestore-db';
 import { CurrencyHelper } from '../payments/currencies';
 import { configureSentry } from '../sentry';
-import { AuthFirestore, AuthLogger, ProfileClient } from '../types';
+import { AppConfig, AuthFirestore, AuthLogger, ProfileClient } from '../types';
 import { StripeHelper } from './stripe';
 
 const config = require('../../config').getProperties();
@@ -17,6 +17,8 @@ export async function setupProcesingTaskObjects(processName: string) {
   configureSentry(undefined, config, processName);
   // Establish database connection and bind instance to Model using Knex
   setupAuthDatabase(config.database.mysql.auth);
+
+  Container.set(AppConfig, config);
 
   const statsd = config.statsd.enabled
     ? new StatsD({


### PR DESCRIPTION
Because:

* Our cron job scripts weren't running, as StripeHelper now requires
  AppConfig to be setup.

This commit:

* Sets AppConfig for the Container for the scripts to start correctly.

Closes #11519

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
