### PR TITLE
feat(auth): upgrade stripe dependency

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -121,7 +121,7 @@
     "safe-regex": "^2.1.1",
     "safe-url-assembler": "1.3.5",
     "sandboxed-regexp": "^0.3.0",
-    "stripe": "^8.203.0",
+    "stripe": "^8.215.0",
     "superagent": "^7.1.1",
     "typedi": "^0.8.0",
     "uuid": "^8.3.2",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -118,7 +118,7 @@
     "objection": "^2.2.17",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
-    "stripe": "^8.203.0",
+    "stripe": "^8.215.0",
     "superagent": "^7.1.1",
     "typesafe-joi": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -22056,7 +22056,7 @@ fsevents@~2.1.1:
     sass: ^1.49.7
     simplesmtp: 0.3.35
     sinon: ^9.0.3
-    stripe: ^8.203.0
+    stripe: ^8.215.0
     superagent: ^7.1.1
     through: 2.3.8
     typedi: ^0.8.0
@@ -22904,7 +22904,7 @@ fsevents@~2.1.1:
     reflect-metadata: ^0.1.13
     rxjs: ^7.2.0
     sinon: ^9.0.3
-    stripe: ^8.203.0
+    stripe: ^8.215.0
     superagent: ^7.1.1
     ts-jest: ^27.1.4
     ts-loader: ^8.3.0
@@ -36076,7 +36076,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.1":
+"qs@npm:^6.10.1, qs@npm:^6.10.3":
   version: 6.10.3
   resolution: "qs@npm:6.10.3"
   dependencies:
@@ -40329,13 +40329,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stripe@npm:^8.203.0":
-  version: 8.203.0
-  resolution: "stripe@npm:8.203.0"
+"stripe@npm:^8.215.0":
+  version: 8.215.0
+  resolution: "stripe@npm:8.215.0"
   dependencies:
     "@types/node": ">=8.1.0"
-    qs: ^6.6.0
-  checksum: 98d921d0c4e779dc9bbd52bc645c0b17bf7770e14013757fdfadb448766285d921e94ce8e1e132dff8f3e06b084de873c43c52203f947089b18260a928e836a1
+    qs: ^6.10.3
+  checksum: 0ccf3c66a259450a63b8d6f27920e04be1fad1207fb6a9c93bdffc250008e1dc915c44bac1d8b4a63be10fcd1865d4aa3de90c79f7966798c43fecab7e4f489d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* We want to use the latest types for Stripe.

This commit:

* Updates stripe to the 8.215.0.

Closes #12265

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
