### PR TITLE
feat(payments): add Email Verification to Passwordless Flow

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -120,6 +120,8 @@ const ERRNO = {
 
   THIRD_PARTY_ACCOUNT_ERROR: 205,
   CANNOT_CREATE_PASSWORD: 206,
+  ACCOUNT_CREATION_REJECTED: 207,
+
   INTERNAL_VALIDATION_ERROR: 998,
   UNEXPECTED_ERROR: 999,
 };
@@ -1572,6 +1574,15 @@ AppError.missingSubscriptionForSourceError = (op, data) =>
       data,
     }
   );
+
+AppError.accountCreationRejected = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.ACCOUNT_CREATION_REJECTED,
+    message: 'Account creation rejected.',
+  });
+};
 
 function decorateErrorWithRequest(error, request) {
   if (request) {

--- a/packages/fxa-content-server/app/scripts/lib/email-domain-validator.js
+++ b/packages/fxa-content-server/app/scripts/lib/email-domain-validator.js
@@ -30,7 +30,7 @@
 import $ from 'jquery';
 import AuthErrors from './auth-errors';
 import Tooltip from '../views/tooltip';
-import TopEmailDomains from './top-email-domains';
+import TopEmailDomains from 'fxa-shared/email/topEmailDomains';
 import xhr from './xhr';
 const t = (msg) => msg;
 

--- a/packages/fxa-content-server/app/tests/spec/lib/email-domain-validator.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/email-domain-validator.js
@@ -9,7 +9,7 @@ import checkEmailDomain from 'lib/email-domain-validator';
 import p from 'lib/promise';
 import sinon from 'sinon';
 import Tooltip from 'views/tooltip';
-import TopEmailDomains from 'lib/top-email-domains';
+import TopEmailDomains from 'fxa-shared/email/topEmailDomains';
 import xhr from 'lib/xhr';
 
 // This is from the email-domain-validator module

--- a/packages/fxa-content-server/tests/server/routes/validate-email-domain.js
+++ b/packages/fxa-content-server/tests/server/routes/validate-email-domain.js
@@ -7,24 +7,13 @@ const assert = intern.getPlugin('chai').assert;
 const path = require('path');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
+const validateEmail = require('fxa-shared/email/validateEmail');
 
 const ERROR_CODES = {
   NODATA: 'ENODATA',
   NOTFOUND: 'ENOTFOUND',
   SERVFAIL: 'ESERVFAIL',
 };
-
-const proxyquireWithDns = (dns) =>
-  proxyquire(
-    path.join(
-      process.cwd(),
-      'server',
-      'lib',
-      'routes',
-      'validate-email-domain'
-    ),
-    { dns }
-  );
 
 registerSuite('routes/validate-email-domain', {
   tests: {
@@ -37,17 +26,20 @@ registerSuite('routes/validate-email-domain', {
 
     'route.process': {
       'responds with {result: "MX"} when there is a MX record': () => {
-        const resolveMxStub = sinon.stub().resolves(['mx.abc.xyz']);
-        const dns = {
-          ...ERROR_CODES,
-          promises: {
-            Resolver: function () {
-              this.resolveMx = resolveMxStub;
-            },
-          },
-        };
+        const resolveMxStub = sinon
+          .stub(validateEmail, 'tryResolveMx')
+          .resolves(true);
+        const validateEmailDomainRoute = proxyquire(
+          path.join(
+            process.cwd(),
+            'server',
+            'lib',
+            'routes',
+            'validate-email-domain'
+          ),
+          { tryResolveMx: resolveMxStub }
+        );
 
-        const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
         const route = validateEmailDomainRoute({
@@ -71,19 +63,24 @@ registerSuite('routes/validate-email-domain', {
         });
       },
       'responds with {result: "A"} when there is an A record': () => {
-        const resolveMxStub = sinon.stub().resolves([]);
-        const resolve4Stub = sinon.stub().resolves(['abc.xyz']);
-        const dns = {
-          ...ERROR_CODES,
-          promises: {
-            Resolver: function () {
-              this.resolveMx = resolveMxStub;
-              this.resolve4 = resolve4Stub;
-            },
-          },
-        };
+        validateEmail.tryResolveMx.restore();
+        const resolveMxStub = sinon
+          .stub(validateEmail, 'tryResolveMx')
+          .resolves(false);
+        const resolve4Stub = sinon
+          .stub(validateEmail, 'tryResolveIpv4')
+          .resolves(true);
+        const validateEmailDomainRoute = proxyquire(
+          path.join(
+            process.cwd(),
+            'server',
+            'lib',
+            'routes',
+            'validate-email-domain'
+          ),
+          { tryResolveMx: resolveMxStub, tryResolveIpv4: resolve4Stub }
+        );
 
-        const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
         const route = validateEmailDomainRoute({
@@ -98,54 +95,29 @@ registerSuite('routes/validate-email-domain', {
       },
 
       'responds with {result: "none"} when there are no DNS records': () => {
-        const resolveMxStub = sinon.stub().resolves([]);
-        const resolve4Stub = sinon.stub().resolves([]);
-        const dns = {
-          ...ERROR_CODES,
-          promises: {
-            Resolver: function () {
-              this.resolveMx = resolveMxStub;
-              this.resolve4 = resolve4Stub;
-            },
-          },
-        };
-
-        const validateEmailDomainRoute = proxyquireWithDns(dns);
-        const req = { query: { domain: 'abc.xyz' } };
-        const res = { json: sinon.stub() };
-        const route = validateEmailDomainRoute({
-          get: sinon.stub().returns(true),
-        });
-
-        return route.process(req, res).then(() => {
-          assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
-          assert.isTrue(resolve4Stub.calledOnceWith('abc.xyz'));
-          assert.isTrue(res.json.calledOnceWith({ result: 'none' }));
-        });
-      },
-
-      'responds with {result: "none"} when resolve functions throw NODATA or NOTFOUND errors': () => {
+        validateEmail.tryResolveMx.restore();
+        validateEmail.tryResolveIpv4.restore();
         const resolveMxStub = sinon
-          .stub()
-          .rejects({ code: ERROR_CODES.NODATA });
+          .stub(validateEmail, 'tryResolveMx')
+          .resolves(false);
         const resolve4Stub = sinon
-          .stub()
-          .rejects({ code: ERROR_CODES.NOTFOUND });
-        const dns = {
-          ...ERROR_CODES,
-          promises: {
-            Resolver: function () {
-              this.resolveMx = resolveMxStub;
-              this.resolve4 = resolve4Stub;
-            },
-          },
-        };
+          .stub(validateEmail, 'tryResolveIpv4')
+          .resolves(false);
+        const validateEmailDomainRoute = proxyquire(
+          path.join(
+            process.cwd(),
+            'server',
+            'lib',
+            'routes',
+            'validate-email-domain'
+          ),
+          { tryResolveMx: resolveMxStub, tryResolveIpv4: resolve4Stub }
+        );
 
-        const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
         const route = validateEmailDomainRoute({
-          get: sinon.stub().returns('true'),
+          get: sinon.stub().returns(true),
         });
 
         return route.process(req, res).then(() => {
@@ -155,66 +127,148 @@ registerSuite('routes/validate-email-domain', {
         });
       },
 
-      'calls next() with an error when resolve functions throw a non- dns.* error ': () => {
-        const error = { code: 'SOME_SERIOUS_ERROR!' };
-        const resolveMxStub = sinon.stub().resolves([]);
-        const resolve4Stub = sinon.stub().rejects(error);
-        const dns = {
-          ...ERROR_CODES,
-          promises: {
-            Resolver: function () {
-              this.resolveMx = resolveMxStub;
-              this.resolve4 = resolve4Stub;
+      'responds with {result: "none"} when resolve functions throw NODATA or NOTFOUND errors':
+        () => {
+          const resolveMxStub = sinon
+            .stub()
+            .rejects({ code: ERROR_CODES.NODATA });
+          const resolve4Stub = sinon
+            .stub()
+            .rejects({ code: ERROR_CODES.NOTFOUND });
+          const dns = {
+            promises: {
+              Resolver: function () {
+                this.resolveMx = resolveMxStub;
+                this.resolve4 = resolve4Stub;
+              },
             },
-          },
-        };
+          };
 
-        const validateEmailDomainRoute = proxyquireWithDns(dns);
-        const req = { query: { domain: 'abc.xyz' } };
-        const res = { json: sinon.stub() };
-        const next = sinon.stub();
-        const route = validateEmailDomainRoute({
-          get: sinon.stub().returns(true),
-        });
-
-        return route.process(req, res, next).then(() => {
-          assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
-          assert.isTrue(resolve4Stub.calledOnceWith('abc.xyz'));
-          assert.isTrue(next.calledOnceWith(error));
-        });
-      },
-
-      'calls next() with a wrapped error on a dns.* error, excluding NODATA and NOTFOUND': () => {
-        const error = { code: ERROR_CODES.SERVFAIL };
-        const resolveMxStub = sinon.stub().resolves([]);
-        const resolve4Stub = sinon.stub().rejects(error);
-        const dns = {
-          ...ERROR_CODES,
-          promises: {
-            Resolver: function () {
-              this.resolveMx = resolveMxStub;
-              this.resolve4 = resolve4Stub;
-            },
-          },
-        };
-
-        const validateEmailDomainRoute = proxyquireWithDns(dns);
-        const req = { query: { domain: 'abc.xyz' } };
-        const res = { json: sinon.stub() };
-        const next = sinon.stub();
-        const route = validateEmailDomainRoute({
-          get: sinon.stub().returns(true),
-        });
-
-        return route.process(req, res, next).then(() => {
-          assert.isFalse(next.calledWith(error));
-          assert.isTrue(next.calledOnce);
-          assert.equal(
-            next.args[0][0].message,
-            `DNS query error: ${ERROR_CODES.SERVFAIL}`
+          const validateEmailDomainRoute = proxyquire(
+            path.join(
+              process.cwd(),
+              'server',
+              'lib',
+              'routes',
+              'validate-email-domain'
+            ),
+            {
+              'fxa-shared/email/validateEmail': proxyquire(
+                'fxa-shared/email/validateEmail',
+                {
+                  dns,
+                }
+              ),
+            }
           );
-        });
-      },
+
+          const req = { query: { domain: 'abc.xyz' } };
+          const res = { json: sinon.stub() };
+          const route = validateEmailDomainRoute({
+            get: sinon.stub().returns('true'),
+          });
+
+          return route.process(req, res).then(() => {
+            assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
+            assert.isTrue(resolve4Stub.calledOnceWith('abc.xyz'));
+            assert.isTrue(res.json.calledOnceWith({ result: 'none' }));
+          });
+        },
+
+      'calls next() with an error when resolve functions throw a non- dns.* error ':
+        () => {
+          const error = { code: 'SOME_SERIOUS_ERROR!' };
+          const resolveMxStub = sinon.stub().resolves([]);
+          const resolve4Stub = sinon.stub().rejects(error);
+          const dns = {
+            promises: {
+              Resolver: function () {
+                this.resolveMx = resolveMxStub;
+                this.resolve4 = resolve4Stub;
+              },
+            },
+          };
+
+          const validateEmailDomainRoute = proxyquire(
+            path.join(
+              process.cwd(),
+              'server',
+              'lib',
+              'routes',
+              'validate-email-domain'
+            ),
+            {
+              'fxa-shared/email/validateEmail': proxyquire(
+                'fxa-shared/email/validateEmail',
+                {
+                  dns,
+                }
+              ),
+            }
+          );
+
+          const req = { query: { domain: 'abc.xyz' } };
+          const res = { json: sinon.stub() };
+          const next = sinon.stub();
+          const route = validateEmailDomainRoute({
+            get: sinon.stub().returns(true),
+          });
+
+          return route.process(req, res, next).then(() => {
+            assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
+            assert.isTrue(resolve4Stub.calledOnceWith('abc.xyz'));
+            assert.isTrue(next.calledOnceWith(error));
+          });
+        },
+
+      'calls next() with a wrapped error on a dns.* error, excluding NODATA and NOTFOUND':
+        () => {
+          const error = { code: ERROR_CODES.SERVFAIL };
+          const resolveMxStub = sinon.stub().resolves([]);
+          const resolve4Stub = sinon.stub().rejects(error);
+          const dns = {
+            promises: {
+              Resolver: function () {
+                this.resolveMx = resolveMxStub;
+                this.resolve4 = resolve4Stub;
+              },
+            },
+          };
+
+          const validateEmailDomainRoute = proxyquire(
+            path.join(
+              process.cwd(),
+              'server',
+              'lib',
+              'routes',
+              'validate-email-domain'
+            ),
+            {
+              'fxa-shared/email/validateEmail': proxyquire(
+                'fxa-shared/email/validateEmail',
+                {
+                  dns,
+                }
+              ),
+            }
+          );
+
+          const req = { query: { domain: 'abc.xyz' } };
+          const res = { json: sinon.stub() };
+          const next = sinon.stub();
+          const route = validateEmailDomainRoute({
+            get: sinon.stub().returns(true),
+          });
+
+          return route.process(req, res, next).then(() => {
+            assert.isFalse(next.calledWith(error));
+            assert.isTrue(next.calledOnce);
+            assert.equal(
+              next.args[0][0].message,
+              `DNS query error: ${ERROR_CODES.SERVFAIL}`
+            );
+          });
+        },
     },
   },
 });

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -464,6 +464,8 @@ new-user-subscribe-product-assurance = We only use your email to create your acc
 new-user-email-validate = Email is not valid
 new-user-email-validate-confirm = Emails do not match
 new-user-already-has-account-sign-in = You already have an account. <a>Sign in</a>
+# $domain (String) - the email domain provided by the user during sign up
+new-user-invalid-email-domain = Mistyped email? { $domain } does not offer email.
 new-user-card-title = Enter your card information
 new-user-submit = Subscribe Now
 

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -4,11 +4,14 @@ import { NewUserEmailForm } from './index';
 
 const WrapNewUserEmailForm = ({
   accountExistsReturnValue,
+  invalidDomain,
 }: {
   accountExistsReturnValue: boolean;
+  invalidDomain: boolean;
 }) => {
   const [, setValidEmail] = useState<string>('');
   const [, setAccountExists] = useState(false);
+  const [, setInvalidEmailDomain] = useState(false);
   const [, setEmailsMatch] = useState(false);
   return (
     <div style={{ display: 'flex' }}>
@@ -18,10 +21,14 @@ const WrapNewUserEmailForm = ({
         }
         setValidEmail={setValidEmail}
         setAccountExists={setAccountExists}
+        setInvalidEmailDomain={setInvalidEmailDomain}
         setEmailsMatch={setEmailsMatch}
         getString={(id: string) => id}
         checkAccountExists={() =>
-          Promise.resolve({ exists: accountExistsReturnValue })
+          Promise.resolve({
+            exists: accountExistsReturnValue,
+            invalidDomain,
+          })
         }
         selectedPlan={{}}
         onToggleNewsletterCheckbox={() => {}}
@@ -32,8 +39,20 @@ const WrapNewUserEmailForm = ({
 
 storiesOf('components/NewUserEmailForm', module)
   .add('default', () => (
-    <WrapNewUserEmailForm accountExistsReturnValue={false} />
+    <WrapNewUserEmailForm
+      accountExistsReturnValue={false}
+      invalidDomain={false}
+    />
   ))
   .add('existing account', () => (
-    <WrapNewUserEmailForm accountExistsReturnValue={true} />
+    <WrapNewUserEmailForm
+      accountExistsReturnValue={true}
+      invalidDomain={false}
+    />
+  ))
+  .add('invalid email domain', () => (
+    <WrapNewUserEmailForm
+      accountExistsReturnValue={false}
+      invalidDomain={true}
+    />
   ));

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -109,9 +109,9 @@ async function apiFetch(
 
 export async function apiFetchAccountStatus(
   email: string
-): Promise<{ exists: boolean }> {
+): Promise<{ exists: boolean; invalidDomain: boolean }> {
   return apiFetch('POST', `${config.servers.auth.url}/v1/account/status`, {
-    body: JSON.stringify({ email }),
+    body: JSON.stringify({ email, checkDomain: true }),
   });
 }
 

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -112,7 +112,7 @@ describe('routes/Checkout', () => {
     (apiFetchPlans as jest.Mock).mockClear().mockResolvedValue(PLANS);
     (apiFetchAccountStatus as jest.Mock)
       .mockClear()
-      .mockResolvedValue({ exists: false });
+      .mockResolvedValue({ exists: false, invalidDomain: false });
     (apiCreatePasswordlessAccount as jest.Mock)
       .mockClear()
       .mockResolvedValue(STUB_ACCOUNT_RESULT);

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -119,6 +119,7 @@ export const Checkout = ({
   const [checkboxSet, setCheckboxSet] = useState(false);
   const [validEmail, setValidEmail] = useState<string>('');
   const [accountExists, setAccountExists] = useState(false);
+  const [invalidEmailDomain, setInvalidEmailDomain] = useState(false);
   const [emailsMatch, setEmailsMatch] = useState(false);
   const [paypalScriptLoaded, setPaypalScriptLoaded] = useState(false);
   const [subscribeToNewsletter, toggleSubscribeToNewsletter] = useState(false);
@@ -348,6 +349,7 @@ export const Checkout = ({
             setValidEmail={setValidEmail}
             signInURL={signInURL}
             setAccountExists={setAccountExists}
+            setInvalidEmailDomain={setInvalidEmailDomain}
             checkAccountExists={checkAccountExists}
             setEmailsMatch={setEmailsMatch}
             getString={l10n.getString.bind(l10n)}
@@ -379,6 +381,7 @@ export const Checkout = ({
                           !checkboxSet ||
                           validEmail === '' ||
                           accountExists ||
+                          invalidEmailDomain ||
                           !emailsMatch
                         }
                         idempotencyKey={submitNonce}
@@ -430,6 +433,7 @@ export const Checkout = ({
                   checkboxSet &&
                   validEmail !== '' &&
                   !accountExists &&
+                  !invalidEmailDomain &&
                   emailsMatch,
 
                 inProgress,

--- a/packages/fxa-shared/email/emailValidatorErrors.ts
+++ b/packages/fxa-shared/email/emailValidatorErrors.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const dns = require('dns');
+
+export const NotFoundErrorCodes = [dns.NODATA, dns.NOTFOUND];
+
+export const WrappedErrorCodes = [
+  dns.FORMERR,
+  dns.SERVFAIL,
+  dns.NOTIMP,
+  dns.REFUSED,
+  dns.BADQUERY,
+  dns.BADNAME,
+  dns.BADFAMILY,
+  dns.BADRESP,
+  dns.CONNREFUSED,
+  dns.TIMEOUT,
+  dns.EOF,
+  dns.FILE,
+  dns.NOMEM,
+  dns.DESTRUCTION,
+  dns.BADSTR,
+  dns.BADFLAGS,
+  dns.NONAME,
+  dns.BADHINTS,
+  dns.NOTINITIALIZED,
+  dns.LOADIPHLPAPI,
+  dns.ADDRGETNETWORKPARAMS,
+  dns.CANCELLED,
+];

--- a/packages/fxa-shared/email/topEmailDomains.ts
+++ b/packages/fxa-shared/email/topEmailDomains.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Email domains that we are not going to validate.
 
 // This is maintained at

--- a/packages/fxa-shared/email/validateEmail.ts
+++ b/packages/fxa-shared/email/validateEmail.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import * as dns from 'dns';
+import { NotFoundErrorCodes } from './emailValidatorErrors';
+const resolver = new dns.promises.Resolver();
+
+const tryResolveWith =
+  (resolveFunc: (arg: any) => any) => async (domain: string) => {
+    try {
+      const records = await resolveFunc(domain);
+      // We don't do anything with the records
+      return records && records.length;
+    } catch (err) {
+      if (NotFoundErrorCodes.includes(err.code)) {
+        return false;
+      }
+      throw err;
+    }
+  };
+
+export const tryResolveMx = async (domain: string) => {
+  return tryResolveWith(resolver.resolveMx.bind(resolver))(domain);
+};
+
+export const tryResolveIpv4 = async (domain: string) => {
+  return tryResolveWith(resolver.resolve4.bind(resolver))(domain);
+};


### PR DESCRIPTION
Because:

* We want to prevent subscriptions created for fraudulent purposes that use invalid email domains

This commit:

* As a temp solution refactors the email domain check used by content server and piggy-backs off the account status check to return information about the validity of the email domain

Closes https://github.com/mozilla/fxa/issues/12406
## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
This is a temporary solution until we evaluate alternatives in #12405 and determine what a more permanent solution will be. I wanted this to be minimally invasive in how things currently work and as easily to remove/revert as possible later.