### PR TITLE
fix(fxa-content-server): add spacing bn 3rd party auth buttons

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -249,7 +249,7 @@
   .login-button {
     border: 1px solid #b2b2b2;
     background-color: white;
-    margin-bottom: 5px;
+    margin-bottom: 10px;
     font-weight: normal;
     &:hover {
       border-color: #1a1a1a;


### PR DESCRIPTION
## Because:

* Github issue #12281 asks for "at least 4 pixels" more spacing between
  third party auth buttons

## This commit/pull request:

* Raises the "margin-bottom" style on ".third-party-auth .login-button"
  from 5px to 10px

Closes # 11281

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before (desktop):
![Screen Shot 2022-04-28 at 12 48 40 PM](https://user-images.githubusercontent.com/11150372/165834875-05dc7739-0034-4cd0-b02f-2699573e2076.png)

Before (mobile):
![Screen Shot 2022-05-02 at 2 20 51 PM](https://user-images.githubusercontent.com/11150372/166329836-d6427eb0-3d97-497b-9b06-8cb227943197.png)

After (desktop):
![Screen Shot 2022-04-28 at 12 48 26 PM](https://user-images.githubusercontent.com/11150372/165834899-037b611a-7cb7-48e4-bb6e-fe833659de1b.png)

After (mobile):
![Screen Shot 2022-05-02 at 2 21 17 PM](https://user-images.githubusercontent.com/11150372/166329851-c7873191-19fb-42bc-a451-67ceb2501f2c.png)
