### PR TITLE
fix(subscriptions): stop considering unverified stub accts as existing

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -900,6 +900,7 @@ by [fxa-customs-server](https://github.com/mozilla/fxa-customs-server).
 ##### Response body
 
 - `exists`: _boolean, required_
+- `verifierSet`: _boolean, optional_
 
   <!--begin-response-body-post-accountstatus-exists-->
 

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1065,9 +1065,10 @@ export class AccountHandler {
     await this.customs.check(request, email, 'accountStatusCheck');
 
     try {
-      const exist = await this.db.accountExists(email);
+      const account = await this.db.accountRecord(email);
       return {
-        exists: exist,
+        exists: !!account,
+        verifierSet: !!account && account.verifierSetAt > 0,
       };
     } catch (err) {
       if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
@@ -1762,6 +1763,7 @@ export const accountRoutes = (
         response: {
           schema: {
             exists: isA.boolean().required(),
+            verifierSet: isA.boolean().optional(),
           },
         },
       },

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -20,9 +20,7 @@ const WrapNewUserEmailForm = ({
         setAccountExists={setAccountExists}
         setEmailsMatch={setEmailsMatch}
         getString={(id: string) => id}
-        checkAccountExists={() =>
-          Promise.resolve({ exists: accountExistsReturnValue })
-        }
+        checkAccountExists={() => Promise.resolve(accountExistsReturnValue)}
         selectedPlan={{}}
         onToggleNewsletterCheckbox={() => {}}
       />

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -107,7 +107,7 @@ async function apiFetch(
 
 export async function apiFetchAccountStatus(
   email: string
-): Promise<{ exists: boolean }> {
+): Promise<{ exists: boolean; verifierSet?: boolean }> {
   return apiFetch('POST', `${config.servers.auth.url}/v1/account/status`, {
     body: JSON.stringify({ email }),
   });


### PR DESCRIPTION
Because:
 - the checkout form for the "passwordless" subscription flow treats an
   unverified account as an existing account, even though a user could
   easily get into that state by encountering an error while trying to
   subscribe (e.g. a failed payment)

This commit:
 - update the account status endpoint to return two properties: exists
   and verified
 - update the payments frontend to consider only verified accounts as
   existing accounts

## Issue that this pull request solves

Closes: #11197
