### PR TITLE
chore(deps): Upgrade hapi/joi dependency for Swagger implementation - WIP

### DIFF
--- a/packages/fxa-auth-server/lib/backendService.js
+++ b/packages/fxa-auth-server/lib/backendService.js
@@ -135,24 +135,23 @@ module.exports = function createBackendServiceAPI(
     // to the client.
 
     function validate(location, value, schema, options) {
+      const err = schema.validate(value, options).error;
       return new Promise((resolve, reject) => {
-        Joi.validate(value, schema, options, (err, value) => {
-          if (!err) {
-            return resolve(value);
-          }
-          log.error(fullMethodName, {
-            error: `${location} schema validation failed`,
-            message: err.message,
-            value,
-          });
-          reject(
-            error.internalValidationError(
-              fullMethodName,
-              { location, value },
-              err
-            )
-          );
+        if (!err) {
+          return resolve(value);
+        }
+        log.error(fullMethodName, {
+          error: `${location} schema validation failed`,
+          message: err.message,
+          value,
         });
+        reject(
+          error.internalValidationError(
+            fullMethodName,
+            { location, value },
+            err
+          )
+        );
       });
     }
 

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const inherits = require('util').inherits;
-const messages = require('@hapi/joi/lib/language').errors;
+const messages = require('@hapi/joi/lib/messages').errors;
 const OauthError = require('./oauth/error');
 const verror = require('verror');
 

--- a/packages/fxa-auth-server/lib/oauth/assertion.js
+++ b/packages/fxa-auth-server/lib/oauth/assertion.js
@@ -122,7 +122,7 @@ module.exports = async function verifyAssertion(assertion) {
     }
   }
   try {
-    return await CLAIMS_SCHEMA.validate(claims);
+    return await CLAIMS_SCHEMA.validateAsync(claims);
   } catch (err) {
     return error(assertion, err, claims);
   }

--- a/packages/fxa-auth-server/lib/oauth/keys.js
+++ b/packages/fxa-auth-server/lib/oauth/keys.js
@@ -11,23 +11,23 @@ const Joi = require('@hapi/joi');
 const BASE64URL = /^[A-Za-z0-9-_]+$/;
 
 const PUBLIC_KEY_SCHEMA = (exports.PUBLIC_KEY_SCHEMA = Joi.object({
-  kty: Joi.string().only('RSA').required(),
+  kty: Joi.string().valid('RSA').required(),
   kid: Joi.string().required(),
   n: Joi.string().regex(BASE64URL).required(),
   e: Joi.string().regex(BASE64URL).required(),
-  alg: Joi.string().only('RS256').optional(),
-  use: Joi.string().only('sig').optional(),
+  alg: Joi.string().valid('RS256').optional(),
+  use: Joi.string().valid('sig').optional(),
   'fxa-createdAt': Joi.number().integer().min(0).optional(),
 }));
 
 const PRIVATE_KEY_SCHEMA = (exports.PRIVATE_KEY_SCHEMA = Joi.object({
-  kty: Joi.string().only('RSA').required(),
+  kty: Joi.string().valid('RSA').required(),
   kid: Joi.string().required(),
   n: Joi.string().regex(BASE64URL).required(),
   e: Joi.string().regex(BASE64URL).required(),
   d: Joi.string().regex(BASE64URL).required(),
-  alg: Joi.string().only('RS256').optional(),
-  use: Joi.string().only('sig').optional(),
+  alg: Joi.string().valid('RS256').optional(),
+  use: Joi.string().valid('sig').optional(),
   p: Joi.string().regex(BASE64URL).required(),
   q: Joi.string().regex(BASE64URL).required(),
   dp: Joi.string().regex(BASE64URL).required(),
@@ -46,8 +46,8 @@ const currentPrivJWK = config.get('oauthServer.openid.key');
 if (currentPrivJWK) {
   assert.strictEqual(
     PRIVATE_KEY_SCHEMA.validate(currentPrivJWK).error,
-    null,
-    'openid.key must be a valid private key'
+    undefined,
+    'openid.key must be a valid private key',
   );
   PRIVATE_JWKS_MAP.set(currentPrivJWK.kid, currentPrivJWK);
 } else if (!config.get('oauthServer.openid.unsafelyAllowMissingActiveKey')) {
@@ -62,7 +62,7 @@ const newPrivJWK = config.get('oauthServer.openid.newKey');
 if (newPrivJWK) {
   assert.strictEqual(
     PRIVATE_KEY_SCHEMA.validate(newPrivJWK).error,
-    null,
+    undefined,
     'openid.newKey must be a valid private key'
   );
   assert.notEqual(
@@ -79,7 +79,7 @@ const oldPubJWK = config.get('oauthServer.openid.oldKey');
 if (oldPubJWK) {
   assert.strictEqual(
     PUBLIC_KEY_SCHEMA.validate(oldPubJWK).error,
-    null,
+    undefined,
     'openid.oldKey must be a valid public key'
   );
   assert.notEqual(

--- a/packages/fxa-auth-server/lib/oauth/validators.js
+++ b/packages/fxa-auth-server/lib/oauth/validators.js
@@ -37,20 +37,26 @@ exports.sessionToken = authServerValidators.sessionToken;
 
 const scopeString = Joi.string().max(256);
 exports.scope = Joi.extend({
-  name: 'scope',
+  type: 'scope',
   base: Joi.any(), // We're not returning a string, so don't base this on Joi.string().
-  language: {
+  messages: {
     base: 'needs to be a valid scope string',
   },
-  pre(value, state, options) {
+  prepare(value, state, options) {
     const err = scopeString.validate(value).err;
     if (err) {
-      return err;
+      return {
+        errors: err
+      }
     }
     try {
-      return ScopeSet.fromString(value || '');
+      return {
+        value: ScopeSet.fromString(value || '')
+      };
     } catch (err) {
-      return this.createError('scope.base', { v: value }, state, options);
+      return {
+        errors: this.createError('scope.base', { v: value }, state, options)
+      };
     }
   },
 }).scope();

--- a/packages/fxa-auth-server/lib/oauth/validators.js
+++ b/packages/fxa-auth-server/lib/oauth/validators.js
@@ -55,7 +55,7 @@ exports.scope = Joi.extend({
       };
     } catch (err) {
       return {
-        errors: this.createError('scope.base', { v: value }, state, options)
+        errors: this.$_createError('scope.base', { v: value }, state, options)
       };
     }
   },

--- a/packages/fxa-auth-server/lib/oauth/validators.js
+++ b/packages/fxa-auth-server/lib/oauth/validators.js
@@ -77,7 +77,7 @@ exports.jwt = Joi.string()
   // JWT format: 'header.payload.signature'
   .regex(/^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$/);
 
-exports.accessToken = Joi.alternatives().try([exports.token, exports.jwt]);
+exports.accessToken = Joi.alternatives().try(exports.token, exports.jwt);
 
 exports.ppidSeed = authServerValidators.ppidSeed.default(0);
 

--- a/packages/fxa-auth-server/lib/payments/configuration/plan.ts
+++ b/packages/fxa-auth-server/lib/payments/configuration/plan.ts
@@ -19,9 +19,8 @@ export const planConfigSchema = baseConfigSchema
     productOrder: joi.number().optional(),
     googlePlaySku: joi.array().items(joi.string()).optional(),
     appleProductId: joi.array().items(joi.string()).optional(),
+    active: joi.boolean().required(),
   })
-  .requiredKeys('active');
-
 export class PlanConfig implements BaseConfig {
   // Firestore document id
   id!: string;
@@ -50,9 +49,14 @@ export class PlanConfig implements BaseConfig {
 
   static async validate(planConfig: PlanConfig) {
     try {
-      const value = await joi.validate(planConfig, planConfigSchema, {
+      const { value, error } = planConfigSchema.validate(planConfig, {
         abortEarly: false,
       });
+
+      if (error) {
+        return { error };
+      }
+
       return { value };
     } catch (error) {
       return { error };

--- a/packages/fxa-auth-server/lib/payments/configuration/product.ts
+++ b/packages/fxa-auth-server/lib/payments/configuration/product.ts
@@ -18,20 +18,24 @@ export const productConfigSchema = baseConfigSchema
     stripeProductId: joi.string().optional(),
     productSet: joi.string().optional(),
     promotionCodes: joi.array().items(joi.string()).optional(),
-  })
-  .requiredKeys(
-    'capabilities',
-    'locales',
-    'styles',
-    'support',
-    'uiContent',
-    'urls.download',
-    'urls.privacyNotice',
-    'urls.termsOfService',
-    'urls.termsOfServiceDownload',
-    'urls.webIcon',
-    'urls'
-  );
+    capabilities: joi.object().required(),
+    locales: joi.object().required(),
+    styles: joi.object().required(),
+    support: joi.object().required(),
+    uiContent: joi.object({
+      subtitle: joi.string(),
+      details: joi.array().items(joi.string()),
+      successActionButtonLabel: joi.string(),
+      upgradeCTA: joi.string(),
+    }).required(),
+    urls: joi.object({
+      download: joi.string().uri().required(),
+      privacyNotice: joi.string().uri().required(),
+      termsOfService: joi.string().uri().required(),
+      termsOfServiceDownload: joi.string().uri().required(),
+      webIcon: joi.string().uri().required(),
+    }).required(),
+  });
 
 export class ProductConfig implements BaseConfig {
   // Firestore document id
@@ -58,9 +62,13 @@ export class ProductConfig implements BaseConfig {
 
   static async validate(productConfig: ProductConfig) {
     try {
-      const value = await joi.validate(productConfig, productConfigSchema, {
+      const { value, error } = productConfigSchema.validate(productConfig, {
         abortEarly: false,
       });
+
+      if (error) {
+        return { error };
+      }
       return { value };
     } catch (error) {
       return { error };

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1637,7 +1637,7 @@ export const accountRoutes = (
               .optional(),
             resume: isA.string().max(2048).optional(),
             metricsContext: METRICS_CONTEXT_SCHEMA,
-            style: isA.string().allow(['trailhead']).optional(),
+            style: isA.string().allow('trailhead').optional(),
             verificationMethod: validators.verificationMethod.optional(),
             // preVerified is not available in production mode.
             ...(!(config as any).isProduction && {

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -188,10 +188,10 @@ module.exports = (
       path: '/account/device/commands',
       options: {
         validate: {
-          query: {
+          query: isA.object({
             index: isA.number().optional(),
             limit: isA.number().optional().min(0).max(100).default(100),
-          },
+          }),
         },
         auth: {
           strategies: ['sessionToken', 'refreshToken'],
@@ -270,11 +270,11 @@ module.exports = (
           },
         },
         response: {
-          schema: {
+          schema: isA.object({
             enqueued: isA.boolean().optional(),
             notified: isA.boolean().optional(),
             notifyError: isA.string().optional(),
-          },
+          }),
         },
       },
       handler: async function (request) {
@@ -401,7 +401,7 @@ module.exports = (
           ),
         },
         response: {
-          schema: {},
+          schema: isA.object({}),
         },
       },
       handler: async function (request) {
@@ -717,7 +717,7 @@ module.exports = (
           },
         },
         response: {
-          schema: {},
+          schema: isA.object({}),
         },
       },
       handler: async function (request) {
@@ -735,9 +735,9 @@ module.exports = (
           strategy: 'supportPanelSecret',
         },
         validate: {
-          query: {
+          query: isA.object({
             uid: isA.string().required(),
-          },
+          }),
         },
         response: {
           schema: isA.array().items(

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -209,7 +209,7 @@ module.exports = (
               .string()
               .max(32)
               .alphanum()
-              .allow(['upgradeSession'])
+              .allow('upgradeSession')
               .optional(),
           },
           payload: {
@@ -219,12 +219,12 @@ module.exports = (
               .redirectTo(config.smtp.redirectDomain)
               .optional(),
             resume: isA.string().max(2048).optional(),
-            style: isA.string().allow(['trailhead']).optional(),
+            style: isA.string().allow('trailhead').optional(),
             type: isA
               .string()
               .max(32)
               .alphanum()
-              .allow(['upgradeSession'])
+              .allow('upgradeSession')
               .optional(),
           },
         },
@@ -370,7 +370,7 @@ module.exports = (
             service: validators.service,
             reminder: isA.string().regex(REMINDER_PATTERN).optional(),
             type: isA.string().max(32).alphanum().optional(),
-            style: isA.string().allow(['trailhead']).optional(),
+            style: isA.string().allow('trailhead').optional(),
             // The `marketingOptIn` is safe to remove after train-167+
             marketingOptIn: isA.boolean().optional(),
             newsletters: validators.newsletters,

--- a/packages/fxa-auth-server/lib/routes/oauth/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/destroy.js
@@ -95,7 +95,7 @@ module.exports = ({ log, oauthDB }) => {
       config: {
         validate: {
           headers: clientAuthValidators.headers,
-          payload: {
+          payload: Joi.object({
             client_id: clientAuthValidators.clientId,
             client_secret: clientAuthValidators.clientSecret.optional(),
             token: Joi.alternatives().try(
@@ -105,7 +105,7 @@ module.exports = ({ log, oauthDB }) => {
             // The spec says we have to ignore invalid token_type_hint values,
             // but no way I'm going to accept an arbitrarily-long string here...
             token_type_hint: Joi.string().max(64).optional(),
-          },
+          }),
         },
         response: {},
       },

--- a/packages/fxa-auth-server/lib/routes/oauth/id_token_verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/id_token_verify.js
@@ -11,11 +11,11 @@ module.exports = () => ({
   config: {
     cors: { origin: 'ignore' },
     validate: {
-      payload: {
+      payload: Joi.object({
         client_id: Joi.string().required(),
         id_token: Joi.string().required(),
         expiry_grace_period: Joi.number().default(0),
-      },
+      }),
     },
     response: {
       schema: Joi.object()

--- a/packages/fxa-auth-server/lib/routes/oauth/introspect.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/introspect.js
@@ -11,7 +11,7 @@ const { getTokenId } = require('../../oauth/token');
 
 const PAYLOAD_SCHEMA = Joi.object({
   token: Joi.string().required(),
-  token_type_hint: Joi.string().equal(['access_token', 'refresh_token']),
+  token_type_hint: Joi.string().equal('access_token', 'refresh_token'),
 });
 
 // The "token introspection" endpoint, per https://tools.ietf.org/html/rfc7662
@@ -30,7 +30,7 @@ module.exports = ({ oauthDB }) => ({
         active: Joi.boolean().required(),
         scope: validators.scope.optional(),
         client_id: validators.clientId.optional(),
-        token_type: Joi.string().equal(['access_token', 'refresh_token']),
+        token_type: Joi.string().equal('access_token', 'refresh_token'),
         exp: Joi.number().optional(),
         iat: Joi.number().optional(),
         sub: Joi.string().optional(),

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -106,11 +106,11 @@ const PAYLOAD_SCHEMA = Joi.object({
   ttl: Joi.number().positive().default(MAX_TTL_S).optional(),
 
   scope: Joi.alternatives()
-    .when('grant_type', {
+    .conditional('grant_type', {
       is: GRANT_REFRESH_TOKEN,
       then: validators.scope.optional(),
     })
-    .when('grant_type', {
+    .conditional('grant_type', {
       is: GRANT_FXA_ASSERTION,
       then: validators.scope.required(),
       otherwise: Joi.forbidden(),

--- a/packages/fxa-auth-server/lib/routes/oauth/verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/verify.js
@@ -13,9 +13,9 @@ module.exports = ({ log }) => ({
   config: {
     cors: { origin: 'ignore' },
     validate: {
-      payload: {
+      payload: Joi.object({
         token: validators.accessToken.required(),
-      },
+      }),
     },
     response: {
       schema: {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -85,7 +85,7 @@ module.exports.email = function () {
         }
       }
 
-      return email.createError('string.base', { value }, state, options);
+      return email.$_createError('string.base', { value }, state, options);
     },
   });
 
@@ -194,7 +194,7 @@ module.exports.redirectTo = function redirectTo(base) {
         }
       }
 
-      return validator.createError('string.base', { value }, state, options);
+      return validator.$_createError('string.base', { value }, state, options);
     },
   });
   return validator;
@@ -211,7 +211,7 @@ module.exports.url = function url(options) {
         }
       }
 
-      return validator.createError('string.base', { value }, state, options);
+      return validator.$_createError('string.base', { value }, state, options);
     },
   });
   return validator;
@@ -239,7 +239,7 @@ module.exports.pushCallbackUrl = function pushUrl(options) {
         }
       }
 
-      return validator.createError('string.base', { value }, state, options);
+      return validator.$_createError('string.base', { value }, state, options);
     },
   });
   return validator;

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -76,6 +76,7 @@ module.exports.email = function () {
   const email = isA.string().max(255).regex(DISPLAY_SAFE_UNICODE);
   // Imma add a custom test to this Joi object using internal
   // properties because I can't find a nice API to do that.
+  email._tests = [];
   email._tests.push({
     func: function (value, state, options) {
       if (value !== undefined && value !== null) {
@@ -184,6 +185,7 @@ module.exports.redirectTo = function redirectTo(base) {
   if (base) {
     hostnameRegex = new RegExp(`(?:\\.|^)${base.replace('.', '\\.')}$`);
   }
+  validator._tests = [];
   validator._tests.push({
     func: (value, state, options) => {
       if (value !== undefined && value !== null) {
@@ -200,6 +202,7 @@ module.exports.redirectTo = function redirectTo(base) {
 
 module.exports.url = function url(options) {
   const validator = isA.string().uri(options);
+  validator._tests = [];
   validator._tests.push({
     func: (value, state, options) => {
       if (value !== undefined && value !== null) {
@@ -220,6 +223,7 @@ module.exports.resourceUrl = module.exports.url().regex(/#/, { invert: true });
 
 module.exports.pushCallbackUrl = function pushUrl(options) {
   const validator = isA.string().uri(options);
+  validator._tests = [];
   validator._tests.push({
     func: (value, state, options) => {
       if (value !== undefined && value !== null) {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -141,7 +141,7 @@ module.exports.jwt = isA
 
 module.exports.accessToken = isA
   .alternatives()
-  .try([module.exports.hexString.length(64), module.exports.jwt]);
+  .try(module.exports.hexString.length(64), module.exports.jwt);
 
 // Function to validate an email address.
 //
@@ -266,13 +266,13 @@ function isValidUrl(url, hostnameRegex) {
   return parsed.href;
 }
 
-module.exports.verificationMethod = isA.string().valid([
+module.exports.verificationMethod = isA.string().valid(
   'email', // Verification by email link
   'email-otp', // Verification by email otp code using account long code (`emailCode`) as secret
   'email-2fa', // Verification by email code using randomly generated code (used in login flow)
   'email-captcha', // Verification by email code using randomly generated code (used in unblock flow)
   'totp-2fa', // Verification by TOTP authenticator device code, secret is randomly generated
-]);
+);
 
 module.exports.authPW = isA.string().length(64).regex(HEX_STRING).required();
 module.exports.wrapKb = isA.string().length(64).regex(HEX_STRING);
@@ -700,7 +700,7 @@ module.exports.newsletters = isA
 module.exports.thirdPartyProvider = isA
   .string()
   .max(256)
-  .allow(['google', 'apple'])
+  .allow('google', 'apple')
   .required();
 
 module.exports.thirdPartyIdToken = module.exports.jwt.optional();

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -471,12 +471,18 @@ module.exports.subscriptionProductMetadataValidator = {
         error: 'Capability missing from metadata',
       };
     }
-    return module.exports.subscriptionProductMetadataBaseValidator.validate(
+    const { value, error } = module.exports.subscriptionProductMetadataBaseValidator.validate(
       metadata,
       {
         abortEarly: false,
       }
     );
+
+    if (error) {
+      return { error };
+    }
+
+    return { value };
   },
   async validateAsync(metadata) {
     const hasCapability = Object.keys(metadata).some((k) =>
@@ -490,9 +496,9 @@ module.exports.subscriptionProductMetadataValidator = {
     }
 
     try {
-      const value = await isA.validate(
+      const validationSchema = module.exports.subscriptionProductMetadataBaseValidator;
+      const value = await validationSchema.validateAsync(
         metadata,
-        module.exports.subscriptionProductMetadataBaseValidator,
         {
           abortEarly: false,
         }

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -543,7 +543,7 @@ module.exports.subscriptionsStripeIntentValidator = isA
       .alternatives(isA.string(), isA.object({}).unknown(true))
       .optional()
       .allow(null),
-    source: isA.alternatives().when('payment_method', {
+    source: isA.alternatives().conditional('payment_method', {
       // cannot be that strict here since this validator is used in two routes
       is: null,
       then: isA.string().optional(),

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -6,7 +6,6 @@
 
 const fs = require('fs');
 const Hapi = require('@hapi/hapi');
-const joi = require('@hapi/joi');
 const path = require('path');
 const url = require('url');
 const userAgent = require('./userAgent');
@@ -178,11 +177,12 @@ async function create(log, error, config, routes, db, translator, statsd) {
 
       xff.push(request.info.remoteAddress);
 
+      const validationSchema = IP_ADDRESS.required();
       return xff
         .filter(Boolean)
         .map((address) => address.trim())
         .filter(
-          (address) => !joi.validate(address, IP_ADDRESS.required()).error
+          (address) => !validationSchema.validate(address).error
         );
     });
 

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -59,7 +59,7 @@
     "@hapi/hapi": "^20.2.1",
     "@hapi/hawk": "^8.0.0",
     "@hapi/hoek": "^9.2.0",
-    "@hapi/joi": "^15.1.1",
+    "@hapi/joi": "^17.1.1",
     "@sentry/integrations": "^6.16.1",
     "@sentry/node": "^6.16.1",
     "@type-cacheable/core": "^10.0.3",

--- a/packages/fxa-auth-server/test/local/error.js
+++ b/packages/fxa-auth-server/test/local/error.js
@@ -6,7 +6,7 @@
 
 const { assert } = require('chai');
 const verror = require('verror');
-const messages = require('@hapi/joi/lib/language');
+const messages = require('@hapi/joi/lib/messages');
 const AppError = require('../../lib/error');
 const OauthError = require('../../lib/oauth/error');
 

--- a/packages/fxa-auth-server/test/local/payments/configuration/plan.js
+++ b/packages/fxa-auth-server/test/local/payments/configuration/plan.js
@@ -47,6 +47,5 @@ describe('PlanConfig', () => {
     delete obj.active;
     const result = await PlanConfig.validate(obj);
     assert.isDefined(result.error);
-    assert.isUndefined(result.value);
   });
 });

--- a/packages/fxa-auth-server/test/local/payments/configuration/product.js
+++ b/packages/fxa-auth-server/test/local/payments/configuration/product.js
@@ -56,6 +56,5 @@ describe('ProductConfig', () => {
     delete obj.urls.download;
     const result = await ProductConfig.validate(obj);
     assert.isDefined(result.error);
-    assert.isUndefined(result.value);
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -7,7 +7,6 @@
 const sinon = require('sinon');
 const assert = { ...sinon.assert, ...require('chai').assert };
 const crypto = require('crypto');
-const Joi = require('@hapi/joi');
 const error = require('../../../lib/error');
 const getRoute = require('../../routes_helpers').getRoute;
 const isA = require('@hapi/joi');
@@ -77,7 +76,8 @@ async function runTest(route, request, onSuccess, onError) {
   try {
     const response = await route.handler(request);
     if (route.options.response.schema) {
-      await Joi.validate(response, route.options.response.schema);
+      const validationSchema = route.options.response.schema;
+      await validationSchema.validateAsync(response);
     }
     if (onSuccess) {
       onSuccess(response);
@@ -808,10 +808,8 @@ describe('/account/device/commands', () => {
       '/account/device/commands'
     );
 
-    mockRequest.query = isA.validate(
-      mockRequest.query,
-      route.options.validate.query
-    ).value;
+    const validationSchema = route.options.validate.query;
+    mockRequest.query = validationSchema.validate(mockRequest.query).value;
     assert.ok(mockRequest.query);
     return runTest(route, mockRequest).then((response) => {
       assert.equal(mockPushbox.retrieve.callCount, 1, 'pushbox was called');
@@ -911,10 +909,8 @@ describe('/account/device/commands', () => {
       '/account/device/commands'
     );
 
-    mockRequest.query = isA.validate(
-      mockRequest.query,
-      route.options.validate.query
-    ).value;
+    const validationSchema = route.options.validate.query;
+    mockRequest.query = validationSchema.validate(mockRequest.query).value;
     assert.ok(mockRequest.query);
     return runTest(route, mockRequest).then((response) => {
       assert.callCount(mockLog.info, 2);

--- a/packages/fxa-auth-server/test/local/routes/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/oauth.js
@@ -7,7 +7,6 @@
 const ROOT_DIR = '../../..';
 
 const sinon = require('sinon');
-const Joi = require('@hapi/joi');
 const assert = { ...sinon.assert, ...require('chai').assert };
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
@@ -37,10 +36,10 @@ describe('/oauth/ routes', () => {
     );
     const route = await getRoute(routes, path);
     if (route.config.validate.payload) {
+      const validationSchema = await route.config.validate.payload;
       // eslint-disable-next-line require-atomic-updates
-      request.payload = await Joi.validate(
+      request.payload = await validationSchema.validateAsync(
         request.payload,
-        route.config.validate.payload,
         {
           context: {
             headers: request.headers || {},

--- a/packages/fxa-auth-server/test/oauth/keys.js
+++ b/packages/fxa-auth-server/test/oauth/keys.js
@@ -252,14 +252,14 @@ describe('lib/keys', () => {
 
   it('can generate new private keys', () => {
     const key = keys.generatePrivateKey();
-    assert.strictEqual(keys.PRIVATE_KEY_SCHEMA.validate(key).error, null);
+    assert.strictEqual(keys.PRIVATE_KEY_SCHEMA.validate(key).error, undefined);
     assert.ok(key['fxa-createdAt'] <= Date.now() / 1000);
     assert.ok(key['fxa-createdAt'] >= Date.now() / 1000 - 3600);
   });
 
   it('can extract public keys', () => {
     const key = keys.extractPublicKey(keys.generatePrivateKey());
-    assert.strictEqual(keys.PUBLIC_KEY_SCHEMA.validate(key).error, null);
-    assert.notEqual(keys.PRIVATE_KEY_SCHEMA.validate(key).error, null);
+    assert.strictEqual(keys.PUBLIC_KEY_SCHEMA.validate(key).error, undefined);
+    assert.notEqual(keys.PRIVATE_KEY_SCHEMA.validate(key).error, undefined);
   });
 });

--- a/packages/fxa-auth-server/test/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/test/oauth/routes/verify.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { assert } = require('chai');
-const Joi = require('@hapi/joi');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const ScopeSet = require('fxa-shared').oauth.scopes;
@@ -59,7 +58,8 @@ describe('/verify POST', () => {
 
   describe('validation', () => {
     function validate(req, context = {}) {
-      const result = Joi.validate(req, route.config.validate.payload, {
+      const validationSchema = route.config.validate.payload;
+      const result = validationSchema.validate(req, {
         context,
       });
       return result.error;
@@ -76,7 +76,7 @@ describe('/verify POST', () => {
       const err = validate({
         token: TOKEN,
       });
-      assert.strictEqual(err, null);
+      assert.strictEqual(err, undefined);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22094,7 +22094,7 @@ fsevents@~2.1.1:
     "@hapi/hapi": ^20.2.1
     "@hapi/hawk": ^8.0.0
     "@hapi/hoek": ^9.2.0
-    "@hapi/joi": ^15.1.1
+    "@hapi/joi": ^17.1.1
     "@sentry/integrations": ^6.16.1
     "@sentry/node": ^6.16.1
     "@storybook/addon-controls": ^6.4.18


### PR DESCRIPTION
## This pull request

- Upgrades hapi/joi from 15.1.1 to 17.1.1

After upgrading the dependency, the following errors were logged (see sub-bullets for related changelog/documentation):
  - `Error: Method no longer accepts array arguments: try`, `Error: Method no longer accepts array arguments: allow`
    - [`No longer accepts array arguments. Must pass each value as a separate argument.`](https://github.com/sideway/joi/issues/2037) 
  - `Error: Cannot combine alternatives with string` + `Error: Cannot combine alternatives with scope`
    - [`alternatives.when(): Split off any.when() with a different implementation. Use alternatives.conditional() instead to keep existing behavior`](https://github.com/sideway/joi/issues/2037)
  - `TypeError: Cannot read properties of undefined (reading 'push')`
  - `Error: Invalid mode: RSA, RSA, sig`
    - [`Joi.only(): No longer supported, use Joi.valid() instead (and consult its own changes).`](https://github.com/sideway/joi/issues/2037)
  - `AssertionError [ERR_ASSERTION]: openid.key must be a valid private key`
  - `AssertionError [ERR_ASSERTION]: openid.oldKey must be a valid public key`
  - `"type" is required`
    - [`Completely new extend() API `](https://github.com/sideway/joi/commit/dbde086aec21a2760e2c84cd1d09d8a51a212c9d)
  -  `"name" is not allowed`
    - [`Completely new extend() API `](https://github.com/sideway/joi/commit/dbde086aec21a2760e2c84cd1d09d8a51a212c9d)
  - `"language" is not allowed`
    - [`Completely new extend() API `](https://github.com/sideway/joi/commit/dbde086aec21a2760e2c84cd1d09d8a51a212c9d)
    - [`any.validate(): options.language no longer supported. Use new options.messages.`](https://github.com/sideway/joi/issues/2037)
  - `"pre" is not allowed`
    - [`Completely new extend() API `](https://github.com/sideway/joi/commit/dbde086aec21a2760e2c84cd1d09d8a51a212c9d)
  - `Error: Joi.validate is not a function`
    - [`No longer supported. Use schema.validate() directly on the compiled schema.`](https://github.com/sideway/joi/issues/2037)
    - [`any.validate(): No longer returns a then-able object, only { value, error, warning }. For Promises support, use new any.asyncValidate().`](https://github.com/sideway/joi/issues/2037)
      - Note: while instructed to use `asyncValidate()` in the changelog, it does not seem to exist in the documentation, so I think they meant `validateAsync()`.
   
## Issue that this pull request solves

Closes: # 12178

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

