### PR TITLE
fix(auth-server): subplat email images are at 100% width using the Mail app

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -17,37 +17,35 @@
     <mj-include path="./css/fxa/index.css" type="css" css-inline="inline" />
     <mj-include path="./css/locale-dir.css" type="css" />
 
-    <mj-raw>
-      <% if (locals.preHeader) { %>
-        <div class="hidden">
-          <%- preHeader %>
-          &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
-        </div>
-      <% } %>
-      <% if (!locals.sync) { %>
-        <div data-l10n-id="fxa-header-firefox-logo">
-          <img
-            data-l10n-name="fxa-logo"
+    <mj-section>
+      <mj-column>
+        <% if (locals.preHeader) { %>
+          <mj-text css-class="hidden">
+            <%- preHeader %>
+            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
+          </mj-text>
+        <% } %>
+        <% if (!locals.sync) { %>
+          <mj-image css-class="fxa-logo"
+            width="60px"
             src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo.png"
-            class="fxa-logo"
             alt="Firefox logo"
-          />
-        </div>
-      <% } else { %>
-        <div data-l10n-id="fxa-header-sync-devices-image" data-l10n-attrs="alt">
-          <img
-            data-l10n-name="sync-devices-image"
+            title="Firefox logo">
+          </mj-image>
+        <% } else { %>
+          <mj-image css-class="sync-img"
+            width="300px"
             src="https://accounts-static.cdn.mozilla.net/other/sync-devices.png"
-            class="sync-img"
             alt="Sync devices"
-          />
-        </div>
-      <% } %>
-    </mj-raw>
+            title="Sync devices">
+          </mj-image>
+        <% } %>
+      </mj-column>
+    </mj-section>
 
     <%- body %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
@@ -12,7 +12,6 @@
 .fxa-logo {
   padding: global.$s-5 global.$s-0 !important;
   height: 60px !important;
-  width: 60px !important;
   margin: 0 auto !important;
   display: block !important;
 }
@@ -20,7 +19,6 @@
 .sync-img {
   padding: global.$s-5 global.$s-0 !important;
   height: 137px;
-  width: 300px;
   margin: 0 auto !important;
   display: block !important;
 }
@@ -70,14 +68,12 @@
 }
 
 .sync-logo img {
-  width: 240px !important;
   margin: 0 auto;
   @extend .mb-5;
   @extend .mt-2;
 }
 
 .graphic-devices img {
-  width: 240px !important;
   margin: 0 auto;
   @extend .mb-5;
   @extend .mt-2;

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -19,22 +19,26 @@
     <mj-include path="./css/subscription/index.css" type="css" css-inline="inline" />
     <mj-include path="./css/locale-dir.css" type="css" />
 
-    <mj-raw>
-      <% if (locals.preHeader) { %>
-        <div class="hidden">
-          <%- preHeader %>
-          &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-          ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
-        </div>
-      <% } %>
-    </mj-raw>
+    <% if (locals.preHeader) { %>
+      <mj-section>
+        <mj-column>
+          <mj-text css-class="hidden">
+            <%- preHeader %>
+            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    <% } %>
 
     <mj-section css-class="header-container">
       <mj-column>
         <mj-image css-class="fxa-logo-firefox"
+          width="171px"
+          align="left"
           href="https://www.mozilla.org/firefox/new"
           src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo-email.png"
           alt="Firefox logo"
@@ -101,6 +105,7 @@
         <% } %>
 
         <mj-image css-class="mozilla-logo"
+          width="120px"
           href="https://www.mozilla.org"
           src="https://accounts-static.cdn.mozilla.net/product-icons/mozilla-logo.png"
           alt="Mozilla logo"

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
@@ -46,14 +46,12 @@
 .fxa-logo-firefox {
   padding: global.$s-5 global.$s-0 !important;
   height: 56px !important;
-  width: 171px !important;
   display: block !important;
 }
 
 .mozilla-logo {
   padding: global.$s-8 global.$s-0 !important;
   height: 34px !important;
-  width: 120px !important;
   display: block !important;
   margin: 0 auto !important;
 }
@@ -86,7 +84,6 @@
 .product-icon {
   display: block;
   margin: 0 auto;
-  width: 58px;
   height: 58px;
 }
 

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.mjml
@@ -13,6 +13,7 @@
     <% if (locals.iosUrl) { %>
       <mj-column>
         <mj-image
+          width="152px"
           css-class="app-badge app-badge-ios"
           href="<%- iosUrl %>"
           src="https://accounts-static.cdn.mozilla.net/product-icons/apple-app-store.png"
@@ -24,6 +25,7 @@
     <% if (locals.androidUrl) { %>
       <mj-column>
         <mj-image
+          width="152px"
           css-class="app-badge app-badge-android"
           href="<%- androidUrl %>"
           src="https://accounts-static.cdn.mozilla.net/product-icons/google-play.png"

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.scss
@@ -13,7 +13,6 @@
   padding: global.$s-10 global.$s-0 global.$s-5 !important;
 
   img {
-    width: 152px !important;
     height: 44px !important;
     margin: 0 auto !important;
   }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/icon/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/icon/index.mjml
@@ -6,17 +6,17 @@
   <% if (locals.productIconURLOld && locals.productIconURLNew) { %>
     <mj-group>
       <mj-column>
-        <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
+        <mj-image width="58px" src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
         </mj-image>
       </mj-column>
       <mj-column>
-        <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
+        <mj-image width="58px" src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
         </mj-image>
       </mj-column>
     </mj-group>
   <% } else { %>
     <mj-column>
-      <mj-image src="<%- icon %>" alt="<%- productName %>" title="<%- productName %>" css-class="product-icon"></mj-image>
+      <mj-image width="58px" src="<%- icon %>" alt="<%- productName %>" title="<%- productName %>" css-class="product-icon"></mj-image>
     </mj-column>
   <% } %>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/images.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/images.mjml
@@ -4,6 +4,20 @@
 
 <% if (!locals.productName) { locals.productName = 'Firefox' %><% } %>
 <mj-html-attributes>
+  <mj-selector path=".fxa-logo td">
+    <mj-html-attribute name="data-l10n-id">fxa-header-firefox-logo</mj-html-attribute>
+  </mj-selector>
+  <mj-selector path=".fxa-logo img">
+    <mj-html-attribute name="data-l10n-name">fxa-logo</mj-html-attribute>
+  </mj-selector>
+
+  <mj-selector path=".sync-img td">
+    <mj-html-attribute name="data-l10n-id">fxa-header-sync-devices-image</mj-html-attribute>
+  </mj-selector>
+  <mj-selector path=".sync-img img">
+    <mj-html-attribute name="data-l10n-name">sync-devices-image</mj-html-attribute>
+  </mj-selector>
+
   <mj-selector path=".fxa-logo-firefox a">
     <mj-html-attribute name="data-l10n-id">subplat-header-firefox-logo</mj-html-attribute>
   </mj-selector>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.mjml
@@ -7,7 +7,7 @@
     <mj-text css-class="text-header">
       <span data-l10n-id="cadReminderFirst-title">Here’s your reminder to sync devices.</span>
     </mj-text>
-    <mj-image css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
+    <mj-image width="240px" css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
   </mj-column>
 </mj-section>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.mjml
@@ -7,7 +7,7 @@
     <mj-text css-class="text-header">
       <span data-l10n-id="cadReminderSecond-title">Last reminder to sync devices!</span>
     </mj-text>
-    <mj-image css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
+    <mj-image width="240px" css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
   </mj-column>
 </mj-section>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.mjml
@@ -10,7 +10,7 @@
     <mj-text css-class="text-header">
       <span data-l10n-id="postVerify-title">Next sync between your devices!</span>
     </mj-text>
-    <mj-image css-class="sync-logo" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
+    <mj-image width="240px" css-class="sync-logo" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
   </mj-column>
 </mj-section>
 


### PR DESCRIPTION
## Because

- per [MJML documentation](https://documentation.mjml.io/#mj-image), a `<mj-image>` tag displays a responsive center-aligned image in an email and, if no width is provided, the image will use the parent column width. When the `<mj-image>` tag is translated into HTML, the image is nested within a `<td>` tag, which utilizes the width attribute set in the `<mj-image>` tag. While the width of the image can be set in a `css-class`, it only sets the image width and not the width of the `<td>` it is nested in. Therefore, it is best practice to also include and set the width attribute when using a `<mj-image>` tag.

Note: The header image within the FxA email templates did not appear at 100% width in the Mail app, as it was written in HTML within a `<mj-raw>` tag and no `<mj-image>` tags were utilized.

<img width="1675" alt="Screen Shot 2022-02-03 at 9 14 53 AM" src="https://user-images.githubusercontent.com/28129806/152360036-f13c763b-0dd6-42ae-86ab-daad40e25076.png">

## This pull request

- Converts the following images in FxA email template to MJML format, sets the width within their `mj-image` tags, and removes their widths in their `css-class`:
  - Header Firefox logo
  - Header Sync image
- Sets the width attribute within all of the following `mj-image` tags  and removes its width in its `css-class`:
  - Header Firefox logo of all subplat email templates
  - Footer Mozilla logo of all subplat email templates
  - App Store badge
  - Google Play badge
  - Product icons within the `icon` partial
  - Device images used in `cadReminderFirst`, `cadReminderSecond`, `postVerify`
- Adds FxA images (header logo and sync devices image) to `emails/partials/images.mjml` which localizes the image alt text

## Issue that this pull request solves

Closes: #11833 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).