### PR TITLE
fix(auth-server): small difference between plaintext and HTML

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
@@ -1,3 +1,4 @@
+payment-details = Payment details:
 # Variables:
 #  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
 payment-plan-invoice-number = Invoice Number: { $invoiceNumber }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/index.txt
@@ -1,15 +1,6 @@
-<% if (locals.productName) { %>
-<%- productName %>
-<% } %>
+payment-details = "Payment details:"
 
-<% if (locals.invoiceNumber) { %>
-payment-plan-invoice-number = "Invoice Number: <%- invoiceNumber %>"
-<% } %>
-
-<% if (locals.invoiceDateOnly && locals.invoiceTotal) { %>
-payment-plan-charged = "Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>"
-<% } %>
-
-<% if (locals.nextInvoiceDateOnly) { %>
-payment-plan-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
-<% } %>
+<% if (locals.productName) { %><%- productName %><% } %>
+<% if (locals.invoiceNumber) { %>payment-plan-invoice-number = "Invoice Number: <%- invoiceNumber %>"<% } %>
+<% if (locals.invoiceDateOnly && locals.invoiceTotal) { %>payment-plan-charged = "Charged: <%- invoiceTotal %> on <%- invoiceDateOnly %>"<% } %>
+<% if (locals.nextInvoiceDateOnly) { %>payment-plan-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"<% } %>


### PR DESCRIPTION
Closes: #11553

`Payment details:` has been added to the plaintext version in the partial. The formatting of the plaintext has also been updated within this pull request.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Previous:
<img width="1757" alt="Screen Shot 2022-01-11 at 6 14 55 PM" src="https://user-images.githubusercontent.com/28129806/149036314-0872e867-b4d6-4e59-ae4f-b5a3773b1514.png">

Fixed within this PR:
<img width="1344" alt="Screen Shot 2022-01-11 at 3 40 44 PM" src="https://user-images.githubusercontent.com/28129806/149018564-057a1ed2-ca3d-4e72-a5a5-92f9dd9b3179.png">
