### PR TITLE
chore(docs): Update auth-server README around emails

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -128,143 +128,19 @@ Executing tests using remote databases (MySQL, Redis, Memcached) is possible by 
 
 This also allows to use temporary throw-away Docker containers to provide these.
 
-## Mailer
+## Mailer and Emails
 
-The mailer library is located in `mailer/` directory.
+See the ["Emails" page in ecosystem platform](https://mozilla.github.io/ecosystem-platform/reference/emails) for docs on our email stack, including styling and l10n guides.
 
-The emails are written to postfix which tends sends them off to SES.
+### Storybook
 
-The auth-mailer also includes a restify API to send emails, but the auth server is using it as a library at the moment.
-
-### Changing Templates
-
-If you are changing or adding templates then you need to update `.html` and `.txt` templates.
-In `mailer/`, use the `/partials` directory to make changes to the HTML templates, then run `grunt templates` to regenerate the template.
-This saves the HTML template into `/templates`. Then make changes to the `.txt` template in the `/templates` directory.
+Storybook is set up in the auth-server for FxA and SubPlat emails. See our "emails" documentation for more info.
 
 ### L10N
 
-After updating a string in one of the templates in `./mailer/templates` you'll need to extract the strings.
-Follow the instructions at [mozilla/fxa-content-server-l10n](https://github.com/mozilla/fxa-content-server-l10n#string-extraction).
+Strings are automatically extracted to the [`fxa-content-server-l10n` repo](https://github.com/mozilla/fxa-content-server-l10n) where they reach Pontoon for translations to occur by our l10n team and contributors. This is achieved by concatenating all of our .ftl (Fluent) files into a single `auth.ftl` file with the `merge-ftl` grunttask, and the `extract-and-pull-request.sh` script that runs in `fxa-content-server-l10n` on a weekly cadence. For more detailed information, check out the [ecosystem platform l10n](http://localhost:3000/ecosystem-platform/reference/localization) doc.
 
-### 2021 Template Updates
-
-In 2021, FxA began converting the email templating system from Mustache, inline CSS, and GetText to a modernized stack using [MJML](https://mjml.io/), [EJS](https://ejs.co/), [Fluent](https://github.com/projectfluent/fluent.js/tree/master/fluent-dom), and [Storybook](https://github.com/storybookjs/storybook/tree/main/app/html) ([see the ADR](https://github.com/mozilla/fxa/blob/main/docs/adr/0024-upgrade-templating-toolset-of-auth-server-emails.md)). Until each template has been converted and verified by QA, the old system described above will be used for emails in production.
-
-#### MJML Feature Flag for Testing
-
-The auth-server has an `MJML` configuration value that designates which email templates have been converted to the new stack (`mjml.templates` array) and controls which user emails will receive those templates (`mjml.enabledEmailAddress` regex). The auth-server exposes a feature flag method to check these values and send the correct rendered template accordingly (old or new) which allows for testing across environments. To generate these new templates locally until we enable them for other environments, change `mjml.enabledEmailAddress` in dev config to `@testuser.com$`.
-
-This flag and logic around it can be removed, as well as old templates and documentation, once all templates have been converted, verified by QA, and tested in production.
-
-#### MJML and EJS
-
-HTML email has a lot of quirks - MJML shifts the burden of maintaining solutions for these off of FxA engineers. Furthermore, using EJS with MJML helps us include more logic in templates thereby making conditional rendering possible without creating any additional helper methods. A small example of how template variables are being passed down from the mailer object and consumed in the templates is shown below:
-
-```js
-const templateValues = {
-  buttonText: 'Sync another device',
-};
-
-const localized = this.templates.render(
-  message.template, // template name
-  message.layout || 'fxa', // template layout
-  templateValues
-);
-```
-
-```mjml
-<mj-include
-  path="./lib/senders/emails/css/button/index.css"
-  type="css"
-  css-inline="inline"
-/>
-<mj-section>
-  <mj-column>
-    <mj-button css-class="primary-button"><%- buttonText %></mj-button>
-  </mj-column>
-</mj-section>
-```
-
-Note: In ejs, `<%=` outputs the value into the template with HTML escaped, whereas `<%-` renders the string as is (unescaped)
-
-The emails for which the MJML feature flag is enabled can be rendered to disk using the `yarn write-emails` command. If you wish to compare before-and-after versions of templates you've converted to MJML you can remove values from the `mjml.templates` array and re-run the `write-emails` command, observing the generated HTML and text templates.
-
-#### Styles
-
-Another advantage of using MJML for emails is that it inlines styles with the compliled HTML elements making emails compatible with all the mail clients. Currently, we are using `scss` stylesheets which get compiled down to css and are included in the MJML templates. We are maintaining shared stylesheets with common styles and variables, and template-specific stylesheet for the styles scoped to the respective template/partial. Although there are a lot of benefits of using stylesheets with MJML, one caveat that we'd like to highlight is the inevitible use of `!important` syntax with some of the styles. While compiling down the templates, MJML internally adds some default styles to the HTML elements, so if we were to add our custom styles on top of it we may have to use `!important` with them to override the default ones.
-Styling classes is not always how it seems due to how MJML compiles our templates and you may need to add `div` or `td` after the class to target that specific element. FxA has created a [styleguide](https://storage.googleapis.com/mozilla-storybooks-fxa/index.html) for engineers to reference convenience classes provided by Tailwind. Since we were creating new stylesheets for our emails, we took this as an opportunity to DRY up the codebase by following Tailwind conventions and their associated styles for sass classes and variables as well as using the closest `px` value to the design guide for consistency across FxA's CSS.
-
-#### l10n (Fluent)
-
-We've setup [Fluent](https://github.com/projectfluent/fluent.js/tree/master/fluent-dom) to localize our newly created MJML emails. Fluent uses `FTL` format to describe translation resources and these resources contain messages that would be used to translate the emails. To localize an element in Fluent, the developer adds a new message to an FTL file and then has to associate an l10n-id with the element by defining a data-l10n-id attribute:
-
-```js
-<p data-l10n-id="update-application-info" data-l10n-args="{'version': '60.0'}">
-  <span class="bold">
-    <a href="http://www.mozilla.org/privacy" />
-  </span>
-</p>
-```
-
-```
--brand-short-name = Firefox
-update-application-info =
-    You are using { -brand-short-name } Version: { $version }.
-    <span>Please, read the <a>privacy policy</a></span>
-```
-
-Fluent will take care of the rest, populating the element with the message value in its content and all localizable attributes if defined. Fluent will overlay the translation onto the source fragment preserving attributes like `class` and `href` from the source and adding translations for the elements inside. The resulting localized content will look like this:
-
-```js
-<p data-l10n-id="update-application-info" data-l10n-args="{'version': '60.0'}">
-  You are using Firefox Version: 60.0.
-  <span class="bold">
-    Please, read the <a href="http://www.mozilla.org/privacy">privacy policy</a>
-  </span>
-</p>
-```
-
-Note that in order to access variables in the dom, we need to pass down a JSON object to the `data-l10n-args` attribute which will be used by the localizer to translate the text.
-
-By default emails render from left to right which could hamper their accessibility for some locales so along with localizing the emails, we took care of rendering them from right to left for rtl locales and vice versa.
-
-##### Fluent for plaintext files
-
-Fluent is also being used to localize plaintext version of templates. Each and every template has an `index.txt` file which contains the plaintext version of it. A pattern is set which will help identify the text that needs to be localized: `fluent-id = "default value provided"` where value of `fluent-id` is same as `data-l10n-id` attribute of the corresponding markup element. If `fluent-id` is present in fluent bundle, the text will be localized else it will be replaced with the fallback value present. In cases, where we don't want to localize the text, just declare a string and it will be rendered as is. The following snippets will demonstrate how plaintext files are localized and generated:
-
-```
-sync-reminder = "<%- headerText %>"
-
-<%- link %>
-```
-
-EJS will compile the above `.txt` file into something like this:
-
-```
-sync-reminder = "Here's your reminder to sync devices."
-
-http://localhost:3030/connect_another_device?utm_medium=email&utm_campaign=fx-cad-reminder-first&utm_content=fx-connect-device
-```
-
-The compiled text will then be localized with fluent and the final plaintext version will be generated something like this:
-
-```
-Here's your reminder to sync devices.
-
-http://localhost:3030/connect_another_device?utm_medium=email&utm_campaign=fx-cad-reminder-first&utm_content=fx-connect-device
-```
-
-#### Storybook and Documentation
-
-As part of the emails revamp project, Storybook was setup locally in order to preview the various states of the emails which was not possible before without manually tweaking the code. The templates that are converted to MJML are compiled down to HTML before they can be rendered in Storybook and with [Controls addon](https://storybook.js.org/docs/react/essentials/controls) in place we can directly modify the variables without touching the codebase.
-
-Each template has an optional `doc` string which serves to document when users will receive the email meaning what triggers the email to be sent. These templates are essentially HTML templates rendered in browser with Storybook and there is a possibility that they may not exactly match with what users see in an email client.
-To preview these templates with Storybook, run `yarn storybook` in `fxa-auth-server` root directory.
-
-In addition to running locally, Storybook can be built into a static format. This is ultimately what happens in our CI. This static format is then deployed and manual QA may be conducted against it. To test what this will look like, run `yarn build-storybook` then navigate to the `storybook-static` folder and run `http-server . -p 8081`. From there, simply navigate to the `http://locahost:8081/index.html` and you will see the resulting static build. _(If you don't have `http-sever` installed, simply run `npm install -g http-server`)_
-
-**Important!** The previews in storybook are generated using the `mjml-browser` module and not the de facto `mjml` module. The difference is subtle but important. As the name indicates, `mjml-browser` is designed to render from a browser context, whereas mjml uses a nodejs context. Ideally these modules would be identical, but at the time of writing this, there are a couple [minor differences](https://github.com/mjmlio/mjml/tree/master/packages/mjml-browser#unavailable-features). Our code introduces a couple work arounds to achieve parity with the way templates would be rendered using the `mjml` module. If styles in sent out emails ever seem off, consider this discrepancy as an unlikely but potential source of error.
+Non-email strings that must be translated are placed directly in `lib/l10n/auth.ftl`, under any brands we have set to [message references](https://projectfluent.org/fluent/guide/references.html). Email strings for translation are placed in a nearby (`templates/[templateName]/en.ftl` or `partials/[partialName]/en.ftl`). For more detailed information on l10n in emails with examples, see the [ecosystem platform doc email page, l10n section](https://mozilla.github.io/ecosystem-platform/reference/emails).
 
 #### Production
 


### PR DESCRIPTION
Because:
* Our auth-server documentation on emails was out of date. Updated docs were written and moved into ecosystem-platform instead

This commit:
* Updates fxa-auth-server README

closes #10617

---

The PR containing the actual updates can be [found here](https://github.com/mozilla/ecosystem-platform/pull/197).

I originally wrote the L10n section here for the auth-server README, but also pulled it into the emails page in that PR. I might end up moving it into the Localization page instead later.