### PR TITLE
fix(subscriptions): no expand on payment detach

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -43,7 +43,10 @@ import { StripeHandler } from './stripe';
 // update our plans handling code.  Prices should be treated in the same
 // fashion as plans, so it's on this list.
 const BYPASS_LATEST_FETCH_TYPES = ['plan', 'price', 'product'];
-const BYPASS_LATEST_FETCH_EVENTS = ['invoice.upcoming'];
+const BYPASS_LATEST_FETCH_EVENTS = [
+  'invoice.upcoming',
+  'payment_method.detached',
+];
 const ALLOWED_EXPAND_RESOURCE_TYPES = Object.fromEntries(
   Object.entries(STRIPE_OBJECT_TYPE_TO_RESOURCE).filter(
     ([k, _]) => !BYPASS_LATEST_FETCH_TYPES.includes(k)

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -437,6 +437,23 @@ describe('StripeWebhookHandler', () => {
           assert.isTrue(scopeContextSpy.calledOnce, 'Expected to call Sentry');
         });
 
+        it('does not call sentry or expand resourche for event payment_method.detached', async () => {
+          const event = deepCopy(subscriptionCreated);
+          event.type = 'payment_method.detached';
+          StripeWebhookHandlerInstance.stripeHelper.constructWebhookEvent.returns(
+            event
+          );
+          StripeWebhookHandlerInstance.stripeHelper.processWebhookEventToFirestore =
+            sinon.stub().resolves(true);
+          await StripeWebhookHandlerInstance.handleWebhookEvent(request);
+          assertNamedHandlerCalled();
+          assert.equal(
+            StripeWebhookHandlerInstance.stripeHelper.expandResource.calledOnce,
+            false
+          );
+          sinon.assert.notCalled(scopeContextSpy);
+        });
+
         it('does not call sentry if handled by firestore', async () => {
           const event = deepCopy(subscriptionCreated);
           event.type = 'firestore.document.created';


### PR DESCRIPTION
## Because

- When a Stripe customers legacy card source is deleted, Stripe sends a
  payment_method.detached webhook with the card id. This causes the
  expand resource stripe helper method to fail, since it expects a
  payment method ID for event object payment_method, not a card id.

## This pull request

- Since we currently don't handle payment_method.detached events, except
  in the firestore handler, we can skip the expand resource for this
  event type.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).