### PR TITLE
feat(scripts): use redlock to prevent >1 instance of paypal-processor

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/processor.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/processor.ts
@@ -350,7 +350,7 @@ export class PaypalProcessor {
     return;
   }
 
-  public async processInvoices() {
+  public async *processInvoices() {
     // Generate a time `invoiceAge` hours prior.
     const invoiceAgeInSeconds = hoursBeforeInSeconds(this.invoiceAge);
 
@@ -369,6 +369,8 @@ export class PaypalProcessor {
         });
         reportSentryError(err);
       }
+
+      yield;
     }
   }
 }

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -113,6 +113,7 @@
     "poolee": "^1.0.1",
     "punycode.js": "2.1.0",
     "qrcode": "^1.5.0",
+    "redlock": "^5.0.0-beta.2",
     "request": "^2.88.2",
     "safe-regex": "^2.1.1",
     "safe-url-assembler": "1.3.5",

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -605,7 +605,11 @@ describe('PaypalProcessor', () => {
           yield invoice;
         },
       });
-      await processor.processInvoices();
+      // eslint-disable-next-line
+      for await (const _ of processor.processInvoices()) {
+        // No value yield'd; yielding control for potential distributed lock
+        // extension in actual use case
+      }
       sinon.assert.calledOnceWithExactly(
         mockLog.info,
         'processInvoice.processing',
@@ -628,7 +632,11 @@ describe('PaypalProcessor', () => {
         },
       });
       try {
-        await processor.processInvoices();
+        // eslint-disable-next-line
+        for await (const _ of processor.processInvoices()) {
+          // No value yield'd; yielding control for potential distributed lock
+          // extension in actual use case
+        }
         assert.fail('Process invoicce should fail');
       } catch (err) {
         sinon.assert.calledOnceWithExactly(

--- a/yarn.lock
+++ b/yarn.lock
@@ -22313,6 +22313,7 @@ fsevents@~2.1.1:
     punycode.js: 2.1.0
     qrcode: ^1.5.0
     read: 1.0.7
+    redlock: ^5.0.0-beta.2
     request: ^2.88.2
     rimraf: ^3.0.2
     safe-regex: ^2.1.1
@@ -32300,6 +32301,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"node-abort-controller@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "node-abort-controller@npm:3.0.1"
+  checksum: 2b3d75c65249fea99e8ba22da3a8bc553f034f44dd12f5f4b38b520f718b01c88718c978f0c24c2a460fc01de9a80b567028f547b94440cb47adeacfeb82c2ee
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:^4.3.0":
   version: 4.3.0
   resolution: "node-addon-api@npm:4.3.0"
@@ -37505,6 +37513,15 @@ fsevents@~2.1.1:
   dependencies:
     redis-errors: ^1.0.0
   checksum: 89290ae530332f2ae37577647fa18208d10308a1a6ba750b9d9a093e7398f5e5253f19855b64c98757f7129cccce958e4af2573fdc33bad41405f87f1943459a
+  languageName: node
+  linkType: hard
+
+"redlock@npm:^5.0.0-beta.2":
+  version: 5.0.0-beta2
+  resolution: "redlock@npm:5.0.0-beta2"
+  dependencies:
+    node-abort-controller: ^3.0.1
+  checksum: d8a0d6d472922d146077e3c12946b942108e3041439fdadced79c3dc285ec3d509a48cee33f7da125e71b3868c65ba248b612fb65825aacfa5e67c118e1ba543
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
 - we could easily end up running two instances of the paypal-processor
   during a deploy

This commit:
 - use a redis based distributed lock to ensure only one
   paypal-processor can run per env
 - add script options to control the lock name and duration, as well as
   completely bypassing the lock
