### PR TITLE
task(all): Change default sentry trace sample rate to 0.0

### DIFF
--- a/packages/browserid-verifier/lib/config.js
+++ b/packages/browserid-verifier/lib/config.js
@@ -104,7 +104,7 @@ function loadConf() {
       },
       tracesSampleRate: {
         doc: 'Rate at which sentry traces are captured.',
-        default: 1.0,
+        default: 0.0,
         format: 'Number',
         env: 'SENTRY_TRACES_SAMPLE_RATE',
       },

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -77,7 +77,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured.',
-      default: 1.0,
+      default: 0.0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-admin-server/src/config.ts
+++ b/packages/fxa-admin-server/src/config.ts
@@ -66,7 +66,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured.',
-      default: 1.0,
+      default: 0.0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1662,7 +1662,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured.',
-      default: 1.0,
+      default: 0.0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -620,7 +620,7 @@ const conf = (module.exports = convict({
       format: Number,
     },
     tracesSampleRate: {
-      default: 1.0,
+      default: 0.0,
       doc: 'Sentry config for client side errors. If not set, then no errors reported.',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
       format: Number,

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -320,7 +320,7 @@ module.exports = function (fs, path, url, convict) {
       },
       tracesSampleRate: {
         doc: 'Rate at which sentry traces are captured.',
-        default: 1.0,
+        default: 0.0,
         format: 'Number',
         env: 'SENTRY_TRACES_SAMPLE_RATE',
       },

--- a/packages/fxa-event-broker/src/config.ts
+++ b/packages/fxa-event-broker/src/config.ts
@@ -210,7 +210,7 @@ const conf = convict({
       format: 'Number',
     },
     tracesSampleRate: {
-      default: 1.0,
+      default: 0.0,
       doc: 'Rate at which traces are sampled.',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
       format: 'Number',

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -207,7 +207,7 @@ const conf = convict({
       format: 'Number',
     },
     tracesSampleRate: {
-      default: 1.0,
+      default: 0.0,
       doc: 'Rate at which traces are sampled.',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
       format: 'Number',

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -231,7 +231,7 @@ const conf = convict({
       format: 'Number',
     },
     tracesSampleRate: {
-      default: 1.0,
+      default: 0.0,
       doc: 'Rate at which traces are sampled.',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
       format: 'Number',

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -104,7 +104,7 @@ const mockConfig = {
     env: 'test',
     sampleRate: 1.0,
     serverName: 'fxa-payments-server',
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.0,
   },
   version: '1.0.0',
 };
@@ -138,7 +138,7 @@ const expectedMergedConfig = {
     env: 'test',
     sampleRate: 1.0,
     serverName: 'fxa-payments-server',
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.0,
   },
   servers: {
     auth: {

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -63,7 +63,7 @@ export function defaultConfig(): Config {
       dsn: '',
       env: 'test',
       sampleRate: 1.0,
-      tracesSampleRate: 1.0,
+      tracesSampleRate: 0.0,
       serverName: 'fxa-payments-server',
       clientName: 'fxa-payments-client',
     },

--- a/packages/fxa-payments-server/src/lib/sentry.test.js
+++ b/packages/fxa-payments-server/src/lib/sentry.test.js
@@ -31,7 +31,7 @@ describe('lib/sentry', function () {
             env,
             serverName,
             sampleRate: 1.0,
-            tracesSampleRate: 1.0,
+            tracesSampleRate: 0.0,
           },
         });
       } catch (e) {
@@ -48,7 +48,7 @@ describe('lib/sentry', function () {
         env,
         serverName,
         sampleRate: 1.0,
-        tracesSampleRate: 1.0,
+        tracesSampleRate: 0.0,
       },
     });
 

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -325,7 +325,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured.',
-      default: 1.0,
+      default: 0.0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -58,7 +58,7 @@ export function getDefault() {
       serverName: 'fxa-settings-server',
       clientName: 'fxa-settings-client',
       sampleRate: 1.0,
-      tracesSampleRate: 1.0,
+      tracesSampleRate: 0.0,
     },
     servers: {
       gql: {

--- a/packages/fxa-shared/sentry/config-builder.ts
+++ b/packages/fxa-shared/sentry/config-builder.ts
@@ -71,10 +71,10 @@ function checkSentryConfig(config: SentryConfigOpts, log: ILogger) {
     raiseError('config missing either release or version.');
   }
 
-  if (!config.sentry?.sampleRate) {
+  if (config.sentry?.sampleRate == null) {
     raiseError('config missing sentry.sampleRate');
   }
-  if (!config.sentry?.tracesSampleRate) {
+  if (config.sentry?.tracesSampleRate == null) {
     raiseError('config missing sentry.tracesSampleRate');
   }
   if (!config.sentry.clientName && !config.sentry.serverName) {

--- a/packages/fxa-shared/test/sentry/config-builder.ts
+++ b/packages/fxa-shared/test/sentry/config-builder.ts
@@ -35,7 +35,7 @@ describe('config-builder', () => {
       dsn: 'https://foo.sentry.io',
       env: 'test',
       sampleRate: 1,
-      tracesSampleRate: 1,
+      tracesSampleRate: 0,
       serverName: 'fxa-shared-test',
       clientName: 'fxa-shared-client-test',
     },

--- a/packages/fxa-support-panel/src/config.ts
+++ b/packages/fxa-support-panel/src/config.ts
@@ -130,7 +130,7 @@ const conf = convict({
       format: 'Number',
     },
     tracesSampleRate: {
-      default: 1.0,
+      default: 0.0,
       doc: 'Rate at which traces are sampled.',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
       format: 'Number',


### PR DESCRIPTION
## Because

- We don't want to exhaust our tracing quota by accident.

## This pull request

- Adjusts all configs to default to a trace sample rate of zero.
- Adjust tests / mock to run with a default trace sample rate of zero.


## Issue that this pull request solves

Closes: #12398

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was requested by SRE. We are still evaluating APM for sentry and have a limited number of traces allowed at the moment. This can still be adjusted with environment variables if needed.
