### PR TITLE
chore(deps): Revert lodash upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "browserid-crypto": "https://github.com/mozilla-fxa/browserid-crypto.git#5979544d13eeb15a02d0b9a6a7a08a698d54d37d",
     "fbjs/isomorphic-fetch": "^3.0.0",
     "eslint-plugin-import": "^2.25.2",
-    "lodash": "^4.17.12",
     "minimist": "^1.2.6",
     "url-parse": "^1.5.8"
   },


### PR DESCRIPTION
Even though the tests passed, it looks like this might be breaking our build scripts.  Reverting until we can look at it again.