### PR TITLE
fix(auth-server): subscriptionUpgrade email includes variable when value is missing

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2700,7 +2700,6 @@ export class StripeHelper {
     const {
       amount: paymentAmountOldInCents,
       currency: paymentAmountOldCurrency,
-      interval: productPaymentCycleOld,
     } = planOld;
     const { product_id: productIdOld, product_name: productNameOld } =
       abbrevProductOld;
@@ -2722,7 +2721,7 @@ export class StripeHelper {
       productNameOld,
       productIconURLOld,
       productDownloadURLOld,
-      productPaymentCycleOld,
+      productPaymentCycleOld: planOld.interval ?? baseDetails.productPaymentCycleNew,
       paymentAmountOldInCents,
       paymentAmountOldCurrency,
       invoiceNumber,


### PR DESCRIPTION
## Because

- it appears the email template on staging includes the variable name `{ $productPaymentCycleOld }`, when `productPaymentCycleOld` and `productPaymentCycleNew` are the same (e.g., the plan is upgraded from a monthly subscription to another monthly subscription). However, there is no issue when the two variables are different (e.g., the plan is upgraded from a monthly subscription to an annual subscription) - see screenshots below.

## This pull request

- sets `productPaymentCycleOld` to the current plan's interval value (`productPaymentCycleNew`), if there is no interval value from the plan's `previous_attribute` object.

## Issue that this pull request solves

Closes: #11848

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Currently on staging - month to month upgrade:
![Screen Shot 2022-02-03 at 3 00 23 PM](https://user-images.githubusercontent.com/28129806/153461562-02bdc8c2-d590-4a61-add0-8151fa0f3fcc.png)

Currently on staging - month to year upgrade:
<img width="968" alt="Screen Shot 2022-02-09 at 9 46 46 AM" src="https://user-images.githubusercontent.com/28129806/153461588-530d7076-92f0-42f1-95d9-cc50adf72582.png">


