### PR TITLE
fix(auth): Fixes build error in CI.

### DIFF
--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -1,8 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { RedisShared } from 'fxa-shared/db/redis';
-import { resolve } from 'path';
+const { RedisShared } = require('fxa-shared/db/redis');
+const { resolve } = require('path');
 
 ('use strict');
 


### PR DESCRIPTION
## Because

-  The command `yarn workspace fxa-auth-server build` was failing

## This pull request

- Switching to require statements in redis.js file clears typescript error saying the 'default export was not defined'.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).