### PR TITLE
feat(auth): use capabilities of subscribed price, not all prices

### DIFF
--- a/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
@@ -85,7 +85,7 @@ export class PlaySubscriptions
     const iapSubscribedGooglePlayAbbrevPlayPurchases =
       await this.getAbbrevPlayPurchases(uid);
     const iapAbbrevPlayPurchasesWithStripeProductData =
-      await this.stripeHelper.addProductInfoToAbbrevPlayPurchases(
+      await this.stripeHelper.addPriceInfoToAbbrevPlayPurchases(
         iapSubscribedGooglePlayAbbrevPlayPurchases
       );
     return iapAbbrevPlayPurchasesWithStripeProductData.map((purchase) => ({

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -81,33 +81,41 @@ describe('CapabilityService', () => {
     };
     mockStripeHelper.allAbbrevPlans = sinon.spy(async () => [
       {
+        plan_id: 'plan_123456',
         product_id: 'prod_123456',
-        product_metadata: {
+        plan_metadata: {
           capabilities: 'capAll',
           'capabilities:c1': 'cap4,cap5',
           'capabilities:c2': 'cap5,cap6',
         },
+        product_metadata: {
+          'capabilities:c1': 'capZZ',
+        },
       },
       {
+        plan_id: 'plan_876543',
         product_id: 'prod_876543',
-        product_metadata: {
+        plan_metadata: {
           'capabilities:c2': 'capC,   capD',
           'capabilities:c3': 'capD, capE',
         },
       },
       {
+        plan_id: 'plan_ABCDEF',
         product_id: 'prod_ABCDEF',
         product_metadata: {
           'capabilities:c3': ' capZ,   capW   ',
         },
       },
       {
+        plan_id: 'plan_456789',
         product_id: 'prod_456789',
         product_metadata: {
           'capabilities:c3': '   capZ,capW',
         },
       },
       {
+        plan_id: 'plan_PLAY',
         product_id: 'prod_PLAY',
         product_metadata: {
           'capabilities:c3': '   capP',
@@ -134,40 +142,40 @@ describe('CapabilityService', () => {
         email: EMAIL,
       });
       sinon.replace(authDbModule, 'getUidAndEmailByStripeCustomerId', fake);
-      capabilityService.subscribedProductIds = sinon.fake.resolves([
-        'prod_FUUNYnlDso7FeB',
+      capabilityService.subscribedPriceIds = sinon.fake.resolves([
+        'price_GWScEDK6LT8cSV',
       ]);
-      capabilityService.processProductIdDiff = sinon.fake.resolves();
+      capabilityService.processPriceIdDiff = sinon.fake.resolves();
     });
 
-    it('handles a stripe product update with new products', async () => {
+    it('handles a stripe price update with new prices', async () => {
       const sub = deepCopy(subscriptionCreated);
       await capabilityService.stripeUpdate({ sub, uid: UID, email: EMAIL });
       assert.notCalled(authDbModule.getUidAndEmailByStripeCustomerId);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, UID);
-      assert.calledWith(capabilityService.processProductIdDiff, {
+      assert.calledWith(capabilityService.subscribedPriceIds, UID);
+      assert.calledWith(capabilityService.processPriceIdDiff, {
         uid: UID,
-        priorProductIds: [],
-        currentProductIds: ['prod_FUUNYnlDso7FeB'],
+        priorPriceIds: [],
+        currentPriceIds: ['price_GWScEDK6LT8cSV'],
       });
     });
 
-    it('handles a stripe product update with removed products', async () => {
+    it('handles a stripe price update with removed prices', async () => {
       const sub = deepCopy(subscriptionCreated);
-      capabilityService.subscribedProductIds = sinon.fake.resolves([]);
+      capabilityService.subscribedPriceIds = sinon.fake.resolves([]);
       await capabilityService.stripeUpdate({ sub, uid: UID, email: EMAIL });
       assert.notCalled(authDbModule.getUidAndEmailByStripeCustomerId);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, UID);
-      assert.calledWith(capabilityService.processProductIdDiff, {
+      assert.calledWith(capabilityService.subscribedPriceIds, UID);
+      assert.calledWith(capabilityService.processPriceIdDiff, {
         uid: UID,
-        priorProductIds: ['prod_FUUNYnlDso7FeB'],
-        currentProductIds: [],
+        priorPriceIds: ['price_GWScEDK6LT8cSV'],
+        currentPriceIds: [],
       });
     });
 
-    it('handles a stripe product update without uid/email', async () => {
+    it('handles a stripe price update without uid/email', async () => {
       const sub = deepCopy(subscriptionCreated);
       await capabilityService.stripeUpdate({ sub });
       assert.calledWith(
@@ -175,11 +183,11 @@ describe('CapabilityService', () => {
         sub.customer
       );
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, UID);
-      assert.calledWith(capabilityService.processProductIdDiff, {
+      assert.calledWith(capabilityService.subscribedPriceIds, UID);
+      assert.calledWith(capabilityService.processPriceIdDiff, {
         uid: UID,
-        priorProductIds: [],
-        currentProductIds: ['prod_FUUNYnlDso7FeB'],
+        priorPriceIds: [],
+        currentPriceIds: ['price_GWScEDK6LT8cSV'],
       });
     });
   });
@@ -193,10 +201,10 @@ describe('CapabilityService', () => {
         email: EMAIL,
       });
       sinon.replace(authDbModule, 'getUidAndEmailByStripeCustomerId', fake);
-      capabilityService.subscribedProductIds = sinon.fake.resolves([
+      capabilityService.subscribedPriceIds = sinon.fake.resolves([
         'prod_FUUNYnlDso7FeB',
       ]);
-      capabilityService.processProductIdDiff = sinon.fake.resolves();
+      capabilityService.processPriceIdDiff = sinon.fake.resolves();
       subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
         VALID_SUB_API_RESPONSE,
         'testPackage',
@@ -204,7 +212,7 @@ describe('CapabilityService', () => {
         'testSku',
         Date.now()
       );
-      mockStripeHelper.purchasesToProductIds = sinon.fake.resolves([
+      mockStripeHelper.purchasesToPriceIds = sinon.fake.resolves([
         'prod_FUUNYnlDso7FeB',
       ]);
     });
@@ -212,23 +220,23 @@ describe('CapabilityService', () => {
     it('handles a play purchase with new product', async () => {
       await capabilityService.playUpdate(UID, EMAIL, subscriptionPurchase);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, UID);
-      assert.calledWith(capabilityService.processProductIdDiff, {
+      assert.calledWith(capabilityService.subscribedPriceIds, UID);
+      assert.calledWith(capabilityService.processPriceIdDiff, {
         uid: UID,
-        priorProductIds: [],
-        currentProductIds: ['prod_FUUNYnlDso7FeB'],
+        priorPriceIds: [],
+        currentPriceIds: ['prod_FUUNYnlDso7FeB'],
       });
     });
 
     it('handles a play purchase with a removed product', async () => {
-      capabilityService.subscribedProductIds = sinon.fake.resolves([]);
+      capabilityService.subscribedPriceIds = sinon.fake.resolves([]);
       await capabilityService.playUpdate(UID, EMAIL, subscriptionPurchase);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, UID);
-      assert.calledWith(capabilityService.processProductIdDiff, {
+      assert.calledWith(capabilityService.subscribedPriceIds, UID);
+      assert.calledWith(capabilityService.processPriceIdDiff, {
         uid: UID,
-        priorProductIds: ['prod_FUUNYnlDso7FeB'],
-        currentProductIds: [],
+        priorPriceIds: ['prod_FUUNYnlDso7FeB'],
+        currentPriceIds: [],
       });
     });
   });
@@ -252,13 +260,13 @@ describe('CapabilityService', () => {
     });
   });
 
-  describe('processProductIdDiff', () => {
+  describe('processPriceIdDiff', () => {
     it('should process the product diff', async () => {
       mockAuthEvents.emit = sinon.fake.returns({});
-      await capabilityService.processProductIdDiff({
+      await capabilityService.processPriceIdDiff({
         uid: UID,
-        priorProductIds: ['prod_123456', 'prod_876543'],
-        currentProductIds: ['prod_876543', 'prod_ABCDEF'],
+        priorPriceIds: ['plan_123456', 'plan_876543'],
+        currentPriceIds: ['plan_876543', 'plan_ABCDEF'],
       });
       sinon.assert.calledTwice(log.notifyAttachedServices);
     });
@@ -272,27 +280,25 @@ describe('CapabilityService', () => {
             {
               status: 'active',
               items: {
-                data: [{ price: { product: 'prod_123456' } }],
+                data: [{ price: { id: 'plan_123456' } }],
               },
             },
             {
               status: 'active',
               items: {
-                data: [{ price: { product: 'prod_876543' } }],
+                data: [{ price: { id: 'plan_876543' } }],
               },
             },
             {
               status: 'incomplete',
               items: {
-                data: [{ price: { product: 'prod_456789' } }],
+                data: [{ price: { id: 'plan_456789' } }],
               },
             },
           ],
         },
       }));
-      mockStripeHelper.purchasesToProductIds = sinon.fake.returns([
-        'prod_PLAY',
-      ]);
+      mockStripeHelper.purchasesToPriceIds = sinon.fake.returns(['plan_PLAY']);
       mockSubscriptionPurchase = {
         sku: 'play_1234',
         isEntitlementActive: sinon.fake.returns(true),
@@ -327,7 +333,7 @@ describe('CapabilityService', () => {
       );
       assert.deepEqual(allCapabilities, {
         '*': ['capAll'],
-        c1: ['cap4', 'cap5'],
+        c1: ['cap4', 'cap5', 'capZZ'],
         c2: ['cap5', 'cap6', 'capC', 'capD'],
         c3: ['capD', 'capE'],
       });
@@ -340,7 +346,7 @@ describe('CapabilityService', () => {
     it('only reveals capabilities relevant to the client', async () => {
       const expected = {
         c0: ['capAll'],
-        c1: ['capAll', 'cap4', 'cap5'],
+        c1: ['capAll', 'cap4', 'cap5', 'capZZ'],
         c2: ['capAll', 'cap5', 'cap6', 'capC', 'capD'],
         c3: ['capAll', 'capD', 'capE', 'capP'],
         null: [
@@ -352,6 +358,7 @@ describe('CapabilityService', () => {
           'capD',
           'capE',
           'capP',
+          'capZZ',
         ],
       };
       for (const clientId in expected) {
@@ -362,18 +369,21 @@ describe('CapabilityService', () => {
     it('supports capabilities visible to all clients', async () => {
       mockStripeHelper.allAbbrevPlans = sinon.spy(async () => [
         {
+          plan_id: 'plan_123456',
           product_id: 'prod_123456',
           product_metadata: {
             capabilities: 'cap1,cap2,cap3',
           },
         },
         {
+          plan_id: 'plan_876543',
           product_id: 'prod_876543',
           product_metadata: {
             capabilities: 'capA,capB,capC',
           },
         },
         {
+          plan_id: 'plan_ABCDEF',
           product_id: 'prod_ABCDEF',
           product_metadata: {
             capabilities: 'cap00,  cap01,cap02',

--- a/packages/fxa-auth-server/test/local/payments/google-play/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/subscriptions.js
@@ -128,7 +128,7 @@ describe('PlaySubscriptions', () => {
       sandbox
         .stub(playSubscriptions, 'getAbbrevPlayPurchases')
         .resolves([mockAbbrevPlayPurchase]);
-      mockStripeHelper.addProductInfoToAbbrevPlayPurchases = sinon
+      mockStripeHelper.addPriceInfoToAbbrevPlayPurchases = sinon
         .stub()
         .resolves([mockIapAbbrevPlayPurchasesWithStripeProductData]);
       const result = await playSubscriptions.getSubscriptions(UID);
@@ -137,7 +137,7 @@ describe('PlaySubscriptions', () => {
         UID
       );
       assert.calledOnceWithExactly(
-        mockStripeHelper.addProductInfoToAbbrevPlayPurchases,
+        mockStripeHelper.addPriceInfoToAbbrevPlayPurchases,
         [mockAbbrevPlayPurchase]
       );
       const expected = [

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -25,7 +25,6 @@ const dbStub = {
 };
 const {
   StripeHelper,
-  STRIPE_PRODUCT_METADATA,
   STRIPE_INVOICE_METADATA,
   SUBSCRIPTION_UPDATE_TYPES,
   MOZILLA_TAX_ID,
@@ -4847,50 +4846,54 @@ describe('StripeHelper', () => {
   describe('Google Play helpers', () => {
     let subPurchase;
     let productId;
+    let priceId;
     let productName;
-    let mockProduct;
-    let mockAllAbbrevProducts;
+    let mockPrice;
+    let mockAllAbbrevPlans;
 
     beforeEach(() => {
       productId = 'prod_test';
+      priceId = 'price_test';
       productName = 'testProduct';
-      mockProduct = {
+      mockPrice = {
+        plan_id: priceId,
+        plan_metadata: {
+          [STRIPE_PRICE_METADATA.PLAY_SKU_IDS]: 'testSku,testSku2',
+        },
         product_id: productId,
         product_name: productName,
-        product_metadata: {
-          [STRIPE_PRODUCT_METADATA.PLAY_SKU_IDS]: 'testSku,testSku2',
-        },
+        product_metadata: {},
       };
-      mockAllAbbrevProducts = [
-        mockProduct,
+      mockAllAbbrevPlans = [
+        mockPrice,
         {
+          plan_id: 'wrong_price_id',
           product_id: 'wrongProduct',
           product_name: 'Wrong Product',
+          plan_metadata: {},
           product_metadata: {},
         },
       ];
-      sandbox
-        .stub(stripeHelper, 'allAbbrevProducts')
-        .resolves(mockAllAbbrevProducts);
+      sandbox.stub(stripeHelper, 'allAbbrevPlans').resolves(mockAllAbbrevPlans);
     });
 
-    describe('productToPlaySkus', () => {
-      it('formats skus from product metadata, including transforming them to lowercase', () => {
-        const result = stripeHelper.productToPlaySkus(mockProduct);
+    describe('priceToPlaySkus', () => {
+      it('formats skus from price metadata, including transforming them to lowercase', () => {
+        const result = stripeHelper.priceToPlaySkus(mockPrice);
         assert.deepEqual(result, ['testsku', 'testsku2']);
       });
 
-      it('handles empty product metadata skus', () => {
-        const prod = {
-          ...mockProduct,
-          product_metadata: {},
+      it('handles empty price metadata skus', () => {
+        const price = {
+          ...mockPrice,
+          plan_metadata: {},
         };
-        const result = stripeHelper.productToPlaySkus(prod);
+        const result = stripeHelper.priceToPlaySkus(price);
         assert.deepEqual(result, []);
       });
     });
 
-    describe('purchasesToProductIds', () => {
+    describe('purchasesToPriceIds', () => {
       beforeEach(() => {
         const apiResponse = {
           kind: 'androidpublisher#subscriptionPurchase',
@@ -4914,21 +4917,21 @@ describe('StripeHelper', () => {
         );
       });
 
-      it('returns product ids for the subscription purchase', async () => {
-        const result = await stripeHelper.purchasesToProductIds([subPurchase]);
-        assert.deepEqual(result, [productId]);
-        sinon.assert.calledOnce(stripeHelper.allAbbrevProducts);
+      it('returns price ids for the subscription purchase', async () => {
+        const result = await stripeHelper.purchasesToPriceIds([subPurchase]);
+        assert.deepEqual(result, [priceId]);
+        sinon.assert.calledOnce(stripeHelper.allAbbrevPlans);
       });
 
-      it('returns no product ids for unknown subscription purchase', async () => {
+      it('returns no price ids for unknown subscription purchase', async () => {
         subPurchase.sku = 'wrongSku';
-        const result = await stripeHelper.purchasesToProductIds([subPurchase]);
+        const result = await stripeHelper.purchasesToPriceIds([subPurchase]);
         assert.deepEqual(result, []);
-        sinon.assert.calledOnce(stripeHelper.allAbbrevProducts);
+        sinon.assert.calledOnce(stripeHelper.allAbbrevPlans);
       });
     });
 
-    describe('addProductInfoToAbbrevPlayPurchases', () => {
+    describe('addPriceInfoToAbbrevPlayPurchases', () => {
       let mockAbbrevPlayPurchase;
 
       beforeEach(() => {
@@ -4943,10 +4946,11 @@ describe('StripeHelper', () => {
       it('adds matching product info to a subscription purchase', async () => {
         const expected = {
           ...mockAbbrevPlayPurchase,
+          price_id: priceId,
           product_id: productId,
           product_name: productName,
         };
-        const result = await stripeHelper.addProductInfoToAbbrevPlayPurchases([
+        const result = await stripeHelper.addPriceInfoToAbbrevPlayPurchases([
           mockAbbrevPlayPurchase,
         ]);
         assert.deepEqual([expected], result);
@@ -4956,7 +4960,7 @@ describe('StripeHelper', () => {
           ...mockAbbrevPlayPurchase,
           sku: 'notMatchingSku',
         };
-        const result = await stripeHelper.addProductInfoToAbbrevPlayPurchases([
+        const result = await stripeHelper.addPriceInfoToAbbrevPlayPurchases([
           mockAbbrevPlayPurchase1,
         ]);
         assert.isEmpty(result);

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -218,13 +218,14 @@ describe('remote subscriptions:', function () {
                 created: date,
                 cancelled_at: null,
                 plan: {
+                  id: PLAN_ID,
                   product: PRODUCT_ID,
                 },
                 items: {
                   data: [
                     {
-                      price: { product: PRODUCT_ID },
-                      plan: { product: PRODUCT_ID },
+                      price: { id: PLAN_ID, product: PRODUCT_ID },
+                      plan: { id: PLAN_ID, product: PRODUCT_ID },
                     },
                   ],
                 },


### PR DESCRIPTION
Because:

* Prior code grabbed capabilities from all the prices under a users
  subscribed product, rather than just the capabilities for the
  specific price the user subscribed to.

This commit:

* Revamps the capability service to use price id's and merge the
  capabilities of the subscribed price with only its product when
  determining a users capabilities.

Closes #11804

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
