### PR TITLE
fix(ios): Don't show Firefox iOS banner when loading signup/signin views

### DIFF
--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -14,12 +14,6 @@
             content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes"
         />
 
-        <!--iOS Smart Banner-->
-        <meta
-            name="apple-itunes-app"
-            content="app-id=989804926, affiliate-data=ct=smartbanner-fxa"
-        />
-
         <!-- build:css(.tmp) /styles/main.css -->
         <link rel="stylesheet" href="/styles/main.css" />
         <!-- endbuild -->


### PR DESCRIPTION
## Because

- We shouldnt show this banner because if FxA is opened in a webview in another app, the user would be take to Firefox iOS to continue signup/signin which is confusing

## This pull request

- Removes the Firefox iOS banner

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11648

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate)
