### PR TITLE
feat(auth): stripe metadata expansion validate url

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -821,6 +821,14 @@ const conf = convict({
         env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED',
         format: Boolean,
       },
+      schemaValidation: {
+        cdnUrlRegex: {
+          default: '^https://accounts-static.cdn.mozilla.net',
+          doc: 'CDN URL Regex',
+          env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_CDN_URL_REGEX',
+          format: String,
+        },
+      },
     },
     sharedSecret: {
       doc: 'Shared secret for authentication between backend subscription services',

--- a/packages/fxa-auth-server/test/local/payments/configuration/manager.js
+++ b/packages/fxa-auth-server/test/local/payments/configuration/manager.js
@@ -43,6 +43,11 @@ const mockConfig = {
       },
       keyFile: 'mock-private-keyfile',
     },
+    productConfigsFirestore: {
+      schemaValidation: {
+        cdnUrlRegex: '^https://',
+      },
+    },
   },
 };
 

--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
@@ -218,7 +218,9 @@ describe('StripeProductsAndPlansConverter', () => {
       const actualProductConfig =
         converter.stripeProductToProductConfig(testProduct);
       assert.deepEqual(expectedProductConfig, actualProductConfig);
-      const { error } = await ProductConfig.validate(actualProductConfig);
+      const { error } = await ProductConfig.validate(actualProductConfig, {
+        cdnUrlRegex: '^http',
+      });
       assert.isUndefined(error);
     });
   });
@@ -251,7 +253,9 @@ describe('StripeProductsAndPlansConverter', () => {
       };
       const actualPlanConfig = converter.stripePlanToPlanConfig(testPlan);
       assert.deepEqual(expectedPlanConfig, actualPlanConfig);
-      const { error } = await PlanConfig.validate(actualPlanConfig);
+      const { error } = await PlanConfig.validate(actualPlanConfig, {
+        cdnUrlRegex: '^https://',
+      });
       assert.isUndefined(error);
     });
   });
@@ -342,6 +346,11 @@ describe('StripeProductsAndPlansConverter', () => {
             clientEmail: 'mock-client-email',
           },
           keyFile: 'mock-private-keyfile',
+        },
+        productConfigsFirestore: {
+          schemaValidation: {
+            cdnUrlRegex: '^http',
+          },
         },
       },
     };

--- a/packages/fxa-shared/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/subscriptions/configuration/plan.ts
@@ -7,6 +7,8 @@ import {
   BaseConfig,
   baseConfigSchema,
   CapabilityConfig,
+  extendBaseConfigSchema,
+  ProductConfigSchemaValidation,
   StyleConfig,
   SupportConfig,
   UiContentConfig,
@@ -24,6 +26,9 @@ export const planConfigJoiKeys = {
 export const planConfigSchema = baseConfigSchema
   .keys(planConfigJoiKeys)
   .requiredKeys('active');
+
+const buildPlanConfigSchema = (baseSchema: joi.ObjectSchema) =>
+  baseSchema.keys(planConfigJoiKeys).requiredKeys('active');
 
 export class PlanConfig implements BaseConfig {
   // Firestore document id
@@ -53,7 +58,17 @@ export class PlanConfig implements BaseConfig {
   googlePlaySku?: string[];
   appleProductId?: string[];
 
-  static async validate(planConfig: PlanConfig) {
+  static async validate(
+    planConfig: PlanConfig,
+    schemaValidation: ProductConfigSchemaValidation
+  ) {
+    const extendedBaseSchema = extendBaseConfigSchema(
+      baseConfigSchema,
+      schemaValidation.cdnUrlRegex
+    );
+
+    const planConfigSchema = buildPlanConfigSchema(extendedBaseSchema);
+
     try {
       const value = await joi.validate(planConfig, planConfigSchema, {
         abortEarly: false,

--- a/packages/fxa-shared/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/subscriptions/configuration/product.ts
@@ -11,6 +11,8 @@ import {
   SupportConfig,
   UiContentConfig,
   UrlConfig,
+  extendBaseConfigSchema,
+  ProductConfigSchemaValidation,
 } from './base';
 
 export const productConfigJoiKeys = {
@@ -19,21 +21,22 @@ export const productConfigJoiKeys = {
   promotionCodes: joi.array().items(joi.string()).optional(),
 };
 
-export const productConfigSchema = baseConfigSchema
-  .keys(productConfigJoiKeys)
-  .requiredKeys(
-    'capabilities',
-    'locales',
-    'styles',
-    'support',
-    'uiContent',
-    'urls.download',
-    'urls.privacyNotice',
-    'urls.termsOfService',
-    'urls.termsOfServiceDownload',
-    'urls.webIcon',
-    'urls'
-  );
+const buildProductConfigSchema = (baseSchema: joi.ObjectSchema) =>
+  baseSchema
+    .keys(productConfigJoiKeys)
+    .requiredKeys(
+      'capabilities',
+      'locales',
+      'styles',
+      'support',
+      'uiContent',
+      'urls.download',
+      'urls.privacyNotice',
+      'urls.termsOfService',
+      'urls.termsOfServiceDownload',
+      'urls.webIcon',
+      'urls'
+    );
 
 export class ProductConfig implements BaseConfig {
   // Firestore document id
@@ -58,7 +61,17 @@ export class ProductConfig implements BaseConfig {
   stripeProductId?: string;
   productSet?: string;
 
-  static async validate(productConfig: ProductConfig) {
+  static async validate(
+    productConfig: ProductConfig,
+    schemaValidation: ProductConfigSchemaValidation
+  ) {
+    const extendedBaseSchema = extendBaseConfigSchema(
+      baseConfigSchema,
+      schemaValidation.cdnUrlRegex
+    );
+
+    const productConfigSchema = buildProductConfigSchema(extendedBaseSchema);
+
     try {
       const value = await joi.validate(productConfig, productConfigSchema, {
         abortEarly: false,

--- a/packages/fxa-shared/test/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/plan.ts
@@ -23,6 +23,16 @@ const firestoreObject = {
   urls: { download: 'gopher://example.gg' },
 };
 
+const localesObject = {
+  support: {},
+  uiContent: {},
+  urls: { webIcon: 'https://web-icon.com' },
+};
+
+const validSchemaValidation = {
+  cdnUrlRegex: '^https://',
+};
+
 describe('PlanConfig', () => {
   it('loads an object from firestore', () => {
     const planConfig = PlanConfig.fromFirestoreObject(
@@ -39,7 +49,32 @@ describe('PlanConfig', () => {
   });
 
   it('validates a valid planConfig', async () => {
-    const result = await PlanConfig.validate(firestoreObject);
+    const result = await PlanConfig.validate(
+      firestoreObject,
+      validSchemaValidation
+    );
+    assert.isDefined(result.value);
+    assert.isUndefined(result.error);
+  });
+
+  it('validates a valid URL regex in planConfig', async () => {
+    const obj = JSON.parse(JSON.stringify(firestoreObject));
+    obj.urls.webIcon = 'https://web-icon.com';
+    const result = await PlanConfig.validate(
+      firestoreObject,
+      validSchemaValidation
+    );
+    assert.isDefined(result.value);
+    assert.isUndefined(result.error);
+  });
+
+  it('validates a valid URL regex in planConfig.locales', async () => {
+    const obj = JSON.parse(JSON.stringify(firestoreObject));
+    obj.locales = localesObject;
+    const result = await PlanConfig.validate(
+      firestoreObject,
+      validSchemaValidation
+    );
     assert.isDefined(result.value);
     assert.isUndefined(result.error);
   });
@@ -47,7 +82,27 @@ describe('PlanConfig', () => {
   it('validates with error on an invalid planConfig', async () => {
     const obj = JSON.parse(JSON.stringify(firestoreObject));
     delete obj.active;
-    const result = await PlanConfig.validate(obj);
+    const result = await PlanConfig.validate(obj, validSchemaValidation);
+    assert.isDefined(result.error);
+    assert.isUndefined(result.value);
+  });
+
+  it('validates with error on an invalid URL regex in planConfig', async () => {
+    const obj = JSON.parse(JSON.stringify(firestoreObject));
+    obj.urls.webIcon = 'https://web-icon.com';
+    const result = await PlanConfig.validate(obj, {
+      cdnUrlRegex: 'invalidpattern',
+    });
+    assert.isDefined(result.error);
+    assert.isUndefined(result.value);
+  });
+
+  it('validates with error on an invalid URL regex in planConfig.locales', async () => {
+    const obj = JSON.parse(JSON.stringify(firestoreObject));
+    obj.locales = localesObject;
+    const result = await PlanConfig.validate(obj, {
+      cdnUrlRegex: 'invalidpattern',
+    });
     assert.isDefined(result.error);
     assert.isUndefined(result.value);
   });

--- a/packages/fxa-shared/test/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/product.ts
@@ -28,6 +28,18 @@ const firestoreObject = {
   },
 };
 
+const localesObject = {
+  en: {
+    support: {},
+    uiContent: {},
+    urls: { webIcon: 'https://web-icon.com' },
+  },
+};
+
+const validSchemaValidation = {
+  cdnUrlRegex: '^https://',
+};
+
 describe('ProductConfig', () => {
   it('loads an object from firestore', () => {
     const prodConfig = ProductConfig.fromFirestoreObject(
@@ -44,7 +56,18 @@ describe('ProductConfig', () => {
   });
 
   it('validates a valid productConfig', async () => {
-    const result = await ProductConfig.validate(firestoreObject);
+    const result = await ProductConfig.validate(
+      firestoreObject,
+      validSchemaValidation
+    );
+    assert.isDefined(result.value);
+    assert.isUndefined(result.error);
+  });
+
+  it('validates a valid URL Regex in productConfig.locales', async () => {
+    const obj = JSON.parse(JSON.stringify(firestoreObject));
+    obj.locales = localesObject;
+    const result = await ProductConfig.validate(obj, validSchemaValidation);
     assert.isDefined(result.value);
     assert.isUndefined(result.error);
   });
@@ -52,7 +75,25 @@ describe('ProductConfig', () => {
   it('validates with error on an invalid productConfig', async () => {
     const obj = JSON.parse(JSON.stringify(firestoreObject));
     delete obj.urls.download;
-    const result = await ProductConfig.validate(obj);
+    const result = await ProductConfig.validate(obj, validSchemaValidation);
+    assert.isDefined(result.error);
+    assert.isUndefined(result.value);
+  });
+
+  it('validates with error on an invalid URL Regex in productConfig', async () => {
+    const result = await ProductConfig.validate(firestoreObject, {
+      cdnUrlRegex: 'invalidpattern',
+    });
+    assert.isDefined(result.error);
+    assert.isUndefined(result.value);
+  });
+
+  it('validates with error on an invalid URL Regex in productConfig.locales', async () => {
+    const obj = JSON.parse(JSON.stringify(firestoreObject));
+    obj.locales = localesObject;
+    const result = await ProductConfig.validate(obj, {
+      cdnUrlRegex: 'invalidpattern',
+    });
     assert.isDefined(result.error);
     assert.isUndefined(result.value);
   });


### PR DESCRIPTION
## Because

- We need to validate that webIcon, termsOfServiceDownload and
  privacyNoticeDownload URLs start with a specific value, set in config.

## This pull request

- Add a value to the auth-sever configuration to set valid URL.
- Update productConfig classes to include valid URL regex from config.

## Issue that this pull request solves

Closes: #12063

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).