### PR TITLE
chore(repo): set fxa-devs to own all things

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mozilla/fxa-devs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-/assets/ @mozilla/fxa-devs


### PR DESCRIPTION
Because:
 - we shouldn't depend on humans to remember to request a PR review from
   mozilla/fxa-devs

This commit:
 - update and move CODEOWNERS so that mozilla/fxa-devs is the owner of
   the entire repo

