### PR TITLE
chore(yarn): fix yarn ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "_scripts/test-package.sh",
     "config-fxios": "node _scripts/config-fxios.js",
     "format": "yarn workspaces foreach run format",
-    "ports": "pm2 jlist | json -d'\\t' -a -c 'this.pm2_env.env.PORT' pm2_env.env.PORT name",
+    "ports": "pm2 jlist | json -a -c 'this.pm2_env.env.PORT' pm2_env.env.PORT name",
     "heroku-postbuild": "yarn workspace 123done install",
     "mysql": "docker exec -it $(docker container ls | grep mysql | cut -d' ' -f1) mysql"
   },


### PR DESCRIPTION
Because:
 - `yarn ports` was not working

This commit:
 - get `yarn ports` working
