### PR TITLE
fix(auth): wait for auth to avoid unhandled exc

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -335,7 +335,7 @@ module.exports = ({ log, oauthDB, config }) => {
         checkDisabledClientId(req.payload);
         const sessionToken = req.auth.credentials;
         req.payload.assertion = await makeAssertionJWT(config, sessionToken);
-        const result = authorizationHandler(req);
+        const result = await authorizationHandler(req);
 
         const geoData = req.app.geo;
         const country = geoData.location && geoData.location.country;


### PR DESCRIPTION
Because:

* If the devices or notify fails, the authorizationHandler promise
  will become unhandled, which is the most likely cause of the
  sentry bug as there's no other caller of this code in the code-base
  which could lose the stack.

This commit:

* awaits the authorization handler to avoid an unhandled exception.

Closes #12625

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
