### PR TITLE
chore(prettier): Update .prettierignore files to ignore files without inferred parsers

### DIFF
--- a/packages/123done/.prettierignore
+++ b/packages/123done/.prettierignore
@@ -1,6 +1,7 @@
 LICENSE
 .*
 Dockerfile
+Procfile
 *.sh
 *.ico
 *.txt

--- a/packages/fortress/.prettierignore
+++ b/packages/fortress/.prettierignore
@@ -4,5 +4,7 @@ Dockerfile
 *.sh
 *.ico
 *.txt
+*.woff*
+*.ejs
 ansible/*
 static/img/*

--- a/packages/fxa-admin-panel/.prettierignore
+++ b/packages/fxa-admin-panel/.prettierignore
@@ -4,6 +4,7 @@ LICENSE
 *.png
 *.svg
 *.docker
+*.sh
 Dockerfile*
 public/images/*
 coverage/*

--- a/packages/fxa-auth-server/.prettierignore
+++ b/packages/fxa-auth-server/.prettierignore
@@ -4,6 +4,8 @@ LICENSE
 *.sql
 *.sh
 *.txt
+*.ftl
+*.lua
 *.po
 *.pot
 *.graffle

--- a/packages/fxa-customs-server/.prettierignore
+++ b/packages/fxa-customs-server/.prettierignore
@@ -3,3 +3,4 @@ LICENSE
 *.sh
 Dockerfile*
 test/mocks/*
+tap-parallel-not-ok

--- a/packages/fxa-geodb/.prettierignore
+++ b/packages/fxa-geodb/.prettierignore
@@ -1,3 +1,4 @@
 LICENSE
 .*
 db/*
+*.pl

--- a/packages/fxa-payments-server/.prettierignore
+++ b/packages/fxa-payments-server/.prettierignore
@@ -3,11 +3,15 @@ LICENSE
 *.sh
 *.txt
 *.mustache
+*.enc
+*.ftl
+*.po*
 *.ico
 *.png
 *.svg
 *.docker
 *.json-dist
+*.toml
 Dockerfile*
 src/images/*
 public/images/*
@@ -16,3 +20,4 @@ locale/*
 coverage/*
 build/*
 node_modules/*
+secret-env-cipher

--- a/packages/fxa-profile-server/.prettierignore
+++ b/packages/fxa-profile-server/.prettierignore
@@ -5,3 +5,4 @@ LICENSE
 *.png
 Dockerfile*
 *.docker
+*.woff*

--- a/packages/fxa-shared/.prettierignore
+++ b/packages/fxa-shared/.prettierignore
@@ -1,3 +1,4 @@
 LICENSE
 .*
+*.sql
 dist


### PR DESCRIPTION
## Because

- We're currently getting a lot of "No parser cold be inferred for file:" errors when running root <kbd>yarn format</kbd>. 

## This pull request

- Adds a bunch of unsupported file globs to the packages's respective .prettierignore files to silence the noise.

## Issue that this pull request solves

Closes: #11709

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

n/a

## Other information (Optional)

n/a
