### PR TITLE
fix(email): Fixes issue where the user could not login when switching primary email

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -291,7 +291,13 @@ FxaClientWrapper.prototype = {
               accountData.verificationMethod = VerificationMethods.EMAIL;
             }
           }
-
+          
+          // The `originalLoginEmail` is a users current primary email, ensure
+          // the account model uses this email and updates local storage with it
+          if (signInOptions.originalLoginEmail) {
+            email = signInOptions.originalLoginEmail
+          }
+          
           return getUpdatedSessionData(email, relier, accountData, options);
         });
     }

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -651,6 +651,10 @@ const Account = Backbone.Model.extend(
           ) {
             updatedSessionData.email = options.originalLoginEmail;
           }
+          
+          // We don't really need this value other than in login flow, it can
+          // sometimes cause issues when user switches primary email
+          this.unset('originalLoginEmail');
 
           this.set(updatedSessionData);
 

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -654,7 +654,7 @@ describe('models/account', function () {
           );
 
           assert.equal(account.get('email'), EMAIL);
-          assert.equal(account.get('originalLoginEmail'), upperCaseEmail);
+          assert.equal(account.get('originalLoginEmail'), undefined);
         });
       });
 


### PR DESCRIPTION
## Because

- We needed to unset the `originalLoginEmail` param after successfully logging in otw the user would be shown the old primary email

## This pull request

- unsets `originalLoginEmail` after login and sets the `email` to the actualy primary email

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12109

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
