### PR TITLE
fix(subscriptions): fix product/plan webhook event handling

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -34,6 +34,11 @@ import { StripeHandler } from './stripe';
 // object in the request payload.  Products and plans are excluded because
 // `expandResource` uses the cached lists for products and plans, but the
 // cached lists themselves are updated through webhooks.
+//
+// 'price' is included in this list of exclusion because the Prices API
+// replaced Plans, but since it is backwards compatible, we haven't needed to
+// update our plans handling code.  Prices should be treated in the same
+// fashion as plans, so it's on this list.
 const BYPASS_LATEST_FETCH_TYPES = ['plan', 'price', 'product'];
 const ALLOWED_EXPAND_RESOURCE_TYPES = Object.fromEntries(
   Object.entries(STRIPE_OBJECT_TYPE_TO_RESOURCE).filter(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -277,14 +277,10 @@ describe('StripeWebhookHandler', () => {
       });
 
       describe('when the event.type is coupon.created', () => {
-        itOnlyCallsThisHandler(
-          'handleCouponEvent',
-          {
-            data: { object: { id: 'coupon_123', object: 'coupon' } },
-            type: 'coupon.created',
-          },
-          false
-        );
+        itOnlyCallsThisHandler('handleCouponEvent', {
+          data: { object: { id: 'coupon_123', object: 'coupon' } },
+          type: 'coupon.created',
+        });
 
         itOnlyCallsThisHandler(
           'handleCouponEvent',

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -208,7 +208,8 @@ describe('StripeWebhookHandler', () => {
       const itOnlyCallsThisHandler = (
         expectedHandlerName,
         event,
-        expectSentry = false
+        expectSentry = false,
+        expectExpandResource = true
       ) =>
         it(`only calls ${expectedHandlerName}`, async () => {
           const createdEvent = deepCopy(event);
@@ -227,11 +228,11 @@ describe('StripeWebhookHandler', () => {
               scopeContextSpy.notCalled,
               'Expected to not call Sentry'
             );
-            assert.isTrue(
-              StripeWebhookHandlerInstance.stripeHelper.expandResource
-                .calledOnce
-            );
           }
+          assert.equal(
+            StripeWebhookHandlerInstance.stripeHelper.expandResource.calledOnce,
+            expectExpandResource
+          );
         });
 
       describe('ignorable errors', () => {
@@ -276,10 +277,14 @@ describe('StripeWebhookHandler', () => {
       });
 
       describe('when the event.type is coupon.created', () => {
-        itOnlyCallsThisHandler('handleCouponEvent', {
-          data: { object: { id: 'coupon_123', object: 'coupon' } },
-          type: 'coupon.created',
-        });
+        itOnlyCallsThisHandler(
+          'handleCouponEvent',
+          {
+            data: { object: { id: 'coupon_123', object: 'coupon' } },
+            type: 'coupon.created',
+          },
+          false
+        );
 
         itOnlyCallsThisHandler(
           'handleCouponEvent',
@@ -287,7 +292,8 @@ describe('StripeWebhookHandler', () => {
             data: { object: { id: 'coupon_123' } },
             type: 'coupon.created',
           },
-          true
+          true,
+          false
         );
       });
 
@@ -343,14 +349,18 @@ describe('StripeWebhookHandler', () => {
       describe('when the event.type is product.updated', () => {
         itOnlyCallsThisHandler(
           'handleProductWebhookEvent',
-          eventProductUpdated
+          eventProductUpdated,
+          false,
+          false
         );
       });
 
       describe('when the event.type is plan.updated', () => {
         itOnlyCallsThisHandler(
           'handlePlanCreatedOrUpdatedEvent',
-          eventPlanUpdated
+          eventPlanUpdated,
+          false,
+          false
         );
       });
 

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -110,8 +110,8 @@
     "sinon": "^9.0.3",
     "style-loader": "^1.3.0",
     "supertest": "^6.2.2",
-    "ts-jest": "^27.1.3",
     "tailwindcss": "1.9.1",
+    "ts-jest": "^27.1.3",
     "typescript": "^4.5.2",
     "wait-for-expect": "^3.0.2",
     "webpack": "^4.43.0"


### PR DESCRIPTION
Because:
 - while handling a product or plan webhook event, we try to use the
   product or plan from the cache; however, the products and plans in
   the cache are updated through webhook events, so no product or plan
   can ever be added or updated

This:
 - exclude product and plan/price from the types that require fetching
   the latest object during webhook event handling


## Issue that this pull request solves

Closes: #11750
