### PR TITLE
feat(config): Add options for connection pool limit & queue limit

### DIFF
--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -186,6 +186,14 @@ const conf = convict({
       default: '3306',
       env: 'MYSQL_PORT',
     },
+    connectionLimit: {
+      default: 10,
+      env: 'MYSQL_CONNECTION_LIMIT',
+    },
+    queueLimit: {
+      default: 0,
+      env: 'MYSQL_QUEUE_LIMIT',
+    },
   },
   oauth: {
     url: {


### PR DESCRIPTION
## Because

- We want to increase the mysql connection limit

## This pull request

- Adds an option to configure the mysql connection limit (and the queue limit just in case)

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
