### PR TITLE
fix(coupon): In email hide pay method on 0 invoice

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2264,6 +2264,8 @@ export class StripeHelper {
 
     const payment_provider = this.getPaymentProvider(customer);
 
+    const showPaymentMethod: boolean = !!invoiceTotalInCents;
+
     return {
       uid,
       email,
@@ -2285,6 +2287,7 @@ export class StripeHelper {
       planEmailIconURL,
       planDownloadURL,
       productMetadata,
+      showPaymentMethod,
     };
   }
 

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2264,8 +2264,6 @@ export class StripeHelper {
 
     const payment_provider = this.getPaymentProvider(customer);
 
-    const showPaymentMethod: boolean = !!invoiceTotalInCents;
-
     return {
       uid,
       email,
@@ -2287,7 +2285,7 @@ export class StripeHelper {
       planEmailIconURL,
       planDownloadURL,
       productMetadata,
-      showPaymentMethod,
+      showPaymentMethod: !!invoiceTotalInCents,
     };
   }
 

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2709,6 +2709,7 @@ module.exports = function (log, config, bounces) {
       payment_provider,
       paymentProratedInCents,
       paymentProratedCurrency,
+      showPaymentMethod,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2790,6 +2791,7 @@ module.exports = function (log, config, bounces) {
         nextInvoiceDate,
         paymentProrated,
         showProratedAmount,
+        showPaymentMethod,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -403,7 +403,7 @@ module.exports = function (log, config, bounces) {
 
   Mailer.prototype._constructLocalTimeString = function (
     timeZone,
-    acceptLanguage,
+    acceptLanguage
   ) {
     return constructLocalTimeString(timeZone, acceptLanguage);
   };
@@ -625,7 +625,7 @@ module.exports = function (log, config, bounces) {
     );
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -801,7 +801,7 @@ module.exports = function (log, config, bounces) {
     const links = this._generateLinks(null, message, query, templateName);
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -873,7 +873,7 @@ module.exports = function (log, config, bounces) {
       const action = gettext('Confirm sign-in');
       const [time, date] = this._constructLocalTimeString(
         message.timeZone,
-        message.acceptLanguage,
+        message.acceptLanguage
       );
 
       return this.send({
@@ -933,7 +933,7 @@ module.exports = function (log, config, bounces) {
     );
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1000,7 +1000,7 @@ module.exports = function (log, config, bounces) {
     );
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1046,7 +1046,7 @@ module.exports = function (log, config, bounces) {
     const links = this._generateLinks(undefined, message, {}, templateName);
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1109,7 +1109,7 @@ module.exports = function (log, config, bounces) {
     );
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1152,7 +1152,7 @@ module.exports = function (log, config, bounces) {
     );
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1253,7 +1253,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1304,7 +1304,7 @@ module.exports = function (log, config, bounces) {
       const action = gettext('Manage account');
       const [time, date] = this._constructLocalTimeString(
         message.timeZone,
-        message.acceptLanguage,
+        message.acceptLanguage
       );
 
       return this.send({
@@ -1500,7 +1500,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1543,7 +1543,7 @@ module.exports = function (log, config, bounces) {
     const links = this._generateSettingLinks(message, templateName);
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1585,7 +1585,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1630,7 +1630,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1725,7 +1725,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1773,7 +1773,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Manage account');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -1821,7 +1821,7 @@ module.exports = function (log, config, bounces) {
     const action = gettext('Create new recovery key');
     const [time, date] = this._constructLocalTimeString(
       message.timeZone,
-      message.acceptLanguage,
+      message.acceptLanguage
     );
 
     const headers = {
@@ -2609,6 +2609,7 @@ module.exports = function (log, config, bounces) {
       payment_provider,
       paymentProratedInCents,
       paymentProratedCurrency,
+      showPaymentMethod,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2680,6 +2681,7 @@ module.exports = function (log, config, bounces) {
         nextInvoiceDate,
         paymentProrated,
         showProratedAmount,
+        showPaymentMethod,
       },
     });
   };
@@ -2809,6 +2811,7 @@ module.exports = function (log, config, bounces) {
       cardType,
       lastFour,
       nextInvoiceDate,
+      showPaymentMethod,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2867,6 +2870,7 @@ module.exports = function (log, config, bounces) {
         cardType: cardTypeToText(cardType),
         lastFour,
         nextInvoiceDate,
+        showPaymentMethod,
       },
     });
   };
@@ -2892,6 +2896,7 @@ module.exports = function (log, config, bounces) {
       cardType,
       lastFour,
       nextInvoiceDate,
+      showPaymentMethod,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2960,6 +2965,7 @@ module.exports = function (log, config, bounces) {
         cardType: cardTypeToText(cardType),
         lastFour,
         nextInvoiceDate,
+        showPaymentMethod,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -2,15 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<% if (payment_provider === 'paypal') { %>
+<% if (payment_provider === 'paypal' && showPaymentMethod) { %>
   <mj-text css-class="text-body margin-top">
-    <span data-l10n-id="payment-method">Payment Method: </span>
+    <span data-l10n-id="payment-method">Payment Method:&nbsp;</span>
     <span>PayPal</span>
   </mj-text>
   <%# Stripe is the default payment provider, but check for truthiness in case of coupons %>
-<% } else if (cardType && lastFour) { %>
+<% } else if (cardType && lastFour && showPaymentMethod) { %>
   <mj-text css-class="text-body margin-top">
-    <span data-l10n-id="payment-method">Payment Method: </span>
+    <span data-l10n-id="payment-method">Payment Method:&nbsp;</span>
     <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
       <%- cardType %> card ending in <%- lastFour %>
     </span>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,3 +1,3 @@
-<% if (payment_provider === "paypal") { %>payment-provider-paypal-plaintext = "Payment Method: PayPal"
-<% } else if (cardType && lastFour) {%>payment-method = "Payment Method: "
+<% if (payment_provider === "paypal" && showPaymentMethod) { %>payment-provider-paypal-plaintext = "Payment Method: PayPal"
+<% } else if (cardType && lastFour && showPaymentMethod) {%>payment-method = "Payment Method: "
 card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
@@ -22,6 +22,7 @@ const createStory = subplatStoryWithProps(
     invoiceTotal: '$20.00',
     nextInvoiceDateOnly: '11/13/2021',
     subscriptionSupportUrl: 'http://localhost:3030/support',
+    showPaymentMethod: true,
   }
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
@@ -24,6 +24,7 @@ const createStory = subplatStoryWithProps(
     invoiceDiscountAmount: '$2.00',
     nextInvoiceDateOnly: '11/13/2021',
     subscriptionSupportUrl: 'http://localhost:3030/support',
+    showPaymentMethod: true,
   }
 );
 
@@ -50,6 +51,7 @@ export const SubscriptionFirstInvoiceWithCoupon = createStory(
     payment_provider: 'stripe',
     invoiceTotal: '$0.00',
     invoiceDiscountAmount: '$20.00',
+    showPaymentMethod: false,
   },
   'Payment method - coupon covered entire amount'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
@@ -53,5 +53,5 @@ export const SubscriptionFirstInvoiceWithCoupon = createStory(
     invoiceDiscountAmount: '$20.00',
     showPaymentMethod: false,
   },
-  'Payment method - coupon covered entire amount'
+  'Payment method hidden - coupon covered entire amount'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.stories.ts
@@ -22,6 +22,7 @@ const createStory = subplatStoryWithProps(
       'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
     nextInvoiceDateOnly: '1/14/2022',
     subscriptionSupportUrl: 'http://localhost:3030/support',
+    showPaymentMethod: true,
   }
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.stories.ts
@@ -24,6 +24,7 @@ const createStory = subplatStoryWithProps(
       'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
     nextInvoiceDateOnly: '1/14/2022',
     subscriptionSupportUrl: 'http://localhost:3030/support',
+    showPaymentMethod: true,
   }
 );
 
@@ -63,4 +64,15 @@ export const SubscriptionSubsequentInvoiceStripeNoProrated = createStory(
     showProratedAmount: false,
   },
   'Stripe with no prorated amount'
+);
+
+export const SubscriptionSubsequentInvoiceCouponFullAmount = createStory(
+  {
+    cardType: 'MasterCard',
+    lastFour: '5309',
+    payment_provider: 'stripe',
+    showProratedAmount: false,
+    showPaymentMethod: false,
+  },
+  'Payment method hidden - coupon covered entire amount'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.stories.ts
@@ -71,6 +71,8 @@ export const SubscriptionSubsequentInvoiceCouponFullAmount = createStory(
     cardType: 'MasterCard',
     lastFour: '5309',
     payment_provider: 'stripe',
+    invoiceTotal: '$0.00',
+    invoiceDiscountAmount: '$20.00',
     showProratedAmount: false,
     showPaymentMethod: false,
   },

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3775,6 +3775,7 @@ describe('StripeHelper', () => {
           'product:privacyNoticeURL': privacyNoticeURL,
           'product:termsOfServiceURL': termsOfServiceURL,
         },
+        showPaymentMethod: true,
       };
 
       const expectedDiscount = {
@@ -3862,6 +3863,25 @@ describe('StripeHelper', () => {
         assert.isFalse(mockStripe.products.retrieve.called);
         sinon.assert.calledTwice(expandMock);
         assert.deepEqual(result, expectedDiscount);
+      });
+
+      it('extracts expected details from an invoice with 100% discount', async () => {
+        const fixtureDiscount100 = fixtureDiscount;
+        fixtureDiscount100.total = 0;
+        fixtureDiscount100.total_discount_amounts[0].amount = 500;
+        const expectedDiscount100 = {
+          ...expectedDiscount,
+          invoiceDiscountAmountInCents: 500,
+          invoiceTotalInCents: 0,
+          showPaymentMethod: false,
+        };
+        const result = await stripeHelper.extractInvoiceDetailsForEmail(
+          fixtureDiscount100
+        );
+        assert.isTrue(stripeHelper.allAbbrevProducts.called);
+        assert.isFalse(mockStripe.products.retrieve.called);
+        sinon.assert.calledTwice(expandMock);
+        assert.deepEqual(result, expectedDiscount100);
       });
 
       it('throws an exception for deleted customer', async () => {

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1647,6 +1647,46 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'PayPal' },
     ]]
   ])],
+  ['subscriptionSubsequentInvoiceDiscountEmail', new Map<string, Test | any>([
+      ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment received` }],
+      ['headers', new Map([
+        ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionSubsequentInvoiceDiscount') }],
+        ['X-Template-Name', { test: 'equal', expected: 'subscriptionSubsequentInvoiceDiscount' }],
+        ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionSubsequentInvoiceDiscount }],
+      ])],
+      ['html', [
+        { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-subsequent-invoice-discount', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+        { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-subsequent-invoice-discount', 'subscription-terms') },
+        { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-subsequent-invoice-discount', 'subscription-support')) },
+        { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+        { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+        { test: 'include', expected: `Plan change: ${MESSAGE_FORMATTED.paymentProrated}` },
+        { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+        { test: 'include', expected: `Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+        { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+        { test: 'include', expected: `Next Invoice: 04/19/2020` },
+        { test: 'include', expected: `View your invoice` },
+        { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+        { test: 'notInclude', expected: 'utm_source=email' },
+        { test: 'notInclude', expected: 'PayPal' },
+      ]],
+      ['text', [
+        { test: 'include', expected: `${MESSAGE.productName} payment received` },
+        { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+        { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+        { test: 'include', expected: `Plan change: ${MESSAGE_FORMATTED.paymentProrated}` },
+        { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+        { test: 'include', expected: `Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+        { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+        { test: 'include', expected: `Next Invoice: 04/19/2020` },
+        { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+        { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+        { test: 'notInclude', expected: 'utm_source=email' },
+        { test: 'notInclude', expected: 'PayPal' },
+      ]]
+    ]),
+    {updateTemplateValues: x => ({...x, showPaymentMethod: false})}
+  ],
 
   ['subscriptionUpgradeEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
@@ -1939,6 +1979,61 @@ const TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER: [
         ],
       ],
     ]),
+  ],
+  [
+    'subscriptionSubsequentInvoiceDiscountEmail',
+    new Map<string, Test | any>([
+      [
+        'subject',
+        {
+          test: 'equal',
+          expected: `${PAYPAL_MESSAGE.productName} payment received`,
+        },
+      ],
+      [
+        'headers',
+        new Map([
+          [
+            'X-SES-MESSAGE-TAGS',
+            {
+              test: 'equal',
+              expected: sesMessageTagsHeaderValue(
+                'subscriptionSubsequentInvoiceDiscount'
+              ),
+            },
+          ],
+          [
+            'X-Template-Name',
+            {
+              test: 'equal',
+              expected: 'subscriptionSubsequentInvoiceDiscount',
+            },
+          ],
+          [
+            'X-Template-Version',
+            {
+              test: 'equal',
+              expected: TEMPLATE_VERSIONS.subscriptionSubsequentInvoiceDiscount,
+            },
+          ],
+        ]),
+      ],
+      [
+        'html',
+        [
+          { test: 'notInclude', expected: `PayPal` },
+          { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+        ],
+      ],
+      [
+        'text',
+        [
+          { test: 'notInclude', expected: `PayPal` },
+          { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+        ],
+      ],
+    ]),
+    { updateTemplateValues: (x) => ({ ...x, showPaymentMethod: false }) },
   ],
 ];
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -115,6 +115,7 @@ const MESSAGE = {
     { productName: 'Firefox Fortress' },
     { productName: 'Cooking with Foxkeh' },
   ],
+  showPaymentMethod: true,
 };
 
 const MESSAGE_FORMATTED = {
@@ -1382,6 +1383,42 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'PayPal' },
     ]]
   ])],
+  // Do not display the Payment Method when "showPaymentMethod" is false
+  ['subscriptionFirstInvoiceDiscountEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionFirstInvoiceDiscount') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionFirstInvoiceDiscount' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionFirstInvoiceDiscount }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-first-invoice-discount', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-first-invoice-discount', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-first-invoice-discount', 'subscription-support')) },
+      { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
+      { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.productName} payment confirmed` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]]]),
+    {updateTemplateValues: x => (
+      {...x, showPaymentMethod: false})}
+  ],
 
   ['subscriptionPaymentExpiredEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `Credit card for ${MESSAGE.productName} expiring soon` }],
@@ -1641,7 +1678,11 @@ const PAYPAL_MESSAGE = Object.assign({}, MESSAGE);
 
 PAYPAL_MESSAGE.payment_provider = 'paypal';
 
-const TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER = new Map([
+const TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER: [
+  string,
+  any,
+  Record<string, any>?
+][] = [
   [
     'subscriptionFirstInvoiceEmail',
     new Map<string, Test | any>([
@@ -1741,6 +1782,58 @@ const TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER = new Map([
         ],
       ],
     ]),
+  ],
+  [
+    'subscriptionFirstInvoiceDiscountEmail',
+    new Map<string, Test | any>([
+      [
+        'subject',
+        {
+          test: 'equal',
+          expected: `${PAYPAL_MESSAGE.productName} payment confirmed`,
+        },
+      ],
+      [
+        'headers',
+        new Map([
+          [
+            'X-SES-MESSAGE-TAGS',
+            {
+              test: 'equal',
+              expected: sesMessageTagsHeaderValue(
+                'subscriptionFirstInvoiceDiscount'
+              ),
+            },
+          ],
+          [
+            'X-Template-Name',
+            { test: 'equal', expected: 'subscriptionFirstInvoiceDiscount' },
+          ],
+          [
+            'X-Template-Version',
+            {
+              test: 'equal',
+              expected: TEMPLATE_VERSIONS.subscriptionFirstInvoiceDiscount,
+            },
+          ],
+        ]),
+      ],
+      [
+        'html',
+        [
+          { test: 'notInclude', expected: `PayPal` },
+          { test: 'notInclude', expected: `MasterCard card ending in 5309` },
+        ],
+      ],
+      [
+        'text',
+        [
+          { test: 'notInclude', expected: `PayPal` },
+          { test: 'notInclude', expected: 'MasterCard card ending in 5309' },
+        ],
+      ],
+    ]),
+    { updateTemplateValues: (x) => ({ ...x, showPaymentMethod: false }) },
   ],
   [
     'subscriptionSubsequentInvoiceEmail',
@@ -1847,7 +1940,7 @@ const TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER = new Map([
       ],
     ]),
   ],
-]);
+];
 
 describe('lib/senders/emails:', () => {
   type LocalizeFn = (message: Record<any, any>) => Promise<Record<any, string>>;
@@ -1916,14 +2009,22 @@ describe('lib/senders/emails:', () => {
   }
 
   describe('payment info is correctly rendered when payment_provider === "paypal"', () => {
-    for (const [type, test] of TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER) {
+    for (const [
+      type,
+      test,
+      opts = {},
+    ] of TESTS_WITH_PAYPAL_AS_PAYMENT_PROVIDER) {
       it(`"Paypal" is rendered instead of credit card and last four digits - ${type}`, async () => {
         mailer.mailer.sendMail = stubSendMail((message) => {
           test.forEach((assertions, property) => {
             applyAssertions(type, message, property, assertions);
           });
         });
-        await mailer[type](PAYPAL_MESSAGE);
+        const { updateTemplateValues }: any = opts;
+        const tmplVals = updateTemplateValues
+          ? updateTemplateValues(PAYPAL_MESSAGE)
+          : PAYPAL_MESSAGE;
+        await mailer[type](tmplVals);
       });
     }
   });


### PR DESCRIPTION
## Because

- When a discount is applied that results in a zero dollar invoice, do
  not display the Payment Method in emails sent to the customer, since
  no payment was processed.

## This pull request

- Hides the payment method from the relevant emails.

## Issue that this pull request solves

Closes: #11993

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
