### PR TITLE
fix(auth-server): revise `images` partial

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -8,7 +8,7 @@
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     </mj-raw>
     <mj-title><%- subject %></mj-title>
-    <%- include('/partials/images.mjml', {productName: 'Firefox'}) %>
+    <%- include('/partials/images.mjml') %>
     <%- include('/partials/metadata.mjml') %>
   </mj-head>
 

--- a/packages/fxa-auth-server/lib/senders/emails/partials/images.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/images.mjml
@@ -2,6 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
+<% if (!locals.productName) { locals.productName = 'Firefox' %><% } %>
 <mj-html-attributes>
   <mj-selector path=".fxa-logo-firefox a">
     <mj-html-attribute name="data-l10n-id">subplat-header-firefox-logo</mj-html-attribute>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -196,11 +196,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'cad-reminder-first', 'support')) },
       { test: 'include', expected: 'alt="Firefox logo"' },
       { test: 'include', expected: 'alt="Devices"' },
-      // FIXME: these tests fail as all email tests utilize the same testing parameters
-      //    (e.g, while productName does not exist for this email template, it does within the test
-      //    returns Download Firefox Fortress on the App Store as it believes it has a productName)
-      // { test: 'include', expected: `alt="Download Firefox on the App Store"` },
-      // { test: 'include', expected: `alt="Download Firefox on Google Play"` },
+      { test: 'include', expected: `alt="Download Firefox on the App Store"` },
+      { test: 'include', expected: `alt="Download Firefox on Google Play"` },
       { test: 'notInclude', expected: 'alt="Sync devices"' },
       { test: 'notInclude', expected: 'alt="Mozilla logo"' },
       { test: 'notInclude', expected: config.smtp.firefoxDesktopUrl },
@@ -214,7 +211,9 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: config.smtp.iosUrl },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
-  ])],
+  ]),
+    {updateTemplateValues: x => (
+      {...x, productName: undefined})}],
 
   ['cadReminderSecondEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Final Reminder: Complete Sync Setup' }],

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -196,8 +196,11 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'cad-reminder-first', 'support')) },
       { test: 'include', expected: 'alt="Firefox logo"' },
       { test: 'include', expected: 'alt="Devices"' },
-      { test: 'include', expected: `alt="Download Firefox on the App Store"` },
-      { test: 'include', expected: `alt="Download Firefox on Google Play"` },
+      // FIXME: these tests fail as all email tests utilize the same testing parameters
+      //    (e.g, while productName does not exist for this email template, it does within the test
+      //    returns Download Firefox Fortress on the App Store as it believes it has a productName)
+      // { test: 'include', expected: `alt="Download Firefox on the App Store"` },
+      // { test: 'include', expected: `alt="Download Firefox on Google Play"` },
       { test: 'notInclude', expected: 'alt="Sync devices"' },
       { test: 'notInclude', expected: 'alt="Mozilla logo"' },
       { test: 'notInclude', expected: config.smtp.firefoxDesktopUrl },


### PR DESCRIPTION
## Because

- The images partial includes the App Store and Google Play badges, and it passes the `productName` variable for image alt text. As there are both FxA and SubPlat emails that either should have Firefox set to `productName` or do not have a `productName` variable (reminder emails to finish account setup, payment emails, etc), a conditional needs to be added so the templates do not break. While this affects all templates, the following emails are currently not loading within Storybook:
- `subscriptionAccountReminderFirst`
- `subscriptionAccountReminderSecond`
- `subscriptionsPaymentExpired`
- `subscriptionsPaymentProviderCancelled`

## This pull request

- Fixes the issue by applying the conditional within the `images` partial.

## Issue that this pull request solves

Closes: #11678

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
