### PR TITLE
Connection pool investigation

### DIFF
--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -52,6 +52,7 @@
     "graphql": "^15.6.1",
     "graphql-tools": "^8.0.0",
     "helmet": "^5.0.0",
+    "hot-shots": "^9.0.0",
     "knex": "^1.0.3",
     "mozlog": "^3.0.2",
     "mysql": "^2.18.1",

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -8,6 +8,7 @@ import { HealthModule } from 'fxa-shared/nestjs/health/health.module';
 import { LoggerModule } from 'fxa-shared/nestjs/logger/logger.module';
 import { SentryModule } from 'fxa-shared/nestjs/sentry/sentry.module';
 import { SentryPlugin } from 'fxa-shared/nestjs/sentry/sentry.plugin';
+import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { getVersionInfo } from 'fxa-shared/nestjs/version';
 import { join } from 'path';
 
@@ -62,6 +63,6 @@ const version = getVersionInfo(__dirname);
     }),
   ],
   controllers: [],
-  providers: [],
+  providers: [MetricsFactory],
 })
 export class AppModule {}

--- a/packages/fxa-admin-server/src/config.ts
+++ b/packages/fxa-admin-server/src/config.ts
@@ -51,6 +51,32 @@ const conf = convict({
     env: 'SENTRY_DSN',
     format: 'String',
   },
+  metrics: {
+    host: {
+      default: '',
+      doc: 'Metrics host to report to',
+      env: 'METRIC_HOST',
+      format: String,
+    },
+    port: {
+      default: 8125,
+      doc: 'Metric port to report to',
+      env: 'METRIC_PORT',
+      format: Number,
+    },
+    prefix: {
+      default: 'fxa-auth-server.',
+      doc: 'Metric prefix for statsD',
+      env: 'METRIC_PREFIX',
+      format: String,
+    },
+    telegraf: {
+      default: true,
+      doc: 'Whether to use telegraf formatted metrics',
+      env: 'METRIC_USE_TELEGRAF',
+      format: Boolean,
+    },
+  },
   hstsEnabled: {
     default: true,
     doc: 'Send a Strict-Transport-Security header',

--- a/packages/fxa-admin-server/src/database/database.module.ts
+++ b/packages/fxa-admin-server/src/database/database.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
+import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { DatabaseService } from './database.service';
 
 @Module({
-  providers: [DatabaseService],
+  providers: [DatabaseService, MetricsFactory],
   exports: [DatabaseService],
 })
 export class DatabaseModule {}

--- a/packages/fxa-admin-server/src/database/database.service.spec.ts
+++ b/packages/fxa-admin-server/src/database/database.service.spec.ts
@@ -1,15 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Provider } from '@nestjs/common';
+import { Logger, Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import config from '../config';
 import { DatabaseService } from './database.service';
 
 describe('DatabaseService', () => {
   let service: DatabaseService;
+  let logger: any;
 
   beforeEach(async () => {
     const MockConfig: Provider = {
@@ -35,8 +37,28 @@ describe('DatabaseService', () => {
         }),
       },
     };
+    const logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      trace: jest.fn(),
+    };
+    const MockLogService: Provider = {
+      provide: MozLoggerService,
+      useValue: logger,
+    };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DatabaseService, MockConfig],
+      providers: [
+        DatabaseService,
+        MockConfig,
+        MockLogService,
+        MockMetricsFactory,
+      ],
     }).compile();
 
     service = module.get<DatabaseService>(DatabaseService);

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -125,11 +125,16 @@ describe('AccountResolver', () => {
         }),
       },
     };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AccountResolver,
         MockMozLogger,
         MockConfig,
+        MockMetricsFactory,
         { provide: DatabaseService, useValue: db },
       ],
     }).compile();

--- a/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.spec.ts
@@ -55,11 +55,16 @@ describe('EmailBounceResolver', () => {
         get: jest.fn().mockReturnValue({ authHeader: 'test' }),
       },
     };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EmailBounceResolver,
         MockMozLogger,
         MockConfig,
+        MockMetricsFactory,
         { provide: DatabaseService, useValue: db },
       ],
     }).compile();

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -5,6 +5,7 @@
 const hex = require('buf').to.hex;
 
 const config = require('../../../config');
+import { Container } from 'typedi';
 const encrypt = require('fxa-shared/auth/encrypt');
 const mysql = require('./mysql');
 const redis = require('./redis');
@@ -12,6 +13,7 @@ const AccessToken = require('./accessToken');
 const { SHORT_ACCESS_TOKEN_TTL_IN_MS } = require('fxa-shared/oauth/constants');
 const RefreshTokenMetadata = require('./refreshTokenMetadata');
 const { ConnectedServicesDb } = require('fxa-shared/connected-services');
+import { AuthLogger } from '../../types';
 
 const JWT_ACCESS_TOKENS_ENABLED = config.get(
   'oauthServer.jwtAccessTokens.enabled'
@@ -34,6 +36,10 @@ const POCKET_IDS = getPocketIds(
   config.get('oauthServer.clientIdToServiceNames')
 );
 
+function resolveLogger() {
+  if (Container.has(AuthLogger)) return Container.get(AuthLogger);
+}
+
 class OauthDB extends ConnectedServicesDb {
   get mysql() {
     return this.db;
@@ -44,7 +50,14 @@ class OauthDB extends ConnectedServicesDb {
   }
 
   constructor() {
-    super(mysql.connect(config.get('oauthServer.mysql')), redis(config));
+    super(
+      mysql.connect(
+        config.get('oauthServer.mysql'),
+        undefined,
+        resolveLogger()
+      ),
+      redis(config)
+    );
 
     // A better inheritance model would be preferable, but for now
     // this is still backwards compatible.

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -9,7 +9,10 @@ const unique = require('../../unique');
 const AccessToken = require('../accessToken');
 
 // Shared base class
-const { MysqlStoreShared } = require('fxa-shared/db/mysql');
+const { MysqlOAuthShared } = require('fxa-shared/db/mysql');
+const { Container } = require('typedi');
+const { AuthLogger } = require('../../../types');
+const { StatsD } = require('hot-shots');
 
 const REQUIRED_SQL_MODES = ['STRICT_ALL_TABLES', 'NO_ENGINE_SUBSTITUTION'];
 
@@ -156,9 +159,16 @@ function firstRow(rows) {
   return rows[0];
 }
 
-class MysqlStore extends MysqlStoreShared {
+function resolveLogger() {
+  if (Container.has(AuthLogger)) return Container.get(AuthLogger);
+}
+function resolveMetrics() {
+  if (Container.has(StatsD)) return Container.get(StatsD);
+}
+
+class MysqlStore extends MysqlOAuthShared {
   constructor(config) {
-    super(config);
+    super(config, undefined, resolveLogger(), resolveMetrics());
   }
 
   async ping() {
@@ -513,6 +523,7 @@ class MysqlStore extends MysqlStoreShared {
   }
 
   _touchRefreshToken(token, now) {
+    this.log('authdb.FXA-4648', { msg: 'touchRefreshToken', now });
     return this._write(QUERY_REFRESH_TOKEN_LAST_USED_UPDATE, [
       now,
       // WHERE

--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -15,8 +15,6 @@ const config = require('../../config').getProperties();
 
 export async function setupProcesingTaskObjects(processName: string) {
   configureSentry(undefined, config, processName);
-  // Establish database connection and bind instance to Model using Knex
-  setupAuthDatabase(config.database.mysql.auth);
 
   Container.set(AppConfig, config);
 
@@ -42,6 +40,9 @@ export async function setupProcesingTaskObjects(processName: string) {
 
   const log = require('../log')({ ...config.log, statsd });
   Container.set(AuthLogger, log);
+
+  // Establish database connection and bind instance to Model using Knex
+  setupAuthDatabase(config.database.mysql.auth, log, statsd);
 
   const translator = await require('../senders/translator')(
     config.i18n.supportedLanguages,

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -3,14 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 const { RedisShared } = require('fxa-shared/db/redis');
 const { resolve } = require('path');
+const { AuthLogger } = require('./types');
+import { Container } from 'typedi';
 
 ('use strict');
 
 const hex = require('buf').to.hex;
 
+function resolveLogger() {
+  if (Container.has(AuthLogger)) return Container.get(AuthLogger);
+}
+
 class FxaRedis extends RedisShared {
   constructor(config) {
-    super(config);
+    super(config, resolveLogger());
 
     // Applies custom scripts which are turned into methods on
     // the redis object.

--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -65,10 +65,8 @@ module.exports = (log, db, devices, clientUtils) => {
         log.begin('Account.attachedClients', request);
 
         const sessionToken = request.auth && request.auth.credentials;
-        sessionToken.lastAccessTime = Date.now(
-          sessionToken.id,
-          request.app.acceptLanguage
-        );
+
+        sessionToken.lastAccessTime = Date.now();
         await db.touchSessionToken(sessionToken, {}, true);
         const { uid, id } = sessionToken;
         const factory = new ConnectedServicesFactory({

--- a/packages/fxa-auth-server/scripts/bulk-mailer/index.js
+++ b/packages/fxa-auth-server/scripts/bulk-mailer/index.js
@@ -52,7 +52,11 @@ module.exports = async function (
         console.info(JSON.stringify(msg));
       }
     },
-    debug() {},
+    debug(msg) {
+      if (useVerboseLogging) {
+        console.debug(JSON.stringify(msg));
+      }
+    },
   };
 
   const translator = await createTranslator(config);

--- a/packages/fxa-auth-server/scripts/dump-users/index.js
+++ b/packages/fxa-auth-server/scripts/dump-users/index.js
@@ -12,6 +12,8 @@ module.exports = function dumpUsers(keys, dbFunc, usePretty) {
     error: (msg) => {},
     info: (msg) => {},
     trace: (msg) => {},
+    debug: (msg) => {},
+    warn: (msg) => {},
   };
 
   const Token = require('../../lib/tokens')(log, config);

--- a/packages/fxa-auth-server/scripts/populate-stripe-customer-db.ts
+++ b/packages/fxa-auth-server/scripts/populate-stripe-customer-db.ts
@@ -38,6 +38,7 @@ export async function init() {
     maxNetworkRetries: 3,
   });
 
+  // TODO: Setup Logger and StatsD
   setupAuthDatabase(config.database.mysql.auth);
 
   await processCustomers(stripe);

--- a/packages/fxa-auth-server/test/local/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails/fluent-localizer.ts
@@ -65,11 +65,11 @@ describe('fluent localizer', () => {
         );
 
         const result = await l10n.formatValue(
-          'subscriptionAccountFinishSetup-action',
+          'subscriptionAccountFinishSetup-action-2',
           {}
         );
 
-        assert.equal(result, 'Passwort erstellen');
+        assert.equal(result, 'Einführung');
       });
 
       it('localizes properly with preferred Dialect', async () => {

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
@@ -12,7 +12,7 @@ const config = require('../../config').getProperties();
 const buf = require('buf').hex;
 const testUtils = require('../lib/util');
 const encrypt = require('fxa-shared/auth/encrypt');
-const log = { trace() {}, info() {}, error() {} };
+const log = { trace() {}, info() {}, error() {}, debug() {}, warn() {} };
 
 const lastAccessTimeUpdates = {
   enabled: true,

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -9,7 +9,7 @@ const uuid = require('uuid');
 const crypto = require('crypto');
 const base64url = require('base64url');
 const proxyquire = require('proxyquire');
-const log = { trace() {}, info() {}, error() {} };
+const log = { trace() {}, info() {}, error() {}, debug() {}, warn() {} };
 
 const config = require('../../config').getProperties();
 const TestServer = require('../test_server');

--- a/packages/fxa-auth-server/test/remote/verifier_upgrade_tests.js
+++ b/packages/fxa-auth-server/test/remote/verifier_upgrade_tests.js
@@ -7,7 +7,7 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
-const log = { trace() {}, info() {} };
+const log = { trace() {}, info() {}, debug() {}, warn() {}, error() {} };
 
 const config = require('../../config').getProperties();
 

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -61,6 +61,7 @@
     "graphql-tools": "^8.0.0",
     "graphql-upload": "^13.0.0",
     "helmet": "^5.0.0",
+    "hot-shots": "^9.0.0",
     "ioredis": "^4.28.2",
     "knex": "^1.0.3",
     "mozlog": "^3.0.2",

--- a/packages/fxa-graphql-api/src/app.module.ts
+++ b/packages/fxa-graphql-api/src/app.module.ts
@@ -8,6 +8,7 @@ import { HealthModule } from 'fxa-shared/nestjs/health/health.module';
 import { LoggerModule } from 'fxa-shared/nestjs/logger/logger.module';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { SentryModule } from 'fxa-shared/nestjs/sentry/sentry.module';
+import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { getVersionInfo } from 'fxa-shared/nestjs/version';
 
 import { AuthModule } from './auth/auth.module';
@@ -54,6 +55,6 @@ const version = getVersionInfo(__dirname);
     }),
   ],
   controllers: [],
-  providers: [],
+  providers: [MetricsFactory],
 })
 export class AppModule {}

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
@@ -29,10 +29,15 @@ describe('ProfileClientService', () => {
         }),
       },
     };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ProfileClientService,
         MockConfig,
+        MockMetricsFactory,
         { provide: AuthClientService, useValue: authClient },
       ],
     }).compile();

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -114,6 +114,38 @@ const conf = convict({
       },
     },
   },
+  metrics: {
+    host: {
+      default: '',
+      doc: 'Metrics host to report to',
+      env: 'METRIC_HOST',
+      format: String,
+    },
+    port: {
+      default: 8125,
+      doc: 'Metric port to report to',
+      env: 'METRIC_PORT',
+      format: Number,
+    },
+    prefix: {
+      default: 'fxa-graphql-api.',
+      doc: 'Metric prefix for statsD',
+      env: 'METRIC_PREFIX',
+      format: String,
+    },
+    telegraf: {
+      default: true,
+      doc: 'Whether to use telegraf formatted metrics',
+      env: 'METRIC_USE_TELEGRAF',
+      format: Boolean,
+    },
+    sampleRate: {
+      doc: 'Sampling rate for StatsD',
+      format: Number,
+      default: 1,
+      env: 'METRIC_SAMPLE_RATE',
+    },
+  },
   oauth: {
     clientId: {
       default: '98e6508e88680e1a',

--- a/packages/fxa-graphql-api/src/database/database.module.ts
+++ b/packages/fxa-graphql-api/src/database/database.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
+import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { DatabaseService } from './database.service';
 
 @Module({
-  providers: [DatabaseService],
+  providers: [DatabaseService, MetricsFactory],
   exports: [DatabaseService],
 })
 export class DatabaseModule {}

--- a/packages/fxa-graphql-api/src/database/database.service.spec.ts
+++ b/packages/fxa-graphql-api/src/database/database.service.spec.ts
@@ -7,9 +7,13 @@ import { DatabaseService } from './database.service';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Account } from 'fxa-shared/db/models/auth';
+import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { Profile } from 'fxa-shared/db/models/profile';
+import { StatsD } from 'hot-shots';
 
 describe('DatabaseService', () => {
   let service: DatabaseService;
+  let logger: any;
 
   beforeEach(async () => {
     const dbConfig = {
@@ -33,8 +37,22 @@ describe('DatabaseService', () => {
         }),
       },
     };
+    logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
+    const MockMozLogger: Provider = {
+      provide: MozLoggerService,
+      useValue: logger,
+    };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DatabaseService, MockConfig],
+      providers: [
+        DatabaseService,
+        MockConfig,
+        MockMozLogger,
+        MockMetricsFactory,
+      ],
     }).compile();
 
     service = module.get<DatabaseService>(DatabaseService);

--- a/packages/fxa-graphql-api/src/database/database.service.ts
+++ b/packages/fxa-graphql-api/src/database/database.service.ts
@@ -1,10 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { setupAuthDatabase, setupProfileDatabase } from 'fxa-shared/db';
 import { Account } from 'fxa-shared/db/models/auth';
+import { StatsD } from 'hot-shots';
+import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { Knex } from 'knex';
 
 import { AppConfig } from '../config';
@@ -14,10 +16,18 @@ export class DatabaseService {
   public authKnex: Knex;
   public profileKnex: Knex;
 
-  constructor(configService: ConfigService<AppConfig>) {
+  constructor(
+    configService: ConfigService<AppConfig>,
+    logger: MozLoggerService,
+    @Inject('METRICS') metrics: StatsD
+  ) {
     const dbConfig = configService.get('database') as AppConfig['database'];
-    this.authKnex = setupAuthDatabase(dbConfig.mysql.auth);
-    this.profileKnex = setupProfileDatabase(dbConfig.mysql.profile);
+    this.authKnex = setupAuthDatabase(dbConfig.mysql.auth, logger, metrics);
+    this.profileKnex = setupProfileDatabase(
+      dbConfig.mysql.profile,
+      logger,
+      metrics
+    );
   }
 
   async dbHealthCheck(): Promise<Record<string, any>> {

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -35,12 +35,17 @@ describe('AccountResolver', () => {
       provide: MozLoggerService,
       useValue: logger,
     };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     authClient = {};
     profileClient = {};
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AccountResolver,
         MockMozLogger,
+        MockMetricsFactory,
         { provide: CustomsService, useValue: {} },
         { provide: AuthClientService, useValue: authClient },
         { provide: ProfileClientService, useValue: profileClient },

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -20,11 +20,16 @@ describe('AccountResolver', () => {
       provide: MozLoggerService,
       useValue: logger,
     };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
     authClient = {};
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SessionResolver,
         MockMozLogger,
+        MockMetricsFactory,
         { provide: CustomsService, useValue: {} },
         { provide: AuthClientService, useValue: authClient },
       ],

--- a/packages/fxa-shared/connected-services/factories.ts
+++ b/packages/fxa-shared/connected-services/factories.ts
@@ -189,12 +189,12 @@ export class ConnectedServicesFactory {
       }
 
       client.createdTime = Math.min(
-        client.createdTime || Number.MAX_VALUE,
+        client.createdTime || Number.POSITIVE_INFINITY,
         session.createdAt
       );
 
       client.lastAccessTime = Math.max(
-        client.lastAccessTime || Number.MIN_VALUE,
+        client.lastAccessTime || 0,
         session.lastAccessTime
       );
 
@@ -241,11 +241,11 @@ export class ConnectedServicesFactory {
       client.clientId = oauthClient.client_id;
       client.scope = oauthClient.scope;
       client.createdTime = Math.min(
-        client.createdTime || Number.MAX_VALUE,
+        client.createdTime || Number.POSITIVE_INFINITY,
         oauthClient.created_time
       );
       client.lastAccessTime = Math.max(
-        client.lastAccessTime || Number.MIN_VALUE,
+        client.lastAccessTime || 0,
         oauthClient.last_access_time
       );
       // We fill in a default device name from the OAuth client name,

--- a/packages/fxa-shared/connected-services/formatters.ts
+++ b/packages/fxa-shared/connected-services/formatters.ts
@@ -62,7 +62,7 @@ export class ClientFormatter implements IClientFormatter {
           const territoriesLang =
             language === 'en-US' ? 'en-US-POSIX' : language;
 
-          const territories = require(`cldr-localenames-full/main/${language}/territories.json`);
+          const territories = require(`cldr-localenames-full/main/${territoriesLang}/territories.json`);
           client.location = {
             country:
               territories.main[language].localeDisplayNames.territories[

--- a/packages/fxa-shared/connected-services/models/AttachedClient.ts
+++ b/packages/fxa-shared/connected-services/models/AttachedClient.ts
@@ -31,7 +31,7 @@ export const attachedClientsDefaults: AttachedClient = {
   isCurrentSession: false,
   deviceType: null,
   name: null,
-  createdTime: null,
+  createdTime: Infinity,
   lastAccessTime: 0,
   scope: null,
   location: null,

--- a/packages/fxa-shared/db/index.ts
+++ b/packages/fxa-shared/db/index.ts
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { StatsD } from 'hot-shots';
 import { knex, Knex } from 'knex';
 import { promisify } from 'util';
+import { ILogger } from '../log';
 
 import { MySQLConfig } from './config';
 import { BaseAuthModel } from './models/auth';
@@ -54,8 +56,64 @@ function typeCasting(field: any, next: any) {
   return next();
 }
 
-export function setupDatabase(opts: MySQLConfig): Knex {
-  return knex({
+export function monitorKnexConnectionPool(
+  pool: any,
+  log?: ILogger,
+  metrics?: StatsD
+) {
+  metrics?.increment('mysql.pool_creation');
+  const getPoolStats = () => {
+    return {
+      // returns the number of non-free resources
+      numUsed: pool.numUsed(),
+      // returns the number of free resources
+      numFree: pool.numFree(),
+      // how many acquires are waiting for a resource to be released
+      numPendingAcquires: pool.numPendingAcquires(),
+      // how many asynchronous create calls are running
+      numPendingCreates: pool.numPendingCreates(),
+    };
+  };
+  pool.on('acquireRequest', (eventId: any) => {
+    log?.info('db.FXA-4648', {
+      msg: `Knex acquireRequest`,
+      eventId,
+      ...getPoolStats(),
+    });
+    metrics?.increment('knex.aquire_request');
+  });
+  pool.on('createRequest', (eventId: any) => {
+    log?.info('db.FXA-4648', {
+      msg: `Knex createRequest`,
+      eventId,
+      ...getPoolStats(),
+    });
+    metrics?.increment('knex.create_request');
+  });
+  pool.on('destroyRequest', (eventId: any, resource: any) => {
+    log?.info('db.FXA-4648', {
+      msg: `Knex destroyRequest`,
+      eventId,
+      ...getPoolStats(),
+    });
+    metrics?.increment('knex.destroy_request');
+  });
+  pool.on('destroyFail', (eventId: any, resource: any) => {
+    log?.info('db.FXA-4648', {
+      msg: `Knex destroyFail`,
+      eventId,
+      ...getPoolStats(),
+    });
+    metrics?.increment('knex.destroy_fail');
+  });
+}
+
+export function setupDatabase(
+  opts: MySQLConfig,
+  log?: ILogger,
+  metrics?: StatsD
+): Knex {
+  const db = knex({
     connection: {
       typeCast: typeCasting,
       charset: 'UTF8MB4_BIN',
@@ -69,16 +127,35 @@ export function setupDatabase(opts: MySQLConfig): Knex {
       acquireTimeoutMillis: opts.acquireTimeoutMillis,
     },
   });
+
+  // Monitor connection pool
+  monitorKnexConnectionPool(db.client.pool, log, metrics);
+
+  log?.info('db.FXA-4648', {
+    msg: `Creating Knex`,
+    connLimit: opts.connectionLimitMax,
+  });
+  log?.info('db.FXA-4648', { msg: `Creating Knex`, stack: Error().stack });
+
+  return db;
 }
 
-export function setupAuthDatabase(opts: MySQLConfig) {
-  const knex = setupDatabase(opts);
+export function setupAuthDatabase(
+  opts: MySQLConfig,
+  log?: ILogger,
+  metrics?: StatsD
+) {
+  const knex = setupDatabase(opts, log, metrics);
   BaseAuthModel.knex(knex);
   return knex;
 }
 
-export function setupProfileDatabase(opts: MySQLConfig) {
-  const knex = setupDatabase(opts);
+export function setupProfileDatabase(
+  opts: MySQLConfig,
+  log?: ILogger,
+  metrics?: StatsD
+) {
+  const knex = setupDatabase(opts, log, metrics);
   ProfileBaseModel.knex(knex);
   return knex;
 }

--- a/packages/fxa-shared/db/mysql.ts
+++ b/packages/fxa-shared/db/mysql.ts
@@ -1,9 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { randomUUID } from 'crypto';
+import { StatsD } from 'hot-shots';
 import mysql from 'mysql';
 
 import { AccessToken as AccessToken } from '../db/models/auth/access-token';
+import { ILogger } from '../log';
 import * as ScopeSet from '../oauth/scopes';
 
 // TODO: Improve types. Ported form javascript...
@@ -99,12 +102,32 @@ export function notFound() {
 }
 
 /**
+ * Interface for monitoring key events on the base class.
+ */
+export interface IMysqlStoreSharedEvents {
+  onPoolConnection(connection: any): void;
+  onPoolAquired(connection: any): void;
+  onPoolRelease(connection: any): void;
+  onPoolEnqueue(): void;
+
+  onConnection(connection: any, err: any): void;
+  onInitialize(connected: any): void;
+  onInitializeError(err: any): void;
+}
+
+/**
  * Base MysqlStore class. This is the foundation for calls going to sql.
  */
 export class MysqlStoreShared {
-  protected readonly _pool: mysql.Pool;
+  protected _pool: mysql.Pool;
+  protected readonly _uid: string;
 
-  constructor(options: mysql.PoolConfig) {
+  constructor(
+    options: mysql.PoolConfig,
+    protected readonly events?: IMysqlStoreSharedEvents,
+    protected readonly log?: ILogger,
+    protected readonly metrics?: StatsD
+  ) {
     if (options.charset && options.charset !== REQUIRED_CHARSET) {
       throw new Error('You cannot use any charset besides ' + REQUIRED_CHARSET);
     } else {
@@ -117,20 +140,83 @@ export class MysqlStoreShared {
       return next();
     };
     this._pool = mysql.createPool(options);
+    this.metrics?.increment('mysql.pool_creation');
+
+    // Tag with uid to keep instances seperate
+    const uid = randomUUID();
+    this._uid = uid;
+
+    this.events = events;
+
+    // Monitor pool events
+    const getPoolStats = () => {
+      return {
+        uid: this._uid,
+        connectionLimit: this._pool.config.connectionLimit,
+        connections: (<any>this._pool)._allConnections?.length,
+        aquiring: (<any>this._pool)._acquiringConnections?.length,
+        free: (<any>this._pool)._acquiringConnections?.length,
+      };
+    };
+    this._pool.on('enqueue', () => {
+      log?.info('mysql.FXA-4648', { msg: 'on enqueue', uid: this._uid });
+      this.metrics?.increment('mysql.connection');
+      this.events?.onPoolEnqueue();
+    });
+
+    this._pool.on('connection', (connection: any) => {
+      log?.info('mysql.FXA-4648', { msg: 'on enqueue', ...getPoolStats() });
+      this.metrics?.increment('mysql.connection', {
+        new: (!!connection._ruid).toString(),
+      });
+      this.events?.onPoolConnection(connection);
+    });
+    this._pool.on('acquire', (connection: any) => {
+      log?.info('mysql.FXA-4648', { msg: 'on enqueue', ...getPoolStats() });
+      this.events?.onPoolAquired(connection);
+      this.metrics?.increment('mysql.aquire', {
+        new: (!!connection._ruid).toString(),
+      });
+    });
+    this._pool.on('release', (connection) => {
+      log?.info('mysql.FXA-4648', { msg: 'on enqueue', ...getPoolStats() });
+      this.events?.onPoolRelease(connection);
+      this.metrics?.increment('mysql.release');
+    });
+
+    log?.info('mysql.FXA-4648', {
+      msg: 'Creating new MysqlStoreShared.',
+      ...getPoolStats(),
+      stack: Error().stack,
+    });
   }
 
   protected async _query(sql: any, params: any): Promise<any> {
+    const log = this.log;
+    const uid = this._uid;
     const conn: any = await this._getConnection();
+
+    log?.debug('FXA-4648', { msg: `Got connection, ${conn?._ruid}`, uid });
+
     try {
       return await new Promise(function (resolve, reject) {
         conn.query(sql, params || [], function (err: any, results: any) {
           if (err) {
+            log?.error('mysql.FXA-4648', {
+              msg: `Mysql query failed, ${conn?._ruid}`,
+              err,
+              uid,
+            });
             return reject(err);
           }
           resolve(results);
         });
       });
     } finally {
+      log?.debug('mysql.FXA-4648', {
+        msg: `Released connection, ${conn?._ruid}`,
+        uid,
+      });
       conn.release();
     }
   }
@@ -149,13 +235,32 @@ export class MysqlStoreShared {
 
   protected _getConnection() {
     var pool = this._pool;
+    var events = this.events;
+    var log = this.log;
+    var metrics = this.metrics;
+    var uid = this._uid;
+
     return new Promise(function (resolve, reject) {
+      log?.debug('mysql.FXA-4648', { msg: 'Requesting connection', uid });
+
       pool.getConnection(function (err: any, conn: any) {
+        log?.debug('mysql.FXA-4648', { msg: 'Got connection', uid });
+        events?.onConnection(conn, err);
+
         if (err) {
+          log?.error('mysql.FXA-4648', {
+            msg: 'Failed to get connection.',
+            err,
+          });
           return reject(err);
         }
 
         if (conn._fxa_initialized) {
+          log?.debug('mysql.FXA-4648', {
+            msg: 'Reusing connection',
+            uid,
+            conn_ruid: conn._ruid,
+          });
           return resolve(conn);
         }
 
@@ -166,6 +271,12 @@ export class MysqlStoreShared {
           new Promise<any>((resolve, reject) => {
             conn.query(sql, (err: any, result: any) => {
               if (err) {
+                log?.error('FXA-4648', {
+                  msg: `Mysql connection init query failed`,
+                  err,
+                  uid,
+                  conn_ruid: conn._ruid,
+                });
                 return reject(err);
               }
               resolve(result);
@@ -174,30 +285,61 @@ export class MysqlStoreShared {
 
         return resolve(
           (async () => {
-            // Always communicate timestamps in UTC.
-            await query("SET time_zone = '+00:00'");
-            // Always use full 4-byte UTF-8 for communicating unicode.
-            await query('SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;');
-            // Always have certain modes active. The complexity here is to
-            // preserve any extra modes active by default on the server.
-            // We also try to preserve the order of the existing mode flags,
-            // just in case the order has some obscure effect we don't know about.
-            const rows = await query('SELECT @@sql_mode AS mode');
-            const modes = rows[0]['mode'].split(',');
-            let needToSetMode = false;
-            for (const requiredMode of REQUIRED_SQL_MODES) {
-              if (modes.indexOf(requiredMode) === -1) {
-                modes.push(requiredMode);
-                needToSetMode = true;
+            try {
+              events?.onInitialize(conn);
+
+              // Always communicate timestamps in UTC.
+              await query("SET time_zone = '+00:00'");
+              // Always use full 4-byte UTF-8 for communicating unicode.
+              await query('SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;');
+              // Always have certain modes active. The complexity here is to
+              // preserve any extra modes active by default on the server.
+              // We also try to preserve the order of the existing mode flags,
+              // just in case the order has some obscure effect we don't know about.
+              const rows = await query('SELECT @@sql_mode AS mode');
+              const modes = rows[0]['mode'].split(',');
+              let needToSetMode = false;
+              for (const requiredMode of REQUIRED_SQL_MODES) {
+                if (modes.indexOf(requiredMode) === -1) {
+                  modes.push(requiredMode);
+                  needToSetMode = true;
+                }
               }
+              if (needToSetMode) {
+                const mode = modes.join(',');
+                await query("SET SESSION sql_mode = '" + mode + "'");
+              }
+              // Avoid repeating all that work for existing connections.
+              conn._fxa_initialized = true;
+
+              // Tag with random value to make logs more transparent
+              conn._ruid = randomUUID();
+
+              return conn;
+            } catch (err) {
+              events?.onInitializeError(err);
+              metrics?.increment('mysql.initialize_connection_error');
+              log?.error('mysql.FXA-4648', {
+                msg: 'Error initializing connection.',
+                err,
+                uid,
+              });
+
+              // Important! Although unlikely, if for some reason this setup routine
+              // fails, we must close the connection. Otherwise, the connection can
+              // get stuck in an unreleased state
+              if (conn) {
+                log?.info('mysql.FXA-4648', {
+                  msg: 'Release connection after DB initialization fails.',
+                  uid,
+                });
+
+                conn.release();
+              }
+
+              // Let error bubble up.
+              throw err;
             }
-            if (needToSetMode) {
-              const mode = modes.join(',');
-              await query("SET SESSION sql_mode = '" + mode + "'");
-            }
-            // Avoid repeating all that work for existing connections.
-            conn._fxa_initialized = true;
-            return conn;
           })()
         );
       });
@@ -206,16 +348,6 @@ export class MysqlStoreShared {
 
   protected firstRow(rows: any[]) {
     return rows[0];
-  }
-
-  async getRefreshTokensByUid(uid: string) {
-    const refreshTokens = await this._read(QUERY_LIST_REFRESH_TOKENS_BY_UID, [
-      buf(uid),
-    ]);
-    refreshTokens.forEach((t: any) => {
-      t.scope = ScopeSet.fromString(t.scope);
-    });
-    return refreshTokens;
   }
 
   async close() {
@@ -232,12 +364,18 @@ export class MysqlStoreShared {
       });
     });
   }
+}
 
-  /**
-   * Get all access tokens for a given user.
-   * @param {String} uid User ID as hex
-   * @returns {Promise}
-   */
+export class MysqlOAuthShared extends MysqlStoreShared {
+  constructor(
+    options: mysql.PoolConfig,
+    events?: IMysqlStoreSharedEvents,
+    log?: ILogger,
+    metrics?: StatsD
+  ) {
+    super(options, events, log, metrics);
+  }
+
   async getAccessTokensByUid(uid: string) {
     const accessTokens = await this._read(QUERY_LIST_ACCESS_TOKENS_BY_UID, [
       buf(uid),
@@ -246,5 +384,15 @@ export class MysqlStoreShared {
     return accessTokens.map((t: any) => {
       return AccessToken.fromMySQL(t);
     });
+  }
+
+  async getRefreshTokensByUid(uid: string) {
+    const refreshTokens = await this._read(QUERY_LIST_REFRESH_TOKENS_BY_UID, [
+      buf(uid),
+    ]);
+    refreshTokens.forEach((t: any) => {
+      t.scope = ScopeSet.fromString(t.scope);
+    });
+    return refreshTokens;
   }
 }

--- a/packages/fxa-shared/db/redis.ts
+++ b/packages/fxa-shared/db/redis.ts
@@ -66,6 +66,12 @@ export class RedisShared {
       config.keyPrefix = config.prefix;
     }
 
+    log?.info('redis.FXA-4648', { msg: 'Creating RedisShared' });
+    log?.debug('redis.FXA-4648', {
+      msg: 'Creating RedisShared',
+      stack: Error().stack,
+    });
+
     const redis = new Redis(config);
     const scriptsDirectory = resolve(__dirname, 'luaScripts');
 

--- a/packages/fxa-shared/test/db/mysql.ts
+++ b/packages/fxa-shared/test/db/mysql.ts
@@ -1,0 +1,148 @@
+import { assert } from 'chai';
+import { IMysqlStoreSharedEvents, MysqlStoreShared } from '../../db/mysql';
+import { defaultOpts, testDatabaseSetup } from './helpers';
+
+const dbOpts = Object.assign({}, defaultOpts.testDbConfig, {
+  connectionLimit: 20,
+});
+
+type TestStats = {
+  pool: {
+    connection: number;
+    release: number;
+    aquire: number;
+    enqueue: number;
+    threadIds: Record<string, number>;
+  };
+  connection: {
+    connection: number;
+    initialize: number;
+    initializeError: number;
+  };
+};
+
+class MysqlStoreTestEvents implements IMysqlStoreSharedEvents {
+  /**
+   * Collect some basic counts for events that are occurring.
+   */
+  public stats: TestStats = {
+    pool: {
+      connection: 0,
+      release: 0,
+      aquire: 0,
+      enqueue: 0,
+      threadIds: {},
+    },
+    connection: {
+      connection: 0,
+      initialize: 0,
+      initializeError: 0,
+    },
+  };
+
+  public ErrorOnInit = false;
+
+  onPoolConnection(connection: any): void {
+    this.stats.pool.connection++;
+    this.stats.pool.threadIds[connection.threadId] =
+      (this.stats.pool.threadIds[connection.threadId] || 0) + 1;
+  }
+  onPoolAquired(connection: any): void {
+    this.stats.pool.aquire++;
+  }
+  onPoolRelease(connection: any): void {
+    this.stats.pool.release++;
+  }
+  onPoolEnqueue(): void {
+    this.stats.pool.enqueue++;
+  }
+  onConnection(connection: any, err: any) {
+    this.stats.connection.connection++;
+  }
+  onInitialize(connected: any) {
+    this.stats.connection.initialize++;
+    if (this.ErrorOnInit) {
+      throw new Error('Testing init error');
+    }
+  }
+  onInitializeError(err: any) {
+    this.stats.connection.initializeError++;
+  }
+}
+
+/**
+ * Test class that keeps tabs on connection pool and other events
+ * for tracking creation management of connections.
+ */
+class MySqlStoreTest extends MysqlStoreShared {
+  constructor(events: IMysqlStoreSharedEvents) {
+    super(dbOpts, events);
+  }
+
+  getConnection() {
+    return super._getConnection();
+  }
+
+  query(sql: any, params: any) {
+    return this._query(sql, params);
+  }
+}
+
+describe('mysql', function () {
+  this.timeout(-1);
+  let events: MysqlStoreTestEvents;
+  let mysql: MySqlStoreTest;
+  let mysql2: MySqlStoreTest;
+
+  before(async () => {
+    const knex = await testDatabaseSetup(defaultOpts);
+    await knex.destroy();
+    events = new MysqlStoreTestEvents();
+    mysql = new MySqlStoreTest(events);
+    mysql2 = new MySqlStoreTest(events);
+  });
+
+  after(async () => {
+    await mysql.close();
+    await mysql2.close();
+  });
+
+  it('releases connections ', async () => {
+    const promises = [];
+    for (let i = 0; i < 2000; i++) {
+      promises.push(mysql.query('show tables;', {}));
+    }
+    await Promise.all(promises);
+    assert.equal(events.stats.pool.aquire, events.stats.pool.release);
+    assert.equal(events.stats.pool.connection, dbOpts.connectionLimit);
+  });
+
+  it('detects closes connection on error ', async () => {
+    for (let i = 0; i < 1000; i++) {
+      try {
+        await mysql.query('show foo;', {});
+      } catch (_err) {}
+    }
+    assert.equal(events.stats.pool.aquire, events.stats.pool.release);
+    assert.equal(events.stats.pool.aquire, events.stats.pool.release);
+    assert.equal(events.stats.pool.connection, dbOpts.connectionLimit);
+  });
+
+  it('shares pools accross instances', async () => {
+    const promises = [];
+    for (let i = 0; i < 1000; i++) {
+      promises.push(mysql.query('show tables;', {}));
+      promises.push(mysql2.query('show tables;', {}));
+    }
+    await Promise.all(promises);
+
+    console.log('connectionLimit', dbOpts.connectionLimit * 2);
+    console.log('otehr', Object.keys(events.stats.pool.threadIds).length);
+    assert.equal(events.stats.pool.aquire, events.stats.pool.release);
+    assert.equal(events.stats.pool.connection, dbOpts.connectionLimit * 2);
+    assert.equal(
+      Object.keys(events.stats.pool.threadIds).length,
+      dbOpts.connectionLimit * 2
+    );
+  });
+});

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -49,6 +49,7 @@
     "handlebars": "^4.7.7",
     "hbs": "^4.2.0",
     "helmet": "^5.0.0",
+    "hot-shots": "^9.0.0",
     "mozlog": "^3.0.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/packages/fxa-support-panel/src/app.module.ts
+++ b/packages/fxa-support-panel/src/app.module.ts
@@ -13,6 +13,7 @@ import Config, { AppConfig } from './config';
 import { RemoteLookupService } from './remote-lookup/remote-lookup.service';
 import { DatabaseModule } from './database/database.module';
 import { DatabaseService } from './database/database.service';
+import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 
 const version = getVersionInfo(__dirname);
 
@@ -43,6 +44,6 @@ const version = getVersionInfo(__dirname);
     }),
   ],
   controllers: [AppController],
-  providers: [RemoteLookupService],
+  providers: [RemoteLookupService, MetricsFactory],
 })
 export class AppModule {}

--- a/packages/fxa-support-panel/src/config.ts
+++ b/packages/fxa-support-panel/src/config.ts
@@ -84,6 +84,32 @@ const conf = convict({
       format: 'url',
     },
   },
+  metrics: {
+    host: {
+      default: '',
+      doc: 'Metrics host to report to',
+      env: 'METRIC_HOST',
+      format: String,
+    },
+    port: {
+      default: 8125,
+      doc: 'Metric port to report to',
+      env: 'METRIC_PORT',
+      format: Number,
+    },
+    prefix: {
+      default: 'fxa-support-panel.',
+      doc: 'Metric prefix for statsD',
+      env: 'METRIC_PREFIX',
+      format: String,
+    },
+    telegraf: {
+      default: true,
+      doc: 'Whether to use telegraf formatted metrics',
+      env: 'METRIC_USE_TELEGRAF',
+      format: Boolean,
+    },
+  },
   sentryDsn: {
     default: '',
     doc: 'Sentry DSN for error and log reporting',

--- a/packages/fxa-support-panel/src/database/database.module.ts
+++ b/packages/fxa-support-panel/src/database/database.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { DatabaseService } from './database.service';
+import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 
 @Module({
-  providers: [DatabaseService],
+  providers: [DatabaseService, MetricsFactory],
   exports: [DatabaseService],
 })
 export class DatabaseModule {}

--- a/packages/fxa-support-panel/src/database/database.service.spec.ts
+++ b/packages/fxa-support-panel/src/database/database.service.spec.ts
@@ -7,9 +7,11 @@ import { DatabaseService } from './database.service';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Account } from 'fxa-shared/db/models/auth';
+import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 describe('DatabaseService', () => {
   let service: DatabaseService;
+  let logger: any;
 
   beforeEach(async () => {
     const dbConfig = {
@@ -29,8 +31,23 @@ describe('DatabaseService', () => {
         }),
       },
     };
+    logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
+    const MockMozLogger: Provider = {
+      provide: MozLoggerService,
+      useValue: logger,
+    };
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DatabaseService, MockConfig],
+      providers: [
+        DatabaseService,
+        MockConfig,
+        MockMozLogger,
+        MockMetricsFactory,
+      ],
     }).compile();
 
     service = module.get<DatabaseService>(DatabaseService);

--- a/packages/fxa-support-panel/src/database/database.service.ts
+++ b/packages/fxa-support-panel/src/database/database.service.ts
@@ -1,10 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { setupAuthDatabase } from 'fxa-shared/db';
+import { StatsD } from 'hot-shots';
 import { Account } from 'fxa-shared/db/models/auth';
+import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { Knex } from 'knex';
 
 import { AppConfig } from '../config';
@@ -13,9 +15,13 @@ import { AppConfig } from '../config';
 export class DatabaseService {
   public authKnex: Knex;
 
-  constructor(configService: ConfigService<AppConfig>) {
+  constructor(
+    configService: ConfigService<AppConfig>,
+    logger: MozLoggerService,
+    @Inject('METRICS') metrics: StatsD
+  ) {
     const dbConfig = configService.get('database') as AppConfig['database'];
-    this.authKnex = setupAuthDatabase(dbConfig.mysql.auth);
+    this.authKnex = setupAuthDatabase(dbConfig.mysql.auth, logger, metrics);
   }
 
   async dbHealthCheck(): Promise<Record<string, any>> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21565,6 +21565,7 @@ fsevents@~2.1.1:
     graphql: ^15.6.1
     graphql-tools: ^8.0.0
     helmet: ^5.0.0
+    hot-shots: ^9.0.0
     jest: 27.4.7
     knex: ^1.0.3
     mozlog: ^3.0.2
@@ -22150,6 +22151,7 @@ fsevents@~2.1.1:
     graphql-tools: ^8.0.0
     graphql-upload: ^13.0.0
     helmet: ^5.0.0
+    hot-shots: ^9.0.0
     ioredis: ^4.28.2
     jest: 27.4.7
     knex: ^1.0.3
@@ -22637,6 +22639,7 @@ fsevents@~2.1.1:
     handlebars: ^4.7.7
     hbs: ^4.2.0
     helmet: ^5.0.0
+    hot-shots: ^9.0.0
     jest: 27.4.7
     mozlog: ^3.0.2
     pm2: ^5.1.2


### PR DESCRIPTION
## Because

- We had connection pooling issues during original rollout.

## This pull request

- Adds logging 
- Binds to connection pool events
- Reintroduces changes rolled back in train 226.2
- Adds statsD metrics where possible. Note that StatsD has not been configured on some services, and this is outside the scope of the commit.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
