### PR TITLE
fix(email): lower the maxMessages sent via nodemailer before creating a new connection

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -257,6 +257,7 @@ module.exports = function (log, config, bounces) {
       ignoreTLS: !mailerConfig.secure,
       port: mailerConfig.port,
       pool: true,
+      maxMessages: 10,
     };
 
     if (mailerConfig.user && mailerConfig.password) {


### PR DESCRIPTION
fixes #11575

The SES SMTP connections were hanging out too long so SES would disconnect them. By reducing the `maxMessages` from the default 100 to 10 we shouldn't be holding onto the connections long enough to "expire".

