### PR TITLE
fix(auth-server): updated template to match old email template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/index.txt
@@ -10,5 +10,3 @@ subscriptionAccountReminderFirst-action-plaintext = "Create Password:"
 <%- link %>
 
 <%- include ('/partials/subscriptionSupport/index.txt') %>
-
-<%- include ('/partials/automatedEmailResetPassword/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/index.txt
@@ -10,5 +10,3 @@ subscriptionAccountReminderSecond-action-plaintext = "Create Password:"
 <%- link %>
 
 <%- include ('/partials/subscriptionSupport/index.txt') %>
-
-<%- include ('/partials/automatedEmailResetPassword/index.txt') %>


### PR DESCRIPTION
Closes #11554

This pull request updates the `subscriptionAccountReminderFirst` and `subscriptionAccountReminderSecond` emails so that the new email templates matches the old email templates. This revision removes the line "If you did not change it, please reset your password now at (resetPasswordLink)" in the plaintext of its partial.

Note: We are aware and have noted that the fine print and footer links are different between the HTML and plaintext version of the email templates.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Previously:
![accountReminderFirst difference](https://user-images.githubusercontent.com/28129806/149163257-9c394550-805b-439d-8305-678da7c054f1.PNG)

Update made within this PR:
`subscriptionAccountReminderFirst`
Old template
<img width="1614" alt="Screen Shot 2022-01-11 at 6 01 23 PM" src="https://user-images.githubusercontent.com/28129806/149035016-9a0edb53-49ca-4c7e-9105-e92548363f00.png">

New template
<img width="1349" alt="Screen Shot 2022-01-11 at 5 59 35 PM" src="https://user-images.githubusercontent.com/28129806/149034928-30471e87-d873-4b87-b0d2-4eca3f71d0ad.png">

`subscriptionAccountReminderSecond`
Old template
<img width="1667" alt="Screen Shot 2022-01-11 at 6 01 06 PM" src="https://user-images.githubusercontent.com/28129806/149035026-25b8c1d5-f761-4ac9-8747-d52efa1c0799.png">

New template
<img width="1349" alt="Screen Shot 2022-01-11 at 5 59 46 PM" src="https://user-images.githubusercontent.com/28129806/149034914-0445f552-80af-4589-be89-128225ad5abc.png">

