### PR TITLE
fix(subscriptions): l10n fix payment method header

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -424,6 +424,6 @@ manage-pocket-title = Looking for your { -brand-name-pocket } premium subscripti
 manage-pocket-body = To manage it, <a>click here</a>.
 
 payment-method-header = Choose your payment method
-# $prefix (string) - If header is part of a multi step process and needs a header. eg. '2.'
-payment-method-header-prefix = { $prefix } Choose your payment method
+# This message is used to indicate the second step in a multi step process.
+payment-method-header-second-step = 2. { payment-method-header }
 payment-method-required = Required

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import MockApp from '../../../.storybook/components/MockApp';
-import { PaymentMethodHeader } from './index';
+import { PaymentMethodHeader, PaymentMethodHeaderType } from './index';
 import { Plan } from '../../store/types';
 
 const selectedPlan: Plan = {
@@ -25,7 +25,11 @@ storiesOf('components/PaymentMethodHeader', module)
   .add('With prefix', () => (
     <MockApp>
       <PaymentMethodHeader
-        {...{ plan: selectedPlan, onClick: () => {}, prefix: '2. ' }}
+        {...{
+          plan: selectedPlan,
+          onClick: () => {},
+          type: PaymentMethodHeaderType.SecondStep,
+        }}
       />
     </MockApp>
   ));

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { cleanup, fireEvent, render, act } from '@testing-library/react';
-import { PaymentMethodHeader } from '.';
+import { PaymentMethodHeader, PaymentMethodHeaderType } from '.';
 import {
   getLocalizedMessage,
   MOCK_PLANS,
@@ -27,7 +27,11 @@ describe('components/PaymentMethodHeader', () => {
 
   it('render header with prefix', async () => {
     const plan = MOCK_PLANS[0];
-    const props = { plan, onClick: () => {}, prefix: '2.' };
+    const props = {
+      plan,
+      onClick: () => {},
+      type: PaymentMethodHeaderType.SecondStep,
+    };
     const { queryByTestId } = render(<PaymentMethodHeader {...props} />);
 
     expect(queryByTestId('header')).not.toBeInTheDocument();
@@ -46,10 +50,9 @@ describe('components/PaymentMethodHeader', () => {
     });
 
     it('returns correct heading with prefix', async () => {
-      const msgId = 'payment-method-header-prefix';
-      const prefix = '2.';
+      const msgId = 'payment-method-header-second-step';
       const expected = '2. Choose your payment method';
-      const actual = getLocalizedMessage(bundle, msgId, { prefix });
+      const actual = getLocalizedMessage(bundle, msgId, {});
 
       expect(actual).toEqual(expected);
     });

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -7,33 +7,48 @@ import { PaymentConsentCheckbox } from '../PaymentConsentCheckbox';
 
 import './index.scss';
 
-export type PaymentMethodHeaderProps = {
-  plan: Plan;
-  onClick: (event: React.MouseEvent<HTMLInputElement>) => void;
-  prefix?: string;
-};
+export enum PaymentMethodHeaderType {
+  NoPrefix,
+  SecondStep,
+}
 
-export const PaymentMethodHeader = ({
-  plan,
-  onClick,
-  prefix = '',
-}: PaymentMethodHeaderProps) => {
-  const checkboxValidator = useValidatorState();
-  return (
-    <>
-      {prefix ? (
-        <Localized id="payment-method-header-prefix" vars={{ prefix }}>
+const returnPaymentMethodHeader = (type: PaymentMethodHeaderType) => {
+  switch (type) {
+    case PaymentMethodHeaderType.SecondStep:
+      return (
+        <Localized id="payment-method-header-second-step">
           <h2 className="step-header" data-testid="header-prefix">
-            {`${prefix} Choose your payment method`}
+            2. Choose your payment method
           </h2>
         </Localized>
-      ) : (
+      );
+    case PaymentMethodHeaderType.NoPrefix:
+    default:
+      return (
         <Localized id="payment-method-header">
           <h2 className="step-header" data-testid="header">
             Choose your payment method
           </h2>
         </Localized>
-      )}
+      );
+  }
+};
+
+export type PaymentMethodHeaderProps = {
+  plan: Plan;
+  onClick: (event: React.MouseEvent<HTMLInputElement>) => void;
+  type?: PaymentMethodHeaderType;
+};
+
+export const PaymentMethodHeader = ({
+  plan,
+  onClick,
+  type,
+}: PaymentMethodHeaderProps) => {
+  const checkboxValidator = useValidatorState();
+  return (
+    <>
+      {returnPaymentMethodHeader(type || PaymentMethodHeaderType.NoPrefix)}
       <Localized id="payment-method-required">
         <strong>Required</strong>
       </Localized>

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -59,7 +59,10 @@ import * as apiClient from '../../lib/apiClient';
 import sentry from '../../lib/sentry';
 import { ButtonBaseProps } from '../../components/PayPalButton';
 import { AlertBar } from '../../components/AlertBar';
-import { PaymentMethodHeader } from '../../components/PaymentMethodHeader';
+import {
+  PaymentMethodHeader,
+  PaymentMethodHeaderType,
+} from '../../components/PaymentMethodHeader';
 import CouponForm from '../../components/CouponForm';
 import { Coupon } from '../../lib/Coupon';
 import { useParams } from 'react-router-dom';
@@ -325,7 +328,7 @@ export const Checkout = ({
           <PaymentMethodHeader
             plan={selectedPlan}
             onClick={() => setCheckboxSet(!checkboxSet)}
-            prefix="2."
+            type={PaymentMethodHeaderType.SecondStep}
           />
           <>
             {paypalScriptLoaded && (


### PR DESCRIPTION
## Because

- Hard coded prefix can't be translated for different locales.

## This pull request

- Removes hard coded prefix from header, and instead provides a new
  message that can be translated by.

## Issue that this pull request solves

Closes: #11560

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
