### PR TITLE
fix(subscriptions): send email and reduce errors for SCA flow

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
@@ -28,12 +28,15 @@ export async function sendFinishSetupEmailForStubAccount({
   // However, a successful subscription creation does not imply a successful
   // payment. For a user creating an account and subscribing to a product at
   // the same time, we should not send this email until we truly have a
-  // successful, active, subscription.  Otherwise, the user will see an error
-  // on the front end but also receive the welcome email.
+  // successful, active, subscription, OR, the payment method requires further
+  // action (e.g. a 3D Secure card that requires authorization from the issuing
+  // bank).  Otherwise, the user will see an error on the front end but also
+  // receive the welcome email.
   if (
     account &&
     account.verifierSetAt <= 0 &&
-    ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)
+    (ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status) ||
+      subscription.latest_invoice?.payment_intent?.status === 'requires_action')
   ) {
     const token = await jwt.sign(
       {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
@@ -76,6 +76,37 @@ describe('routes/subscriptions/account', () => {
       sinon.assert.notCalled(mailer.sendSubscriptionAccountFinishSetupEmail);
     });
 
+    it('sends an email for subscription with a payment intent that "requires_action"', async () => {
+      const sub = {
+        ...subscription,
+        latest_invoice: {
+          ...subscription.latest_invoice,
+          payment_intent: { status: 'requires_action' },
+        },
+      };
+      await sendFinishSetupEmailForStubAccount({
+        uid,
+        account,
+        subscription: sub,
+        stripeHelper,
+        mailer,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.extractInvoiceDetailsForEmail,
+        sub.latest_invoice
+      );
+      sinon.assert.calledOnceWithExactly(
+        mailer.sendSubscriptionAccountFinishSetupEmail,
+        [],
+        account,
+        {
+          acceptLanguage: account.locale,
+          ...invoiceDetails,
+          token,
+        }
+      );
+    });
+
     it('sends an email to the stub account', async () => {
       await sendFinishSetupEmailForStubAccount({
         uid,

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -285,6 +285,22 @@ describe('routes/Checkout', () => {
       expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
     });
 
+    it('retries apiFetchCustomer', async () => {
+      (apiFetchCustomer as jest.Mock)
+        .mockClear()
+        .mockResolvedValueOnce({ ...CUSTOMER, subscriptions: [] })
+        .mockResolvedValueOnce(CUSTOMER);
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiFetchCustomer).toHaveBeenCalledTimes(2);
+      });
+
+      expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
+    });
+
     it('displays an error when account creation failed', async () => {
       (apiCreatePasswordlessAccount as jest.Mock).mockRejectedValue(
         FXA_SIGNUP_ERROR

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -169,6 +169,22 @@ export const Product = ({
 
   const [coupon, setCoupon] = useState<CouponDetails>();
 
+  // Please read the comment in `fetchProfileAndCustomer` in Checkout/index.tsx
+  // regarding a possible race condition first.  The workaround here is to
+  // simply delay the request on the front end so that the subscription is more
+  // likely to have been updated by the time the fetch is handled.
+  //
+  // It's simpler, but the downside is that it affects all customers.  The
+  // retry approach is tricker in this route due to a combination of, a) React
+  // rendering and Redux app state, and, b) the customer could be a returning
+  // customer, thus the initial subscriptions list won't be empty.
+  //
+  // (Note that the Checkout route uses hooks and so the retry fetches won't
+  // affect any component state until some state updating setter function is
+  // called.)
+  const delayedFetchCustomerAndSubscriptions = () =>
+    setTimeout(fetchCustomerAndSubscriptions, 500);
+
   if (!accessToken || customer.loading || plans.loading || profile.loading) {
     return <LoadingOverlay isLoading={true} />;
   }
@@ -274,7 +290,7 @@ export const Product = ({
             profile: profile.result,
             customer: customer.result,
             selectedPlan,
-            refreshSubscriptions: fetchCustomerAndSubscriptions,
+            refreshSubscriptions: delayedFetchCustomerAndSubscriptions,
             coupon: coupon,
             setCoupon: setCoupon,
           }}
@@ -322,7 +338,7 @@ export const Product = ({
         profile: profile.result,
         customer: customer.result,
         selectedPlan,
-        refreshSubscriptions: fetchCustomerAndSubscriptions,
+        refreshSubscriptions: delayedFetchCustomerAndSubscriptions,
         coupon: coupon,
         setCoupon: setCoupon,
       }}


### PR DESCRIPTION
Moving the previously approved patch from https://github.com/mozilla/fxa/pull/12014 to the train 226 branch.
