### PR TITLE
feat(auth): trim whitespace off metadata

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -35,6 +35,7 @@ import {
 } from 'fxa-shared/subscriptions/types';
 import { StatsD } from 'hot-shots';
 import ioredis from 'ioredis';
+import mapValues from 'lodash/mapValues';
 import moment from 'moment';
 import { Logger } from 'mozlog';
 import { Stripe } from 'stripe';
@@ -1608,6 +1609,8 @@ export class StripeHelper {
         );
         continue;
       }
+      item.product.metadata = mapValues(item.product.metadata, (v) => v.trim());
+      item.metadata = mapValues(item.metadata, (v) => v.trim());
 
       const { error } =
         await subscriptionProductMetadataValidator.validateAsync({


### PR DESCRIPTION
Because:

* Extra white space in the metadta values should be ignored.

This commit:

* Trims whitespace on metadata.

Closes #11932

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
