### PR TITLE
fix(subscriptions): on upgrade use correct invoice line

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2584,14 +2584,20 @@ export class StripeHelper {
       total: invoiceTotalInCents,
       subtotal: invoiceSubtotalInCents,
       hosted_invoice_url: invoiceLink,
-      lines: {
-        data: [
-          {
-            period: { end: nextInvoiceDate },
-          },
-        ],
-      },
+      lines: { data: invoiceLines },
     } = invoice;
+
+    const nextInvoiceDate = invoiceLines.find(
+      (line) => line.type === 'subscription'
+    )?.period.end;
+
+    if (!nextInvoiceDate) {
+      throw error.internalValidationError(
+        'extractInvoiceDetailsForEmail',
+        invoice,
+        'Could not find next invoice date for subscription.'
+      );
+    }
 
     const invoiceDiscountAmountInCents =
       (invoice.total_discount_amounts &&


### PR DESCRIPTION
## Because

- The incorrect next invoice date is shown in the subsequent invoice
  email
- For a subscription upgrade, the Stripe invoice can have a line item
  for the previous and current subscription. The existing logic assumes
  there is only one invoice line item.

## This pull request

- Use the invoice line item with type "subscription" to determine the
  correct next invoice date.

## Issue that this pull request solves

Closes: #12690

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).