### PR TITLE
fix(mjml): Use `minifyOptions` instead of `minify` for mjml templates

### DIFF
--- a/packages/fxa-auth-server/lib/senders/renderer/bindings-node.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/bindings-node.ts
@@ -36,7 +36,11 @@ export class NodeRendererBindings extends RendererBindings {
           // (#10018) Ignore mj-includes since we don't test template styles
           // This is going to cause issues
           ignoreIncludes: typeof global.it === 'function',
-          minify: true,
+          minifyOptions: {
+            collapseWhitespace: true,
+            minifyCSS: true,
+            removeEmptyAttributes: true,
+          },
         },
         translations: {
           basePath: join(__dirname, '../../../public/locales'),


### PR DESCRIPTION
## Because

- Auth-server output gets noisey with mjml warnings

## This pull request

- Updates the render to specify options for mjml

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12737

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

@xlisachan @LZoog You mind taking a look at this when you get a moment? I believe these are the right configs for mjml render but I am not super familiar with it.
