### PR TITLE
fix(auth-server): different order of text in plaintext version of `postRemoveAccountRecovery`

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.txt
@@ -4,9 +4,9 @@ postRemoveAccountRecovery-description = "You have successfully removed an accoun
 
 <%- include('/partials/location/index.txt') %>
 
-<%- include('/partials/manageAccount/index.txt') %>
-
 postRemoveAccountRecovery-invalid = "This recovery key can no longer be used to recover your account."
+
+<%- include('/partials/manageAccount/index.txt') %>
 
 <%- include('/partials/changePassword/index.txt') %>
 


### PR DESCRIPTION
## Because

- “This recovery key can no longer be used…“ should be displayed after the Manage account link.

## This pull request

- Fixes the plaintext version

## Issue that this pull request solves

Closes: #11770

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![postRemoveAccRecovery - sentence placed different](https://user-images.githubusercontent.com/28129806/151439045-f5a2dca3-04ba-48be-8188-855a5edfe36f.PNG)

New:
<img width="804" alt="Screen Shot 2022-01-27 at 3 33 37 PM" src="https://user-images.githubusercontent.com/28129806/151439121-5cbfa029-7f0f-439e-8c16-578f6b424723.png">

