### PR TITLE
fix(email): Use uppercase provider name in email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -9,7 +9,7 @@ import * as uuid from 'uuid';
 import * as random from '../crypto/random';
 import validators from './validators';
 import jwtDecode from 'jwt-decode';
-import { Provider } from 'fxa-shared/db/models/auth/linked-account';
+import { Provider, PROVIDER_NAME } from 'fxa-shared/db/models/auth/linked-account';
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
 const error = require('../error');
@@ -143,7 +143,7 @@ export class LinkedAccountHandler {
           flowBeginTime,
           ip,
           location: geoData.location,
-          providerName: provider,
+          providerName: PROVIDER_NAME[provider],
           timeZone: geoData.timeZone,
           uaBrowser: request.app.ua.browser,
           uaBrowserVersion: request.app.ua.browserVersion,

--- a/packages/fxa-shared/db/models/auth/linked-account.ts
+++ b/packages/fxa-shared/db/models/auth/linked-account.ts
@@ -11,6 +11,11 @@ export const PROVIDER = {
   apple: 2,
 } as const;
 export type Provider = keyof typeof PROVIDER;
+export const PROVIDER_NAME = {
+  __fxa__unmapped: 'Unknown',
+  google: 'Google',
+  apple: 'Apple',
+} as const;
 
 export class LinkedAccount extends BaseAuthModel {
   static tableName = 'linkedAccounts';


### PR DESCRIPTION
## Because

- Provider name in email needs to have the right case

## This pull request

- Adds map to provider names

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12214

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
