### PR TITLE
fix(auth): send Subscription Delete Email When User Deletes Fx Account

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -428,8 +428,7 @@ export class StripeWebhookHandler extends StripeHandler {
       }
 
       const uid = customer.metadata.userid;
-      const account = await this.db.account(uid);
-
+      const account = await Account.findByUid(uid);
       if (
         // When SubPlat cannot collect a PayPal customer's first payment while
         // attempting to subscribe to a product, the subscription is canceled.
@@ -437,6 +436,11 @@ export class StripeWebhookHandler extends StripeHandler {
         // `_createPaypalBillingAgreementAndSubscription` of the
         // `PayPalHandler` route handler.)  We should not send an email in that
         // case.
+        //
+        // If we can retreive the subscription and customer, but the account record
+        // cannot be retrieved from the db, the user has deleted their firefox
+        // account which subsequently deletes their subscription from stripe.
+        !account ||
         !(
           sub.collection_method === 'send_invoice' && account.verifierSetAt <= 0
         )


### PR DESCRIPTION
Because:

* We want to notify a user that their subscriptions have been deleted when they delete their fx account

This commit:

* Updates the stripe event handler to send emails to accounts that have been deleted

Closes #12262

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
