### PR TITLE
feat(auth): dont report location set on repeat customers

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -500,7 +500,9 @@ export class StripeHandler {
           postalCode: paymentMethod.billing_details.address.postal_code,
           country: sourceCountry,
         });
-      } else {
+      } else if (paymentMethod) {
+        // Only report this if we have a payment method.
+        // Note: Payment method is already on the user if its a returning customer.
         Sentry.withScope((scope) => {
           scope.setContext('createSubscriptionWithPMI', {
             customerId: customer.id,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -934,6 +934,64 @@ describe('DirectStripeRoutes', () => {
       );
     });
 
+    it('does not report to Sentry if the customer has a payment method on file', async () => {
+      const sentryScope = { setContext: sandbox.stub() };
+      sandbox.stub(Sentry, 'withScope').callsFake((cb) => cb(sentryScope));
+      sandbox.stub(Sentry, 'captureMessage');
+
+      delete paymentMethod.billing_details.address;
+      const sourceCountry = 'US';
+      directStripeRoutesInstance.stripeHelper.extractSourceCountryFromSubscription.returns(
+        sourceCountry
+      );
+      const expected = deepCopy(subscription2);
+      directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI.resolves(
+        subscription2
+      );
+      directStripeRoutesInstance.stripeHelper.customerTaxId.returns(false);
+      directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer.resolves({});
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        idempotencyKey: uuidv4(),
+      };
+
+      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
+        VALID_REQUEST
+      );
+
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.getPaymentMethod
+      );
+      sinon.assert.calledWith(
+        directStripeRoutesInstance.customerChanged,
+        VALID_REQUEST,
+        UID,
+        TEST_EMAIL
+      );
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.taxRateByCountryCode
+      );
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.customerTaxId
+      );
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer
+      );
+
+      assert.deepEqual(
+        {
+          sourceCountry,
+          subscription: filterSubscription(expected),
+        },
+        actual
+      );
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.setCustomerLocation
+      );
+      sinon.assert.notCalled(sentryScope.setContext);
+      sinon.assert.notCalled(Sentry.captureMessage);
+    });
+
     it('skips location lookup when source country is not needed', async () => {
       const sourceCountry = 'DE';
       directStripeRoutesInstance.stripeHelper.extractSourceCountryFromSubscription.returns(


### PR DESCRIPTION
Because:

* We already have payment methods on file for repeat customers,
  so there's no reason to report a sentry error as no PMI is included.

This commit:

* Updates the sentry reporting to require a payment method to exist.

Closes #11615

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
