### PR TITLE
feat(auth): add coupon validation

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -580,6 +580,13 @@ export class StripeHelper {
     });
   }
 
+  /** Fetch a coupon with `applies_to` expanded. */
+  async getCoupon(couponId: string) {
+    return this.stripe.coupons.retrieve(couponId, {
+      expand: ['applies_to'],
+    });
+  }
+
   /**
    * Determines whether a given promotion code is
    * a valid code in the system for the given price, and if it hasn't

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_coupon_created.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_coupon_created.json
@@ -1,0 +1,29 @@
+{
+  "id": "evt_1GQf15BVqmGyQTMamwMk1kdP",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1585164955,
+  "data": {
+    "object": {
+      "id": "dlCMiuwT",
+      "object": "coupon",
+      "amount_off": null,
+      "created": 1641498279,
+      "currency": null,
+      "duration": "forever",
+      "duration_in_months": null,
+      "livemode": false,
+      "max_redemptions": null,
+      "metadata": {},
+      "name": "Test1234",
+      "percent_off": 50,
+      "redeem_by": null,
+      "times_redeemed": 0,
+      "valid": true
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 0,
+  "request": {},
+  "type": "coupon.created"
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1020,6 +1020,15 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('getCoupon', () => {
+    it('returns a coupon', async () => {
+      const coupon = { id: 'couponId' };
+      sandbox.stub(stripeHelper.stripe.coupons, 'retrieve').resolves(coupon);
+      const actual = await stripeHelper.getCoupon('couponId');
+      assert.deepEqual(actual, coupon);
+    });
+  });
+
   describe('findValidPromoCode', () => {
     it('finds a valid promotionCode with plan metadata', async () => {
       const promotionCode = { code: 'promo1', coupon: { valid: true } };


### PR DESCRIPTION
Because:

* We want to know if coupons are created with product
  requirements as we enforce them differently.

This commit:

* Reports a product restriction on a coupon to Sentry if one is
  created in Stripe.

Closes #11427

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
