### PR TITLE
fix(fxa-settings) remove static list of feature from account deletion…

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
@@ -6,12 +6,12 @@ delete-account-header =
 delete-account-step-1-2 = Step 1 of 2
 delete-account-step-2-2 = Step 2 of 2
 
-delete-account-confirm-title-2 = You’ve connected your { -product-firefox-account } to { -brand-mozilla } products that keep you secure and productive on the web:
+delete-account-confirm-title-2 = You’ve connected your { -product-firefox-account } to { -brand-mozilla } products that keep you secure and productive on the web.
 
 delete-account-acknowledge = Please acknowledge that by deleting your account:
 
-delete-account-chk-box-1-v2 =
- .label = Any paid subscriptions you have will be canceled (Except { product-pocket })
+delete-account-chk-box-1-v3 =
+ .label = Any paid subscriptions you have will be canceled
 delete-account-chk-box-2 =
  .label = You may lose saved information and features within { -brand-mozilla } products
 delete-account-chk-box-3 =

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -9,7 +9,7 @@ import { useAccount, useAlertBar } from '../../models';
 import InputPassword from '../InputPassword';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
-import { HomePath, MonitorLink, ROOTPATH, VPNLink } from '../../constants';
+import { HomePath, ROOTPATH } from '../../constants';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { Checkbox } from '../Checkbox';
 import { useLocalization } from '@fluent/react';
@@ -21,7 +21,7 @@ type FormData = {
 };
 
 const checkboxLabels = [
-  'delete-account-chk-box-1-v2',
+  'delete-account-chk-box-1-v3',
   'delete-account-chk-box-2',
   'delete-account-chk-box-3',
   'delete-account-chk-box-4',
@@ -115,25 +115,9 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
             <Localized id="delete-account-confirm-title-2">
               <p className="mb-4">
                 You've connected your Firefox account to Mozilla products that
-                keep you secure and productive on the web:
+                keep you secure and productive on the web.
               </p>
             </Localized>
-            <div className="p-2">
-              <ul className="list-inside mb-4">
-                <li className="list-disc">
-                  <a className="link-blue" href={VPNLink}>
-                    <Localized id="product-mozilla-vpn">Mozilla VPN</Localized>
-                  </a>
-                </li>
-                <li className="list-disc">
-                  <a className="link-blue" href={MonitorLink}>
-                    <Localized id="product-firefox-monitor">
-                      Firefox Monitor
-                    </Localized>
-                  </a>
-                </li>
-              </ul>
-            </div>
             <Localized id="delete-account-acknowledge">
               <p className="mb-4">
                 Please acknowledge that by deleting your account:

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -5,5 +5,3 @@
 export const ROOTPATH = '/';
 export const HomePath = '/settings';
 export const DeleteAccountPath = '/settings/delete_account';
-export const VPNLink = 'https://vpn.mozilla.org/';
-export const MonitorLink = 'https://monitor.firefox.com/';


### PR DESCRIPTION
… warning

## Because

- [This ticket](https://mozilla-hub.atlassian.net/browse/FXA-4419) asks that we remove the static list of features shown on account deletion warning screen. The motivation is that, since the list is static, we should remove it so that we no longer have to maintain it.

## This pull request

- Deletes the static list, and changes the punctuation at the end of the preceding sentence from a `:` to `.`

## Issue that this pull request solves

Closes: #11578 #12515

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

Before:
![Screen Shot 2022-05-02 at 10 11 11 AM](https://user-images.githubusercontent.com/11150372/166293096-f001dee3-3271-41f0-a7d9-11d23e4117f7.png)

After:
![Screen Shot 2022-05-05 at 10 50 32 AM](https://user-images.githubusercontent.com/11150372/166983035-eafa3322-0a41-4576-bfd5-e4209096afbf.png)


## Testing
To see the changes, start up `fxa` and navigate to `fxa-settings` in local, at `localhost:3030`. Create and log into an account. On the default first page you'll see, if you can see the menu on the left you should see that you're on the `Profile` tab. If you can't see the menu on the left, you should still see that the block at the top of your page is labelled `Profile`. Scroll to the bottom of the page and you should see a red button with the CTA `Delete account`.  Click this button, and you will see the screen that was changed in this PR. If you're on `main`, you should see a vertical list of blue links for `Mozilla VPN` and `Firefox Monitor`. If you are on this branch, the list should be gone. 