### PR TITLE
Added missing permissions needed to interact with GitHub's OIDC Token endpoint

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   Upload-assets-to-CDN:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v2


### PR DESCRIPTION
## Because

The upload action will fail trying to interact with GitHub's OIDC token endpoint

## This pull request

Adds the permissions required to query the endpoint and get AWS credentials to upload.

## Issue that this pull request solves

Failing GitHub action: https://github.com/mozilla/fxa/actions/runs/1853703627
