### PR TITLE
fix(auth): ignore already paid invoice errors

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1151,7 +1151,17 @@ export class StripeHelper {
    * Pays an invoice out of band.
    */
   async payInvoiceOutOfBand(invoice: Stripe.Invoice) {
-    return this.stripe.invoices.pay(invoice.id, { paid_out_of_band: true });
+    try {
+      return await this.stripe.invoices.pay(invoice.id, {
+        paid_out_of_band: true,
+      });
+    } catch (err) {
+      if (err.message.includes('Invoice is already paid')) {
+        // This was already marked paid, we can ignore the error.
+        return;
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2205,6 +2205,15 @@ describe('StripeHelper', () => {
         { paid_out_of_band: true }
       );
     });
+
+    it('ignores error if the invoice was already paid', async () => {
+      const paidInvoice = { ...deepCopy(unpaidInvoice), paid: true };
+      sandbox
+        .stub(stripeHelper.stripe.invoices, 'pay')
+        .rejects(new Error('Invoice is already paid'));
+      await stripeHelper.payInvoiceOutOfBand(paidInvoice);
+      sinon.assert.calledOnce(stripeHelper.stripe.invoices.pay);
+    });
   });
 
   describe('updateCustomerBillingAddress', () => {


### PR DESCRIPTION
Because:

* Duplicate processor runs or close payment conditions can trigger
  invoice processing to occur in duplicate such that an invoice is
  marked as paid twice, throwing an error.

This commit:

* Ignores already paid errors.

Closes #11409

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
