### PR TITLE
fix(auth): address TS errors in ProductConfig and PlanConfig classes

### DIFF
--- a/packages/fxa-auth-server/lib/payments/configuration/plan.ts
+++ b/packages/fxa-auth-server/lib/payments/configuration/plan.ts
@@ -24,11 +24,11 @@ export const planConfigSchema = baseConfigSchema
 
 export class PlanConfig implements BaseConfig {
   // Firestore document id
-  id: string;
+  id!: string;
   // Firestore ProductConfig document id
-  productConfigId: string;
+  productConfigId!: string;
 
-  active: boolean;
+  active!: boolean;
   capabilities?: CapabilityConfig;
   urls?: UrlConfig;
   uiContent?: UiContentConfig;
@@ -62,6 +62,7 @@ export class PlanConfig implements BaseConfig {
   static fromFirestoreObject(firestoreObject: any, docId: string): PlanConfig {
     const planConfig = new PlanConfig();
     Object.keys(firestoreObject).map((key) => {
+      // @ts-ignore
       planConfig[key] = firestoreObject[key];
     });
     planConfig.id = docId;

--- a/packages/fxa-auth-server/lib/payments/configuration/product.ts
+++ b/packages/fxa-auth-server/lib/payments/configuration/product.ts
@@ -35,21 +35,21 @@ export const productConfigSchema = baseConfigSchema
 
 export class ProductConfig implements BaseConfig {
   // Firestore document id
-  id: string;
+  id!: string;
 
-  active: boolean;
-  capabilities: CapabilityConfig;
-  locales: {
+  active!: boolean;
+  capabilities!: CapabilityConfig;
+  locales!: {
     [key: string]: {
       uiContent: Partial<UiContentConfig>;
       urls: Partial<UrlConfig>;
       support: Partial<SupportConfig>;
     };
   };
-  styles: StyleConfig;
-  support: SupportConfig;
-  uiContent: UiContentConfig;
-  urls: UrlConfig;
+  styles!: StyleConfig;
+  support!: SupportConfig;
+  uiContent!: UiContentConfig;
+  urls!: UrlConfig;
 
   // Extended by ProductConfig
   stripeProductId?: string;
@@ -73,6 +73,7 @@ export class ProductConfig implements BaseConfig {
   ): ProductConfig {
     const productConfig = new ProductConfig();
     Object.keys(firestoreObject).map((key) => {
+      // @ts-ignore
       productConfig[key] = firestoreObject[key];
     });
     productConfig.id = docId;


### PR DESCRIPTION
Because:

* #12040 failed CI after being merged into main due to TS errors.
* I'm not sure why the TS errors surfaced here and not in #12005, as #12040
  did not modify these classes that are causing errors (though it did modify
  other parts of the files).

This commit:

* Fixes those TS errors.

Closes #No issue

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other
FWIW we have a maintenance ticket, #11545 that I added to our [Train 230 maintenance sprint](https://mozilla-hub.atlassian.net/browse/FXA-4659) to ensure we find and fix TS errors in the PR before merging.