### PR TITLE
maintenance(auth): Remove confusing / unneded config from OauthRedis …

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/redis.js
+++ b/packages/fxa-auth-server/lib/oauth/db/redis.js
@@ -41,10 +41,7 @@ class OAuthRedis extends ConnectedServicesCache {
       redis({
         ...config.get('redis.refreshTokens'),
       }),
-      redis({
-        ...config.get('redis'),
-        ...config.get('redis.refreshTokens'),
-      }),
+      undefined,
       resolveLogger()
     );
   }

--- a/packages/fxa-shared/connected-services/accessors.ts
+++ b/packages/fxa-shared/connected-services/accessors.ts
@@ -49,7 +49,7 @@ export class ConnectedServicesCache {
   constructor(
     protected readonly redisAccessTokens: IAccessTokensCache,
     protected readonly redisRefreshTokens: IRefreshTokensCache,
-    protected readonly redisSessionTokens: ISessionTokensCache,
+    protected readonly redisSessionTokens?: ISessionTokensCache,
     protected readonly log?: ILogger
   ) {}
 


### PR DESCRIPTION
## Because

- During a code audit we noticed that OAuthRedis doesn't rely on the sessionTokenCache
- We also noticed that the wrong config setting was referenced.

## This pull request

- Removes the redis session token instance being provided to the base class of OAuthRedis

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We noticed this during a pairing session. The OAuthRedis instance never actually makes any calls to the session token cache, and furthermore it was misconfigured anyways. This simply removes sessionTokenCache from the OAuthRedis instance. This change essentially has no impact on the behavior of the code, but is more 'correct' now, and should ensure the session token cache isn't invoked inadvertently from an OAuthRedis instance.
