### PR TITLE
fix(subscriptions): stop retry w/ old invoice; stop sending welcome email

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
@@ -33,6 +33,7 @@ describe('routes/subscriptions/account', () => {
       current_period_end: '2001',
       latest_invoice: invoice,
       plan,
+      status: 'active',
     };
     const invoiceDetails = {
       email,
@@ -59,6 +60,18 @@ describe('routes/subscriptions/account', () => {
 
     it('does not send an email when the account is not a stub', async () => {
       await sendFinishSetupEmailForStubAccount({ email, uid, account: null });
+      sinon.assert.notCalled(stripeHelper.findPlanById);
+      sinon.assert.notCalled(mailer.sendSubscriptionAccountFinishSetupEmail);
+    });
+
+    it('does not send an email when the subscription is not active', async () => {
+      await sendFinishSetupEmailForStubAccount({
+        uid,
+        account,
+        subscription: { ...subscription, status: 'incomplete' },
+        stripeHelper,
+        mailer,
+      });
       sinon.assert.notCalled(stripeHelper.findPlanById);
       sinon.assert.notCalled(mailer.sendSubscriptionAccountFinishSetupEmail);
     });

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -178,8 +178,10 @@ export const Checkout = ({
           retryStatus,
           onSuccess: fetchProfileAndCustomer,
           onFailure: setSubscriptionError,
-          onRetry: (status: RetryStatus) => {
-            setRetryStatus(status);
+          onRetry: () => {
+            // for a passwordless subscription we retry from a clean state
+            // every time.  new stub account, new customer, new invoice, etc.
+            setRetryStatus(undefined);
             setSubscriptionError({ type: 'card_error', code: 'card_declined' });
           },
         });


### PR DESCRIPTION
Because:
 - on the "passwordless" subscription flow, when a user retries after a
   failed subscription attempt due to a payment failure, the old invoice
   of the failed subscription is used
 - the finish setup email for the new FxA "stub" account was sent even
   when the payment for the subscription failed

This commit:
 - update the payments frontend to stop retrying the old invoice of the
   failed subscription when the user is in the passwordless flow
 - send the finish setup email only when the subscription is active

## Issue that this pull request solves

Closes: #11198
