### PR TITLE
task(auth,shared): Logging improvements after observing last canary

### DIFF
--- a/packages/fxa-admin-server/src/database/database.service.ts
+++ b/packages/fxa-admin-server/src/database/database.service.ts
@@ -81,7 +81,8 @@ export class DatabaseService implements OnModuleDestroy {
       new ConnectedServicesCache(
         new RedisShared(redisConfig.accessTokens, logger),
         new RedisShared(redisConfig.refreshTokens, logger),
-        new RedisShared(redisConfig.sessionTokens, logger)
+        new RedisShared(redisConfig.sessionTokens, logger),
+        logger
       )
     );
   }

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -137,7 +137,7 @@ class OauthDB extends ConnectedServicesDb {
   async getAccessTokensByUid(uid) {
     await this.ready();
     const tokens = await this.redis.getAccessTokens(uid);
-    const otherTokens = await await this.mysql._getAccessTokensByUid(uid);
+    const otherTokens = await this.mysql._getAccessTokensByUid(uid);
     return tokens.concat(otherTokens);
   }
 
@@ -164,7 +164,7 @@ class OauthDB extends ConnectedServicesDb {
 
   async getRefreshTokensByUid(uid) {
     await this.ready();
-    const tokens = await await this.mysql._getRefreshTokensByUid(uid);
+    const tokens = await this.mysql._getRefreshTokensByUid(uid);
     const extraMetadata = await this.redis.getRefreshTokens(uid);
     // We'll take this opportunity to clean up any tokens that exist in redis but
     // not in mysql, so this loop deletes each token from `extraMetadata` once handled.

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -523,7 +523,10 @@ class MysqlStore extends MysqlOAuthShared {
   }
 
   _touchRefreshToken(token, now) {
-    this.log('authdb.FXA-4648', { msg: 'touchRefreshToken', now });
+    this.log?.info('MysqlStore', {
+      msg: 'MysqlStore.FXA-4648: touchRefreshToken',
+      now,
+    });
     return this._write(QUERY_REFRESH_TOKEN_LAST_USED_UPDATE, [
       now,
       // WHERE

--- a/packages/fxa-shared/connected-services/accessors.ts
+++ b/packages/fxa-shared/connected-services/accessors.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { ILogger } from '../log';
 import { hex } from './util';
 
 /** Base token cache interface */
@@ -47,16 +48,26 @@ export class ConnectedServicesCache {
   constructor(
     protected readonly redisAccessTokens: IAccessTokensCache,
     protected readonly redisRefreshTokens: IRefreshTokensCache,
-    protected readonly redisSessionTokens: ISessionTokensCache
+    protected readonly redisSessionTokens: ISessionTokensCache,
+    protected readonly log?: ILogger
   ) {
     if (!redisAccessTokens) {
-      throw new Error('redisAccessTokens not provided');
+      this.log?.warn('ConnectedServicesCache', {
+        msg: 'ConnectedServicesCache.FXA-4648: redisAccessTokens not provided.',
+        stack: Error().stack,
+      });
     }
     if (!redisRefreshTokens) {
-      throw new Error('redisRefreshTokens not provided');
+      this.log?.warn('ConnectedServicesCache', {
+        msg: 'ConnectedServicesCache.FXA-4648: redisRefreshTokens not provided.',
+        stack: Error().stack,
+      });
     }
     if (!redisSessionTokens) {
-      throw new Error('redisSessionTokens not provided');
+      this.log?.warn('ConnectedServicesCache', {
+        msg: 'ConnectedServicesCache.FXA-4648: redisSessionTokens not provided.',
+        stack: Error().stack,
+      });
     }
   }
 
@@ -65,6 +76,10 @@ export class ConnectedServicesCache {
     tokenIdsToPrune: Buffer[] | string[]
   ): Promise<void | null> {
     if (!this.redisRefreshTokens) {
+      this.log?.warn('ConnectedServicesCache', {
+        msg: 'ConnectedServicesCache.FXA-4648: pruneRefreshTokens invoked but redisRefreshTokens instance not provided.',
+        stack: Error().stack,
+      });
       return null;
     }
     return await this.redisRefreshTokens.pruneRefreshTokens(
@@ -83,6 +98,10 @@ export class ConnectedServicesCache {
 
   async getRefreshTokens(uid: Buffer | string) {
     if (!this.redisRefreshTokens) {
+      this.log?.warn('ConnectedServicesCache', {
+        msg: 'ConnectedServicesCache.FXA-4648: getRefreshTokens invoked but redisRefreshTokens instance not provided.',
+        stack: Error().stack,
+      });
       return {};
     }
     return this.redisRefreshTokens.getRefreshTokens(uid);
@@ -90,6 +109,10 @@ export class ConnectedServicesCache {
 
   async getSessionTokens(uid: string) {
     if (!this.redisSessionTokens) {
+      this.log?.warn('ConnectedServicesCache', {
+        msg: 'ConnectedServicesCache.FXA-4648: getSessionTokens invoked but redisSessionTokens instance not provided.',
+        stack: Error().stack,
+      });
       return {};
     }
     return await this.redisSessionTokens.getSessionTokens(uid);

--- a/packages/fxa-shared/db/index.ts
+++ b/packages/fxa-shared/db/index.ts
@@ -63,7 +63,7 @@ export function monitorKnexConnectionPool(
 ) {
   metrics?.increment('mysql.pool_creation');
   const getPoolStats = () => {
-    return {
+    return JSON.stringify({
       // returns the number of non-free resources
       numUsed: pool.numUsed(),
       // returns the number of free resources
@@ -72,37 +72,37 @@ export function monitorKnexConnectionPool(
       numPendingAcquires: pool.numPendingAcquires(),
       // how many asynchronous create calls are running
       numPendingCreates: pool.numPendingCreates(),
-    };
+    });
   };
   pool.on('acquireRequest', (eventId: any) => {
-    log?.info('db.FXA-4648', {
-      msg: `Knex acquireRequest`,
+    log?.info('db', {
+      msg: `db.FXA-4648: Knex acquireRequest`,
       eventId,
-      ...getPoolStats(),
+      poolStats: getPoolStats(),
     });
     metrics?.increment('knex.aquire_request');
   });
   pool.on('createRequest', (eventId: any) => {
-    log?.info('db.FXA-4648', {
-      msg: `Knex createRequest`,
+    log?.info('db', {
+      msg: `db.FXA-4648: Knex createRequest`,
       eventId,
-      ...getPoolStats(),
+      poolStats: getPoolStats(),
     });
     metrics?.increment('knex.create_request');
   });
   pool.on('destroyRequest', (eventId: any, resource: any) => {
-    log?.info('db.FXA-4648', {
-      msg: `Knex destroyRequest`,
+    log?.info('db', {
+      msg: `db.FXA-4648: Knex destroyRequest`,
       eventId,
-      ...getPoolStats(),
+      poolStats: getPoolStats(),
     });
     metrics?.increment('knex.destroy_request');
   });
   pool.on('destroyFail', (eventId: any, resource: any) => {
-    log?.info('db.FXA-4648', {
-      msg: `Knex destroyFail`,
+    log?.info('db', {
+      msg: `db.FXA-4648: Knex destroyFail`,
       eventId,
-      ...getPoolStats(),
+      poolStats: getPoolStats(),
     });
     metrics?.increment('knex.destroy_fail');
   });
@@ -131,11 +131,10 @@ export function setupDatabase(
   // Monitor connection pool
   monitorKnexConnectionPool(db.client.pool, log, metrics);
 
-  log?.info('db.FXA-4648', {
-    msg: `Creating Knex`,
+  log?.info('db', {
+    msg: `db.FXA-4648: Creating Knex`,
     connLimit: opts.connectionLimitMax,
   });
-  log?.info('db.FXA-4648', { msg: `Creating Knex`, stack: Error().stack });
 
   return db;
 }

--- a/packages/fxa-shared/test/db/mysql.ts
+++ b/packages/fxa-shared/test/db/mysql.ts
@@ -136,8 +136,6 @@ describe('mysql', function () {
     }
     await Promise.all(promises);
 
-    console.log('connectionLimit', dbOpts.connectionLimit * 2);
-    console.log('otehr', Object.keys(events.stats.pool.threadIds).length);
     assert.equal(events.stats.pool.aquire, events.stats.pool.release);
     assert.equal(events.stats.pool.connection, dbOpts.connectionLimit * 2);
     assert.equal(


### PR DESCRIPTION
## Because

- We need more visibility into how Redis is starting up.
- Previous canary didn't go through cleanly due to bad log statement causing runtime error. 

## This pull request

- Add more logging around Redis during initialization.
- Removes random doubly awaited database calls.
- Doctored up some log messages to make them easier to query for.
- Fixes bad log statement in fxa-auth-server/lib/oauth/db/mysql/index.js
- Removes stray console.log statement in fxa-shared/test/db/mysql.ts

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

