### PR TITLE
fix(tsconfig): Transpile email templates includes.ts files

### DIFF
--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -9,5 +9,9 @@
     "types": ["accept-language", "mocha", "mozlog", "node"]
   },
   "references": [{ "path": "../fxa-shared" }],
-  "include": ["bin/*", "scripts/*.ts"]
+  "include": [
+    "bin/*",
+    "scripts/*.ts",
+    "lib/senders/emails/templates/*/includes.ts"
+  ]
 }


### PR DESCRIPTION
Because:
* We dynamically import an includes.ts file if the template needs logic based on a template value to determine 'subject' or 'action' and TS was not transpiling this file

This commit:
* Adds the path to tsconfig.json

fixes #12228

---

I double checked this worked as expected by running `yarn build` before and after the change.

An alternative approach instead of this is to just [import the file](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/senders/renderer/index.ts#L128) at the top instead of course, but meh we'd be unnecessarily importing it most of the time since the `lowRecoveryCodes` email doesn't get sent much.