### PR TITLE
fix(payments): missing metrics props on success

### DIFF
--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -185,7 +185,6 @@ export const Checkout = ({
             setSubscriptionError({ type: 'card_error', code: 'card_declined' });
           },
         });
-        Amplitude.createSubscriptionWithPaymentMethod_FULFILLED(selectedPlan);
         if (subscribeToNewsletter) {
           await handleNewsletterSignup();
         }


### PR DESCRIPTION
## Because

- Some of the success metrics are missing the country and payment
  provider properties.

## This pull request

- Remove the duplicate success metric, which had the missing properties.

## Issue that this pull request solves

Closes: #12577

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).