### PR TITLE
feat(auth): add Coupon Duration Info to Invoice Emails

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -943,6 +943,15 @@ export class StripeHelper {
     return this.expandResource<Stripe.Invoice>(id, INVOICES_RESOURCE);
   }
 
+  /*
+   * Expand the discounts property of an invoice
+   * TODO: We may be able to remove this method in the future if we want to add logic
+   * to expandResource to check if the discounts property is expanded.
+   */
+  getInvoiceWithDiscount(invoiceId: string) {
+    return this.stripe.invoices.retrieve(invoiceId, { expand: ['discounts'] });
+  }
+
   /**
    * Finalizes an invoice and marks auto_advance as false.
    */
@@ -2293,6 +2302,35 @@ export class StripeHelper {
       this.expandResource(invoice.charge, CHARGES_RESOURCE),
     ]);
 
+    // if the invoice does not have the deprecated discount property but has a discount ID in discounts
+    // expand the discount
+    let discountType = null;
+    let discountDuration = null;
+
+    if (invoice.discount) {
+      discountType = invoice.discount.coupon.duration;
+      discountDuration = invoice.discount.coupon.duration_in_months;
+    }
+
+    if (
+      !invoice.discount &&
+      !!invoice.discounts?.length &&
+      invoice.discounts.length === 1
+    ) {
+      const invoiceWithDiscount = await this.getInvoiceWithDiscount(invoice.id);
+      const discount = invoiceWithDiscount.discounts?.pop() as Stripe.Discount;
+      discountType = discount.coupon.duration;
+      discountDuration = discount.coupon.duration_in_months;
+    }
+
+    if (!!invoice.discounts?.length && invoice.discounts.length > 1) {
+      throw error.internalValidationError(
+        'extractInvoiceDetailsForEmail',
+        invoice,
+        new Error(`Invoice has multiple discounts.`)
+      );
+    }
+
     if (!abbrevProduct) {
       throw error.internalValidationError(
         'extractInvoiceDetailsForEmail',
@@ -2371,6 +2409,8 @@ export class StripeHelper {
       planDownloadURL,
       productMetadata,
       showPaymentMethod: !!invoiceTotalInCents,
+      discountType,
+      discountDuration,
     };
   }
 
@@ -2877,12 +2917,17 @@ export class StripeHelper {
         return this.stripeFirestore.retrieveAndFetchSubscription(resource);
       case INVOICES_RESOURCE:
         try {
+          // TODO we could remove the getInvoiceWithDiscount method if we add logic
+          // here to check if the discounts field is expanded but it would mean
+          // adding another stipe call to get discounts even when unnecessary
           const invoice = await this.stripeFirestore.retrieveInvoice(resource);
           // @ts-ignore
           return invoice;
         } catch (err) {
           if (err.name === FirestoreStripeError.FIRESTORE_INVOICE_NOT_FOUND) {
-            const invoice = await this.stripe.invoices.retrieve(resource);
+            const invoice = await this.stripe.invoices.retrieve(resource, {
+              expand: ['discounts'],
+            });
             await this.stripeFirestore.retrieveAndFetchCustomer(
               invoice.customer as string
             );

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -745,8 +745,13 @@ export class StripeWebhookHandler extends StripeHandler {
   async sendSubscriptionInvoiceEmail(invoice: Stripe.Invoice) {
     const invoiceDetails =
       await this.stripeHelper.extractInvoiceDetailsForEmail(invoice);
-    const { uid, invoiceSubtotalInCents, invoiceDiscountAmountInCents } =
-      invoiceDetails;
+    const {
+      uid,
+      invoiceSubtotalInCents,
+      invoiceDiscountAmountInCents,
+      discountType,
+      discountDuration,
+    } = invoiceDetails;
     const account = await this.db.account(uid);
     const mailParams = [
       account.emails,
@@ -758,7 +763,11 @@ export class StripeWebhookHandler extends StripeHandler {
     ];
     switch (invoice.billing_reason) {
       case 'subscription_create':
-        if (invoiceSubtotalInCents && invoiceDiscountAmountInCents) {
+        if (
+          invoiceSubtotalInCents &&
+          invoiceDiscountAmountInCents &&
+          discountType
+        ) {
           await this.mailer.sendSubscriptionFirstInvoiceDiscountEmail(
             ...mailParams
           );
@@ -775,7 +784,11 @@ export class StripeWebhookHandler extends StripeHandler {
       default:
         // Other billing reasons should be covered in subsequent invoice email
         // https://stripe.com/docs/api/invoices/object#invoice_object-billing_reason
-        if (invoiceSubtotalInCents && invoiceDiscountAmountInCents) {
+        if (
+          invoiceSubtotalInCents &&
+          invoiceDiscountAmountInCents &&
+          discountType
+        ) {
           this.mailer.sendSubscriptionSubsequentInvoiceDiscountEmail(
             ...mailParams
           );

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2395,6 +2395,8 @@ module.exports = function (log, config, bounces) {
       paymentProratedInCents,
       paymentProratedCurrency,
       showPaymentMethod,
+      discountType,
+      discountDuration,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2471,6 +2473,8 @@ module.exports = function (log, config, bounces) {
         paymentProrated,
         showProratedAmount,
         showPaymentMethod,
+        discountType,
+        discountDuration,
       },
     });
   };
@@ -2571,6 +2575,8 @@ module.exports = function (log, config, bounces) {
       lastFour,
       nextInvoiceDate,
       showPaymentMethod,
+      discountType,
+      discountDuration,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2633,6 +2639,8 @@ module.exports = function (log, config, bounces) {
         lastFour,
         nextInvoiceDate,
         showPaymentMethod,
+        discountType,
+        discountDuration,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/en.ftl
@@ -21,6 +21,13 @@ subscriptionFirstInvoiceDiscount-content-subtotal = Subtotal: { $invoiceSubtotal
 # Variables:
 #  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
 subscriptionFirstInvoiceDiscount-content-discount = Discount: -{ $invoiceDiscountAmount }
+# Variables
+#  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
+subscriptionFirstInvoiceDiscount-content-discount-one-time = One time Discount: -{ $invoiceDiscountAmount }
+# Variables
+#  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
+#  $discountDuration - The duration of the discount in number of months, e.g. 3 months
+subscriptionFirstInvoiceDiscount-content-discount-repeating = { $discountDuration } month Discount: -{ $invoiceDiscountAmount }
 # Variables:
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
 #  $invoiceTotal (String) - The amount, after discount, of the subscription invoice, including currency, e.g. $8.00

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.mjml
@@ -7,11 +7,7 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-title"
-        data-l10n-args="<%= JSON.stringify({productName}) %>"
-        >Thank you for subscribing to <%- productName %></span
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for subscribing to <%- productName %></span>
     </mj-text>
 
     <mj-text css-class="text-body">
@@ -22,10 +18,7 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-install-2"
-        data-l10n-args="<%= JSON.stringify({productName}) %>"
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-install-2" data-l10n-args="<%= JSON.stringify({productName}) %>">
         You will receive a separate email on how to start using <%- productName
         %>.
       </span>
@@ -39,37 +32,43 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
     </mj-text>
 
     <mj-text css-class="text-body-no-bottom-margin">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-invoice-number"
-        data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>"
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-invoice-number" data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>">
         Invoice Number: <b><%- invoiceNumber %></b>
       </span>
     </mj-text>
 
     <mj-text css-class="text-body-no-bottom-margin">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-subtotal"
-        data-l10n-args="<%= JSON.stringify({invoiceSubtotal}) %>"
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-subtotal" data-l10n-args="<%= JSON.stringify({invoiceSubtotal}) %>">
         Subtotal: <%- invoiceSubtotal %>
       </span>
     </mj-text>
 
+    <% if (discountType === 'once') { %>
     <mj-text css-class="text-body-no-bottom-margin">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-discount"
-        data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount}) %>"
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-discount-one-time" data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount}) %>">
+        One time Discount: -<%- invoiceDiscountAmount %>
+      </span>
+    </mj-text>
+    <% } %>
+
+    <% if (discountType === 'repeating') { %>
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-discount-repeating" data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount, discountDuration}) %>">
+        <%discountDuration%> month Discount: -<%- invoiceDiscountAmount %>
+      </span>
+    </mj-text>
+    <% } %>
+
+    <% if (discountType === 'forever') { %>
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-discount" data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount}) %>">
         Discount: -<%- invoiceDiscountAmount %>
       </span>
     </mj-text>
+    <% } %>
 
     <mj-text css-class="text-body-no-bottom-margin">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-charge"
-        data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>"
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-charge" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">
         Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>
       </span>
     </mj-text>
@@ -78,10 +77,7 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
     <%- include ('/partials/paymentProvider/index.mjml') %>
 
     <mj-text css-class="text-body">
-      <span
-        data-l10n-id="subscriptionFirstInvoiceDiscount-content-next-invoice"
-        data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>"
-      >
+      <span data-l10n-id="subscriptionFirstInvoiceDiscount-content-next-invoice" data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>">
         Next Invoice: <%- nextInvoiceDateOnly %>
       </span>
     </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.stories.ts
@@ -25,6 +25,8 @@ const createStory = subplatStoryWithProps(
     nextInvoiceDateOnly: '11/13/2021',
     subscriptionSupportUrl: 'http://localhost:3030/support',
     showPaymentMethod: true,
+    discountType: 'forever',
+    discountDuration: null,
   }
 );
 
@@ -54,4 +56,26 @@ export const SubscriptionFirstInvoiceWithCoupon = createStory(
     showPaymentMethod: false,
   },
   'Payment method hidden - coupon covered entire amount'
+);
+
+export const SubscriptionFirstInvoiceWithStripe3Month = createStory(
+  {
+    cardType: 'MasterCard',
+    lastFour: '5309',
+    payment_provider: 'stripe',
+    discountType: 'repeating',
+    discountDuration: 3,
+  },
+  'Stripe - 3 month Coupon'
+);
+
+export const SubscriptionFirstInvoiceWithStripeOneTime = createStory(
+  {
+    cardType: 'MasterCard',
+    lastFour: '5309',
+    payment_provider: 'stripe',
+    discountType: 'once',
+    discountDuration: null,
+  },
+  'Stripe - One Time Coupon'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoiceDiscount/index.txt
@@ -10,7 +10,9 @@ subscriptionFirstInvoiceDiscount-content-auto-renew = "Your subscription will au
 
 subscriptionFirstInvoiceDiscount-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
 subscriptionFirstInvoiceDiscount-content-subtotal = "Subtotal: <%- invoiceSubtotal %>"
-subscriptionFirstInvoiceDiscount-content-discount = "Discount: -<%- invoiceDiscountAmount %>"
+<% if (discountType === 'once') { %>subscriptionFirstInvoiceDiscount-content-discount-one-time = "One time Discount: -<%- invoiceDiscountAmount %>"<% } %>
+<% if (discountType === 'repeating') { %>subscriptionFirstInvoiceDiscount-content-discount-repeating = "<%discountDuration%> month Discount: -<%- invoiceDiscountAmount %>"<% } %>
+<% if (discountType === 'forever') { %>subscriptionFirstInvoiceDiscount-content-discount = "Discount: -<%- invoiceDiscountAmount %>"<% } %>
 subscriptionFirstInvoiceDiscount-content-charge = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
 <%- include ('/partials/viewInvoice/index.txt') %>
 <%- include ('/partials/paymentProvider/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/en.ftl
@@ -12,10 +12,10 @@ subscriptionSubsequentInvoiceDiscount-content-invoice-number = Invoice Number: <
 #  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
 subscriptionSubsequentInvoiceDiscount-content-invoice-number-plaintext = Invoice Number: { $invoiceNumber }
 # Variables:
-# $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
+#  $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
 subscriptionSubsequentInvoiceDiscount-content-plan-change = Plan change: { $paymentProrated }
 # Variables:
-# $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 subscriptionSubsequentInvoiceDiscount-content-charge = Charged { $invoiceTotal } on { $invoiceDateOnly }
 # Variables:
@@ -27,3 +27,10 @@ subscriptionSubsequentInvoiceDiscount-content-subtotal = Subtotal: { $invoiceSub
 # Variables:
 #  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
 subscriptionSubsequentInvoiceDiscount-content-discount = Discount: -{ $invoiceDiscountAmount }
+# Variables
+#  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
+subscriptionSubsequentInvoiceDiscount-content-discount-one-time = One time Discount: -{ $invoiceDiscountAmount }
+# Variables
+#  $invoiceDiscountAmount (String) - The amount of the discount of the subscription invoice, including currency, e.g. $2.00
+#  $discountDuration - The duration of the discount in number of months, e.g. 3 months
+subscriptionSubsequentInvoiceDiscount-content-discount-repeating = { $discountDuration } month Discount: -{ $invoiceDiscountAmount }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.mjml
@@ -37,11 +37,29 @@
       </span>
     </mj-text>
 
+    <% if (discountType === 'once') { %>
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span data-l10n-id="subscriptionSubsequentInvoiceDiscount-content-discount-one-time" data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount}) %>">
+        One time Discount: -<%- invoiceDiscountAmount %>
+      </span>
+    </mj-text>
+    <% } %>
+
+    <% if (discountType === 'repeating') { %>
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span data-l10n-id="subscriptionSubsequentInvoiceDiscount-content-discount-repeating" data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount, discountDuration}) %>">
+        <%discountDuration%> month Discount: -<%- invoiceDiscountAmount %>
+      </span>
+    </mj-text>
+    <% } %>
+
+    <% if (discountType === 'forever') { %>
     <mj-text css-class="text-body-no-bottom-margin">
       <span data-l10n-id="subscriptionSubsequentInvoiceDiscount-content-discount" data-l10n-args="<%= JSON.stringify({invoiceDiscountAmount}) %>">
         Discount: -<%- invoiceDiscountAmount %>
       </span>
     </mj-text>
+    <% } %>
 
     <mj-text css-class="text-body-no-bottom-margin">
       <span data-l10n-id="subscriptionSubsequentInvoiceDiscount-content-charge" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.stories.ts
@@ -25,6 +25,8 @@ const createStory = subplatStoryWithProps(
     nextInvoiceDateOnly: '1/14/2022',
     subscriptionSupportUrl: 'http://localhost:3030/support',
     showPaymentMethod: true,
+    discountType: 'forever',
+    discountDuration: null,
   }
 );
 
@@ -77,4 +79,28 @@ export const SubscriptionSubsequentInvoiceCouponFullAmount = createStory(
     showPaymentMethod: false,
   },
   'Payment method hidden - coupon covered entire amount'
+);
+
+export const SubscriptionSubsequentInvoiceStripeNoProrated3Month = createStory(
+  {
+    cardType: 'MasterCard',
+    lastFour: '5309',
+    payment_provider: 'stripe',
+    showProratedAmount: false,
+    discountType: 'repeating',
+    discountDuration: 3,
+  },
+  'Stripe - 3 Month Coupon'
+);
+
+export const SubscriptionSubsequentInvoiceStripeNoProratedOneTime = createStory(
+  {
+    cardType: 'MasterCard',
+    lastFour: '5309',
+    payment_provider: 'stripe',
+    showProratedAmount: false,
+    discountType: 'once',
+    discountDuration: null,
+  },
+  'Stripe - One Time Coupon'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoiceDiscount/index.txt
@@ -7,7 +7,9 @@ subscriptionSubsequentInvoiceDiscount-content-received = "We received your lates
 subscriptionSubsequentInvoiceDiscount-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
 <% if (showProratedAmount) { %>subscriptionSubsequentInvoiceDiscount-content-plan-change = "Plan change: <%- paymentProrated %>"<% } %>
 subscriptionSubsequentInvoiceDiscount-content-subtotal = "Subtotal: <%- invoiceSubtotal %>"
-subscriptionSubsequentInvoiceDiscount-content-discount = "Discount: -<%- invoiceDiscountAmount %>"
+<% if (discountType === 'once') { %>subscriptionSubsequentInvoiceDiscount-content-discount-one-time = "One time Discount: -<%- invoiceDiscountAmount %>"<% } %>
+<% if (discountType === 'repeating') { %>subscriptionSubsequentInvoiceDiscount-content-discount-repeating = "<%discountDuration%> month Discount: -<%- invoiceDiscountAmount %>"<% } %>
+<% if (discountType === 'forever') { %>subscriptionSubsequentInvoiceDiscount-content-discount = "Discount: -<%- invoiceDiscountAmount %>"<% } %>
 subscriptionSubsequentInvoiceDiscount-content-charged = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
 <%- include ('/partials/viewInvoice/index.txt') %><%- include ('/partials/paymentProvider/index.txt') %>
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -1669,6 +1669,8 @@ describe('StripeWebhookHandler', () => {
         ) {
           mockInvoiceDetails.invoiceSubtotalInCents = 12;
           mockInvoiceDetails.invoiceDiscountAmountInCents = 34;
+          mockInvoiceDetails.discountType = 'forever';
+          mockInvoiceDetails.discountDuration = null;
         }
         StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.resolves(
           mockInvoiceDetails

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -126,6 +126,8 @@ const MESSAGE = {
     { productName: 'Cooking with Foxkeh' },
   ],
   showPaymentMethod: true,
+  discountType: 'forever',
+  discountDuration: null,
 };
 
 const MESSAGE_FORMATTED = {
@@ -1535,6 +1537,86 @@ const TESTS: [string, any, Record<string, any>?][] = [
       {...x, showPaymentMethod: false})}
   ],
 
+  ['subscriptionFirstInvoiceDiscountEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionFirstInvoiceDiscount') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionFirstInvoiceDiscount' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionFirstInvoiceDiscount }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-first-invoice-discount', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-first-invoice-discount', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-first-invoice-discount', 'subscription-support')) },
+      { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `One time Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.productName} payment confirmed` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `One time Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]]
+  ]), {updateTemplateValues: x => (
+    {...x, discountType: 'once', discountDuration: null})}
+  ],
+
+  ['subscriptionFirstInvoiceDiscountEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionFirstInvoiceDiscount') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionFirstInvoiceDiscount' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionFirstInvoiceDiscount }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-first-invoice-discount', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-first-invoice-discount', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-first-invoice-discount', 'subscription-support')) },
+      { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `3 month Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.productName} payment confirmed` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `3 month Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]]
+  ]), {updateTemplateValues: x => (
+    {...x, discountType: 'repeating', discountDuration: 3})}
+  ],
+
   ['subscriptionPaymentExpiredEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `Credit card for ${MESSAGE.productName} expiring soon` }],
     ['headers', new Map([
@@ -1823,7 +1905,86 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]),
     {updateTemplateValues: x => ({...x, showPaymentMethod: false})}
   ],
-
+  ['subscriptionSubsequentInvoiceDiscountEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment received` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionSubsequentInvoiceDiscount') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionSubsequentInvoiceDiscount' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionSubsequentInvoiceDiscount }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-subsequent-invoice-discount', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-subsequent-invoice-discount', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-subsequent-invoice-discount', 'subscription-support')) },
+      { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+      { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `Plan change: ${MESSAGE_FORMATTED.paymentProrated}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `One time Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.productName} payment received` },
+      { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Plan change: ${MESSAGE_FORMATTED.paymentProrated}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `One time Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]]
+  ]), {updateTemplateValues: x => (
+    {...x, discountType: 'once', discountDuration: null})}
+  ],
+  ['subscriptionSubsequentInvoiceDiscountEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment received` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionSubsequentInvoiceDiscount') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionSubsequentInvoiceDiscount' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionSubsequentInvoiceDiscount }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-subsequent-invoice-discount', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-subsequent-invoice-discount', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-subsequent-invoice-discount', 'subscription-support')) },
+      { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+      { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `Plan change: ${MESSAGE_FORMATTED.paymentProrated}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `3 month Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.productName} payment received` },
+      { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Plan change: ${MESSAGE_FORMATTED.paymentProrated}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Subtotal: ${MESSAGE_FORMATTED.invoiceSubtotal}` },
+      { test: 'include', expected: `3 month Discount: -${MESSAGE_FORMATTED.invoiceDiscountAmount}` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]]
+  ]), {updateTemplateValues: x => (
+    {...x, discountType: 'repeating', discountDuration: 3})}
+  ],
   ['subscriptionUpgradeEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
     ['headers', new Map([


### PR DESCRIPTION
Because:

* We want the invoice emails to indicate the duration of the applied subscription discount

This commit:

* Extracts necessary info from the invoice and retreives it if necessary, and passes it to the email templates

Closes #12030 

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
