### PR TITLE
fix(subscriptions): remove promo codes from plans

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -45,9 +45,10 @@ const addressLookupCountries = Object.values(
 const METRICS_CONTEXT_SCHEMA = require('../../metrics/context').schema;
 
 /**
- * Delete any metadata keys prefixed by `capabilities:` before
- * sending response. We don't need to reveal those.
+ * Delete any metadata keys prefixed by `capabilities:` and promotion codes
+ * before sending response. We don't need to reveal those.
  * https://github.com/mozilla/fxa/issues/3273#issuecomment-552637420
+ * https://github.com/mozilla/fxa/issues/12181
  */
 export function sanitizePlans(plans: AbbrevPlan[]) {
   return plans.map((planIn) => {
@@ -55,8 +56,12 @@ export function sanitizePlans(plans: AbbrevPlan[]) {
     const plan = { ...planIn };
     const isCapabilityKey = (value: string, key: string) =>
       key.startsWith('capabilities');
-    plan.plan_metadata = omitBy(plan.plan_metadata, isCapabilityKey);
-    plan.product_metadata = omitBy(plan.product_metadata, isCapabilityKey);
+    const isPromotionCodes = (value: string, key: string) =>
+      key.toLowerCase() === 'promotioncodes';
+    const isOmittable = (value: string, key: string) =>
+      isCapabilityKey(value, key) || isPromotionCodes(value, key);
+    plan.plan_metadata = omitBy(plan.plan_metadata, isOmittable);
+    plan.product_metadata = omitBy(plan.product_metadata, isOmittable);
     return plan;
   });
 }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -82,6 +82,7 @@ const PLANS = [
       downloadURL: 'http://getfirefox.com',
       capabilities: 'exampleCap0',
       'capabilities:client1': 'exampleCap1',
+      promotionCodes: 'earlybirds',
     },
   },
   {
@@ -107,6 +108,7 @@ const PLANS = [
       'capabilities:client1': 'exampleCap3',
       // NOTE: whitespace in capabilities list should be flexible for human entry
       'capabilities:client2': 'exampleCap5,exampleCap6,   exampleCap7',
+      promotionCodes: 'gettheworms?',
     },
     product_metadata: {},
   },


### PR DESCRIPTION
Because:
 - the front end does not need the promotion codes

This commit:
 - remove the promotion codes from the plans



## Issue that this pull request solves

Closes: #12181