### PR TITLE
fix(content-server): Decrease flakiness of content server tests

### DIFF
--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -79,7 +79,7 @@ const config = {
   fxaUntrustedOauthApp: fxaUntrustedOauthApp,
   fxaPaymentsRoot,
 
-  pageLoadTimeout: 20000,
+  pageLoadTimeout: 30000,
   reporters: [
     {
       name: 'junit',


### PR DESCRIPTION
#Because:
- Tests in CI exhibited flakiness

## This pull request
- Addresses edge cases where the document could be caught in an unloaded state when running querySelector
- Increases allowed pageLoadTimeout. When flakiness does occur, it appears to be due to resource constraints in the CI runner. Allowing a little more time for things to settle reduces the chance something fails due to a random slow down.

Closes: #11223

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Reproducing flakiness seen in the CI can be tricky to do locally. To accomplish this I used cgroups and did several experiments with different memory limits in place. Ultimately, it seems like flakiness is correlated to available system resources, which has more or less been the suspicion all along. When there are plenty of resources and things are running full throttle, flakiness is not observed. 

