### PR TITLE
feat(google): return provider user id to the oauth client

### DIFF
--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -43,6 +43,12 @@
         Sign In (Require 2FA)
       </button>
       <button
+        class="btn btn-large btn-info btn-persona third-party"
+        type="submit"
+      >
+        Sign In (Third Party)
+      </button>
+      <button
         class="btn btn-large btn-info btn-persona prompt-none"
         type="submit"
       >

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -203,11 +203,16 @@ $(document).ready(function () {
         });
     };
 
-    function authenticate(endpoint) {
-      // propagate query parameters to the authorization request.
+    function authenticate(endpoint, params = {}) {
+      // propagate or override query parameters to the authorization request.
       // This is used by the functional tests to, e.g., override
       // the client_id or propagate an email.
-      window.location.href = `/api/${endpoint}${window.location.search}`;
+
+      const currentParams = new URLSearchParams(window.location.search);
+      Object.keys(params).forEach((key) => {
+        currentParams.set(key, params[key]);
+      });
+      window.location.href = `/api/${endpoint}?${currentParams.toString()}`;
     }
 
     $('button.signin').click(function (ev) {
@@ -232,6 +237,13 @@ $(document).ready(function () {
 
     $('button.two-step-authentication').click(function (ev) {
       authenticate('two_step_authentication');
+    });
+
+    $('button.third-party').click(function (ev) {
+      authenticate('best_choice', {
+        forceExperiment: 'thirdPartyAuth',
+        forceExperimentGroup: 'google',
+      });
     });
 
     $('button.force-auth').click(function (ev) {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -21,7 +21,7 @@ export class LinkedAccountHandler {
     private log: AuthLogger,
     private db: any,
     private config: ConfigType,
-    private mailer: any,
+    private mailer: any
   ) {
     const tokenCodeConfig = config.signinConfirmation.tokenVerificationCode;
     this.tokenCodeLifetime =
@@ -98,7 +98,8 @@ export class LinkedAccountHandler {
 
         const geoData = request.app.geo;
         const ip = request.app.clientAddress;
-        const { deviceId, flowId, flowBeginTime } = await request.app.metricsContext;
+        const { deviceId, flowId, flowBeginTime } = await request.app
+          .metricsContext;
         const emailOptions = {
           acceptLanguage: request.app.acceptLanguage,
           deviceId,
@@ -114,11 +115,11 @@ export class LinkedAccountHandler {
           uaOSVersion: request.app.ua.osVersion,
           uaDeviceType: request.app.ua.deviceType,
           uid: accountRecord.uid,
-        }
+        };
         await this.mailer.sendPostAddLinkedAccountEmail(
           accountRecord.emails,
           accountRecord,
-          emailOptions,
+          emailOptions
         );
       } catch (err) {
         this.log.trace(
@@ -126,7 +127,7 @@ export class LinkedAccountHandler {
           {
             error: err,
           }
-        )
+        );
 
         if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
           throw err;
@@ -173,6 +174,7 @@ export class LinkedAccountHandler {
     return {
       uid: sessionToken.uid,
       sessionToken: sessionToken.data,
+      providerUid: userid,
     };
   }
 
@@ -195,7 +197,7 @@ export const linkedAccountRoutes = (
   log: AuthLogger,
   db: any,
   config: ConfigType,
-  mailer: any,
+  mailer: any
 ) => {
   const handler = new LinkedAccountHandler(log, db, config, mailer);
 

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -114,6 +114,7 @@ function getUpdatedSessionData(email, relier, accountData, options = {}) {
     verificationReason: accountData.verificationReason,
     verified: accountData.verified || false,
     metricsEnabled: accountData.metricsEnabled || false,
+    providerUid: accountData.providerUid,
   };
 
   if (wantsKeys(relier, sessionTokenContext)) {

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -57,6 +57,7 @@ const PERSISTENT = {
   metricsEnabled: undefined,
   verified: undefined,
   alertText: undefined,
+  providerUid: undefined,
 };
 
 const DEFAULTS = _.extend(
@@ -76,7 +77,7 @@ const DEFAULTS = _.extend(
     verificationMethod: undefined,
     verificationReason: undefined,
     totpVerified: undefined,
-    isThirdPartyLogin: undefined,
+    providerUid: undefined,
   },
   PERSISTENT
 );

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -96,9 +96,10 @@ export default BaseAuthenticationBroker.extend({
    *   @param {String} [result.state] - OAuth state
    *   @param {String} [result.error] - OAuth error string
    *   @param {String} [result.action] - Action taken by the user, such as 'signin' or 'signup'
+   *   @param {Object} [account] - Account object
    * @returns {Promise}
    */
-  sendOAuthResultToRelier(result) {
+  sendOAuthResultToRelier(result, account) {
     if (this.hasCapability('supportsPairing') || result.action === 'pairing') {
       if (!this.relier.has('service')) {
         // the service in the query parameter currently overrides the status message
@@ -116,6 +117,12 @@ export default BaseAuthenticationBroker.extend({
       }
       if (result.action) {
         extraParams.action = result.action;
+      }
+      const providerUid = account && account.get('providerUid');
+      if (providerUid) {
+        // When we support multiple providers, the provider id might
+        // be returned in different param. For Google, it is returned as `gid`.
+        extraParams.gid = providerUid;
       }
       // Always use the state the RP passed in.
       // This is necessary to complete the prompt=none

--- a/packages/fxa-content-server/app/scripts/models/user.js
+++ b/packages/fxa-content-server/app/scripts/models/user.js
@@ -352,7 +352,6 @@ var User = Backbone.Model.extend({
   setSignedInAccount(accountData) {
     var account = this.initAccount(accountData);
     account.set('lastLogin', Date.now());
-
     return this.updateSignedInAccount(account);
   },
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/google-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/google-auth-mixin.js
@@ -43,9 +43,9 @@ export default {
   googleSignIn() {
     this.clearStoredParams();
 
-    // We stash all FxA oauth params in the Google state oauth param
+    // We stash originating location in the Google state oauth param
     // because we will need it to use it to log the user into FxA
-    const state = encodeURIComponent(this.window.location.search);
+    const state = encodeURIComponent(this.window.location.href);
 
     // To avoid any CORs issues we create element to store the
     // params need for the request and do a form submission
@@ -88,8 +88,8 @@ export default {
       searchParams
     );
 
-    const oauthState = decodeURIComponent(searchParams.state);
-    this.navigateAway(`/oauth/${oauthState}`);
+    const redirectUrl = decodeURIComponent(searchParams.state);
+    this.navigateAway(redirectUrl);
   },
 
   completeSignIn() {
@@ -105,7 +105,7 @@ export default {
         this.clearStoredParams();
         return this.signIn(updatedAccount);
       })
-      .catch((err) => {
+      .catch(() => {
         this.clearStoredParams();
       });
   },

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -32,6 +32,7 @@ function generateOAuthCode() {
 const REDIRECT_URI = 'https://localhost:8080';
 const VALID_OAUTH_CODE = generateOAuthCode();
 const VALID_OAUTH_CODE_REDIRECT_URL = `${REDIRECT_URI}?code=${VALID_OAUTH_CODE}&state=state`;
+const PROVIDER_UID = 'provider_uid';
 
 describe('models/auth_brokers/oauth-redirect', () => {
   var account;
@@ -295,6 +296,23 @@ describe('models/auth_brokers/oauth-redirect', () => {
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'action=' + action);
             assert.include(windowMock.location.href, 'state=state');
+          });
+      });
+    });
+
+    describe('with an providerId', () => {
+      it('appends an action query parameter', () => {
+        account.set('providerUid', PROVIDER_UID);
+        return broker
+          .sendOAuthResultToRelier(
+            {
+              redirect: REDIRECT_TO,
+            },
+            account
+          )
+          .then(() => {
+            assert.include(windowMock.location.href, REDIRECT_TO);
+            assert.include(windowMock.location.href, `gid=${PROVIDER_UID}`);
           });
       });
     });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/google-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/google-auth-mixin.js
@@ -87,7 +87,7 @@ describe('views/mixins/google-auth-mixin', function () {
   });
 
   it('googleSignIn', async () => {
-    windowMock.location.search = '?orignal_oauth_params';
+    windowMock.location.href = 'http://localhost?orignal_oauth_params';
 
     view.googleSignIn();
 
@@ -111,7 +111,7 @@ describe('views/mixins/google-auth-mixin', function () {
     assertInputEl(
       mockInput,
       'state',
-      encodeURIComponent(windowMock.location.search)
+      encodeURIComponent(windowMock.location.href)
     );
     assertInputEl(mockInput, 'access_type', 'offline');
     assertInputEl(mockInput, 'prompt', 'consent');
@@ -122,11 +122,12 @@ describe('views/mixins/google-auth-mixin', function () {
   });
 
   it('handleOauthResponse', () => {
-    windowMock.location.search = '?state=state';
+    windowMock.location.search = '?state=localhost';
     sinon.stub(view, 'navigateAway');
 
     view.handleOauthResponse();
-    assert.isTrue(view.navigateAway.calledOnceWith(`/oauth/state`));
+
+    assert.isTrue(view.navigateAway.calledOnceWith('localhost'));
   });
 
   it('completeSignIn', async () => {


### PR DESCRIPTION
## Because

- Pocket needs to know the associated google user to update their database

## This pull request

- Returns the google id when the user completes the oauth flow

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11963

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
