### PR TITLE
fix(broker): use workspace focus first

### DIFF
--- a/packages/fxa-event-broker/scripts/test-ci.sh
+++ b/packages/fxa-event-broker/scripts/test-ci.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
+yarn workspaces focus fxa-event-broker
 yarn test --runInBand


### PR DESCRIPTION
Because:

* Workspace focus commands needs to be run to use appropriate CLI
  programs.

This commit:

* Adds the workspaces focus to the test-ci script for event-broker.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
