### PR TITLE
feat(auth-server): Don't include email UTM params for metrics opted out users

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -306,6 +306,7 @@ module.exports = function (log, config, bounces) {
     this.verifySecondaryEmailUrl = mailerConfig.verifySecondaryEmailUrl;
     this.verifyPrimaryEmailUrl = mailerConfig.verifyPrimaryEmailUrl;
     this.fluentLocalizer = new FluentLocalizer(new NodeLocalizerBindings());
+    this.metricsEnabled = true;
   }
 
   Mailer.prototype.stop = function () {
@@ -3091,15 +3092,17 @@ module.exports = function (log, config, bounces) {
       parsedLink.searchParams.set(key, value);
     });
 
-    parsedLink.searchParams.set('utm_medium', 'email');
+    if (this.metricsEnabled) {
+      parsedLink.searchParams.set('utm_medium', 'email');
 
-    const campaign = templateNameToCampaignMap[templateName];
-    if (campaign && !parsedLink.searchParams.has('utm_campaign')) {
-      parsedLink.searchParams.set('utm_campaign', UTM_PREFIX + campaign);
-    }
+      const campaign = templateNameToCampaignMap[templateName];
+      if (campaign && !parsedLink.searchParams.has('utm_campaign')) {
+        parsedLink.searchParams.set('utm_campaign', UTM_PREFIX + campaign);
+      }
 
-    if (content) {
-      parsedLink.searchParams.set('utm_content', UTM_PREFIX + content);
+      if (content) {
+        parsedLink.searchParams.set('utm_content', UTM_PREFIX + content);
+      }
     }
 
     const isAccountOrEmailVerification =
@@ -3122,7 +3125,9 @@ module.exports = function (log, config, bounces) {
     appStoreLink,
     playStoreLink
   ) {
-    const { email, uid } = message;
+    const { email, uid, metricsEnabled } = message;
+    // set this to avoid passing `metricsEnabled` around to all link functions
+    this.metricsEnabled = metricsEnabled;
 
     const translator = this.translator(message.acceptLanguage);
     const {

--- a/packages/fxa-auth-server/lib/senders/index.js
+++ b/packages/fxa-auth-server/lib/senders/index.js
@@ -67,6 +67,7 @@ module.exports = async (
             ccEmails: cc,
             email: to || account.email,
             uid: account.uid,
+            metricsEnabled: !account.metricsOptOutAt,
           });
         };
 
@@ -91,6 +92,7 @@ module.exports = async (
       email: emails[0].email,
       primaryEmail: account.email,
       uid: account.uid,
+      metricsEnabled: !account.metricsOptOutAt,
     });
   };
 
@@ -101,6 +103,7 @@ module.exports = async (
       email: emails[0].email,
       primaryEmail: account.email,
       uid: account.uid,
+      metricsEnabled: !account.metricsOptOutAt,
     });
   };
 
@@ -109,6 +112,7 @@ module.exports = async (
       ...options,
       acceptLanguage: options.acceptLanguage || defaultLanguage,
       email: account.primaryEmail.email,
+      metricsEnabled: !account.metricsOptOutAt,
     });
   };
 

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -159,6 +159,7 @@ function sendMail(mailer, messageToSend) {
     unblockCode: '1ILO0Z5P',
     tokenCode: 'LIT12345',
     uid: '6510cb04abd742c6b3e4abefc7e39c9f',
+    metricsEnabled: true,
     productMetadata,
     subscription: {
       planDownloadURL: 'http://getfirefox.com/',

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -108,6 +108,7 @@ const MESSAGE = {
   uaOS: 'Windows',
   uaOSVersion: '10',
   uid: 'uid',
+  metricsEnabled: true,
   unblockCode: 'AS6334PK',
 };
 
@@ -163,6 +164,13 @@ const COMMON_TESTS = new Map([
   ],
 ]);
 
+const COMMON_METRICS_OPT_OUT_TESTS = [
+  { test: 'notInclude', expected: 'utm_source=email' },
+  { test: 'notInclude', expected: 'utm_medium=email' },
+  { test: 'notInclude', expected: 'utm_campaign=' },
+  { test: 'notInclude', expected: 'utm_context=' },
+];
+
 // prettier-ignore
 const TESTS = [
   ['verifySecondaryCodeEmail', new Map([
@@ -203,6 +211,10 @@ const TESTS = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['verifySecondaryCodeEmail', new Map([
+    ['html', COMMON_METRICS_OPT_OUT_TESTS],
+    ['text', COMMON_METRICS_OPT_OUT_TESTS]]),
+      {updateTemplateValues: values => ({...values, metricsEnabled: false })}],
   ['downloadSubscriptionEmail', new Map([
     ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}` }],
     ['headers', new Map([
@@ -233,6 +245,10 @@ const TESTS = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['downloadSubscriptionEmail', new Map([
+    ['html', COMMON_METRICS_OPT_OUT_TESTS],
+    ['text', COMMON_METRICS_OPT_OUT_TESTS]]),
+      {updateTemplateValues: values => ({...values, metricsEnabled: false })}],
   ['subscriptionFirstInvoiceEmail', new Map([
     ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
     ['headers', new Map([

--- a/packages/fxa-auth-server/test/local/senders/index.js
+++ b/packages/fxa-auth-server/test/local/senders/index.js
@@ -39,6 +39,7 @@ describe('lib/senders/index', () => {
     const acct = {
       email: EMAIL,
       uid: UID,
+      metricsOptOutAt: null,
     };
 
     function createSender(config, log) {
@@ -80,6 +81,11 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.verifyEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
           });
       });
     });
@@ -137,6 +143,11 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.recoveryEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -150,13 +161,21 @@ describe('lib/senders/index', () => {
     describe('.sendPasswordChangedEmail()', () => {
       it('should call mailer.passwordChangedEmail()', () => {
         let email;
+        const acctMetricsOptOut = {
+          ...acct,
+          metricsOptOutAt: 1642801160000,
+        };
         return createSender(config)
           .then((e) => {
             email = e;
             email._ungatedMailer.passwordChangedEmail = sinon.spy(() =>
               Promise.resolve({})
             );
-            return email.sendPasswordChangedEmail(EMAILS, acct, {});
+            return email.sendPasswordChangedEmail(
+              EMAILS,
+              acctMetricsOptOut,
+              {}
+            );
           })
           .then(() => {
             assert.equal(
@@ -167,6 +186,11 @@ describe('lib/senders/index', () => {
             const args =
               email._ungatedMailer.passwordChangedEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              false,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -194,6 +218,11 @@ describe('lib/senders/index', () => {
             const args =
               email._ungatedMailer.passwordResetEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -221,6 +250,11 @@ describe('lib/senders/index', () => {
             const args =
               email._ungatedMailer.newDeviceLoginEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -247,6 +281,11 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.postVerifyEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.lengthOf(args[0].ccEmails, 1);
           });
       });
@@ -270,6 +309,11 @@ describe('lib/senders/index', () => {
 
             const args = email._ungatedMailer.unblockCodeEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -306,6 +350,11 @@ describe('lib/senders/index', () => {
                 0
               ).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -342,6 +391,11 @@ describe('lib/senders/index', () => {
                 0
               ).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
+            assert.equal(
+              args[0].metricsEnabled,
+              true,
+              'metricsEnabled correctly set'
+            );
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
               args[0].ccEmails[0],
@@ -374,6 +428,7 @@ describe('lib/senders/index', () => {
           ccEmails: EMAILS.slice(1, 2).map((e) => e.email),
           email: EMAIL,
           productId: 'blee',
+          metricsEnabled: true,
           uid: UID,
         });
       });

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -71,6 +71,7 @@ const MESSAGE = {
   uaOS: 'Windows',
   uaOSVersion: '10',
   uid: 'uid',
+  metricsEnabled: true,
   unblockCode: 'AS6334PK',
   cardType: 'mastercard',
   icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
@@ -175,6 +176,13 @@ const COMMON_TESTS = new Map<string, Test | any>([
     ],
   ],
 ]);
+
+const COMMON_METRICS_OPT_OUT_TESTS: { test: string; expected: string }[] = [
+  { test: 'notInclude', expected: 'utm_source=email' },
+  { test: 'notInclude', expected: 'utm_medium=email' },
+  { test: 'notInclude', expected: 'utm_campaign=' },
+  { test: 'notInclude', expected: 'utm_context=' },
+];
 
 // prettier-ignore
 const TESTS: [string, any, Record<string, any>?][] = [
@@ -473,6 +481,10 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['verifySecondaryCodeEmail', new Map<string, Test | any>([
+    ['html', COMMON_METRICS_OPT_OUT_TESTS],
+    ['text', COMMON_METRICS_OPT_OUT_TESTS]]),
+      {updateTemplateValues: values => ({...values, metricsEnabled: false })}],
 
   ['passwordResetEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Password updated' }],
@@ -1092,6 +1104,10 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['downloadSubscriptionEmail', new Map<string, Test | any>([
+    ['html', COMMON_METRICS_OPT_OUT_TESTS],
+    ['text', COMMON_METRICS_OPT_OUT_TESTS]]),
+      {updateTemplateValues: values => ({...values, metricsEnabled: false })}],
 
   ['subscriptionAccountDeletionEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],


### PR DESCRIPTION
Because:
* Users that have opted out of metrics collection shouldn't have UTM params attached to links in emails

This commit:
* Passes 'metricsEnabled' into the mailer via metricsOptOutAt, which then checks for this value before adding UTM params to links

fixes #10874

---

Thankfully I over-complicated this with my first pass (re: my comments in the bug), with some fresh eyes it wasn't so bad 😛

Running `COMMON_METRICS_OPT_OUT_TESTS` for _every_ template seemed unnecessary, but I can easily add more if preferred.