### PR TITLE
fix(admin-panel): revise style

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -551,9 +551,9 @@ const EmailBounce = ({
         <li className="account-li">
           bounce subtype: <span>{bounceSubType}</span>
         </li>
-        <li className={styleClasses.li}>
+        <li className="account-li">
           diagnostic code:{' '}
-          <span className={styleClasses.result}>
+          <span>
             {diagnosticCode?.length ? diagnosticCode : 'none'}
           </span>
         </li>


### PR DESCRIPTION
## Because
```
#10 242.8 ➤ YN0000: [fxa-admin-panel]: Process started
#10 251.8 ➤ YN0000: [fxa-admin-panel]: src/components/AccountSearch/Account/index.tsx(554,24): error TS2304: Cannot find name 'styleClasses'.
#10 251.8 ➤ YN0000: [fxa-admin-panel]: src/components/AccountSearch/Account/index.tsx(556,28): error TS2304: Cannot find name 'styleClasses'.
#10 251.9 ➤ YN0000: [fxa-admin-panel]: ERROR: "build:client" exited with 1.
#10 251.9 ➤ YN0000: [fxa-admin-panel]: Process exited (exit code 1), completed in 9s 156ms
```

## This pull request

- fixes the style from the recent push/merge - https://github.com/mozilla/fxa/pull/12637 - where:
  -  `styleClasses.li` becomes `account.li`
  - `styleClasses.result` is no longer utilized.

## Issue that this pull request solves

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.