### PR TITLE
fix(pocket): Only show pocket account suggestion when creating an account

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -19,7 +19,6 @@
     <div class="error"></div>
     <div class="success"></div>
     {{{ syncSuggestionHTML }}}
-    {{{ accountSuggestionHTML }}}
 
     <form novalidate>
       <div class="input-row">

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -18,6 +18,7 @@
   <section>
     <div class="error"></div>
     <div class="success"></div>
+    {{{ accountSuggestionHTML }}}
 
     <form novalidate>
       <p class="prefillEmail">{{ email }}</p>

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -22,7 +22,6 @@ import ServiceMixin from './mixins/service-mixin';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import GoogleAuthMixin from './mixins/google-auth-mixin';
 import SyncSuggestionMixin from './mixins/sync-suggestion-mixin';
-import AccountSuggestionMixin from './mixins/account-suggestion-mixin';
 import Template from 'templates/index.mustache';
 import checkEmailDomain from '../lib/email-domain-validator';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
@@ -276,7 +275,6 @@ Cocktail.mixin(
     entrypoint: 'fxa:enter_email',
     flowEvent: 'link.signin',
   }),
-  AccountSuggestionMixin,
   PocketMigrationMixin
 );
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/pocket-migration-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pocket-migration-mixin.js
@@ -5,6 +5,7 @@
 export const POCKET_CLIENTIDS = [
   '7377719276ad44ee', // pocket-mobile
   '749818d3f2e7857f', // pocket-web
+  'dcdb5ae7add825d2', // pocket-web
 ];
 
 export default {

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -19,6 +19,7 @@ import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignUpMixin from './mixins/signup-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 import Template from 'templates/sign_up_password.mustache';
+import AccountSuggestionMixin from './mixins/account-suggestion-mixin';
 
 const t = (msg) => msg;
 
@@ -157,7 +158,8 @@ Cocktail.mixin(
   ServiceMixin,
   SignedInNotificationMixin,
   SignUpMixin,
-  PocketMigrationMixin
+  PocketMigrationMixin,
+  AccountSuggestionMixin
 );
 
 export default SignUpPasswordView;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12987,40 +12987,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.1089.0":
-  version: 2.1089.0
-  resolution: "aws-sdk@npm:2.1089.0"
-  dependencies:
-    buffer: 4.9.2
-    events: 1.1.1
-    ieee754: 1.1.13
-    jmespath: 0.16.0
-    querystring: 0.2.0
-    sax: 1.2.1
-    url: 0.10.3
-    uuid: 3.3.2
-    xml2js: 0.4.19
-  checksum: ad31c214a14cded9777c894b011f21ea54594412b1ceba51a28189d03c0b7a2cc04973bfa72a05fe15e09c43dae73e491b4c745bc3aef6d12bbb30ef39d33994
-  languageName: node
-  linkType: hard
-
-"aws-sdk@npm:^2.1089.0":
-  version: 2.1089.0
-  resolution: "aws-sdk@npm:2.1089.0"
-  dependencies:
-    buffer: 4.9.2
-    events: 1.1.1
-    ieee754: 1.1.13
-    jmespath: 0.16.0
-    querystring: 0.2.0
-    sax: 1.2.1
-    url: 0.10.3
-    uuid: 3.3.2
-    xml2js: 0.4.19
-  checksum: ad31c214a14cded9777c894b011f21ea54594412b1ceba51a28189d03c0b7a2cc04973bfa72a05fe15e09c43dae73e491b4c745bc3aef6d12bbb30ef39d33994
-  languageName: node
-  linkType: hard
-
 "aws-sign2@npm:~0.7.0":
   version: 0.7.0
   resolution: "aws-sign2@npm:0.7.0"


### PR DESCRIPTION
## Because

- We only need to show this for new accounts

## This pull request

- Removes the account suggestion for signin and puts it only in the signup view

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12138

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="773" alt="image" src="https://user-images.githubusercontent.com/1295288/158249363-d60e2969-8c44-4eff-8e7a-065a2cc894bf.png">

