### PR TITLE
fix(admin-panel): trim whitespace from admin panel search bar

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -125,17 +125,22 @@ export const AccountSearch = () => {
     useLazyQuery(GET_EMAILS_LIKE);
 
   const handleSubmit = (event: React.FormEvent) => {
+    const trimmedSearchInput = searchInput.trim();
     event.preventDefault();
-    const isUID = validateUID(searchInput);
+    const isUID = validateUID(trimmedSearchInput);
     // choose correct query if email or uid
     if (isUID) {
       // uid and non-empty
-      getAccountbyUID({ variables: { uid: searchInput } });
+      getAccountbyUID({ variables: { uid: trimmedSearchInput } });
       setIsEmail(false);
       setShowResult(true);
-    } else if (!isUID && searchInput.search('@') !== -1 && searchInput !== '') {
+    } else if (
+      !isUID &&
+      trimmedSearchInput.search('@') !== -1 &&
+      trimmedSearchInput !== ''
+    ) {
       // assume email if not uid and non-empty; must at least have '@'
-      getAccountbyEmail({ variables: { email: searchInput } });
+      getAccountbyEmail({ variables: { email: trimmedSearchInput } });
       setIsEmail(true);
       setShowResult(true);
     }
@@ -153,14 +158,12 @@ export const AccountSearch = () => {
   }
 
   const onTextChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-
-    setSearchInput(value);
+    const value = event.target.value.trim();
 
     if (value.length < 5) {
       setShowSuggestion(false);
     } else if (value.length >= 5) {
-      getEmailLike({ variables: { search: value } });
+      getEmailLike({ variables: { search: value.trim() } });
       setShowSuggestion(true);
     }
   };
@@ -260,7 +263,7 @@ export const AccountSearch = () => {
             loading: queryResults.loading,
             error: queryResults.error,
             data: queryResults.data,
-            query: searchInput,
+            query: searchInput.trim(),
           }}
         />
       ) : null}


### PR DESCRIPTION
Because:

* When copying and pasting values into the search bar, it's easy to accidentally include whitespace either before or after the copied value. Currently, this will result in the search not returning a result (as it will search for the entire input, including whitespace.)

This pull request:

* Trims the search input value before we submit it to the search (in the `handleSubmit` action, in the input length check that determines whether or not to show suggestions, and also in the search that returns suggested matching emails.) There is a slightly simpler way to this -- we could just trim
"event.target.value" before it's set into state using `setSearchInput`, but this could result in the user trying to type
in the input (with spaces, for example) and thinking they couldn't interact with the search input (since the value of the search input would be constantly trimmed). While slightly more complicated, I think this is a safer solution. 

* There also seemed to be a duplicate `setSearchInput` action happening in `onTextChanged`, which I have removed. `onTextChanged` seems to only ever be called by `handleChange`, which already calls `setSearchInput`.

Closes # 12567

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

Before (whitespace before or after search input value is included in query term and returns nothing):
![Screen Shot 2022-04-29 at 10 27 25 AM](https://user-images.githubusercontent.com/11150372/165993826-fa7beca6-8f2c-4a31-a1dc-6eb558c70d5c.png)

After (whitespace is trimmed and search returns correct record):
![Screen Shot 2022-04-29 at 10 25 25 AM](https://user-images.githubusercontent.com/11150372/165993843-c67f7bbf-e4b0-44e0-8c4a-818144d771ac.png)
