### PR TITLE
feat(auth): update webhook for payment method

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2764,6 +2764,12 @@ export class StripeHelper {
    * only change in their entirety.
    */
   async processPaymentMethodEventToFirestore(event: Stripe.Event) {
+    // If this payment method is not attached, we can't store it in firestore as
+    // the customer may not exist.
+    if (!(event.data.object as Stripe.PaymentMethod).customer) {
+      return;
+    }
+
     const paymentMethod = await this.stripe.paymentMethods.retrieve(
       (event.data.object as Stripe.PaymentMethod).id
     );

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4459,6 +4459,21 @@ describe('StripeHelper', () => {
           event.data.object.id
         );
       });
+
+      it(`ignores ${type} operations with no customer attached`, async () => {
+        const event = deepCopy(eventPaymentMethodAttached);
+        event.type = type;
+        event.data.object.customer = null;
+        delete event.data.previous_attributes;
+        stripeHelper.stripe.paymentMethods.retrieve = sandbox.stub();
+        stripeFirestore.retrievePaymentMethod = sandbox.stub().resolves({});
+        stripeFirestore.insertPaymentMethodRecordWithBackfill = sandbox.stub();
+        await stripeHelper.processWebhookEventToFirestore(event);
+        sinon.assert.notCalled(
+          stripeHelper.stripeFirestore.insertPaymentMethodRecordWithBackfill
+        );
+        sinon.assert.notCalled(stripeHelper.stripe.paymentMethods.retrieve);
+      });
     }
 
     it('handles payment_method.detached operations', async () => {


### PR DESCRIPTION
Because:

* Payment methods aren't always attached to a user when they're
  added to Stripe.

This commit:

* Ignores payment method changes for unattached payment methods.

Closes #11611

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
