### PR TITLE
fix(auth): dont report error on deleted customers

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -471,6 +471,10 @@ export class StripeWebhookHandler extends StripeHandler {
   async handleCustomerUpdatedEvent(request: AuthRequest, event: Stripe.Event) {
     const customer = event.data.object as Stripe.Customer;
     const uid = customer.metadata.userid;
+    if (!uid || customer.deleted) {
+      // There's nothing to do if this event is for a customer being deleted.
+      return;
+    }
     const account = await Account.findByUid(uid, { include: ['emails'] });
     if (!account) {
       reportSentryError(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -553,6 +553,23 @@ describe('StripeWebhookHandler', () => {
         );
         assert.calledOnce(sentryModule.reportSentryError);
       });
+
+      it('does not report error with no customer if the customer was deleted', async () => {
+        const authDbModule = require('fxa-shared/db/models/auth');
+        const sentryModule = require('../../../../lib/sentry');
+        sandbox.stub(sentryModule, 'reportSentryError').returns({});
+        sandbox.stub(authDbModule.Account, 'findByUid').resolves(null);
+        const customer = deepCopy(customerFixture);
+        customer.deleted = true;
+        await StripeWebhookHandlerInstance.handleCustomerUpdatedEvent(
+          {},
+          {
+            data: { object: customer },
+            type: 'customer.updated',
+          }
+        );
+        assert.notCalled(sentryModule.reportSentryError);
+      });
     });
 
     describe('handleProductWebhookEvent', () => {


### PR DESCRIPTION
Because:

* Deleting a customer causes events that trigger a sentry report
  even though things are operating properly.

This commit:

* Ignores update events if the customer was deleted.

Closes #12627

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
