### PR TITLE
fix(admin-sever): fix broken connection in email-bounce script

### DIFF
--- a/packages/fxa-admin-server/scripts/email-bounce.ts
+++ b/packages/fxa-admin-server/scripts/email-bounce.ts
@@ -20,7 +20,7 @@ const argv = yargs.options({
 }).argv;
 
 async function addBounceToDB() {
-  const instance = knex({ client: 'mysql', connection: config.database });
+  const instance = knex({ client: 'mysql', connection: config.database.fxa });
   Model.knex(instance);
   const count = argv.count;
 


### PR DESCRIPTION
## Because

- A command like `email-bounce --email test@example.com --count 3` would fail to connect to the db.

## This pull request

- Fixes the connection string. It should have referenced config.database.fxa, which appears to be collateral damage from a previous refactor.

## Issue that this pull request solves

Closes: #12507

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
