### PR TITLE
feat(subscriptions): add Firestore based config to plans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,9 @@ jobs:
       - image: pafortin/goaws
       - image: cimg/mysql:5.7
       - image: jdlk7/firestore-emulator
-        environment:
-          NODE_ENV: dev
-          AUTH_FIRESTORE_EMULATOR_HOST: localhost:9090
-
+    environment:
+      NODE_ENV: dev
+      FIRESTORE_EMULATOR_HOST: localhost:9090
     parameters:
       package:
         type: string

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -688,7 +688,10 @@ export class StripeWebhookHandler extends StripeHandler {
           });
           reportValidationError(msg, error as any);
         } else {
-          updatedPlans.push({ ...plan, product });
+          updatedPlans.push({
+            ...plan,
+            product,
+          });
         }
       }
     }

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -9,6 +9,15 @@ const { URL } = require('url');
 const punycode = require('punycode.js');
 const isA = require('@hapi/joi');
 const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
+const {
+  minimalConfigSchema,
+} = require('fxa-shared/subscriptions/configuration/base');
+const {
+  productConfigJoiKeys,
+} = require('fxa-shared/subscriptions/configuration/product');
+const {
+  planConfigJoiKeys,
+} = require('fxa-shared/subscriptions/configuration/plan');
 
 // Match any non-empty hex-encoded string.
 const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
@@ -514,6 +523,11 @@ module.exports.subscriptionsPlanValidator = isA.object({
   interval_count: isA.number().required(),
   amount: isA.number().required(),
   currency: isA.string().required(),
+  configuration: minimalConfigSchema
+    .keys(productConfigJoiKeys)
+    .keys(planConfigJoiKeys)
+    .optional()
+    .allow(null),
 });
 
 module.exports.subscriptionsCustomerValidator = isA.object({

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents.ts
@@ -43,7 +43,6 @@ async function init() {
     stripeHelper,
     supportedLanguages: config.i18n.supportedLanguages,
   });
-  await stripeProductsAndPlansConverter.load();
   await stripeProductsAndPlansConverter.convert({ productId, isDryRun });
   return 0;
 }

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
@@ -15,10 +15,10 @@ import {
   UiContentConfigKeys,
   UrlConfig,
   UrlConfigKeys,
-} from '../../lib/payments/configuration/base';
+} from 'fxa-shared/subscriptions/configuration/base';
 import { PaymentConfigManager } from '../../lib/payments/configuration/manager';
-import { PlanConfig } from '../../lib/payments/configuration/plan';
-import { ProductConfig } from '../../lib/payments/configuration/product';
+import { PlanConfig } from 'fxa-shared/subscriptions/configuration/plan';
+import { ProductConfig } from 'fxa-shared/subscriptions/configuration/product';
 import { StripeHelper } from '../../lib/payments/stripe';
 import { commaSeparatedListToArray } from '../../lib/payments/utils';
 
@@ -50,7 +50,6 @@ export class StripeProductsAndPlansConverter {
       l.toLowerCase()
     );
     this.paymentConfigManager = Container.get(PaymentConfigManager);
-    this.paymentConfigManager.startListeners();
   }
 
   /**
@@ -332,10 +331,6 @@ export class StripeProductsAndPlansConverter {
       planConfig.appleProductId = commaSeparatedListToArray(appleProductId);
     }
     return planConfig;
-  }
-
-  async load() {
-    await this.paymentConfigManager.load();
   }
 
   /**

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -14,6 +14,7 @@ node -r esbuild-register ./scripts/gen_keys.js
 node -r esbuild-register ./scripts/gen_vapid_keys.js
 node -r esbuild-register ./scripts/oauth_gen_keys.js
 ../../_scripts/check-mysql.sh
+../../_scripts/check-url.sh localhost:9090
 node ../db-migrations/bin/patcher.mjs
 
 yarn run merge-ftl:test

--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
@@ -21,8 +21,10 @@ const {
   PaymentConfigManager,
 } = require('../../lib/payments/configuration/manager');
 const { Container } = require('typedi');
-const { ProductConfig } = require('../../lib/payments/configuration/product');
-const { PlanConfig } = require('../../lib/payments/configuration/plan');
+const {
+  ProductConfig,
+} = require('fxa-shared/subscriptions/configuration/product');
+const { PlanConfig } = require('fxa-shared/subscriptions/configuration/plan');
 
 const sandbox = sinon.createSandbox();
 
@@ -470,8 +472,8 @@ describe('StripeProductsAndPlansConverter', () => {
     });
     it('processes new products and plans', async () => {
       await converter.convert(args);
-      products = paymentConfigManager.allProducts();
-      plans = paymentConfigManager.allPlans();
+      products = await paymentConfigManager.allProducts();
+      plans = await paymentConfigManager.allPlans();
       // We don't care what the values of the Firestore doc IDs as long
       // as they match the expected productConfigId for planConfigs.
       assert.deepEqual(products[0], {
@@ -507,8 +509,8 @@ describe('StripeProductsAndPlansConverter', () => {
         planConfig1,
         productConfigDocId1
       );
-      products = paymentConfigManager.allProducts();
-      plans = paymentConfigManager.allPlans();
+      products = await paymentConfigManager.allProducts();
+      plans = await paymentConfigManager.allPlans();
       assert.deepEqual(products[0], {
         ...productConfig1,
         id: products[0].id,
@@ -557,8 +559,8 @@ describe('StripeProductsAndPlansConverter', () => {
         plans: { list: sandbox.stub().returns(planGeneratorUpdated()) },
       };
       await converter.convert(args);
-      products = paymentConfigManager.allProducts();
-      plans = paymentConfigManager.allPlans();
+      products = await paymentConfigManager.allProducts();
+      plans = await paymentConfigManager.allPlans();
       assert.deepEqual(products[0], {
         ...updatedProductConfig,
         id: products[0].id,
@@ -622,8 +624,8 @@ describe('StripeProductsAndPlansConverter', () => {
         },
       };
       await converter.convert(args);
-      products = paymentConfigManager.allProducts();
-      plans = paymentConfigManager.allPlans();
+      products = await paymentConfigManager.allProducts();
+      plans = await paymentConfigManager.allPlans();
       const expected = {
         'es-ES': {
           uiContent: {

--- a/packages/fxa-auth-server/test/test_server.js
+++ b/packages/fxa-auth-server/test/test_server.js
@@ -13,7 +13,7 @@ const proxyquire = require('proxyquire').noPreserveCache();
 const createMailHelper = require('./mail_helper');
 const createProfileHelper = require('./profile_helper');
 const { CapabilityService } = require('../lib/payments/capability');
-const { AuthFirestore, AppConfig } = require('../lib/types');
+const { AppConfig } = require('../lib/types');
 
 let currentServer;
 
@@ -24,11 +24,6 @@ function TestServer(config, printLogs, options = {}) {
     Container.set(CapabilityService, {
       subscriptionCapabilities: sinon.fake.resolves([]),
       determineClientVisibleSubscriptionCapabilities: sinon.fake.resolves(''),
-    });
-  }
-  if (!Container.has(AuthFirestore)) {
-    Container.set(AuthFirestore, {
-      collection: sinon.fake.returns({}),
     });
   }
   this.options = options;

--- a/packages/fxa-shared/dto/auth/payments/plan-configuration.ts
+++ b/packages/fxa-shared/dto/auth/payments/plan-configuration.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PlanConfig } from '../../../subscriptions/configuration/plan';
+
+export const planConfigurationDtoOmitKeys = [
+  'active',
+  'capabilities',
+  'id',
+  'productConfigId',
+  'promotionCodes',
+] as const;
+
+export type PlanConfigurationDtoT = Omit<
+  PlanConfig,
+  typeof planConfigurationDtoOmitKeys[number]
+>;
+
+export const formatPlanConfigDto: (x: PlanConfig) => PlanConfigurationDtoT = (
+  planConfig
+) =>
+  Object.keys(planConfig).reduce((acc, k) => {
+    // @ts-ignore
+    if (!planConfigurationDtoOmitKeys.includes(k)) {
+      // @ts-ignore
+      acc[k] = planConfig[k];
+    }
+    return acc;
+  }, {});

--- a/packages/fxa-shared/subscriptions/configuration/base.ts
+++ b/packages/fxa-shared/subscriptions/configuration/base.ts
@@ -96,24 +96,30 @@ export interface BaseConfig {
     };
   };
   support?: SupportConfig;
+  promotionCodes?: string[];
 }
 
-export const baseConfigSchema = joi
-  .object({
+export const minimalConfigSchema = joi.object({
+  id: joi.string().optional().allow(null).allow(''),
+  productSet: joi.string().optional().allow(null).allow(''),
+  urls: urlsSchema,
+  uiContent: uiContentSchema,
+  styles: stylesSchema,
+  locales: joi.object({}).pattern(
+    joi.string(),
+    joi.object({
+      uiContent: uiContentSchema,
+      urls: urlsSchema,
+      support: supportSchema,
+    })
+  ),
+  support: supportSchema,
+});
+
+export const baseConfigSchema = minimalConfigSchema
+  .keys({
     active: joi.boolean().required(),
     promotionCodes: joi.array().items(joi.string()),
     capabilities: capabilitySchema,
-    urls: urlsSchema,
-    uiContent: uiContentSchema,
-    styles: stylesSchema,
-    locales: joi.object({}).pattern(
-      joi.string(),
-      joi.object({
-        uiContent: uiContentSchema,
-        urls: urlsSchema,
-        support: supportSchema,
-      })
-    ),
-    support: supportSchema,
   })
   .required();

--- a/packages/fxa-shared/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/subscriptions/configuration/plan.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import joi from '@hapi/joi';
+import joi from 'joi';
 
 import {
   BaseConfig,
@@ -13,13 +13,16 @@ import {
   UrlConfig,
 } from './base';
 
+export const planConfigJoiKeys = {
+  productConfigId: joi.string().allow(null).allow(''),
+  stripePriceId: joi.string().optional(),
+  productOrder: joi.number().optional(),
+  googlePlaySku: joi.array().items(joi.string()).optional(),
+  appleProductId: joi.array().items(joi.string()).optional(),
+};
+
 export const planConfigSchema = baseConfigSchema
-  .keys({
-    stripePriceId: joi.string().optional(),
-    productOrder: joi.number().optional(),
-    googlePlaySku: joi.array().items(joi.string()).optional(),
-    appleProductId: joi.array().items(joi.string()).optional(),
-  })
+  .keys(planConfigJoiKeys)
   .requiredKeys('active');
 
 export class PlanConfig implements BaseConfig {
@@ -35,15 +38,17 @@ export class PlanConfig implements BaseConfig {
   styles?: StyleConfig;
   locales?: {
     [key: string]: {
-      uiContent: Partial<UiContentConfig>;
-      urls: Partial<UrlConfig>;
-      support: Partial<SupportConfig>;
+      uiContent?: Partial<UiContentConfig>;
+      urls?: Partial<UrlConfig>;
+      support?: Partial<SupportConfig>;
     };
   };
   support?: SupportConfig;
+  promotionCodes?: string[];
 
   // Extended by PlanConfig
   stripePriceId?: string;
+  productSet?: string;
   productOrder?: number;
   googlePlaySku?: string[];
   appleProductId?: string[];

--- a/packages/fxa-shared/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/subscriptions/configuration/product.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import joi from '@hapi/joi';
+import joi from 'joi';
 
 import {
   BaseConfig,
@@ -13,12 +13,14 @@ import {
   UrlConfig,
 } from './base';
 
+export const productConfigJoiKeys = {
+  stripeProductId: joi.string().optional(),
+  productSet: joi.string().optional(),
+  promotionCodes: joi.array().items(joi.string()).optional(),
+};
+
 export const productConfigSchema = baseConfigSchema
-  .keys({
-    stripeProductId: joi.string().optional(),
-    productSet: joi.string().optional(),
-    promotionCodes: joi.array().items(joi.string()).optional(),
-  })
+  .keys(productConfigJoiKeys)
   .requiredKeys(
     'capabilities',
     'locales',
@@ -41,20 +43,20 @@ export class ProductConfig implements BaseConfig {
   capabilities!: CapabilityConfig;
   locales!: {
     [key: string]: {
-      uiContent: Partial<UiContentConfig>;
-      urls: Partial<UrlConfig>;
-      support: Partial<SupportConfig>;
+      uiContent?: Partial<UiContentConfig>;
+      urls?: Partial<UrlConfig>;
+      support?: Partial<SupportConfig>;
     };
   };
   styles!: StyleConfig;
   support!: SupportConfig;
   uiContent!: UiContentConfig;
   urls!: UrlConfig;
+  promotionCodes?: string[];
 
   // Extended by ProductConfig
   stripeProductId?: string;
   productSet?: string;
-  promotionCodes?: string[];
 
   static async validate(productConfig: ProductConfig) {
     try {

--- a/packages/fxa-shared/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/subscriptions/configuration/utils.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PlanConfig } from './plan';
+import { ProductConfig } from './product';
+
+/**
+ * Build a "complete" config from merging the product's config into the plan's
+ * config.  The plan's config values have a high precedence.
+ */
+export const mergeConfigs = (
+  planConfig: PlanConfig,
+  productConfig: ProductConfig
+): PlanConfig => ({
+  ...planConfig,
+
+  capabilities: {
+    ...productConfig.capabilities,
+    ...planConfig.capabilities,
+  },
+  urls: { ...productConfig.urls, ...planConfig.urls },
+  uiContent: { ...productConfig.uiContent, ...planConfig.uiContent },
+  styles: { ...productConfig.styles, ...planConfig.styles },
+  locales: { ...productConfig.locales, ...planConfig.locales },
+  support: { ...productConfig.support, ...planConfig.support },
+  productSet: planConfig.productSet || productConfig.productSet,
+  promotionCodes: [
+    ...new Set([
+      ...(productConfig.promotionCodes || []),
+      ...(planConfig.promotionCodes || []),
+    ]),
+  ],
+});
+
+export const mapPlanConfigsByPriceId = (configs: PlanConfig[]) =>
+  configs.reduce(
+    (acc: { [key: string]: PlanConfig }, planConfig: PlanConfig) => {
+      if (planConfig.stripePriceId) {
+        acc[planConfig.stripePriceId] = planConfig;
+      }
+      return acc;
+    },
+    {}
+  );

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -1,4 +1,5 @@
 import { Stripe } from 'stripe';
+import { PlanConfigurationDtoT } from '../dto/auth/payments/plan-configuration';
 
 export type PlanInterval = Stripe.Plan['interval'];
 
@@ -22,7 +23,10 @@ export interface Plan {
   product_name: string;
 }
 
-// https://mozilla.github.io/ecosystem-platform/tutorials/subscription-platform#product-metadata
+export type ConfiguredPlan = Stripe.Plan & {
+  configuration: PlanConfigurationDtoT | null;
+};
+
 export interface PlanMetadata {
   // note: empty for now, but may be expanded in the future
 }
@@ -87,6 +91,8 @@ export type AbbrevPlan = {
   product_id: string;
   product_metadata: Stripe.Product['metadata'];
   product_name: string;
+  // TODO remove the '?' here when removing the SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED feature flag
+  configuration?: PlanConfigurationDtoT | null;
 };
 
 // Do not re-order the list items without updating their references.

--- a/packages/fxa-shared/test/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/plan.ts
@@ -4,11 +4,12 @@
 
 'use strict';
 
-const { assert } = require('chai');
-
-const { PlanConfig } = require('../../../../lib/payments/configuration/plan');
+import { assert } from 'chai';
+import { PlanConfig } from '../../../subscriptions/configuration/plan';
 
 const firestoreObject = {
+  id: 'abc123',
+  productConfigId: 'bleepbloop',
   active: true,
   capabilities: {
     '*': ['stuff'],
@@ -19,6 +20,7 @@ const firestoreObject = {
   },
   support: {},
   uiContent: {},
+  urls: { download: 'gopher://example.gg' },
 };
 
 describe('PlanConfig', () => {

--- a/packages/fxa-shared/test/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/product.ts
@@ -4,13 +4,11 @@
 
 'use strict';
 
-const { assert } = require('chai');
-
-const {
-  ProductConfig,
-} = require('../../../../lib/payments/configuration/product');
+import { assert } from 'chai';
+import { ProductConfig } from '../../../subscriptions/configuration/product';
 
 const firestoreObject = {
+  id: 'bleepbloop',
   active: true,
   capabilities: {
     '*': ['stuff'],

--- a/packages/fxa-shared/test/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/utils.ts
@@ -1,0 +1,137 @@
+import 'chai';
+import { assert } from 'chai';
+import {
+  mergeConfigs,
+  mapPlanConfigsByPriceId,
+} from '../../../subscriptions/configuration/utils';
+
+describe('product configuration util functions', () => {
+  const productCapabilities = {
+    '*': ['product', 'plan'],
+    abc123: ['product'],
+    foo: ['wibble'],
+  };
+  const planCapabilities = {
+    '*': ['plan'],
+    '789xyz': ['plan'],
+    foo: ['testo'],
+  };
+  const productUrls = {
+    webIcon: 'product',
+    emailIcon: 'product',
+    termsOfService: 'product',
+    termsOfServiceDownload: 'product',
+    privacyNotice: 'product',
+    privacyNoticeDownload: 'product',
+  };
+  const planUrls = {
+    download: 'plan',
+    emailIcon: 'plan',
+    termsOfService: 'plan',
+    termsOfServiceDownload: 'plan',
+  };
+  const productUiContent = {
+    subtitle: 'subtitle',
+    details: ['this', 'is', 'FxA'],
+    successActionButtonLabel: 'great success',
+    upgradeCTA: 'make it better',
+  };
+  const planUiContent = {
+    details: ['this', 'is', '$ubPlat'],
+    upgradeCTA: 'make it huge',
+  };
+  const productStyles = { webIconBackground: 'orange' };
+  const planStyles = { webIconBackground: 'gray' };
+  const productLocales = {
+    es: { uiContent: { details: ['lol'] } },
+    nl: { uiContent: { details: ['lol'] } },
+  };
+  const planLocales = {
+    nl: { uiContent: { details: ['trolol'] } },
+    de: { uiContent: { details: ['HGW'] } },
+  };
+  const productSupport = { app: ['windows', 'mac', 'SunOS'] };
+  const planSupport = { app: ['SunOS', 'BSD'] };
+  const productPromotionCodes = ['generous', 'very'];
+  const planPromotionCodes = ['generous', 'insane'];
+
+  const productConfig = {
+    id: '001',
+    active: true,
+    productSet: 'testo',
+    capabilities: productCapabilities,
+    urls: productUrls,
+    uiContent: productUiContent,
+    styles: productStyles,
+    locales: productLocales,
+    support: productSupport,
+    promotionCodes: productPromotionCodes,
+  };
+  const planConfig = {
+    id: '0001',
+    productConfigId: 'xyxyxyxy',
+    active: true,
+    productOrder: 3,
+    capabilities: planCapabilities,
+    urls: planUrls,
+    uiContent: planUiContent,
+    styles: planStyles,
+    locales: planLocales,
+    support: planSupport,
+    promotionCodes: planPromotionCodes,
+  };
+
+  describe('mergeConfigs', () => {
+    it('merges product configs into plans configs', () => {
+      const expected = {
+        id: '0001',
+        productConfigId: 'xyxyxyxy',
+        active: true,
+        capabilities: {
+          abc123: ['product'],
+          '*': ['plan'],
+          '789xyz': ['plan'],
+          foo: ['testo'],
+        },
+        urls: {
+          webIcon: 'product',
+          privacyNotice: 'product',
+          privacyNoticeDownload: 'product',
+          download: 'plan',
+          emailIcon: 'plan',
+          termsOfService: 'plan',
+          termsOfServiceDownload: 'plan',
+        },
+        uiContent: {
+          subtitle: 'subtitle',
+          successActionButtonLabel: 'great success',
+          details: ['this', 'is', '$ubPlat'],
+          upgradeCTA: 'make it huge',
+        },
+        styles: { webIconBackground: 'gray' },
+        locales: {
+          es: { uiContent: { details: ['lol'] } },
+          nl: { uiContent: { details: ['trolol'] } },
+          de: { uiContent: { details: ['HGW'] } },
+        },
+        support: planSupport,
+        promotionCodes: ['generous', 'very', 'insane'],
+        productSet: 'testo',
+        productOrder: 3,
+      };
+
+      const actual = mergeConfigs(planConfig, productConfig);
+      assert.deepEqual(actual, expected);
+    });
+  });
+
+  describe('mapPlanConfigsByPriceId', () => {
+    it('maps plans config by Stripe price ids', () => {
+      const planConfigA = { ...planConfig, stripePriceId: 'a' };
+      const planConfigB = { ...planConfig, stripePriceId: 'bb' };
+      const expected = { a: planConfigA, bb: planConfigB };
+      const actual = mapPlanConfigsByPriceId([planConfigA, planConfigB]);
+      assert.deepEqual(actual, expected);
+    });
+  });
+});

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -272,6 +272,7 @@ describe('subscriptions/metadata', () => {
         product_id: 'prod_HzXGNuO76B5o6g',
         product_metadata: { 'support:app:1': 'Pop!_OS' },
         product_name: 'myproduct',
+        configuration: null,
       },
     ];
 


### PR DESCRIPTION
Because:
 - we want the front end to be able to use the Firestore document based
   configurations

This commit:
 - add the 'configuration' property to the plans returned from the all
   plans endpoint
 - move some models into fxa-shared
 - refactor the configuration manager so that its users do not need to
   manually initialize the product and plan config lists prior to
   accessing them

closes #10239