### PR TITLE
fix(content): fix validation tests

### DIFF
--- a/packages/fxa-content-server/tests/server/validation.js
+++ b/packages/fxa-content-server/tests/server/validation.js
@@ -10,7 +10,7 @@ const request = require('request-promise');
 const validation = require('../../server/lib/validation');
 
 const METRICS_DOCS_URL =
-  'https://raw.githubusercontent.com/mozilla/ecosystem-platform/master/docs/relying-parties/metrics-for-relying-parties.md';
+  'https://raw.githubusercontent.com/mozilla/ecosystem-platform/master/docs/relying-parties/reference/metrics-for-relying-parties.md';
 const UTM_REGEX = validation.TYPES.UTM._tests[1].arg.pattern;
 const REGEXES = new Map([
   ['entrypoint', validation.PATTERNS.ENTRYPOINT],


### PR DESCRIPTION
## Because

- The documentation URL for metrics for relying parties changed, causing
  the content-server validation tests to fail

## This pull request

- Updates the URL in the test to the new URL.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
