### PR TITLE
feature(content): add Product and Category Support field for Zendesk …

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1951,6 +1951,12 @@ const conf = convict({
       env: 'ZENDESK_PRODUCT_NAME_FIELD_ID',
       format: Number,
     },
+    productFieldId: {
+      doc: 'Zendesk support ticket custom field for the product drop down',
+      default: 360047198211,
+      env: 'ZENDESK_PRODUCT_FIELD_ID',
+      format: Number,
+    },
     locationCityFieldId: {
       doc: 'Zendesk support ticket custom field for the city of the location',
       default: 360026463311,
@@ -1973,6 +1979,12 @@ const conf = convict({
       doc: 'Zendesk support ticket custom field for topic',
       default: 360028484432,
       env: 'ZENDESK_TOPIC_FIELD_ID',
+      format: Number,
+    },
+    categoryFieldId: {
+      doc: 'Zendesk support ticket category field for category drop down',
+      default: 360047206172,
+      env: 'ZENDESK_CATEGORY_FIELD_ID',
       format: Number,
     },
     appFieldId: {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
@@ -97,9 +97,11 @@ export const supportRoutes = (
 
         const {
           productName,
+          product,
           productPlatform,
           productVersion,
           topic,
+          category,
           app,
           subject: payloadSubject,
           message,
@@ -111,12 +113,14 @@ export const supportRoutes = (
 
         const {
           productNameFieldId,
+          productFieldId,
           productPlatformFieldId,
           productVersionFieldId,
           locationCityFieldId,
           locationStateFieldId,
           locationCountryFieldId,
           topicFieldId,
+          categoryFieldId,
           appFieldId,
         } = config.zendesk;
 
@@ -130,9 +134,11 @@ export const supportRoutes = (
             },
             custom_fields: [
               { id: productNameFieldId, value: productName },
+              { id: productFieldId, value: product },
               { id: productPlatformFieldId, value: productPlatform },
               { id: productVersionFieldId, value: productVersion },
               { id: topicFieldId, value: topic },
+              { id: categoryFieldId, value: category },
               { id: appFieldId, value: app },
               { id: locationCityFieldId, value: location?.city },
               { id: locationStateFieldId, value: location?.state },

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -171,9 +171,11 @@ describe('support', () => {
     payload: {
       plan: '123done',
       productName: 'FxA - 123done Pro',
+      product: '',
       productPlatform: 'BeOS',
       productVersion: '5',
-      topic: 'Billing',
+      topic: 'Payments & Billing',
+      category: 'payment',
       app: 'FxOS Client',
       subject: 'Change of address',
       message: 'How do I change it?',
@@ -195,9 +197,11 @@ describe('support', () => {
 
     const customFieldsOnTicket = [
       'FxA - 123done Pro',
+      '',
       requestOptions.payload.productPlatform,
       requestOptions.payload.productVersion,
       requestOptions.payload.topic,
+      'payment',
       requestOptions.payload.app,
       'Mountain View',
       'California',

--- a/packages/fxa-content-server/app/scripts/models/support-form.js
+++ b/packages/fxa-content-server/app/scripts/models/support-form.js
@@ -26,6 +26,22 @@ const LOWERED_TOPICS = [
   t('not listed'),
 ];
 
+const PRODUCT_TAGS = {
+  'Mozilla VPN': 'firefox-private-network-vpn',
+  'Firefox Relay': 'relay',
+  'Firefox Account': 'firefox_accounts',
+  'Firefox Private Network': 'firefox-private-netowrk',
+  Other: 'product_other',
+};
+
+const CATEGORY_TAGS = {
+  'Payment & billing': 'payment',
+  'Account issues': 'accounts',
+  'Technical issues': 'technical',
+  'Provide feedback / request features': 'feedback',
+  'Not listed': 'not_listed',
+};
+
 const topicOptions = _.zipWith(TOPICS, LOWERED_TOPICS, (topic, lowered) => ({
   topic,
   lowered,
@@ -47,6 +63,12 @@ const SupportForm = Backbone.Model.extend({
   getLoweredTopic: function (topic) {
     const selected = topicOptions.find((t) => t.topic === topic);
     return selected ? selected.lowered : topic;
+  },
+  getProductTag: function (product) {
+    return PRODUCT_TAGS[product] || '';
+  },
+  getCategoryTag: function (category) {
+    return CATEGORY_TAGS[category] || '';
   },
 });
 

--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -195,12 +195,15 @@ const SupportView = BaseView.extend({
       this.appEl.trigger('chosen:updated');
     }
 
+    const topic = this.topicEl.val();
     this.supportForm.set({
       productName: this.formatProductName(productName),
-      topic: this.topicEl.val(),
+      topic: topic,
       app: this.appEl.val() || '',
       subject: this.subjectEl.val().trim(),
       message: this.messageEl.val().trim(),
+      product: this.supportForm.getProductTag(productName),
+      category: this.supportForm.getCategoryTag(topic),
     });
 
     if (this.supportForm.isValid()) {

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -36,6 +36,8 @@ describe('views/support', function () {
     app: 'Mobile',
     subject: '',
     message: 'inquiries from generals',
+    product: '',
+    category: 'payment',
   };
 
   function createSupportView() {
@@ -88,6 +90,12 @@ describe('views/support', function () {
         product_id: '123done_xyz',
         product_name: '123Done Pro',
       },
+      {
+        plan_id: 'moz_vpn_9001',
+        product_id: 'moz_vpn_premium',
+        product_name: 'Mozilla VPN',
+        product_metadata: {},
+      },
     ]);
     sinon.stub(account, 'fetchSubscriptionPlans').resolves([
       {
@@ -103,6 +111,12 @@ describe('views/support', function () {
         plan_id: 'foobar_9001',
         product_id: 'foobar_plus',
         product_name: 'FooBar Plus',
+        product_metadata: {},
+      },
+      {
+        plan_id: 'moz_vpn_9001',
+        product_id: 'moz_vpn_premium',
+        product_name: 'Mozilla VPN',
         product_metadata: {},
       },
     ]);
@@ -251,10 +265,46 @@ describe('views/support', function () {
         })
         .then(function () {
           view
-            .$('#product option:eq(2)')
+            .$('#product option:eq(3)')
             .prop('selected', true)
             .trigger('change');
           assert.equal(view.supportForm.get('productName'), 'FxA - Other');
+        });
+    });
+    it('should populate the correct product tag when selected', function () {
+      return view
+        .render()
+        .then(function () {
+          view.afterVisible();
+          $('#container').append(view.el);
+        })
+        .then(function () {
+          view
+            .$('#product option:eq(2)')
+            .prop('selected', true)
+            .trigger('change');
+          assert.equal(
+            view.supportForm.get('product'),
+            'firefox-private-network-vpn'
+          );
+        });
+    });
+  });
+
+  describe('category', function () {
+    it('should be the tag of the selected topic', function () {
+      return view
+        .render()
+        .then(function () {
+          view.afterVisible();
+          $('#container').append(view.el);
+        })
+        .then(function () {
+          view
+            .$('#topic option:eq(1)')
+            .prop('selected', true)
+            .trigger('change');
+          assert.equal(view.supportForm.get('category'), 'payment');
         });
     });
   });


### PR DESCRIPTION
## Because

Support wants to transition the product name and topic fields into drop downs. They have created new custom fields in Zendesk.

## This pull request

Adds new product and category fields to the zendesk config
Updates the metadata of these fields in the support form.

## Issue that this pull request solves

Closes: # 10734

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
