### PR TITLE
fix(auth): delete Stub Account When Subscription Fails

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -31,6 +31,7 @@ import { sendFinishSetupEmailForStubAccount } from '../subscriptions/account';
 import validators from '../validators';
 import { StripeWebhookHandler } from './stripe-webhook';
 import { handleAuth } from './utils';
+import { deleteAccountIfUnverified } from '../utils/account';
 
 const METRICS_CONTEXT_SCHEMA = require('../../metrics/context').schema;
 
@@ -89,66 +90,93 @@ export class PayPalHandler extends StripeWebhookHandler {
       request.auth,
       true
     );
-    await this.customs.check(request, email, 'createSubscriptionWithPaypal');
 
-    let customer = await this.stripeHelper.fetchCustomer(uid, [
-      'subscriptions',
-    ]);
+    try {
+      await this.customs.check(request, email, 'createSubscriptionWithPaypal');
 
-    if (!customer) {
-      throw error.unknownCustomer(uid);
+      let customer = await this.stripeHelper.fetchCustomer(uid, [
+        'subscriptions',
+      ]);
+
+      if (!customer) {
+        throw error.unknownCustomer(uid);
+      }
+
+      const isPaypalCustomer = hasPaypalSubscription(customer);
+      const { token, metricsContext } = request.payload as Record<
+        string,
+        string
+      >;
+      const currentBillingAgreement =
+        this.stripeHelper.getCustomerPaypalAgreement(customer);
+
+      // In theory the frontend should handle this state upon the customer
+      // response.  The customer should fix their payment method before we can
+      // allow any additional subscriptions.
+      if (isPaypalCustomer && !currentBillingAgreement) {
+        throw error.missingPaypalBillingAgreement(customer.id);
+      }
+      if (!isPaypalCustomer && !token) {
+        throw error.missingPaypalPaymentToken(customer.id);
+      }
+      if (isPaypalCustomer && token) {
+        // This seems unfriendly to users since we could just proceed with the BA
+        // on record.  But it's a bug with the frontend if it happens and we
+        // shouldn't allow it.
+        throw error.billingAgreementExists(customer.id);
+      }
+
+      const { sourceCountry, subscription } = !!token
+        ? await this._createPaypalBillingAgreementAndSubscription({
+            request,
+            uid,
+            customer,
+          })
+        : await this._createPaypalSubscription({ request, customer });
+
+      await this.customerChanged(request, uid, email);
+
+      this.log.info('subscriptions.createSubscriptionWithPaypal.success', {
+        uid,
+        subscriptionId: subscription.id,
+      });
+
+      await sendFinishSetupEmailForStubAccount({
+        uid,
+        account,
+        subscription,
+        stripeHelper: this.stripeHelper,
+        mailer: this.mailer,
+        subscriptionAccountReminders: this.subscriptionAccountReminders,
+        metricsContext,
+      });
+
+      return {
+        sourceCountry,
+        subscription: filterSubscription(subscription),
+      };
+    } catch (err) {
+      try {
+        if (account.verifierSetAt <= 0) {
+          await deleteAccountIfUnverified(
+            this.db,
+            this.stripeHelper,
+            this.log,
+            request,
+            email
+          );
+        }
+      } catch (deleteAccountError) {
+        if (
+          deleteAccountError.errno !== error.ERRNO.ACCOUNT_EXISTS &&
+          deleteAccountError.errno !==
+            error.ERRNO.VERIFIED_SECONDARY_EMAIL_EXISTS
+        ) {
+          throw deleteAccountError;
+        }
+      }
+      throw err;
     }
-
-    const isPaypalCustomer = hasPaypalSubscription(customer);
-    const { token, metricsContext } = request.payload as Record<string, string>;
-    const currentBillingAgreement =
-      this.stripeHelper.getCustomerPaypalAgreement(customer);
-
-    // In theory the frontend should handle this state upon the customer
-    // response.  The customer should fix their payment method before we can
-    // allow any additional subscriptions.
-    if (isPaypalCustomer && !currentBillingAgreement) {
-      throw error.missingPaypalBillingAgreement(customer.id);
-    }
-    if (!isPaypalCustomer && !token) {
-      throw error.missingPaypalPaymentToken(customer.id);
-    }
-    if (isPaypalCustomer && token) {
-      // This seems unfriendly to users since we could just proceed with the BA
-      // on record.  But it's a bug with the frontend if it happens and we
-      // shouldn't allow it.
-      throw error.billingAgreementExists(customer.id);
-    }
-
-    const { sourceCountry, subscription } = !!token
-      ? await this._createPaypalBillingAgreementAndSubscription({
-          request,
-          uid,
-          customer,
-        })
-      : await this._createPaypalSubscription({ request, customer });
-
-    await this.customerChanged(request, uid, email);
-
-    this.log.info('subscriptions.createSubscriptionWithPaypal.success', {
-      uid,
-      subscriptionId: subscription.id,
-    });
-
-    await sendFinishSetupEmailForStubAccount({
-      uid,
-      account,
-      subscription,
-      stripeHelper: this.stripeHelper,
-      mailer: this.mailer,
-      subscriptionAccountReminders: this.subscriptionAccountReminders,
-      metricsContext,
-    });
-
-    return {
-      sourceCountry,
-      subscription: filterSubscription(subscription),
-    };
   }
 
   async _createPaypalBillingAgreementAndSubscription({

--- a/packages/fxa-auth-server/lib/routes/utils/account.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.ts
@@ -1,0 +1,63 @@
+import { StripeHelper } from '../../payments/stripe';
+import { AuthLogger, AuthRequest } from '../../types';
+import error from '../../error';
+import { reportSentryError } from '../../../lib/sentry';
+
+export const deleteAccountIfUnverified = async (
+  db: any,
+  stripeHelper: StripeHelper,
+  log: AuthLogger,
+  request: AuthRequest,
+  email: string
+) => {
+  try {
+    const secondaryEmailRecord = await db.getSecondaryEmail(email);
+    // Currently, users cannot create an account from a verified
+    // secondary email address
+    if (secondaryEmailRecord.isPrimary) {
+      if (
+        secondaryEmailRecord.isVerified ||
+        (await stripeHelper.hasActiveSubscription(secondaryEmailRecord.uid))
+      ) {
+        throw error.accountExists(secondaryEmailRecord.email);
+      }
+      request.app.accountRecreated = true;
+
+      // If an unverified (stub) account has a Stripe customer without any
+      // subscriptions, delete the customer.
+      try {
+        await stripeHelper.removeCustomer(
+          secondaryEmailRecord.uid,
+          secondaryEmailRecord.email
+        );
+      } catch (err) {
+        // It's not an error where we'd want to stop the deletion of the
+        // account.
+        reportSentryError(err, request);
+      }
+
+      const deleted = await db.deleteAccount(secondaryEmailRecord);
+      log.info('accountDeleted.unverifiedSecondaryEmail', {
+        ...secondaryEmailRecord,
+      });
+      return deleted;
+    } else {
+      if (secondaryEmailRecord.isVerified) {
+        throw error.verifiedSecondaryEmailAlreadyExists();
+      }
+
+      return await db.deleteEmail(
+        secondaryEmailRecord.uid,
+        secondaryEmailRecord.email
+      );
+    }
+  } catch (err) {
+    if (err.errno !== error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
+      throw err;
+    }
+  }
+};
+
+module.exports = {
+  deleteAccountIfUnverified,
+};

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -32,6 +32,7 @@ const { StripeHandler: DirectStripeRoutes } = proxyquire(
   }
 );
 
+const accountUtils = require('../../../../lib/routes/utils/account.ts');
 const { AuthLogger, AppConfig } = require('../../../../lib/types');
 const { CapabilityService } = require('../../../../lib/payments/capability');
 const { PlayBilling } = require('../../../../lib/payments/iap/google-play');
@@ -935,6 +936,149 @@ describe('DirectStripeRoutes', () => {
           err.message,
           'Funding source country does not match plan currency.'
         );
+      }
+    });
+
+    it('calls deleteAccountIfUnverified when there is an error', async () => {
+      paymentMethod.card.country = 'FR';
+      directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
+        paymentMethod
+      );
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        paymentMethodId: 'pm_asdf',
+        idempotencyKey: uuidv4(),
+      };
+
+      const deleteAccountIfUnverifiedStub = sandbox
+        .stub(accountUtils, 'deleteAccountIfUnverified')
+        .returns(null);
+
+      try {
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
+        assert.fail('Create subscription with wrong planCurrency should fail.');
+      } catch (err) {
+        assert.equal(deleteAccountIfUnverifiedStub.calledOnce, true);
+        assert.instanceOf(err, WError);
+        assert.equal(err.errno, error.ERRNO.INVALID_REGION);
+      }
+    });
+
+    it('ignores account exists error from deleteAccountIfUnverified', async () => {
+      paymentMethod.card.country = 'FR';
+      directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
+        paymentMethod
+      );
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        paymentMethodId: 'pm_asdf',
+        idempotencyKey: uuidv4(),
+      };
+
+      const deleteAccountIfUnverifiedStub = sandbox
+        .stub(accountUtils, 'deleteAccountIfUnverified')
+        .throws(error.accountExists(null));
+
+      try {
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
+        assert.fail('Create subscription with wrong planCurrency should fail.');
+      } catch (err) {
+        assert.equal(deleteAccountIfUnverifiedStub.calledOnce, true);
+        assert.instanceOf(err, WError);
+        assert.equal(err.errno, error.ERRNO.INVALID_REGION);
+      }
+    });
+
+    it('ignores verified email error from deleteAccountIfUnverified', async () => {
+      paymentMethod.card.country = 'FR';
+      directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
+        paymentMethod
+      );
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        paymentMethodId: 'pm_asdf',
+        idempotencyKey: uuidv4(),
+      };
+
+      const deleteAccountIfUnverifiedStub = sandbox
+        .stub(accountUtils, 'deleteAccountIfUnverified')
+        .throws(error.verifiedSecondaryEmailAlreadyExists());
+
+      try {
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
+        assert.fail('Create subscription with wrong planCurrency should fail.');
+      } catch (err) {
+        assert.equal(deleteAccountIfUnverifiedStub.calledOnce, true);
+        assert.instanceOf(err, WError);
+        assert.equal(err.errno, error.ERRNO.INVALID_REGION);
+      }
+    });
+
+    it('skips calling deleteAccountIfUnverified if verifiedSetAt is greater than 0', async () => {
+      sandbox = sinon.createSandbox();
+
+      config = {
+        subscriptions: {
+          enabled: true,
+          managementClientId: MOCK_CLIENT_ID,
+          managementTokenTTL: MOCK_TTL,
+          stripeApiKey: 'sk_test_1234',
+        },
+      };
+
+      log = mocks.mockLog();
+      customs = mocks.mockCustoms();
+      profile = mocks.mockProfile({
+        deleteCache: sinon.spy(async (uid) => ({})),
+      });
+      mailer = mocks.mockMailer();
+
+      db = mocks.mockDB({
+        uid: UID,
+        email: TEST_EMAIL,
+        locale: ACCOUNT_LOCALE,
+      });
+      const stripeHelperMock = sandbox.createStubInstance(StripeHelper);
+      stripeHelperMock.currencyHelper = currencyHelper;
+
+      directStripeRoutesInstance = new DirectStripeRoutes(
+        log,
+        db,
+        config,
+        customs,
+        push,
+        mailer,
+        profile,
+        stripeHelperMock
+      );
+
+      paymentMethod.card.country = 'FR';
+      directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
+        paymentMethod
+      );
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        paymentMethodId: 'pm_asdf',
+        idempotencyKey: uuidv4(),
+      };
+
+      const deleteAccountIfUnverifiedStub = sandbox
+        .stub(accountUtils, 'deleteAccountIfUnverified')
+        .throws(error.verifiedSecondaryEmailAlreadyExists());
+
+      try {
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
+        assert.fail('Create subscription with wrong planCurrency should fail.');
+      } catch (err) {
+        assert.equal(deleteAccountIfUnverifiedStub.calledOnce, false);
       }
     });
 


### PR DESCRIPTION
Because:

* We want to remove the stub account on the passwordless flow when the subscription fails so that it does not present the user with an error that the
account already exists

This commit:

* Catches any error from the function for creating the subscription, deletes the account if it is unverified and has no active subscriptions, then throws
the error to resume normal flow

Closes #11936

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).