### PR TITLE
fix(recovery-codes): Remove context.numberRemaining check in getGlobalTemplateValues

### DIFF
--- a/packages/fxa-auth-server/lib/senders/renderer/index.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/index.ts
@@ -137,7 +137,7 @@ class Renderer extends Localizer {
     // error. Might be a config option to make it work?
     try {
       // make this a switch statement on 'template' if more cases arise?
-      if (context.template === 'lowRecoveryCodes' && context.numberRemaining) {
+      if (context.template === 'lowRecoveryCodes') {
         return (
           await require('../emails/templates/lowRecoveryCodes/includes')
         ).getIncludes(context.numberRemaining);


### PR DESCRIPTION
Because:
* This check should have been '!== undefined' instead of checking for truthiness so when a user attempted to use their last remaining recovery code, numberRemaining was 0 and it caused the fallback to happen, requiring includes.json, which doesn't exist for lowRecoveryCodes template. We don't need this check at all because numberRemaining should never be undefined if the email template is lowRecoveryCodes

This commit:
* Removes checking for numberRemaining truthiness before returning includes.ts