### PR TITLE
fix(graphql): Fixes formatting on codegen file.

### DIFF
--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -1,3 +1,4 @@
+
 /*
  * -------------------------------------------------------
  * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
@@ -7,134 +8,134 @@
 /* tslint:disable */
 /* eslint-disable */
 export enum BounceType {
-  unmapped = 'unmapped',
-  Permanent = 'Permanent',
-  Transient = 'Transient',
-  Complaint = 'Complaint',
+    unmapped = "unmapped",
+    Permanent = "Permanent",
+    Transient = "Transient",
+    Complaint = "Complaint"
 }
 
 export enum BounceSubType {
-  unmapped = 'unmapped',
-  Undetermined = 'Undetermined',
-  General = 'General',
-  NoEmail = 'NoEmail',
-  Suppressed = 'Suppressed',
-  MailboxFull = 'MailboxFull',
-  MessageTooLarge = 'MessageTooLarge',
-  ContentRejected = 'ContentRejected',
-  AttachmentRejected = 'AttachmentRejected',
-  Abuse = 'Abuse',
-  AuthFailure = 'AuthFailure',
-  Fraud = 'Fraud',
-  NotSpam = 'NotSpam',
-  Other = 'Other',
-  Virus = 'Virus',
+    unmapped = "unmapped",
+    Undetermined = "Undetermined",
+    General = "General",
+    NoEmail = "NoEmail",
+    Suppressed = "Suppressed",
+    MailboxFull = "MailboxFull",
+    MessageTooLarge = "MessageTooLarge",
+    ContentRejected = "ContentRejected",
+    AttachmentRejected = "AttachmentRejected",
+    Abuse = "Abuse",
+    AuthFailure = "AuthFailure",
+    Fraud = "Fraud",
+    NotSpam = "NotSpam",
+    Other = "Other",
+    Virus = "Virus"
 }
 
 export enum ProviderId {
-  unmapped = 'unmapped',
-  GOOGLE = 'GOOGLE',
-  APPLE = 'APPLE',
+    unmapped = "unmapped",
+    GOOGLE = "GOOGLE",
+    APPLE = "APPLE"
 }
 
 export interface Location {
-  city?: Nullable<string>;
-  country?: Nullable<string>;
-  countryCode?: Nullable<string>;
-  state?: Nullable<string>;
-  stateCode?: Nullable<string>;
+    city?: Nullable<string>;
+    country?: Nullable<string>;
+    countryCode?: Nullable<string>;
+    state?: Nullable<string>;
+    stateCode?: Nullable<string>;
 }
 
 export interface AttachedClient {
-  clientId?: Nullable<string>;
-  deviceId?: Nullable<string>;
-  sessionTokenId?: Nullable<string>;
-  refreshTokenId?: Nullable<string>;
-  isCurrentSession?: Nullable<boolean>;
-  deviceType?: Nullable<string>;
-  name?: Nullable<string>;
-  scope?: Nullable<string[]>;
-  location?: Nullable<Location>;
-  userAgent?: Nullable<string>;
-  os?: Nullable<string>;
-  createdTime?: Nullable<number>;
-  createdTimeFormatted?: Nullable<string>;
-  lastAccessTime?: Nullable<number>;
-  lastAccessTimeFormatted?: Nullable<string>;
-  approximateLastAccessTime?: Nullable<number>;
-  approximateLastAccessTimeFormatted?: Nullable<string>;
+    clientId?: Nullable<string>;
+    deviceId?: Nullable<string>;
+    sessionTokenId?: Nullable<string>;
+    refreshTokenId?: Nullable<string>;
+    isCurrentSession?: Nullable<boolean>;
+    deviceType?: Nullable<string>;
+    name?: Nullable<string>;
+    scope?: Nullable<string[]>;
+    location?: Nullable<Location>;
+    userAgent?: Nullable<string>;
+    os?: Nullable<string>;
+    createdTime?: Nullable<number>;
+    createdTimeFormatted?: Nullable<string>;
+    lastAccessTime?: Nullable<number>;
+    lastAccessTimeFormatted?: Nullable<string>;
+    approximateLastAccessTime?: Nullable<number>;
+    approximateLastAccessTimeFormatted?: Nullable<string>;
 }
 
 export interface EmailBounce {
-  email: string;
-  templateName: string;
-  bounceType: BounceType;
-  bounceSubType: BounceSubType;
-  createdAt: number;
+    email: string;
+    templateName: string;
+    bounceType: BounceType;
+    bounceSubType: BounceSubType;
+    createdAt: number;
 }
 
 export interface Email {
-  email: string;
-  isVerified: boolean;
-  isPrimary: boolean;
-  createdAt: number;
+    email: string;
+    isVerified: boolean;
+    isPrimary: boolean;
+    createdAt: number;
 }
 
 export interface RecoveryKeys {
-  createdAt?: Nullable<number>;
-  verifiedAt?: Nullable<number>;
-  enabled?: Nullable<boolean>;
+    createdAt?: Nullable<number>;
+    verifiedAt?: Nullable<number>;
+    enabled?: Nullable<boolean>;
 }
 
 export interface SecurityEvents {
-  uid?: Nullable<string>;
-  nameId?: Nullable<number>;
-  verified?: Nullable<boolean>;
-  ipAddrHmac?: Nullable<string>;
-  createdAt?: Nullable<number>;
-  tokenVerificationId?: Nullable<string>;
-  name?: Nullable<string>;
+    uid?: Nullable<string>;
+    nameId?: Nullable<number>;
+    verified?: Nullable<boolean>;
+    ipAddrHmac?: Nullable<string>;
+    createdAt?: Nullable<number>;
+    tokenVerificationId?: Nullable<string>;
+    name?: Nullable<string>;
 }
 
 export interface Totp {
-  verified: boolean;
-  createdAt: number;
-  enabled: boolean;
+    verified: boolean;
+    createdAt: number;
+    enabled: boolean;
 }
 
 export interface LinkedAccount {
-  uid: string;
-  authAt: number;
-  providerId: ProviderId;
-  enabled: boolean;
+    uid: string;
+    authAt: number;
+    providerId: ProviderId;
+    enabled: boolean;
 }
 
 export interface Account {
-  uid: string;
-  email: string;
-  emailVerified: boolean;
-  createdAt: number;
-  disabledAt?: Nullable<number>;
-  emails?: Nullable<Email[]>;
-  emailBounces?: Nullable<EmailBounce[]>;
-  totp?: Nullable<Totp[]>;
-  recoveryKeys?: Nullable<RecoveryKeys[]>;
-  securityEvents?: Nullable<SecurityEvents[]>;
-  attachedClients?: Nullable<AttachedClient[]>;
-  linkedAccounts?: Nullable<LinkedAccount[]>;
+    uid: string;
+    email: string;
+    emailVerified: boolean;
+    createdAt: number;
+    disabledAt?: Nullable<number>;
+    emails?: Nullable<Email[]>;
+    emailBounces?: Nullable<EmailBounce[]>;
+    totp?: Nullable<Totp[]>;
+    recoveryKeys?: Nullable<RecoveryKeys[]>;
+    securityEvents?: Nullable<SecurityEvents[]>;
+    attachedClients?: Nullable<AttachedClient[]>;
+    linkedAccounts?: Nullable<LinkedAccount[]>;
 }
 
 export interface IQuery {
-  accountByUid(uid: string): Nullable<Account> | Promise<Nullable<Account>>;
-  accountByEmail(email: string): Nullable<Account> | Promise<Nullable<Account>>;
-  getEmailsLike(search: string): Nullable<Email[]> | Promise<Nullable<Email[]>>;
+    accountByUid(uid: string): Nullable<Account> | Promise<Nullable<Account>>;
+    accountByEmail(email: string): Nullable<Account> | Promise<Nullable<Account>>;
+    getEmailsLike(search: string): Nullable<Email[]> | Promise<Nullable<Email[]>>;
 }
 
 export interface IMutation {
-  unverifyEmail(email: string): boolean | Promise<boolean>;
-  disableAccount(uid: string): boolean | Promise<boolean>;
-  unlinkAccount(uid: string): boolean | Promise<boolean>;
-  clearEmailBounce(email: string): boolean | Promise<boolean>;
+    unverifyEmail(email: string): boolean | Promise<boolean>;
+    disableAccount(uid: string): boolean | Promise<boolean>;
+    unlinkAccount(uid: string): boolean | Promise<boolean>;
+    clearEmailBounce(email: string): boolean | Promise<boolean>;
 }
 
 type Nullable<T> = T | null;


### PR DESCRIPTION
## Because

- A previous merge inadvertently reverted the generated code's formatting.

## This pull request

- Restores original formatting.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is mostly annoyance. When the graphql api starts up, it will generate this file. Previously, prettier formatting was applied to this file which changed the white space and quote characters. As a result, every time the graphql api was run locally, this file would end up showing changes in git. This fix undoes the prettier formatting and goes with the default code gen formatting, which fixes the issue. The file was prettier ignored in a previous PR, so this has already been taken care.
