### PR TITLE
feat(coupon): update info box for coupon type

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -775,6 +775,7 @@ export class StripeHelper {
       const couponDetails: Coupon.couponDetailsSchema = {
         promotionCode: promotionCode,
         type: stripeCoupon.duration,
+        durationInMonths: stripeCoupon.duration_in_months,
         valid: false,
       };
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1357,6 +1357,7 @@ describe('StripeHelper', () => {
         type: 'forever',
         discountAmount: 200,
         valid: true,
+        durationInMonths: null,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1368,6 +1369,7 @@ describe('StripeHelper', () => {
           id: 'promo',
           duration: 'forever',
           valid: true,
+          duration_in_months: null,
         },
       });
 
@@ -1396,6 +1398,7 @@ describe('StripeHelper', () => {
         type: 'forever',
         discountAmount: 200,
         valid: true,
+        durationInMonths: null,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1407,6 +1410,7 @@ describe('StripeHelper', () => {
           id: 'promo',
           duration: 'forever',
           valid: true,
+          duration_in_months: null,
         },
       });
 
@@ -1435,6 +1439,7 @@ describe('StripeHelper', () => {
         type: 'forever',
         expired: true,
         valid: false,
+        durationInMonths: null,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1447,6 +1452,7 @@ describe('StripeHelper', () => {
           duration: 'forever',
           valid: false,
           redeem_by: 1000,
+          duration_in_months: null,
         },
       });
 
@@ -1464,6 +1470,7 @@ describe('StripeHelper', () => {
         type: 'forever',
         maximallyRedeemed: true,
         valid: false,
+        durationInMonths: null,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1477,6 +1484,7 @@ describe('StripeHelper', () => {
           valid: false,
           max_redemptions: 1,
           times_redeemed: 1,
+          duration_in_months: null,
         },
       });
 
@@ -1493,6 +1501,7 @@ describe('StripeHelper', () => {
         promotionCode: 'promo',
         type: 'forever',
         valid: false,
+        durationInMonths: null,
       };
       const err = new AppError('previewInvoiceFailed');
       sandbox.stub(stripeHelper, 'previewInvoice').rejects(err);
@@ -1503,6 +1512,7 @@ describe('StripeHelper', () => {
           id: 'promo',
           duration: 'forever',
           valid: true,
+          duration_in_months: null,
         },
       });
 
@@ -1529,6 +1539,7 @@ describe('StripeHelper', () => {
         promotionCode: 'promo',
         type: 'forever',
         valid: false,
+        durationInMonths: null,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1540,6 +1551,7 @@ describe('StripeHelper', () => {
           id: 'promo',
           duration: 'forever',
           valid: true,
+          duration_in_months: null,
         },
       });
 
@@ -1571,6 +1583,7 @@ describe('StripeHelper', () => {
           id: 'promo',
           duration: 'forever',
           valid: true,
+          duration_in_months: null,
         },
       });
       try {

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -361,6 +361,8 @@ coupon-error-expired = The code you entered has expired.
 coupon-error-limit-reached = The code you entered has reached its limit.
 coupon-error-invalid = The code you entered is invalid.
 coupon-success = Your plan will automatically renew at the list price.
+# $couponDurationDate (Date) - The date at which the coupon is no longer valid, and the subscription is billed the list price.
+coupon-success-repeating = Your plan will automatically renew after { $couponDurationDate } at the list price.
 coupon-enter-code =
   .placeholder = Enter Code
 

--- a/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
@@ -26,6 +26,7 @@ storiesOf('components/Coupon', module)
     const [coupon, setCoupon] = useState<CouponDetails>({
       promotionCode: 'Test',
       type: 'repeating',
+      durationInMonths: 1,
       discountAmount: 10,
       valid: true,
     });
@@ -59,6 +60,7 @@ storiesOf('components/Coupon', module)
     const [coupon, setCoupon] = useState<CouponDetails>({
       promotionCode: 'Test',
       type: 'repeating',
+      durationInMonths: 1,
       discountAmount: 10,
       valid: true,
     });

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -126,17 +126,9 @@ export const CouponForm = ({
     event.stopPropagation();
     try {
       setCheckingCoupon(true);
-      const { discountAmount, type, valid } = await checkPromotionCode(
-        planId,
-        promotionCode
-      );
+      const coupon = await checkPromotionCode(planId, promotionCode);
       setHasCoupon(true);
-      setCoupon({
-        promotionCode,
-        discountAmount,
-        type,
-        valid,
-      });
+      setCoupon(coupon);
     } catch (err) {
       setCoupon(undefined);
       setError(err.message);

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -75,6 +75,7 @@ const coupon: CouponDetails = {
   discountAmount: 200,
   promotionCode: 'TEST',
   type: '',
+  durationInMonths: 1,
   valid: true,
 };
 

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -7,6 +7,7 @@ import { storiesOf } from '@storybook/react';
 import MockApp from '../../../.storybook/components/MockApp';
 import PlanDetails from './index';
 import { Profile } from '../../store/types';
+import { COUPON_DETAILS_VALID } from '../../lib/mock-data';
 
 const userProfile: Profile = {
   avatar: 'http://placekitten.com/256/256',
@@ -79,6 +80,61 @@ storiesOf('components/PlanDetail', module)
           showExpandButton: true,
           selectedPlan,
           isMobile: false,
+        }}
+      />
+    </MockApp>
+  ))
+  .add('with coupon - type "forever"', () => (
+    <MockApp>
+      <PlanDetails
+        {...{
+          profile: userProfile,
+          showExpandButton: false,
+          selectedPlan,
+          isMobile: false,
+          coupon: { ...COUPON_DETAILS_VALID, type: 'forever' },
+        }}
+      />
+    </MockApp>
+  ))
+  .add('with coupon - type "once"', () => (
+    <MockApp>
+      <PlanDetails
+        {...{
+          profile: userProfile,
+          showExpandButton: false,
+          selectedPlan,
+          isMobile: false,
+          coupon: { ...COUPON_DETAILS_VALID, type: 'once' },
+        }}
+      />
+    </MockApp>
+  ))
+  .add(
+    'with coupon - type "repeating" with misaligned plan and coupon interval',
+    () => (
+      <MockApp>
+        <PlanDetails
+          {...{
+            profile: userProfile,
+            showExpandButton: false,
+            selectedPlan: { ...selectedPlan, interval_count: 6 },
+            isMobile: false,
+            coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
+          }}
+        />
+      </MockApp>
+    )
+  )
+  .add('with coupon - type "repeating"', () => (
+    <MockApp>
+      <PlanDetails
+        {...{
+          profile: userProfile,
+          showExpandButton: false,
+          selectedPlan,
+          isMobile: false,
+          coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
         }}
       />
     </MockApp>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -111,7 +111,7 @@ storiesOf('components/PlanDetail', module)
     </MockApp>
   ))
   .add(
-    'with coupon - type "repeating" with misaligned plan and coupon interval',
+    'with coupon - type "repeating" where plan interval is greater than coupon duration',
     () => (
       <MockApp>
         <PlanDetails
@@ -134,7 +134,11 @@ storiesOf('components/PlanDetail', module)
           showExpandButton: false,
           selectedPlan,
           isMobile: false,
-          coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
+          coupon: {
+            ...COUPON_DETAILS_VALID,
+            durationInMonths: 3,
+            type: 'repeating',
+          },
         }}
       />
     </MockApp>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -265,7 +265,7 @@ describe('PlanDetails', () => {
               coupon: {
                 ...coupon,
                 type: 'repeating',
-                durationInMonths: 1,
+                durationInMonths: 2,
               },
             }}
           />

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -4,6 +4,7 @@ import {
   getLocalizedCurrency,
   formatPlanPricing,
   getLocalizedCurrencyString,
+  getLocalizedDate,
 } from '../../lib/formats';
 import {
   metadataFromPlan,
@@ -19,6 +20,7 @@ import ffLogo from '../../images/firefox-logo.svg';
 import './index.scss';
 import { Plan } from '../../store/types';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { useInfoBoxMessage } from '../../lib/hooks';
 
 type PlanDetailsProps = {
   selectedPlan: Plan;
@@ -61,6 +63,8 @@ export const PlanDetails = ({
     interval,
     interval_count
   );
+
+  const infoBoxMessage = useInfoBoxMessage(coupon, selectedPlan);
 
   return (
     <div
@@ -191,12 +195,31 @@ export const PlanDetails = ({
                     </p>
                   </Localized>
                 </div>
-                {coupon ? (
-                  <Localized id="coupon-success">
-                    <div className="coupon-info" data-testid="coupon-success">
-                      Your plan will automatically renew at the list price.
-                    </div>
-                  </Localized>
+                {infoBoxMessage ? (
+                  infoBoxMessage.couponDurationDate ? (
+                    <Localized
+                      id={infoBoxMessage.message}
+                      vars={{
+                        couponDurationDate: getLocalizedDate(
+                          infoBoxMessage.couponDurationDate,
+                          true
+                        ),
+                      }}
+                    >
+                      <div
+                        className="coupon-info"
+                        data-testid="coupon-success-with-date"
+                      >
+                        {infoBoxMessage.message}
+                      </div>
+                    </Localized>
+                  ) : (
+                    <Localized id={infoBoxMessage.message}>
+                      <div className="coupon-info" data-testid="coupon-success">
+                        {infoBoxMessage.message}
+                      </div>
+                    </Localized>
+                  )
                 ) : null}
               </div>
             </div>

--- a/packages/fxa-payments-server/src/lib/coupon.test.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.test.ts
@@ -1,0 +1,105 @@
+import { planIntervalLessThanCouponDuration } from './coupon';
+
+describe('planIntervalLessThanCouponDuration', () => {
+  let interval: string;
+  let interval_count: number;
+  let durationInMonths: number;
+
+  it('day - plan interval is greater', () => {
+    interval = 'day';
+    interval_count = 40;
+    durationInMonths = 1;
+    const expected = false;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('day - plan interval is less', () => {
+    interval = 'day';
+    interval_count = 1;
+    durationInMonths = 1;
+    const expected = true;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('week - plan interval is greater', () => {
+    interval = 'week';
+    interval_count = 6;
+    durationInMonths = 1;
+    const expected = false;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('week - plan interval is less', () => {
+    interval = 'week';
+    interval_count = 1;
+    durationInMonths = 1;
+    const expected = true;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('month - plan interval is greater', () => {
+    interval = 'month';
+    interval_count = 2;
+    durationInMonths = 1;
+    const expected = false;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('month - plan interval is less', () => {
+    interval = 'month';
+    interval_count = 1;
+    durationInMonths = 1;
+    const expected = true;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('year - plan interval is greater', () => {
+    interval = 'year';
+    interval_count = 1;
+    durationInMonths = 1;
+    const expected = false;
+
+    const actual = planIntervalLessThanCouponDuration(
+      interval_count,
+      interval,
+      durationInMonths
+    );
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/fxa-payments-server/src/lib/coupon.test.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.test.ts
@@ -1,105 +1,119 @@
-import { planIntervalLessThanEqualCouponDuration } from './coupon';
+import {
+  checkCouponRepeating,
+  incDateByInterval,
+  incDateByMonth,
+} from './coupon';
 
-describe('planIntervalLessThanEqualCouponDuration', () => {
-  let interval: string;
-  let interval_count: number;
-  let durationInMonths: number;
+describe('lib/coupon', () => {
+  describe('incDateByMonth', () => {
+    const incrementMonth = 1;
+    it('should incremenet current date by specified amount', () => {
+      const date = new Date();
+      const expected = new Date(
+        date.setMonth(date.getMonth() + incrementMonth)
+      );
+      const actual = incDateByMonth(incrementMonth);
+      expect(actual).toEqual(expected);
+    });
 
-  it('day - plan interval is greater', () => {
-    interval = 'day';
-    interval_count = 40;
-    durationInMonths = 1;
-    const expected = false;
-
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
+    it('should incremenet input date by specified amount', () => {
+      const date = new Date(2022, 0, 1);
+      const expected = new Date(2022, 1, 1);
+      const actual = incDateByMonth(incrementMonth, date);
+      expect(actual).toEqual(expected);
+    });
   });
 
-  it('day - plan interval is less', () => {
-    interval = 'day';
-    interval_count = 1;
-    durationInMonths = 1;
-    const expected = true;
+  describe('incDateByInterval', () => {
+    it('should increment the date by the provided day', () => {
+      const incrementValue = 6;
+      const date = new Date(2022, 0, 1);
+      const expected = new Date(2022, 0, 7);
+      const actual = incDateByInterval(incrementValue, 'day', date);
+      expect(actual).toEqual(expected);
+    });
 
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
+    it('should increment the date by the provided week', () => {
+      const incrementValue = 2;
+      const date = new Date(2022, 0, 1);
+      const expected = new Date(2022, 0, 15);
+      const actual = incDateByInterval(incrementValue, 'week', date);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should increment the date by the provided month', () => {
+      const incrementValue = 6;
+      const date = new Date(2022, 0, 1);
+      const expected = new Date(2022, 6, 1);
+      const actual = incDateByInterval(incrementValue, 'month', date);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should increment the date by the provided year', () => {
+      const incrementValue = 1;
+      const date = new Date(2022, 0, 1);
+      const expected = new Date(2023, 0, 1);
+      const actual = incDateByInterval(incrementValue, 'year', date);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should increment the current date by the provided value', () => {
+      const incrementValue = 2;
+      const expected = incDateByMonth(incrementValue);
+      const actual = incDateByInterval(incrementValue, 'month');
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return the input date if incorrect interval is provided', () => {
+      const incrementValue = 2;
+      const expected = new Date();
+      const actual = incDateByInterval(incrementValue, 'invalid', expected);
+      expect(actual).toEqual(expected);
+    });
   });
 
-  it('week - plan interval is greater', () => {
-    interval = 'week';
-    interval_count = 6;
-    durationInMonths = 1;
-    const expected = false;
+  describe('checkCouponRepeating', () => {
+    let interval: string;
+    let interval_count: number;
+    let durationInMonths: number;
 
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
-  });
+    it('should return true if coupon duration is greater than the interval', () => {
+      interval = 'month';
+      interval_count = 1;
+      durationInMonths = 3;
+      const expected = true;
+      const actual = checkCouponRepeating(
+        interval_count,
+        interval,
+        durationInMonths
+      );
+      expect(actual).toEqual(expected);
+    });
 
-  it('week - plan interval is less', () => {
-    interval = 'week';
-    interval_count = 1;
-    durationInMonths = 1;
-    const expected = true;
+    it('should return false if coupon duration is less than the interval', () => {
+      interval = 'year';
+      interval_count = 1;
+      durationInMonths = 3;
+      const expected = false;
+      const actual = checkCouponRepeating(
+        interval_count,
+        interval,
+        durationInMonths
+      );
+      expect(actual).toEqual(expected);
+    });
 
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
-  });
-
-  it('month - plan interval is greater', () => {
-    interval = 'month';
-    interval_count = 2;
-    durationInMonths = 1;
-    const expected = false;
-
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
-  });
-
-  it('month - plan interval is less', () => {
-    interval = 'month';
-    interval_count = 1;
-    durationInMonths = 2;
-    const expected = true;
-
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
-  });
-
-  it('year - plan interval is greater', () => {
-    interval = 'year';
-    interval_count = 1;
-    durationInMonths = 1;
-    const expected = false;
-
-    const actual = planIntervalLessThanEqualCouponDuration(
-      interval_count,
-      interval,
-      durationInMonths
-    );
-    expect(actual).toEqual(expected);
+    it('should return false if coupon duration is equal to the interval', () => {
+      interval = 'month';
+      interval_count = 1;
+      durationInMonths = 1;
+      const expected = false;
+      const actual = checkCouponRepeating(
+        interval_count,
+        interval,
+        durationInMonths
+      );
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/packages/fxa-payments-server/src/lib/coupon.test.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.test.ts
@@ -1,6 +1,6 @@
-import { planIntervalLessThanCouponDuration } from './coupon';
+import { planIntervalLessThanEqualCouponDuration } from './coupon';
 
-describe('planIntervalLessThanCouponDuration', () => {
+describe('planIntervalLessThanEqualCouponDuration', () => {
   let interval: string;
   let interval_count: number;
   let durationInMonths: number;
@@ -11,7 +11,7 @@ describe('planIntervalLessThanCouponDuration', () => {
     durationInMonths = 1;
     const expected = false;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths
@@ -25,7 +25,7 @@ describe('planIntervalLessThanCouponDuration', () => {
     durationInMonths = 1;
     const expected = true;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths
@@ -39,7 +39,7 @@ describe('planIntervalLessThanCouponDuration', () => {
     durationInMonths = 1;
     const expected = false;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths
@@ -53,7 +53,7 @@ describe('planIntervalLessThanCouponDuration', () => {
     durationInMonths = 1;
     const expected = true;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths
@@ -67,7 +67,7 @@ describe('planIntervalLessThanCouponDuration', () => {
     durationInMonths = 1;
     const expected = false;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths
@@ -78,10 +78,10 @@ describe('planIntervalLessThanCouponDuration', () => {
   it('month - plan interval is less', () => {
     interval = 'month';
     interval_count = 1;
-    durationInMonths = 1;
+    durationInMonths = 2;
     const expected = true;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths
@@ -95,7 +95,7 @@ describe('planIntervalLessThanCouponDuration', () => {
     durationInMonths = 1;
     const expected = false;
 
-    const actual = planIntervalLessThanCouponDuration(
+    const actual = planIntervalLessThanEqualCouponDuration(
       interval_count,
       interval,
       durationInMonths

--- a/packages/fxa-payments-server/src/lib/coupon.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.ts
@@ -1,0 +1,42 @@
+export const planIntervalLessThanCouponDuration = (
+  interval_count: number,
+  interval: string,
+  durationInMonths: number
+) => {
+  let renewalDate: Date;
+  let currentDate = new Date();
+
+  switch (interval) {
+    case 'day':
+      renewalDate = new Date(
+        currentDate.setHours(currentDate.getHours() + interval_count * 24)
+      );
+      break;
+    case 'week':
+      renewalDate = new Date(
+        currentDate.setHours(currentDate.getHours() + interval_count * 24 * 7)
+      );
+      break;
+    case 'month':
+      renewalDate = new Date(
+        currentDate.setMonth(currentDate.getMonth() + interval_count)
+      );
+      break;
+    case 'year':
+      renewalDate = new Date(
+        currentDate.setFullYear(currentDate.getFullYear() + interval_count)
+      );
+      break;
+    default:
+      return false;
+  }
+
+  currentDate = new Date();
+  const couponDurationDate = new Date(
+    currentDate.setMonth(currentDate.getMonth() + durationInMonths)
+  );
+
+  return couponDurationDate.getTime() - renewalDate.getTime() < 0
+    ? false
+    : true;
+};

--- a/packages/fxa-payments-server/src/lib/coupon.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.ts
@@ -1,4 +1,4 @@
-export const planIntervalLessThanCouponDuration = (
+export const planIntervalLessThanEqualCouponDuration = (
   interval_count: number,
   interval: string,
   durationInMonths: number
@@ -36,7 +36,7 @@ export const planIntervalLessThanCouponDuration = (
     currentDate.setMonth(currentDate.getMonth() + durationInMonths)
   );
 
-  return couponDurationDate.getTime() - renewalDate.getTime() < 0
+  return couponDurationDate.getTime() - renewalDate.getTime() <= 0
     ? false
     : true;
 };

--- a/packages/fxa-payments-server/src/lib/coupon.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.ts
@@ -1,42 +1,38 @@
-export const planIntervalLessThanEqualCouponDuration = (
+export const incDateByMonth = (month: number, date: Date = new Date()) =>
+  new Date(date.setMonth(date.getMonth() + month));
+
+export const incDateByInterval = (
+  interval_count: number,
+  interval: string,
+  date: Date = new Date()
+) => {
+  switch (interval) {
+    case 'day':
+      return new Date(date.setHours(date.getHours() + interval_count * 24));
+    case 'week':
+      return new Date(date.setHours(date.getHours() + interval_count * 24 * 7));
+    case 'month':
+      return incDateByMonth(interval_count, date);
+    case 'year':
+      return new Date(date.setFullYear(date.getFullYear() + interval_count));
+    default:
+      return date;
+  }
+};
+
+/*
+ * Check if the coupon will be reused on the next billing cycle.
+ */
+export const checkCouponRepeating = (
   interval_count: number,
   interval: string,
   durationInMonths: number
 ) => {
-  let renewalDate: Date;
-  let currentDate = new Date();
+  // TODO - Instead of calculating this get it from the coupon invoice preview
+  // Get the date the plan will renew.
+  const renewalDate = incDateByInterval(interval_count, interval);
+  // Get the date the coupon ends.
+  const couponDurationDate = incDateByMonth(durationInMonths);
 
-  switch (interval) {
-    case 'day':
-      renewalDate = new Date(
-        currentDate.setHours(currentDate.getHours() + interval_count * 24)
-      );
-      break;
-    case 'week':
-      renewalDate = new Date(
-        currentDate.setHours(currentDate.getHours() + interval_count * 24 * 7)
-      );
-      break;
-    case 'month':
-      renewalDate = new Date(
-        currentDate.setMonth(currentDate.getMonth() + interval_count)
-      );
-      break;
-    case 'year':
-      renewalDate = new Date(
-        currentDate.setFullYear(currentDate.getFullYear() + interval_count)
-      );
-      break;
-    default:
-      return false;
-  }
-
-  currentDate = new Date();
-  const couponDurationDate = new Date(
-    currentDate.setMonth(currentDate.getMonth() + durationInMonths)
-  );
-
-  return couponDurationDate.getTime() - renewalDate.getTime() <= 0
-    ? false
-    : true;
+  return couponDurationDate.getTime() <= renewalDate.getTime() ? false : true;
 };

--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -149,7 +149,21 @@ describe('useInfoBoxMessage', () => {
     expect(messageText).toBe(CouponInfoBoxMessageType.Default);
   });
 
-  it('coupon type is "repeating" plan interval greater than or equal coupon duration', () => {
+  it('coupon type is "repeating" plan interval greater than coupon duration', () => {
+    const { queryByTestId, getByTestId } = render(
+      <Subject
+        coupon={{ ...coupon, type: 'repeating' }}
+        selectedPlan={{ ...selectedPlan, interval_count: 6 }}
+      />
+    );
+    expect(
+      queryByTestId('couponDurationDate-container')
+    ).not.toBeInTheDocument();
+    const messageText = getByTestId('message').textContent;
+    expect(messageText).toBe(CouponInfoBoxMessageType.Default);
+  });
+
+  it('coupon type is "repeating" plan interval equal to coupon duration', () => {
     const { queryByTestId, getByTestId } = render(
       <Subject
         coupon={{ ...coupon, type: 'repeating' }}
@@ -176,7 +190,7 @@ describe('useInfoBoxMessage', () => {
     const expectedCouponDurationDate = `${Math.round(
       new Date(
         date.setMonth(
-          date.getMonth() + (couponLongerDuration.durationInMonths || 1)
+          date.getMonth() + (couponLongerDuration.durationInMonths || 2)
         )
       ).getTime() / 1000
     )}`;

--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -1,10 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { Plan } from 'fxa-shared/subscriptions/types';
+import React from 'react';
 
 import {
   CouponInfoBoxMessageType,
@@ -13,8 +15,6 @@ import {
   useNonce,
 } from './hooks';
 import { COUPON_DETAILS_VALID, SELECTED_PLAN } from './mock-data';
-import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
-import { Plan } from 'fxa-shared/subscriptions/types';
 
 afterEach(cleanup);
 
@@ -149,7 +149,7 @@ describe('useInfoBoxMessage', () => {
     expect(messageText).toBe(CouponInfoBoxMessageType.Default);
   });
 
-  it('coupon type is "repeating" plan interval great than coupon duration', () => {
+  it('coupon type is "repeating" plan interval greater than or equal coupon duration', () => {
     const { queryByTestId, getByTestId } = render(
       <Subject
         coupon={{ ...coupon, type: 'repeating' }}
@@ -163,17 +163,21 @@ describe('useInfoBoxMessage', () => {
     expect(messageText).toBe(CouponInfoBoxMessageType.Default);
   });
 
-  it('coupon type is "repeating" and plan interval less than or equal coupon duration', () => {
+  it('coupon type is "repeating" and plan interval less than coupon duration', () => {
+    const couponLongerDuration = {
+      ...coupon,
+      durationInMonths: 2,
+      type: 'repeating',
+    };
     const { getByTestId } = render(
-      <Subject
-        coupon={{ ...coupon, type: 'repeating' }}
-        selectedPlan={selectedPlan}
-      />
+      <Subject coupon={couponLongerDuration} selectedPlan={selectedPlan} />
     );
     const date = new Date();
     const expectedCouponDurationDate = `${Math.round(
       new Date(
-        date.setMonth(date.getMonth() + (coupon.durationInMonths || 1))
+        date.setMonth(
+          date.getMonth() + (couponLongerDuration.durationInMonths || 1)
+        )
       ).getTime() / 1000
     )}`;
     const messageText = getByTestId('message').textContent;

--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -152,7 +152,7 @@ describe('useInfoBoxMessage', () => {
   it('coupon type is "repeating" plan interval great than coupon duration', () => {
     const { queryByTestId, getByTestId } = render(
       <Subject
-        coupon={{ ...coupon, type: 'once' }}
+        coupon={{ ...coupon, type: 'repeating' }}
         selectedPlan={selectedPlan}
       />
     );
@@ -163,7 +163,7 @@ describe('useInfoBoxMessage', () => {
     expect(messageText).toBe(CouponInfoBoxMessageType.Default);
   });
 
-  it('coupon type is "repeating" and plan interval less than or equalcoupon duration', () => {
+  it('coupon type is "repeating" and plan interval less than or equal coupon duration', () => {
     const { getByTestId } = render(
       <Subject
         coupon={{ ...coupon, type: 'repeating' }}

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -14,7 +14,7 @@ import AppContext from './AppContext';
 import { v4 as uuidv4 } from 'uuid';
 import { ButtonBaseProps } from '../components/PayPalButton';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
-import { planIntervalLessThanCouponDuration } from './coupon';
+import { planIntervalLessThanEqualCouponDuration } from './coupon';
 import { Plan } from 'fxa-shared/subscriptions/types';
 
 export function useCallbackOnce(cb: Function, deps: any[]) {
@@ -129,7 +129,7 @@ export function useInfoBoxMessage(
       case 'repeating':
         if (
           coupon.durationInMonths &&
-          planIntervalLessThanCouponDuration(
+          planIntervalLessThanEqualCouponDuration(
             selectedPlan.interval_count,
             selectedPlan.interval,
             coupon.durationInMonths

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -8,13 +8,11 @@ import React, {
   useEffect,
   useRef,
   ChangeEvent,
-  useContext,
 } from 'react';
-import AppContext from './AppContext';
 import { v4 as uuidv4 } from 'uuid';
 import { ButtonBaseProps } from '../components/PayPalButton';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
-import { planIntervalLessThanEqualCouponDuration } from './coupon';
+import { checkCouponRepeating, incDateByMonth } from './coupon';
 import { Plan } from 'fxa-shared/subscriptions/types';
 
 export function useCallbackOnce(cb: Function, deps: any[]) {
@@ -129,16 +127,13 @@ export function useInfoBoxMessage(
       case 'repeating':
         if (
           coupon.durationInMonths &&
-          planIntervalLessThanEqualCouponDuration(
+          checkCouponRepeating(
             selectedPlan.interval_count,
             selectedPlan.interval,
             coupon.durationInMonths
           )
         ) {
-          const date = new Date();
-          const couponDurationDate = new Date(
-            date.setMonth(date.getMonth() + coupon.durationInMonths)
-          );
+          const couponDurationDate = incDateByMonth(coupon.durationInMonths);
           setInfoBoxMessage({
             message: CouponInfoBoxMessageType.Repeating,
             couponDurationDate: Math.round(couponDurationDate.getTime() / 1000),

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -279,6 +279,7 @@ export const INVOICE_PREVIEW_WITH_VALID_DISCOUNT: FirstInvoicePreview = {
 export const COUPON_DETAILS_VALID: CouponDetails = {
   promotionCode: 'VALID',
   type: '',
+  durationInMonths: 1,
   valid: true,
   discountAmount: 50,
   expired: false,
@@ -288,12 +289,14 @@ export const COUPON_DETAILS_VALID: CouponDetails = {
 export const COUPON_DETAILS_INVALID: CouponDetails = {
   promotionCode: 'INVALID',
   type: '',
+  durationInMonths: 1,
   valid: false,
 };
 
 export const COUPON_DETAILS_EXPIRED: CouponDetails = {
   promotionCode: 'EXPIRED',
   type: '',
+  durationInMonths: 1,
   valid: false,
   expired: true,
 };
@@ -301,6 +304,7 @@ export const COUPON_DETAILS_EXPIRED: CouponDetails = {
 export const COUPON_DETAILS_MAX_REDEEMED: CouponDetails = {
   promotionCode: 'EXPIRED',
   type: '',
+  durationInMonths: 1,
   valid: false,
   maximallyRedeemed: true,
 };

--- a/packages/fxa-shared/dto/auth/payments/coupon.ts
+++ b/packages/fxa-shared/dto/auth/payments/coupon.ts
@@ -3,6 +3,7 @@ import joi from 'typesafe-joi';
 export interface CouponDetails {
   promotionCode: string;
   type: string;
+  durationInMonths: number | null;
   valid: boolean;
   discountAmount?: number;
   expired?: boolean;
@@ -12,6 +13,7 @@ export interface CouponDetails {
 export const couponDetailsSchema = joi.object({
   promotionCode: joi.string().required(),
   type: joi.string().required(),
+  durationInMonths: joi.number().required().allow(null),
   valid: joi.boolean().required(),
   discountAmount: joi.number().optional(),
   expired: joi.boolean().optional(),


### PR DESCRIPTION
## Because

- Once a coupon is successfully applied, we need to show an appropriate
  message depending on coupon type.

## This pull request

- Adds a new hook to determine if a message should be shown and what the
  message should be.

## Issue that this pull request solves

Closes: #11439

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
