### PR TITLE
fix(payments): fix lint script and suggestions 

### DIFF
--- a/packages/fxa-payments-server/.eslintignore
+++ b/packages/fxa-payments-server/.eslintignore
@@ -1,4 +1,4 @@
 # React built files
 build
 storybook-static
-
+fxa-content-server-l10n

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.scss -o src/styles/tailwind.out.scss",
     "postinstall": "../../_scripts/clone-l10n.sh fxa-payments-server",
-    "lint": "npm-run-all --parallel lint:eslint lint:sass",
+    "lint": "npm-run-all --parallel lint:eslint",
     "lint:eslint": "eslint .",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "start": "tsc --build ../fxa-react && npm run build-postcss && pm2 start pm2.config.js && ../../_scripts/check-url.sh localhost:3031/__lbheartbeat__",

--- a/packages/fxa-payments-server/server/bin/fxa-payments-server.js
+++ b/packages/fxa-payments-server/server/bin/fxa-payments-server.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const server = require('../lib/server')();
 
 server.listen();

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const {
   GROUPS,
   initialize,

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -34,6 +34,7 @@ jest.mock('../config', () => ({
     switch (key) {
       case 'amplitude':
         return mockAmplitudeConfig;
+      default:
     }
   },
 }));

--- a/packages/fxa-payments-server/server/lib/csp.js
+++ b/packages/fxa-payments-server/server/lib/csp.js
@@ -5,7 +5,6 @@
 // Middleware to take care of CSP. CSP headers are not sent unless config
 // option 'csp.enabled' is set (default true).
 
-'use strict';
 const helmet = require('helmet');
 const htmlOnly = require('./html-middleware');
 

--- a/packages/fxa-payments-server/server/lib/html-middleware.js
+++ b/packages/fxa-payments-server/server/lib/html-middleware.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const onHeaders = require('on-headers');
 const noOp = () => {};
 

--- a/packages/fxa-payments-server/server/lib/logging/log.js
+++ b/packages/fxa-payments-server/server/lib/logging/log.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const config = require('../../config').getProperties();
 
 module.exports = require('mozlog')(config.logging);

--- a/packages/fxa-payments-server/server/lib/logging/route-logging.js
+++ b/packages/fxa-payments-server/server/lib/logging/route-logging.js
@@ -4,8 +4,6 @@
 
 // Middleware to log the requests
 
-'use strict';
-
 const logger = require('./log')('server.requests');
 const morgan = require('morgan');
 const config = require('../../config');

--- a/packages/fxa-payments-server/server/lib/no-robots.js
+++ b/packages/fxa-payments-server/server/lib/no-robots.js
@@ -21,8 +21,6 @@
 //
 // [1] https://support.google.com/webmasters/answer/93710
 
-'use strict';
-
 const htmlOnly = require('./html-middleware');
 
 module.exports = htmlOnly((req, res, next) => {

--- a/packages/fxa-payments-server/server/lib/routes/legal-docs.js
+++ b/packages/fxa-payments-server/server/lib/routes/legal-docs.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const config = require('../../config');
 const joi = require('joi');
 const fetch = require('node-fetch');

--- a/packages/fxa-payments-server/server/lib/routes/navigation-timing.js
+++ b/packages/fxa-payments-server/server/lib/routes/navigation-timing.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const URL = require('url').URL;
 const {
   navigationTimingSchema,

--- a/packages/fxa-payments-server/server/lib/routes/navigation-timing.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/navigation-timing.test.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const mockStatsd = { timing: jest.fn() };
 const mockResponse = { status: jest.fn().mockReturnValue({ end: () => {} }) };
 const navTimingRoute = require('./navigation-timing');

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const joi = require('joi');
 const amplitude = require('../amplitude');
 const logger = require('../logging/log')('server.post-metrics');

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 module.exports = () => {
   const path = require('path');
   const fs = require('fs');

--- a/packages/fxa-payments-server/server/lib/version.js
+++ b/packages/fxa-payments-server/server/lib/version.js
@@ -18,8 +18,6 @@
  *
  */
 
-'use strict';
-
 // TODO - Make this shared code
 
 const cp = require('child_process');

--- a/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
@@ -6,7 +6,6 @@ import { AppContext, defaultAppContext } from '../../lib/AppContext';
 
 import AppLayout, { SignInLayout, SettingsLayout } from './index';
 import TermsAndPrivacy from '../TermsAndPrivacy';
-import { DEFAULT_PRODUCT_DETAILS } from 'fxa-shared/subscriptions/metadata';
 import { SELECTED_PLAN } from '../../lib/mock-data';
 
 afterEach(cleanup);

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -24,15 +24,11 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
   );
 };
 
-export type SignInLayout = {
-  children: ReactNode;
-};
-
 export const SignInLayoutContext = React.createContext({
   setHideLogo: (hideLogo: boolean) => {},
 });
 
-export const SignInLayout = ({ children }: SignInLayout) => {
+export const SignInLayout = ({ children }: { children: ReactNode }) => {
   const [hideLogo, setHideLogo] = useState(false);
   const mainContentClassNames = classNames('card', 'payments-card', {
     'hide-logo': hideLogo,
@@ -48,11 +44,7 @@ export const SignInLayout = ({ children }: SignInLayout) => {
   );
 };
 
-export type SettingsLayout = {
-  children: ReactNode;
-};
-
-export const SettingsLayout = ({ children }: SettingsLayout) => {
+export const SettingsLayout = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     document.body.classList.add('settings');
     return () => document.body.classList.remove('settings');

--- a/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.stories.tsx
@@ -23,7 +23,7 @@ storiesOf('components/Coupon', module)
     );
   })
   .add('readOnly with Coupon - subscription success', () => {
-    const [coupon, setCoupon] = useState<CouponDetails>({
+    const [coupon] = useState<CouponDetails>({
       promotionCode: 'Test',
       type: 'repeating',
       durationInMonths: 1,
@@ -59,7 +59,7 @@ storiesOf('components/Coupon', module)
     );
   })
   .add('has coupon - subscription in progress', () => {
-    const [coupon, setCoupon] = useState<CouponDetails>({
+    const [coupon] = useState<CouponDetails>({
       promotionCode: 'Test',
       type: 'repeating',
       durationInMonths: 1,

--- a/packages/fxa-payments-server/src/components/FetchErrorDialogMessage.tsx
+++ b/packages/fxa-payments-server/src/components/FetchErrorDialogMessage.tsx
@@ -3,7 +3,7 @@ import { FetchState } from '../store/types';
 import { APIError } from '../lib/apiClient';
 import DialogMessage from './DialogMessage';
 
-export default ({
+const FetchErrorDialogMessage = ({
   title,
   testid = '',
   fetchState,
@@ -21,3 +21,5 @@ export default ({
     )}
   </DialogMessage>
 );
+
+export default FetchErrorDialogMessage;

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -7,9 +7,9 @@ const WrapNewUserEmailForm = ({
 }: {
   accountExistsReturnValue: boolean;
 }) => {
-  const [validEmail, setValidEmail] = useState<string>('');
-  const [accountExists, setAccountExists] = useState(false);
-  const [emailsMatch, setEmailsMatch] = useState(false);
+  const [, setValidEmail] = useState<string>('');
+  const [, setAccountExists] = useState(false);
+  const [, setEmailsMatch] = useState(false);
   return (
     <div style={{ display: 'flex' }}>
       <NewUserEmailForm

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -1,18 +1,17 @@
 import React, { useState } from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-
-jest.mock('../../lib/apiClient', () => ({
-  apiFetchAccountStatus: jest.fn(),
-}));
 import { apiFetchAccountStatus } from '../../lib/apiClient';
-
 import {
   NewUserEmailForm,
   emailInputValidationAndAccountCheck,
   checkAccountExists,
 } from './index';
 import { Localized } from '@fluent/react';
+
+jest.mock('../../lib/apiClient', () => ({
+  apiFetchAccountStatus: jest.fn(),
+}));
 const selectedPlan = {
   plan_id: 'planId',
   plan_name: 'Pro level',
@@ -36,9 +35,9 @@ const WrapNewUserEmailForm = ({
 }: {
   accountExistsReturnValue: boolean;
 }) => {
-  const [validEmail, setValidEmail] = useState<string>('');
-  const [accountExists, setAccountExists] = useState(false);
-  const [emailsMatch, setEmailsMatch] = useState(false);
+  const [, setValidEmail] = useState<string>('');
+  const [, setAccountExists] = useState(false);
+  const [, setEmailsMatch] = useState(false);
   (apiFetchAccountStatus as jest.Mock)
     .mockClear()
     .mockResolvedValue({ exists: accountExistsReturnValue });
@@ -184,7 +183,7 @@ describe('NewUserEmailForm test', () => {
     expect(result.valid).toEqual(true);
     expect(result.error).toMatchObject(
       <Localized
-        elems={{ a: <a href="example.com/signin" /> }}
+        elems={{ a: <a href="example.com/signin">Sign in</a> }}
         id="new-user-already-has-account-sign-in"
       >
         <React.Fragment>

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -79,7 +79,13 @@ export const NewUserEmailForm = ({
     >
       <Localized
         id="new-user-sign-in-link"
-        elems={{ a: <a onClick={onClickSignInButton} href={signInURL}></a> }}
+        elems={{
+          a: (
+            <a onClick={onClickSignInButton} href={signInURL}>
+              Sign in
+            </a>
+          ),
+        }}
       >
         <p className="sign-in-copy" data-testid="sign-in-copy">
           Already have a Firefox account?{' '}
@@ -210,7 +216,13 @@ export async function emailInputValidationAndAccountCheck(
   const accountExistsMsg = (
     <Localized
       id="new-user-already-has-account-sign-in"
-      elems={{ a: <a onClick={onClickSignInButton} href={signInURL}></a> }}
+      elems={{
+        a: (
+          <a onClick={onClickSignInButton} href={signInURL}>
+            Sign in
+          </a>
+        ),
+      }}
     >
       <>
         You already have an account.{' '}

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -157,6 +157,7 @@ export const PaypalButton = ({
       postSubscriptionAttemptPaypalCallback,
       setSubscriptionError,
       setTransactionInProgress,
+      promotionCode,
     ]
   );
 

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -10,7 +10,6 @@ import {
   MOCK_PLANS,
   setupFluentLocalizationTest,
   getLocalizedMessage,
-  defaultAppContextValue,
 } from '../../lib/test-utils';
 import AppContext, { defaultAppContext } from '../../lib/AppContext';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -39,7 +39,7 @@ export const PaymentConfirmation = ({
   const { config, navigatorLanguages } = useContext(AppContext);
   const { amount, currency, interval, interval_count, product_name } =
     selectedPlan;
-  const { displayName, email } = profile;
+  const { email } = profile;
 
   const { payment_provider, subscriptions } = customer;
 

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
@@ -3,13 +3,9 @@ import TestRenderer from 'react-test-renderer';
 import { render, cleanup, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { APIError } from '../../lib/apiClient';
 import { Plan } from '../../store/types';
 
-jest.mock('../../lib/sentry');
-
 import {
-  MockApp,
   MOCK_PLANS,
   setupFluentLocalizationTest,
   getLocalizedMessage,
@@ -17,9 +13,10 @@ import {
 
 import { getLocalizedCurrency } from '../../lib/formats';
 import { PaymentConsentCheckbox } from './index';
-import { SELECTED_PLAN, UPGRADE_FROM_PLAN } from '../../lib/mock-data';
 import useValidatorState from '../../lib/validator';
 import { Form } from '../fields';
+
+jest.mock('../../lib/sentry');
 
 const findMockPlan = (planId: string): Plan => {
   const plan = MOCK_PLANS.find((x) => x.plan_id === planId);
@@ -62,7 +59,7 @@ describe('components/PaymentConsentCheckbox', () => {
       plan,
       onClick: onClickSpy,
     };
-    const { findByTestId, container } = render(<WrapCheckbox {...props} />);
+    const { findByTestId } = render(<WrapCheckbox {...props} />);
     const checkbox = await findByTestId('confirm');
 
     await act(async () => {

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
@@ -34,8 +34,8 @@ export const PaymentConsentCheckbox = ({
       }}
       elems={{
         strong: <strong></strong>,
-        termsOfServiceLink: <a href={termsOfServiceURL}></a>,
-        privacyNoticeLink: <a href={privacyNoticeURL}></a>,
+        termsOfServiceLink: <a href={termsOfServiceURL}>Terms of Service</a>,
+        privacyNoticeLink: <a href={privacyNoticeURL}>Privacy Notice</a>,
       }}
     >
       <Checkbox name="confirm" data-testid="confirm" onClick={onClick} required>

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -5,7 +5,7 @@ import { StripeError } from '@stripe/stripe-js';
 
 import { getErrorMessage, GeneralError } from '../../lib/errors';
 import errorIcon from '../../images/error.svg';
-import SubscriptionTitle from '../SubscriptionTitle';
+import SubscriptionTitle, { SubscriptionTitleType } from '../SubscriptionTitle';
 import TermsAndPrivacy from '../TermsAndPrivacy';
 
 import './index.scss';
@@ -18,7 +18,7 @@ export type PaymentErrorViewProps = {
   plan: Plan;
   error?: StripeError | GeneralError;
   className?: string;
-  subscriptionTitle?: React.ReactElement<SubscriptionTitle>;
+  subscriptionTitle?: React.ReactElement<SubscriptionTitleType>;
   showFxaLegalFooterLinks?: boolean;
   contentProps?: { [key: string]: unknown };
 };

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -4,28 +4,17 @@ import '@testing-library/jest-dom/extend-expect';
 import waitForExpect from 'wait-for-expect';
 
 import { Omit } from '../../lib/types';
-import { Plan } from '../../store/types';
-
-jest.mock('../../lib/sentry');
 
 import {
   mockStripeElementOnChangeFns,
   mockStripeElementOnBlurFns,
   elementChangeResponse,
-  MOCK_PLANS,
   MOCK_CUSTOMER,
 } from '../../lib/test-utils';
 
 import PaymentForm, { PaymentFormProps } from './index';
-import { getLocalizedCurrency } from '../../lib/formats';
 
-const findMockPlan = (planId: string): Plan => {
-  const plan = MOCK_PLANS.find((x) => x.plan_id === planId);
-  if (plan) {
-    return plan;
-  }
-  throw new Error('unable to find suitable Plan object for test execution.');
-};
+jest.mock('../../lib/sentry');
 
 const MOCK_PLAN = {
   plan_id: 'plan_123',
@@ -232,7 +221,7 @@ it('displays an error for empty name', () => {
   expect(getByText('Please enter your name')).toBeInTheDocument();
 });
 
-it('enables submit button when all fields are valid', () => {
+it('submit button should still be enabled when all fields are valid', () => {
   let { getByTestId } = renderWithValidFields();
   expect(getByTestId('submit')).not.toHaveAttribute('disabled');
 });

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -151,7 +151,7 @@ export const PaymentForm = ({
         promotionCode: promotionCode,
       });
     },
-    [onSubmitForParent, submitNonce]
+    [onSubmitForParent, submitNonce, plan, promotionCode]
   );
 
   const onStripeFormSubmit = useCallback(
@@ -175,7 +175,16 @@ export const PaymentForm = ({
         });
       }
     },
-    [validator, onSubmitForParent, stripe, submitNonce, allowSubmit]
+    [
+      validator,
+      onSubmitForParent,
+      stripe,
+      submitNonce,
+      allowSubmit,
+      elements,
+      isStripeCustomer,
+      promotionCode,
+    ]
   );
 
   const onSubmit = getPaymentProviderMappedVal(customer, {

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import { MockApp } from '../../../.storybook/components/MockApp';
 import PaymentLegalBlub from './index';
 import * as PaymentProvider from '../../lib/PaymentProvider';

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -6,11 +6,11 @@ import * as PaymentProvider from '../../lib/PaymentProvider';
 import './index.scss';
 
 function getPrivacyLinkText(): string {
-  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>';
+  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> <paypalPrivacyLink>PayPal privacy policy</paypalPrivacyLink>';
 }
 
 function getPaypalPrivacyLinkText(): string {
-  return '<paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>';
+  return '<paypalPrivacyLink>PayPal privacy policy</paypalPrivacyLink>';
 }
 
 function getStripePrivacyLinkText(): string {
@@ -23,7 +23,7 @@ const PaypalPaymentLegalBlurb = () => (
     data-testid="payment-legal-blurb-component"
   >
     <Localized id="payment-legal-copy-paypal">
-      <p>Mozilla uses Paypal for secure payment processing.</p>
+      <p>Mozilla uses PayPal for secure payment processing.</p>
     </Localized>
 
     <Localized
@@ -34,7 +34,9 @@ const PaypalPaymentLegalBlurb = () => (
             href="https://www.paypal.com/webapps/mpp/ua/privacy-full"
             target="_blank"
             rel="noopener noreferrer"
-          ></a>
+          >
+            PayPal privacy policy
+          </a>
         ),
       }}
     >
@@ -57,7 +59,9 @@ const StripePaymentLegalBlurb = () => (
             href="https://stripe.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
-          ></a>
+          >
+            Stripe privacy policy
+          </a>
         ),
       }}
     >
@@ -69,7 +73,7 @@ const StripePaymentLegalBlurb = () => (
 const DefaultPaymentLegalBlurb = () => (
   <div className="payment-legal-blurb">
     <Localized id="payment-legal-copy-stripe-and-paypal-2">
-      <p>Mozilla uses Stripe and Paypal for secure payment processing.</p>
+      <p>Mozilla uses Stripe and PayPal for secure payment processing.</p>
     </Localized>
 
     <Localized
@@ -80,14 +84,18 @@ const DefaultPaymentLegalBlurb = () => (
             href="https://stripe.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
-          ></a>
+          >
+            Stripe privacy policy
+          </a>
         ),
         paypalPrivacyLink: (
           <a
             href="https://www.paypal.com/webapps/mpp/ua/privacy-full"
             target="_blank"
             rel="noopener noreferrer"
-          ></a>
+          >
+            PayPal privacy policy
+          </a>
         ),
       }}
     >

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
@@ -44,5 +44,5 @@ export const SubscriptionTitle = ({
   );
 };
 
-export type SubscriptionTitle = typeof SubscriptionTitle;
+export type SubscriptionTitleType = typeof SubscriptionTitle;
 export default SubscriptionTitle;

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
@@ -6,7 +6,6 @@ import { MOCK_PLANS } from '../../lib/test-utils';
 import { TermsAndPrivacy } from './index';
 import { defaultAppContext, AppContext } from '../../lib/AppContext';
 import { DEFAULT_PRODUCT_DETAILS } from 'fxa-shared/subscriptions/metadata';
-import { config } from '../../lib/config';
 
 const enTermsOfServiceURL =
   'https://www.mozilla.org/en-US/about/legal/terms/services/';

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -88,7 +88,7 @@ export const TermsAndPrivacy = ({
           </a>
         </Localized>
         &nbsp;&nbsp;&nbsp;
-        <Localized id="accounts-legal-copy">
+        <Localized id="privacy">
           <a
             href={`${contentServerURL}/legal/privacy`}
             target="_blank"

--- a/packages/fxa-payments-server/src/components/Tooltip/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/Tooltip/index.test.tsx
@@ -3,11 +3,7 @@ import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Omit } from '../../lib/types';
 import ScreenInfo from '../../lib/screen-info';
-import {
-  AppContext,
-  AppContextType,
-  defaultAppContext,
-} from '../../lib/AppContext';
+import { AppContext, defaultAppContext } from '../../lib/AppContext';
 import {
   Tooltip,
   TooltipProps,
@@ -63,12 +59,10 @@ it('renders children as label', () => {
   const { queryByText } = render(<Subject>{LABEL_TEXT}</Subject>);
   const result = queryByText(LABEL_TEXT);
   expect(result).toBeInTheDocument();
-  if (result) {
-    expect(result).toHaveClass('tooltip');
-    expect(result).toHaveClass('tooltip-below');
-    expect(result).toHaveClass('fade-up-tt');
-    expect(result.style.top).not.toContain('-');
-  }
+  expect(result).toHaveClass('tooltip');
+  expect(result).toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-up-tt');
+  expect(result?.style.top).not.toContain('-');
 });
 
 it('renders with expected id and class names', () => {

--- a/packages/fxa-payments-server/src/components/fields/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.test.tsx
@@ -71,9 +71,7 @@ describe('Field', () => {
     );
     const label = container.querySelector('label .label-text');
     expect(label).not.toBeNull();
-    if (label) {
-      expect(label.textContent).toEqual('This is a label');
-    }
+    expect(label?.textContent).toEqual('This is a label');
   });
 
   it('renders a tooltip for errors', () => {
@@ -331,9 +329,6 @@ describe('StripeElement', () => {
 
   const buildMockStripeElement = (value: any) =>
     class extends React.Component<MockStripeElementProps> {
-      constructor(props: MockStripeElementProps) {
-        super(props);
-      }
       handleClick = (ev: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
         ev.preventDefault();
         this.props.onChange(value);
@@ -543,9 +538,7 @@ describe('Checkbox', () => {
     );
     const label = container.querySelector('span.label-text.checkbox');
     expect(label).not.toBeNull();
-    if (label) {
-      expect(label.textContent).toContain('nice label');
-    }
+    expect(label?.textContent).toContain('nice label');
   });
 
   it('renders children as a label with markup when available', () => {
@@ -559,13 +552,9 @@ describe('Checkbox', () => {
     const label = container.querySelector('span.label-text.checkbox');
     const labelInnerSpan = container.querySelector('.label-inner-span');
     expect(label).not.toBeNull();
-    if (label) {
-      expect(label.textContent).toEqual('nice label');
-    }
+    expect(label?.textContent).toEqual('nice label');
     expect(labelInnerSpan).not.toBeNull();
-    if (labelInnerSpan) {
-      expect(labelInnerSpan.textContent).toEqual('label');
-    }
+    expect(labelInnerSpan?.textContent).toEqual('label');
   });
 
   it('accepts an alternate className', () => {

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -316,7 +316,7 @@ export const StripeElement = (props: WrappedStripeElementProps) => {
         ...onValidate(value, true, props, getString),
       });
     },
-    [name, props, validator, onValidate, elementValue]
+    [name, props, validator, onValidate, elementValue, getString]
   );
 
   const onBlur = useCallback(
@@ -327,7 +327,7 @@ export const StripeElement = (props: WrappedStripeElementProps) => {
         ...onValidate(value, false, props, getString),
       });
     },
-    [name, props, validator, onValidate, elementValue]
+    [name, props, validator, onValidate, elementValue, getString]
   );
 
   const tooltipParentRef = useRef<any>(null);

--- a/packages/fxa-payments-server/src/index.test.tsx
+++ b/packages/fxa-payments-server/src/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-window.console.log = jest.fn();
 import './index';
+window.console.log = jest.fn();
 
 describe('index.tsx', () => {
   describe('init', () => {

--- a/packages/fxa-payments-server/src/lib/PaymentProvider.ts
+++ b/packages/fxa-payments-server/src/lib/PaymentProvider.ts
@@ -11,8 +11,8 @@ export const PaymentProviders = {
   none: 'not_chosen',
 } as const;
 
-type PaymentProviders = typeof PaymentProviders;
-export type PaymentProvider = PaymentProviders[keyof PaymentProviders];
+type PaymentProvidersType = typeof PaymentProviders;
+export type PaymentProvider = PaymentProvidersType[keyof PaymentProvidersType];
 export type NoPaymentProvider = 'not_chosen';
 
 type PaymentProviderKey = Exclude<PaymentProvider, NoPaymentProvider>;
@@ -45,7 +45,8 @@ export const getPaymentProviderMappedVal: GetPaymentProviderMappedVal = (
   }
 
   const k = Object.keys(PaymentProviders).find(
-    (x) => PaymentProviders[x as keyof PaymentProviders] === c!.payment_provider
+    (x) =>
+      PaymentProviders[x as keyof PaymentProvidersType] === c!.payment_provider
   );
 
   if (k && PaymentProviders[k as PaymentProviderKey] in dict) {
@@ -55,6 +56,7 @@ export const getPaymentProviderMappedVal: GetPaymentProviderMappedVal = (
   return dict.stripe;
 };
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   isStripe,
   isPaypal,

--- a/packages/fxa-payments-server/src/lib/account.test.ts
+++ b/packages/fxa-payments-server/src/lib/account.test.ts
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  apiCreatePasswordlessAccount,
+  updateAPIClientToken,
+} from './apiClient';
+import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
+import sentry from './sentry';
 jest.mock('./apiClient', () => ({
   apiCreatePasswordlessAccount: jest
     .fn()
@@ -12,12 +18,6 @@ jest.mock('./sentry', () => ({
   __esModule: true,
   default: { captureException: jest.fn() },
 }));
-import {
-  apiCreatePasswordlessAccount,
-  updateAPIClientToken,
-} from './apiClient';
-import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
-import sentry from './sentry';
 
 const accountParam = { email: 'me@example.com', clientId: 'tests' };
 

--- a/packages/fxa-payments-server/src/lib/account.ts
+++ b/packages/fxa-payments-server/src/lib/account.ts
@@ -5,7 +5,6 @@
 import {
   apiCreatePasswordlessAccount,
   updateAPIClientToken,
-  MetricsContext,
 } from './apiClient';
 import { GeneralError } from './errors';
 import sentry from './sentry';

--- a/packages/fxa-payments-server/src/lib/amplitude.test.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.test.ts
@@ -1,12 +1,12 @@
 import FlowEvent from '../lib/flow-event';
+
+import * as Amplitude from './amplitude';
 jest.mock('../lib/flow-event');
 
 jest.mock('./sentry');
 
-import * as Amplitude from './amplitude';
-
 beforeEach(() => {
-  (<jest.Mock>FlowEvent.logAmplitudeEvent).mockClear();
+  (FlowEvent.logAmplitudeEvent as jest.Mock).mockClear();
 });
 
 it('should call logAmplitudeEvent with the correct event group and type names', () => {
@@ -45,6 +45,6 @@ it('should call logAmplitudeEvent with the correct event group and type names', 
       expect(FlowEvent.logAmplitudeEvent).toBeCalledWith(...args, {});
     }
 
-    (<jest.Mock>FlowEvent.logAmplitudeEvent).mockClear();
+    (FlowEvent.logAmplitudeEvent as jest.Mock).mockClear();
   }
 });

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -253,10 +253,10 @@ describe('API requests', () => {
         .put(path(params.subscriptionId), { planId: params.planId })
         .reply(200, expectedResponse);
       expect(await apiUpdateSubscriptionPlan(params)).toEqual(expectedResponse);
-      expect(<jest.Mock>updateSubscriptionPlan_PENDING).toBeCalledWith(
+      expect(updateSubscriptionPlan_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>updateSubscriptionPlan_FULFILLED).toBeCalledWith(
+      expect(updateSubscriptionPlan_FULFILLED as jest.Mock).toBeCalledWith(
         metricsOptions
       );
       requestMock.done();
@@ -273,10 +273,10 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>updateSubscriptionPlan_PENDING).toBeCalledWith(
+      expect(updateSubscriptionPlan_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>updateSubscriptionPlan_REJECTED).toBeCalledWith({
+      expect(updateSubscriptionPlan_REJECTED as jest.Mock).toBeCalledWith({
         ...metricsOptions,
         error,
       });
@@ -308,10 +308,10 @@ describe('API requests', () => {
       expect(await apiCancelSubscription(params)).toEqual({
         subscriptionId: params.subscriptionId,
       });
-      expect(<jest.Mock>cancelSubscription_PENDING).toBeCalledWith(
+      expect(cancelSubscription_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>cancelSubscription_FULFILLED).toBeCalledWith(
+      expect(cancelSubscription_FULFILLED as jest.Mock).toBeCalledWith(
         metricsOptions
       );
       requestMock.done();
@@ -328,10 +328,10 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>cancelSubscription_PENDING).toBeCalledWith(
+      expect(cancelSubscription_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>cancelSubscription_REJECTED).toBeCalledWith({
+      expect(cancelSubscription_REJECTED as jest.Mock).toBeCalledWith({
         ...metricsOptions,
         error,
       });
@@ -397,10 +397,10 @@ describe('API requests', () => {
       );
 
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_PENDING
+        createSubscriptionWithPaymentMethod_PENDING as jest.Mock
       ).toBeCalledWith(metricsOptions);
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_FULFILLED
+        createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         sourceCountry: expected.sourceCountry,
@@ -421,10 +421,10 @@ describe('API requests', () => {
       }
       expect(error).not.toBeNull();
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_PENDING
+        createSubscriptionWithPaymentMethod_PENDING as jest.Mock
       ).toBeCalledWith(metricsOptions);
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_REJECTED
+        createSubscriptionWithPaymentMethod_REJECTED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         error,
@@ -444,13 +444,13 @@ describe('API requests', () => {
       ).toEqual(expected.subscription);
 
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_PENDING
+        createSubscriptionWithPaymentMethod_PENDING as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         promotionCode,
       });
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_FULFILLED
+        createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         sourceCountry: expected.sourceCountry,
@@ -598,10 +598,10 @@ describe('API requests', () => {
         MOCK_CUSTOMER
       );
 
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
+      expect(updateDefaultPaymentMethod_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>updateDefaultPaymentMethod_FULFILLED).toBeCalledWith(
+      expect(updateDefaultPaymentMethod_FULFILLED as jest.Mock).toBeCalledWith(
         metricsOptions
       );
       requestMock.done();
@@ -619,10 +619,10 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
+      expect(updateDefaultPaymentMethod_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>updateDefaultPaymentMethod_REJECTED).toBeCalledWith({
+      expect(updateDefaultPaymentMethod_REJECTED as jest.Mock).toBeCalledWith({
         ...metricsOptions,
         error,
       });
@@ -678,10 +678,10 @@ describe('API requests', () => {
       );
 
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_PENDING
+        createSubscriptionWithPaymentMethod_PENDING as jest.Mock
       ).toBeCalledWith(metricsOptions);
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_FULFILLED
+        createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         sourceCountry: 'FR',
@@ -702,10 +702,10 @@ describe('API requests', () => {
       }
       expect(error).not.toBeNull();
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_PENDING
+        createSubscriptionWithPaymentMethod_PENDING as jest.Mock
       ).toBeCalledWith(metricsOptions);
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_REJECTED
+        createSubscriptionWithPaymentMethod_REJECTED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         error,
@@ -725,13 +725,13 @@ describe('API requests', () => {
       );
 
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_PENDING
+        createSubscriptionWithPaymentMethod_PENDING as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         promotionCode,
       });
       expect(
-        <jest.Mock>createSubscriptionWithPaymentMethod_FULFILLED
+        createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
         sourceCountry: 'FR',
@@ -758,10 +758,10 @@ describe('API requests', () => {
 
       expect(await apiUpdateBillingAgreement(params)).toEqual(MOCK_CUSTOMER);
 
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
+      expect(updateDefaultPaymentMethod_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>updateDefaultPaymentMethod_FULFILLED).toBeCalledWith(
+      expect(updateDefaultPaymentMethod_FULFILLED as jest.Mock).toBeCalledWith(
         metricsOptions
       );
       requestMock.done();
@@ -779,10 +779,10 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
+      expect(updateDefaultPaymentMethod_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
-      expect(<jest.Mock>updateDefaultPaymentMethod_REJECTED).toBeCalledWith({
+      expect(updateDefaultPaymentMethod_REJECTED as jest.Mock).toBeCalledWith({
         ...metricsOptions,
         error,
       });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -8,7 +8,6 @@ import {
   FirstInvoicePreview,
   SubsequentInvoicePreview,
 } from 'fxa-shared/dto/auth/payments/invoice';
-import { CouponErrorMessageType } from '../components/CouponForm';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 
 // TODO: Use a better type here

--- a/packages/fxa-payments-server/src/lib/customer.ts
+++ b/packages/fxa-payments-server/src/lib/customer.ts
@@ -55,6 +55,7 @@ export const findCustomerIapSubscriptionByProductId = (
 export const needsCustomer = (customer: Customer | null) =>
   !(customer && customer.customerId);
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   hasSubscriptions,
   hasPaymentProvider,

--- a/packages/fxa-payments-server/src/lib/flow-event.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.ts
@@ -78,6 +78,7 @@ export function logAmplitudeEvent(
   }
 }
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   init,
   logAmplitudeEvent,

--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -3,13 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import '@testing-library/jest-dom/extend-expect';
 
-import {
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { Plan, WebSubscription } from 'fxa-shared/subscriptions/types';
 import React from 'react';
@@ -25,7 +19,6 @@ import { COUPON_DETAILS_VALID, CUSTOMER, SELECTED_PLAN } from './mock-data';
 
 // eslint-disable-next-line import/first
 import { apiInvoicePreview } from '../lib/apiClient';
-import { wait } from './test-utils';
 
 jest.mock('../lib/apiClient', () => {
   return {
@@ -63,7 +56,7 @@ describe('useCheckboxStateResult', () => {
 });
 
 describe('useNonce', () => {
-  const Subject = ({}) => {
+  const Subject = () => {
     const [nonce, refresh] = useNonce();
     return (
       <div>

--- a/packages/fxa-payments-server/src/lib/stripe.test.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.test.ts
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
+import { handlePasswordlessSubscription, localeToStripeLocale } from './stripe';
+import { NEW_CUSTOMER, PLAN } from './mock-data';
+
 jest.mock('./account', () => ({
   handlePasswordlessSignUp: jest.fn(),
 }));
 jest.mock('./apiClient');
-
-import * as apiClient from './apiClient';
-import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
-import { handlePasswordlessSubscription, localeToStripeLocale } from './stripe';
-import { NEW_CUSTOMER, PLAN } from './mock-data';
 
 const stripeOverride = {
   createPaymentMethod: jest.fn().mockResolvedValue({ paymentMethod: {} }),

--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -302,24 +302,6 @@ export const STRIPE_ELEMENT_STYLES = {
   },
 };
 
-/**
- * Stripe locales do not exactly match FxA locales. Mostly language tags
- * without subtags. This function should convert / normalize as necessary.
- */
-type StripeLocale = StripeElementsOptions['locale'];
-export const localeToStripeLocale = (locale?: string): StripeLocale => {
-  if (locale) {
-    if (locale in stripeLocales) {
-      return locale as StripeLocale;
-    }
-    const lang = locale.split('-').shift();
-    if (lang && lang in stripeLocales) {
-      return lang as StripeLocale;
-    }
-  }
-  return 'auto';
-};
-
 // TODO: Move to fxa-shared/l10n?
 // see also: https://stripe.com/docs/js/appendix/supported_locales
 enum stripeLocales {
@@ -356,3 +338,21 @@ enum stripeLocales {
   'tk',
   'zh',
 }
+
+/**
+ * Stripe locales do not exactly match FxA locales. Mostly language tags
+ * without subtags. This function should convert / normalize as necessary.
+ */
+type StripeLocale = StripeElementsOptions['locale'];
+export const localeToStripeLocale = (locale?: string): StripeLocale => {
+  if (locale) {
+    if (locale in stripeLocales) {
+      return locale as StripeLocale;
+    }
+    const lang = locale.split('-').shift();
+    if (lang && lang in stripeLocales) {
+      return lang as StripeLocale;
+    }
+  }
+  return 'auto';
+};

--- a/packages/fxa-payments-server/src/routes/Checkout/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.stories.tsx
@@ -8,8 +8,7 @@ import { QueryParams } from '../../lib/types';
 import { APIError } from '../../lib/apiClient';
 import { SignInLayout } from '../../components/AppLayout';
 import { Checkout, CheckoutProps } from './index';
-import { PLANS, PRODUCT_ID } from '../../lib/mock-data';
-import { linkTo } from '@storybook/addon-links';
+import { PLANS } from '../../lib/mock-data';
 
 function init() {
   storiesOf('routes/Checkout', module)

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -7,7 +7,6 @@ import {
   fireEvent,
   act,
   screen,
-  queryByTestId,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import waitForExpect from 'wait-for-expect';
@@ -47,6 +46,21 @@ import { FXA_NEWSLETTER_SIGNUP_ERROR } from '../../lib/newsletter';
 import { FXA_SIGNUP_ERROR } from '../../lib/account';
 import { getErrorMessage } from '../../lib/errors';
 
+import {
+  updateAPIClientToken,
+  apiCreateCustomer,
+  apiCreatePasswordlessAccount,
+  apiFetchCustomer,
+  apiFetchPlans,
+  apiFetchProfile,
+  apiCreateSubscriptionWithPaymentMethod,
+  apiFetchAccountStatus,
+  apiGetPaypalCheckoutToken,
+  apiCapturePaypalPayment,
+  apiSignupForNewsletter,
+} from '../../lib/apiClient';
+import { ButtonBaseProps } from '../../components/PayPalButton';
+
 jest.mock('../../lib/apiClient', () => {
   return {
     ...jest.requireActual('../../lib/apiClient'),
@@ -69,22 +83,6 @@ const stripeOverride = {
   createPaymentMethod: jest.fn(),
   confirmCardPayment: jest.fn(),
 };
-
-import {
-  updateAPIClientToken,
-  apiCreateCustomer,
-  apiCreatePasswordlessAccount,
-  apiFetchCustomer,
-  apiFetchPlans,
-  apiFetchProfile,
-  apiCreateSubscriptionWithPaymentMethod,
-  apiFetchAccountStatus,
-  apiGetPaypalCheckoutToken,
-  apiCapturePaypalPayment,
-  apiSignupForNewsletter,
-} from '../../lib/apiClient';
-import { ButtonBaseProps } from '../../components/PayPalButton';
-import { updateConfig } from '../../lib/config';
 
 const newAccountEmail = 'testo@example.gd';
 

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
@@ -14,7 +14,6 @@ import PlanDetails from '../../../components/PlanDetails';
 import SubscriptionTitle from '../../../components/SubscriptionTitle';
 import { Customer, Profile, Plan } from '../../../store/types';
 import { getIapSubscriptionManagementUrl } from '../../../lib/formats';
-import { useNavigate } from 'react-router-dom';
 
 export type IapRoadblockProps = {
   isMobile: boolean;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Stripe, PaymentMethod, PaymentIntent } from '@stripe/stripe-js';
 import { storiesOf } from '@storybook/react';
 import { linkTo } from '@storybook/addon-links';
@@ -69,7 +69,7 @@ function init() {
         stripeOverride={{
           ...defaultStripeOverride,
           createPaymentMethod: async () => {
-            throw 'barf';
+            throw new Error('barf');
           },
         }}
       />
@@ -88,7 +88,7 @@ function init() {
         stripeOverride={{
           ...defaultStripeOverride,
           confirmCardPayment: async () => {
-            throw 'barf';
+            throw new Error('barf');
           },
         }}
       />

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -39,9 +39,6 @@ import {
   mockStripeElementOnChangeFns,
 } from '../../../lib/test-utils';
 import { PickPartial } from '../../../lib/types';
-import PaymentProvider, {
-  PaymentProviders,
-} from '../../../lib/PaymentProvider';
 
 jest.mock('../../../lib/hooks', () => {
   const refreshNonceMock = jest.fn().mockImplementation(Math.random);
@@ -145,7 +142,7 @@ describe('routes/Product/SubscriptionCreate', () => {
     expect(queryByTestId('privacy')).toBeInTheDocument();
     expect(
       queryByText(
-        'Mozilla uses Stripe and Paypal for secure payment processing.'
+        'Mozilla uses Stripe and PayPal for secure payment processing.'
       )
     ).toBeInTheDocument();
     expect(queryByTestId('coupon-component')).toBeInTheDocument();
@@ -153,7 +150,7 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('renders as expected with PayPal UI enabled', async () => {
     const { queryByTestId, findByTestId } = screen;
-    const MockedButtonBase = ({}: ButtonBaseProps) => {
+    const MockedButtonBase = () => {
       return <button data-testid="paypal-button" />;
     };
     await act(async () => {
@@ -183,7 +180,7 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('renders as expected with PayPal UI enabled and an existing Stripe customer', async () => {
     const { queryByTestId } = screen;
-    const MockedButtonBase = ({}: ButtonBaseProps) => {
+    const MockedButtonBase = () => {
       return <button data-testid="paypal-button" />;
     };
     await act(async () => {
@@ -201,7 +198,7 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('renders as expected with PayPal UI enabled and an existing PayPal customer', async () => {
     const { queryByTestId } = screen;
-    const MockedButtonBase = ({}: ButtonBaseProps) => {
+    const MockedButtonBase = () => {
       return <button data-testid="paypal-button" />;
     };
     await act(async () => {
@@ -628,7 +625,7 @@ describe('routes/Product/SubscriptionCreate', () => {
           .fn()
           .mockRejectedValue(error),
       };
-      const { stripeOverride, refreshSubscriptions } = await commonSubmitSetup({
+      const { refreshSubscriptions } = await commonSubmitSetup({
         apiClientOverrides,
       });
       await act(async () => {
@@ -692,10 +689,9 @@ describe('routes/Product/SubscriptionCreate', () => {
           ...defaultStripeOverride(),
           createPaymentMethod,
         };
-        const { apiClientOverrides, refreshSubscriptions } =
-          await commonSubmitSetup({
-            stripeOverride,
-          });
+        const { refreshSubscriptions } = await commonSubmitSetup({
+          stripeOverride,
+        });
         await act(async () => {
           fireEvent.click(screen.getByTestId('submit'));
         });
@@ -868,7 +864,7 @@ describe('routes/Product/SubscriptionCreate', () => {
   });
 
   it('displays apiCapturePaypalPayment failure', async () => {
-    const [_, refreshSubmitNonce] = useNonce();
+    const [, refreshSubmitNonce] = useNonce();
     (refreshSubmitNonce as jest.Mock).mockClear();
     const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
       return (

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -7,13 +7,10 @@ import { APIError } from '../../../lib/apiClient';
 import { Plan } from '../../../store/types';
 import { PlanDetailsCard } from './PlanUpgradeDetails';
 
-jest.mock('../../../lib/sentry');
-
 import {
   updateSubscriptionPlanMounted,
   updateSubscriptionPlanEngaged,
 } from '../../../lib/amplitude';
-jest.mock('../../../lib/amplitude');
 
 import {
   MockApp,
@@ -33,6 +30,9 @@ import { SignInLayout } from '../../../components/AppLayout';
 
 import SubscriptionUpgrade, { SubscriptionUpgradeProps } from './index';
 import { getLocalizedCurrency } from '../../../lib/formats';
+
+jest.mock('../../../lib/sentry');
+jest.mock('../../../lib/amplitude');
 
 describe('routes/Product/SubscriptionUpgrade', () => {
   afterEach(() => {
@@ -93,7 +93,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
   });
 
   it('displays a loading spinner while submitting', async () => {
-    const { findByTestId, getByTestId, getByText } = render(
+    const { findByTestId, getByTestId } = render(
       <Subject
         props={{
           updateSubscriptionPlanStatus: {

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { linkTo } from '@storybook/addon-links';
 import MockApp, {
   defaultAppContextValue,
 } from '../../../.storybook/components/MockApp';
 import { QueryParams } from '../../lib/types';
 import { APIError } from '../../lib/apiClient';
 import { SignInLayout } from '../../components/AppLayout';
-import { State as ValidatorState } from '../../lib/validator';
 import { Product, ProductProps } from './index';
 import { Customer, Plan, Profile } from '../../store/types';
 import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
-import { Route, BrowserRouter, Routes } from 'react-router-dom';
 
 function init() {
   storiesOf('routes/Product', module)
@@ -275,68 +272,5 @@ const MOCK_PROPS: ProductProps = {
     result: null,
   },
 };
-
-const FAILURE_PROPS = {
-  ...MOCK_PROPS,
-  resetCreateSubscription: linkTo(
-    'routes/Product',
-    'subscribing with existing account'
-  ),
-};
-
-const mkValidPaymentFormState = (): ValidatorState => ({
-  error: null,
-  fields: {
-    name: {
-      value: 'Foo Barson',
-      valid: true,
-      error: null,
-      fieldType: 'input',
-      required: true,
-    },
-    zip: {
-      value: '90210',
-      valid: true,
-      error: null,
-      fieldType: 'input',
-      required: true,
-    },
-    creditCardNumber: {
-      value: true,
-      valid: null,
-      error: null,
-      fieldType: 'stripe',
-      required: true,
-    },
-    expDate: {
-      value: true,
-      valid: null,
-      error: null,
-      fieldType: 'stripe',
-      required: true,
-    },
-    cvc: {
-      value: true,
-      valid: null,
-      error: null,
-      fieldType: 'stripe',
-      required: true,
-    },
-    confirm: {
-      value: true,
-      valid: true,
-      error: null,
-      fieldType: 'input',
-      required: true,
-    },
-    submit: {
-      value: null,
-      valid: null,
-      error: null,
-      fieldType: 'input',
-      required: false,
-    },
-  },
-});
 
 init();

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -179,6 +179,7 @@ describe('routes/Product', () => {
     const { findByTestId } = render(<Subject />);
     const errorEl = await findByTestId('error-loading-profile');
     expect(errorEl).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
   });
 
   it('displays an error on failure to load plans', async () => {
@@ -196,6 +197,7 @@ describe('routes/Product', () => {
     const { findByTestId } = render(<Subject />);
     const errorEl = await findByTestId('error-loading-plans');
     expect(errorEl).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
   });
 
   it('displays an error on failure to load customer', async () => {
@@ -215,6 +217,7 @@ describe('routes/Product', () => {
     const { findByTestId } = render(<Subject />);
     const errorEl = await findByTestId('error-loading-customer');
     expect(errorEl).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
   });
 
   it('does not display an error on missing / new customer', async () => {
@@ -238,6 +241,7 @@ describe('routes/Product', () => {
     const { findAllByText } = render(<Subject />);
     const headingEls = await findAllByText('Set up your subscription');
     expect(headingEls.length).toBeGreaterThan(0);
+    expectNockScopesDone(apiMocks);
   });
 
   it('does not display an error on customer with no subscriptions', async () => {
@@ -261,6 +265,7 @@ describe('routes/Product', () => {
     const { findAllByText } = render(<Subject />);
     const headingEls = await findAllByText('Set up your subscription');
     expect(headingEls.length).toBeGreaterThan(0);
+    expectNockScopesDone(apiMocks);
   });
 
   it('offers upgrade if user is already subscribed to another plan in the same product set', async () => {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
@@ -9,7 +9,6 @@ import { Customer } from '../../store/types';
 import AppContext from '../../lib/AppContext';
 
 import * as PaymentProvider from '../../lib/PaymentProvider';
-import { lastEventId } from '@sentry/browser';
 import {
   PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
   PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
@@ -26,11 +25,8 @@ export const ActionButton = ({
   onRevealUpdateClick,
   revealFixPaymentModal,
 }: ActionButtonProps) => {
-  const {
-    billing_agreement_id,
-    payment_provider,
-    paypal_payment_error,
-  } = customer;
+  const { billing_agreement_id, payment_provider, paypal_payment_error } =
+    customer;
 
   const { config } = useContext(AppContext);
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -7,7 +7,6 @@ import { screen, render, act, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import waitForExpect from 'wait-for-expect';
 import * as Amplitude from '../../../lib/amplitude';
-jest.mock('../../../lib/amplitude');
 import CancelSubscriptionPanel, {
   CancelSubscriptionPanelProps,
 } from './CancelSubscriptionPanel';
@@ -25,6 +24,7 @@ import {
 import { defaultState } from 'fxa-payments-server/src/store/state';
 import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { LocalizationProvider, ReactLocalization } from '@fluent/react';
+jest.mock('../../../lib/amplitude');
 
 const { queryByTestId, queryByText, queryAllByText, getByTestId } = screen;
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -68,6 +68,8 @@ const CancelSubscriptionPanel = ({
     plan,
     paymentProvider,
     promotionCode,
+    resetIsLocalCancellation,
+    setIsLocalCancellation,
   ]);
 
   const viewed = useRef(false);
@@ -93,7 +95,7 @@ const CancelSubscriptionPanel = ({
       onConfirmationChanged(evt);
       hideCancel();
     },
-    [hideCancel, engage]
+    [hideCancel, engage, onConfirmationChanged]
   );
 
   const engagedOnConfirmationChanged = useCallback(

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -20,7 +20,7 @@ import {
 import { CUSTOMER, FILTERED_SETUP_INTENT, PLAN } from '../../lib/mock-data';
 
 import { PickPartial } from '../../lib/types';
-import { defaultConfig, updateConfig } from '../../lib/config';
+import { defaultConfig } from '../../lib/config';
 import {
   PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
   PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -175,7 +175,18 @@ export const PaymentUpdateForm = ({
       stripeSubmitResetInProgress();
       refreshSubmitNonce();
     },
-    []
+    [
+      stripeSubmitSetInProgress,
+      resetUpdatePaymentIsSuccess,
+      setPaymentError,
+      apiClientOverrides,
+      hideUpdate,
+      refreshSubmitNonce,
+      refreshSubscriptions,
+      setUpdatePaymentIsSuccess,
+      stripeOverride,
+      stripeSubmitResetInProgress,
+    ]
   );
 
   // clear any error rendered with `ErrorMessage`
@@ -230,7 +241,7 @@ export const PaymentUpdateForm = ({
             </Localized>
             <Localized id="sub-route-payment-modal-message">
               <p>
-                There seems to be an error with your Paypal account, we need you
+                There seems to be an error with your PayPal account, we need you
                 to take the necessary steps to resolve this payment issue.
               </p>
             </Localized>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 import {
   getLocalizedDate,
@@ -10,7 +10,6 @@ import DialogMessage from '../../../components/DialogMessage';
 import fpnImage from '../../../images/fpn';
 import { Plan, Customer } from '../../../store/types';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
-import { apiInvoicePreview } from '../../../lib/apiClient';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import { useHandleConfirmationDialog } from '../../../lib/hooks';

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
@@ -5,7 +5,13 @@ import DialogMessage from '../../../components/DialogMessage';
 import fpnImage from '../../../images/fpn';
 import { Localized } from '@fluent/react';
 
-export default ({ plan, onDismiss }: { plan: Plan; onDismiss: () => void }) => {
+const SuccessDialog = ({
+  plan,
+  onDismiss,
+}: {
+  plan: Plan;
+  onDismiss: () => void;
+}) => {
   const { product_name: productName } = plan;
   const { webIconURL, webIconBackground } = metadataFromPlan(plan);
 
@@ -44,3 +50,5 @@ export default ({ plan, onDismiss }: { plan: Plan; onDismiss: () => void }) => {
     </DialogMessage>
   );
 };
+
+export default SuccessDialog;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -18,15 +18,13 @@ import {
   cancelSubscriptionEngaged,
 } from '../../lib/amplitude';
 
-import { ProductMetadata, Plan } from '../../store/types';
+import { ProductMetadata } from '../../store/types';
 
 import { AuthServerErrno } from '../../lib/errors';
 
 import { Store } from '../../store';
 
-import { PAYMENT_ERROR_1 } from '../../lib/errors';
 import {
-  wait,
   defaultAppContextValue,
   MockApp,
   setupMockConfig,
@@ -44,8 +42,6 @@ import {
   PRODUCT_ID,
   MOCK_SUBSEQUENT_INVOICES,
 } from '../../lib/test-utils';
-
-import FlowEvent from '../../lib/flow-event';
 
 import { SettingsLayout } from '../../components/AppLayout';
 import Subscriptions from './index';
@@ -259,24 +255,10 @@ describe('routes/Subscriptions', () => {
   });
 
   it('redirects to settings if no subscriptions are available', async () => {
-    const apiMocks = [
-      nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
-      nock(authServer)
-        .get('/v1/oauth/subscriptions/plans')
-        .reply(200, MOCK_PLANS),
-      nock(authServer).get('/v1/oauth/subscriptions/active').reply(200, []),
-      nock(authServer)
-        .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-        .reply(200, MOCK_SUBSEQUENT_INVOICES),
-      nock(authServer)
-        .get(
-          '/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions'
-        )
-        .reply(200, {
-          ...MOCK_CUSTOMER,
-          subscriptions: [],
-        }),
-    ];
+    initApiMocks({
+      mockActiveSubscriptions: [],
+      mockCustomer: { ...MOCK_CUSTOMER, subscriptions: [] },
+    });
 
     const navigateToUrl = jest.fn();
     render(<Subject navigateToUrl={navigateToUrl} />);
@@ -773,9 +755,13 @@ describe('routes/Subscriptions', () => {
       });
     };
 
-  describe('reactivation with defined webIconURL', reactivationTests(false));
+  describe('reactivation with defined webIconURL', () => {
+    reactivationTests(false);
+  });
 
-  describe('reactivation with default icon', reactivationTests(true));
+  describe('reactivation with default icon', () => {
+    reactivationTests(true);
+  });
 
   it('should display an error message for a plan found in auth-server but not subhub', async () => {
     nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -98,7 +98,7 @@ export const Subscriptions = ({
   const resetUpdatePaymentIsSuccessAndAlert = useCallback(() => {
     resetUpdatePaymentIsSuccess();
     resetSuccessAlert();
-  }, [resetUpdatePaymentIsSuccess]);
+  }, [resetUpdatePaymentIsSuccess, resetSuccessAlert]);
 
   const showPaymentSuccessAlert =
     !updatePaymentSuccessAlertIsHidden && updatePaymentIsSuccessViaSCA;
@@ -405,7 +405,9 @@ export const Subscriptions = ({
                         rel="noopener noreferrer"
                         href="https://getpocket.com/premium/manage"
                         data-testid="manage-pocket-link"
-                      ></a>
+                      >
+                        click here
+                      </a>
                     ),
                   }}
                 >
@@ -499,7 +501,7 @@ const CancellationDialogMessage = ({
       <Localized
         id="sub-route-idx-cancel-aside"
         vars={{ url: supportFormUrl }}
-        elems={{ a: <a href={supportFormUrl}></a> }}
+        elems={{ a: <a href={supportFormUrl}>Mozilla Support</a> }}
       >
         <p className="small">
           Have questions? Visit <a href={supportFormUrl}>Mozilla Support</a>.

--- a/packages/fxa-payments-server/src/store/actions/index.test.ts
+++ b/packages/fxa-payments-server/src/store/actions/index.test.ts
@@ -1,33 +1,18 @@
 import actions, { Action } from './index';
-import { Plan } from '../types';
 
 type ActionsCollection = typeof actions;
 type ActionsKey = keyof ActionsCollection;
 type ActionsParameters = Parameters<ActionsCollection[ActionsKey]>;
 
-const assertActionType = (
-  name: ActionsKey,
-  type: Action['type'],
-  args: ActionsParameters = []
-) => () =>
-  expect(
-    actions[name](
-      // @ts-ignore TODO figure out if / how this type can work
-      ...args
-    ).type
-  ).toEqual(type);
-
-const assertActionPayload = (
-  name: ActionsKey,
-  payload: any,
-  args: ActionsParameters = []
-) => () =>
-  expect(
-    actions[name](
-      // @ts-ignore TODO figure out if / how this type can work
-      ...args
-    ).payload
-  ).toEqual(payload);
+const assertActionType =
+  (name: ActionsKey, type: Action['type'], args: ActionsParameters = []) =>
+  () =>
+    expect(
+      actions[name](
+        // @ts-ignore TODO figure out if / how this type can work
+        ...args
+      ).type
+    ).toEqual(type);
 
 describe('resetActions', () => {
   const actionNames: ActionsKey[] = [
@@ -36,7 +21,7 @@ describe('resetActions', () => {
     'resetUpdateSubscriptionPlan',
   ];
   actionNames.forEach((name) => {
-    describe(name, () => {
+    describe(`${name}`, () => {
       const type = name;
       it('produces the expected type', assertActionType(name, type));
     });

--- a/packages/fxa-payments-server/src/store/reducers/api.ts
+++ b/packages/fxa-payments-server/src/store/reducers/api.ts
@@ -49,7 +49,7 @@ for (const apiType in apiTypeToStoreMap) {
   }
 }
 
-export default (state: State, action: Action): State => {
+const apiReducer = (state: State, action: Action): State => {
   if (action.type in apiPromiseTypeToStoreMap) {
     // promise-middleware actions are close enough to ApiAction type
     const payload = (action as ApiAction).payload;
@@ -74,3 +74,5 @@ export default (state: State, action: Action): State => {
   }
   return state;
 };
+
+export default apiReducer;

--- a/packages/fxa-payments-server/src/store/reducers/reset.ts
+++ b/packages/fxa-payments-server/src/store/reducers/reset.ts
@@ -9,7 +9,7 @@ const resetTypeToStoreMap: ResetTypeToStoreMap = {
   resetReactivateSubscription: 'reactivateSubscription',
 };
 
-export default (state: State, action: Action): State => {
+const resetReducer = (state: State, action: Action): State => {
   if (action.type in resetTypeToStoreMap) {
     const stateKey =
       resetTypeToStoreMap[action.type as keyof ResetTypeToStoreMap];
@@ -20,3 +20,5 @@ export default (state: State, action: Action): State => {
   }
   return state;
 };
+
+export default resetReducer;

--- a/packages/fxa-payments-server/src/store/sequences.test.ts
+++ b/packages/fxa-payments-server/src/store/sequences.test.ts
@@ -1,5 +1,8 @@
 import { MOCK_PLANS } from '../lib/test-utils';
 
+import { actions } from './actions';
+import { sequences } from './sequences';
+
 jest.mock('../lib/sentry');
 
 jest.mock('./actions', () => ({
@@ -19,9 +22,6 @@ jest.mock('./actions', () => ({
   },
 }));
 
-import { actions } from './actions';
-import { sequences } from './sequences';
-
 const dispatch = jest.fn().mockImplementation(async (action) => {
   if (typeof action === 'function') {
     return await action(dispatch);
@@ -30,7 +30,7 @@ const dispatch = jest.fn().mockImplementation(async (action) => {
 });
 
 const dispatchError = jest.fn().mockImplementation(() => {
-  throw 'ohno';
+  throw new Error('ohno');
 });
 
 describe('updateSubscriptionPlanAndRefresh', () => {

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -13,11 +13,6 @@ const {
   fetchSubsequentInvoices,
 } = actions;
 
-// This is the length fo time that alert bar is displayed before
-// auto-dismissing, in milliseconds. It should be long enough for the user to
-// read the message.
-const RESET_PAYMENT_DELAY = 5000;
-
 // TODO: Find another way to handle these errors? Rejected promises result
 // in Redux actions dispatched *and* exceptions thrown. We handle the
 // actions in the UI, but the exceptions bubble and get caught by dev server


### PR DESCRIPTION
## Because

- Since removing the `lint:sass` script the lint script has not been
  working on the fxa-payments-server.

## This pull request

- Fix the lint script and all errors and warnings raised by the linter

## Issue that this pull request solves

Closes: #11546

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).