### PR TITLE
feat(subscriptions): add feature flag for Firestore product configs

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -928,6 +928,14 @@ const conf = convict({
         env: 'SUBSCRIPTIONS_PLAY_API_ENABLED',
       },
     },
+    productConfigsFirestore: {
+      enabled: {
+        default: false,
+        doc: 'Whether to use Firestore for product configurations',
+        env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED',
+        format: Boolean,
+      },
+    },
     sharedSecret: {
       doc: 'Shared secret for authentication between backend subscription services',
       format: String,

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -688,7 +688,13 @@ const conf = (module.exports = convict({
       default: true,
       doc: 'Whether to allow any redirects to Payments for an unauthenticated user',
       env: 'SUBSCRIPTIONS_UNAUTHED_REDIRECTS',
-      formlat: Boolean,
+      format: Boolean,
+    },
+    useFirestoreProductConfigs: {
+      default: false,
+      doc: 'Feature flag on whether to expect Firestore (and not Stripe metadata) based product and plan configurations',
+      env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED',
+      format: Boolean,
     },
   },
   surveyFeature: {

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -17,6 +17,12 @@ const conf = convict({
       env: 'FEATURE_SHOW_COUPON',
       format: Boolean,
     },
+    useFirestoreProductConfigs: {
+      default: false,
+      doc: 'Feature flag on whether to expect Firestore (and not Stripe metadata) based product and plan configurations',
+      env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED',
+      format: Boolean,
+    },
   },
   amplitude: {
     enabled: {


### PR DESCRIPTION
Because:
 - we want a feature flag to control the source of the product and plan
   configurations, toggling between Stripe metadata (false) and
   Firestore (true)

This commit:
 - add a feature flag config to the auth, payments, and content servers

## Issue that this pull request solves

Closes: #10354 