### PR TITLE
fix(swagger): SyntaxError: Cannot use import statement outside a module

### DIFF
--- a/packages/fxa-auth-server/lib/devices.js
+++ b/packages/fxa-auth-server/lib/devices.js
@@ -4,9 +4,8 @@
 
 'use strict';
 
-import DESCRIPTION from '../docs/swagger/shared/descriptions';
-
 const isA = require('@hapi/joi');
+const DESCRIPTION = require('../docs/swagger/shared/descriptions').default;
 const validators = require('./routes/validators');
 const error = require('./error');
 const oauthDB = require('./oauth/db');

--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -4,8 +4,6 @@
 
 'use strict';
 
-import doc from '../../docs/swagger/devices-and-sessions-api';
-
 const isA = require('@hapi/joi');
 const validators = require('./validators');
 const authorizedClients = require('../oauth/authorized_clients');
@@ -13,6 +11,8 @@ const error = require('../error');
 
 const HEX_STRING = validators.HEX_STRING;
 const DEVICES_SCHEMA = require('../devices').schema;
+const DEVICES_AND_SESSIONS_DOC =
+  require('../../docs/swagger/devices-and-sessions-api').default;
 
 const { ConnectedServicesFactory } = require('fxa-shared/connected-services');
 
@@ -22,7 +22,7 @@ module.exports = (log, db, devices, clientUtils) => {
       method: 'GET',
       path: '/account/attached_clients',
       options: {
-        ...doc.ACCOUNT_ATTACHED_CLIENTS_GET,
+        ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_CLIENTS_GET,
         auth: {
           strategy: 'sessionToken',
         },
@@ -109,7 +109,7 @@ module.exports = (log, db, devices, clientUtils) => {
       method: 'POST',
       path: '/account/attached_client/destroy',
       options: {
-        ...doc.ACCOUNT_ATTACHED_CLIENT_DESTROY_POST,
+        ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_CLIENT_DESTROY_POST,
         auth: {
           strategy: 'sessionToken',
           payload: 'required',

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -4,9 +4,6 @@
 
 'use strict';
 
-import DEVICES_AND_SERVICES_DOCS from '../../docs/swagger/devices-and-sessions-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-
 const { URL } = require('url');
 const Ajv = require('ajv');
 const ajv = new Ajv();
@@ -17,6 +14,9 @@ const isA = require('@hapi/joi');
 const path = require('path');
 const validators = require('./validators');
 
+const DEVICES_AND_SERVICES_DOCS =
+  require('../../docs/swagger/devices-and-sessions-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const HEX_STRING = validators.HEX_STRING;
 const DEVICES_SCHEMA = require('../devices').schema;
 const PUSH_PAYLOADS_SCHEMA_PATH = path.resolve(

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -4,9 +4,6 @@
 
 'use strict';
 
-import EMAILS_DOCS from '../../docs/swagger/emails-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-
 const butil = require('../crypto/butil');
 const emailUtils = require('./utils/email');
 const error = require('../error');
@@ -16,6 +13,8 @@ const Sentry = require('@sentry/node');
 const validators = require('./validators');
 const { emailsMatch, normalizeEmail } = require('fxa-shared').email.helpers;
 
+const EMAILS_DOCS = require('../../docs/swagger/emails-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const HEX_STRING = validators.HEX_STRING;
 const MAX_SECONDARY_EMAILS = 3;
 

--- a/packages/fxa-auth-server/lib/routes/idp.js
+++ b/packages/fxa-auth-server/lib/routes/idp.js
@@ -4,9 +4,8 @@
 
 'use strict';
 
-import MISC_DOCS from '../../docs/swagger/misc-api';
-
 const jwtool = require('fxa-jwtool');
+const MISC_DOCS = require('../../docs/swagger/misc-api').default;
 
 function b64toDec(str) {
   const n = new jwtool.BN(Buffer.from(str, 'base64'));

--- a/packages/fxa-auth-server/lib/routes/newsletters.js
+++ b/packages/fxa-auth-server/lib/routes/newsletters.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-import MISC_DOCS from '../../docs/swagger/misc-api';
+const MISC_DOCS = require('../../docs/swagger/misc-api').default;
 const validators = require('./validators');
 const ScopeSet = require('fxa-shared/oauth/scopes');
 const AppError = require('../../lib/error');

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-import OAUTH_DOCS from '../../../docs/swagger/oauth-api';
-import DESCRIPTION from '../../../docs/swagger/shared/descriptions';
-
 const hex = require('buf').to.hex;
 const Joi = require('@hapi/joi');
 
@@ -15,6 +11,10 @@ const validators = require('../../oauth/validators');
 const { validateRequestedGrant, generateTokens } = require('../../oauth/grant');
 const { makeAssertionJWT } = require('../../oauth/util');
 const verifyAssertion = require('../../oauth/assertion');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
+const OAUTH_DOCS = require('../../../docs/swagger/oauth-api').default;
+const DESCRIPTION =
+  require('../../../docs/swagger/shared/descriptions').default;
 
 const RESPONSE_TYPE_CODE = 'code';
 const RESPONSE_TYPE_TOKEN = 'token';

--- a/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/destroy.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../../docs/swagger/misc-api';
-
+const Joi = require('joi');
 const validators = require('../../../oauth/validators');
 const authorizedClients = require('../../../oauth/authorized_clients');
 const verifyAssertion = require('../../../oauth/assertion');
-const Joi = require('joi');
+const MISC_DOCS = require('../../../../docs/swagger/misc-api').default;
 
 module.exports = () => ({
   method: 'POST',

--- a/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/list.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/list.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../../docs/swagger/misc-api';
-
 const Joi = require('@hapi/joi');
 
 const validators = require('../../../oauth/validators');
 const verifyAssertion = require('../../../oauth/assertion');
 const authorizedClients = require('../../../oauth/authorized_clients');
+const MISC_DOCS = require('../../../../docs/swagger/misc-api').default;
 
 module.exports = () => ({
   method: 'POST',

--- a/packages/fxa-auth-server/lib/routes/oauth/client/get.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/client/get.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../../docs/swagger/misc-api';
-
 const hex = require('buf').to.hex;
 const Joi = require('@hapi/joi');
 
 const AppError = require('../../../oauth/error');
 const validators = require('../../../oauth/validators');
+const MISC_DOCS = require('../../../../docs/swagger/misc-api').default;
 
 module.exports = ({ log, oauthDB }) => ({
   method: 'GET',

--- a/packages/fxa-auth-server/lib/routes/oauth/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/destroy.js
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-import OAUTH_DOCS from '../../../docs/swagger/oauth-api';
-import DESCRIPTION from '../../../docs/swagger/shared/descriptions';
-
 const crypto = require('crypto');
 const Joi = require('@hapi/joi');
 const hex = require('buf').to.hex;
@@ -19,6 +15,10 @@ const {
   authenticateClient,
   clientAuthValidators,
 } = require('../../oauth/client');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
+const OAUTH_DOCS = require('../../../docs/swagger/oauth-api').default;
+const DESCRIPTION =
+  require('../../../docs/swagger/shared/descriptions').default;
 
 /*jshint camelcase: false*/
 module.exports = ({ log, oauthDB }) => {

--- a/packages/fxa-auth-server/lib/routes/oauth/id_token_verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/id_token_verify.js
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-
 const Joi = require('@hapi/joi');
 const JWTIdToken = require('../../oauth/jwt_id_token');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
 
 module.exports = () => ({
   method: 'POST',

--- a/packages/fxa-auth-server/lib/routes/oauth/introspect.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/introspect.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-
 /*jshint camelcase: false*/
 const Joi = require('@hapi/joi');
 const validators = require('../../oauth/validators');
 const hex = require('buf').to.hex;
 const AppError = require('../../oauth/error');
 const { getTokenId } = require('../../oauth/token');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
 
 const PAYLOAD_SCHEMA = Joi.object({
   token: Joi.string().required(),

--- a/packages/fxa-auth-server/lib/routes/oauth/jwks.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/jwks.js
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-
 const { PUBLIC_KEYS } = require('../../oauth/keys');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
 
 module.exports = () => ({
   method: 'GET',

--- a/packages/fxa-auth-server/lib/routes/oauth/key_data.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/key_data.js
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-import OAUTH_DOCS from '../../../docs/swagger/oauth-api';
-
 const Joi = require('@hapi/joi');
 
 const OauthError = require('../../oauth/error');
@@ -14,6 +11,8 @@ const validators = require('../../oauth/validators');
 const verifyAssertion = require('../../oauth/assertion');
 const { validateRequestedGrant } = require('../../oauth/grant');
 const { makeAssertionJWT } = require('../../oauth/util');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
+const OAUTH_DOCS = require('../../../docs/swagger/oauth-api').default;
 
 /**
  * We don't yet support rotating individual scoped keys,

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -24,10 +24,6 @@
 //
 // So, we've tried to make it as readable as possible, but...be careful in there!
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-import OAUTH_DOCS from '../../../docs/swagger/oauth-api';
-import DESCRIPTION from '../../../docs/swagger/shared/descriptions';
-
 /*jshint camelcase: false*/
 const crypto = require('crypto');
 const OauthError = require('../../oauth/error');
@@ -54,6 +50,10 @@ const {
   clientAuthValidators,
 } = require('../../oauth/client');
 const ScopeSet = require('fxa-shared').oauth.scopes;
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
+const OAUTH_DOCS = require('../../../docs/swagger/oauth-api').default;
+const DESCRIPTION =
+  require('../../../docs/swagger/shared/descriptions').default;
 
 const MAX_TTL_S = config.get('oauthServer.expiration.accessToken') / 1000;
 

--- a/packages/fxa-auth-server/lib/routes/oauth/verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/verify.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import MISC_DOCS from '../../../docs/swagger/misc-api';
-
 const Joi = require('@hapi/joi');
 
 const token = require('../../oauth/token');
 const validators = require('../../oauth/validators');
+const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
 
 module.exports = ({ log }) => ({
   method: 'POST',

--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -4,9 +4,6 @@
 
 'use strict';
 
-import PASSWORD_DOCS from '../../docs/swagger/password-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-
 const validators = require('./validators');
 const HEX_STRING = validators.HEX_STRING;
 
@@ -17,6 +14,8 @@ const random = require('../crypto/random');
 const requestHelper = require('../routes/utils/request_helper');
 const { emailsMatch } = require('fxa-shared').email.helpers;
 
+const PASSWORD_DOCS = require('../../docs/swagger/password-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
 module.exports = function (

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -4,11 +4,11 @@
 
 'use strict';
 
-import RECOVERY_CODES_DOCS from '../../docs/swagger/recovery-codes-api';
-
 const errors = require('../error');
 const isA = require('@hapi/joi');
 const validators = require('./validators');
+const RECOVERY_CODES_DOCS =
+  require('../../docs/swagger/recovery-codes-api').default;
 
 const RECOVERY_CODE_SANE_MAX_LENGTH = 20;
 

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -4,8 +4,9 @@
 
 'use strict';
 
-import RECOVERY_KEY_DOCS from '../../docs/swagger/recovery-key-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
+const RECOVERY_KEY_DOCS =
+  require('../../docs/swagger/recovery-key-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 
 const errors = require('../error');
 const validators = require('./validators');

--- a/packages/fxa-auth-server/lib/routes/security-events.js
+++ b/packages/fxa-auth-server/lib/routes/security-events.js
@@ -4,7 +4,8 @@
 
 'use strict';
 
-import SECURITY_EVENTS_DOCS from '../../docs/swagger/security-events-api';
+const SECURITY_EVENTS_DOCS =
+  require('../../docs/swagger/security-events-api').default;
 
 module.exports = (log, db, config) => {
   return [

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -4,9 +4,6 @@
 
 'use strict';
 
-import SESSION_DOCS from '../../docs/swagger/session-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-
 const error = require('../error');
 const isA = require('@hapi/joi');
 const requestHelper = require('../routes/utils/request_helper');
@@ -15,6 +12,8 @@ const validators = require('./validators');
 const Localizer = require('../l10n').default;
 const NodeRendererBindings =
   require('../senders/renderer/bindings-node').default;
+const SESSION_DOCS = require('../../docs/swagger/session-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const HEX_STRING = validators.HEX_STRING;
 
 module.exports = function (

--- a/packages/fxa-auth-server/lib/routes/sign.js
+++ b/packages/fxa-auth-server/lib/routes/sign.js
@@ -4,12 +4,11 @@
 
 'use strict';
 
-import SIGN_DOCS from '../../docs/swagger/sign-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-
 const error = require('../error');
 const isA = require('@hapi/joi');
 const validators = require('./validators');
+const SIGN_DOCS = require('../../docs/swagger/sign-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 
 module.exports = (log, signer, db, domain, devices) => {
   const HOUR = 1000 * 60 * 60;

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -4,9 +4,6 @@
 
 'use strict';
 
-import TOTP_DOCS from '../../docs/swagger/totp-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-
 const errors = require('../error');
 const validators = require('./validators');
 const isA = require('@hapi/joi');
@@ -14,6 +11,8 @@ const otplib = require('otplib');
 const qrcode = require('qrcode');
 const { promisify } = require('util');
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
+const TOTP_DOCS = require('../../docs/swagger/totp-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 
 module.exports = (log, db, mailer, customs, config) => {
   const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);

--- a/packages/fxa-auth-server/lib/routes/unblock-codes.js
+++ b/packages/fxa-auth-server/lib/routes/unblock-codes.js
@@ -4,8 +4,9 @@
 
 'use strict';
 
-import UNBLOCK_CODES_DOCS from '../../docs/swagger/unblock-codes-api';
-import DESCRIPTION from '../../docs/swagger/shared/descriptions';
+const UNBLOCK_CODES_DOCS =
+  require('../../docs/swagger/unblock-codes-api').default;
+const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 
 const isA = require('@hapi/joi');
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;

--- a/packages/fxa-auth-server/lib/routes/util.js
+++ b/packages/fxa-auth-server/lib/routes/util.js
@@ -4,11 +4,11 @@
 
 'use strict';
 
-import UTIL_DOCS from '../../docs/swagger/util-api';
-
 const isA = require('@hapi/joi');
 const random = require('../crypto/random');
 const validators = require('./validators');
+const UTIL_DOCS = require('../../docs/swagger/util-api').default;
+
 const HEX_STRING = validators.HEX_STRING;
 
 module.exports = (log, config, redirectDomain) => {


### PR DESCRIPTION
## Because

```
/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/devices.js:7
import DESCRIPTION from '../docs/swagger/shared/descriptions';
^^^^^^
SyntaxError: Cannot use import statement outside a module
at compileFunction (<anonymous>)
at Object.compileFunction (node:vm:352:18)
at wrapSafe (node:internal/modules/cjs/loader:1032:15)
at Module._compile (node:internal/modules/cjs/loader:1067:27)
at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
at Module.load (node:internal/modules/cjs/loader:981:32)
at Function.Module._load (node:internal/modules/cjs/loader:822:12)
at Module.require (node:internal/modules/cjs/loader:1005:19)
at require (node:internal/modules/cjs/helpers:102:18)
at module.exports (/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/routes/index.js:27:23)
at run (/fxa/packages/fxa-auth-server/dist/fxa-auth-server/bin/key_server.js:102:44)
at processTicksAndRejections (node:internal/process/task_queues:96:5)
at async main (/fxa/packages/fxa-auth-server/dist/fxa-auth-server/bin/key_server.js:139:24)
```

## This pull request

- Changes import statement to `require()`

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
