### PR TITLE
feat(pocket): Add FAQ tool tip for pocket migration

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -126,6 +126,9 @@ module.exports = {
   MOZ_ORG_SYNC_GET_STARTED_LINK:
     'https://www.mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len
 
+  POCKET_MORE_INFO_LINK:
+    'https://support.mozilla.org/en-US/kb/pocket-firefox-account-migration',
+
   // 20 most popular email domains, used for metrics. Matches the list
   // we use in the auth server, converted to a map for faster lookup.
   POPULAR_EMAIL_DOMAINS: popularDomains.reduce((map, domain) => {

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -19,6 +19,7 @@
     <div class="error"></div>
     <div class="success"></div>
     {{{ syncSuggestionHTML }}}
+    {{{ accountSuggestionHTML }}}
 
     <form novalidate>
       <div class="input-row">

--- a/packages/fxa-content-server/app/scripts/templates/partial/account-suggestion.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/account-suggestion.mustache
@@ -1,0 +1,6 @@
+{{#showAccountSuggestion}}
+  <div class="info" id="suggest-account">
+      {{#unsafeTranslate}}Why do I need to create this account? <a %(escapedSuggestionAttrs)s>Find out here</a>{{/unsafeTranslate}}
+      <span class="dismiss" tabindex="-1">&#10005;</span>
+  </div>
+{{/showAccountSuggestion}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -19,6 +19,7 @@
     <div class="success"></div>
 
     {{{ userCardHTML }}}
+    {{{ accountSuggestionHTML }}}
 
     <form novalidate>
       <input type="email" class="email hidden" value="{{ email }}" disabled />

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -22,6 +22,7 @@ import ServiceMixin from './mixins/service-mixin';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import GoogleAuthMixin from './mixins/google-auth-mixin';
 import SyncSuggestionMixin from './mixins/sync-suggestion-mixin';
+import AccountSuggestionMixin from './mixins/account-suggestion-mixin';
 import Template from 'templates/index.mustache';
 import checkEmailDomain from '../lib/email-domain-validator';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
@@ -275,6 +276,7 @@ Cocktail.mixin(
     entrypoint: 'fxa:enter_email',
     flowEvent: 'link.signin',
   }),
+  AccountSuggestionMixin,
   PocketMigrationMixin
 );
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/account-suggestion-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/account-suggestion-mixin.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mix into views that show the "Why do I need this account? Find out here"
+ * helper tooltip for Pocket accounts. This is based on the sync-suggestion-mixin.js.
+ *
+ * Sets the context field `accountSuggestionHTML`
+ * which contains the HTML to display.
+ */
+
+import Constants from '../../lib/constants';
+import FlowEventsMixin from './flow-events-mixin';
+import AccountSuggestionTemplate from 'templates/partial/account-suggestion.mustache';
+import { POCKET_CLIENTIDS } from '../../views/mixins/pocket-migration-mixin';
+
+export default {
+  dependsOn: [FlowEventsMixin],
+
+  events: {
+    'click #suggest-account .dismiss': 'onSuggestAccountDismiss',
+  },
+
+  afterVisible() {
+    if (this.isAccountSuggestionEnabled()) {
+      this.logViewEvent('account-suggest.visible');
+    }
+  },
+
+  setInitialContext(context) {
+    const escapedSuggestionUrl = encodeURI(Constants.POCKET_MORE_INFO_LINK);
+
+    const escapedSuggestionAttrs = `href="${escapedSuggestionUrl}"`;
+
+    const accountSuggestionHTML = this.renderTemplate(
+      AccountSuggestionTemplate,
+      {
+        escapedSuggestionAttrs,
+        showAccountSuggestion: this.isAccountSuggestionEnabled(),
+      }
+    );
+
+    context.set({
+      accountSuggestionHTML,
+    });
+  },
+
+  /**
+   * Show the account suggestion popover only for Pocket clients.
+   *
+   * @returns {Boolean}
+   */
+  isAccountSuggestionEnabled() {
+    return POCKET_CLIENTIDS.includes(this.relier.get('clientId'));
+  },
+
+  onSuggestAccountDismiss() {
+    this.$('#suggest-account').hide();
+  },
+};

--- a/packages/fxa-content-server/app/scripts/views/mixins/pocket-migration-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pocket-migration-mixin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const POCKET_CLIENTIDS = [
+export const POCKET_CLIENTIDS = [
   '7377719276ad44ee', // pocket-mobile
   '749818d3f2e7857f', // pocket-web
 ];

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -19,6 +19,7 @@ import Template from 'templates/sign_in_password.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 import GoogleAuthMixin from './mixins/google-auth-mixin';
+import AccountSuggestionMixin from './mixins/account-suggestion-mixin';
 
 const SignInPasswordView = FormView.extend({
   template: Template,
@@ -96,7 +97,8 @@ Cocktail.mixin(
   SignedInNotificationMixin,
   UserCardMixin,
   GoogleAuthMixin,
-  PocketMigrationMixin
+  PocketMigrationMixin,
+  AccountSuggestionMixin
 );
 
 export default SignInPasswordView;

--- a/packages/fxa-content-server/app/styles/_state.scss
+++ b/packages/fxa-content-server/app/styles/_state.scss
@@ -208,7 +208,7 @@ div + .error {
 }
 
 // custom state indicators
-#suggest-sync {
+#suggest-sync, #suggest-account {
   /*Pull the message up to bring it closer to the header*/
   margin: -6px auto 16px;
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/account-suggestion-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/account-suggestion-mixin.js
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import $ from 'jquery';
+import { assert } from 'chai';
+import BaseView from 'views/base';
+import Cocktail from 'cocktail';
+import Notifier from 'lib/channels/notifier';
+import Relier from 'models/reliers/browser';
+import sinon from 'sinon';
+import AccountSuggestionMixin from 'views/mixins/account-suggestion-mixin';
+
+const AccountSuggestView = BaseView.extend({
+  template: (context) => context.accountSuggestionHTML,
+});
+
+Cocktail.mixin(AccountSuggestView, AccountSuggestionMixin);
+
+describe('views/mixins/account-suggestion-mixin', () => {
+  let notifier;
+  let relier;
+  let view;
+
+  beforeEach(() => {
+    notifier = new Notifier();
+    relier = new Relier();
+
+    view = new AccountSuggestView({
+      notifier,
+      relier,
+    });
+
+    sinon.stub(view, 'logViewEvent').callsFake(() => {});
+  });
+
+  describe('account suggestion', async () => {
+    it('displays account suggestion message if Pocket client', async () => {
+      relier.set('clientId', '749818d3f2e7857f');
+
+      await view.render();
+
+      view.afterVisible();
+
+      assert.lengthOf(view.$('#suggest-account'), 1);
+
+      const $suggestAccountEl = view.$('#suggest-account');
+      assert.include(
+        $suggestAccountEl.text(),
+        'Why do I need to create this account?'
+      );
+      assert.include($suggestAccountEl.text(), 'Find out here');
+
+      const $getStartedEl = $suggestAccountEl.find('a');
+      assert.equal($getStartedEl.attr('rel'), 'noopener noreferrer');
+
+      assert.isTrue(view.logViewEvent.calledWith('account-suggest.visible'));
+    });
+
+    it('not pocket client', async () => {
+      relier.set('service', null);
+
+      sinon.stub(view, 'isAccountSuggestionEnabled').callsFake(() => false);
+      await view.render();
+
+      view.afterVisible();
+
+      assert.lengthOf(view.$('#suggest-account'), 0);
+    });
+
+    it('can be dismissed', async () => {
+      relier.set('clientId', '749818d3f2e7857f');
+
+      await view.render();
+
+      $('#container').html(view.el);
+      assert.isTrue(view.$('#suggest-account').is(':visible'), 'visible');
+      view.$('#suggest-account .dismiss').click();
+      assert.isFalse(view.$('#suggest-account').is(':visible'), 'hidden');
+    });
+
+    it('does not display account suggestion message if there is a subscription product ID set', async () => {
+      relier.set('service', null);
+      relier.set('subscriptionProductId', 'prod_8675309');
+
+      await view.render();
+      assert.lengthOf(view.$('#suggest-account'), 0);
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -168,6 +168,7 @@ require('./spec/views/index');
 require('./spec/views/marketing_snippet');
 require('./spec/views/mixins/account-by-uid-mixin');
 require('./spec/views/mixins/account-reset-mixin');
+require('./spec/views/mixins/account-suggestion-mixin');
 require('./spec/views/mixins/avatar-mixin');
 require('./spec/views/mixins/back-mixin');
 require('./spec/views/mixins/cached-credentials-mixin');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8901,23 +8901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^5.16.2":
-  version: 5.16.2
-  resolution: "@testing-library/jest-dom@npm:5.16.2"
-  dependencies:
-    "@babel/runtime": ^7.9.2
-    "@types/testing-library__jest-dom": ^5.9.1
-    aria-query: ^5.0.0
-    chalk: ^3.0.0
-    css: ^3.0.0
-    css.escape: ^1.5.1
-    dom-accessibility-api: ^0.5.6
-    lodash: ^4.17.15
-    redent: ^3.0.0
-  checksum: e4569df67c4c4998d2c60c6cf00ce2f1ac10c9397e0970320728c8be8f4e2c17a0e801705ce8a7384f7f5629b598a6f58db91d4401dde02044f5625405ca0988
-  languageName: node
-  linkType: hard
-
 "@testing-library/react-hooks@npm:*, @testing-library/react-hooks@npm:^7.0.2":
   version: 7.0.2
   resolution: "@testing-library/react-hooks@npm:7.0.2"


### PR DESCRIPTION
## Because

- We need to let Pocket users why they are migrating over to Firefox accounts

## This pull request

- Adds a FAQ tooltip to our signin and email first pages

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11842

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="541" alt="Screen Shot 2022-02-28 at 10 25 55 PM" src="https://user-images.githubusercontent.com/1295288/156203571-857445b3-261a-4273-a0d6-7cbd76296761.png">
<img width="553" alt="Screen Shot 2022-02-28 at 10 21 21 PM" src="https://user-images.githubusercontent.com/1295288/156203578-ed4206f7-d463-45d7-9d05-b516b277eb60.png">

