### PR TITLE
fix(email): remove pooling to fix delivery failures

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -326,6 +326,12 @@ const conf = convict({
       default: 'Firefox Accounts <no-reply@lcip.org>',
       env: 'SMTP_SENDER',
     },
+    pool: {
+      default: false,
+      doc: 'Should pooling be enabled for sending mail?',
+      env: 'SMTP_POOL',
+      format: Boolean,
+    },
     maxMessages: {
       default: 10,
       doc: 'Maximum number of messages to be sent via nodemailer before a new SES SMTP connection is made',

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -258,7 +258,7 @@ module.exports = function (log, config, bounces) {
       secure: mailerConfig.secure,
       ignoreTLS: !mailerConfig.secure,
       port: mailerConfig.port,
-      pool: true,
+      pool: mailerConfig.pool,
       maxConnections: mailerConfig.maxConnections,
       maxMessages: mailerConfig.maxMessages,
     };


### PR DESCRIPTION
Because:

* We're getting 451 errors from SES saying there is too much time
between requests.  This is an attempt to fix that

This commit:

* Removes pooling so every email gets its own request.

Closes #11939