### PR TITLE
fix(subscriptions): send email and reduce errors for SCA flow

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
@@ -28,12 +28,15 @@ export async function sendFinishSetupEmailForStubAccount({
   // However, a successful subscription creation does not imply a successful
   // payment. For a user creating an account and subscribing to a product at
   // the same time, we should not send this email until we truly have a
-  // successful, active, subscription.  Otherwise, the user will see an error
-  // on the front end but also receive the welcome email.
+  // successful, active, subscription, OR, the payment method requires further
+  // action (e.g. a 3D Secure card that requires authorization from the issuing
+  // bank).  Otherwise, the user will see an error on the front end but also
+  // receive the welcome email.
   if (
     account &&
     account.verifierSetAt <= 0 &&
-    ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)
+    (ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status) ||
+      subscription.latest_invoice?.payment_intent?.status === 'requires_action')
   ) {
     const token = await jwt.sign(
       {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
@@ -76,6 +76,37 @@ describe('routes/subscriptions/account', () => {
       sinon.assert.notCalled(mailer.sendSubscriptionAccountFinishSetupEmail);
     });
 
+    it('sends an email for subscription with a payment intent that "requires_action"', async () => {
+      const sub = {
+        ...subscription,
+        latest_invoice: {
+          ...subscription.latest_invoice,
+          payment_intent: { status: 'requires_action' },
+        },
+      };
+      await sendFinishSetupEmailForStubAccount({
+        uid,
+        account,
+        subscription: sub,
+        stripeHelper,
+        mailer,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.extractInvoiceDetailsForEmail,
+        sub.latest_invoice
+      );
+      sinon.assert.calledOnceWithExactly(
+        mailer.sendSubscriptionAccountFinishSetupEmail,
+        [],
+        account,
+        {
+          acceptLanguage: account.locale,
+          ...invoiceDetails,
+          token,
+        }
+      );
+    });
+
     it('sends an email to the stub account', async () => {
       await sendFinishSetupEmailForStubAccount({
         uid,

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -285,6 +285,22 @@ describe('routes/Checkout', () => {
       expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
     });
 
+    it('retries apiFetchCustomer', async () => {
+      (apiFetchCustomer as jest.Mock)
+        .mockClear()
+        .mockResolvedValueOnce({ ...CUSTOMER, subscriptions: [] })
+        .mockResolvedValueOnce(CUSTOMER);
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiFetchCustomer).toHaveBeenCalledTimes(2);
+      });
+
+      expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
+    });
+
     it('displays an error when account creation failed', async () => {
       (apiCreatePasswordlessAccount as jest.Mock).mockRejectedValue(
         FXA_SIGNUP_ERROR

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -169,6 +169,22 @@ export const Product = ({
 
   const [coupon, setCoupon] = useState<CouponDetails>();
 
+  // Please read the comment in `fetchProfileAndCustomer` in Checkout/index.tsx
+  // regarding a possible race condition first.  The workaround here is to
+  // simply delay the request on the front end so that the subscription is more
+  // likely to have been updated by the time the fetch is handled.
+  //
+  // It's simpler, but the downside is that it affects all customers.  The
+  // retry approach is tricker in this route due to a combination of, a) React
+  // rendering and Redux app state, and, b) the customer could be a returning
+  // customer, thus the initial subscriptions list won't be empty.
+  //
+  // (Note that the Checkout route uses hooks and so the retry fetches won't
+  // affect any component state until some state updating setter function is
+  // called.)
+  const delayedFetchCustomerAndSubscriptions = () =>
+    setTimeout(fetchCustomerAndSubscriptions, 500);
+
   if (!accessToken || customer.loading || plans.loading || profile.loading) {
     return <LoadingOverlay isLoading={true} />;
   }
@@ -274,7 +290,7 @@ export const Product = ({
             profile: profile.result,
             customer: customer.result,
             selectedPlan,
-            refreshSubscriptions: fetchCustomerAndSubscriptions,
+            refreshSubscriptions: delayedFetchCustomerAndSubscriptions,
             coupon: coupon,
             setCoupon: setCoupon,
           }}
@@ -322,7 +338,7 @@ export const Product = ({
         profile: profile.result,
         customer: customer.result,
         selectedPlan,
-        refreshSubscriptions: fetchCustomerAndSubscriptions,
+        refreshSubscriptions: delayedFetchCustomerAndSubscriptions,
         coupon: coupon,
         setCoupon: setCoupon,
       }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -39915,16 +39915,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stripe@npm:^8.203.0":
-  version: 8.203.0
-  resolution: "stripe@npm:8.203.0"
-  dependencies:
-    "@types/node": ">=8.1.0"
-    qs: ^6.6.0
-  checksum: 98d921d0c4e779dc9bbd52bc645c0b17bf7770e14013757fdfadb448766285d921e94ce8e1e132dff8f3e06b084de873c43c52203f947089b18260a928e836a1
-  languageName: node
-  linkType: hard
-
 "stubs@npm:^3.0.0":
   version: 3.0.0
   resolution: "stubs@npm:3.0.0"


### PR DESCRIPTION
Because:
 - customers who use credit cards that require the additional SCA step
   won't receive the welcome/finish setup email (if they used the
   passwordless flow), and they might encounter a front end error even
   though their subscription was successful

This commit:
 - send the finish setup email to new users with an 'incomplete'
   subscription that has a payment intent that 'requires_action' (the
   SCA approval)
 - add a couple workarounds to reduce the probability of the customer
   encountering a front end error despite a successful subscription
   - context: on the front end, we fetch the customer's subscriptions on
     a successful subscription creation response, however, over time,
     due to Stripe rate limit mitigation, we stopped directly querying
     the source of truth, Stripe, for the list of subscriptions, and
     that, along with subscriptions that are created with an
     'incomplete' status and then updated to an active status, produced
     a race condition between the fetch on the front end and the
     subscription update between Stripe and the auth-server on the
     back end

## Issue that this pull request solves

Closes: #11998
