### PR TITLE
fix(metrics): add oauth client ids to names config

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -177,6 +177,15 @@ const conf = convict({
       },
     },
   },
+  oauth_client_id_map: {
+    default: {
+      dcdb5ae7add825d2: '123done',
+      '325b4083e32fe8e7': '321done',
+    },
+    doc: 'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
+    env: 'OAUTH_CLIENT_IDS',
+    format: Object,
+  },
   productRedirectURLs: {
     default: {
       '123doneProProduct': 'http://localhost:8080/',

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -34,7 +34,11 @@ const FUZZY_EVENTS = new Map([
   ],
 ]);
 
-const transform = initialize({}, {}, FUZZY_EVENTS);
+const transform = initialize(
+  config.get('oauth_client_id_map'),
+  {},
+  FUZZY_EVENTS
+);
 
 module.exports = (event, request, data) => {
   const statsd = Container.get(StatsD);


### PR DESCRIPTION
Because:
 - the "Amplitude" event transform function in the payments was not
   initialized with an OAuth client ids to service names map, so
   'service' in the metric event properties is always 'undefined_oauth'

This commit:
 - add an OAuth client ids to names map and initialize the metrics
   transform function with it


## Issue that this pull request solves

Closes: #11897

There is also a related PR to add the config for stage and prod at https://github.com/mozilla-services/cloudops-infra/pull/3830