### PR TITLE
fix(swagger): Copy .ts files into Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .DS_Store
 **/coverage
 **/docs
+!packages/fxa-auth-server/docs/swagger
 **/node_modules
 #**/test
 **/tests


### PR DESCRIPTION
## Because

- We can't deploy Train 231 to stage

## This pull request

- Fixes the Docker image build to include the Swagger API descriptions

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
