### PR TITLE
feat(google): Add backend support to disconnect google linked account

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -486,8 +486,19 @@ export default class AuthClient {
   }> {
     const payload = {
       code,
+      // Once we land support for more auth providers we can update this
+      provider: 'google',
     };
     return await this.request('POST', '/linked_account/login', payload);
+  }
+
+  async unlinkThirdParty(
+    sessionToken: hexstring,
+    provider: string
+  ): Promise<{ success: boolean }> {
+    return await this.sessionPost('/linked_account/unlink', sessionToken, {
+      provider,
+    });
   }
 
   async accountKeys(

--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -380,6 +380,11 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     return LinkedAccount.createLinkedGoogleAccount(uid, googleUserId);
   };
 
+  DB.prototype.deleteLinkedGoogleAccount = async function (uid) {
+    log.trace('DB.deleteLinkedGoogleAccount', { uid });
+    return LinkedAccount.deleteLinkedGoogleAccount(uid);
+  };
+
   DB.prototype.totpToken = async function (uid) {
     log.trace('DB.totpToken', { uid });
     const totp = await TotpToken.findByUid(uid);

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -51,7 +51,6 @@ export class AccountHandler {
   private otpOptions: ConfigType['otp'];
   private skipConfirmationForEmailAddresses: string[];
   private capabilityService: CapabilityService;
-  private googleAuthClient: any;
 
   constructor(
     private log: AuthLogger,

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -694,3 +694,12 @@ module.exports.newsletters = isA
   )
   .default([])
   .optional();
+
+module.exports.thirdPartyProvider = isA
+  .string()
+  .max(256)
+  .allow(['google', 'apple'])
+  .required();
+
+module.exports.thirdPartyIdToken = module.exports.jwt.optional();
+module.exports.thirdPartyOAuthCode = isA.string().optional();

--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -207,4 +207,67 @@ describe('/linked_account', () => {
       });
     });
   });
+
+  describe('/linked_account/unlink', () => {
+    let mockLog, mockDB, mockRequest, route;
+
+    const UID = 'fxauid';
+    const mockGoogleUser = {
+      sub: '123123123',
+      email: `${Math.random()}@gmail.com`,
+    };
+
+    beforeEach(async () => {
+      mockLog = mocks.mockLog();
+      mockLog.info = sinon.spy();
+      mockDB = mocks.mockDB({
+        email: mockGoogleUser.email,
+        uid: UID,
+      });
+      const mockConfig = {
+        googleAuthConfig: { clientId: 'OooOoo' },
+      };
+      mockRequest = mocks.mockRequest({
+        log: mockLog,
+        credentials: {
+          uid: UID,
+        },
+        payload: {
+          provider: 'google',
+        },
+      });
+
+      const OAuth2ClientMock = class OAuth2Client {
+        verifyIdToken() {
+          return {
+            getPayload: () => {
+              return mockGoogleUser;
+            },
+          };
+        }
+      };
+
+      route = getRoute(
+        makeRoutes(
+          {
+            config: mockConfig,
+            db: mockDB,
+            log: mockLog,
+          },
+          {
+            'google-auth-library': {
+              OAuth2Client: OAuth2ClientMock,
+            },
+          }
+        ),
+        '/linked_account/unlink'
+      );
+    });
+
+    it('calls deleteLinkedGoogleAccount', async () => {
+      const result = await runTest(route, mockRequest);
+      assert.isTrue(mockDB.deleteLinkedGoogleAccount.calledOnceWith(UID));
+      assert.isTrue(result.success);
+    });
+  });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -106,6 +106,7 @@ const DB_METHOD_NAMES = [
   'fetchAccountSubscriptions',
   'getGoogleId',
   'createLinkedGoogleAccount',
+  'deleteLinkedGoogleAccount',
 ];
 
 const LOG_METHOD_NAMES = [

--- a/packages/fxa-graphql-api/src/gql/model/account.ts
+++ b/packages/fxa-graphql-api/src/gql/model/account.ts
@@ -8,6 +8,7 @@ import { Avatar } from './avatar';
 import { Email } from './emails';
 import { Subscription } from './subscription';
 import { Totp } from './totp';
+import { LinkedAccount } from './linkedAccount';
 
 @ObjectType({
   description: "The current authenticated user's Firefox Account record.",
@@ -52,4 +53,9 @@ export class Account {
     description: 'Client sessions attached to the user.',
   })
   public attachedClients!: AttachedClient;
+
+  @Field((type) => [LinkedAccount], {
+    description: 'Linked accounts',
+  })
+  public linkedAccounts!: LinkedAccount;
 }

--- a/packages/fxa-graphql-api/src/gql/model/linkedAccount.ts
+++ b/packages/fxa-graphql-api/src/gql/model/linkedAccount.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class LinkedAccount {
+  @Field()
+  public providerId!: number;
+
+  @Field()
+  public enabled!: boolean;
+
+  @Field()
+  public authAt!: number;
+}

--- a/packages/fxa-shared/db/models/auth/account.ts
+++ b/packages/fxa-shared/db/models/auth/account.ts
@@ -12,7 +12,7 @@ import { intBoolTransformer, uuidTransformer } from '../../transformers';
 import { convertError, notFound } from '../../mysql';
 
 export type AccountOptions = {
-  include?: 'emails'[];
+  include?: Array<'emails' | 'linkedAccounts'>;
 };
 
 const selectFields = [
@@ -71,6 +71,7 @@ export class Account extends BaseAuthModel {
   metricsOptOutAt?: number;
   devices?: Device[];
   emails?: Email[];
+  linkedAccounts?: LinkedAccount[];
 
   static relationMappings = {
     emails: {
@@ -434,6 +435,11 @@ export class Account extends BaseAuthModel {
       account.emails = await Email.findByUid(uid);
       account.primaryEmail = account.emails?.find((email) => email.isPrimary);
     }
+
+    if (options?.include?.includes('linkedAccounts')) {
+      account.linkedAccounts = await LinkedAccount.findByUid(uid);
+    }
+
     return account;
   }
 

--- a/packages/fxa-shared/db/models/auth/linked-account.ts
+++ b/packages/fxa-shared/db/models/auth/linked-account.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { BaseAuthModel, Proc } from './base-auth';
+import { BaseAuthModel } from './base-auth';
 import { uuidTransformer } from '../../transformers';
 
 const PROVIDER = {
@@ -47,13 +47,17 @@ export class LinkedAccount extends BaseAuthModel {
     });
   }
 
-  static async deleteLinkedGoogleAccount(uid: string, id: string) {
-    await LinkedAccount.query()
+  static async deleteLinkedGoogleAccount(uid: string) {
+    return LinkedAccount.query()
       .delete()
       .where({
         uid: uuidTransformer.to(uid),
-        id,
         providerId: PROVIDER['GOOGLE'],
       });
+
+    // TODO: In a follow up we can consider automatically revoking sessions
+    // that were created from a Google auth flow. Currently, a user
+    // can manually disconnect a connection in the `Connected services`
+    // section in settings
   }
 }

--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -526,7 +526,7 @@ describe('auth', () => {
         const id = getRandomId();
         await LinkedAccount.createLinkedGoogleAccount(userId, id);
 
-        await LinkedAccount.deleteLinkedGoogleAccount(userId, id);
+        await LinkedAccount.deleteLinkedGoogleAccount(userId);
 
         const linkedAccount = await LinkedAccount.findByGoogleId(id);
         assert.isUndefined(linkedAccount);


### PR DESCRIPTION
## Because

- This adds support to disconnect a linked Google account from an FxA account

## This pull request

- Creates a new endpoint `/linked_account/unlink` that removes association between Google and FxA accounts
- Updates graphql server to return linked accounts
- Does not revoke sessions created by a Google account, a user can manually revoke this session in the `Connected services` in section. Follow up issue https://github.com/mozilla/fxa/issues/11886

## Issue that this pull request solves

Closes: #11316

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
