### PR TITLE
refactor(emails): Add includes.json for each template, remove subject/action from emails.js

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -431,13 +431,14 @@ module.exports = function (log, config, bounces) {
     const translator = this.translator(message.acceptLanguage);
     message.layout = message.layout || 'fxa';
 
-    const { html, text } = await this.fluentLocalizer.localizeEmail(
+    const { html, text, subject } = await this.fluentLocalizer.localizeEmail(
       message
     );
 
     return {
       html,
       language: translator.language,
+      subject,
       text,
     };
   };

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "cadReminderFirst-subject",
+    "message": "Your Friendly Reminder: How To Complete Your Sync Setup"
+  },
+  "action": {
+    "id": "cadReminderFirst-action",
+    "message": "Sync another device"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "cadReminderSecond-subject",
+    "message": "Final Reminder: Complete Sync Setup"
+  },
+  "action": {
+    "id": "cadReminderSecond-action",
+    "message": "Sync another device"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/downloadSubscription/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/downloadSubscription/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "downloadSubscription-subject",
+    "message": "Welcome to <%- productName %>"
+  },
+  "action": {
+    "id": "downloadSubscription-link-action",
+    "message": "Download <%- productName %>"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "newDeviceLogin-subject",
+    "message": "New sign-in to <%- clientName %>"
+  },
+  "action": {
+    "id": "newDeviceLogin-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "passwordChangeRequired-subject",
+    "message": "Suspicious activity detected"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "passwordChanged-subject",
+    "message": "Password updated"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "passwordReset-subject",
+    "message": "Password updated"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "passwordResetAccountRecovery-subject",
+    "message": "Password updated using recovery key"
+  },
+  "action": {
+    "id": "passwordResetAccountRecovery-action",
+    "message": "Create new recovery key"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postAddAccountRecovery-subject",
+    "message": "Account recovery key generated"
+  },
+  "action": {
+    "id": "postAddAccountRecovery-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddLinkedAccount/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddLinkedAccount/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postAddLinkedAccount-subject",
+    "message": "New account linked to Firefox"
+  },
+  "action": {
+    "id": "postAddLinkedAccount-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postAddTwoStepAuthentication-subject",
+    "message": "Two-step authentication enabled"
+  },
+  "action": {
+    "id": "postAddTwoStepAuthentication-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postChangePrimary-subject",
+    "message": "Primary email updated"
+  },
+  "action": {
+    "id": "postChangePrimary-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postConsumeRecoveryCode-subject",
+    "message": "Recovery code used"
+  },
+  "action": {
+    "id": "postConsumeRecoveryCode-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postNewRecoveryCodes-subject",
+    "message": "New recovery codes generated"
+  },
+  "action": {
+    "id": "postNewRecoveryCodes-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postRemoveAccountRecovery-subject",
+    "message": "Account recovery key removed"
+  },
+  "action": {
+    "id": "postRemoveAccountRecovery-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postRemoveSecondary-subject",
+    "message": "Secondary email removed"
+  },
+  "action": {
+    "id": "postRemoveSecondary-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postRemoveTwoStepAuthentication-subject-line",
+    "message": "Two-step authentication is off"
+  },
+  "action": {
+    "id": "postRemoveTwoStepAuthentication-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postVerify-subject",
+    "message": "Account verified. Next, sync another device to finish setup"
+  },
+  "action": {
+    "id": "postVerify-action",
+    "message": "Set up next device"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "postVerifySecondary-subject",
+    "message": "Secondary email added"
+  },
+  "action": {
+    "id": "postVerifySecondary-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "recovery-subject",
+    "message": "Reset your password"
+  },
+  "action": {
+    "id": "recovery-action",
+    "message": "Create new password"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionAccountDeletion-subject",
+    "message": "Your <%- productName %> subscription has been cancelled"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "subscriptionAccountFinishSetup-subject",
+    "message": "Welcome to <%- productName %>: Please set your password."
+  },
+  "action": {
+    "id": "subscriptionAccountFinishSetup-action-2",
+    "message": "Get started"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "subscriptionAccountReminderFirst-subject",
+    "message": "Reminder: Finish setting up your account"
+  },
+  "action": {
+    "id": "subscriptionAccountReminderFirst-action",
+    "message": "Create Password"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "subscriptionAccountReminderSecond-subject",
+    "message": "Final reminder: Setup your account"
+  },
+  "action": {
+    "id": "subscriptionAccountReminderSecond-action",
+    "message": "Create Password"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionCancellation-subject",
+    "message": "Your <%- productName %> subscription has been cancelled"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionDowngrade-subject",
+    "message": "You have switched to <%- productNameNew %>"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFailedPaymentsCancellation/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionFailedPaymentsCancellation-subject",
+    "message": "Your <%- productName %> subscription has been cancelled"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionFirstInvoice-subject",
+    "message": "<%- productName %> payment confirmed"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionFirstInvoiceDiscount-subject",
+    "message": "<%- productName %> payment confirmed"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentExpired/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentExpired/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionPaymentExpired-subject",
+    "message": "Credit card for <%- productName %> expiring soon"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionPaymentFailed-subject",
+    "message": "<%- productName %> payment failed"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionPaymentProviderCancelled-subject",
+    "message": "Payment information update required for <%- productName %>"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionReactivation-subject",
+    "message": "<%- productName %> subscription reactivated"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionRenewalReminder-subject",
+    "message": "<%- productName %> automatic renewal notice"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionSubsequentInvoice-subject",
+    "message": "<%- productName %> payment received"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionUpgrade-subject",
+    "message": "You have upgraded to <%- productNameNew %>"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionsPaymentExpired-subject",
+    "message": "Credit card for your subscriptions is expiring soon"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "subscriptionsPaymentProviderCancelled-subject",
+    "message": "Payment information update required for Mozilla subscriptions"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "unblockCode-subject",
+    "message": "Account authorization code"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verificationReminderFirst-subject",
+    "message": "Reminder: Finish creating your account"
+  },
+  "action": {
+    "id": "verificationReminderFirst-action",
+    "message": "Confirm email"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verificationReminderSecond-subject",
+    "message": "Final reminder: Activate your account"
+  },
+  "action": {
+    "id": "verificationReminderSecond-action",
+    "message": "Confirm email"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verify-subject",
+    "message": "Finish creating your account"
+  },
+  "action": {
+    "id": "verify-action",
+    "message": "Confirm email"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verifyLogin-subject",
+    "message": "Confirm new sign-in to <%- clientName %>"
+  },
+  "action": {
+    "id": "verifyLogin-action",
+    "message": "Confirm sign-in"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "verifyLoginCode-subject-line",
+    "message": "Sign-in code for <%- serviceName %>"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyPrimary/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyPrimary/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verifyPrimary-subject",
+    "message": "Confirm primary email"
+  },
+  "action": {
+    "id": "verifyPrimary-action",
+    "message": "Verify email"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verifySecondaryCode-subject",
+    "message": "Confirm secondary email"
+  },
+  "action": {
+    "id": "verifySecondaryCode-action",
+    "message": "Verify email"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/includes.json
@@ -1,0 +1,6 @@
+{
+  "subject": {
+    "id": "verifyShortCode-subject",
+    "message": "Verification code: <%- code %>"
+  }
+}


### PR DESCRIPTION
## Because

- we are retiring gettext in auth-server

## This pull request

- removes the remaining `subject`s and `action`s in `emails.js`
- adds `includes.json` for each template

## To do

- Retire gettext for `lowRecoveryCodes` template - it has two subjects

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
