### PR TITLE
chore(circleci): increase container size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
           path: artifacts/tests
 
   build-and-deploy-storybooks:
-    resource_class: small
+    resource_class: medium
     docker:
       - image: cimg/node:16.13
     steps:


### PR DESCRIPTION
Because:

* builds are failing

This commit:

* increases the storybook container size
