### PR TITLE
fix(auth): handle paypal refused errors

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/error.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/error.ts
@@ -1,0 +1,12 @@
+export class PaypalFailure extends Error {}
+
+export class RefusedError extends PaypalFailure {
+  public constructor(
+    message: string,
+    public readonly longMessage: string,
+    public readonly errorCode: string
+  ) {
+    super(message);
+    this.name = 'RefusedError';
+  }
+}

--- a/packages/fxa-auth-server/lib/payments/paypal/index.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/index.ts
@@ -1,0 +1,3 @@
+export { PayPalHelper } from './helper';
+export { RefusedError } from './error';
+export { PaypalProcessor } from './processor';

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -42,7 +42,6 @@ import { StatsD } from 'hot-shots';
 import ioredis from 'ioredis';
 import mapValues from 'lodash/mapValues';
 import moment from 'moment';
-import { Logger } from 'mozlog';
 import { Stripe } from 'stripe';
 import { Container } from 'typedi';
 import { ConfigType } from '../../config';
@@ -121,6 +120,7 @@ export enum STRIPE_PRODUCT_METADATA {
 export enum STRIPE_INVOICE_METADATA {
   PAYPAL_TRANSACTION_ID = 'paypalTransactionId',
   PAYPAL_REFUND_TRANSACTION_ID = 'paypalRefundTransactionId',
+  PAYPAL_REFUND_REASON = 'paypalRefundRefused',
   EMAIL_SENT = 'emailSent',
   RETRY_ATTEMPTS = 'paymentAttempts',
 }
@@ -1066,6 +1066,20 @@ export class StripeHelper {
     return this.stripe.invoices.update(invoice.id, {
       metadata: {
         [STRIPE_INVOICE_METADATA.PAYPAL_REFUND_TRANSACTION_ID]: transactionId,
+      },
+    });
+  }
+
+  /**
+   * Updates invoice metadata with the reason the PayPal Refund failed.
+   */
+  async updateInvoiceWithPaypalRefundReason(
+    invoice: Stripe.Invoice,
+    reason: string
+  ) {
+    return this.stripe.invoices.update(invoice.id, {
+      metadata: {
+        [STRIPE_INVOICE_METADATA.PAYPAL_REFUND_REASON]: reason,
       },
     });
   }

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2038,6 +2038,24 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('updateInvoiceWithPaypalRefundReason', () => {
+    it('works successfully', async () => {
+      sandbox.stub(stripeHelper.stripe.invoices, 'update').resolves({});
+      const actual = await stripeHelper.updateInvoiceWithPaypalRefundReason(
+        unpaidInvoice,
+        'reason'
+      );
+      assert.deepEqual(actual, {});
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.invoices.update,
+        unpaidInvoice.id,
+        {
+          metadata: { paypalRefundRefused: 'reason' },
+        }
+      );
+    });
+  });
+
   describe('getPaymentAttempts', () => {
     it('returns 0 with no attempts', () => {
       const actual = stripeHelper.getPaymentAttempts(unpaidInvoice);


### PR DESCRIPTION
Because:

* We want to update the invoice for support if the paypal refund
  is refused.

This commit:

* Updates the credit note webhook handler so that if the paypal refund
  is refused, the invoice metadata will be updated to reflect why.

Closes #11592

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
