### PR TITLE
fix(auth): always broadcast stripe sub changes

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -388,9 +388,9 @@ export class StripeWebhookHandler extends StripeHandler {
   ) {
     const sub = event.data.object as Stripe.Subscription;
 
-    let uid, email;
+    let uid;
     try {
-      ({ uid, email } = await this.sendSubscriptionUpdatedEmail(event));
+      ({ uid } = await this.sendSubscriptionUpdatedEmail(event));
     } catch (err) {
       // It's unexpected that we don't know about the customer or an error happens.
       if (err.output && typeof err.output.payload === 'object') {
@@ -400,14 +400,8 @@ export class StripeWebhookHandler extends StripeHandler {
       return;
     }
 
-    // if the subscription changed from 'incomplete' to 'active' or 'trialing'
-    if (
-      ['active', 'trialing'].includes(sub.status) &&
-      (event.data?.previous_attributes as any)?.status === 'incomplete'
-    ) {
-      return this.capabilityService.stripeUpdate({ sub, uid });
-    }
-    return;
+    // Always send subscription changes to the capability service.
+    return this.capabilityService.stripeUpdate({ sub, uid });
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -868,14 +868,17 @@ describe('StripeWebhookHandler', () => {
         assert.calledWith(sendSubscriptionUpdatedEmailStub, updatedEvent);
       });
 
-      it('does not emit a notification for any other subscription state change', async () => {
+      it('emits a notification for any subscription state change', async () => {
         const updatedEvent = deepCopy(subscriptionUpdated);
         await StripeWebhookHandlerInstance.handleSubscriptionUpdatedEvent(
           {},
           updatedEvent
         );
+        assert.calledWithExactly(mockCapabilityService.stripeUpdate, {
+          sub: updatedEvent.data.object,
+          uid: UID,
+        });
         assert.calledWith(sendSubscriptionUpdatedEmailStub, updatedEvent);
-        assert.notCalled(mockCapabilityService.stripeUpdate);
       });
 
       it('reports a sentry error with an eventId if sendSubscriptionUpdatedEmail fails', async () => {


### PR DESCRIPTION
Because:

* We want to ensure upgrades and other subscription updates result in
  events sent to relying parties if changes are needed.

This commit:

* Always calls the stripe capability service to communicate subscription
  changes.

Closes #12705

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
