### PR TITLE
feat(auth): Add third party auth metrics

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -95,6 +95,7 @@ $(document).ready(function () {
       let currencyMappedURL = $(this).attr('href');
 
       if (data) {
+        flowData = data;
         const additionalParams =
           'service=dcdb5ae7add825d2&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing';
         currencyMappedURL = `${currencyMappedURL}&${additionalParams}&flow_id=${data.flowId}&flow_begin_time=${data.flowBeginTime}&device_id=${data.deviceId}`;
@@ -212,6 +213,13 @@ $(document).ready(function () {
       Object.keys(params).forEach((key) => {
         currentParams.set(key, params[key]);
       });
+
+      if (flowData) {
+        currentParams.set('flow_id', flowData.flowId);
+        currentParams.set('flow_begin_time', flowData.flowBeginTime);
+        currentParams.set('device_id', flowData.deviceId);
+      }
+      
       window.location.href = `/api/${endpoint}?${currentParams.toString()}`;
     }
 

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -486,7 +486,8 @@ export default class AuthClient {
 
   async verifyAccountThirdParty(
     code: string,
-    provider: AUTH_PROVIDER = AUTH_PROVIDER.GOOGLE
+    provider: AUTH_PROVIDER = AUTH_PROVIDER.GOOGLE,
+    metricsContext: MetricsContext = {}
   ): Promise<{
     uid: hexstring;
     sessionToken: hexstring;
@@ -495,6 +496,7 @@ export default class AuthClient {
     const payload = {
       code,
       provider,
+      metricsContext
     };
     return await this.request('POST', '/linked_account/login', payload);
   }

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -10,6 +10,7 @@ import * as random from '../crypto/random';
 import validators from './validators';
 import jwtDecode from 'jwt-decode';
 import { Provider } from 'fxa-shared/db/models/auth/linked-account';
+const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
 const error = require('../error');
 
@@ -156,6 +157,10 @@ export class LinkedAccountHandler {
           accountRecord,
           emailOptions
         );
+        request.setMetricsFlowCompleteSignal('account.login', 'login');
+        await request.emitMetricsEvent('account.login', {
+          uid: accountRecord.uid,
+        });
       } catch (err) {
         this.log.trace(
           'Account.login.sendPostAddLinkedAccountNotification.error',
@@ -188,10 +193,21 @@ export class LinkedAccountHandler {
           locale: request.app.acceptLanguage,
         });
         await this.db.createLinkedAccount(accountRecord.uid, userid, provider);
+        // Currently, we treat accounts created from a linked account as a new
+        // registration and emit the correspond event. Note that depending on
+        // where might not be a top of funnel for this completion event.
+        request.setMetricsFlowCompleteSignal('account.verified', 'registration');
+        await request.emitMetricsEvent('account.verified', {
+          uid: accountRecord.uid,
+        });
       }
     } else {
       // This is an existing user and existing FxA user
       accountRecord = await this.db.account(linkedAccountRecord.uid);
+      request.setMetricsFlowCompleteSignal('account.login', 'login');
+      await request.emitMetricsEvent('account.login', {
+        uid: accountRecord.uid,
+      });
     }
 
     const sessionTokenOptions = {
@@ -245,6 +261,7 @@ export const linkedAccountRoutes = (
             idToken: validators.thirdPartyIdToken,
             provider: validators.thirdPartyProvider,
             code: validators.thirdPartyOAuthCode,
+            metricsContext: METRICS_CONTEXT_SCHEMA,
           },
         },
       },

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1433,9 +1433,9 @@ FxaClientWrapper.prototype = {
     });
   }),
 
-  verifyAccountThirdParty: withClient((client, relier, token, provider) => {
+  verifyAccountThirdParty: withClient((client, relier, token, provider, metricsContext) => {
     return client
-      .verifyAccountThirdParty(token, provider)
+      .verifyAccountThirdParty(token, provider, metricsContext)
       .then((accountData) => {
         return getUpdatedSessionData(accountData.email, relier, accountData);
       });

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1186,7 +1186,7 @@ const Account = Backbone.Model.extend(
 
     verifyAccountThirdParty(relier, code, provider) {
       return this._fxaClient
-        .verifyAccountThirdParty(relier, code, provider)
+        .verifyAccountThirdParty(relier, code, provider, this._metrics.getFlowEventMetadata())
         .then(this.set.bind(this));
     },
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -6,15 +6,22 @@ import SigninMixin from './signin-mixin';
 import Storage from '../../lib/storage';
 import Url from '../../lib/url';
 import ThirdPartyAuthExperimentMixin from '../../views/mixins/third-party-auth-experiment-mixin';
+import FlowEventsMixin from '../mixins/flow-events-mixin';
 
 const DEFAULT_SCOPES = 'openid email profile';
 
 export default {
-  dependsOn: [SigninMixin, ThirdPartyAuthExperimentMixin],
+  dependsOn: [SigninMixin, ThirdPartyAuthExperimentMixin, FlowEventsMixin],
 
   events: {
     'click #google-login-button': 'googleSignIn',
     'click #apple-login-button': 'appleSignIn',
+  },
+
+  initialize() {
+    // Flow events need to be initialized before the navigation
+    // so the flow_id and flow_begin_time are propagated
+    this.initializeFlowEvents();
   },
 
   setInitialContext(context) {
@@ -25,14 +32,16 @@ export default {
 
   beforeRender() {
     // Check to see if this is a request to deeplink into Google/Apple login
-    // flow. We do a promise we want to keep our loading indicator on while
+    // flow. A bit of a hack but we do a promise to keep our loading indicator on while
     // page navigates to third party auth flow.
     const params = new URLSearchParams(this.window.location.search);
     if (params.get('deeplink') === 'googleLogin') {
+      this.logFlowEvent('google.deeplink');
       return new Promise(()=> {
         this.googleSignIn();
       });
     } else if (params.get('deeplink') === 'appleLogin') {
+      this.logFlowEvent('apple.deeplink');
       return new Promise(()=> {
         this.appleSignIn();
       });
@@ -47,6 +56,8 @@ export default {
     if (thirdPartyAuth) {
       return this.completeSignIn();
     }
+
+    this.logViewEvent('thirdPartyAuth');
   },
 
   clearStoredParams() {
@@ -57,6 +68,8 @@ export default {
 
   googleSignIn() {
     this.clearStoredParams();
+
+    this.logFlowEvent('google.oauth-start');
 
     // We stash originating location in the Google state oauth param
     // because we will need it to use it to log the user into FxA
@@ -99,6 +112,8 @@ export default {
 
   appleSignIn() {
     this.clearStoredParams();
+
+    this.logFlowEvent('apple.oauth-start');
 
     const currentParams = new URLSearchParams(this.window.location.search);
     currentParams.delete("deeplink");
@@ -151,7 +166,7 @@ export default {
     this.navigateAway(redirectUrl);
   },
 
-  completeSignIn() {
+  async completeSignIn() {
     const account = this.getSignedInAccount();
     const authParams = Storage.factory('localStorage', this.window).get(
       'fxa_third_party_params'
@@ -163,6 +178,9 @@ export default {
       .verifyAccountThirdParty(account, this.relier, code, provider)
       .then((updatedAccount) => {
         this.clearStoredParams();
+
+        this.logFlowEvent(`${provider}.signin-complete`);
+
         return this.signIn(updatedAccount);
       })
       .catch(() => {

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -18,7 +18,6 @@ import SignInMixin from './mixins/signin-mixin';
 import Template from 'templates/sign_in_password.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
-import ThirdPartyAuthMixin from './mixins/third-party-auth-mixin';
 
 const SignInPasswordView = FormView.extend({
   template: Template,
@@ -95,7 +94,6 @@ Cocktail.mixin(
   SignInMixin,
   SignedInNotificationMixin,
   UserCardMixin,
-  ThirdPartyAuthMixin,
   PocketMigrationMixin,
 );
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
@@ -44,6 +44,11 @@ describe('views/mixins/third-party-auth-mixin', function () {
         redirectUri: 'http://redirect.com',
         authorizationEndpoint: 'http://example.com',
       },
+      appleAuthConfig: {
+        clientId: 'MOCK_CLIENT_ID',
+        redirectUri: 'http://redirect.com',
+        authorizationEndpoint: 'http://example.com',
+      },
     };
 
     mockForm = document.createElement('form');
@@ -66,19 +71,50 @@ describe('views/mixins/third-party-auth-mixin', function () {
       window: windowMock,
       user,
     });
-
+    sinon.spy(notifier, 'trigger');
     await view.render();
   });
 
-  it('beforeRender', () => {
-    sinon.stub(view, 'completeSignIn');
-    Storage.factory('localStorage', windowMock).set(
-      'fxa_third_party_params',
-      'some params'
-    );
+  describe('beforeRender', () => {
+    beforeEach(() => {
+      sinon.spy(view, 'logViewEvent');
+      sinon.spy(view, 'logFlowEvent');
+      sinon.stub(view, 'completeSignIn');
+      sinon.stub(view, 'appleSignIn');
+      sinon.stub(view, 'googleSignIn');
+    });
+    
+    it('no deeplink', () => {
+      view.beforeRender();
+      assert.isTrue(view.logViewEvent.calledOnceWith('thirdPartyAuth'));
+    });
 
-    view.beforeRender();
-    assert.isTrue(view.completeSignIn.calledOnce);
+    it('with third party auth set', () => {
+      Storage.factory('localStorage', windowMock).set(
+        'fxa_third_party_params',
+        'some params'
+      );
+      view.beforeRender();
+      assert.isTrue(view.completeSignIn.calledOnce);
+      assert.isTrue(notifier.trigger.calledOnce);
+      assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
+      assert.isFalse(view.logViewEvent.called);
+    });
+    
+    
+    it('google login deeplink', () => {
+      windowMock.location.search = '?deeplink=googleLogin';
+      view.beforeRender();
+      assert.isTrue(view.googleSignIn.calledOnce);
+      assert.isTrue(view.logFlowEvent.calledOnceWith('google.deeplink'));
+    });
+
+    it('apple login deeplink', () => {
+      windowMock.location.search = '?deeplink=appleLogin';
+      view.beforeRender();
+      assert.isTrue(view.appleSignIn.calledOnce);
+      assert.isTrue(view.logFlowEvent.calledOnceWith('apple.deeplink'));
+    });
   });
 
   it('clearStoredParams', () => {
@@ -86,10 +122,14 @@ describe('views/mixins/third-party-auth-mixin', function () {
     assert.isUndefined(windowMock.localStorage.get('fxa_third_party_params'));
   });
 
-  it('googleSignIn', async () => {
-    windowMock.location.href = 'http://127.0.0.1:3030/?orignal_oauth_params';
+  it('googleSignIn', () => {
+    sinon.spy(view, 'logFlowEvent');
+
+    windowMock.location.href = 'http://127.0.0.1:3030/?original_oauth_params';
 
     view.googleSignIn();
+
+    assert.isTrue(view.logFlowEvent.calledWith('google.oauth-start'));
 
     assert.isTrue(mockForm.setAttribute.calledWith('method', 'GET'));
     assert.isTrue(
@@ -121,6 +161,46 @@ describe('views/mixins/third-party-auth-mixin', function () {
     assert.isTrue(mockForm.submit.calledOnce);
   });
 
+  it('appleSignIn', () => {
+    sinon.spy(view, 'logFlowEvent');
+
+    windowMock.location.href = 'http://127.0.0.1:3030/?original_oauth_params';
+
+    view.appleSignIn();
+
+    assert.isTrue(view.logFlowEvent.calledWith('apple.oauth-start'));
+
+    assert.isTrue(mockForm.setAttribute.calledWith('method', 'GET'));
+    assert.isTrue(
+      mockForm.setAttribute.calledWith(
+        'action',
+        config.appleAuthConfig.authorizationEndpoint
+      )
+    );
+
+    assert.equal(mockInput.setAttribute.args.length, 24);
+
+    assertInputEl(mockInput, 'client_id', config.appleAuthConfig.clientId);
+    assertInputEl(mockInput, 'scope', 'email');
+    assertInputEl(
+      mockInput,
+      'redirect_uri',
+      config.appleAuthConfig.redirectUri
+    );
+    assertInputEl(
+      mockInput,
+      'state',
+      encodeURIComponent(`${windowMock.location.origin}${windowMock.location.pathname}?`)
+    );
+    assertInputEl(mockInput, 'access_type', 'offline');
+    assertInputEl(mockInput, 'prompt', 'consent');
+    assertInputEl(mockInput, 'response_type', 'code id_token');
+    assertInputEl(mockInput, 'response_mode', 'form_post');
+
+    assert.equal(mockForm.appendChild.args.length, 8);
+    assert.isTrue(mockForm.submit.calledOnce);
+  });
+  
   it('handleOauthResponse', () => {
     windowMock.location.search = '?state=localhost';
     sinon.stub(view, 'navigateAway');
@@ -135,6 +215,8 @@ describe('views/mixins/third-party-auth-mixin', function () {
     sinon.stub(view, 'signIn').callsFake(() => {});
     sinon.stub(view, 'getSignedInAccount').callsFake(() => {});
     sinon.spy(view, 'clearStoredParams');
+    sinon.spy(view, 'logFlowEvent');
+
     Storage.factory('localStorage', windowMock).set('fxa_third_party_params', {
       code: '123',
     });
@@ -146,5 +228,6 @@ describe('views/mixins/third-party-auth-mixin', function () {
     );
     assert.isTrue(view.clearStoredParams.calledOnce);
     assert.isTrue(view.signIn.calledOnceWith(undefined));
+    assert.isTrue(view.logFlowEvent.calledWith('google.signin-complete'));
   });
 });

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -256,6 +256,10 @@ const EVENTS = {
     group: GROUPS.qrConnectDevice,
     event: 'connected_done',
   },
+  'enter-email.thirdPartyAuth': {
+    group: GROUPS.thirdPartyAuth,
+    event: 'view',
+  },
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
@@ -453,6 +457,15 @@ const FUZZY_EVENTS = new Map([
     {
       group: GROUPS.registration,
       event: 'domain_validation_result',
+    },
+  ],
+  [
+    /^flow\.?(apple|google)?\.(deeplink|oauth-start|oauth-complete|signin-complete)$/,
+    {
+      group: GROUPS.thirdPartyAuth,
+      event: (eventCategory, eventTarget) => {
+       return `${eventCategory.replace(/-/g, '_')}_${eventTarget.replace(/-/g, '_')}`
+      }
     },
   ],
 ]);

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -34,6 +34,7 @@ const GROUPS = {
   subPayUpgrade: 'fxa_pay_upgrade',
   subSupport: 'fxa_subscribe_support',
   subCoupon: 'fxa_subscribe_coupon',
+  thirdPartyAuth: 'fxa_third_party_auth',
   qrConnectDevice: 'fxa_qr_connect_device',
 };
 
@@ -68,6 +69,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.subSupport]: NOP,
   [GROUPS.subCoupon]: NOP,
   [GROUPS.qrConnectDevice]: NOP,
+  [GROUPS.thirdPartyAuth]: NOP,
 };
 
 function NOP() {}


### PR DESCRIPTION
## Because

- We need to define these metrics and call out any issues
-  The events that are emitted are defined in https://docs.google.com/document/d/1fTEduCVtuPXorsi9AIc9_GL-bYTN67UepJhku2eahHI/edit# along with the corresponding screens

## This pull request

- Adds basic amount of metrics for the third party auth login flow

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12223

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
