### PR TITLE
fix(auth): update cached customer on customer.subscription.created

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5239,11 +5239,19 @@ describe('StripeHelper', () => {
         stripeFirestore.insertSubscriptionRecordWithBackfill = sandbox
           .stub()
           .resolves({});
+        stripeFirestore.fetchAndInsertCustomer = sandbox.stub().resolves({});
         await stripeHelper.processWebhookEventToFirestore(event);
-        sinon.assert.calledOnceWithExactly(
-          stripeHelper.stripeFirestore.insertSubscriptionRecordWithBackfill,
-          subscription1
-        );
+        if (type === 'customer.subscription.created') {
+          sinon.assert.calledOnceWithExactly(
+            stripeHelper.stripeFirestore.fetchAndInsertCustomer,
+            subscription1.customer
+          );
+        } else {
+          sinon.assert.calledOnceWithExactly(
+            stripeHelper.stripeFirestore.insertSubscriptionRecordWithBackfill,
+            subscription1
+          );
+        }
         sinon.assert.calledOnceWithExactly(
           stripeHelper.stripe.subscriptions.retrieve,
           event.data.object.id


### PR DESCRIPTION
Because:

* Stripe fails to send customer.updated webhooks when it updates customer.currency for PayPal users.
* This causes our cached customer in Firestore to be stale, with PayPal customers potentially having a customer.currency of null.

This commit:

* Updates the customer in Firestore on customer.subscription.created events, since that's when Stripe updates customer.currency.

Closes #12289

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).