### PR TITLE
fix(auth-server): wrong HTML version displayed for `verifyLoginCode` template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -78,7 +78,10 @@ class FluentLocalizer {
     context = { ...context, ...context.templateValues };
     if (template !== '_storybook') {
       // TODO: #11471 Improve dynamically rendered actions & subjects in email.js, etc.
-      if (template === 'postRemoveTwoStepAuthentication') {
+      if (
+        template === 'postRemoveTwoStepAuthentication' ||
+        template === 'verifyLoginCode'
+      ) {
         context.subject = await l10n.formatValue(
           `${template}-subject-line`,
           context

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verifyShortCode-title">Is this you signing in?</span>
+      <span data-l10n-id="unblockCode-title">Is this you signing in?</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/en.ftl
@@ -1,6 +1,6 @@
 # Variables:
-#  $code (Number) - e.g. 123456
-verifyLoginCode-subject = Verification code: { $code }
+#  $serviceName (String) - A service the user hasn't signed into before (e.g. Firefox)
+verifyLoginCode-subject-line = Sign-in code for { $serviceName }
 verifyLoginCode-title = Is this you signing in?
 verifyLoginCode-prompt = If yes, here is the verification code:
 verifyLoginCode-expiry-notice = It expires in 5 minutes.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verifyLoginCode-title">Is this you signing up?</span>
+      <span data-l10n-id="verifyLoginCode-title">Is this you signing in?</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -16,7 +16,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="verifyLoginCode-prompt">
-        If yes, use this verification code in your registration form:
+        If yes, here is the verification code:
       </span>
     </mj-text>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.stories.ts
@@ -17,6 +17,7 @@ const createStory = storyWithProps(
     ...MOCK_LOCATION,
     code: '918398',
     passwordChangeLink: 'http://localhost:3030/settings/change_password',
+    serviceName: 'Firefox',
   }
 );
 

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -731,6 +731,34 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
   ])],
 
+  ['verifyLoginCodeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Sign-in code for Mock Relier' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifyLoginCode') }],
+      ['X-Signin-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
+      ['X-Template-Name', { test: 'equal', expected: 'verifyLoginCode' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verifyLoginCode }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'new-signin-verify-code', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'new-signin-verify-code', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'new-signin-verify-code', 'support')) },
+      { test: 'include', expected: MESSAGE.code },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'new-signin-verify-code', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'new-signin-verify-code', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'new-signin-verify-code', 'support')}` },
+      { test: 'include', expected: `If yes, here is the verification code:\n${MESSAGE.code}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
   ['recoveryEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Reset your password' }],
     ['headers', new Map([


### PR DESCRIPTION
## Because

- the HTML did not match plaintext for `verifyLoginCode` template

## This pull request

includes the following updates:
- As the string of the subject of the email was updated, a new ftl ID was created:
   - `fxa-auth-server/lib/senders/emails/fluent-localizer.ts`
   - `fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/en.ftl`
   - `fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.stories.ts`
- The mjml file was updated to match the string values of the ftl IDs:
  - `fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.mjml`
- Adds the test:
  - `fxa-auth-server/test/local/senders/mjml-emails.ts `
 

## Issue that this pull request solves

Closes: ##11696

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
The mjml file for the `unblockCode` email included another email title's ftl ID. Please note, both email titles have the same string value.
- `fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml` 
