### PR TITLE
fix(metrics): Populate relier `service` value if param exists

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -95,7 +95,9 @@ $(document).ready(function () {
       let currencyMappedURL = $(this).attr('href');
 
       if (data) {
-        currencyMappedURL = `${currencyMappedURL}&utm_campaign=123done&flow_id=${data.flowId}&flow_begin_time=${data.flowBeginTime}&device_id=${data.deviceId}`;
+        const additionalParams =
+          'service=dcdb5ae7add825d2&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing';
+        currencyMappedURL = `${currencyMappedURL}&${additionalParams}&flow_id=${data.flowId}&flow_begin_time=${data.flowBeginTime}&device_id=${data.deviceId}`;
       }
 
       $(this).attr('href', currencyMappedURL);

--- a/packages/fxa-content-server/app/scripts/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/relier.js
@@ -53,6 +53,9 @@ const QUERY_PARAMETER_SCHEMA = {
   entrypoint_variation: Vat.string().renameTo('entrypointVariation'),
   reset_password_confirm: Vat.boolean().renameTo('resetPasswordConfirm'),
   setting: Vat.string(),
+  // During the subscription flow, the service param is populated so that we
+  // can emit it correctly for metrics
+  service: Vat.string(),
   style: Vat.string().valid(Constants.STYLE_TRAILHEAD), // deprecated but still valid
   uid: Vat.uid(),
   utm_campaign: Vat.string().renameTo('utmCampaign'),
@@ -99,6 +102,7 @@ var Relier = BaseRelier.extend({
     entrypointVariation: null,
     resetPasswordConfirm: true,
     setting: null,
+    service: null,
     serviceName: t(Constants.RELIER_DEFAULT_SERVICE_NAME),
     subscriptionProductId: null,
     subscriptionProductName: null,

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/relier.js
@@ -22,6 +22,7 @@ describe('models/reliers/relier', function () {
   var ENTRYPOINT_EXPERIMENT = 'wibble';
   var ENTRYPOINT_VARIATION = 'blee';
   var SETTING = 'avatar';
+  var SERVICE = 'some_service_client_id';
   var UID = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
   var UTM_CAMPAIGN = 'utm_campaign';
   var UTM_CONTENT = 'utm_content';
@@ -59,6 +60,7 @@ describe('models/reliers/relier', function () {
       entrypoint_variation: ENTRYPOINT_VARIATION, //eslint-disable-line camelcase
       ignored: 'ignored',
       setting: SETTING,
+      service: SERVICE,
       uid: UID,
       utm_campaign: UTM_CAMPAIGN, //eslint-disable-line camelcase
       utm_content: UTM_CONTENT, //eslint-disable-line camelcase
@@ -76,6 +78,7 @@ describe('models/reliers/relier', function () {
       assert.equal(relier.get('email'), EMAIL);
 
       assert.equal(relier.get('setting'), SETTING);
+      assert.equal(relier.get('service'), SERVICE);
       assert.equal(relier.get('uid'), UID);
       assert.equal(relier.get('entrypoint'), ENTRYPOINT);
       assert.equal(relier.get('entrypointExperiment'), ENTRYPOINT_EXPERIMENT);

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -39,7 +39,7 @@
   "subscriptions": {
     "enabled": true
   },
-  "allowed_metrics_flow_cors_origins": ["http://localhost:8001"],
+  "allowed_metrics_flow_cors_origins": ["http://localhost:8001", "http://localhost:8080"],
   "allowed_parent_origins": ["http://localhost:8080"],
   "sourceMapType": "cheap-source-map",
   "csp": {


### PR DESCRIPTION
## Because

- The service value was not being sent to the auth server

## This pull request

- Populates the `service` param correctly so that it can be sent to the auth-server

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/10839

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
