### PR TITLE
feat(subscriptions): save promo code to subscription metadata

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -83,8 +83,7 @@ export class StripeFirestore {
     } catch (err) {
       if (err.name === FirestoreStripeError.FIRESTORE_SUBSCRIPTION_NOT_FOUND) {
         const subscription = await this.stripe.subscriptions.retrieve(
-          subscriptionId,
-          { expand: ['discount.promotion_code'] }
+          subscriptionId
         );
         await this.fetchAndInsertCustomer(subscription.customer as string);
         return subscription;
@@ -105,7 +104,6 @@ export class StripeFirestore {
       this.stripe.subscriptions
         .list({
           customer: customerId,
-          expand: ['data.discount.promotion_code'],
         })
         .autoPagingToArray({ limit: 100 }),
     ]);

--- a/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
@@ -137,8 +137,7 @@ describe('StripeFirestore', () => {
       assert.calledOnce(stripeFirestore.fetchAndInsertCustomer);
       assert.calledOnceWithExactly(
         stripe.subscriptions.retrieve,
-        subscription.id,
-        { expand: ['discount.promotion_code'] }
+        subscription.id
       );
     });
 
@@ -184,7 +183,6 @@ describe('StripeFirestore', () => {
       assert.calledOnce(stripe.customers.retrieve);
       assert.calledOnceWithExactly(stripe.subscriptions.list, {
         customer: customer.id,
-        expand: ['data.discount.promotion_code'],
       });
       assert.calledOnce(stripeFirestore.insertCustomerRecord);
       assert.calledOnce(customerCollectionDbRef.doc);


### PR DESCRIPTION
Because:
 - we need a sure way of finding the applied promotion code for a
   subscription
 - subscription.discount is null when a one time coupon is used

This commit:
 - save the applied promotion code to the subscription metadata

## Issue that this pull request solves

Closes: #11378 
