### PR TITLE
feature(admin-panel): Add support for user group spoofing

### DIFF
--- a/packages/fxa-admin-panel/constants/index.ts
+++ b/packages/fxa-admin-panel/constants/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const USER_GROUP_HEADER = 'REMOTE-GROUP';
+export const USER_EMAIL_HEADER = 'oidc-claim-id-token-email';
+export const SERVER_CONFIG_PLACEHOLDER = '__SERVER_CONFIG__';

--- a/packages/fxa-admin-panel/interfaces/index.ts
+++ b/packages/fxa-admin-panel/interfaces/index.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IncomingHttpHeaders } from 'http';
+import { USER_EMAIL_HEADER, USER_GROUP_HEADER } from '../constants';
+
+export interface IPermission {
+  name: string;
+  enabled: boolean;
+}
+
+export interface IUserInfo {
+  group: string;
+  email: string;
+  permissions: Record<string, IPermission>;
+}
+
+export interface IServerInfo {
+  url: string;
+}
+
+export interface IClientConfig {
+  env: string;
+  user: IUserInfo;
+  servers: {
+    admin: IServerInfo;
+  };
+}
+
+export interface IncomingAdminPanelHttpHeaders extends IncomingHttpHeaders {
+  [USER_EMAIL_HEADER]?: string | undefined;
+  [USER_GROUP_HEADER]?: string | undefined;
+}

--- a/packages/fxa-admin-panel/pm2.config.js
+++ b/packages/fxa-admin-panel/pm2.config.js
@@ -23,6 +23,8 @@ module.exports = {
         CONFIG_FILES: '../config/secrets.json',
         PORT: '8091',
         PATH,
+        TEST_USER_EMAIL: 'hello@mozilla.com',
+        TEST_USER_GROUP: 'vpn_fxa_admin_panel_prod',
       },
       filter_env: ['npm_'],
       time: true,

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -18,8 +18,7 @@ const conf = convict({
   },
   proxyStaticResourcesFrom: {
     default: '',
-    doc:
-      'Instead of loading static resources from disk, get them by proxy from this URL (typically a special reloading dev server)',
+    doc: 'Instead of loading static resources from disk, get them by proxy from this URL (typically a special reloading dev server)',
     env: 'PROXY_STATIC_RESOURCES_FROM',
     format: String,
   },
@@ -132,6 +131,20 @@ const conf = convict({
       doc: 'The origin of the static resources',
       env: 'STATIC_RESOURCE_URL',
       format: 'url',
+    },
+  },
+  user: {
+    group: {
+      default: '',
+      doc: 'Group to operate under for dev / test.',
+      env: 'TEST_USER_GROUP',
+      format: String,
+    },
+    email: {
+      default: '',
+      doc: 'Email to operate under for dev / test.',
+      env: 'TEST_USER_EMAIL',
+      format: String,
     },
   },
 });

--- a/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ClientConfig } from '.';
+import { SERVER_CONFIG_PLACEHOLDER } from '../../../constants';
+import { JSDOM } from 'jsdom';
+
+describe('ClientConfig', () => {
+  it('provides default config', () => {
+    const config = ClientConfig.defaultConfig;
+    expect(config).toBeDefined();
+  });
+
+  it('injects into html', () => {
+    const html = `<head><meta name="fxa-config" content="${SERVER_CONFIG_PLACEHOLDER}"/></meta></head>`;
+    const expectedConfig = Object.assign({}, ClientConfig.defaultConfig, {
+      user: { email: 'bar', group: 'foo', permissions: {} },
+    });
+    const injectedHtml = ClientConfig.injectIntoHtml(html, {
+      'REMOTE-GROUP': expectedConfig.user.group,
+      'oidc-claim-id-token-email': expectedConfig.user.email,
+    });
+
+    const injectedVal = JSDOM.fragment(injectedHtml)
+      .querySelector('meta[name="fxa-config"]')
+      ?.getAttribute('content');
+
+    expect(injectedVal).toBeDefined();
+    expect(injectedHtml).not.toEqual(html);
+    expect(JSON.parse(decodeURIComponent(injectedVal || ''))).toEqual(
+      expectedConfig
+    );
+  });
+});

--- a/packages/fxa-admin-panel/server/lib/client-config/index.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import config from '../../config';
+import {
+  IClientConfig,
+  IUserInfo,
+  IncomingAdminPanelHttpHeaders,
+} from '../../../interfaces';
+import {
+  USER_EMAIL_HEADER,
+  USER_GROUP_HEADER,
+  SERVER_CONFIG_PLACEHOLDER,
+} from '../../../constants';
+
+/** Client Config Defaults provided by env */
+const defaultConfig: IClientConfig = {
+  env: config.get('env'),
+  user: {
+    group: config.get('user.group'),
+    email: config.get('user.email'),
+    permissions: {},
+  },
+  servers: {
+    admin: {
+      url: config.get('servers.admin.url'),
+    },
+  },
+};
+
+/** Utility class providing functionality for dealing with generation of client side configuration. */
+export class ClientConfig {
+  static get defaultConfig() {
+    return defaultConfig;
+  }
+
+  /** Adds an encoded config to the provided html. */
+  static injectIntoHtml(html: string, headers: IncomingAdminPanelHttpHeaders) {
+    const config = this.update(defaultConfig, headers);
+    return this.injectMetaContent(html, {
+      [SERVER_CONFIG_PLACEHOLDER]: config,
+    });
+  }
+
+  private static injectMetaContent(
+    html: string,
+    metaContent: { [x: string]: any }
+  ) {
+    let result = html;
+
+    Object.keys(metaContent).forEach((k) => {
+      result = result.replace(
+        k,
+        encodeURIComponent(JSON.stringify(metaContent[k]))
+      );
+    });
+
+    return result;
+  }
+
+  /** Provides a customized config object that takes state of http headers into account. */
+  private static update(
+    baseConfig: IClientConfig,
+    headers: IncomingAdminPanelHttpHeaders
+  ) {
+    const user = this.getUserFromHeader(headers, baseConfig.user);
+    const merged = this.mergeConfig(baseConfig, { user });
+    return merged;
+  }
+
+  private static getUserFromHeader(
+    headers: IncomingAdminPanelHttpHeaders,
+    user: IUserInfo
+  ) {
+    user.email = headers[USER_EMAIL_HEADER] || user.email;
+    user.group = headers[USER_GROUP_HEADER] || user.group;
+    return user;
+  }
+
+  private static mergeConfig(c1: IClientConfig, c2: Partial<IClientConfig>) {
+    return Object.assign({}, c1, c2);
+  }
+}

--- a/packages/fxa-admin-panel/src/App.test.tsx
+++ b/packages/fxa-admin-panel/src/App.test.tsx
@@ -7,6 +7,7 @@ import { render } from '@testing-library/react';
 import App from './App';
 
 it('renders without imploding', () => {
-  const { queryByTestId } = render(<App />);
+  const user = { user: { email: 'test', group: 'test', permissions: {} } };
+  const { queryByTestId } = render(<App {...user} />);
   expect(queryByTestId('app')).toBeInTheDocument();
 });

--- a/packages/fxa-admin-panel/src/App.tsx
+++ b/packages/fxa-admin-panel/src/App.tsx
@@ -6,15 +6,18 @@ import React from 'react';
 import { Route, Routes, BrowserRouter, Navigate } from 'react-router-dom';
 import AppLayout from './components/AppLayout';
 import AccountSearch from './components/AccountSearch';
+import Permissions from './components/Permissions';
 import AdminLogs from './components/AdminLogs';
 import SiteStatus from './components/SiteStatus';
+import { IUserInfo } from '../interfaces';
 
-const App = () => (
+const App = ({ user }: { user: IUserInfo }) => (
   <BrowserRouter>
     <AppLayout>
       <Routes>
         <Route path="/admin-logs" element={<AdminLogs />} />
         <Route path="/site-status" element={<SiteStatus />} />
+        <Route path="/permissions" element={<Permissions {...{ user }} />} />
         <Route path="/account-search" element={<AccountSearch />} />
         <Route path="/" element={<Navigate to="/account-search" />} />
       </Routes>

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -67,7 +67,7 @@ export const LinkedAccount = ({
   providerId: string;
   onCleared: () => void;
 }) => {
-  const [unlinkAccount, {}] = useMutation(UNLINK_ACCOUNT, {
+  const [unlinkAccount] = useMutation(UNLINK_ACCOUNT, {
     onCompleted: () => {
       window.alert('The linked account has been removed.');
     },
@@ -166,18 +166,15 @@ export const DangerZone = ({
     unverify({ variables: { email: email.email } });
   };
 
-  const [disableAccount, { loading: disableLoading }] = useMutation(
-    DISABLE_ACCOUNT,
-    {
-      onCompleted: () => {
-        window.alert('The account has been disabled.');
-        onCleared();
-      },
-      onError: () => {
-        window.alert('Error disabling account');
-      },
-    }
-  );
+  const [disableAccount] = useMutation(DISABLE_ACCOUNT, {
+    onCompleted: () => {
+      window.alert('The account has been disabled.');
+      onCleared();
+    },
+    onError: () => {
+      window.alert('Error disabling account');
+    },
+  });
 
   const handleDisable = () => {
     if (!window.confirm('Are you sure? This cannot be undone.')) {

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -181,7 +181,6 @@ export const AccountSearch = () => {
   return (
     <div className="text-grey-600" data-testid="account-search">
       <h2 className="text-lg font-semibold mb-2">Account Search</h2>
-
       <p className="mb-1">
         Search for a Firefox user account by email or UID and view its details,
         including: secondary emails, email bounces, time-based one-time

--- a/packages/fxa-admin-panel/src/components/Nav/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Nav/index.tsx
@@ -66,6 +66,23 @@ export const Nav = () => (
             Admin Logs
           </NavLink>
         </li>
+        <li>
+          <NavLink
+            to="/permissions"
+            className={({ isActive }) =>
+              `rounded text-grey-600 flex mt-2 px-3 py-2 no-underline hover:bg-grey-100 focus:bg-grey-100 ${
+                isActive ? 'bg-grey-50 font-semibold' : 'bg-grey-10'
+              }`
+            }
+          >
+            <img
+              className="inline-flex mr-2 w-4"
+              src={logsIcon}
+              alt="logs icon"
+            />
+            Your Permissions
+          </NavLink>
+        </li>
       </ul>
     </div>
   </nav>

--- a/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { IUserInfo } from '../../../interfaces';
+import { Permissions } from './index';
+
+const testUser: IUserInfo = {
+  email: 'test@mozilla.com',
+  group: 'vpn_fxa_admin_panel_prod',
+  permissions: {
+    p1: {
+      name: 'Feature 1',
+      enabled: true,
+    },
+    p2: {
+      name: 'Feature 2',
+      enabled: false,
+    },
+  },
+};
+
+describe('rendered', () => {
+  let renderResult: RenderResult;
+
+  beforeEach(() => {
+    renderResult = render(<Permissions {...{ user: testUser }} />);
+  });
+
+  function getByTestId(id: string) {
+    return renderResult.getByTestId(id);
+  }
+
+  it('has user email', () => {
+    expect(getByTestId('permissions-user-email-val').textContent).toEqual(
+      testUser.email
+    );
+  });
+
+  it('has user group', () => {
+    expect(getByTestId('permissions-user-group-val').textContent).toEqual(
+      testUser.group
+    );
+  });
+
+  it('has enabled feature', () => {
+    expect(getByTestId('permissions-row-p1-label').textContent).toEqual(
+      testUser.permissions.p1.name
+    );
+    expect(getByTestId('permissions-row-p1-val').textContent).toEqual('✓');
+  });
+
+  it('has disabled feature', () => {
+    expect(getByTestId('permissions-row-p2-label').textContent).toEqual(
+      testUser.permissions.p2.name
+    );
+    expect(getByTestId('permissions-row-p2-val').textContent).toEqual('x');
+  });
+});

--- a/packages/fxa-admin-panel/src/components/Permissions/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.tsx
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { IUserInfo, IPermission } from '../../../interfaces';
+
+const styleClasses = {
+  label: 'px-4 py-2',
+  val: 'font-medium text-violet-900 px-4 py-2',
+};
+
+export const LabelValRow = ({
+  label,
+  val,
+  testId,
+}: {
+  label: string;
+  val: string;
+  testId: string;
+}) => (
+  <tr key={testId}>
+    <td className={styleClasses.label} data-testid={`${testId}-label`}>
+      {label}
+    </td>
+    <td className={styleClasses.val} data-testid={`${testId}-val`}>
+      {val}
+    </td>
+  </tr>
+);
+
+export const PermissionRow = ({
+  id,
+  permission,
+}: {
+  id: string;
+  permission: IPermission;
+}) => {
+  const testId = `permissions-row-${id}`;
+  return (
+    <LabelValRow
+      {...{
+        testId,
+        label: permission.name,
+        val: permission.enabled ? '✓' : 'x',
+      }}
+    ></LabelValRow>
+  );
+};
+
+export const PermissionsTable = ({
+  permissions,
+}: {
+  permissions: Record<string, IPermission>;
+}) => {
+  return Object.keys(permissions).length === 0 ? (
+    <></>
+  ) : (
+    <table className="table-auto" aria-label="permissions table">
+      <thead>
+        <tr>
+          <th>Feature</th>
+          <th>Enabled</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Object.keys(permissions).map((id: string) => (
+          <PermissionRow key={id} {...{ id, permission: permissions[id] }} />
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export const Permissions = ({ user }: { user: IUserInfo }) => {
+  if (!user.permissions) {
+    // Features and permissions TBD!
+    user.permissions = {
+      p1: { name: 'Permissions for Feature 1', enabled: true },
+      p2: { name: 'Permissions for Feature 2', enabled: false },
+    };
+  }
+
+  return (
+    <div className="text-grey-600">
+      <h2 className="text-lg font-semibold mb-2">Permissions</h2>
+      <p className="mb-2">
+        This page displays your current user, group, and associated permissions.
+      </p>
+      <table className="table-auto">
+        <tbody>
+          <LabelValRow
+            {...{
+              testId: 'permissions-user-email',
+              label: 'Signed In As:',
+              val: user.email,
+            }}
+          />
+          <LabelValRow
+            {...{
+              testId: 'permissions-user-group',
+              label: 'Your Group:',
+              val: user.group,
+            }}
+          />
+        </tbody>
+      </table>
+      <br />
+      <PermissionsTable {...{ permissions: user.permissions }} />
+    </div>
+  );
+};
+
+export default Permissions;

--- a/packages/fxa-admin-panel/src/index.tsx
+++ b/packages/fxa-admin-panel/src/index.tsx
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloProvider } from '@apollo/client';
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
-import { config, readConfigFromMeta } from './lib/config';
+import { config, readConfigFromMeta, getExtraHeaders } from './lib/config';
 import App from './App';
 import './styles/tailwind.out.css';
 
@@ -20,9 +19,7 @@ const httpLink = createHttpLink({
 const authLink = setContext((_, { headers }) => ({
   headers: {
     ...headers,
-    ...(process.env.NODE_ENV === 'development' && {
-      'oidc-claim-id-token-email': 'johndope@example.com',
-    }),
+    ...getExtraHeaders(config),
   },
 }));
 
@@ -33,7 +30,7 @@ const client = new ApolloClient({
 
 ReactDOM.render(
   <ApolloProvider {...{ client }}>
-    <App />
+    <App {...{ user: config.user }} />
   </ApolloProvider>,
   document.getElementById('root')
 );

--- a/packages/fxa-admin-panel/src/lib/config.spec.ts
+++ b/packages/fxa-admin-panel/src/lib/config.spec.ts
@@ -1,0 +1,14 @@
+import { config } from './config';
+
+describe('config', () => {
+  it('gets config', () => {
+    expect(config.env).toBeDefined();
+    expect(config.user).toBeDefined();
+    expect(config.user.email).toBeDefined();
+    expect(config.user.group).toBeDefined();
+    expect(config.user.permissions).toBeDefined();
+    expect(config.servers).toBeDefined();
+    expect(config.servers.admin).toBeDefined();
+    expect(config.servers.admin.url).toBeDefined();
+  });
+});

--- a/packages/fxa-admin-server/README.md
+++ b/packages/fxa-admin-server/README.md
@@ -6,13 +6,23 @@ This is the GraphQL server for an internal resource for FxA Admins to access a s
 
 The [GraphQL playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/) for this package is available at [localhost:8095/graphql](http://localhost:8095/graphql), providing a GUI for an up-to-date schema and API docs, as well as a way to test queries and mutations.
 
-The playground requires an `oidc-claim-id-token-email` authorization header. In production this is supplied through an nginx header after LDAP credentials have been verified but in development, a dummy email should be supplied in the bottom left-hand corner of the GQL playground labeled "HTTP Headers":
+The playground requires an `oidc-claim-id-token-email` authorization header. In production this is supplied through an nginx header after LDAP credentials, which have been verified but in development, a dummy email should be supplied in the bottom left-hand corner of the GQL playground labeled "HTTP Headers":
+
+In addition a `REMOTE-GROUPS` header must also be set to indicate the user's LDAP group memebership. Again, in production this will be set by nginx, but in development, a dummy value must be suplied.
 
 ```
 {
-  "oidc-claim-id-token-email": "hello@gmail.com"
+  "oidc-claim-id-token-email": "hello@mozilla.com",
+  "REMOTE-GROUPS": "vpn_fxa_admin_panel_prod"
 }
 ```
+
+Valid remote groups are as follows:
+
+- `vpn_fxa_admin_panel_prod` - production users with admin level permissions
+- `vpn_fxa_supportagent_prod` - production users with support level permissions
+- `vpn_fxa_admin_panel_stage` - stage users with admin level permissions
+- `vpn_fxa_supportagent_stage` - stage users with support level permissions
 
 Hit the "play" button and the schema and docs will populate.
 


### PR DESCRIPTION
## Because
- We need a way to see / test how the admin panel will behave with different user groups.

## This pull request
- Adds support to the config for setting the default user group via an environment variable. These config settings are only used for development. Once deployed these values will come from our headers.
- Creates a type for UserInfo that holds the current user's email and group. This info will be set from the current request headers, or fall back to values held in the application config.
- Sends this info down to client via a meta field in the header.
- Adds a UI widget to give visibility into the user who is currently signed in and their user group.

## Issue that this pull request solves

Closes: #11102

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/94418270/160438358-0e9c5971-8d5d-426e-b7ed-24bcdcb598f8.png">

