### PR TITLE
fix(auth): Broken l10n test

### DIFF
--- a/packages/fxa-auth-server/test/local/l10n/index.ts
+++ b/packages/fxa-auth-server/test/local/l10n/index.ts
@@ -61,11 +61,11 @@ describe('Localizer', () => {
         );
 
         const result = await l10n.formatValue(
-          'subscriptionAccountReminderFirst-action',
+          'subscriptionAccountFinishSetup-action-2',
           {}
         );
 
-        assert.equal(result, 'Passwort erstellen');
+        assert.equal(result, 'Einführung');
       });
 
       it('localizes properly with preferred Dialect', async () => {


### PR DESCRIPTION
## Because

- Underlying language strings changed and just so happened to impact test.

## This pull request

- Uses new/updated string l10n string in test.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
