### PR TITLE
fix(Subscriptions): Sub manage zero sub amount

### DIFF
--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -577,7 +577,7 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
   {
     subscriptionId: 'sub0.21234123424',
     period_start: 1565816388.815,
-    total: 500,
+    total: 0,
   },
 ];
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -38,6 +38,8 @@ export const SubscriptionItem = ({
   subsequentInvoice,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
+  const total = subsequentInvoice && subsequentInvoice.total;
+  const period_start = subsequentInvoice && subsequentInvoice.period_start;
 
   const paymentProvider: PaymentProvider | undefined =
     customer?.payment_provider;
@@ -60,7 +62,7 @@ export const SubscriptionItem = ({
 
   if (
     customerSubscription.cancel_at_period_end === false &&
-    !(subsequentInvoice?.total && subsequentInvoice?.period_start)
+    !((total || total === 0) && period_start)
   ) {
     return (
       <DialogMessage className="dialog-error" onDismiss={locationReload}>
@@ -84,8 +86,8 @@ export const SubscriptionItem = ({
         </header>
 
         {!customerSubscription.cancel_at_period_end &&
-        subsequentInvoice?.total &&
-        subsequentInvoice.period_start ? (
+        (total || total === 0) &&
+        period_start ? (
           <CancelSubscriptionPanel
             {...{
               cancelSubscription,
@@ -94,8 +96,8 @@ export const SubscriptionItem = ({
               plan,
               paymentProvider,
               promotionCode,
-              subsequentInvoiceAmount: subsequentInvoice.total,
-              subsequentInvoiceDate: subsequentInvoice.period_start,
+              subsequentInvoiceAmount: total,
+              subsequentInvoiceDate: period_start,
             }}
           />
         ) : (


### PR DESCRIPTION
## Because

- The subsequent invoice not found message is shown when a subscription
  has a 0 total amount. This can happen when a subscription has a 100
  percent disount applied.

## This pull request

- Allow 0 values for total amount.

## Issue that this pull request solves

Closes: #12308

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).