### PR TITLE
fix(pocket): Update password reset and delete account notice to mention pocket

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
@@ -41,7 +41,7 @@
     <form novalidate>
         {{#showSyncWarning}}
             <p class="reset-warning">
-                {{#unsafeTranslate}}<span>REMEMBER:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have.{{/unsafeTranslate}}
+                {{#unsafeTranslate}}<span>REMEMBER:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and Pocket data will not be affected.{{/unsafeTranslate}}
             </p>
         {{/showSyncWarning}}
 

--- a/packages/fxa-content-server/app/scripts/templates/reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/reset_password.mustache
@@ -11,7 +11,7 @@
 
     <form novalidate>
       <p class="reset-warning">
-        {{#unsafeTranslate}}<span>NOTE:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have.{{/unsafeTranslate}}
+        {{#unsafeTranslate}}<span>NOTE:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and Pocket data will not be affected.{{/unsafeTranslate}}
       </p>
       <div class="input-row">
         {{#forceEmail}}

--- a/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
@@ -10,8 +10,8 @@ delete-account-confirm-title-2 = You’ve connected your { -product-firefox-acco
 
 delete-account-acknowledge = Please acknowledge that by deleting your account:
 
-delete-account-chk-box-1 =
- .label = Any paid subscriptions you have will be canceled
+delete-account-chk-box-1-v2 =
+ .label = Any paid subscriptions you have will be canceled (Except { product-pocket })
 delete-account-chk-box-2 =
  .label = You may lose saved information and features within { -brand-mozilla } products
 delete-account-chk-box-3 =

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -21,7 +21,7 @@ type FormData = {
 };
 
 const checkboxLabels = [
-  'delete-account-chk-box-1',
+  'delete-account-chk-box-1-v2',
   'delete-account-chk-box-2',
   'delete-account-chk-box-3',
   'delete-account-chk-box-4',


### PR DESCRIPTION
## Because

- Pocket isn't changed when you reset password or delete account

## This pull request

- Updates our text based on their recommendations

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11572

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="487" alt="Screen Shot 2022-01-11 at 10 49 02 PM" src="https://user-images.githubusercontent.com/1295288/149180701-7c4d02e5-f8b3-4285-86d9-d3401b6b6c00.png">
<img width="523" alt="Screen Shot 2022-01-11 at 10 50 55 PM" src="https://user-images.githubusercontent.com/1295288/149180706-470d7b49-c2be-4c78-ac4c-d68d5176b96e.png">
<img width="761" alt="Screen Shot 2022-01-11 at 10 51 17 PM" src="https://user-images.githubusercontent.com/1295288/149180714-b2e35a38-f0eb-4fb3-9546-ca4b421124dc.png">

