### PR TITLE
fix(auth-server): time is not expressed based on user's location in emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -155,7 +155,7 @@ module.exports = function (log, config, bounces) {
     return `href="${url}" style="color: #0a84ff; text-decoration: none; font-family: sans-serif;"`;
   }
 
-  function constructLocalTimeString(timeZone, locale, date, time) {
+  function constructLocalTimeString(timeZone, locale) {
     // if no timeZone is passed, use DEFAULT_TIMEZONE
     moment.tz.setDefault(DEFAULT_TIMEZONE);
     // if no locale is passed, use DEFAULT_LOCALE
@@ -167,8 +167,8 @@ module.exports = function (log, config, bounces) {
     }
     // return a locale-specific time
     // if date or time is passed, return it as the current date or time
-    const timeNow = time || timeMoment.format('LTS (z)');
-    const dateNow = date || timeMoment.format('dddd, ll');
+    const timeNow = timeMoment.format('LTS (z)');
+    const dateNow = timeMoment.format('dddd, ll');
     return [timeNow, dateNow];
   }
 
@@ -401,11 +401,8 @@ module.exports = function (log, config, bounces) {
   Mailer.prototype._constructLocalTimeString = function (
     timeZone,
     acceptLanguage,
-    date,
-    time
   ) {
-    const translator = this.translator(acceptLanguage);
-    return constructLocalTimeString(timeZone, translator.language, date, time);
+    return constructLocalTimeString(timeZone, acceptLanguage);
   };
 
   Mailer.prototype._constructLocalDateString = function (
@@ -633,8 +630,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -811,8 +806,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -885,8 +878,6 @@ module.exports = function (log, config, bounces) {
       const [time, date] = this._constructLocalTimeString(
         message.timeZone,
         message.acceptLanguage,
-        message.date,
-        message.time
       );
 
       return this.send({
@@ -948,8 +939,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1018,8 +1007,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1066,8 +1053,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1131,8 +1116,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1176,8 +1159,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1279,8 +1260,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1332,8 +1311,6 @@ module.exports = function (log, config, bounces) {
       const [time, date] = this._constructLocalTimeString(
         message.timeZone,
         message.acceptLanguage,
-        message.date,
-        message.time
       );
 
       return this.send({
@@ -1530,8 +1507,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1577,8 +1552,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1624,8 +1597,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1671,8 +1642,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1768,8 +1737,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1818,8 +1785,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {
@@ -1868,8 +1833,6 @@ module.exports = function (log, config, bounces) {
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
       message.acceptLanguage,
-      message.date,
-      message.time
     );
 
     const headers = {

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -10,6 +10,7 @@ import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 import { URL } from 'url';
 
+const moment = require('moment-timezone');
 const config = require(`${ROOT_DIR}/config`).getProperties();
 if (!config.smtp.prependVerificationSubdomain.enabled) {
   config.smtp.prependVerificationSubdomain.enabled = true;
@@ -40,7 +41,7 @@ const MESSAGE = {
   acceptLanguage: 'en;q=0.8,en-US;q=0.5,en;q=0.3"',
   appStoreLink: 'https://example.com/app-store',
   code: 'abc123',
-  date: 'Wednesday, Apr 7, 2021',
+  date: moment().tz('America/Los_Angeles').format('dddd, ll'),
   deviceId: 'foo',
   location: {
     city: 'Mountain View',
@@ -55,7 +56,7 @@ const MESSAGE = {
   numberRemaining: 2,
   primaryEmail: 'c@d.com',
   service: 'sync',
-  time: '5:48:20 PM (PDT)',
+  time: moment().tz('America/Los_Angeles').format('LTS (z)'),
   timeZone: 'America/Los_Angeles',
   tokenCode: 'abc123',
   type: 'secondary',
@@ -101,6 +102,7 @@ const MESSAGE = {
   productPaymentCycleOld: 'year',
   providerName:'Google',
   reminderLength: 14,
+  secondaryEmail: 'secondary@email.com',
   serviceLastActiveDate: new Date(1587339098816),
   subscription: {
     productName: 'Cooking with Foxkeh',
@@ -422,7 +424,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'include', expected: 'If yes, use this verification code in your registration form:' },
       { test: 'include', expected: MESSAGE.code },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -433,7 +435,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'include', expected: `If yes, use this verification code in your registration form:\n${MESSAGE.code}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
@@ -458,7 +460,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.code}` },
       { test: 'include', expected: 'It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.' },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -473,7 +475,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.code}` },
       { test: 'include', expected: 'It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.' },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -521,7 +523,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -533,7 +535,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -555,7 +557,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -567,7 +569,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -587,7 +589,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -598,7 +600,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -620,7 +622,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: MESSAGE.unblockCode },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -631,7 +633,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `If yes, here is the authorization code you need: ${MESSAGE.unblockCode}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -654,7 +656,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -666,7 +668,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -686,7 +688,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'include', expected: 'If yes, use this verification code in your registration form:' },
       { test: 'include', expected: MESSAGE.code },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -697,7 +699,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'include', expected: `If yes, use this verification code in your registration form:\n${MESSAGE.code}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
@@ -719,7 +721,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -730,7 +732,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -749,7 +751,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'new-signin-verify-code', 'support')) },
       { test: 'include', expected: MESSAGE.code },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -758,7 +760,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'new-signin-verify-code', 'support')}` },
       { test: 'include', expected: `If yes, here is the verification code:\n${MESSAGE.code}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -777,7 +779,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -787,7 +789,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -809,7 +811,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -821,7 +823,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -840,7 +842,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-recovery-generated', 'privacy')) },
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-recovery-generated', 'support')) },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -849,7 +851,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-recovery-generated', 'privacy')}` },
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-recovery-generated', 'support')}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -871,7 +873,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -883,7 +885,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -905,7 +907,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -917,7 +919,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -963,7 +965,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -975,7 +977,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -1021,7 +1023,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -1033,7 +1035,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -1055,7 +1057,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -1067,7 +1069,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
-      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -1944,6 +1946,59 @@ describe('lib/senders/mjml-emails:', () => {
     return mailer.send({
       ...MESSAGE,
       template: 'wibble-blee-definitely-does-not-exist',
+    });
+  });
+
+  describe('constructLocalTimeString - returns date/time', () => {
+    it('returns date/time based on given values', () => {
+      const message = {
+        timeZone: 'America/Los_Angeles',
+        acceptLanguage: 'en',
+      }
+
+      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      const testTime = moment().tz(message.timeZone).format('LTS (z)');
+      const testDay = moment().tz(message.timeZone).format('dddd, ll');
+      assert.deepEqual(result, [ testTime, testDay]);
+    });
+
+    it('returns date/time based on default timezone (UTC) if timezone is undefined', () => {
+      const message = {
+        timeZone: undefined,
+        acceptLanguage: 'en',
+      }
+      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      assert.include(result[0], 'UTC');
+    });
+
+    it('returns date/time based on default locale (en) if locale is undefined', () => {
+      const message = {
+        timeZone: 'Europe/Berlin',
+        acceptLanguage: undefined,
+      }
+
+      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      assert.include(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'], result[1].split(',')[0]);
+    });
+
+    it('returns date/time in another timezone (at the time of writing - EST', () => {
+      const message = {
+        timeZone: 'Europe/Berlin',
+        acceptLanguage: 'en',
+      }
+
+      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      assert.include(result[0], 'CET');
+    });
+
+    it('returns date/time in Spanish', () => {
+      const message = {
+        timeZone: 'America/Los_Angeles',
+        acceptLanguage: 'es',
+      }
+
+      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      assert.include(['lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado', 'domingo'], result[1].split(',')[0]);
     });
   });
 


### PR DESCRIPTION
## Because

- `date` and `time` are properties that are not actually passed into the `message` object. They are created with `constructLocalTimeString` and passed into the email templates.

## This pull request

- Reverts parameters of `constructLocalTimeString` to its original parameters of `timeZone` and `acceptLanguage` ([see pull request](https://github.com/mozilla/fxa/pull/8114/files))
- Adds tests to check that the `constructLocalTimeString` function returns expected results
- Revises tests for emails to check that date and time are within email templates
  - Note: The tests to check that a specific time is included in the email templates failed because the seconds did not match (e.g 8:02:11AM and 8:02:16AM). Therefore, the tests have been revised to check that the time merely exists in the email templates.

- Also fixes a separate issue (see screenshots below) by adding `secondaryEmail` within the test file
![image (1)](https://user-images.githubusercontent.com/28129806/154312323-cbbdf978-58c7-4dfb-8846-2b5af914f82e.png)
![image](https://user-images.githubusercontent.com/28129806/154312690-a2a1d2cc-d4b2-47b1-8d50-767f8c5ef76d.png)

## Issue that this pull request solves

Closes: #9254

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).