### PR TITLE
fix(fxa-settings): align password CTA

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -21,6 +21,7 @@ module.exports = {
       },
       margin: {
         7: '1.75rem',
+        9: '2.25rem',
         11: '2.75rem',
         18: '4.5rem',
         '-18': '-4.5rem',

--- a/packages/fxa-settings/src/components/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Security/index.tsx
@@ -33,6 +33,7 @@ export const Security = () => {
             headerValue="••••••••••••••••••"
             route="/settings/change_password"
             prefixDataTestId="password"
+            isLevelWithRefreshButton={true}
           >
             <Localized
               id="security-password-created-date"

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -80,6 +80,7 @@ type UnitRowProps = {
   alertBarRevealed?: boolean;
   hideCtaText?: boolean;
   prefixDataTestId?: string;
+  isLevelWithRefreshButton?: boolean;
 };
 
 export const UnitRow = ({
@@ -103,6 +104,7 @@ export const UnitRow = ({
   alertBarRevealed,
   hideCtaText,
   prefixDataTestId = '',
+  isLevelWithRefreshButton = false,
 }: UnitRowProps & RouteComponentProps) => {
   const { l10n } = useLocalization();
   const localizedCtaAdd = l10n.getString(
@@ -158,7 +160,10 @@ export const UnitRow = ({
         <div className="flex items-center">
           {!hideCtaText && route && (
             <Link
-              className="cta-neutral cta-base transition-standard rtl:ml-1"
+              className={classNames(
+                'cta-neutral cta-base transition-standard rtl:ml-1',
+                isLevelWithRefreshButton && 'mr-9'
+              )}
               data-testid={formatDataTestId('unit-row-route')}
               to={`${route}${location.search}`}
             >


### PR DESCRIPTION
Because:

* Since all other UnitRow components in the Security section have
  refresh buttons, the Password row CTA button seems out of alignment.

This commit:

* Adds a descriptive prop so that the user can align the CTA within a
UnitRow with buttons that have a refresh button.

Closes #11972

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="755" alt="Screen Shot 2022-04-14 at 12 04 18 PM" src="https://user-images.githubusercontent.com/11150372/163459208-d1a03634-5e9f-45ea-9488-86cdc0d1042a.png">



After: 
<img width="748" alt="Screen Shot 2022-04-14 at 12 06 27 PM" src="https://user-images.githubusercontent.com/11150372/163459419-58e16497-f80c-4b8a-8209-14e9ea60f696.png">

RTL (before changes):
<img width="794" alt="Screen Shot 2022-04-14 at 12 48 47 PM" src="https://user-images.githubusercontent.com/11150372/163465164-eb152173-5716-4632-b0aa-37517b465405.png">


## Other information (Optional)
Styles deliberately do not have the `rtl` prefix, as the position of the buttons does not change when the text direction of the page changes, as shown in the above screenshot. Has been tested in Arabic and Hebrew.

Looking at the new button alignment, I think it might be worth leaving the designs as they originally were -- to my eye the buttons have a slight optical illusion of being misaligned (even when they do line up) due to the buttons above the Security section all lining up flatly with the right-hand side of their container. I would really appreciate eyes + opinions on it! 
