### PR TITLE
feat(auth): update payment method tax rates on payment change

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_payment_method_updated.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_payment_method_updated.json
@@ -1,0 +1,60 @@
+{
+  "id": "evt_1Kb0RyKb9q6OnNsLgl0rCnV6",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1646735969,
+  "data": {
+    "object": {
+      "id": "pm_1Kb0RuKb9q6OnNsLRByudUMT",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": "pass"
+        },
+        "country": "NL",
+        "exp_month": 2,
+        "exp_year": 2032,
+        "fingerprint": "sziwe9vCUDXjRtc2",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "0002",
+        "networks": {
+          "available": ["visa"],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1646735967,
+      "customer": "cus_LHZbUXrzwQtItN",
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_DvXLIeo4lxziCU",
+    "idempotency_key": "pma-69e0da27-d193-445c-8c49-bff3df4fd827-createSub"
+  },
+  "type": "payment_method.updated"
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2307,6 +2307,38 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('updateCustomerPaymentMethodTaxRates', () => {
+    it('ignores deleted customers or with no country or no subscriptions', async () => {
+      let customer = deepCopy(customer1);
+      customer.deleted = true;
+      const paymentMethod = deepCopy(paymentMethodAttach);
+      const result = await stripeHelper.updateCustomerPaymentMethodTaxRates(
+        customer,
+        paymentMethod
+      );
+      assert.deepEqual(result, undefined);
+      customer = deepCopy(customer1);
+      customer.subscriptions = undefined;
+      const result2 = await stripeHelper.updateCustomerPaymentMethodTaxRates(
+        customer,
+        paymentMethod
+      );
+      assert.deepEqual(result2, undefined);
+    });
+
+    it('updates the subscription tax rates from one rate to a different one', async () => {
+      const customer = deepCopy(customer1);
+      const paymentMethod = deepCopy(paymentMethodAttach);
+      sinon.stub(stripeHelper.stripe.subscriptions, 'update').resolves({});
+      const result = await stripeHelper.updateCustomerPaymentMethodTaxRates(
+        customer,
+        paymentMethod
+      );
+      assert.deepEqual(result, [{}]);
+      assert(stripeHelper.stripe.subscriptions.update.calledOnce);
+    });
+  });
+
   describe('allPlans', () => {
     it('pulls a list of plans and caches it', async () => {
       assert.lengthOf(await stripeHelper.allPlans(), 3);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -42,6 +42,7 @@ const eventPlanUpdated = require('../../payments/fixtures/stripe/plan_updated_ev
 const eventCreditNoteCreated = require('../../payments/fixtures/stripe/event_credit_note_created.json');
 const eventTaxRateCreated = require('../../payments/fixtures/stripe/event_tax_rate_created.json');
 const eventTaxRateUpdated = require('../../payments/fixtures/stripe/event_tax_rate_created.json');
+const eventPaymentMethodUpdated = require('../../payments/fixtures/stripe/event_payment_method_updated.json');
 const { default: Container } = require('typedi');
 const { PayPalHelper } = require('../../../../lib/payments/paypal');
 const { CapabilityService } = require('../../../../lib/payments/capability');
@@ -173,6 +174,7 @@ describe('StripeWebhookHandler', () => {
         'handleSubscriptionDeletedEvent',
         'handleCustomerUpdatedEvent',
         'handleCustomerSourceExpiringEvent',
+        'handlePaymentMethodUpdated',
         'handleProductWebhookEvent',
         'handlePlanCreatedOrUpdatedEvent',
         'handlePlanDeletedEvent',
@@ -350,6 +352,13 @@ describe('StripeWebhookHandler', () => {
         itOnlyCallsThisHandler(
           'handleCustomerSourceExpiringEvent',
           eventCustomerSourceExpiring
+        );
+      });
+
+      describe('when the event.type is payment_method.updated', () => {
+        itOnlyCallsThisHandler(
+          'handlePaymentMethodUpdated',
+          eventPaymentMethodUpdated
         );
       });
 
@@ -1020,6 +1029,47 @@ describe('StripeWebhookHandler', () => {
         assert.calledWith(
           StripeWebhookHandlerInstance.stripeHelper.finalizeInvoice,
           invoiceCreatedEvent.data.object
+        );
+      });
+    });
+
+    describe('handlePaymentMethodUpdated', () => {
+      it('returns with no customer', async () => {
+        const paymentMethodUpdatedEvent = deepCopy(eventPaymentMethodUpdated);
+        paymentMethodUpdatedEvent.data.object.customer = null;
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.resolves();
+        const result =
+          await StripeWebhookHandlerInstance.handlePaymentMethodUpdated(
+            {},
+            paymentMethodUpdatedEvent
+          );
+        assert.isUndefined(result);
+        assert.notCalled(
+          StripeWebhookHandlerInstance.stripeHelper.expandResource
+        );
+      });
+
+      it('updates tax rates', async () => {
+        const paymentMethodUpdatedEvent = deepCopy(eventPaymentMethodUpdated);
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.resolves(
+          customerFixture
+        );
+        StripeWebhookHandlerInstance.stripeHelper.updateCustomerPaymentMethodTaxRates.resolves();
+        const result =
+          await StripeWebhookHandlerInstance.handlePaymentMethodUpdated(
+            {},
+            paymentMethodUpdatedEvent
+          );
+        assert.equal(result, undefined);
+        assert.calledWith(
+          StripeWebhookHandlerInstance.stripeHelper.expandResource,
+          paymentMethodUpdatedEvent.data.object.customer,
+          CUSTOMER_RESOURCE
+        );
+        assert.calledWith(
+          StripeWebhookHandlerInstance.stripeHelper
+            .updateCustomerPaymentMethodTaxRates,
+          customerFixture
         );
       });
     });


### PR DESCRIPTION
Because:

* We want to properly reflect the VAT if the customer change countries
  within a tax region.

This commit:

* Updates the subscription tax rates based on the payment method country
  when a payment method update webhook event occurs.

Closes #11881

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
