### PR TITLE
fix(auth-server): wrong email title in plaintext version of verifyLogin template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.txt
@@ -1,4 +1,4 @@
-verifyLogin-title = "Activate the Firefox family of products"
+verifyLogin-title = "New sign-in to <%- clientName %>"
 
 verifyLogin-description = "For added security, please confirm this sign-in from the following device:"
 


### PR DESCRIPTION
Closes: #11642

The email title in the plaintext version should be "New sign-in to Firefox" instead of "Activate the Firefox family of products".

Note: While this error was reflected in emails using `yarn write-emails`, this error was not reflected in Storybook.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old 
![wrong email title plaintext](https://user-images.githubusercontent.com/28129806/149955141-4b1febca-4ceb-4725-b995-3c3824e1d8ed.PNG)

New
<img width="1228" alt="Screen Shot 2022-01-18 at 9 21 10 AM" src="https://user-images.githubusercontent.com/28129806/149955004-d3ed15ad-d1b9-4cae-a1ce-e282a779afb6.png">
