### PR TITLE
fix(auth): Temporarily disable isMetricsEnabled db calls for oauth clients

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -258,7 +258,9 @@ async function create(log, error, config, routes, db, translator, statsd) {
         request.auth.credentials.user
       ) {
         // oauthToken strategy comes with uid as user
-        uid = request.auth.credentials.user;
+        // TODO: re-enable this. We're disabling for now to see if it helps with auth server
+        // performance issues.
+        // uid = request.auth.credentials.user;
       } else if (request.payload && request.payload.uid) {
         // Some unauthenticated requests might set uid in payload, ex. `/account/status`
         uid = request.payload.uid;


### PR DESCRIPTION
Because:
* Train 224 saw huge spikes in DB calls/oauth connections and we're attempting to see if this line is causing the performance problems

This commit:
* Disables setting the uid from oauth

---

Maybe probably hopefully this is it? Either way we'll need a follow up to re-enable this if there's no change or figure out how we can better cache this or hit this case.

I believe the downside to disabling this is that users with an oauth token will not have their metrics opt-out preference taken into account if they've opted out.