### PR TITLE
feat(auth): use latest stripe object with proper invoice close

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -53,18 +53,24 @@ import { CurrencyHelper } from './currencies';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
 import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
 
-export const CUSTOMER_RESOURCE = 'customers';
-export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
-export const PRODUCT_RESOURCE = 'products';
-export const PLAN_RESOURCE = 'plans';
+export const CARD_RESOURCE = 'sources';
 export const CHARGES_RESOURCE = 'charges';
+export const COUPON_RESOURCE = 'coupons';
+export const CREDIT_NOTE_RESOURCE = 'credit_notes';
+export const CUSTOMER_RESOURCE = 'customers';
 export const INVOICES_RESOURCE = 'invoices';
 export const PAYMENT_METHOD_RESOURCE = 'paymentMethods';
+export const PLAN_RESOURCE = 'plans';
+export const PRICE_RESOURCE = 'prices';
+export const PRODUCT_RESOURCE = 'products';
+export const SOURCE_RESOURSE = 'sources';
+export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
+export const TAX_RATE_RESOURCE = 'tax_rates';
 
 export const MOZILLA_TAX_ID = 'Tax ID';
 
-export const STRIPE_PRODUCTS_CACHE_KEY = 'listStripeProducts';
 export const STRIPE_PLANS_CACHE_KEY = 'listStripePlans';
+export const STRIPE_PRODUCTS_CACHE_KEY = 'listStripeProducts';
 export const STRIPE_TAX_RATES_CACHE_KEY = 'listStripeTaxRates';
 
 export const SUBSCRIPTION_PROMOTION_CODE_METADATA_KEY = 'appliedPromotionCode';
@@ -72,6 +78,22 @@ export const SUBSCRIPTION_PROMOTION_CODE_METADATA_KEY = 'appliedPromotionCode';
 enum STRIPE_CUSTOMER_METADATA {
   PAYPAL_AGREEMENT = 'paypalAgreementId',
 }
+
+export const STRIPE_OBJECT_TYPE_TO_RESOURCE: Record<string, string> = {
+  card: CARD_RESOURCE,
+  charge: CHARGES_RESOURCE,
+  coupon: COUPON_RESOURCE,
+  credit_note: CREDIT_NOTE_RESOURCE,
+  customer: CUSTOMER_RESOURCE,
+  invoice: INVOICES_RESOURCE,
+  payment_method: PAYMENT_METHOD_RESOURCE,
+  plan: PLAN_RESOURCE,
+  price: PRICE_RESOURCE,
+  product: PRODUCT_RESOURCE,
+  source: SOURCE_RESOURSE,
+  subscription: SUBSCRIPTIONS_RESOURCE,
+  tax_rate: TAX_RATE_RESOURCE,
+};
 
 export enum STRIPE_PRICE_METADATA {
   PROMOTION_CODES = 'promotionCodes',
@@ -94,9 +116,11 @@ const VALID_RESOURCE_TYPES = [
   SUBSCRIPTIONS_RESOURCE,
   PRODUCT_RESOURCE,
   PLAN_RESOURCE,
+  PRICE_RESOURCE,
   CHARGES_RESOURCE,
   INVOICES_RESOURCE,
   PAYMENT_METHOD_RESOURCE,
+  TAX_RATE_RESOURCE,
 ] as const;
 
 export const SUBSCRIPTION_UPDATE_TYPES = {
@@ -2776,8 +2800,6 @@ export class StripeHelper {
           break;
         case 'customer.subscription.created':
         case 'customer.subscription.updated':
-          await this.processSubscriptionEventToFirestore(event);
-          break;
         case 'customer.subscription.deleted':
           await this.processSubscriptionEventToFirestore(event);
           break;

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -21,6 +21,7 @@ import { PayPalHelper } from '../../payments/paypal';
 import {
   INVOICES_RESOURCE,
   StripeHelper,
+  STRIPE_OBJECT_TYPE_TO_RESOURCE,
   SUBSCRIPTION_UPDATE_TYPES,
 } from '../../payments/stripe';
 import { AuthLogger, AuthRequest } from '../../types';
@@ -66,8 +67,39 @@ export class StripeWebhookHandler extends StripeHandler {
         request.headers['stripe-signature']
       );
 
+      // This must run before expansion below to ensure the types that Firestore
+      // can store are updated first to prevent multiple fetches from Stripe.
       const firestoreHandled =
         await this.stripeHelper.processWebhookEventToFirestore(event);
+
+      // Ensure the object is the latest version.
+      const stripeObject = event.data.object as Record<string, any>;
+      const resourceType =
+        STRIPE_OBJECT_TYPE_TO_RESOURCE[stripeObject.object as string];
+      if (resourceType) {
+        // Replace the object with the latest version if we support this object.
+        event.data.object = await this.stripeHelper.expandResource(
+          resourceType,
+          stripeObject.id
+        );
+      } else {
+        // We shouldn't be handling events that we can't fetch the latest version
+        // of with expandResource. If we have a handler below for this type, then
+        // we should have it included as a resource type to expand above.
+        Sentry.withScope((scope) => {
+          scope.setContext('stripeEvent', {
+            event: {
+              id: event.id,
+              type: event.type,
+              objectType: (event.data.object as any).object,
+            },
+          });
+          Sentry.captureMessage(
+            'Event being handled that is not using latest object from Stripe.',
+            Sentry.Severity.Info
+          );
+        });
+      }
 
       switch (event.type as Stripe.WebhookEndpointUpdateParams.EnabledEvent) {
         case 'credit_note.created':
@@ -357,7 +389,10 @@ export class StripeWebhookHandler extends StripeHandler {
       return;
     }
     const invoice = event.data.object as Stripe.Invoice;
-    if (!(await this.stripeHelper.invoicePayableWithPaypal(invoice))) {
+    if (
+      !(await this.stripeHelper.invoicePayableWithPaypal(invoice)) ||
+      invoice.status !== 'draft'
+    ) {
       return;
     }
     return this.stripeHelper.finalizeInvoice(invoice);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -151,6 +151,7 @@ describe('StripeWebhookHandler', () => {
         product_name: validProduct.data.object.name,
         product_metadata: validProduct.data.object.metadata,
       });
+      StripeWebhookHandlerInstance.stripeHelper.expandResource.resolves({});
     });
 
     describe('handleWebhookEvent', () => {
@@ -213,6 +214,9 @@ describe('StripeWebhookHandler', () => {
           await StripeWebhookHandlerInstance.handleWebhookEvent(request);
           assertNamedHandlerCalled(expectedHandlerName);
           assert.isTrue(
+            StripeWebhookHandlerInstance.stripeHelper.expandResource.calledOnce
+          );
+          assert.isTrue(
             scopeContextSpy.notCalled,
             'Expected to not call Sentry'
           );
@@ -261,14 +265,14 @@ describe('StripeWebhookHandler', () => {
 
       describe('when the event.type is coupon.created', () => {
         itOnlyCallsThisHandler('handleCouponEvent', {
-          data: { object: { id: 'coupon_123' } },
+          data: { object: { id: 'coupon_123', object: 'coupon' } },
           type: 'coupon.created',
         });
       });
 
       describe('when the event.type is coupon.updated', () => {
         itOnlyCallsThisHandler('handleCouponEvent', {
-          data: { object: { id: 'coupon_123' } },
+          data: { object: { id: 'coupon_123', object: 'coupon' } },
           type: 'coupon.updated',
         });
       });
@@ -887,6 +891,7 @@ describe('StripeWebhookHandler', () => {
 
       it('stops if the invoice is not paypal payable', async () => {
         const invoiceCreatedEvent = deepCopy(eventInvoiceCreated);
+        invoiceCreatedEvent.data.object.status = 'draft';
         StripeWebhookHandlerInstance.stripeHelper.invoicePayableWithPaypal.resolves(
           false
         );
@@ -905,8 +910,29 @@ describe('StripeWebhookHandler', () => {
         );
       });
 
+      it('stops if the invoice is not in draft', async () => {
+        const invoiceCreatedEvent = deepCopy(eventInvoiceCreated);
+        StripeWebhookHandlerInstance.stripeHelper.invoicePayableWithPaypal.resolves(
+          true
+        );
+        StripeWebhookHandlerInstance.stripeHelper.finalizeInvoice.resolves({});
+        const result =
+          await StripeWebhookHandlerInstance.handleInvoiceCreatedEvent(
+            {},
+            invoiceCreatedEvent
+          );
+        assert.isUndefined(result);
+        assert.notCalled(
+          StripeWebhookHandlerInstance.stripeHelper.expandResource
+        );
+        assert.notCalled(
+          StripeWebhookHandlerInstance.stripeHelper.finalizeInvoice
+        );
+      });
+
       it('finalizes invoices for invoice subscriptions', async () => {
         const invoiceCreatedEvent = deepCopy(eventInvoiceCreated);
+        invoiceCreatedEvent.data.object.status = 'draft';
         StripeWebhookHandlerInstance.stripeHelper.invoicePayableWithPaypal.resolves(
           true
         );


### PR DESCRIPTION
Because:

* Our code was using the invoice object rather than the latest version
  in some parts.
* We didn't check if the invoice was in draft state before finalizing.

This commit:

* Ensures the latest version of the object is always fetched before
  running the webhook handler.
* Only finalizes invoices if they're in draft state.

Closes #10934

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
