### PR TITLE
fix(auth-server): `subscriptionAccountFinishSetup` email has strings in purple

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
@@ -28,6 +28,11 @@
   @extend .mb-6;
 }
 
+// NOTE: some list items appeared purple in stage
+.text-body li {
+  color: global.$grey-500 !important;
+}
+
 .text-body-no-bottom-margin div {
   @extend %text-body-common;
   @extend .mb-0;


### PR DESCRIPTION
While I unable to reproduce the bug within the issue, the revised stylesheet sets the font color of `li` items to match the rest of the `div`.

## Issue that this pull request solves

Closes: #11759

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old
![Screen Shot 2022-01-26 at 12 54 06](https://user-images.githubusercontent.com/28129806/151382405-7a7b3b99-6bd9-44a9-96b4-106d0dcb3acc.png)

Current
<img width="1165" alt="Screen Shot 2022-01-27 at 9 58 36 AM" src="https://user-images.githubusercontent.com/28129806/151384269-de7bc770-fd29-47b7-bf89-4e3fc9126a1c.png">

