### PR TITLE
fix(auth-server): wrong apostrophe in plaintext of `subscriptionAccountReminderFirst`

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/index.txt
@@ -1,6 +1,6 @@
 subscriptionAccountReminderFirst-subject = "Reminder: Finish setting up your account"
 
-subscriptionAccountReminderFirst-title = "You can‘t access your subscription yet"
+subscriptionAccountReminderFirst-title = "You can’t access your subscription yet"
 
 subscriptionAccountReminderFirst-content-info = "A few days ago you created a Firefox account but never verified it. We hope you’ll finish setting up your account, so you can use your new subscription."
 


### PR DESCRIPTION
Closes: #11739

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
Old
![subplat - apostrophe issue](https://user-images.githubusercontent.com/28129806/150996707-5f59f36d-db21-410f-b232-27d0ab62670b.PNG)

New
<img width="698" alt="Screen Shot 2022-01-25 at 9 34 27 AM" src="https://user-images.githubusercontent.com/28129806/150996746-36cf28de-0cd4-464c-aa4f-3b0ac35b664d.png">


