### PR TITLE
fix(settings): wrong green successful message is displayed when user resets password

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
@@ -45,7 +45,7 @@ export default BaseBroker.extend({
       proto.defaultBehaviors.afterCompleteSignUp
     ),
     afterForceAuth: new NavigateBehavior('settings'),
-    afterResetPasswordConfirmationPoll: redirectToSettingsBehavior,
+    afterResetPasswordConfirmationPoll: redirectToSettingsAfterResetBehavior,
     afterSignIn: new NavigateBehavior('settings'),
     afterSignInConfirmationPoll: redirectToSettingsBehavior,
     afterSignUpConfirmationPoll: redirectToSettingsBehavior,

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/web.js
@@ -40,7 +40,7 @@ describe('models/auth_brokers/web', function () {
 
   testRedirectsToSettings('afterCompleteResetPassword');
   testRedirectsToSettings('afterForceAuth');
-  testRedirectsToSettingsOrRedirectTo('afterResetPasswordConfirmationPoll');
+  testRedirectsToSettings('afterResetPasswordConfirmationPoll');
   testRedirectsToSettings('afterSignIn');
   testRedirectsToSettingsOrRedirectTo('afterSignInConfirmationPoll');
   testRedirectsToSettingsOrRedirectTo('afterSignUpConfirmationPoll');


### PR DESCRIPTION
Because:

* The green message displayed should be "Password reset successfully"

This commit:

* Revises success message of `afterResetPasswordConfirmationPoll`

Closes: #11740

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
