### PR TITLE
fix(subscriptions): sub invoice api 500 on cancel

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -446,13 +446,19 @@ export class StripeHandler {
       return [];
     }
 
-    const subsequentInvoicePreviews = await Promise.all(
-      customer.subscriptions?.data.map((sub) =>
-        this.stripeHelper.previewInvoiceBySubscriptionId({
-          subscriptionId: sub.id,
+    const subsequentInvoicePreviews = (
+      await Promise.all(
+        customer.subscriptions.data.map((sub) => {
+          if (!sub.canceled_at) {
+            return this.stripeHelper.previewInvoiceBySubscriptionId({
+              subscriptionId: sub.id,
+            });
+          } else {
+            return Promise.resolve(null);
+          }
         })
       )
-    );
+    ).filter((sub): sub is Stripe.Response<Stripe.Invoice> => sub !== null);
 
     return stripeInvoicesToSubsequentInvoicePreviewsDTO(
       subsequentInvoicePreviews


### PR DESCRIPTION
## Because

- Cancelled subscriptions cause the subsequent invoice API to return a
  500 status code.


## This pull request

- Does not attempt to retrieve a subsequent invoice for subscriptions
  that have already been cancelled.

## Issue that this pull request solves

Closes: #12071

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
