### PR TITLE
chore(emails): update finish setup email with more generic language

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
@@ -7,7 +7,5 @@ subscriptionAccountFinishSetup-subject = Welcome to { $productName }: Please set
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionAccountFinishSetup-title = Welcome to { $productName }
 subscriptionAccountFinishSetup-content-processing = Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel.
-# Variables:
-#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionAccountFinishSetup-content-create = Next, you’ll create a Firefox account password and download { $productName }.
-subscriptionAccountFinishSetup-action = Create a password
+subscriptionAccountFinishSetup-content-create-2 = Next, you’ll create a { -product-firefox-account } password to start using your new subscription.
+subscriptionAccountFinishSetup-action-2 = Get started

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.mjml
@@ -19,16 +19,16 @@
     <%- include ('/partials/paymentPlanDetails/index.mjml') %>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionAccountFinishSetup-content-create" data-l10n-args="<%= JSON.stringify({productName}) %>">
-        Next, you’ll create a Firefox account password and download <%- productName %>.
+      <span data-l10n-id="subscriptionAccountFinishSetup-content-create-2">
+        Next, you’ll create a Firefox account password to start using your new subscription.
       </span>
     </mj-text>
   </mj-column>
 </mj-section>
 
 <%- include ('/partials/button/index.mjml', {
-  buttonL10nId: "subscriptionAccountFinishSetup-action",
-  buttonText: "Create a password",
+  buttonL10nId: "subscriptionAccountFinishSetup-action-2",
+  buttonText: "Get started",
   cssClass: 'mb-8'
   }) %>
 <%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.txt
@@ -6,7 +6,7 @@ subscriptionAccountFinishSetup-content-processing = "Your payment is processing 
 
 <%- include ('/partials/paymentPlanDetails/index.txt') %>
 
-subscriptionAccountFinishSetup-content-create = "Next, you’ll create a Firefox account password and download <%- productName %>."
+subscriptionAccountFinishSetup-content-create-2 = "Next, you’ll create a Firefox account password to start using your new subscription."
 
 <%- link %>
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -100,7 +100,7 @@ const MESSAGE = {
   productNameNew: 'Product B',
   productPaymentCycleNew: 'month',
   productPaymentCycleOld: 'year',
-  providerName:'Google',
+  providerName: 'Google',
   reminderLength: 14,
   secondaryEmail: 'secondary@email.com',
   serviceLastActiveDate: new Date(1587339098816),
@@ -1179,7 +1179,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
       { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
-      { test: 'include', expected: `create a Firefox account password and download ${MESSAGE.productName}` },
+      { test: 'include', expected: 'Next, you’ll create a Firefox account password to start using your new subscription.' },
       { test: 'notInclude', expected: `alt="${MESSAGE.productName}"` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
@@ -1191,7 +1191,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
       { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
-      { test: 'include', expected: `create a Firefox account password and download ${MESSAGE.productName}` },
+      { test: 'include', expected: 'Next, you’ll create a Firefox account password to start using your new subscription.' },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
@@ -1954,20 +1954,26 @@ describe('lib/senders/mjml-emails:', () => {
       const message = {
         timeZone: 'America/Los_Angeles',
         acceptLanguage: 'en',
-      }
+      };
 
-      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      const result = mailer._constructLocalTimeString(
+        message.timeZone,
+        message.acceptLanguage
+      );
       const testTime = moment().tz(message.timeZone).format('LTS (z)');
       const testDay = moment().tz(message.timeZone).format('dddd, ll');
-      assert.deepEqual(result, [ testTime, testDay]);
+      assert.deepEqual(result, [testTime, testDay]);
     });
 
     it('returns date/time based on default timezone (UTC) if timezone is undefined', () => {
       const message = {
         timeZone: undefined,
         acceptLanguage: 'en',
-      }
-      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      };
+      const result = mailer._constructLocalTimeString(
+        message.timeZone,
+        message.acceptLanguage
+      );
       assert.include(result[0], 'UTC');
     });
 
@@ -1975,19 +1981,36 @@ describe('lib/senders/mjml-emails:', () => {
       const message = {
         timeZone: 'Europe/Berlin',
         acceptLanguage: undefined,
-      }
+      };
 
-      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
-      assert.include(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'], result[1].split(',')[0]);
+      const result = mailer._constructLocalTimeString(
+        message.timeZone,
+        message.acceptLanguage
+      );
+      assert.include(
+        [
+          'Monday',
+          'Tuesday',
+          'Wednesday',
+          'Thursday',
+          'Friday',
+          'Saturday',
+          'Sunday',
+        ],
+        result[1].split(',')[0]
+      );
     });
 
     it('returns date/time in another timezone (at the time of writing - EST', () => {
       const message = {
         timeZone: 'Europe/Berlin',
         acceptLanguage: 'en',
-      }
+      };
 
-      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
+      const result = mailer._constructLocalTimeString(
+        message.timeZone,
+        message.acceptLanguage
+      );
       assert.include(result[0], 'CET');
     });
 
@@ -1995,10 +2018,24 @@ describe('lib/senders/mjml-emails:', () => {
       const message = {
         timeZone: 'America/Los_Angeles',
         acceptLanguage: 'es',
-      }
+      };
 
-      const result = mailer._constructLocalTimeString(message.timeZone, message.acceptLanguage);
-      assert.include(['lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado', 'domingo'], result[1].split(',')[0]);
+      const result = mailer._constructLocalTimeString(
+        message.timeZone,
+        message.acceptLanguage
+      );
+      assert.include(
+        [
+          'lunes',
+          'martes',
+          'miércoles',
+          'jueves',
+          'viernes',
+          'sábado',
+          'domingo',
+        ],
+        result[1].split(',')[0]
+      );
     });
   });
 


### PR DESCRIPTION
Because:
 - Not all subscription products are "downloadable"

This commit:
 - Update the content of the finish setup email to not mention
   downloading

## Issue that this pull request solves

Closes: #11158
