### PR TITLE
feat(google): Add settings section for linked accounts

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -494,8 +494,12 @@ export default class AuthClient {
 
   async unlinkThirdParty(
     sessionToken: hexstring,
-    provider: string
+    providerId: number
   ): Promise<{ success: boolean }> {
+    // Let's change this once we land support for more than one third
+    // party account
+    let provider = providerId === 1 ? 'google' : '';
+
     return await this.sessionPost('/linked_account/unlink', sessionToken, {
       provider,
     });

--- a/packages/fxa-settings/src/components/App/en-US.ftl
+++ b/packages/fxa-settings/src/components/App/en-US.ftl
@@ -14,6 +14,7 @@
 
 -brand-mozilla = Mozilla
 -brand-firefox = Firefox
+-brand-google = Google
 # “Accounts” can be localized, “Firefox” must be treated as a brand.
 -product-firefox-accounts = Firefox Accounts
 # “Account” can be localized, “Firefox” must be treated as a brand.

--- a/packages/fxa-settings/src/components/LinkedAccounts/LinkedAccount.tsx
+++ b/packages/fxa-settings/src/components/LinkedAccounts/LinkedAccount.tsx
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+
+import { Localized, useLocalization } from '@fluent/react';
+import { ReactComponent as GoogleIcon } from './google.svg';
+import { Modal } from '../Modal';
+import { useAccount } from '../../models';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+
+export function LinkedAccount({ providerId }: { providerId: number }) {
+  const account = useAccount();
+  const { l10n } = useLocalization();
+
+  const [confirmUnlinkModalRevealed, revealUnlinkModal, hideUnlinkModal] =
+    useBooleanState();
+
+  const onConfirmUnlinkAccountClick = async () => {
+    await account.unlinkThirdParty(providerId);
+  };
+
+  const onUnlinkAccountClick = () => {
+    revealUnlinkModal();
+  };
+
+  return (
+    <div
+      className="my-1"
+      id="linked-account"
+      data-testid="settings-linked-accounts"
+      data-name={providerId}
+    >
+      <div className="p-4 border-2 border-solid border-grey-100 rounded flex mobileLandscape:justify-around items-center flex-col mobileLandscape:flex-row">
+        <div className="flex flex-grow w-full mobileLandscape:flex-2">
+          <span className="flex justify-center items-center flex-0">
+            {providerId === 1 && <GoogleIcon />}
+          </span>
+          <div className="flex flex-col flex-5 mobileLandscape:items-center mobileLandscape:flex-row">
+            <div className="flex flex-col mobileLandscape:flex-2">
+              <Localized id="settings-provider-name">
+                <p className="text-xs break-word" data-testid="provider-name">
+                  Google
+                </p>
+              </Localized>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-grow w-full mobileLandscape:justify-end mobileLandscape:flex-1">
+          <Localized id="la-unlink-button">
+            <button
+              className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap"
+              data-testid="linked-account-unlink"
+              onClick={onUnlinkAccountClick}
+            >
+              Unlink
+            </button>
+          </Localized>
+        </div>
+      </div>
+
+      {confirmUnlinkModalRevealed && (
+        <Modal
+          onDismiss={hideUnlinkModal}
+          onConfirm={onConfirmUnlinkAccountClick}
+          confirmBtnClassName="cta-primary"
+          confirmText={l10n.getString(
+            'la-unlink-account-button',
+            null,
+            'Unlink'
+          )}
+          data-testid="linked-account-unlink-header-test-id"
+          headerId="linked-account-unlink-header"
+          descId="linked-account-unlink-description"
+        >
+          <Localized id="la-unlink-heading">
+            <h2
+              id="linked-account-unlink-header"
+              className="font-bold text-xl text-center mb-2"
+              data-testid="linked-account-modal-header"
+            >
+              Unlink from third party account
+            </h2>
+          </Localized>
+
+          <Localized id="la-unlink-content">
+            <p
+              id="linked-accounts-unlink-description"
+              className="my-4 text-center"
+            >
+              Are you sure you want to unlink your Google account? Unlinking
+              your account does not automatically sign you out of those
+              services, to do that you will need to manually sign out from the
+              Connected services section.
+            </p>
+          </Localized>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export default LinkedAccount;

--- a/packages/fxa-settings/src/components/LinkedAccounts/en-US.ftl
+++ b/packages/fxa-settings/src/components/LinkedAccounts/en-US.ftl
@@ -1,0 +1,9 @@
+## Linked Accounts section
+
+la-heading = Linked Accounts
+la-description = You have authorized access to the following accounts.
+la-unlink-button = Unlink
+la-unlink-account-button = Unlink
+la-unlink-heading = Unlink from third party account
+la-unlink-content = Are you sure you want to unlink your { -brand-google } account? Unlinking your account does not automatically sign you out of those services, to do that you will need to manually sign out from the Connected services section.
+nav-linked-accounts = { la-heading }

--- a/packages/fxa-settings/src/components/LinkedAccounts/google.svg
+++ b/packages/fxa-settings/src/components/LinkedAccounts/google.svg
@@ -1,0 +1,36 @@
+<svg width="46" height="46" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="a">
+            <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+            <feGaussianBlur stdDeviation=".5" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+            <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.168 0" in="shadowBlurOuter1"
+                           result="shadowMatrixOuter1"/>
+            <feOffset in="SourceAlpha" result="shadowOffsetOuter2"/>
+            <feGaussianBlur stdDeviation=".5" in="shadowOffsetOuter2" result="shadowBlurOuter2"/>
+            <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.084 0" in="shadowBlurOuter2"
+                           result="shadowMatrixOuter2"/>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"/>
+                <feMergeNode in="shadowMatrixOuter2"/>
+                <feMergeNode in="SourceGraphic"/>
+            </feMerge>
+        </filter>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <g transform="translate(3 3)" filter="url(#a)">
+            <use fill="#FFF" xlink:href="#b"/>
+            <use xlink:href="#b"/>
+            <use xlink:href="#b"/>
+            <use xlink:href="#b"/>
+        </g>
+        <path d="M31.64 23.205c0-.639-.057-1.252-.164-1.841H23v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
+              fill="#4285F4"/>
+        <path d="M23 32c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711h-3.007v2.332A8.997 8.997 0 0 0 23 32Z"
+              fill="#34A853"/>
+        <path d="M17.964 24.71a5.41 5.41 0 0 1-.282-1.71c0-.593.102-1.17.282-1.71v-2.332h-3.007A8.996 8.996 0 0 0 14 23c0 1.452.348 2.827.957 4.042l3.007-2.332Z"
+              fill="#FBBC05"/>
+        <path d="M23 17.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C27.463 14.891 25.426 14 23 14a8.997 8.997 0 0 0-8.043 4.958l3.007 2.332c.708-2.127 2.692-3.71 5.036-3.71Z"
+              fill="#EA4335"/>
+        <path d="M14 14h18v18H14V14Z"/>
+    </g>
+</svg>

--- a/packages/fxa-settings/src/components/LinkedAccounts/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkedAccounts/index.stories.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { LinkedAccounts } from '.';
+
+import { MOCK_LINKED_ACCOUNTS } from './mocks';
+import { AppContext } from 'fxa-settings/src/models';
+import { mockAppContext } from 'fxa-settings/src/models/mocks';
+
+storiesOf('Components/LinkedAccounts', module).add('default', () => (
+  <AppContext.Provider
+    value={mockAppContext({
+      account: { linkedAccounts: MOCK_LINKED_ACCOUNTS } as any,
+    })}
+  >
+    <LinkedAccounts />
+  </AppContext.Provider>
+));

--- a/packages/fxa-settings/src/components/LinkedAccounts/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkedAccounts/index.test.tsx
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { mockAppContext, renderWithRouter } from '../../models/mocks';
+import { Account, AppContext } from '../../models';
+import LinkedAccounts from '../LinkedAccounts';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
+
+const account = {
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+} as unknown as Account;
+
+const clickUnlinkButton = async () => {
+  await act(async () => {
+    const unlinkButtons = await screen.findAllByTestId('linked-account-unlink');
+    fireEvent.click(unlinkButtons[0]);
+  });
+};
+const clickConfirmUnlinkButton = async () => {
+  await act(async () => {
+    const confirmButton = await screen.findByTestId('modal-confirm');
+    fireEvent.click(confirmButton);
+  });
+};
+describe('Linked Accounts', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders "fresh load" <LinkedAccounts/> with correct content', async () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <LinkedAccounts />
+      </AppContext.Provider>
+    );
+
+    expect(await screen.findByText('Linked Accounts')).toBeTruthy();
+    expect(await screen.findByText('Google')).toBeTruthy();
+  });
+
+  it('does not render linked accounts section if no linked accounts', async () => {
+    const account = {
+      linkedAccounts: [],
+    } as unknown as Account;
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <LinkedAccounts />
+      </AppContext.Provider>
+    );
+
+    expect(screen.queryByTestId('linked-account')).toBeNull();
+  });
+
+  it('renders proper modal when "unlink" is clicked', async () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <LinkedAccounts />
+      </AppContext.Provider>
+    );
+    await clickUnlinkButton();
+
+    expect(
+      screen.queryByTestId('linked-account-unlink-header-test-id')
+    ).toBeInTheDocument();
+  });
+
+  it('on unlink, removes linked account', async () => {
+    const linkedAccounts = MOCK_LINKED_ACCOUNTS;
+
+    const account = {
+      linkedAccounts,
+      unlinkThirdParty: () => account.linkedAccounts.shift(),
+    } as unknown as Account;
+
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <LinkedAccounts />
+      </AppContext.Provider>
+    );
+
+    await clickUnlinkButton();
+
+    expect(
+      screen.queryByTestId('linked-account-unlink-header-test-id')
+    ).toBeInTheDocument();
+
+    await clickConfirmUnlinkButton();
+
+    expect(screen.queryAllByTestId('linked-account')).toHaveLength(0);
+  });
+});

--- a/packages/fxa-settings/src/components/LinkedAccounts/index.tsx
+++ b/packages/fxa-settings/src/components/LinkedAccounts/index.tsx
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { useAccount } from '../../models';
+import { Localized } from '@fluent/react';
+import { LinkedAccount as LinkedAccountSection } from './LinkedAccount';
+
+export const LinkedAccounts = () => {
+  const account = useAccount();
+  const linkedAccounts = account.linkedAccounts;
+
+  return (
+    <>
+      {!!linkedAccounts.length && (
+        <section className="mt-11" data-testid="settings-linked-accounts">
+          <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4 relative">
+            <span id="linked-accounts" className="nav-anchor"></span>
+            <Localized id="la-heading">Linked Accounts</Localized>
+          </h2>
+          <div className="bg-white tablet:rounded-xl shadow px-4 tablet:px-6 pt-7 pb-8">
+            <div className="flex justify-between mb-4">
+              <Localized id="la-description">
+                <p>
+                  You have linked and authorized access to the following
+                  accounts.
+                </p>
+              </Localized>
+            </div>
+
+            {linkedAccounts.map((linkedAccount) => (
+              <LinkedAccountSection
+                {...{
+                  key: linkedAccount.providerId,
+                  providerId: linkedAccount.providerId,
+                }}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  );
+};
+
+export default LinkedAccounts;

--- a/packages/fxa-settings/src/components/LinkedAccounts/mocks.ts
+++ b/packages/fxa-settings/src/components/LinkedAccounts/mocks.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_LINKED_ACCOUNTS = [
+  {
+    providerId: 1,
+    authAt: Date.now(),
+    enabled: true,
+  },
+];

--- a/packages/fxa-settings/src/components/Nav/index.test.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.test.tsx
@@ -13,6 +13,7 @@ const account = {
     email: 'stomlinson@mozilla.com',
   },
   subscriptions: [],
+  linkedAccounts: [],
 } as unknown as Account;
 
 describe('Nav', () => {
@@ -72,6 +73,7 @@ describe('Nav', () => {
         email: 'stomlinson@mozilla.com',
       },
       subscriptions: [{ created: 1, productName: 'x' }],
+      linkedAccounts: [],
     } as unknown as Account;
     render(
       <AppContext.Provider value={{ account }}>
@@ -100,5 +102,32 @@ describe('Nav', () => {
     );
 
     expect(screen.queryByTestId('nav-link-newsletters')).toBeNull();
+  });
+
+  it('renders as expected with linkedAccounts link', () => {
+    const account = {
+      primaryEmail: {
+        email: 'stomlinson@mozilla.com',
+      },
+      subscriptions: [{ created: 1, productName: 'x' }],
+      linkedAccounts: [
+        {
+          providerId: 1,
+        },
+      ],
+    } as unknown as Account;
+    render(
+      <AppContext.Provider value={{ account }}>
+        <Nav />
+      </AppContext.Provider>
+    );
+
+    expect(screen.getByTestId('nav-link-linked-accounts')).toHaveTextContent(
+      'Linked Accounts'
+    );
+    expect(screen.getByTestId('nav-link-linked-accounts')).toHaveAttribute(
+      'href',
+      '#linked-accounts'
+    );
   });
 });

--- a/packages/fxa-settings/src/components/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.tsx
@@ -14,6 +14,7 @@ export const Nav = () => {
   const config = useConfig();
   const primaryEmail = account.primaryEmail.email;
   const hasSubscription = account.subscriptions.length > 0;
+  const hasLinkedAccounts = account.linkedAccounts.length > 0;
   const marketingCommPrefLink =
     config.marketingEmailPreferencesUrl &&
     `${config.marketingEmailPreferencesUrl}?email=${encodeURIComponent(
@@ -68,6 +69,19 @@ export const Nav = () => {
                 </a>
               </Localized>
             </li>
+            {hasLinkedAccounts && (
+              <li className="mt-3">
+                <Localized id="nav-linked-accounts">
+                  <a
+                    href="#linked-accounts"
+                    data-testid="nav-link-linked-accounts"
+                    className="inline-block py-1 px-2 hover:bg-grey-100"
+                  >
+                    Linked Accounts
+                  </a>
+                </Localized>
+              </li>
+            )}
             <li className="mt-3">
               <Localized id="nav-data-collection">
                 <a

--- a/packages/fxa-settings/src/components/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.tsx
@@ -8,6 +8,7 @@ import Nav from '../Nav';
 import Security from '../Security';
 import { Profile } from '../Profile';
 import ConnectedServices from '../ConnectedServices';
+import LinkedAccounts from '../LinkedAccounts';
 
 import * as Metrics from '../../lib/metrics';
 import { useAccount } from '../../models';
@@ -33,6 +34,7 @@ export const PageSettings = (_: RouteComponentProps) => {
         <Profile />
         <Security />
         <ConnectedServices />
+        <LinkedAccounts />
         <DataCollection />
         <div className="flex mx-4 tablet:mx-0" id="delete-account">
           <Localized id="delete-account-link">

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -44,6 +44,7 @@ export const MOCK_ACCOUNT: AccountData = {
     exists: true,
     verified: true,
   },
+  linkedAccounts: [],
 };
 
 export function renderWithRouter(


### PR DESCRIPTION
## Because

- A user needs the ability to see what third party accounts are linked to their FxA account
- A user needs to be able to disconnect a linked account

## This pull request

- Adds a new settings section `Linked Accounts`
- Displays the provider logo and an option to unlink
- Some parts mention Google directly, I plan on updating when we add support for Apple

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11317

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1087" alt="Screen Shot 2022-02-10 at 3 50 09 PM" src="https://user-images.githubusercontent.com/1295288/153902225-80eedf53-c08d-4e11-92e2-af936a1a72cc.png">

<img width="523" alt="Screen Shot 2022-02-10 at 3 50 14 PM" src="https://user-images.githubusercontent.com/1295288/153902204-3fffe14e-4f06-4bb1-b940-cd2ce87999db.png">

<img width="395" alt="Screen Shot 2022-02-10 at 3 50 03 PM" src="https://user-images.githubusercontent.com/1295288/153902253-fd2ae8b3-9784-4454-8482-9f9be62b3471.png">

