### PR TITLE
fix(broker): update test timeouts

### DIFF
--- a/packages/fxa-event-broker/scripts/test-ci.sh
+++ b/packages/fxa-event-broker/scripts/test-ci.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+yarn test --runInBand


### PR DESCRIPTION
Because:

* Firestore tests run slow in the CI environment.

This commit:

* Updates the test timetouts for 30s on firestire tests.

Closes #9236

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
