### PR TITLE
fix(payments): fix flaky test with different dates

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -210,13 +210,15 @@ describe('useInfoBoxMessage', () => {
         date.setMonth(
           date.getMonth() + (couponLongerDuration.durationInMonths || 2)
         )
-      ).getTime() / 1000
+      ).getTime() / 100
     )}`;
     const messageText = getByTestId('message').textContent;
     const couponDurationDate = getByTestId('couponDurationDate').textContent;
     expect(messageText).toBe(CouponInfoBoxMessageType.Repeating);
     expect(couponDurationDate).not.toBeNull();
-    expect(couponDurationDate).toBe(expectedCouponDurationDate);
+    expect(couponDurationDate?.slice(0, 8)).toBe(
+      expectedCouponDurationDate.slice(0, 8)
+    );
   });
 });
 


### PR DESCRIPTION
## Because

- Expected and actual values could be off by a few milliseconds causing
  the test to fail

## This pull request

- Reduce the granularity of the date check.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).