### PR TITLE
fix(admin-panel): FXA-4231 - missing Device type for desktop sessions

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -51,6 +51,18 @@ let accountResponse: AccountProps = {
       uaDeviceType: 'Mac',
       lastAccessTime: 1589467100316,
     },
+    {
+      tokenId: 'abcd1235',
+      tokenData: 'abcd1235',
+      uid: 'ca1c61239f2448b2af618f0b50226cdf',
+      createdAt: 1589467100317,
+      uaBrowser: 'Chrome',
+      uaBrowserVersion: '89.0.4390',
+      uaOS: 'Mac OS X',
+      uaOSVersion: '11.2.2',
+      uaDeviceType: null,
+      lastAccessTime: 1589467100317,
+    }
   ],
   securityEvents: [],
 };
@@ -116,15 +128,23 @@ it('displays the recovery key status', async () => {
 });
 
 it('displays the session token status', async () => {
-  const { getByTestId } = render(
+  const { findAllByTestId } = render(
     <MockedProvider>
       <Account {...accountResponse} />
     </MockedProvider>
   );
-  expect(getByTestId('session-token-accessed-at')).toBeInTheDocument();
-  expect(getByTestId('session-token-browser')).toBeInTheDocument();
-  expect(getByTestId('session-token-operating-system')).toBeInTheDocument();
-  expect(getByTestId('session-token-device')).toBeInTheDocument();
+
+  expect(await findAllByTestId('session-token-accessed-at')).toHaveLength(2);
+  expect(await findAllByTestId('session-token-browser')).toHaveLength(2);
+  expect(await findAllByTestId('session-token-operating-system')).toHaveLength(2);
+  expect(await findAllByTestId('session-token-device')).toHaveLength(2);
+  await findAllByTestId('session-token-device').then((session) => {
+    // checks that the uaDeviceType value is returned if not null
+    expect(session[0]).toHaveTextContent('Mac');
+
+    // checks that 'Desktop' is returned if uaDeviceType value is null
+    expect(session[1]).toHaveTextContent('Desktop');
+  });
 });
 
 it('displays secondary emails', async () => {

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -591,7 +591,7 @@ const SessionTokens = ({
             data-testid="session-token-device"
             className={styleClasses.result}
           >
-            {uaDeviceType}
+            {uaDeviceType === null ? 'Desktop' : uaDeviceType}
           </span>
         </li>
       </ul>


### PR DESCRIPTION
## Because

- Device row displays a blank value when a session belongs to a desktop device.

## This pull request

- Updates to display 'Desktop' when `uaDeviceType` is null

## Issue that this pull request solves

Closes: #11089

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before
<img width="360" alt="Screen Shot 2022-02-08 at 1 10 34 PM" src="https://user-images.githubusercontent.com/28129806/153049538-724846ad-c441-4100-9ada-ed9305841e9f.png">

After
<img width="375" alt="Screen Shot 2022-02-08 at 1 08 45 PM" src="https://user-images.githubusercontent.com/28129806/153049220-c88ef167-1582-4172-a4a2-7e63ba1bba18.png">
