### PR TITLE
fix(google): Pocket third party auth fixes, FAQ link fix

### DIFF
--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -46,7 +46,7 @@
         class="btn btn-large btn-info btn-persona third-party"
         type="submit"
       >
-        Sign In (Third Party)
+        Sign In (Google)
       </button>
       <button
         class="btn btn-large btn-info btn-persona prompt-none"

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -243,6 +243,7 @@ $(document).ready(function () {
       authenticate('best_choice', {
         forceExperiment: 'thirdPartyAuth',
         forceExperimentGroup: 'google',
+        deeplink: 'googleLogin',
       });
     });
 

--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -127,7 +127,7 @@ module.exports = {
     'https://www.mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len
 
   POCKET_MORE_INFO_LINK:
-    'https://support.mozilla.org/en-US/kb/pocket-firefox-account-migration',
+    'https://support.mozilla.org/kb/pocket-firefox-account-migration',
 
   // 20 most popular email domains, used for metrics. Matches the list
   // we use in the auth server, converted to a map for faster lookup.

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -19,7 +19,6 @@
     <div class="success"></div>
 
     {{{ userCardHTML }}}
-    {{{ accountSuggestionHTML }}}
 
     <form novalidate>
       <input type="email" class="email hidden" value="{{ email }}" disabled />

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -24,6 +24,20 @@ export default {
   },
 
   beforeRender() {
+    // Check to see if this is a request to deeplink into Google/Apple login
+    // flow. We do a promise we want to keep our loading indicator on while
+    // page navigates to third party auth flow.
+    const params = new URLSearchParams(this.window.location.search);
+    if (params.get('deeplink') === 'googleLogin') {
+      return new Promise(()=> {
+        this.googleSignIn();
+      });
+    } else if (params.get('deeplink') === 'appleLogin') {
+      return new Promise(()=> {
+        this.appleSignIn();
+      });
+    }
+
     // Check to see if this page is being redirected to at the end of a
     // Google auth flow and if so, restore the original
     // query params and complete the FxA oauth signin
@@ -46,7 +60,10 @@ export default {
 
     // We stash originating location in the Google state oauth param
     // because we will need it to use it to log the user into FxA
-    const state = encodeURIComponent(this.window.location.href);
+    const currentParams = new URLSearchParams(this.window.location.search);
+    currentParams.delete("deeplink");
+
+    const state = encodeURIComponent(`${this.window.location.origin}${this.window.location.pathname}?${currentParams.toString()}`);
 
     // To avoid any CORs issues we create element to store the
     // params need for the request and do a form submission
@@ -83,7 +100,10 @@ export default {
   appleSignIn() {
     this.clearStoredParams();
 
-    const state = encodeURIComponent(this.window.location.href);
+    const currentParams = new URLSearchParams(this.window.location.search);
+    currentParams.delete("deeplink");
+
+    const state = encodeURIComponent(`${this.window.location.origin}${this.window.location.pathname}?${currentParams.toString()}`);
 
     // To avoid any CORs issues we create element to store the
     // params need for the request and do a form submission

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -19,7 +19,6 @@ import Template from 'templates/sign_in_password.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 import ThirdPartyAuthMixin from './mixins/third-party-auth-mixin';
-import AccountSuggestionMixin from './mixins/account-suggestion-mixin';
 
 const SignInPasswordView = FormView.extend({
   template: Template,
@@ -98,7 +97,6 @@ Cocktail.mixin(
   UserCardMixin,
   ThirdPartyAuthMixin,
   PocketMigrationMixin,
-  AccountSuggestionMixin
 );
 
 export default SignInPasswordView;

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
@@ -87,7 +87,7 @@ describe('views/mixins/third-party-auth-mixin', function () {
   });
 
   it('googleSignIn', async () => {
-    windowMock.location.href = 'http://localhost?orignal_oauth_params';
+    windowMock.location.href = 'http://127.0.0.1:3030/?orignal_oauth_params';
 
     view.googleSignIn();
 
@@ -111,7 +111,7 @@ describe('views/mixins/third-party-auth-mixin', function () {
     assertInputEl(
       mockInput,
       'state',
-      encodeURIComponent(windowMock.location.href)
+      encodeURIComponent(`${windowMock.location.origin}${windowMock.location.pathname}?`)
     );
     assertInputEl(mockInput, 'access_type', 'offline');
     assertInputEl(mockInput, 'prompt', 'consent');


### PR DESCRIPTION
## Because

- Pocket needs to be able to open the third party auth from their homepage

## This pull request

- Adds support to deeplink directly into an Apple or Google login flow
- Fix to use right FAQ for Pocket

Note that is will be targetted as a point release on train 228.

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12176 https://github.com/mozilla/fxa/issues/12175

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
