### PR TITLE
feat(auth): get cards with card API

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -57,7 +57,6 @@ import * as Coupon from 'fxa-shared/dto/auth/payments/coupon';
 import { getMinimumAmount } from 'fxa-shared/subscriptions/stripe';
 import AppError from '../error';
 
-export const CARD_RESOURCE = 'sources';
 export const CHARGES_RESOURCE = 'charges';
 export const COUPON_RESOURCE = 'coupons';
 export const CREDIT_NOTE_RESOURCE = 'creditNotes';
@@ -67,7 +66,7 @@ export const PAYMENT_METHOD_RESOURCE = 'paymentMethods';
 export const PLAN_RESOURCE = 'plans';
 export const PRICE_RESOURCE = 'prices';
 export const PRODUCT_RESOURCE = 'products';
-export const SOURCE_RESOURSE = 'sources';
+export const SOURCE_RESOURCE = 'sources';
 export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
 export const TAX_RATE_RESOURCE = 'taxRates';
 
@@ -84,7 +83,6 @@ enum STRIPE_CUSTOMER_METADATA {
 }
 
 export const STRIPE_OBJECT_TYPE_TO_RESOURCE: Record<string, string> = {
-  card: CARD_RESOURCE,
   charge: CHARGES_RESOURCE,
   coupon: COUPON_RESOURCE,
   credit_note: CREDIT_NOTE_RESOURCE,
@@ -94,7 +92,7 @@ export const STRIPE_OBJECT_TYPE_TO_RESOURCE: Record<string, string> = {
   plan: PLAN_RESOURCE,
   price: PRICE_RESOURCE,
   product: PRODUCT_RESOURCE,
-  source: SOURCE_RESOURSE,
+  source: SOURCE_RESOURCE,
   subscription: SUBSCRIPTIONS_RESOURCE,
   tax_rate: TAX_RATE_RESOURCE,
 };
@@ -876,6 +874,16 @@ export class StripeHelper {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Get Card for a customer.
+   */
+  async getCard(customerId: string, cardId: string): Promise<Stripe.Card> {
+    return this.stripe.customers.retrieveSource(
+      customerId,
+      cardId
+    ) as Promise<Stripe.Card>;
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -106,6 +106,12 @@ export class StripeWebhookHandler extends StripeHandler {
             resourceType as typeof VALID_RESOURCE_TYPES[number]
           );
         }
+      } else if (stripeObject.object === 'card' && stripeObject.customer) {
+        // Cards are not expandable using `expandResource` and are handled separately.
+        event.data.object = await this.stripeHelper.getCard(
+          stripeObject.customer,
+          stripeObject.id
+        );
       } else if (
         !BYPASS_LATEST_FETCH_TYPES.includes(stripeObject.object as string)
       ) {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -154,6 +154,7 @@ describe('StripeWebhookHandler', () => {
         product_metadata: validProduct.data.object.metadata,
       });
       StripeWebhookHandlerInstance.stripeHelper.expandResource.resolves({});
+      StripeWebhookHandlerInstance.stripeHelper.getCard.resolves({});
     });
 
     describe('handleWebhookEvent', () => {
@@ -232,10 +233,17 @@ describe('StripeWebhookHandler', () => {
               'Expected to not call Sentry'
             );
           }
-          assert.equal(
-            StripeWebhookHandlerInstance.stripeHelper.expandResource.calledOnce,
-            expectExpandResource
-          );
+          if (expectedHandlerName === 'handleCustomerSourceExpiringEvent') {
+            sinon.assert.calledOnce(
+              StripeWebhookHandlerInstance.stripeHelper.getCard
+            );
+          } else {
+            assert.equal(
+              StripeWebhookHandlerInstance.stripeHelper.expandResource
+                .calledOnce,
+              expectExpandResource
+            );
+          }
         });
 
       describe('ignorable errors', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8901,23 +8901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^5.16.2":
-  version: 5.16.2
-  resolution: "@testing-library/jest-dom@npm:5.16.2"
-  dependencies:
-    "@babel/runtime": ^7.9.2
-    "@types/testing-library__jest-dom": ^5.9.1
-    aria-query: ^5.0.0
-    chalk: ^3.0.0
-    css: ^3.0.0
-    css.escape: ^1.5.1
-    dom-accessibility-api: ^0.5.6
-    lodash: ^4.17.15
-    redent: ^3.0.0
-  checksum: e4569df67c4c4998d2c60c6cf00ce2f1ac10c9397e0970320728c8be8f4e2c17a0e801705ce8a7384f7f5629b598a6f58db91d4401dde02044f5625405ca0988
-  languageName: node
-  linkType: hard
-
 "@testing-library/react-hooks@npm:*, @testing-library/react-hooks@npm:^7.0.2":
   version: 7.0.2
   resolution: "@testing-library/react-hooks@npm:7.0.2"


### PR DESCRIPTION
Because:

* We were using a sources retrieve for a card instead of the card
  retrieve for card fetching in the stripe webhook.

This commit:

* Removes card as a source expansion resource and custom loads it
  for the stripe webhook.

Closes #11872

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
