### PR TITLE
maintenance(content): Remove fxaccounts:verified webchannel msg

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/channels/web.js
+++ b/packages/fxa-content-server/app/scripts/lib/channels/web.js
@@ -41,7 +41,9 @@ const COMMANDS = {
   /*
     SYNC_PREFERENCES: 'fxaccounts:sync_preferences', // Removed in issue #4250
     */
-  VERIFIED: 'fxaccounts:verified',
+  /*
+    VERIFIED: 'fxaccounts:verified', // Removed in issue #9389
+    */
 };
 
 function WebChannel(id) {

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync-web-channel.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync-web-channel.js
@@ -16,8 +16,8 @@ import ChannelMixin from './mixins/channel';
 
 const proto = FxSyncChannelAuthenticationBroker.prototype;
 
-const FxSyncWebChannelAuthenticationBroker = FxSyncChannelAuthenticationBroker.extend(
-  {
+const FxSyncWebChannelAuthenticationBroker =
+  FxSyncChannelAuthenticationBroker.extend({
     type: 'fx-sync-web-channel',
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
@@ -30,8 +30,7 @@ const FxSyncWebChannelAuthenticationBroker = FxSyncChannelAuthenticationBroker.e
       'CHANGE_PASSWORD',
       'DELETE_ACCOUNT',
       'LOADED',
-      'LOGIN',
-      'VERIFIED'
+      'LOGIN'
     ),
 
     createChannel() {
@@ -73,8 +72,7 @@ const FxSyncWebChannelAuthenticationBroker = FxSyncChannelAuthenticationBroker.e
         proto.beforeForcePasswordChange.call(this, account)
       );
     },
-  }
-);
+  });
 
 Cocktail.mixin(FxSyncWebChannelAuthenticationBroker, ChannelMixin);
 

--- a/packages/fxa-content-server/app/tests/spec/lib/channels/web.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/channels/web.js
@@ -46,7 +46,6 @@ describe('lib/channels/web', () => {
     assert.ok(WebChannel.PAIR_DECLINE);
     assert.ok(WebChannel.PAIR_REQUEST_SUPPLICANT_METADATA);
     assert.ok(WebChannel.PROFILE_CHANGE);
-    assert.ok(WebChannel.VERIFIED);
   });
 
   it('exports the expected commands on an instance', () => {
@@ -55,7 +54,7 @@ describe('lib/channels/web', () => {
       window: windowMock,
     });
 
-    assert.lengthOf(Object.keys(channel.COMMANDS), 17);
+    assert.lengthOf(Object.keys(channel.COMMANDS), 16);
     assert.ok(channel.COMMANDS.CAN_LINK_ACCOUNT);
     assert.ok(channel.COMMANDS.CHANGE_PASSWORD);
     assert.ok(channel.COMMANDS.DELETE);
@@ -72,7 +71,6 @@ describe('lib/channels/web', () => {
     assert.ok(channel.COMMANDS.PAIR_PREFERENCES);
     assert.ok(channel.COMMANDS.PAIR_REQUEST_SUPPLICANT_METADATA);
     assert.ok(channel.COMMANDS.PROFILE_CHANGE);
-    assert.ok(channel.COMMANDS.VERIFIED);
   });
 
   describe('send', () => {


### PR DESCRIPTION
## Because

- fxaccounts:verified  is no longer a message sent by the FF.

## This pull request

- Removes  support for the fxaccounts:verified command

## Issue that this pull request solves

Closes: #9389

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
