### PR TITLE
feature(admin-panel): Add guard to serverside

### DIFF
--- a/packages/fxa-admin-panel/constants/index.ts
+++ b/packages/fxa-admin-panel/constants/index.ts
@@ -2,6 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const USER_GROUP_HEADER = 'REMOTE-GROUP';
-export const USER_EMAIL_HEADER = 'oidc-claim-id-token-email';
+export { USER_GROUP_HEADER, USER_EMAIL_HEADER } from 'fxa-shared/guards';
 export const SERVER_CONFIG_PLACEHOLDER = '__SERVER_CONFIG__';

--- a/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
@@ -40,6 +40,7 @@ describe('ClientConfig', () => {
       email: 'hello@mozilla.com',
       group: {
         name: 'Admin',
+        header: 'vpn_fxa_admin_panel_prod',
         level: PermissionLevel.Admin,
       },
     });
@@ -50,6 +51,7 @@ describe('ClientConfig', () => {
       email: 'hello@mozilla.com',
       group: {
         name: 'Support',
+        header: 'vpn_fxa_supportagent_prod',
         level: PermissionLevel.Support,
       },
     });
@@ -60,6 +62,7 @@ describe('ClientConfig', () => {
       email: 'hello@mozilla.com',
       group: {
         name: 'Unknown',
+        header: '',
         level: PermissionLevel.None,
       },
     });

--- a/packages/fxa-admin-panel/src/App.test.tsx
+++ b/packages/fxa-admin-panel/src/App.test.tsx
@@ -6,16 +6,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 import { mockConfigBuilder } from './lib/config';
-import { PermissionLevel } from 'fxa-shared/guards';
+import { AdminPanelGroup, guard } from 'fxa-shared/guards';
 
 it('renders without imploding', () => {
   const config = mockConfigBuilder({
     user: {
       email: 'hello@mozilla.com',
-      group: {
-        name: 'Admin',
-        level: PermissionLevel.Admin,
-      },
+      group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
     },
   });
   const { queryByTestId } = render(<App {...{ config }} />);

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -2,22 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { Account, AccountProps } from './index';
-import { AdminPanelGroup } from 'fxa-shared/guards';
+import { AdminPanelGroup, guard } from 'fxa-shared/guards';
 import { IClientConfig } from '../../../../interfaces';
 import { mockConfigBuilder } from '../../../lib/config';
-import { PermissionLevel } from 'fxa-shared/guards';
 
 export const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',
-    group: {
-      name: AdminPanelGroup.SupportAgentProd,
-      level: PermissionLevel.Support,
-    },
+    group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
   },
 });
 

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -191,8 +191,8 @@ export const DangerZone = ({
     <>
       <Guard
         features={[
-          AdminPanelFeature.UnVerifyAccounts,
-          AdminPanelFeature.DisableAccounts,
+          AdminPanelFeature.UnverifyEmail,
+          AdminPanelFeature.DisableAccount,
         ]}
       >
         <h3 className="mt-0 my-0 mb-1 bg-red-600 font-medium h-8 pb-8 pl-1 pt-1 rounded-sm text-lg text-white">
@@ -203,8 +203,8 @@ export const DangerZone = ({
           irreversible.
         </p>
       </Guard>
-      <Guard features={[AdminPanelFeature.UnVerifyAccounts]}>
-        <h2 className="account-header">Email Verification</h2>
+      <Guard features={[AdminPanelFeature.UnverifyEmail]}>
+        <h2 className="text-lg">Email Verification</h2>
         <p className="text-base leading-6 border-l-2 border-red-600 mb-4 pl-4">
           Reset email verification. User needs to re-verify on next login.
           <br />
@@ -219,8 +219,8 @@ export const DangerZone = ({
           {unverifyMessage}
         </p>
       </Guard>
-      <Guard features={[AdminPanelFeature.DisableAccounts]}>
-        <h2 className="account-header">Disable Login</h2>
+      <Guard features={[AdminPanelFeature.DisableAccount]}>
+        <h2 className="text-lg">Disable Login</h2>
         <p className="text-base leading-6 border-l-2 border-red-600 mb-4 pl-4">
           Stops this account from logging in.
           <br />

--- a/packages/fxa-admin-panel/src/components/Guard/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Guard/index.test.tsx
@@ -6,20 +6,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { IClientConfig } from '../../../interfaces';
 import { Guard } from './index';
-import {
-  AdminPanelFeature,
-  AdminPanelGroup,
-  PermissionLevel,
-} from 'fxa-shared/guards';
+import { AdminPanelFeature, AdminPanelGroup, guard } from 'fxa-shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
 
 export const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',
-    group: {
-      name: AdminPanelGroup.SupportAgentProd,
-      level: PermissionLevel.Support,
-    },
+    group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
   },
 });
 
@@ -43,7 +36,7 @@ describe('Permissions', () => {
   }
 
   it('restricts access', async () => {
-    const renderResult = renderTest([AdminPanelFeature.DisableAccounts]);
+    const renderResult = renderTest([AdminPanelFeature.DisableAccount]);
     expect(renderResult.getByTestId('foo').textContent).toEqual('');
   });
 
@@ -55,7 +48,7 @@ describe('Permissions', () => {
   it('allows access if one or more features is allowed', () => {
     const renderResult = renderTest([
       AdminPanelFeature.AccountSearch,
-      AdminPanelFeature.DisableAccounts,
+      AdminPanelFeature.DisableAccount,
     ]);
     expect(renderResult.getByTestId('foo').textContent).toEqual('bar');
   });

--- a/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
@@ -6,16 +6,13 @@ import React from 'react';
 import { render, RenderResult } from '@testing-library/react';
 import { IClientConfig } from '../../../interfaces';
 import { Permissions } from './index';
-import { AdminPanelGroup, guard, PermissionLevel } from 'fxa-shared/guards';
+import { AdminPanelGroup, guard } from 'fxa-shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
 
 export const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',
-    group: {
-      name: AdminPanelGroup.SupportAgentProd,
-      level: PermissionLevel.Support,
-    },
+    group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
   },
 });
 

--- a/packages/fxa-admin-panel/src/lib/config.ts
+++ b/packages/fxa-admin-panel/src/lib/config.ts
@@ -1,6 +1,6 @@
 // This configuration is a subset of the configuration declared in server/config/index.ts
 
-import { PermissionLevel } from 'fxa-shared/guards';
+import { AdminPanelGroup, guard, PermissionLevel } from 'fxa-shared/guards';
 import { SERVER_CONFIG_PLACEHOLDER } from '../../constants';
 import { IClientConfig } from '../../interfaces';
 
@@ -9,10 +9,7 @@ export const config: IClientConfig = defaultConfig();
 export function defaultUser() {
   return {
     email: 'hello@mozilla.com',
-    group: {
-      name: 'Unknown',
-      level: PermissionLevel.None,
-    },
+    group: guard.getGroup(AdminPanelGroup.None),
   };
 }
 
@@ -41,7 +38,7 @@ export function getExtraHeaders(config: IClientConfig) {
     }
 
     if (config.user.group) {
-      headers['REMOTE-GROUP'] = config.user.group.name;
+      headers['REMOTE-GROUP'] = config.user.group.header;
     }
   }
   return headers;

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/mozilla/fxa#readme",
   "readmeFilename": "README.md",
   "dependencies": {
+    "@golevelup/ts-jest": "^0.3.2",
     "@nestjs/common": "^8.4.4",
     "@nestjs/config": "^2.0.0",
     "@nestjs/core": "^8.4.4",

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -20,6 +20,8 @@ import Config, { AppConfig } from './config';
 import { DatabaseModule } from './database/database.module';
 import { DatabaseService } from './database/database.service';
 import { GqlModule } from './gql/gql.module';
+import { APP_GUARD } from '@nestjs/core';
+import { UserGroupGuard } from './auth/user-group-header.guard';
 
 const version = getVersionInfo(__dirname);
 
@@ -45,6 +47,7 @@ const version = getVersionInfo(__dirname);
         },
         context: ({ req, connection }) => createContext({ req, connection }),
         plugins: [SentryPlugin],
+        fieldResolverEnhancers: ['guards'],
       }),
     }),
     HealthModule.forRootAsync({
@@ -68,6 +71,12 @@ const version = getVersionInfo(__dirname);
     }),
   ],
   controllers: [],
-  providers: [MetricsFactory],
+  providers: [
+    MetricsFactory,
+    {
+      provide: APP_GUARD,
+      useClass: UserGroupGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/packages/fxa-admin-server/src/auth/user-group-header.decorator.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.decorator.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AdminPanelFeature } from 'fxa-shared/guards';
+import { SetMetadata } from '@nestjs/common';
+
+export const FEATURE_KEY = 'AdminPanelFeature';
+export const Features = (...features: AdminPanelFeature[]) =>
+  SetMetadata(FEATURE_KEY, features);

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.spec.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.spec.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserGroupGuard } from './user-group-header.guard';
+import {
+  USER_GROUP_HEADER,
+  AdminPanelFeature,
+  AdminPanelGroup,
+} from 'fxa-shared/guards';
+import { createMock } from '@golevelup/ts-jest';
+
+describe('UserGroupGuard for graphql', () => {
+  let module: TestingModule;
+  let guard: UserGroupGuard;
+  let reflector: Reflector;
+
+  function buildRequest(group?: AdminPanelGroup) {
+    const headers: Record<string, AdminPanelGroup | undefined> = {
+      [USER_GROUP_HEADER]: group,
+    };
+    return {
+      get: (key: string) => headers[key],
+    };
+  }
+
+  function mockContext(features: AdminPanelFeature[], group?: AdminPanelGroup) {
+    // This fakes the set of features that would be provided by a UserGroupGuard.
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(features);
+
+    // GqlExecutionContext, expects the context to be arg 2 of the passed in context's
+    // getArgs() return value.
+    const context = createMock<ExecutionContext>();
+    context.getArgs.mockImplementation(() => [
+      ,
+      ,
+      { req: buildRequest(group) },
+    ]);
+    context.getType.mockImplementation(() => 'graphql');
+    return context;
+  }
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        Reflector,
+        {
+          provide: UserGroupGuard,
+          useClass: UserGroupGuard,
+        },
+      ],
+    }).compile();
+
+    reflector = module.get<Reflector>(Reflector);
+    guard = module.get<UserGroupGuard>(UserGroupGuard);
+  });
+
+  it(`should prevent access if user group header is not provided`, async () => {
+    const context = mockContext([AdminPanelFeature.AccountSearch]);
+    const result = await guard.canActivate(context);
+    expect(result).toBeFalsy();
+  });
+
+  it(`should prevent access if invalid user group header is provided`, async () => {
+    const context = mockContext(
+      [AdminPanelFeature.AccountSearch],
+      AdminPanelGroup.None
+    );
+    const result = await guard.canActivate(context);
+    expect(result).toBeFalsy();
+  });
+
+  it(`should prevent access if user group doesn't have enough permissions`, async () => {
+    const context = mockContext(
+      [AdminPanelFeature.DisableAccount],
+      AdminPanelGroup.SupportAgentProd
+    );
+    const result = await guard.canActivate(context);
+    expect(result).toBeFalsy();
+  });
+
+  it(`should allow access if user group has partial permissions`, async () => {
+    const context = mockContext(
+      [AdminPanelFeature.AccountSearch, AdminPanelFeature.DisableAccount],
+      AdminPanelGroup.SupportAgentProd
+    );
+    const result = await guard.canActivate(context);
+    expect(result).toBeTruthy();
+  });
+
+  it(`should allow access if user group has permissions`, async () => {
+    const context = mockContext(
+      [AdminPanelFeature.DisableAccount],
+      AdminPanelGroup.AdminProd
+    );
+    const result = await guard.canActivate(context);
+    expect(result).toBeTruthy();
+  });
+});

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { USER_GROUP_HEADER, guard, AdminPanelFeature } from 'fxa-shared/guards';
+import { FEATURE_KEY } from './user-group-header.decorator';
+
+@Injectable()
+export class UserGroupGuard implements CanActivate {
+  constructor(private reflector?: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    // Reflect on the end point to determine if it has been tagged with admin panel feature.
+    // If it does, check to make sure the user's group has a permission level that permits access.
+    const features =
+      this.reflector?.getAllAndOverride<AdminPanelFeature[]>(FEATURE_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]) || [];
+
+    if (features.length === 0) {
+      return true;
+    }
+
+    // Requires different setup depending on context type. Currently
+    // guards are only applied to GQL contexts.
+    let userGroupHeader = '';
+    if (context.getType().toString() === 'graphql') {
+      userGroupHeader =
+        GqlExecutionContext.create(context)
+          ?.getContext()
+          ?.req?.get(USER_GROUP_HEADER) || '';
+    }
+
+    const group = guard.getBestGroup(userGroupHeader);
+    return features.some((x) => guard.allow(x, group));
+  }
+}

--- a/packages/fxa-admin-server/src/config.ts
+++ b/packages/fxa-admin-server/src/config.ts
@@ -16,6 +16,20 @@ const conf = convict({
     env: 'AUTH_HEADER',
     format: String,
   },
+  user: {
+    group: {
+      default: '',
+      doc: 'Group to operate under for dev / test.',
+      env: 'TEST_USER_GROUP',
+      format: String,
+    },
+    email: {
+      default: '',
+      doc: 'Email to operate under for dev / test.',
+      env: 'TEST_USER_EMAIL',
+      format: String,
+    },
+  },
   database: {
     fxa: makeMySQLConfig('AUTH', 'fxa'),
     fxa_oauth: makeMySQLConfig('OAUTH', 'fxa_oauth'),

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -20,6 +20,7 @@ import { AttachedSession } from 'fxa-shared/connected-services/models/AttachedSe
 import { Account } from 'fxa-shared/db/models/auth';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
+import { Features } from '../../auth/user-group-header.decorator';
 import { CurrentUser } from '../../auth/auth-header.decorator';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
 import { AppConfig } from '../../config';
@@ -28,6 +29,7 @@ import { uuidTransformer } from '../../database/transformers';
 import { Account as AccountType } from '../../gql/model/account.model';
 import { AttachedClient } from '../../gql/model/attached-clients.model';
 import { Email as EmailType } from '../../gql/model/emails.model';
+import { AdminPanelFeature } from 'fxa-shared/guards';
 
 const ACCOUNT_COLUMNS = [
   'uid',
@@ -73,6 +75,7 @@ export class AccountResolver {
     private configService: ConfigService<AppConfig>
   ) {}
 
+  @Features(AdminPanelFeature.AccountSearch)
   @Query((returns) => AccountType, { nullable: true })
   public accountByUid(
     @Args('uid', { nullable: false }) uid: string,
@@ -91,6 +94,7 @@ export class AccountResolver {
       .findOne({ uid: uidBuffer });
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @Query((returns) => AccountType, { nullable: true })
   public accountByEmail(
     @Args('email', { nullable: false }) email: string,
@@ -105,6 +109,7 @@ export class AccountResolver {
       .first();
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @Query((returns) => [EmailType], { nullable: true })
   public getEmailsLike(@Args('search', { nullable: false }) search: string) {
     return this.db.emails
@@ -115,6 +120,7 @@ export class AccountResolver {
   }
 
   // unverifies the user's email. will have to verify again on next login
+  @Features(AdminPanelFeature.UnverifyEmail)
   @Mutation((returns) => Boolean)
   public async unverifyEmail(
     @Args('email') email: string,
@@ -130,6 +136,7 @@ export class AccountResolver {
     return !!result;
   }
 
+  @Features(AdminPanelFeature.DisableAccount)
   @Mutation((returns) => Boolean)
   public async disableAccount(
     @Args('uid') uid: string,
@@ -143,6 +150,7 @@ export class AccountResolver {
     return !!result;
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @ResolveField()
   public async emailBounces(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
@@ -163,6 +171,7 @@ export class AccountResolver {
     return result;
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @ResolveField()
   public async emails(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
@@ -172,6 +181,7 @@ export class AccountResolver {
       .where('uid', uidBuffer);
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @ResolveField()
   public async securityEvents(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
@@ -188,6 +198,7 @@ export class AccountResolver {
       .orderBy('createdAt', 'DESC');
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @ResolveField()
   public async totp(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
@@ -197,6 +208,7 @@ export class AccountResolver {
       .where('uid', uidBuffer);
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @ResolveField()
   public async recoveryKeys(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
@@ -206,6 +218,7 @@ export class AccountResolver {
       .where('uid', uidBuffer);
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   @ResolveField()
   public subscriptions(@Root() account: Account) {
     // TODO: FXA-4237 / #11094, get real subscription data
@@ -236,6 +249,7 @@ export class AccountResolver {
       .where('uid', uidBuffer);
   }
 
+  @Features(AdminPanelFeature.ConnectedServices)
   @ResolveField(() => [AttachedClient])
   public async attachedClients(@Root() account: Account) {
     const clientFormatter = new ClientFormatter(
@@ -281,6 +295,7 @@ export class AccountResolver {
       });
   }
 
+  @Features(AdminPanelFeature.UnlinkAccount)
   @Mutation((returns) => Boolean)
   public async unlinkAccount(
     @Args('uid') uid: string,

--- a/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.ts
@@ -5,16 +5,19 @@ import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
+import { Features } from '../../auth/user-group-header.decorator';
 import { CurrentUser } from '../../auth/auth-header.decorator';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
 import { DatabaseService } from '../../database/database.service';
 import { EmailBounce as EmailBounceType } from '../../gql/model/email-bounces.model';
+import { AdminPanelFeature } from 'fxa-shared/guards';
 
 @UseGuards(GqlAuthHeaderGuard)
 @Resolver((of: any) => EmailBounceType)
 export class EmailBounceResolver {
   constructor(private log: MozLoggerService, private db: DatabaseService) {}
 
+  @Features(AdminPanelFeature.ClearEmailBounces)
   @Mutation((returns) => Boolean)
   public async clearEmailBounce(
     @Args('email') email: string,

--- a/packages/fxa-shared/guards/AdminPanelGuard.ts
+++ b/packages/fxa-shared/guards/AdminPanelGuard.ts
@@ -4,6 +4,12 @@
 
 import { Guard, Permissions, Groups, MaxPermissionLevel } from './Guard';
 
+/** The header key containing the user group. */
+export const USER_GROUP_HEADER = 'REMOTE-GROUP';
+
+/** The header key containing the user email. */
+export const USER_EMAIL_HEADER = 'oidc-claim-id-token-email';
+
 /** Enum of known permission levels. A lower level will indicate increased permissions. */
 export enum PermissionLevel {
   Admin = 0,
@@ -15,11 +21,14 @@ export enum PermissionLevel {
 export enum AdminPanelFeature {
   AccountLogs = 'AccountLogs',
   AccountSearch = 'AccountSearch',
-  ConnectedServices = 'ActiveSessions',
+  AccountHistory = 'AccountHistory',
+  ConnectedServices = 'ConnectedServices',
+  LinkedAccounts = 'LinkedAccounts',
   ClearEmailBounces = 'ClearEmailBounces',
-  DisableAccounts = 'DisableAccounts',
+  DisableAccount = 'DisableAccount',
   SiteStatus = 'SiteStatus',
-  UnVerifyAccounts = 'UnVerifyAccounts',
+  UnverifyEmail = 'UnverifyEmail',
+  UnlinkAccount = 'UnlinkAccount',
 }
 
 /** Enum of known user groups */
@@ -28,28 +37,33 @@ export enum AdminPanelGroup {
   AdminStage = 'vpn_fxa_admin_panel_stage',
   SupportAgentProd = 'vpn_fxa_supportagent_prod',
   SupportAgentStage = 'vpn_fxa_supportagent_stage',
-  None = 'None',
+  None = '',
 }
 
-const defaultAdminPanelGroups: Groups = {
+const adminPanelGroups: Groups = {
   [AdminPanelGroup.AdminProd]: {
     name: 'Admin',
+    header: AdminPanelGroup.AdminProd,
     level: PermissionLevel.Admin,
   },
   [AdminPanelGroup.AdminStage]: {
     name: 'Admin',
+    header: AdminPanelGroup.AdminStage,
     level: PermissionLevel.Admin,
   },
   [AdminPanelGroup.SupportAgentProd]: {
     name: 'Support',
+    header: AdminPanelGroup.SupportAgentProd,
     level: PermissionLevel.Support,
   },
   [AdminPanelGroup.SupportAgentStage]: {
     name: 'Support',
+    header: AdminPanelGroup.SupportAgentStage,
     level: PermissionLevel.Support,
   },
   [AdminPanelGroup.None]: {
     name: 'Unknown',
+    header: AdminPanelGroup.None,
     level: PermissionLevel.None,
   },
 };
@@ -60,6 +74,10 @@ const defaultAdminPanelPermissions: Permissions = {
     name: 'Lookup Account By Email/UID',
     level: PermissionLevel.Support,
   },
+  [AdminPanelFeature.AccountHistory]: {
+    name: 'Account History',
+    level: PermissionLevel.Support,
+  },
   [AdminPanelFeature.AccountLogs]: {
     name: 'View Account Logs',
     level: PermissionLevel.Support,
@@ -68,20 +86,28 @@ const defaultAdminPanelPermissions: Permissions = {
     name: 'View Active Sessions',
     level: PermissionLevel.Support,
   },
+  [AdminPanelFeature.LinkedAccounts]: {
+    name: 'View Linked Accounts',
+    level: PermissionLevel.Support,
+  },
   [AdminPanelFeature.ClearEmailBounces]: {
     name: 'Clear Email Bounces',
     level: PermissionLevel.Support,
   },
-  [AdminPanelFeature.DisableAccounts]: {
-    name: 'Disable Accounts',
+  [AdminPanelFeature.DisableAccount]: {
+    name: 'Disable Account',
     level: PermissionLevel.Admin,
   },
   [AdminPanelFeature.SiteStatus]: {
     name: 'Site Status',
     level: PermissionLevel.Support,
   },
-  [AdminPanelFeature.UnVerifyAccounts]: {
-    name: 'Unverify Accounts',
+  [AdminPanelFeature.UnverifyEmail]: {
+    name: 'Unverify Email Address',
+    level: PermissionLevel.Admin,
+  },
+  [AdminPanelFeature.UnlinkAccount]: {
+    name: 'Unlink Account',
     level: PermissionLevel.Admin,
   },
 };
@@ -89,7 +115,7 @@ const defaultAdminPanelPermissions: Permissions = {
 /** Setup configured guard for admin panel */
 class AdminPanelGuard extends Guard<AdminPanelFeature, AdminPanelGroup> {
   constructor() {
-    super(defaultAdminPanelPermissions, defaultAdminPanelGroups);
+    super(defaultAdminPanelPermissions, adminPanelGroups);
   }
 }
 

--- a/packages/fxa-shared/guards/Guard.ts
+++ b/packages/fxa-shared/guards/Guard.ts
@@ -25,8 +25,11 @@ export interface IFeatureFlag extends Pick<IFeature, 'name' | 'description'> {
 
 /** Group configuration */
 export interface IGroup {
-  /* Human readable name for group */
+  /** Human readable name for group */
   name: string;
+
+  /** Header value */
+  header: string;
 
   /** Groups assigned permission level */
   level: number;
@@ -48,7 +51,7 @@ export abstract class Guard<TFeatures extends string, TGroup extends string> {
     if (list.length > 0) {
       return list[0];
     }
-    return { name: '', level: MaxPermissionLevel };
+    return { name: '', header: '', level: MaxPermissionLevel };
   }
 
   private getBestGroups(remoteGroupHeader: string): IGroup[] {

--- a/packages/fxa-shared/test/guard/AdminPanelGuard.ts
+++ b/packages/fxa-shared/test/guard/AdminPanelGuard.ts
@@ -14,28 +14,29 @@ describe('support agents', () => {
   describe('Admin Panel Guard', () => {
     it('allows', () => {
       expect(
-        guard.allow(
-          AdminPanelFeature.DisableAccounts,
-          AdminPanelGroup.AdminProd
-        )
+        guard.allow(AdminPanelFeature.DisableAccount, AdminPanelGroup.AdminProd)
       ).true;
     });
 
     it('looks up group', () => {
       expect(guard.getGroup(AdminPanelGroup.AdminProd)).deep.equal({
         name: 'Admin',
+        header: 'vpn_fxa_admin_panel_prod',
         level: PermissionLevel.Admin,
       });
       expect(guard.getGroup(AdminPanelGroup.AdminStage)).deep.equal({
         name: 'Admin',
+        header: 'vpn_fxa_admin_panel_stage',
         level: PermissionLevel.Admin,
       });
       expect(guard.getGroup(AdminPanelGroup.SupportAgentProd)).deep.equal({
         name: 'Support',
+        header: 'vpn_fxa_supportagent_prod',
         level: PermissionLevel.Support,
       });
       expect(guard.getGroup(AdminPanelGroup.SupportAgentStage)).deep.equal({
         name: 'Support',
+        header: 'vpn_fxa_supportagent_stage',
         level: PermissionLevel.Support,
       });
     });
@@ -43,7 +44,7 @@ describe('support agents', () => {
     it('denies', () => {
       expect(
         guard.allow(
-          AdminPanelFeature.DisableAccounts,
+          AdminPanelFeature.DisableAccount,
           AdminPanelGroup.SupportAgentStage
         )
       ).false;

--- a/packages/fxa-shared/test/guard/Guard.ts
+++ b/packages/fxa-shared/test/guard/Guard.ts
@@ -26,10 +26,12 @@ describe('support agents', () => {
         {
           foo: {
             name: 'test foo',
+            header: 'test_foo',
             level: 0,
           },
           bar: {
             name: 'test bar',
+            header: 'test_bar',
             level: 1,
           },
         }
@@ -39,21 +41,25 @@ describe('support agents', () => {
     it('gets best group', () => {
       expect(guard.getBestGroup('foo')).deep.equal({
         name: 'test foo',
+        header: 'test_foo',
         level: 0,
       });
 
       expect(guard.getBestGroup('bar')).deep.equal({
         name: 'test bar',
+        header: 'test_bar',
         level: 1,
       });
 
       expect(guard.getBestGroup('foo, bar')).deep.equal({
         name: 'test foo',
+        header: 'test_foo',
         level: 0,
       });
 
       expect(guard.getBestGroup('bar, foo')).deep.equal({
         name: 'test foo',
+        header: 'test_foo',
         level: 0,
       });
     });
@@ -61,10 +67,12 @@ describe('support agents', () => {
     it('gets group', () => {
       expect(guard.getGroup('foo')).deep.equal({
         name: 'test foo',
+        header: 'test_foo',
         level: 0,
       });
       expect(guard.getGroup('bar')).deep.equal({
         name: 'test bar',
+        header: 'test_bar',
         level: 1,
       });
     });

--- a/packages/fxa-shared/test/l10n/determineLocale.ts
+++ b/packages/fxa-shared/test/l10n/determineLocale.ts
@@ -55,7 +55,7 @@ describe('l10n/determineLocale:', () => {
   });
 
   it('handles q-values out of range', () => {
-    // The spec says q-values must be between 0 and 1. We will still gaurd against bad q-values,
+    // The spec says q-values must be between 0 and 1. We will still guard against bad q-values,
     // by forcing them into that range.
     expect(determineLocale('en;q=0.5, fr;q=1.1')).to.eq('fr');
     expect(determineLocale('en;q=0.5, fr;q=-.1')).to.eq('en');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,6 +3558,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@golevelup/ts-jest@npm:^0.3.2":
+  version: 0.3.3
+  resolution: "@golevelup/ts-jest@npm:0.3.3"
+  checksum: be7f2258f349e480f7a8537321743349e3b39d8fdf9dad8d93de296f0fbbb7e2891fb29872fad0aca1f973a7726fd89fba235082ef127c2cfcd1865837595bd5
+  languageName: node
+  linkType: hard
+
 "@google-cloud/bigquery@npm:^5.12.0":
   version: 5.12.0
   resolution: "@google-cloud/bigquery@npm:5.12.0"
@@ -22299,6 +22306,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa-admin-server@workspace:packages/fxa-admin-server"
   dependencies:
+    "@golevelup/ts-jest": ^0.3.2
     "@nestjs/cli": ^8.2.5
     "@nestjs/common": ^8.4.4
     "@nestjs/config": ^2.0.0


### PR DESCRIPTION
## Because:
- We want to restrict access to certain data.

## This pull request
- Introduces nest js gaurd based on remote-group header
- Fixes issue where the remote-group header wasn't relayed properly in development mode.
- Cleans up readme file. REMOTE-GROUPS header name changed to REMOTE-GROUP
- Added a couple more AdminPanelFeature: UnLinkAccount, LinkedAccounts, AccountHistory
- Renames AdminPanelFeature.UnVerifyAccounts to This pull AdminPanelFeature.UnVerifyEmail
- Moves constants for USER_GROUP_HEADER and USER_EMAIL_HEADER to AdminPanelGaurds.ts

## Issue that this pull request solves

Closes: #11104,  Closes: #11105 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
