### PR TITLE
fix(auth): allow price_id in response

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -626,6 +626,7 @@ module.exports.subscriptionsGooglePlaySubscriptionValidator = isA.object({
   package_name: isA.string().required(),
   product_id: isA.string().required(),
   product_name: isA.string().required(),
+  price_id: isA.string().required(),
   sku: isA.string().required(),
 });
 

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -612,6 +612,7 @@ describe('lib/routes/validators:', () => {
           _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
           product_id: 'xyz',
           product_name: 'Awesome product',
+          price_id: 'abc',
           ...mockAbbrevPlayPurchase,
         });
       assert.ok(!res.error);
@@ -622,6 +623,7 @@ describe('lib/routes/validators:', () => {
         validators.subscriptionsGooglePlaySubscriptionValidator.validate({
           _subscription_type: 'unknown',
           product_id: 'xyz',
+          price_id: 'abc',
           ...mockAbbrevPlayPurchase,
         });
       assert.ok(res.error);
@@ -712,6 +714,7 @@ describe('lib/routes/validators:', () => {
     };
     const playSub = {
       _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+      price_id: 'abc',
       product_id: 'xyz',
       product_name: 'Awesome product',
       auto_renewing: true,


### PR DESCRIPTION
Because:

* We were throwing an error on the account reply for IAP
  purchases.

This commit:

* Allows price_id in the response.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
