### PR TITLE
fix(admin-panel): update resp validation for Play subs

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -395,6 +395,7 @@ module.exports.subscriptionsWebSubscriptionSupportValidator = isA.object({
   subscription_id: module.exports.subscriptionsSubscriptionId.required(),
 });
 module.exports.subscriptionsPlaySubscriptionSupportValidator = isA.object({
+  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
   auto_renewing: isA.bool().required(),
   cancel_reason: isA.number().optional(),
   expiry_time_millis: isA.number().required(),

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -771,6 +771,7 @@ describe('lib/routes/validators:', () => {
       subscription_id: 'sub_1Ju0yUBVqmGyQTMaG1mtTbdZ',
     };
     const playSub = {
+      _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
       auto_renewing: false,
       expiry_time_millis: 1591650790000,
       package_name: 'club.foxkeh',


### PR DESCRIPTION
Because:
 - the subscriptions endpoint for the admin-panel was returning 500s for
   customers with Google Play subscriptions

This commit:
 - fix the response validation that was the source of the 500s

## Issue that this pull request solves

Closes: #11491
