### PR TITLE
feat(coupons): coupon detail api check valid promo

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1346,6 +1346,15 @@ describe('StripeHelper', () => {
       total_discount_amounts: [{ amount: 200 }],
     };
 
+    const expectedTemplate = {
+      promotionCode: 'promo',
+      type: 'forever',
+      valid: true,
+      durationInMonths: null,
+      expired: false,
+      maximallyRedeemed: false,
+    };
+
     let sentryScope;
 
     beforeEach(() => {
@@ -1355,13 +1364,7 @@ describe('StripeHelper', () => {
     });
 
     it('retrieves coupon details', async () => {
-      const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
-        discountAmount: 200,
-        valid: true,
-        durationInMonths: null,
-      };
+      const expected = { ...expectedTemplate, discountAmount: 200 };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
         .resolves(validInvoicePreview);
@@ -1396,13 +1399,7 @@ describe('StripeHelper', () => {
     });
 
     it('retrieves coupon details for 100% discount', async () => {
-      const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
-        discountAmount: 200,
-        valid: true,
-        durationInMonths: null,
-      };
+      const expected = { ...expectedTemplate, discountAmount: 200 };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
         .resolves({ ...validInvoicePreview, total: 0 });
@@ -1438,11 +1435,9 @@ describe('StripeHelper', () => {
 
     it('retrieves details on an expired coupon', async () => {
       const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
-        expired: true,
+        ...expectedTemplate,
         valid: false,
-        durationInMonths: null,
+        expired: true,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1469,11 +1464,9 @@ describe('StripeHelper', () => {
 
     it('retrieves details on a maximally redeemed coupon', async () => {
       const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
-        maximallyRedeemed: true,
+        ...expectedTemplate,
         valid: false,
-        durationInMonths: null,
+        maximallyRedeemed: true,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1501,11 +1494,9 @@ describe('StripeHelper', () => {
 
     it('retrieves details on an expired promotion code', async () => {
       const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
-        expired: true,
+        ...expectedTemplate,
         valid: false,
-        durationInMonths: null,
+        expired: true,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1532,11 +1523,9 @@ describe('StripeHelper', () => {
 
     it('retrieves details on a maximally redeemed promotion code', async () => {
       const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
-        maximallyRedeemed: true,
+        ...expectedTemplate,
         valid: false,
-        durationInMonths: null,
+        maximallyRedeemed: true,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1564,10 +1553,8 @@ describe('StripeHelper', () => {
 
     it('return coupon details even when previewInvoice rejects', async () => {
       const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
+        ...expectedTemplate,
         valid: false,
-        durationInMonths: null,
       };
       const err = new AppError('previewInvoiceFailed');
       sandbox.stub(stripeHelper, 'previewInvoice').rejects(err);
@@ -1602,10 +1589,8 @@ describe('StripeHelper', () => {
 
     it('return coupon details even when getMinAmount rejects', async () => {
       const expected = {
-        promotionCode: 'promo',
-        type: 'forever',
+        ...expectedTemplate,
         valid: false,
-        durationInMonths: null,
       };
       sandbox
         .stub(stripeHelper, 'previewInvoice')
@@ -1729,8 +1714,14 @@ describe('StripeHelper', () => {
       },
     };
 
+    const expectedTemplate = {
+      valid: false,
+      expired: false,
+      maximallyRedeemed: false,
+    };
+
     it('return valid for valid coupon and promotion code', () => {
-      const expected = { valid: true };
+      const expected = { ...expectedTemplate, valid: true };
       const actual = stripeHelper.verifyPromotionAndCoupon(
         promotionCodeTemplate
       );
@@ -1747,7 +1738,7 @@ describe('StripeHelper', () => {
           times_redeemed: 1,
         },
       };
-      const expected = { valid: false, maximallyRedeemed: true };
+      const expected = { ...expectedTemplate, maximallyRedeemed: true };
       const actual = stripeHelper.verifyPromotionAndCoupon(promotionCode);
       assert.deepEqual(actual, expected);
     });
@@ -1760,7 +1751,7 @@ describe('StripeHelper', () => {
           redeem_by: 1000,
         },
       };
-      const expected = { valid: false, expired: true };
+      const expected = { ...expectedTemplate, expired: true };
       const actual = stripeHelper.verifyPromotionAndCoupon(promotionCode);
       assert.deepEqual(actual, expected);
     });
@@ -1772,7 +1763,7 @@ describe('StripeHelper', () => {
         max_redemptions: 1,
         times_redeemed: 1,
       };
-      const expected = { valid: false, maximallyRedeemed: true };
+      const expected = { ...expectedTemplate, maximallyRedeemed: true };
       const actual = stripeHelper.verifyPromotionAndCoupon(promotionCode);
       assert.deepEqual(actual, expected);
     });
@@ -1783,13 +1774,13 @@ describe('StripeHelper', () => {
         active: false,
         expires_at: 1000,
       };
-      const expected = { valid: false, expired: true };
+      const expected = { ...expectedTemplate, expired: true };
       const actual = stripeHelper.verifyPromotionAndCoupon(promotionCode);
       assert.deepEqual(actual, expected);
     });
   });
 
-  describe('verifyPromotionAndCouponProperties', () => {
+  describe('checkPromotionAndCouponProperties', () => {
     const propertiesTemplate = {
       valid: false,
       redeem_by: null,
@@ -1806,8 +1797,7 @@ describe('StripeHelper', () => {
         expired: false,
         maximallyRedeemed: false,
       };
-      const actual =
-        stripeHelper.verifyPromotionAndCouponProperties(properties);
+      const actual = stripeHelper.checkPromotionAndCouponProperties(properties);
       assert.deepEqual(actual, expected);
     });
 
@@ -1822,8 +1812,7 @@ describe('StripeHelper', () => {
         expired: false,
         maximallyRedeemed: true,
       };
-      const actual =
-        stripeHelper.verifyPromotionAndCouponProperties(properties);
+      const actual = stripeHelper.checkPromotionAndCouponProperties(properties);
       assert.deepEqual(actual, expected);
     });
 
@@ -1837,8 +1826,7 @@ describe('StripeHelper', () => {
         expired: true,
         maximallyRedeemed: false,
       };
-      const actual =
-        stripeHelper.verifyPromotionAndCouponProperties(properties);
+      const actual = stripeHelper.checkPromotionAndCouponProperties(properties);
       assert.deepEqual(actual, expected);
     });
 
@@ -1849,8 +1837,7 @@ describe('StripeHelper', () => {
         expired: false,
         maximallyRedeemed: false,
       };
-      const actual =
-        stripeHelper.verifyPromotionAndCouponProperties(properties);
+      const actual = stripeHelper.checkPromotionAndCouponProperties(properties);
       assert.deepEqual(actual, expected);
     });
   });

--- a/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
@@ -29,6 +29,8 @@ storiesOf('components/Coupon', module)
       durationInMonths: 1,
       discountAmount: 10,
       valid: true,
+      expired: false,
+      maximallyRedeemed: false,
     });
     return (
       <MockApp>
@@ -63,6 +65,8 @@ storiesOf('components/Coupon', module)
       durationInMonths: 1,
       discountAmount: 10,
       valid: true,
+      expired: false,
+      maximallyRedeemed: false,
     });
     return (
       <MockApp>

--- a/packages/fxa-payments-server/src/components/CouponForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.test.tsx
@@ -77,7 +77,10 @@ describe('CouponForm', () => {
         discountAmount: 200,
         promotionCode: '',
         type: '',
+        durationInMonths: 1,
         valid: true,
+        expired: false,
+        maximallyRedeemed: false,
       };
       const subject = () => {
         return render(
@@ -147,7 +150,10 @@ describe('CouponForm', () => {
         discountAmount: 200,
         promotionCode: '',
         type: '',
+        durationInMonths: 1,
         valid: true,
+        expired: false,
+        maximallyRedeemed: false,
       };
       const subject = () => {
         return render(
@@ -191,7 +197,10 @@ describe('CouponForm', () => {
         discountAmount: 200,
         promotionCode: '',
         type: '',
+        durationInMonths: 1,
         valid: true,
+        expired: false,
+        maximallyRedeemed: false,
       };
       const subject = () => {
         return render(

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -79,6 +79,8 @@ const coupon: CouponDetails = {
   type: '',
   durationInMonths: 1,
   valid: true,
+  expired: false,
+  maximallyRedeemed: false,
 };
 
 storiesOf('components/PaymentConfirmation', module)

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../lib/test-utils';
 import AppContext, { defaultAppContext } from '../../lib/AppContext';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 const userProfile = {
   avatar: './avatar.svg',
@@ -63,6 +64,7 @@ const customer: Customer = {
   brand: 'Visa',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       latest_invoice: '628031D-0002',
       subscription_id: 'sub0.28964929339372136',
       plan_id: 'plan_123',
@@ -75,6 +77,7 @@ const customer: Customer = {
       end_at: null,
       promotion_duration: null,
       promotion_end: null,
+      created: Date.now() / 1000 - 86400 * 31,
     },
   ],
 };
@@ -89,6 +92,7 @@ const paypalCustomer: Customer = {
   brand: 'Visa',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       latest_invoice: '628031D-0002',
       subscription_id: 'sub0.28964929339372136',
       plan_id: 'plan_123',
@@ -101,6 +105,7 @@ const paypalCustomer: Customer = {
       end_at: null,
       promotion_duration: null,
       promotion_end: null,
+      created: Date.now() / 1000 - 86400 * 31,
     },
   ],
 };
@@ -109,7 +114,10 @@ const coupon: CouponDetails = {
   discountAmount: 200,
   promotionCode: 'TEST',
   type: '',
+  durationInMonths: 1,
   valid: true,
+  expired: false,
+  maximallyRedeemed: false,
 };
 
 afterEach(cleanup);

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -197,6 +197,8 @@ describe('PlanDetails', () => {
       durationInMonths: null,
       valid: true,
       discountAmount: 200,
+      maximallyRedeemed: false,
+      expired: false,
     };
 
     it('updates price', async () => {

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -541,6 +541,7 @@ describe('API requests', () => {
         promotionCode,
         type: '',
         valid: true,
+        durationInMonths: 1,
         discountAmount: 50,
         expired: false,
         maximallyRedeemed: false,

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -295,6 +295,8 @@ export const COUPON_DETAILS_INVALID: CouponDetails = {
   type: '',
   durationInMonths: 1,
   valid: false,
+  expired: false,
+  maximallyRedeemed: false,
 };
 
 export const COUPON_DETAILS_EXPIRED: CouponDetails = {
@@ -303,6 +305,7 @@ export const COUPON_DETAILS_EXPIRED: CouponDetails = {
   durationInMonths: 1,
   valid: false,
   expired: true,
+  maximallyRedeemed: false,
 };
 
 export const COUPON_DETAILS_MAX_REDEEMED: CouponDetails = {
@@ -311,6 +314,7 @@ export const COUPON_DETAILS_MAX_REDEEMED: CouponDetails = {
   durationInMonths: 1,
   valid: false,
   maximallyRedeemed: true,
+  expired: false,
 };
 
 export const INVOICE_PREVIEW_WITH_100_VALID_DISCOUNT: FirstInvoicePreview = {

--- a/packages/fxa-shared/dto/auth/payments/coupon.ts
+++ b/packages/fxa-shared/dto/auth/payments/coupon.ts
@@ -6,8 +6,8 @@ export interface CouponDetails {
   durationInMonths: number | null;
   valid: boolean;
   discountAmount?: number;
-  expired?: boolean;
-  maximallyRedeemed?: boolean;
+  expired: boolean;
+  maximallyRedeemed: boolean;
 }
 
 export const couponDetailsSchema = joi.object({
@@ -16,8 +16,8 @@ export const couponDetailsSchema = joi.object({
   durationInMonths: joi.number().required().allow(null),
   valid: joi.boolean().required(),
   discountAmount: joi.number().optional(),
-  expired: joi.boolean().optional(),
-  maximallyRedeemed: joi.boolean().optional(),
+  expired: joi.boolean().required(),
+  maximallyRedeemed: joi.boolean().required(),
 });
 
 export type couponDetailsSchema = joi.Literal<typeof couponDetailsSchema>;


### PR DESCRIPTION
## Because

- The coupon details api endpoint was only checking if a coupon is valid
  and was not also checking the promotion code.

## This pull request

- Verify's that the coupon and promotion code are valid. If either is
  invalid, return the appropriate information so that the UI can display
  the correct error message.

## Issue that this pull request solves

Closes: #11524

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).