### PR TITLE
feat(auth): add firestore stripe populator

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -27,6 +27,7 @@
     "gen-keys": "node -r esbuild-register ./scripts/gen_keys.js; node -r esbuild-register ./scripts/oauth_gen_keys.js; node -r esbuild-register ./scripts/gen_vapid_keys.js",
     "write-emails": "yarn emails-scss && node -r esbuild-register ./scripts/write-emails-to-disk.js",
     "clean-up-old-ci-stripe-customers": "node -r esbuild-register ./scripts/clean-up-old-ci-stripe-customers.js --limit 1000",
+    "populate-firestore-customers": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/populate-firestore-customers.ts",
     "populate-vat-taxes": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/populate-vat-taxes.ts",
     "paypal-processor": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/paypal-processor.ts",
     "subscription-reminders": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/subscription-reminders.ts",

--- a/packages/fxa-auth-server/scripts/populate-firestore-customers.ts
+++ b/packages/fxa-auth-server/scripts/populate-firestore-customers.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+import { setupAuthDatabase } from 'fxa-shared/db';
+
+import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+import { FirestorePopulator } from './populate-firestore-customers/firestore-populator';
+
+const pckg = require('../package.json');
+
+export async function init() {
+  const config = require('../config').getProperties();
+
+  program
+    .version(pckg.version)
+    .option('-c, --config [config]', 'Configuration to use. Ex. dev')
+    .option(
+      '-r, --rate-limit [requestsPerSecond]',
+      'Stripe rate limit. Defaults to 10 requests per second.',
+      '10'
+    )
+    .parse(process.argv);
+
+  const options = program.opts();
+  const rateLimit = parseInt(options.rateLimit);
+  process.env.NODE_ENV = options.config || 'dev';
+  const { log, stripeHelper } = await setupProcessingTaskObjects(
+    'populate-firestore-customers'
+  );
+
+  setupAuthDatabase(config.database.mysql.auth);
+  const firestorePopulator = new FirestorePopulator(
+    log,
+    stripeHelper,
+    rateLimit
+  );
+
+  await firestorePopulator.populate();
+
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/scripts/populate-firestore-customers/firestore-populator.ts
+++ b/packages/fxa-auth-server/scripts/populate-firestore-customers/firestore-populator.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { accountExists } from 'fxa-shared/db/models/auth';
+import { Stripe } from 'stripe';
+
+import { StripeHelper } from '../../lib/payments/stripe';
+import { StripeFirestore } from '../../lib/payments/stripe-firestore';
+import { RateLimitObserver } from './rate-limit-observer';
+
+export class FirestorePopulator {
+  rateLimitObserver: RateLimitObserver;
+  stripe: Stripe;
+
+  constructor(
+    private log: any,
+    private stripeHelper: StripeHelper,
+    rateLimit: number
+  ) {
+    this.stripe = this.stripeHelper.stripe as Stripe;
+    // Hook up the rate limit observer
+    this.rateLimitObserver = new RateLimitObserver(rateLimit);
+    this.stripe.on('request', (request) => this.rateLimitObserver.increment());
+  }
+
+  public async populate() {
+    const stripeFirestore = (this.stripeHelper as any)
+      .stripeFirestore as StripeFirestore;
+
+    for await (const stripeUser of this.stripe.customers.list({ limit: 100 })) {
+      // Skip deleted users or without a userid
+      if (stripeUser.deleted || !stripeUser.metadata.userid) {
+        continue;
+      }
+
+      // Verify the user is in our fxa database
+      const uid = stripeUser.metadata.userid;
+      const exists = await accountExists(uid);
+      if (!exists) {
+        this.log.warn('Stripe user not found in fxa database', { uid });
+        continue;
+      }
+
+      // Ensure the firestore record is loaded, this inserts subscriptions
+      // as well.
+      // Note that we don't use expandResource as that makes an additional
+      // firestore call to fetch subscriptions which is not needed here.
+      await stripeFirestore.retrieveAndFetchCustomer(stripeUser.id);
+
+      // Wait for the next customer to be processed based on rate limiting
+      await this.rateLimitObserver.pause();
+    }
+  }
+}

--- a/packages/fxa-auth-server/scripts/populate-firestore-customers/rate-limit-observer.ts
+++ b/packages/fxa-auth-server/scripts/populate-firestore-customers/rate-limit-observer.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { setTimeout } from 'timers/promises';
+
+export class RateLimitObserver {
+  rateCount: Record<number, number> = {};
+
+  constructor(private readonly rateLimit: number) {}
+
+  /** Increment the current rate count */
+  public increment() {
+    const now = Math.floor(Date.now() / 1000);
+    if (!this.rateCount[now]) {
+      this.rateCount[now] = 0;
+    }
+    this.rateCount[now]++;
+  }
+
+  /**
+   * Pauses for as long as necessary to respect the rate limit.
+   */
+  public async pause() {
+    const now = Math.floor(Date.now() / 1000);
+    const count = this.rateCount[now] ?? 0;
+    if (count < this.rateLimit) {
+      return;
+    }
+
+    const delay = (now + 1) * 1000 - Date.now();
+    if (delay > 0) {
+      await setTimeout(delay);
+    }
+
+    // Reset the rate count
+    this.rateCount = {};
+  }
+}


### PR DESCRIPTION
Because:

* We want to backfill all stripe customers that have had a subscription
  into Firestore.

This commit:

* Iterates through all stripe customers as fast as possible that have
  valid firefox accounts to load them into firestore.

Closes #12070

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
