### PR TITLE
FXA-4454 fix(auth): check for unique state on multiple results from Geocoding API

### DIFF
--- a/packages/fxa-auth-server/lib/google-maps-services.ts
+++ b/packages/fxa-auth-server/lib/google-maps-services.ts
@@ -64,8 +64,23 @@ export class GoogleMapsService {
     if (status === Status.ZERO_RESULTS)
       throw new Error(`Could not find any results for address. (${address})`);
 
-    if (results.length > 1)
-      throw new Error(`Could not find unique results. (${address})`);
+    if (results.length > 1) {
+      const stateShortNames = results.map(
+        (result) =>
+          result.address_components.find((addressComponent) =>
+            addressComponent.types.includes(
+              PlaceType2.administrative_area_level_1
+            )
+          )?.short_name
+      );
+      // Check if the state short names match for each result
+      const states = new Set(stateShortNames);
+      if (states.size === 1) {
+        return results[0];
+      } else {
+        throw new Error(`Could not find unique results. (${address})`);
+      }
+    }
 
     return results[0];
   }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -510,7 +510,7 @@ export class StripeHandler {
             paymentMethodId: paymentMethod?.id,
           });
           Sentry.captureMessage(
-            `Cannot find a postal code for customer ${customer.id}`,
+            `Cannot find a postal code for customer.`,
             Sentry.Severity.Error
           );
         });
@@ -613,7 +613,7 @@ export class StripeHandler {
             paymentMethodId: paymentMethod?.id,
           });
           Sentry.captureMessage(
-            `Cannot find a postal code or country for customer ${customer!.id}`,
+            `Cannot find a postal code or country for customer.`,
             Sentry.Severity.Error
           );
         });

--- a/packages/fxa-auth-server/test/local/google-maps-services.js
+++ b/packages/fxa-auth-server/test/local/google-maps-services.js
@@ -26,6 +26,11 @@ const geocodeResultMany = {
             short_name: 'MD',
             types: ['administrative_area_level_1', 'political'],
           },
+          {
+            long_name: '11111',
+            short_name: '11111',
+            types: ['postal_code'],
+          },
         ],
       },
       {
@@ -159,11 +164,11 @@ describe('GoogleMapsServices', () => {
     });
 
     it('Throws error if more than 1 result is returned with mismatching states', async () => {
-      const expectedMessage = 'Could not find unique results. (11111, Germany)';
+      const expectedMessage = 'Could not find unique results. (22222, Germany)';
       googleClient.geocode = sinon.stub().resolves(geocodeResultMany);
 
       try {
-        await googleMapsServices.getStateFromZip('11111', 'DE');
+        await googleMapsServices.getStateFromZip('22222', 'DE');
         assert.fail(expectedMessage);
       } catch (err) {
         assert.equal(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -929,7 +929,7 @@ describe('DirectStripeRoutes', () => {
       );
       sinon.assert.calledOnceWithExactly(
         Sentry.captureMessage,
-        `Cannot find a postal code for customer ${emptyCustomer.id}`,
+        `Cannot find a postal code for customer.`,
         Sentry.Severity.Error
       );
     });
@@ -1262,7 +1262,7 @@ describe('DirectStripeRoutes', () => {
       );
       sinon.assert.calledOnceWithExactly(
         Sentry.captureMessage,
-        `Cannot find a postal code or country for customer ${emptyCustomer.id}`,
+        `Cannot find a postal code or country for customer.`,
         Sentry.Severity.Error
       );
     });


### PR DESCRIPTION
Because:

* The Geocode API could return multiple address results for a given zipcode.
* Those results may have a unique state, so we shouldn't error until we've checked.

This commit:

* Checks for a unique state when multiple results are returned.

Closes #11661

----

Because:

* Sentry was treating each error as unique, when they should be grouped.

This commit:

* Removes the customer id from some Sentry error messages, so they can be correctly grouped.

Closes #11650

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I'm fixing a small one-pointer in this same PR; each ticket has its own commit.
