### PR TITLE
fix(subscriptions): memoize existing account check result

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -7,7 +7,11 @@ jest.mock('../../lib/apiClient', () => ({
 }));
 import { apiFetchAccountStatus } from '../../lib/apiClient';
 
-import { NewUserEmailForm, emailInputValidationAndAccountCheck } from './index';
+import {
+  NewUserEmailForm,
+  emailInputValidationAndAccountCheck,
+  checkAccountExists,
+} from './index';
 import { Localized } from '@fluent/react';
 const selectedPlan = {
   plan_id: 'planId',
@@ -191,5 +195,25 @@ describe('NewUserEmailForm test', () => {
         </React.Fragment>
       </Localized>
     );
+  });
+});
+
+describe('checkAccountExists', () => {
+  it('returns the response of apiFetchAccountStatus', async () => {
+    const res = { exists: false };
+    (apiFetchAccountStatus as jest.Mock).mockClear().mockResolvedValue(res);
+    const actual = await checkAccountExists('testo@example.gg');
+    expect(actual).toEqual(res);
+    expect(apiFetchAccountStatus).toHaveBeenCalledTimes(1);
+    expect(apiFetchAccountStatus).toHaveBeenCalledWith('testo@example.gg');
+  });
+
+  it('memoizes the response of for an email', async () => {
+    (apiFetchAccountStatus as jest.Mock).mockClear();
+    const email = `${Date.now()}@example.gg`;
+    await checkAccountExists(email);
+    await checkAccountExists(email);
+    expect(apiFetchAccountStatus).toHaveBeenCalledTimes(1);
+    expect(apiFetchAccountStatus).toHaveBeenCalledWith(email);
   });
 });

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -160,9 +160,18 @@ export const NewUserEmailForm = ({
   );
 };
 
-export async function checkAccountExists(userEmail: string) {
-  return apiFetchAccountStatus(userEmail);
-}
+export const checkAccountExists = (() => {
+  const results: { [key: string]: { exists: boolean } } = {};
+  const memoizedCheck = async (userEmail: string) => {
+    if (results[userEmail]) {
+      return results[userEmail];
+    }
+    const res = (results[userEmail] = await apiFetchAccountStatus(userEmail));
+    return res;
+  };
+
+  return memoizedCheck;
+})();
 
 export async function emailInputValidationAndAccountCheck(
   value: string,


### PR DESCRIPTION
Because:
 - when a user encounters an error during their first subscription
   attempt on the passwordless flow, they could end up getting the
   account exists message and will be forced to "reset" (but actually
   create) their FxA password and signin

This commit:
 - memoize the existing account check result to prevent account exists
   message on subscription retries
   - this is a partial fix for retries after the user dismissed the
     error message; it will not work if the user refreshes the checkout
     page

## Issue that this pull request solves

Closes: #11197 
