### PR TITLE
fix(subscriptions): create customer for iap sub

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1502,7 +1502,11 @@ export class StripeHelper {
   async addPriceInfoToAbbrevPlayPurchases(
     purchases: AbbrevPlayPurchase[]
   ): Promise<
-    (AbbrevPlayPurchase & { product_id: string; product_name: string })[]
+    (AbbrevPlayPurchase & {
+      product_id: string;
+      product_name: string;
+      price_id: string;
+    })[]
   > {
     const plans = await this.allAbbrevPlans();
     const appendedAbbrevPlayPurchases = [];

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -10,6 +10,7 @@ import { PaymentUpdateAuthServerAPIs } from '../../routes/Subscriptions/PaymentU
 import classNames from 'classnames';
 
 import './index.scss';
+import { needsCustomer } from '../../lib/customer';
 
 declare var paypal: {
   Buttons: {
@@ -112,7 +113,7 @@ export const PaypalButton = ({
           ...apiClient,
           ...apiClientOverrides,
         };
-        if (!customer?.payment_provider) {
+        if (needsCustomer(customer)) {
           await apiCreateCustomer({
             idempotencyKey,
           });

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -112,7 +112,7 @@ export const PaypalButton = ({
           ...apiClient,
           ...apiClientOverrides,
         };
-        if (!customer) {
+        if (!customer?.payment_provider) {
           await apiCreateCustomer({
             idempotencyKey,
           });

--- a/packages/fxa-payments-server/src/lib/customer.test.ts
+++ b/packages/fxa-payments-server/src/lib/customer.test.ts
@@ -9,12 +9,14 @@ import {
   isExistingCustomer,
   isExistingPaypalCustomer,
   isExistingStripeCustomer,
+  needsCustomer,
 } from './customer';
+import { IAP_CUSTOMER } from './mock-data';
 import { MOCK_CUSTOMER } from './test-utils';
 
 describe('hasSubscriptions', () => {
   it('returns false when the customer does not have a list of subscriptions', () => {
-    const actual = hasSubscriptions(({ id: 'cus_123' } as unknown) as Customer);
+    const actual = hasSubscriptions({ id: 'cus_123' } as unknown as Customer);
     expect(actual).toBe(false);
   });
 
@@ -149,5 +151,20 @@ describe('isExistingStripeCustomer', () => {
       payment_provider: 'stripe',
     });
     expect(actual).toBe(true);
+  });
+});
+
+describe('needsCustomer', () => {
+  it('return true when customer is empty', () => {
+    const actual = needsCustomer(null);
+    expect(actual).toBe(true);
+  });
+  it('return true when does not have payment_provider set', () => {
+    const actual = needsCustomer(IAP_CUSTOMER);
+    expect(actual).toBe(true);
+  });
+  it('return false when payment_provider is set', () => {
+    const actual = needsCustomer(MOCK_CUSTOMER);
+    expect(actual).toBe(false);
   });
 });

--- a/packages/fxa-payments-server/src/lib/customer.test.ts
+++ b/packages/fxa-payments-server/src/lib/customer.test.ts
@@ -159,11 +159,11 @@ describe('needsCustomer', () => {
     const actual = needsCustomer(null);
     expect(actual).toBe(true);
   });
-  it('return true when does not have payment_provider set', () => {
+  it('return true when does not have a customerId set', () => {
     const actual = needsCustomer(IAP_CUSTOMER);
     expect(actual).toBe(true);
   });
-  it('return false when payment_provider is set', () => {
+  it('return false when customerId is set', () => {
     const actual = needsCustomer(MOCK_CUSTOMER);
     expect(actual).toBe(false);
   });

--- a/packages/fxa-payments-server/src/lib/customer.ts
+++ b/packages/fxa-payments-server/src/lib/customer.ts
@@ -52,6 +52,13 @@ export const findCustomerIapSubscriptionByProductId = (
     (s) => isIapSubscription(s) && s.product_id === productId
   ) as IapSubscription);
 
+export const needsCustomer = (customer: Customer | null) =>
+  !(
+    customer &&
+    customer.payment_provider &&
+    Object.values(PaymentProviders).includes(customer.payment_provider)
+  );
+
 export default {
   hasSubscriptions,
   hasPaymentProvider,

--- a/packages/fxa-payments-server/src/lib/customer.ts
+++ b/packages/fxa-payments-server/src/lib/customer.ts
@@ -53,11 +53,7 @@ export const findCustomerIapSubscriptionByProductId = (
   ) as IapSubscription);
 
 export const needsCustomer = (customer: Customer | null) =>
-  !(
-    customer &&
-    customer.payment_provider &&
-    Object.values(PaymentProviders).includes(customer.payment_provider)
-  );
+  !(customer && customer.customerId);
 
 export default {
   hasSubscriptions,

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -231,12 +231,17 @@ export const IAP_GOOGLE_SUBSCRIPTION = {
   package_name: 'org.mozilla.cooking.with.foxkeh',
   sku: 'org.mozilla.foxkeh.yearly',
   product_name: 'Cooking with Foxkeh',
+  price_id: 'plan_123',
 };
 
 export const IAP_APPLE_SUBSCRIPTION = {
   _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
   product_id: 'prod_123',
   product_name: 'Cooking with Foxkeh',
+};
+
+export const IAP_CUSTOMER: Customer = {
+  subscriptions: [IAP_GOOGLE_SUBSCRIPTION],
 };
 
 export const INVOICE_PREVIEW_WITHOUT_DISCOUNT: FirstInvoicePreview = {

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -23,6 +23,7 @@ export const NEW_CUSTOMER: Customer = {
 };
 
 export const CUSTOMER: Customer = {
+  customerId: 'cus_123xyz',
   billing_name: 'Foo Barson',
   billing_agreement_id: 'ba-131243',
   payment_provider: 'stripe',

--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -14,7 +14,7 @@ import {
   handlePasswordlessSignUp,
   PasswordlessSignupHandlerParam,
 } from './account';
-import { isExistingStripeCustomer } from './customer';
+import { isExistingStripeCustomer, needsCustomer } from './customer';
 import { GeneralError } from './errors';
 
 export type RetryStatus = undefined | { invoiceId: string };
@@ -147,7 +147,7 @@ export async function handleSubscriptionPayment({
   }
 
   // 2. Create the customer, if necessary.
-  if (!customer?.payment_provider) {
+  if (needsCustomer(customer)) {
     // We look up the customer by UID & email on the server.
     // No need to retain the result of this call for later.
     await apiCreateCustomer({

--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -147,7 +147,7 @@ export async function handleSubscriptionPayment({
   }
 
   // 2. Create the customer, if necessary.
-  if (!customer) {
+  if (!customer?.payment_provider) {
     // We look up the customer by UID & email on the server.
     // No need to retain the result of this call for later.
     await apiCreateCustomer({

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -15,7 +15,7 @@ import { FluentBundle, FluentResource } from '@fluent/bundle';
 
 import { State } from '../store/state';
 import { Store, createAppStore } from '../../src/store';
-import { Plan, Profile, Token } from '../../src/store/types';
+import { Customer, Plan, Profile, Token } from '../../src/store/types';
 import {
   MozillaSubscription,
   MozillaSubscriptionTypes,
@@ -584,7 +584,7 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
   },
 ];
 
-export const MOCK_CUSTOMER = {
+export const MOCK_CUSTOMER: Customer = {
   billing_name: 'Jane Doe',
   payment_type: 'card',
   payment_provider: 'stripe',

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -585,6 +585,7 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
 ];
 
 export const MOCK_CUSTOMER: Customer = {
+  customerId: 'cus_123xyz',
   billing_name: 'Jane Doe',
   payment_type: 'card',
   payment_provider: 'stripe',

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -302,7 +302,7 @@ describe('routes/Product/SubscriptionCreate', () => {
           customer = null;
           break;
         case CustomerType.WithCustomer:
-          customer = { payment_provider: PaymentProviders.none };
+          customer = { customerId: 'cus_123xyz' };
           break;
         case CustomerType.WithCustomerCard:
           customer = CUSTOMER;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -39,6 +39,9 @@ import {
   mockStripeElementOnChangeFns,
 } from '../../../lib/test-utils';
 import { PickPartial } from '../../../lib/types';
+import PaymentProvider, {
+  PaymentProviders,
+} from '../../../lib/PaymentProvider';
 
 jest.mock('../../../lib/hooks', () => {
   const refreshNonceMock = jest.fn().mockImplementation(Math.random);
@@ -299,7 +302,7 @@ describe('routes/Product/SubscriptionCreate', () => {
           customer = null;
           break;
         case CustomerType.WithCustomer:
-          customer = { payment_provider: 'not_chosen' };
+          customer = { payment_provider: PaymentProviders.none };
           break;
         case CustomerType.WithCustomerCard:
           customer = CUSTOMER;

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -76,6 +76,7 @@ export interface CustomerSubscription {
 }
 
 export type Customer = {
+  customerId?: string;
   billing_name?: string | null;
   billing_agreement_id?: string | null;
   // https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-brand

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -129,6 +129,7 @@ export interface GooglePlaySubscription extends AbbrevPlayPurchase {
   _subscription_type: SubscriptionTypes[1];
   product_id: Stripe.Product['id'];
   product_name: Stripe.Product['name'];
+  price_id: Stripe.Plan['id'];
 }
 export type AppleSubscription = {
   _subscription_type: SubscriptionTypes[2];


### PR DESCRIPTION
## Because

- The web app does not create a Stripe customer when a customer with an
  existing IAP subscription signs up via the Web Application.

## This pull request

- Improves the check if a Stripe customer exists, to support customers
  with a existing IAP subscriptions.

## Issue that this pull request solves

Closes: #12003

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
