### PR TITLE
chore(scripts): Add 'other' assets directory to upload script

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -11,7 +11,6 @@ on:
       - main
     paths:
       - 'assets/**/'
-      - '!assets/other/**'
 
 jobs:
   Upload-assets-to-CDN:
@@ -30,6 +29,7 @@ jobs:
       - name: "Asset upload to stage CDN S3 bucket"
         run: |
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/product-icons  s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
+          aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/other  s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/other
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment  assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
 
       - name: Configure Production AWS credentials
@@ -42,6 +42,7 @@ jobs:
       - name: "Asset upload to production CDN S3 bucket"
         run: |
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/product-icons  s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
+          aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/other  s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/other
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment   assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
 
       - name: "Post to fxa-team Slack channel"


### PR DESCRIPTION
Because:

* the /other/ directory doesn't get uploaded for some reason

This commit:

* adds it to the upload script

Closes #4478

-------------------

Looking for a review from @dlactin or @jbuck .  I noticed the original script was specifically *excluding* the other directory, so, aside from a review for if this will work or not, I want to make sure this is what we want.  Lastly, I noticed it's supposed to be sending a notice to the slack channel, but I'm not sure I've ever seen that notice -- is that hooked up properly?