### PR TITLE
fix(metrics): Attempt to fix login complete events for mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "stop": "nps --prefix=stop",
     "restart": "nps --prefix=restart",
     "delete": "nps --prefix=delete",
+    "rebuild-packages": "yarn workspaces foreach run build",
     "adb-reverse": "./_scripts/adb-reverse.sh",
     "test": "_scripts/test-package.sh",
     "config-fxios": "node _scripts/config-fxios.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8901,23 +8901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^5.16.2":
-  version: 5.16.2
-  resolution: "@testing-library/jest-dom@npm:5.16.2"
-  dependencies:
-    "@babel/runtime": ^7.9.2
-    "@types/testing-library__jest-dom": ^5.9.1
-    aria-query: ^5.0.0
-    chalk: ^3.0.0
-    css: ^3.0.0
-    css.escape: ^1.5.1
-    dom-accessibility-api: ^0.5.6
-    lodash: ^4.17.15
-    redent: ^3.0.0
-  checksum: e4569df67c4c4998d2c60c6cf00ce2f1ac10c9397e0970320728c8be8f4e2c17a0e801705ce8a7384f7f5629b598a6f58db91d4401dde02044f5625405ca0988
-  languageName: node
-  linkType: hard
-
 "@testing-library/react-hooks@npm:*, @testing-library/react-hooks@npm:^7.0.2":
   version: 7.0.2
   resolution: "@testing-library/react-hooks@npm:7.0.2"


### PR DESCRIPTION
## Because

- We were not emitting login events on mobile devices

## This pull request

- Through manual testing, adding a slight delay before navigating to next screen allows our metrics to be sent
- Without the delay iOS blocks these requests....for reasons? I'm guessing something privacy related since this issue just poped up
- This is a bit hard to test locally, so I got a screen grab of before and after

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11917

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="652" alt="Screen Shot 2022-03-03 at 1 48 17 PM" src="https://user-images.githubusercontent.com/1295288/156648498-db9298c9-86d7-4ea7-840d-2ccb0cd76bee.png">

After:
<img width="587" alt="Screen Shot 2022-03-03 at 1 48 30 PM" src="https://user-images.githubusercontent.com/1295288/156648535-6aca3824-c09d-4dd9-bbfc-4dfc9a79abb1.png">

