### PR TITLE
bug(auth): Don't fail when l10n id is missing from en bundle

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -113,10 +113,10 @@ class FluentLocalizer {
       const args: any = {};
       const message = baseBundle.getMessage(attr.id);
 
-      // Require that all data-l10n-id values are present in en file.
-      if (!message) {
-        throw new Error('Missing data-1l0n-id detected. l10n-id=' + attr.id);
-      }
+      // TODO: Require that all data-l10n-id values are present in en file.
+      // if (!message) {
+      //   throw new Error('Missing data-l10n-id detected. l10n-id=' + attr.id);
+      // }
 
       if (message && message.value instanceof Array) {
         message.value

--- a/packages/fxa-auth-server/test/local/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails/fluent-localizer.ts
@@ -137,7 +137,7 @@ describe('fluent localizer', () => {
     });
 
     describe('test template /test-missing-l10n-id', () => {
-      it('fails with missing l10n id', async () => {
+      it.skip('fails with missing l10n id', async () => {
         const template: TemplateContext = getTestContext(
           'test-missing-l10n-id'
         );


### PR DESCRIPTION
##Because:
- Failing on a missing l10n id was probably too aggressive at the moment

##This commit:
- Comments out the error that requires all data-l10n-ids to be present in the en bundle

Closes: #11523


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

We are seeing some failing emails on stage despite all tests passing. This needs a bit more investigation.
