### PR TITLE
feat(mailer): Add maxConnection and maxMessages env vars, re-enable isMetricsEnabled oauth client db calls

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -326,6 +326,18 @@ const conf = convict({
       default: 'Firefox Accounts <no-reply@lcip.org>',
       env: 'SMTP_SENDER',
     },
+    maxMessages: {
+      default: 10,
+      doc: 'Maximum number of messages to be sent via nodemailer before a new SES SMTP connection is made',
+      env: 'SMTP_MAX_MESSAGES',
+      format: Number,
+    },
+    maxConnections: {
+      default: 2,
+      doc: 'Maximum number of simultaneous connections to make against the SES SMTP server',
+      env: 'SMTP_MAX_CONNECTIONS',
+      format: Number,
+    },
     prependVerificationSubdomain: {
       enabled: {
         doc: 'Flag to prepend a verification subdomain to verification emails',

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -257,8 +257,8 @@ module.exports = function (log, config, bounces) {
       ignoreTLS: !mailerConfig.secure,
       port: mailerConfig.port,
       pool: true,
-      maxConnections: 2,
-      maxMessages: 10,
+      maxConnections: mailerConfig.maxConnections,
+      maxMessages: mailerConfig.maxMessages,
     };
 
     if (mailerConfig.user && mailerConfig.password) {

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -258,9 +258,7 @@ async function create(log, error, config, routes, db, translator, statsd) {
         request.auth.credentials.user
       ) {
         // oauthToken strategy comes with uid as user
-        // TODO: re-enable this. We're disabling for now to see if it helps with auth server
-        // performance issues.
-        // uid = request.auth.credentials.user;
+        uid = request.auth.credentials.user;
       } else if (request.payload && request.payload.uid) {
         // Some unauthenticated requests might set uid in payload, ex. `/account/status`
         uid = request.payload.uid;


### PR DESCRIPTION
Because:
* We want these values to be configurable for easy changes on the ops side to investigate recent auth-server performance problems
* We temporarily disabled db calls for oauth clients to see if that was the problem, but it hasn't changed much

This commit:
* Creates SMTP_MAX_MESSAGES and SMTP_MAX_CONNECTIONS env vars with defaults to what we currently have
* Removes the previously commented out line temporarily disabling db calls for oauth clients

fixes #11799, or at least hopefully we can hand it off to ops to experiment with 🤞