### PR TITLE
Patch release 1.228.7

### DIFF
--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.228.7
+
+### Bug fixes
+
+- recovery-codes: Remove context.numberRemaining check in getGlobalTemplateValues ([c66633722f](https://github.com/mozilla/fxa/commit/c66633722f))
+- tsconfig: Transpile email templates includes.ts files ([d9fb5d72ad](https://github.com/mozilla/fxa/commit/d9fb5d72ad))
+
 ## 1.228.6
 
 ### Bug fixes

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.228.5
+
+### Bug fixes
+
+- auth: update cached customer on customer.subscription.created ([f1dea10b18](https://github.com/mozilla/fxa/commit/f1dea10b18))
+
 ## 1.228.4
 
 ### Bug fixes

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.228.4
+
+### Bug fixes
+
+- emails: remove more "download" language from emails ([503300b25](https://github.com/mozilla/fxa/commit/503300b25))
+
 ## 1.228.3
 
 ### Bug fixes

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.228.6
+
+### Bug fixes
+
+- mailer: mailer chainging timezone test (#12257) ([aeebc5fbbf](https://github.com/mozilla/fxa/commit/aeebc5fbbf))
+
 ## 1.228.5
 
 ### Bug fixes

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2921,6 +2921,21 @@ export class StripeHelper {
     const subscription = await this.stripe.subscriptions.retrieve(
       (event.data.object as Stripe.Subscription).id
     );
+    // For PayPal customers, Stripe fails to send a `customer.updated` webhook
+    // when it automatically updates the `customer.currency` on subscription
+    // creation. Update the cached customer here to ensure `customer.currency`
+    // is not `null`.
+    // Since we can't easily differentiate a PayPal customer from others with
+    // an unexpanded subscription object, we update all customers in Firestore.
+    if (event.type === 'customer.subscription.created') {
+      await this.stripeFirestore.fetchAndInsertCustomer(
+        subscription.customer as string
+      );
+      // This is not the exact same object as returned otherwise, but we don't
+      // specify or make use of the return value currently.
+      return subscription;
+    }
+
     return this.stripeFirestore.insertSubscriptionRecordWithBackfill(
       subscription
     );

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5024,11 +5024,19 @@ describe('StripeHelper', () => {
         stripeFirestore.insertSubscriptionRecordWithBackfill = sandbox
           .stub()
           .resolves({});
+        stripeFirestore.fetchAndInsertCustomer = sandbox.stub().resolves({});
         await stripeHelper.processWebhookEventToFirestore(event);
-        sinon.assert.calledOnceWithExactly(
-          stripeHelper.stripeFirestore.insertSubscriptionRecordWithBackfill,
-          subscription1
-        );
+        if (type === 'customer.subscription.created') {
+          sinon.assert.calledOnceWithExactly(
+            stripeHelper.stripeFirestore.fetchAndInsertCustomer,
+            subscription1.customer
+          );
+        } else {
+          sinon.assert.calledOnceWithExactly(
+            stripeHelper.stripeFirestore.insertSubscriptionRecordWithBackfill,
+            subscription1
+          );
+        }
         sinon.assert.calledOnceWithExactly(
           stripeHelper.stripe.subscriptions.retrieve,
           event.data.object.id

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -2440,7 +2440,7 @@ describe('lib/senders/emails:', () => {
         message.timeZone,
         message.acceptLanguage
       );
-      assert.include(result[0], 'CET');
+      assert.include(['CET', 'CEST'], result[0].replace(/(^.*\(|\).*$)/g, ''));
     });
 
     it('returns date/time in Spanish', () => {

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.228.4
+
+### Bug fixes
+
+- content: fix validation tests Because: ([0f9277ae8](https://github.com/mozilla/fxa/commit/0f9277ae8))
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 ### Bug fixes

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.scss -o src/styles/tailwind.out.scss",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.scss -o src/styles/tailwind.out.scss",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.scss -o src/styles/tailwind.out.scss",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.scss -o src/styles/tailwind.out.scss",

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.4
+
+No changes.
+
 ## 1.228.3
 
 No changes.

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.6
+
+No changes.
+
 ## 1.228.5
 
 No changes.

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.5
+
+No changes.
+
 ## 1.228.4
 
 No changes.

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.228.7
+
+No changes.
+
 ## 1.228.6
 
 No changes.

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.228.6",
+  "version": "1.228.7",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.228.4",
+  "version": "1.228.5",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.228.5",
+  "version": "1.228.6",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.228.3",
+  "version": "1.228.4",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"


### PR DESCRIPTION
I'm going to need to resolve the changelog conflicts in another branch since the 229 train branch was merged first.

We need a hotfix landed in production which is why it was cherry-picked into 228.5. CI failed due to a timezone issue fixed in `main` so I pulled in the fix for that and then tagged 228.6. Then, we discovered issues with the `lowRecoveryCodes` email through production smoke tests so two fixes were cherry-picked in for that.