### PR TITLE
fix(subscriptions): do addr lookup for only US and CA

### DIFF
--- a/packages/fxa-auth-server/lib/payments/customer-locations.ts
+++ b/packages/fxa-auth-server/lib/payments/customer-locations.ts
@@ -15,7 +15,7 @@ type PayPalUserLocationResult = {
 };
 
 // The countries we need region data for
-const COUNTRIES_LONG_NAME_TO_SHORT_NAME_MAP = {
+export const COUNTRIES_LONG_NAME_TO_SHORT_NAME_MAP = {
   // The long name is used in the BigQuery metrics logs; the short name is used
   // in the Stripe customer billing address
   'United States': 'US',


### PR DESCRIPTION
Because:
 - accounting only need the province/state for CA and US customers

This commit:
 - skips the address lookup on new subscription or payment method update
   when the customer is not from CA or US

Co-authored-by: Bianca Danforth <bdanforth@mozilla.com>
