### PR TITLE
fix(auth-server): Payment method not displayed for subscriptionSubsequentInvoice template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
@@ -28,7 +28,7 @@
   @extend .mb-6;
 }
 
-// NOTE: some list items appeared purple in stage
+// NOTE: appeared purple in at least one instance/email client in stage
 .text-body li {
   color: global.$grey-500 !important;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -3,13 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
 <mj-text css-class="text-body margin-top">
-  <span data-l10n-id="payment-method">Payment Method: </span>
-
   <% if (payment_provider === 'paypal') { %>
+    <span data-l10n-id="payment-method">Payment Method: </span>
     <span>PayPal</span>
-  <% } %>
-
-  <% if (payment_provider === "stripe" && lastFour) { %>
+  <% } else { %>
+    <span data-l10n-id="payment-method">Payment Method: </span>
     <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
       <%- cardType %> card ending in <%- lastFour %>
     </span>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,7 +1,3 @@
-<% if (payment_provider === "paypal") { %>
-    payment-provider-paypal-plaintext = "Payment Method: PayPal"
-<% } %>
-<% if (payment_provider === "stripe" && lastFour) { %>
-    payment-method = "Payment Method: "
-    card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"
-<% } %>
+<% if (payment_provider === "paypal") { %>payment-provider-paypal-plaintext = "Payment Method: PayPal"
+<% } else {%>payment-method = "Payment Method: "
+card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.txt
@@ -5,12 +5,9 @@ subscriptionSubsequentInvoice-title = "Thank you for being a subscriber!"
 subscriptionSubsequentInvoice-content-received = "We received your latest payment for <%- productName %>."
 
 subscriptionSubsequentInvoice-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
-<% if (showProratedAmount) { %>
-subscriptionSubsequentInvoice-content-plan-change = "Plan change: <%- paymentProrated %>"
-<% } %>
+<% if (showProratedAmount) { %>subscriptionSubsequentInvoice-content-plan-change = "Plan change: <%- paymentProrated %>"<% } %>
 subscriptionSubsequentInvoice-content-charged = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
-<%- include ('/partials/viewInvoice/index.txt') %>
-<%- include ('/partials/paymentProvider/index.txt') %>
+<%- include ('/partials/viewInvoice/index.txt') %><%- include ('/partials/paymentProvider/index.txt') %>
 subscriptionSubsequentInvoice-content-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
 
 <%- include ('/partials/subscriptionSupport/index.txt') %>


### PR DESCRIPTION
## Because

- Payment method value is missing after label

## This pull request

- Moves "Payment method: " label within conditional (`fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml`)
- Refactors and cleans up spacing in plaintext to match HTML version
  - `fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt `
  - `fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.txt `
- Revises comment with more detail
  - `fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss`
## Issue that this pull request solves

Closes: #11786

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old - HTML
![Ge - subscrSubsequentInvoice - pay method missing](https://user-images.githubusercontent.com/28129806/151810603-f9302d71-a179-4679-985f-ae86b1d1f2cf.PNG)
Old - plaintext
<img width="910" alt="Screen Shot 2022-01-31 at 9 28 54 AM" src="https://user-images.githubusercontent.com/28129806/151811586-ed1ebeb6-9dbf-4884-a956-773584580fa8.png">

New - German
<img width="1264" alt="Screen Shot 2022-01-31 at 9 21 37 AM" src="https://user-images.githubusercontent.com/28129806/151810304-f36ca421-36a7-48f2-8c31-a30634c5d396.png">

New - English
<img width="1262" alt="Screen Shot 2022-01-31 at 9 31 09 AM" src="https://user-images.githubusercontent.com/28129806/151812063-4f7d04f8-ab4e-4a7a-9093-f1912a67af08.png">
