### PR TITLE
feat(experiment): Add feature flag for google auth

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -17,6 +17,7 @@ const experimentGroupingRules = [
   require('./sentry'),
   require('./newsletter-sync'),
   require('./push'),
+  require('./third-party-auth'),
 ].map((ExperimentGroupingRule) => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/third-party-auth.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/third-party-auth.js
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const BaseGroupingRule = require('./base');
+const GROUPS = [
+  'control',
+
+  // Treatment branches
+  'google',
+];
+
+// For each client specify which experiment group to show
+const ROLLOUT_CONFIG = {
+  // 123Done
+  dcdb5ae7add825d2: GROUPS,
+  // Pocket
+  '7377719276ad44ee': GROUPS,
+  '749818d3f2e7857f': GROUPS,
+};
+
+// This experiment is disabled by default. If you would like to go through
+// the flow, load email-first screen and append query params
+// `?forceExperiment=thirdPartyAuth&forceExperimentGroup=google`
+const ROLLOUT_RATE = 0.0;
+
+module.exports = class ThirdPartyAuth extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'thirdPartyAuth';
+
+    // Easier to set class properties for testability
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+    this.rolloutConfig = ROLLOUT_CONFIG;
+  }
+
+  /**
+   * For this experiment, we are doing a staged rollout.
+   *
+   * @param {Object} subject data used to decide
+   *  @param {String} clientId clientId
+   * @returns {Any}
+   */
+  choose(subject = {}) {
+    let choice = false;
+    const { clientId } = subject;
+
+    if (!clientId) {
+      return;
+    }
+
+    const clientConfig = this.rolloutConfig[clientId];
+    if (!clientConfig) {
+      return;
+    }
+
+    if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+      choice = this.uniformChoice(clientConfig, subject.uniqueUserId);
+    }
+
+    return choice;
+  }
+};

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -30,9 +30,12 @@
       </div>
     </form>
 
-<!--    TODO: Enable in https://github.com/mozilla/fxa/issues/11312 -->
-<!--    {{{ unsafeThirdPartyAuthHTML }}}-->
+    {{#isInThirdPartyAuthExperiment}}
+      {{{ unsafeThirdPartyAuthHTML }}}
+    {{/isInThirdPartyAuthExperiment}}
 
-    {{{ unsafeFirefoxFamilyHTML }}}
+    {{^isInThirdPartyAuthExperiment}}
+      {{{ unsafeFirefoxFamilyHTML }}}
+    {{/isInThirdPartyAuthExperiment}}
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/mixins/google-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/google-auth-mixin.js
@@ -5,12 +5,19 @@
 import SigninMixin from './signin-mixin';
 import Storage from '../../lib/storage';
 import Url from '../../lib/url';
+import ThirdPartyAuthExperimentMixin from '../../views/mixins/third-party-auth-experiment-mixin';
 
 export default {
-  dependsOn: [SigninMixin],
+  dependsOn: [SigninMixin, ThirdPartyAuthExperimentMixin],
 
   events: {
     'click #google-login-button': 'googleSignIn',
+  },
+
+  setInitialContext(context) {
+    context.set({
+      isInThirdPartyAuthExperiment: this.isInThirdPartyAuthExperiment(),
+    });
   },
 
   beforeRender() {

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-experiment-mixin.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from './experiment-mixin';
+const EXPERIMENT_NAME = 'thirdPartyAuth';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  isInThirdPartyAuthExperiment() {
+    const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
+      clientId: this.relier.get('clientId'),
+    });
+
+    return experimentGroup === 'google';
+  },
+};

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 7);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/third-party-auth.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/third-party-auth.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Experiment from 'lib/experiments/grouping-rules/third-party-auth';
+
+describe('lib/experiments/grouping-rules/third-party-auth', () => {
+  let experiment;
+  const validClientID = 'dcdb5ae7add825d2';
+  const invalidClientID = 'notvalid';
+
+  beforeEach(() => {
+    experiment = new Experiment();
+  });
+
+  describe('choose', () => {
+    it('returns false if no clientId', () => {
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+
+    it('returns false if invalid clientId', () => {
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          clientId: invalidClientID,
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+
+    it('returns treatment if valid clientId', () => {
+      const rules = experiment.groups;
+      assert.isTrue(
+        rules.include(
+          experiment.choose({
+            experimentGroupingRules: { choose: () => experiment.name },
+            clientId: validClientID,
+            uniqueUserId: 'user-id',
+          })
+        )
+      );
+    });
+
+    it('returns false if rollout 0%', () => {
+      experiment.rolloutRate = 0;
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          clientId: validClientID,
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Because

- We need to be able to enable/disable the third party auth of Google

## This pull request

- Adds a feature flag so that we can specify based on `clientId`

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11312

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).