### PR TITLE
fix(settings): Disconnect all associated clients/sessions for given client name on sign out

### DIFF
--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -1,6 +1,11 @@
-import { ApolloClient, createHttpLink, from } from '@apollo/client';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ApolloClient, from } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { ErrorHandler, onError } from '@apollo/client/link/error';
+import { BatchHttpLink } from '@apollo/client/link/batch-http';
 import { cache, sessionToken, typeDefs } from './cache';
 
 export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
@@ -32,7 +37,7 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
 
 export function createApolloClient(gqlServerUri: string) {
   // httpLink makes the actual requests to the server
-  const httpLink = createHttpLink({
+  const httpLink = new BatchHttpLink({
     uri: `${gqlServerUri}/graphql`,
   });
 


### PR DESCRIPTION
Because:
* Since we display only unique client/service names in the UI, users were having to click 'Sign out' multiple times before the session appeared to be cleared if they had multiple sessions of the same service name

This commit:
* Uses Promise.all to disconnect all clients associated with the selected client if multiple sessions exist

fixes #11559
fixes #11658

---

One way to reproduce this and the fix locally, assuming your Nightly version doesn't match FF:
1. On `main`, create/login to an account locally on Nightly
1. Open a private window in Nightly and login to that account - this creates two sessions under one name
1. Log in on FF (not Nightly). Click "sign out" for the Nightly session. Refresh the page, and see that the Nightly session is still present

To verify the fix:
* On this branch, when refreshing the page on step 3, you'll see the Nightly session is no longer present

Also, it's possible we could send all the mutation requests up in one network request instead of using a `Promise.all` for parallel requests, but it'd be more leg work and from what I've seen I don't think users are typically amassing more than 2-3 unique sessions where the performance gains would be minimal.