### PR TITLE
fix(auth): fix collection prefix for iap

### DIFF
--- a/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
@@ -21,7 +21,7 @@ export class IAPConfig {
     this.prefix = `${authFirestore.prefix}iap-`;
     this.firestore = Container.get(AuthFirestore);
     this.iapConfigDbRef = this.firestore.collection(
-      `${this.prefix}iap-config`
+      `${this.prefix}config`
     ) as TypedCollectionReference<IapConfig>;
   }
 


### PR DESCRIPTION
Because:

* A refactor accidentally changed the collection name.

This commit:

* Restores the collection name without the duplicate prefix.

Closes #12727

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
