### PR TITLE
fix(auth): Copy 'public' to dist, don't load non-existent Fluent bundles, Fluent strategy tweak

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -7,9 +7,7 @@ import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { negotiateLanguages } from '@fluent/langneg';
 import { LocalizerBindings, TemplateContext } from './localizer-bindings';
 import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
-import { PatternElement, VariableReference } from '@fluent/bundle/esm/ast';
-
-const OTHER_EN_LOCALES = ['en-NZ', 'en-SG', 'en-MY'];
+import { EN_GB_LOCALES } from 'fxa-shared/l10n/otherLanguages';
 
 const RTL_LOCALES = [
   'ar',
@@ -31,38 +29,23 @@ class FluentLocalizer {
     this.bindings = bindings;
   }
 
-  async localizeEmail(context: TemplateContext) {
-    const { acceptLanguage, template, layout } = context;
-    const parsedLocales = acceptLanguage.split(',');
-    const userLocales: string[] = [];
-
-    for (let locale of parsedLocales) {
-      locale = locale.replace(/^\s*/, '').replace(/\s*$/, '');
-      const [lang] = locale.split(';');
-      userLocales.push(lang);
-    }
-
-    const currentLocales = negotiateLanguages(
-      [...userLocales],
-      [...OTHER_EN_LOCALES, ...availableLocales],
-      {
-        defaultLocale: 'en',
-      }
-    );
-
+  protected async fetchMessages(currentLocales: string[]) {
     const fetched: Record<string, string> = {};
-    for (const locale of currentLocales.filter(
-      (l) => !OTHER_EN_LOCALES.includes(l)
-    )) {
+    for (const locale of currentLocales) {
       fetched[locale] = await this.bindings.fetchLocalizationMessages(locale);
     }
+    return fetched;
+  }
 
-    let selectedLocale: string = 'en';
+  protected getSelectedLocale(currentLocales: string[]) {
+    return currentLocales[0] || 'en';
+  }
+
+  protected createBundleGenerator(fetched: Record<string, string>) {
     async function* generateBundles(currentLocales: string[]) {
       for (const locale of currentLocales) {
         const source = fetched[locale];
-        if (source !== '') {
-          selectedLocale = locale;
+        if (source) {
           const bundle = new FluentBundle(locale, {
             useIsolating: false,
           });
@@ -73,7 +56,22 @@ class FluentLocalizer {
       }
     }
 
+    return generateBundles;
+  }
+
+  async setupLocalizer(acceptLanguage: string) {
+    const currentLocales = parseAcceptLanguage(acceptLanguage);
+    const messages = await this.fetchMessages(currentLocales);
+    const selectedLocale = this.getSelectedLocale(currentLocales);
+    const generateBundles = this.createBundleGenerator(messages);
     const l10n = new DOMLocalization(currentLocales, generateBundles);
+
+    return { currentLocales, messages, generateBundles, selectedLocale, l10n };
+  }
+
+  async localizeEmail(context: TemplateContext) {
+    const { acceptLanguage, template, layout } = context;
+    const { l10n, selectedLocale } = await this.setupLocalizer(acceptLanguage);
 
     context = { ...context, ...context.templateValues };
     if (template !== '_storybook') {
@@ -147,6 +145,40 @@ export function splitPlainTextLine(plainText: string) {
   const val = matches?.groups?.val;
 
   return { key, val };
+}
+
+export function parseAcceptLanguage(acceptLanguage: string) {
+  const parsedLocales = acceptLanguage.split(',');
+  const userLocales: string[] = [];
+
+  for (let locale of parsedLocales) {
+    locale = locale.replace(/^\s*/, '').replace(/\s*$/, '');
+    let [lang] = locale.split(';');
+
+    if (EN_GB_LOCALES.includes(lang)) {
+      lang = 'en-GB';
+    }
+
+    if (!userLocales.includes(lang)) {
+      userLocales.push(lang);
+    }
+  }
+
+  /*
+   * We use the 'matching' strategy because the default strategy, 'filtering', will load all English locales
+   * with dialects included, e.g. `en-CA`, even when the user prefers 'en' or 'en-US', which would then be
+   * shown instead of the English (US) fallback text.
+   */
+  const currentLocales = negotiateLanguages(
+    [...userLocales],
+    [...availableLocales],
+    {
+      defaultLocale: 'en',
+      strategy: 'matching',
+    }
+  );
+
+  return currentLocales;
 }
 
 export default FluentLocalizer;

--- a/packages/fxa-auth-server/lib/senders/emails/localizer-bindings-node.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/localizer-bindings-node.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { JSDOM } from 'jsdom';
 import {
   LocalizerBindings,
@@ -48,7 +48,14 @@ export class NodeLocalizerBindings extends LocalizerBindings {
       opts
     );
 
-    console.log('l10n path', this.opts?.l10n?.basePath);
+    // Make sure config is legit
+    this.validateConfig();
+  }
+
+  protected validateConfig() {
+    if (!existsSync(this.opts.l10n.basePath)) {
+      throw new Error('Invalid l10n basePath');
+    }
   }
 
   protected async fetchResource(path: string): Promise<string> {

--- a/packages/fxa-auth-server/lib/senders/emails/localizer-bindings.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/localizer-bindings.ts
@@ -96,6 +96,8 @@ export abstract class LocalizerBindings {
    * @param locale Locale to use, defaults to en.
    */
   async fetchLocalizationMessages(locale?: string) {
+    // note: 'en' auth.ftl only exists for browser bindings / Storybook
+    // the fallback English strings within the templates will be shown in other envs
     const path = `${this.opts.l10n.basePath}/${locale || 'en'}/auth.ftl`;
 
     try {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "yarn emails-scss && tsc --build && cp -R config fxa-content-server-l10n lib scripts dist/fxa-auth-server",
+    "build": "yarn emails-scss && tsc --build && cp -R config fxa-content-server-l10n public lib scripts dist/fxa-auth-server",
     "bump-template-versions": "node scripts/template-version-bump",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint .",

--- a/packages/fxa-auth-server/test/local/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails/fluent-localizer.ts
@@ -2,13 +2,154 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { FluentBundle, FluentResource } from '@fluent/bundle';
 import chai, { assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { splitPlainTextLine } from '../../../../lib/senders/emails/fluent-localizer';
+import FluentLocalizer, {
+  splitPlainTextLine,
+  parseAcceptLanguage,
+} from '../../../../lib/senders/emails/fluent-localizer';
+
+import { NodeLocalizerBindings } from '../../../../lib/senders/emails/localizer-bindings-node';
 
 chai.use(chaiAsPromised);
 
 describe('fluent localizer', () => {
+  describe('fetches bundles', () => {
+    let LocalizerBindings = new NodeLocalizerBindings();
+    let localizer = new FluentLocalizer(LocalizerBindings);
+
+    it('fails with a bad localizer 1l0n basePath', () => {
+      assert.throws(() => {
+        let LocalizerBindings = new NodeLocalizerBindings({
+          l10n: {
+            basePath: '/not/a/apth',
+          },
+        });
+        new FluentLocalizer(LocalizerBindings);
+      }, 'Invalid l10n basePath');
+    });
+
+    it('produces the current locales', async () => {
+      const { currentLocales } = await localizer.setupLocalizer(
+        'de-CH,it;q=0.8,en-US;q=0.5,en;q=0.3'
+      );
+
+      assert.deepEqual(currentLocales, ['de', 'it', 'en-US', 'en']);
+    });
+
+    it('selects the proper locale', async () => {
+      const { selectedLocale } = await localizer.setupLocalizer(
+        'de-DE,en-US;q=0.7,en;q=0.3'
+      );
+
+      assert.equal(selectedLocale, 'de');
+    });
+
+    it('generates a proper bundle', async () => {
+      const { generateBundles } = await localizer.setupLocalizer('de,en');
+
+      const bundles: Array<FluentBundle> = [];
+      for await (const bundle of generateBundles(['de'])) {
+        bundles.push(bundle);
+      }
+
+      assert.lengthOf(bundles, 1);
+      assert.include(bundles[0].locales, 'de');
+    });
+
+    describe('localizes properly', () => {
+      it('localizes properly with preferred language', async () => {
+        const { l10n } = await localizer.setupLocalizer(
+          'de-DE,en-US;q=0.7,en;q=0.3'
+        );
+
+        const result = await l10n.formatValue(
+          'subscriptionAccountFinishSetup-action',
+          {}
+        );
+
+        assert.equal(result, 'Passwort erstellen');
+      });
+
+      it('localizes properly with preferred Dialect', async () => {
+        const { l10n } = await localizer.setupLocalizer(
+          'en-GB,en-CA;q=0.7,en;q=0.3'
+        );
+
+        const result = await l10n.formatValue('unblockCode-prompt', {});
+
+        assert.equal(
+          result,
+          'If yes, here is the authorisation code you need:'
+        );
+      });
+    });
+  });
+
+  describe('lanugage negotiation', () => {
+    it('handles empty case', () => {
+      const result = parseAcceptLanguage('');
+
+      assert.deepEqual(result, ['en']);
+    });
+
+    it('ignores unknown language', () => {
+      const result = parseAcceptLanguage('zy');
+      assert.deepEqual(result, ['en']);
+    });
+
+    it('handles en case', () => {
+      const result = parseAcceptLanguage('en');
+
+      // Note: We are using the 'filtering' mode for negotiate languages so all are going to be provided
+      assert.deepEqual(result, ['en']);
+    });
+
+    it('handles en-* case', () => {
+      const result = parseAcceptLanguage('en-US');
+
+      // Note: We are using the 'filtering' mode for negotiate languages so all are english dialects are going to be provided
+      assert.deepEqual(result, ['en-US', 'en']);
+    });
+
+    it('handles alias to en-GB', () => {
+      const result = parseAcceptLanguage('en-NZ');
+
+      assert.deepEqual(result, ['en-GB', 'en']);
+    });
+
+    it('always has default language, en, present', () => {
+      const result = parseAcceptLanguage('de');
+
+      assert.deepEqual(result, ['de', 'en']);
+    });
+
+    it('is falls back to root language if dialect is missing', () => {
+      const result = parseAcceptLanguage('fr-FR');
+
+      assert.deepEqual(result, ['fr', 'en']);
+    });
+
+    it('resolves dialects', () => {
+      const result = parseAcceptLanguage('es-MX');
+
+      assert.deepEqual(result, ['es-MX', 'en']);
+    });
+
+    it('handles multiple languages', () => {
+      const result = parseAcceptLanguage('ja, de-CH, en-US, en');
+
+      assert.deepEqual(result, ['ja', 'de', 'en-US', 'en']);
+    });
+
+    it('handles multiple languages with en-GB alias', () => {
+      const result = parseAcceptLanguage('en-NZ, en-GB, en-MY');
+
+      assert.deepEqual(result, ['en-GB', 'en']);
+    });
+  });
+
   describe('key value extraction', () => {
     const pair = {
       key: 'foo_2-Bar',

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -6,10 +6,8 @@ import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { negotiateLanguages } from '@fluent/langneg';
 import { LocalizationProvider, ReactLocalization } from '@fluent/react';
 import React, { Component } from 'react';
-
 import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
-
-const OTHER_EN_LOCALES = ['en-NZ', 'en-SG', 'en-MY'];
+import { EN_GB_LOCALES } from 'fxa-shared/l10n/otherLanguages';
 
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {
@@ -41,7 +39,7 @@ async function createFluentBundleGenerator(
 ) {
   const fetched = await Promise.all(
     currentLocales
-      .filter((l) => !OTHER_EN_LOCALES.includes(l))
+      .filter((l) => !EN_GB_LOCALES.includes(l))
       .map(async (locale) => {
         return { [locale]: await fetchAllMessages(baseDir, locale, bundles) };
       })
@@ -51,7 +49,7 @@ async function createFluentBundleGenerator(
 
   return function* generateFluentBundles() {
     for (const locale of currentLocales) {
-      const sourceLocale = OTHER_EN_LOCALES.includes(locale) ? 'en-GB' : locale;
+      const sourceLocale = EN_GB_LOCALES.includes(locale) ? 'en-GB' : locale;
       const cx = new FluentBundle(locale);
       for (const i of mergedBundle[sourceLocale]) {
         const resource = new FluentResource(i);
@@ -100,7 +98,7 @@ export default class AppLocalizationProvider extends Component<Props, State> {
 
     const currentLocales = negotiateLanguages(
       [...userLocales],
-      [...OTHER_EN_LOCALES, ...availableLocales],
+      [...EN_GB_LOCALES, ...availableLocales],
       {
         defaultLocale: 'en-US',
       }

--- a/packages/fxa-shared/l10n/otherLanguages.ts
+++ b/packages/fxa-shared/l10n/otherLanguages.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * These do not exist in the l10n repo, but we want users with these locales to
+ * receive the 'en-GB' translations to see 'US $x.xx' instead of the en fallback '$x.xx'
+ * which is ambiguous.
+ */
+export const EN_GB_LOCALES = ['en-NZ', 'en-SG', 'en-MY'];


### PR DESCRIPTION
Because:
* For Fluent translations, we pull in ftl files from public/locales, which wasn't present in dist
* Fluent was attempting to load bundles from 'OTHER_EN_LOCALES' which was causing "missing translation" errors
* We were attempting to load English dialects that may not have been correct, e.g. showing 'en-CA' dialect to US users, due to the Fluent strategy

This commit:
* Adds 'public' dir to fxa-auth-server copy list on build
* Tells the bundler to load 'en-GB' if the user locale matches one in 'OTHER_EN_LOCALES', moved into 'fxa-shared' to share with Payments and renamed to EN_GB_LOCALES
* Changes the Fluent strategy from 'filtering' to 'matching'
* Adds tests

fixes #11745

---

I think unfortunately when we work on #11529 is the right time to add the tests for this.

To repro locally:
* Change your browser language to something else, like German (de)
* Change auth-server's `dev.json` `mjmlEnabledEmail` to whatever you want to use locally (currently `b@c.com`)
* Run `yarn build` in the auth server off of `main`
* `yarn start` FxA, then in the auth server, stop the auth process, go into `dist`, and run `yarn start`
* Use MailDev. Register for a new account locally, observe that the sign up email is only partially translated (some gettext translations still exist, will be taken care of in #11471)

To see the fix, follow the same steps as above except run the yarn commands in this branch.