### PR TITLE
fix(auth-server): Legal and Privacy links are not displayed in the plaintext version of the templates

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
@@ -1,4 +1,5 @@
 subplat-automated-email = This is an automated email; if you received it in error, no action is required.
+subplat-privacy-notice = Privacy notice
 subplat-privacy-plaintext = Privacy notice:
 subplat-update-billing-plaintext = { subplat-update-billing }:
 # Variables:

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
@@ -22,4 +22,6 @@ subplat-privacy-policy-plaintext = { subplat-privacy-policy }:
 subplat-cloud-terms = { -product-firefox-cloud } Terms of Service
 subplat-cloud-terms-plaintext = { subplat-cloud-terms }:
 subplat-legal = Legal
+subplat-legal-plaintext = { subplat-legal }:
 subplat-privacy = Privacy
+subplat-privacy-website-plaintext = { subplat-privacy }:

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -77,6 +77,11 @@
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;
             <% } %>
 
+            <% if (locals.productName) { %>
+              <a href="<%- subscriptionPrivacyUrl %>" class="footer-link" data-l10n-id="subplat-privacy-notice">Privacy notice</a>
+              &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+            <% } %>
+
             <% if (locals.isCancellationEmail) { %>
               <a href="<%- reactivateSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-reactivate">Reactivate subscription</a>
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -24,12 +24,18 @@ subplat-cancel-plaintext = "Cancel subscription:"
 subplat-update-billing-plaintext = "Update billing information:"
 <%- updateBillingUrl %>
 <% } else { %>
-subplat-privacy-policy-plaintext = "Mozilla Privacy Policy"
+subplat-privacy-policy-plaintext = "Mozilla Privacy Policy:"
 <%- privacyUrl %>
 
-subplat-cloud-terms-plaintext = "Firefox Cloud Terms Of Service"
+subplat-cloud-terms-plaintext = "Firefox Cloud Terms Of Service:"
 <%- subscriptionTermsUrl %>
 <% } %>
 
 Mozilla Corporation
 2 Harrison St, #175, San Francisco, CA 94105
+
+subplat-legal-plaintext = "Legal:"
+https://www.mozilla.org/about/legal/terms/services/
+
+subplat-privacy-website-plaintext = "Privacy:"
+https://www.mozilla.org/privacy/websites/


### PR DESCRIPTION
Closes: #11498

Legal, Privacy, and Privacy notice links have been added into the plaintext version of the email templates, as reflected in the HTML version. 

Please note, as there is already an existing ftl ID for `subplat-privacy-plaintext` for the string `Privacy notice`, the ID created for the `Privacy` in the plaintext version is `subplat-privacy-website-plaintext` as the link is `https://www.mozilla.org/privacy/websites/`.

Additional minor updates have been included in this PR (missing colons that are included in previously created ftl IDs).

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1749" alt="Screen Shot 2022-01-06 at 3 31 34 PM" src="https://user-images.githubusercontent.com/28129806/148447649-4611c322-7791-4c24-977f-a4d00ff92845.png">

