### PR TITLE
fix(emails): Add conditional around payment method

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -2,14 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-text css-class="text-body margin-top">
-  <% if (payment_provider === 'paypal') { %>
+<% if (payment_provider === 'paypal') { %>
+  <mj-text css-class="text-body margin-top">
     <span data-l10n-id="payment-method">Payment Method: </span>
     <span>PayPal</span>
-  <% } else { %>
+  </mj-text>
+  <%# Stripe is the default payment provider, but check for truthiness in case of coupons %>
+<% } else if (cardType && lastFour) { %>
+  <mj-text css-class="text-body margin-top">
     <span data-l10n-id="payment-method">Payment Method: </span>
     <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
       <%- cardType %> card ending in <%- lastFour %>
     </span>
-  <% } %>
-</mj-text>
+  </mj-text>
+<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,3 +1,3 @@
 <% if (payment_provider === "paypal") { %>payment-provider-paypal-plaintext = "Payment Method: PayPal"
-<% } else {%>payment-method = "Payment Method: "
+<% } else if (cardType && lastFour) {%>payment-method = "Payment Method: "
 card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
@@ -1,7 +1,8 @@
 <%# This Source Code Form is subject to the terms of the Mozilla Public #
 License, v. 2.0. If a copy of the MPL was not distributed with this # file, You
-can obtain one at http://mozilla.org/MPL/2.0/. %> <%- include
-('/partials/icon/index.mjml') %>
+can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<%- include ('/partials/icon/index.mjml') %>
 
 <mj-section>
   <mj-column>
@@ -73,8 +74,8 @@ can obtain one at http://mozilla.org/MPL/2.0/. %> <%- include
       </span>
     </mj-text>
 
-    <%- include ('/partials/viewInvoice/index.mjml') %> <%- include
-    ('/partials/paymentProvider/index.mjml') %>
+    <%- include ('/partials/viewInvoice/index.mjml') %>
+    <%- include ('/partials/paymentProvider/index.mjml') %>
 
     <mj-text css-class="text-body">
       <span

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
@@ -42,3 +42,14 @@ export const SubscriptionFirstInvoiceWithStripe = createStory(
   },
   'Payment method - Stripe'
 );
+
+export const SubscriptionFirstInvoiceWithCoupon = createStory(
+  {
+    cardType: null,
+    lastFour: null,
+    payment_provider: 'stripe',
+    invoiceTotal: '$0.00',
+    invoiceDiscountAmount: '$20.00',
+  },
+  'Payment method - coupon covered entire amount'
+);


### PR DESCRIPTION
Because:
* cardType and lastFour are undefined when the user pays for the entire cost with a coupon

This commit:
* Checks for cardType and lastFour truthiness before displaying them

fixes #11861 