### PR TITLE
fix(auth-server): revise email template stories in Storybook

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/location/mocks.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/location/mocks.ts
@@ -2,10 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_LOCATION = {
-  date: 'Thursday, Sep 2, 2021',
+export const MOCK_LOCATION_TRUNCATED = {
   device: 'Firefox on Mac OSX 10.11',
   ip: '10.246.67.38',
   location: 'Madrid, Spain (estimated)',
+};
+
+export const MOCK_LOCATION = {
+  date: 'Thursday, Sep 2, 2021',
+  ...MOCK_LOCATION_TRUNCATED,
   time: '12:26:44 AM (CEST)',
 };
+
+export const MOCK_LOCATION_ALL = {
+  primaryEmail: 'primaryFoo@bar.com',
+  ...MOCK_LOCATION,
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'cadReminderSecond',
-  'Sent 72 hours after a user clicks "send me a reminder" on the connect another device page.',
+  'Sent 72 hours after a user clicks "send me a reminder" on the connect another device page. At the time of writing, it cannot be triggered in staging (FXA-4515).',
   cadReminderFirst.CadReminderDefault.args.variables
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.stories.ts
@@ -11,7 +11,7 @@ export default {
 
 const createStory = storyWithProps(
   'passwordChangeRequired',
-  "Sent when an account's devices are disconnected and a password change is required due to suspicious activity"
+  "Sent when an account's devices are disconnected and a password change is required due to suspicious activity. It currently needs Ops to manually trigger via bulk-mailer"
 );
 
 export const PasswordChangeRequired = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.stories.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
@@ -14,7 +13,6 @@ const createStory = storyWithProps(
   'postChangePrimary',
   'Sent to new primary email when it has been updated',
   {
-    ...MOCK_LOCATION,
     email: 'foo@bar.com',
     link: 'http://localhost:3030/settings',
     passwordChangeLink: 'http://localhost:3030/settings/change_password',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { MOCK_LOCATION_TRUNCATED } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
@@ -14,7 +14,7 @@ const createStory = storyWithProps(
   'verify',
   "Sent to users that create an account through Firefox, don't verify their email, and go into Sync preferences to resend the verification email as a link.",
   {
-    ...MOCK_LOCATION,
+    ...MOCK_LOCATION_TRUNCATED,
     link: 'http://localhost:3030/verify_email',
     sync: true,
   }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { MOCK_LOCATION_ALL } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
@@ -14,7 +14,7 @@ const createStory = storyWithProps(
   'verifySecondaryCode',
   'Sent to verify the addition of a secondary email via code.',
   {
-    ...MOCK_LOCATION,
+    ...MOCK_LOCATION_ALL,
     email: 'foo@bar.com',
     code: '918398',
   }


### PR DESCRIPTION
## Because

- while the `location` mock included date, device, IP, location, time, the `location` partial also included `primaryEmail`. In addition, not all email templates include all of the information in the `location` partial.
- the description of a few templates included an update of its current state

## This pull request

- revises the `location` mock to include the three variations that are utilized among all email templates.
  - `MOCK_LOCATION` (which was not revised) includes date, device, IP, location, and time
    - All other email templates, with the exception of `verify` and `verifySecondaryCode` utilize this mock
  - `MOCK_LOCATION_TRUNCATED` (which was added) includes information within `MOCK_LOCATION` with the exception of date and time
    - The only email template that utilizes this mock is `verify`
  - `MOCK_LOCATION_ALL` (which was added) includes information within `MOCK_LOCATION` as well as `primaryEmail`
    - The only email template that utilizes this mock is `verifySecondaryCode`

- updates the description of `cadReminderSecond` and `passwordChangeRequired`
  - note: the ticket for `subscriptionPaymentExpired` is currently being worked on
 
Closes: #11830

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
