### PR TITLE
fix(emails): remove more "download" language from emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/en.ftl
@@ -7,7 +7,7 @@ subscriptionFirstInvoice-title = Thank you for subscribing to { $productName }
 subscriptionFirstInvoice-content-processing = Your payment is currently processing and may take up to four business days to complete.
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionFirstInvoice-content-install = You will receive a separate email with download instructions on how to start using { $productName }.
+subscriptionFirstInvoice-content-install-2 = You will receive a separate email on how to start using { $productName }.
 subscriptionFirstInvoice-content-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.
 # Variables:
 #  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
@@ -17,8 +17,8 @@
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionFirstInvoice-content-install" data-l10n-args="<%= JSON.stringify({productName}) %>">
-        You will receive a separate email with download instructions on how to start using <%- productName %>.
+      <span data-l10n-id="subscriptionFirstInvoice-content-install-2" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        You will receive a separate email on how to start using <%- productName %>.
       </span>
     </mj-text>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
@@ -4,7 +4,7 @@ subscriptionFirstInvoice-title = "Thank you for subscribing to <%- productName%>
 
 subscriptionFirstInvoice-content-processing = "Your payment is currently processing and may take up to four business days to complete."
 
-subscriptionFirstInvoice-content-install = "You will receive a separate email with download instructions on how to start using <%- productName %>."
+subscriptionFirstInvoice-content-install-2 = "You will receive a separate email on how to start using <%- productName %>."
 
 subscriptionFirstInvoice-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
@@ -7,7 +7,7 @@ subscriptionFirstInvoiceDiscount-title = Thank you for subscribing to { $product
 subscriptionFirstInvoiceDiscount-content-processing = Your payment is currently processing and may take up to four business days to complete.
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionFirstInvoiceDiscount-content-install = You will receive a separate email with download instructions on how to start using { $productName }.
+subscriptionFirstInvoiceDiscount-content-install-2 = You will receive a separate email on how to start using { $productName }.
 subscriptionFirstInvoiceDiscount-content-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.
 # Variables:
 #  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
@@ -23,11 +23,11 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
 
     <mj-text css-class="text-body">
       <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-install"
+        data-l10n-id="subscriptionFirstInvoiceDiscount-content-install-2"
         data-l10n-args="<%= JSON.stringify({productName}) %>"
       >
-        You will receive a separate email with download instructions on how to
-        start using <%- productName %>.
+        You will receive a separate email on how to start using <%- productName
+        %>.
       </span>
     </mj-text>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
@@ -4,7 +4,7 @@ subscriptionFirstInvoiceDiscount-title = "Thank you for subscribing to <%- produ
 
 subscriptionFirstInvoiceDiscount-content-processing = "Your payment is currently processing and may take up to four business days to complete."
 
-subscriptionFirstInvoiceDiscount-content-install = "You will receive a separate email with download instructions on how to start using <%- productName %>."
+subscriptionFirstInvoiceDiscount-content-install-2 = "You will receive a separate email on how to start using <%- productName %>."
 
 subscriptionFirstInvoiceDiscount-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
 


### PR DESCRIPTION
Because:
 - some products do not require downloading software

This commit:
 - remove mention of download instructions from first invoice emails

## Issue that this pull request solves

Closes: #12215
