### PR TITLE
fix(auth): check paymentAttempts before returning a funding source error

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1988,18 +1988,20 @@ export class StripeHelper {
       billingDetails.payment_provider === 'paypal' &&
       this.hasSubscriptionRequiringPaymentMethod(customer)
     ) {
-      const invoices = await this.getLatestInvoicesForActiveSubscriptions(
-        customer
-      );
       if (!this.getCustomerPaypalAgreement(customer)) {
         billingDetails.paypal_payment_error =
           PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT;
-      } else if (
-        this.hasOpenInvoice(invoices) &&
-        invoices.some((invoice) => this.getPaymentAttempts(invoice) > 0)
-      ) {
-        billingDetails.paypal_payment_error =
-          PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE;
+      } else {
+        const invoices = await this.getLatestInvoicesForActiveSubscriptions(
+          customer
+        );
+        if (
+          this.hasOpenInvoice(invoices) &&
+          invoices.some((invoice) => this.getPaymentAttempts(invoice) > 0)
+        ) {
+          billingDetails.paypal_payment_error =
+            PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE;
+        }
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12987,40 +12987,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.1089.0":
-  version: 2.1089.0
-  resolution: "aws-sdk@npm:2.1089.0"
-  dependencies:
-    buffer: 4.9.2
-    events: 1.1.1
-    ieee754: 1.1.13
-    jmespath: 0.16.0
-    querystring: 0.2.0
-    sax: 1.2.1
-    url: 0.10.3
-    uuid: 3.3.2
-    xml2js: 0.4.19
-  checksum: ad31c214a14cded9777c894b011f21ea54594412b1ceba51a28189d03c0b7a2cc04973bfa72a05fe15e09c43dae73e491b4c745bc3aef6d12bbb30ef39d33994
-  languageName: node
-  linkType: hard
-
-"aws-sdk@npm:^2.1089.0":
-  version: 2.1089.0
-  resolution: "aws-sdk@npm:2.1089.0"
-  dependencies:
-    buffer: 4.9.2
-    events: 1.1.1
-    ieee754: 1.1.13
-    jmespath: 0.16.0
-    querystring: 0.2.0
-    sax: 1.2.1
-    url: 0.10.3
-    uuid: 3.3.2
-    xml2js: 0.4.19
-  checksum: ad31c214a14cded9777c894b011f21ea54594412b1ceba51a28189d03c0b7a2cc04973bfa72a05fe15e09c43dae73e491b4c745bc3aef6d12bbb30ef39d33994
-  languageName: node
-  linkType: hard
-
 "aws-sign2@npm:~0.7.0":
   version: 0.7.0
   resolution: "aws-sign2@npm:0.7.0"


### PR DESCRIPTION
Because: 
* #10857 changed how we process recurring PayPal payments to use the paypal-processor rather than the invoice.finalized Stripe webhook.
* Our mozilla-subscriptions/customer/billing-and-subscriptions endpoint was wrongly returning a PayPal "funding_source" error to the front-end, because the 'getBillingDetailsAndSubscriptions' helper was only checking if an invoice was open -- not whether we've actually tried to pay it.
    
This commit:
* Checks the 'paymentAttempts' metadata on any open invoices for active subscriptions before returning a PayPal funding source error to the client.
    
Closes #11992

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

There's a second commit here related to a yarn.lock change that came up after I `yarn install`ed. Another miss with dependabot?
