### PR TITLE
feat(auth): update capability service to query App Store purchases

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -18,6 +18,7 @@ const {
   ProfileClient,
 } = require('../lib/types');
 const { setupFirestore } = require('../lib/firestore-db');
+const { AppleIAP } = require('../lib/payments/iap/apple-app-store/apple-iap');
 
 async function run(config) {
   Container.set(AppConfig, config);
@@ -102,6 +103,11 @@ async function run(config) {
     config.subscriptions.playApiServiceAccount.enabled
   ) {
     Container.get(PlayBilling);
+  }
+
+  // Create AppleIAP if enabled by fetching it.
+  if (config?.subscriptions?.appStore?.enabled) {
+    Container.get(AppleIAP);
   }
 
   const profile = require('../lib/profile/client')(log, config, statsd);

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -795,6 +795,12 @@ const conf = convict({
         },
         env: 'APP_STORE_CREDENTIALS',
       },
+      enabled: {
+        doc: 'Indicates whether the App Store API is enabled',
+        format: Boolean,
+        default: false,
+        env: 'SUBSCRIPTIONS_APP_STORE_API_ENABLED',
+      },
       sandbox: {
         doc: 'Apple App Store Sandbox mode',
         format: Boolean,

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/purchase-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/purchase-manager.ts
@@ -27,7 +27,7 @@ import {
   PurchaseUpdateError,
   SkuType,
 } from './types';
-import { SubscriptionPurchase } from './subscription-purchase';
+import { PlayStoreSubscriptionPurchase } from './subscription-purchase';
 
 /*
  * A class that provides user-purchase linking features
@@ -69,7 +69,9 @@ export class PurchaseManager extends PurchaseManagerBase {
       .doc(purchaseToken)
       .get();
     if (purchaseRecordDoc.exists) {
-      return SubscriptionPurchase.fromFirestoreObject(purchaseRecordDoc.data());
+      return PlayStoreSubscriptionPurchase.fromFirestoreObject(
+        purchaseRecordDoc.data()
+      );
     }
     return;
   }
@@ -88,7 +90,7 @@ export class PurchaseManager extends PurchaseManagerBase {
     purchaseToken: string,
     skuType: SkuType,
     userId: string
-  ): Promise<SubscriptionPurchase> {
+  ): Promise<PlayStoreSubscriptionPurchase> {
     // The original Google Play sample code did not use Google API efficiency
     // guidelines, the updated version here checks our local Firestore record
     // first to determine if we've seen the token before, and if not, it will
@@ -143,7 +145,7 @@ export class PurchaseManager extends PurchaseManagerBase {
   async processDeveloperNotification(
     packageName: string,
     notification: DeveloperNotification
-  ): Promise<SubscriptionPurchase | null> {
+  ): Promise<PlayStoreSubscriptionPurchase | null> {
     // Type-guard for a real-time developer notification.
     const subscriptionNotification = notification.subscriptionNotification;
     if (!subscriptionNotification) {

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/subscriptions.ts
@@ -12,7 +12,7 @@ import { internalValidationError } from '../../../../lib/error';
 import { AppConfig } from '../../../types';
 import { StripeHelper } from '../../stripe';
 import { PlayBilling } from './play-billing';
-import { SubscriptionPurchase } from './subscription-purchase';
+import { PlayStoreSubscriptionPurchase } from './subscription-purchase';
 
 // TODO move this when we add support for Apple IAP subscriptions
 export interface SubscriptionsService<T> {
@@ -23,7 +23,7 @@ export interface SubscriptionsService<T> {
  * Extract an AbbrevPlayPurchase from a SubscriptionPurchase
  */
 export function abbrevPlayPurchaseFromSubscriptionPurchase(
-  purchase: SubscriptionPurchase
+  purchase: PlayStoreSubscriptionPurchase
 ): AbbrevPlayPurchase {
   return {
     auto_renewing: purchase.autoRenewing,

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/user-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/user-manager.ts
@@ -23,7 +23,7 @@ import { AuthLogger } from '../../../types';
 import { PurchaseManager } from './purchase-manager';
 import {
   GOOGLE_PLAY_FORM_OF_PAYMENT,
-  SubscriptionPurchase,
+  PlayStoreSubscriptionPurchase,
 } from './subscription-purchase';
 import { PurchaseQueryError, SkuType } from './types';
 import { UserManager as UserManagerBase } from 'fxa-shared/payments/iap/google-play/user-manager';
@@ -51,8 +51,8 @@ export class UserManager extends UserManagerBase {
     userId: string,
     sku?: string,
     packageName?: string
-  ): Promise<Array<SubscriptionPurchase>> {
-    const purchaseList = new Array<SubscriptionPurchase>();
+  ): Promise<Array<PlayStoreSubscriptionPurchase>> {
+    const purchaseList = new Array<PlayStoreSubscriptionPurchase>();
 
     try {
       // Create query to fetch possibly active subscriptions from Firestore
@@ -76,8 +76,8 @@ export class UserManager extends UserManagerBase {
 
       // Loop through these subscriptions and filter those that are indeed active
       for (const purchaseRecordSnapshot of queryResult.docs) {
-        let purchase: SubscriptionPurchase =
-          SubscriptionPurchase.fromFirestoreObject(
+        let purchase: PlayStoreSubscriptionPurchase =
+          PlayStoreSubscriptionPurchase.fromFirestoreObject(
             purchaseRecordSnapshot.data()
           );
 

--- a/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
@@ -2,11 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Firestore } from '@google-cloud/firestore';
+import {
+  MozillaSubscriptionTypes,
+  SubscriptionType,
+} from 'fxa-shared/subscriptions/types';
 import { Container } from 'typedi';
 import { TypedCollectionReference } from 'typesafe-node-firestore';
 
 import { AppConfig, AuthFirestore, AuthLogger } from '../../types';
+import { AppStoreSubscriptionPurchase } from './apple-app-store/subscription-purchase';
+import { PlayStoreSubscriptionPurchase } from './google-play/subscription-purchase';
 import { IapConfig } from './types';
+
+// This function is only used in the Stripe Helper currently, but it
+// may be useful in other places in the future, so I put it here for now.
+export function getIapPurchaseType(
+  purchase: PlayStoreSubscriptionPurchase | AppStoreSubscriptionPurchase
+): Omit<SubscriptionType, typeof MozillaSubscriptionTypes.WEB> {
+  if (purchase.hasOwnProperty('purchaseToken')) {
+    return MozillaSubscriptionTypes.IAP_GOOGLE;
+  }
+  if (purchase.hasOwnProperty('originalTransactionId')) {
+    return MozillaSubscriptionTypes.IAP_APPLE;
+  }
+  throw new Error('Purchase is not recognized as either Google or Apple IAP.');
+}
 
 export class IAPConfig {
   private firestore: Firestore;

--- a/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
@@ -80,7 +80,7 @@ export class GoogleIapHandler {
           );
       }
     }
-    await this.capabilityService.playUpdate(uid, purchase);
+    await this.capabilityService.iapUpdate(uid, purchase);
     return { tokenValid: true };
   }
 }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
@@ -74,7 +74,7 @@ export class PlayPubsubHandler {
       return {};
     }
 
-    await this.capabilityService.playUpdate(uid, updatedPurchase);
+    await this.capabilityService.iapUpdate(uid, updatedPurchase);
 
     return {};
   }

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
@@ -1,10 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Logger } from 'mozlog';
-import Stripe from 'stripe';
-import { Container } from 'typedi';
-
+import { STRIPE_PRICE_METADATA } from 'fxa-shared/payments/stripe';
 import {
   CapabilityConfig,
   StyleConfig,
@@ -16,9 +13,13 @@ import {
   UrlConfig,
   UrlConfigKeys,
 } from 'fxa-shared/subscriptions/configuration/base';
-import { PaymentConfigManager } from '../../lib/payments/configuration/manager';
 import { PlanConfig } from 'fxa-shared/subscriptions/configuration/plan';
 import { ProductConfig } from 'fxa-shared/subscriptions/configuration/product';
+import { Logger } from 'mozlog';
+import Stripe from 'stripe';
+import { Container } from 'typedi';
+
+import { PaymentConfigManager } from '../../lib/payments/configuration/manager';
 import { StripeHelper } from '../../lib/payments/stripe';
 import { commaSeparatedListToArray } from '../../lib/payments/utils';
 
@@ -320,15 +321,20 @@ export class StripeProductsAndPlansConverter {
 
     // Extended by PlanConfig
     planConfig.stripePriceId = plan.id;
-    const { productOrder, googlePlaySku, appleProductId } = plan.metadata;
+    const { productOrder } = plan.metadata;
+    const playSkuIds = plan.metadata[STRIPE_PRICE_METADATA.PLAY_SKU_IDS];
+    const appStoreProductIds =
+      plan.metadata[STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS];
     if (productOrder) {
       planConfig.productOrder = parseInt(productOrder);
     }
-    if (googlePlaySku) {
-      planConfig.googlePlaySku = commaSeparatedListToArray(googlePlaySku);
+    if (playSkuIds) {
+      planConfig[STRIPE_PRICE_METADATA.PLAY_SKU_IDS] =
+        commaSeparatedListToArray(playSkuIds);
     }
-    if (appleProductId) {
-      planConfig.appleProductId = commaSeparatedListToArray(appleProductId);
+    if (appStoreProductIds) {
+      planConfig[STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS] =
+        commaSeparatedListToArray(appStoreProductIds);
     }
     return planConfig;
   }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/apple-app-store/api_response_subscription_status.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/apple-app-store/api_response_subscription_status.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "subscriptionGroupIdentifier": "22222222",
+    "lastTransactions": [
+      {
+        "originalTransactionId": "1000000000000000",
+        "status": "Active",
+        "signedRenewalInfo": {},
+        "signedTransactionInfo": {}
+      }
+    ]
+  },
+  "environment": "Production",
+  "appAppleId": "1234567890",
+  "bundleId": "org.mozilla.ios.SkydivingWithFoxkeh"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/apple-app-store/decoded_renewal_info.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/apple-app-store/decoded_renewal_info.json
@@ -1,0 +1,10 @@
+{
+  "expirationIntent": 1,
+  "originalTransactionId": "1000000000000000",
+  "autoRenewProductId": "skydiving.with.foxkeh",
+  "productId": "skydiving.with.foxkeh",
+  "autoRenewStatus": 1,
+  "isInBillingRetryPeriod": false,
+  "signedDate": 1649792142801,
+  "environment": "Production"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/apple-app-store/decoded_transaction_info.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/apple-app-store/decoded_transaction_info.json
@@ -1,0 +1,16 @@
+{
+  "transactionId": "2000000000000000",
+  "originalTransactionId": "1000000000000000",
+  "webOrderLineItemId": "2000000000000000",
+  "bundleId": "org.mozilla.ios.Product",
+  "productId": "skydiving.with.foxkeh",
+  "subscriptionGroupIdentifier": "22222222",
+  "purchaseDate": 1649329745000,
+  "originalPurchaseDate": 1627306493000,
+  "expiresDate": 1649330045000,
+  "quantity": 1,
+  "type": "Auto-Renewable Subscription",
+  "inAppOwnershipType": "PURCHASED",
+  "signedDate": 1649792142801,
+  "environment": "Production"
+}

--- a/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/app-store-helper.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/app-store-helper.js
@@ -31,7 +31,7 @@ const { AppStoreHelper } = proxyquire(
 );
 
 const mockBundleIdWithUnderscores = 'org_mozilla_ios_FirefoxVPN';
-const mockBundleId = mockBundleIdWithUnderscores.replace('_', '.');
+const mockBundleId = mockBundleIdWithUnderscores.replace(/_/g, '.');
 const mockConfig = {
   subscriptions: {
     appStore: {

--- a/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/purchase-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/purchase-manager.js
@@ -17,7 +17,7 @@ const {
   PurchaseUpdateError,
 } = require('../../../../../lib/payments/iap/apple-app-store/types');
 const {
-  SubscriptionPurchase,
+  AppStoreSubscriptionPurchase,
 } = require('../../../../../lib/payments/iap/apple-app-store/subscription-purchase');
 
 const sandbox = sinon.createSandbox();
@@ -51,7 +51,7 @@ const { PurchaseManager } = proxyquire(
       'fxa-shared/payments/iap/apple-app-store/purchase-manager',
       {
         './subscription-purchase': {
-          SubscriptionPurchase: mockSubscriptionPurchase,
+          AppStoreSubscriptionPurchase: mockSubscriptionPurchase,
           mergePurchaseWithFirestorePurchaseRecord: mockMergePurchase,
         },
         'app-store-server-api': {
@@ -429,7 +429,7 @@ describe('PurchaseManager', () => {
     });
 
     it('returns the current subscriptions', async () => {
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
+      const subscriptionPurchase = AppStoreSubscriptionPurchase.fromApiResponse(
         mockApiResult,
         mockStatus,
         {},
@@ -465,7 +465,7 @@ describe('PurchaseManager', () => {
         ],
       };
       mockStatus = SubscriptionStatus.Expired;
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
+      const subscriptionPurchase = AppStoreSubscriptionPurchase.fromApiResponse(
         mockApiExpiredResult,
         mockStatus,
         {},
@@ -503,7 +503,7 @@ describe('PurchaseManager', () => {
         ],
       };
       mockStatus = SubscriptionStatus.Expired;
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
+      const subscriptionPurchase = AppStoreSubscriptionPurchase.fromApiResponse(
         mockApiExpiredResult,
         mockStatus,
         {},

--- a/packages/fxa-auth-server/test/local/payments/iap/google-play/purchase-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/google-play/purchase-manager.js
@@ -24,13 +24,13 @@ const { PurchaseManager } = proxyquire(
   '../../../../../lib/payments/iap/google-play/purchase-manager',
   {
     './subscription-purchase': {
-      SubscriptionPurchase: mockSubscriptionPurchase,
+      PlayStoreSubscriptionPurchase: mockSubscriptionPurchase,
     },
     'fxa-shared/payments/iap/google-play/purchase-manager': proxyquire(
       'fxa-shared/payments/iap/google-play/purchase-manager',
       {
         './subscription-purchase': {
-          SubscriptionPurchase: mockSubscriptionPurchase,
+          PlayStoreSubscriptionPurchase: mockSubscriptionPurchase,
           mergePurchaseWithFirestorePurchaseRecord: mockMergePurchase,
         },
       }

--- a/packages/fxa-auth-server/test/local/payments/iap/google-play/subscription-purchase.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/google-play/subscription-purchase.js
@@ -7,7 +7,7 @@
 const { assert } = require('chai');
 
 const {
-  SubscriptionPurchase,
+  PlayStoreSubscriptionPurchase,
   GOOGLE_PLAY_FORM_OF_PAYMENT,
 } = require('../../../../../lib/payments/iap/google-play/subscription-purchase');
 const {
@@ -32,7 +32,7 @@ describe('SubscriptionPurchase', () => {
         orderId: 'GPA.3313-5503-3858-32549',
       };
 
-      const subscription = SubscriptionPurchase.fromApiResponse(
+      const subscription = PlayStoreSubscriptionPurchase.fromApiResponse(
         apiResponse,
         'testPackage',
         'testToken',
@@ -71,7 +71,7 @@ describe('SubscriptionPurchase', () => {
         paymentState: 2,
         orderId: 'GPA.3313-5503-3858-32549',
       };
-      const subscription = SubscriptionPurchase.fromApiResponse(
+      const subscription = PlayStoreSubscriptionPurchase.fromApiResponse(
         apiResponse,
         'testPackage',
         'testToken',
@@ -94,7 +94,7 @@ describe('SubscriptionPurchase', () => {
         paymentState: 0, // payment haven't been made
         orderId: 'GPA.3313-5503-3858-32549..1',
       };
-      const subscription = SubscriptionPurchase.fromApiResponse(
+      const subscription = PlayStoreSubscriptionPurchase.fromApiResponse(
         apiResponse,
         'testPackage',
         'testToken',
@@ -118,7 +118,7 @@ describe('SubscriptionPurchase', () => {
         purchaseType: 0,
         orderId: 'GPA.3313-5503-3858-32549',
       };
-      const subscription = SubscriptionPurchase.fromApiResponse(
+      const subscription = PlayStoreSubscriptionPurchase.fromApiResponse(
         apiResponse,
         'testPackage',
         'testToken',
@@ -145,7 +145,7 @@ describe('SubscriptionPurchase', () => {
     let subscription;
 
     beforeEach(() => {
-      subscription = SubscriptionPurchase.fromApiResponse(
+      subscription = PlayStoreSubscriptionPurchase.fromApiResponse(
         apiResponse,
         'testPackage',
         'testToken',
@@ -163,7 +163,8 @@ describe('SubscriptionPurchase', () => {
     it('converts from firestore', () => {
       const firestoreObj = subscription.toFirestoreObject();
       firestoreObj.userId = 'testUser';
-      const result = SubscriptionPurchase.fromFirestoreObject(firestoreObj);
+      const result =
+        PlayStoreSubscriptionPurchase.fromFirestoreObject(firestoreObj);
       // Internal keys are not defined on the subscription purchase.
       assert.isUndefined(result.skuType);
       assert.strictEqual(result.userId, 'testUser');
@@ -176,7 +177,7 @@ describe('SubscriptionPurchase', () => {
       const testApiResponse = {
         purchaseType: 0,
       };
-      const testSubscription = SubscriptionPurchase.fromApiResponse(
+      const testSubscription = PlayStoreSubscriptionPurchase.fromApiResponse(
         testApiResponse,
         'testPackage',
         'testToken',

--- a/packages/fxa-auth-server/test/local/payments/iap/google-play/user-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/google-play/user-manager.js
@@ -15,7 +15,7 @@ const {
 } = require('../../../../../lib/payments/iap/google-play/user-manager');
 const { AuthLogger } = require('../../../../../lib/types');
 const {
-  SubscriptionPurchase,
+  PlayStoreSubscriptionPurchase,
 } = require('../../../../../lib/payments/iap/google-play/subscription-purchase');
 const {
   PurchaseQueryError,
@@ -62,13 +62,14 @@ describe('UserManager', () => {
 
   describe('queryCurrentSubscriptions', () => {
     it('returns the current subscriptions', async () => {
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
-        VALID_SUB_API_RESPONSE,
-        'testPackage',
-        'testToken',
-        'testSku',
-        Date.now()
-      );
+      const subscriptionPurchase =
+        PlayStoreSubscriptionPurchase.fromApiResponse(
+          VALID_SUB_API_RESPONSE,
+          'testPackage',
+          'testToken',
+          'testSku',
+          Date.now()
+        );
       const subscriptionSnapshot = {
         data: sinon.fake.returns(subscriptionPurchase.toFirestoreObject()),
       };
@@ -79,13 +80,14 @@ describe('UserManager', () => {
     });
 
     it('queries expired subscription purchases', async () => {
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
-        VALID_SUB_API_RESPONSE,
-        'testPackage',
-        'testToken',
-        'testSku',
-        Date.now()
-      );
+      const subscriptionPurchase =
+        PlayStoreSubscriptionPurchase.fromApiResponse(
+          VALID_SUB_API_RESPONSE,
+          'testPackage',
+          'testToken',
+          'testSku',
+          Date.now()
+        );
       subscriptionPurchase.expiryTimeMillis = Date.now() - 10000;
       subscriptionPurchase.autoRenewing = false;
       const subscriptionSnapshot = {
@@ -100,13 +102,14 @@ describe('UserManager', () => {
     });
 
     it('throws library error on failure', async () => {
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
-        VALID_SUB_API_RESPONSE,
-        'testPackage',
-        'testToken',
-        'testSku',
-        Date.now()
-      );
+      const subscriptionPurchase =
+        PlayStoreSubscriptionPurchase.fromApiResponse(
+          VALID_SUB_API_RESPONSE,
+          'testPackage',
+          'testToken',
+          'testSku',
+          Date.now()
+        );
       subscriptionPurchase.expiryTimeMillis = Date.now() - 10000;
       subscriptionPurchase.autoRenewing = false;
       const subscriptionSnapshot = {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
@@ -59,7 +59,7 @@ describe('GoogleIapHandler', () => {
     });
     db.account = sinon.fake.resolves({ primaryEmail: { email: TEST_EMAIL } });
     mockCapabilityService = {};
-    mockCapabilityService.playUpdate = sinon.fake.resolves({});
+    mockCapabilityService.iapUpdate = sinon.fake.resolves({});
     Container.set(CapabilityService, mockCapabilityService);
     googleIapHandler = new GoogleIapHandler(db);
   });
@@ -95,7 +95,7 @@ describe('GoogleIapHandler', () => {
       const result = await googleIapHandler.registerToken(request);
       assert.calledOnce(playBilling.purchaseManager.registerToUserAccount);
       assert.calledOnce(iapConfig.packageName);
-      assert.calledOnce(mockCapabilityService.playUpdate);
+      assert.calledOnce(mockCapabilityService.iapUpdate);
       assert.deepEqual(result, { tokenValid: true });
     });
 
@@ -110,7 +110,7 @@ describe('GoogleIapHandler', () => {
       const result = await googleIapHandler.registerToken(request);
       assert.calledOnce(playBilling.purchaseManager.registerToUserAccount);
       assert.calledOnce(iapConfig.packageName);
-      assert.calledOnce(mockCapabilityService.playUpdate);
+      assert.calledOnce(mockCapabilityService.iapUpdate);
       assert.deepEqual(result, { tokenValid: true });
     });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
@@ -56,7 +56,7 @@ describe('PlayPubsubHandler', () => {
       purchaseToken: 'test',
     };
     db.account = sinon.fake.resolves({ primaryEmail: { email: TEST_EMAIL } });
-    mockCapabilityService.playUpdate = sinon.fake.resolves({});
+    mockCapabilityService.iapUpdate = sinon.fake.resolves({});
 
     Container.set(AuthLogger, log);
     Container.set(PlayBilling, mockPlayBilling);
@@ -89,7 +89,7 @@ describe('PlayPubsubHandler', () => {
       assert.calledOnce(
         mockPlayBilling.purchaseManager.processDeveloperNotification
       );
-      assert.calledOnce(mockCapabilityService.playUpdate);
+      assert.calledOnce(mockCapabilityService.iapUpdate);
     });
 
     it('test notification', async () => {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -37,6 +37,8 @@
   "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-shared#readme",
   "devDependencies": {
     "@nestjs/testing": "^8.4.4",
+    "@type-cacheable/core": "^10.1.0",
+    "@type-cacheable/ioredis-adapter": "^10.0.4",
     "@types/chai": "^4.2.18",
     "@types/chance": "^1.1.2",
     "@types/generic-pool": "^3.1.9",

--- a/packages/fxa-shared/payments/iap/apple-app-store/app-store-helper.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/app-store-helper.ts
@@ -41,7 +41,7 @@ export class AppStoreHelper {
     )) {
       // Cannot use an actual bundleId (e.g. 'org.mozilla.ios.FirefoxVPN') as the key
       // due to https://github.com/mozilla/node-convict/issues/250
-      const bundleId = bundleIdWithUnderscores.replace('_', '.');
+      const bundleId = bundleIdWithUnderscores.replace(/_/g, '.');
       this.credentialsByBundleId[bundleId] = credentials;
       this.clientByBundleId(bundleId);
     }

--- a/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
@@ -9,7 +9,7 @@ import { AppStoreHelper } from './app-store-helper';
 import {
   APPLE_APP_STORE_FORM_OF_PAYMENT,
   mergePurchaseWithFirestorePurchaseRecord,
-  SubscriptionPurchase,
+  AppStoreSubscriptionPurchase,
 } from './subscription-purchase';
 import { PurchaseQueryError, PurchaseUpdateError } from './types';
 
@@ -65,7 +65,7 @@ export class PurchaseManager {
 
       // Generate SubscriptionPurchase object from API response
       const now = Date.now();
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
+      const subscriptionPurchase = AppStoreSubscriptionPurchase.fromApiResponse(
         apiResponse,
         subscriptionStatus,
         transactionInfo,
@@ -110,7 +110,9 @@ export class PurchaseManager {
       .doc(originalTransactionId)
       .get();
     if (purchaseRecordDoc.exists) {
-      return SubscriptionPurchase.fromFirestoreObject(purchaseRecordDoc.data());
+      return AppStoreSubscriptionPurchase.fromFirestoreObject(
+        purchaseRecordDoc.data()
+      );
     }
     return;
   }
@@ -123,8 +125,8 @@ export class PurchaseManager {
     userId: string,
     bundleId?: string,
     productId?: string
-  ): Promise<Array<SubscriptionPurchase>> {
-    const purchaseList = new Array<SubscriptionPurchase>();
+  ): Promise<Array<AppStoreSubscriptionPurchase>> {
+    const purchaseList = new Array<AppStoreSubscriptionPurchase>();
 
     try {
       // Create query to fetch possibly active subscriptions from Firestore
@@ -146,8 +148,8 @@ export class PurchaseManager {
 
       // Loop through these subscriptions and filter those that are indeed active
       for (const purchaseRecordSnapshot of queryResult.docs) {
-        let purchase: SubscriptionPurchase =
-          SubscriptionPurchase.fromFirestoreObject(
+        let purchase: AppStoreSubscriptionPurchase =
+          AppStoreSubscriptionPurchase.fromFirestoreObject(
             purchaseRecordSnapshot.data()
           );
 

--- a/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
@@ -42,7 +42,9 @@ export const SUBSCRIPTION_PURCHASE_REQUIRED_PROPERTIES = [
 /* Convert a purchase object into a format that will be store in Firestore
  * Adds some shopkeeping metadata to the purchase object.
  */
-function purchaseToFirestoreObject(purchase: SubscriptionPurchase): any {
+function purchaseToFirestoreObject(
+  purchase: AppStoreSubscriptionPurchase
+): any {
   const fObj: any = {};
   Object.assign(fObj, purchase);
   fObj.formOfPayment = APPLE_APP_STORE_FORM_OF_PAYMENT;
@@ -76,7 +78,7 @@ export function mergePurchaseWithFirestorePurchaseRecord(
 /* Library's internal implementation of a SubscriptionPurchase object
  * It's used inside of the library, not to be exposed to library's consumers.
  */
-export class SubscriptionPurchase {
+export class AppStoreSubscriptionPurchase {
   // Response from App Store API server Subscription Status endpoint
   // https://developer.apple.com/documentation/appstoreserverapi/get_all_subscription_statuses
   // IMPORTANT: If adding a new required property, also add it to SUBSCRIPTION_PURCHASE_REQUIRED_PROPERTIES
@@ -87,7 +89,7 @@ export class SubscriptionPurchase {
   private inAppOwnershipType!: OwnershipType;
   private originalPurchaseDate!: number;
   originalTransactionId!: string; // unique identifier for the subscription; analogous to a Stripe subscription id
-  private productId!: string; // unique identifier for the plan; analogous to the Stripe plan id
+  productId!: string; // unique identifier for the plan; analogous to the Stripe plan id
   private status!: SubscriptionStatus;
   private type!: TransactionType;
   private expirationIntent?: number;
@@ -112,8 +114,8 @@ export class SubscriptionPurchase {
     renewalInfo: JWSRenewalInfoDecodedPayload,
     originalTransactionId: string,
     verifiedAt: number
-  ): SubscriptionPurchase {
-    const purchase = new SubscriptionPurchase();
+  ): AppStoreSubscriptionPurchase {
+    const purchase = new AppStoreSubscriptionPurchase();
     purchase.autoRenewStatus = renewalInfo.autoRenewStatus;
     purchase.autoRenewProductId = renewalInfo.autoRenewProductId;
     purchase.bundleId = apiResponse.bundleId;
@@ -166,7 +168,7 @@ export class SubscriptionPurchase {
    * Firestore; see FIRESTORE_OBJECT_INTERNAL_KEYS.
    */
   static fromFirestoreObject(firestoreObject: any) {
-    const purchase = new SubscriptionPurchase();
+    const purchase = new AppStoreSubscriptionPurchase();
     purchase.mergeWithFirestorePurchaseRecord(firestoreObject);
     return purchase;
   }

--- a/packages/fxa-shared/payments/iap/google-play/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/google-play/purchase-manager.ts
@@ -20,7 +20,7 @@ import { CollectionReference } from '@google-cloud/firestore';
 import { androidpublisher_v3 } from 'googleapis';
 import {
   mergePurchaseWithFirestorePurchaseRecord,
-  SubscriptionPurchase,
+  PlayStoreSubscriptionPurchase,
 } from './subscription-purchase';
 import { NotificationType, PurchaseQueryError } from './types';
 
@@ -54,7 +54,7 @@ export class PurchaseManager {
     sku: string,
     purchaseToken: string,
     triggerNotificationType?: NotificationType
-  ): Promise<SubscriptionPurchase> {
+  ): Promise<PlayStoreSubscriptionPurchase> {
     // STEP 1. Query Play Developer API to verify the purchase token
     const apiResponse = await new Promise((resolve, reject) => {
       this.playDeveloperApiClient.purchases.subscriptions.get(
@@ -81,13 +81,14 @@ export class PurchaseManager {
 
       // Generate SubscriptionPurchase object from Firestore response
       const now = Date.now();
-      const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
-        apiResponse,
-        packageName,
-        purchaseToken,
-        sku,
-        now
-      );
+      const subscriptionPurchase =
+        PlayStoreSubscriptionPurchase.fromApiResponse(
+          apiResponse,
+          packageName,
+          purchaseToken,
+          sku,
+          now
+        );
 
       // Store notificationType to database if queryPurchase was triggered by a realtime developer notification
       if (triggerNotificationType !== undefined) {
@@ -195,13 +196,14 @@ export class PurchaseManager {
       if (apiResponse) {
         // STEP 2b. Parse the response from Google Play Developer API and store the purchase detail
         const now = Date.now();
-        const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(
-          apiResponse,
-          packageName,
-          purchaseToken,
-          sku,
-          now
-        );
+        const subscriptionPurchase =
+          PlayStoreSubscriptionPurchase.fromApiResponse(
+            apiResponse,
+            packageName,
+            purchaseToken,
+            sku,
+            now
+          );
         subscriptionPurchase.replacedByAnotherPurchase = true; // Mark the purchase as already being replaced by other purchase.
         subscriptionPurchase.userId = REPLACED_PURCHASE_USERID_PLACEHOLDER;
         const firestoreObject = subscriptionPurchase.toFirestoreObject();

--- a/packages/fxa-shared/payments/iap/google-play/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/google-play/subscription-purchase.ts
@@ -61,7 +61,7 @@ export function mergePurchaseWithFirestorePurchaseRecord(
 /* Library's internal implementation of an SubscriptionPurchase object
  * It's used inside of the library, not to be exposed to library's consumers.
  */
-export class SubscriptionPurchase implements Purchase {
+export class PlayStoreSubscriptionPurchase implements Purchase {
   // Raw response from server
   // https://developers.google.com/android-publisher/api-ref/purchases/subscriptions/get
   startTimeMillis!: number;
@@ -95,11 +95,11 @@ export class SubscriptionPurchase implements Purchase {
     purchaseToken: string,
     sku: string,
     verifiedAt: number
-  ): SubscriptionPurchase {
+  ): PlayStoreSubscriptionPurchase {
     // Intentionally hide developerPayload as the field was deprecated
     apiResponse.developerPayload = null;
 
-    const purchase = new SubscriptionPurchase();
+    const purchase = new PlayStoreSubscriptionPurchase();
     Object.assign(purchase, apiResponse);
     purchase.purchaseToken = purchaseToken;
     purchase.sku = sku;
@@ -126,8 +126,10 @@ export class SubscriptionPurchase implements Purchase {
     return purchase;
   }
 
-  static fromFirestoreObject(firestoreObject: any): SubscriptionPurchase {
-    const purchase = new SubscriptionPurchase();
+  static fromFirestoreObject(
+    firestoreObject: any
+  ): PlayStoreSubscriptionPurchase {
+    const purchase = new PlayStoreSubscriptionPurchase();
     purchase.mergeWithFirestorePurchaseRecord(firestoreObject);
     return purchase;
   }

--- a/packages/fxa-shared/payments/iap/google-play/user-manager.ts
+++ b/packages/fxa-shared/payments/iap/google-play/user-manager.ts
@@ -7,7 +7,7 @@ import { ILogger } from 'fxa-shared/log';
 import { PurchaseManager } from './purchase-manager';
 import {
   GOOGLE_PLAY_FORM_OF_PAYMENT,
-  SubscriptionPurchase,
+  PlayStoreSubscriptionPurchase,
 } from './subscription-purchase';
 import { SkuType } from './types/purchases';
 
@@ -22,8 +22,8 @@ export class UserManager {
     userId: string,
     sku?: string,
     packageName?: string
-  ): Promise<Array<SubscriptionPurchase>> {
-    const purchaseList = new Array<SubscriptionPurchase>();
+  ): Promise<Array<PlayStoreSubscriptionPurchase>> {
+    const purchaseList = new Array<PlayStoreSubscriptionPurchase>();
 
     // Create query to fetch possibly active subscriptions from Firestore
     // Create query to fetch possibly active subscriptions from Firestore
@@ -46,8 +46,10 @@ export class UserManager {
 
     // Loop through these subscriptions and filter those that are indeed active
     for (const purchaseRecordSnapshot of queryResult.docs) {
-      let purchase: SubscriptionPurchase =
-        SubscriptionPurchase.fromFirestoreObject(purchaseRecordSnapshot.data());
+      let purchase: PlayStoreSubscriptionPurchase =
+        PlayStoreSubscriptionPurchase.fromFirestoreObject(
+          purchaseRecordSnapshot.data()
+        );
 
       if (
         !purchase.isEntitlementActive() &&

--- a/packages/fxa-shared/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/subscriptions/configuration/plan.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import joi from 'joi';
 
+import { STRIPE_PRICE_METADATA } from '../../payments/stripe';
 import {
   BaseConfig,
   baseConfigSchema,
@@ -19,8 +20,14 @@ export const planConfigJoiKeys = {
   productConfigId: joi.string().allow(null).allow(''),
   stripePriceId: joi.string().optional(),
   productOrder: joi.number().optional(),
-  googlePlaySku: joi.array().items(joi.string()).optional(),
-  appleProductId: joi.array().items(joi.string()).optional(),
+  [STRIPE_PRICE_METADATA.PLAY_SKU_IDS]: joi
+    .array()
+    .items(joi.string())
+    .optional(),
+  [STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS]: joi
+    .array()
+    .items(joi.string())
+    .optional(),
 };
 
 export const planConfigSchema = baseConfigSchema
@@ -55,8 +62,8 @@ export class PlanConfig implements BaseConfig {
   stripePriceId?: string;
   productSet?: string;
   productOrder?: number;
-  googlePlaySku?: string[];
-  appleProductId?: string[];
+  [STRIPE_PRICE_METADATA.PLAY_SKU_IDS]?: string[];
+  [STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS]?: string[];
 
   static async validate(
     planConfig: PlanConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23323,6 +23323,8 @@ fsevents@~2.1.1:
     "@sentry/integrations": ^6.19.1
     "@sentry/node": ^6.19.1
     "@sentry/tracing": ^6.19.1
+    "@type-cacheable/core": ^10.1.0
+    "@type-cacheable/ioredis-adapter": ^10.0.4
     "@types/chai": ^4.2.18
     "@types/chance": ^1.1.2
     "@types/generic-pool": ^3.1.9


### PR DESCRIPTION
Because:

* We want to include any Apple IAP subscriptions along with other subscriptions when requested by RPs.
* We want to broadcast any Apple IAP subscription state changes to RPs.

This commit:

* Modifies existing Stripe helper methods, priceToPlaySkus --> priceToIapIdentifiers and purchasesToPriceIds --> iapPurchasesToPriceIds, to determine which App Store productIds map to which Stripe priceIds.
* Creates new capability service method fetchSubcribedPricesFromAppStore and modifies playStoreUpdate --> iapUpdate.
* Adds a feature flag for the Apple App Store API and conditionally initializes the AppleIAP module based on the flag in key_server.js.
* Renames SubscriptionPurchase classes for Google IAP and Apple IAP to PlayStoreSubscriptionPurchase and AppStoreSubscriptionPurchase, respectively.
* [BONUS] Fixes a bug in the AppStoreHelper constructor method where only the first underscore was being replaced with a period in the config bundleId transform.

Closes #10386

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
