### PR TITLE
feat(payments): replace <a> external link to <LinkExternal> component

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -431,7 +431,7 @@ new-user-card-title = Enter your card information
 new-user-submit = Subscribe Now
 
 manage-pocket-title = Looking for your { -brand-name-pocket } premium subscription?
-manage-pocket-body = To manage it, <a>click here</a>.
+manage-pocket-body-2 = To manage it, <linkExternal>click here</linkExternal>.
 
 payment-method-header = Choose your payment method
 # This message is used to indicate the second step in a multi step process.

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -4,6 +4,7 @@ import { Localized } from '@fluent/react';
 import * as PaymentProvider from '../../lib/PaymentProvider';
 
 import './index.scss';
+import LinkExternal from 'fxa-react/components/LinkExternal';
 
 function getPrivacyLinkText(): string {
   return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> <paypalPrivacyLink>PayPal privacy policy</paypalPrivacyLink>';
@@ -30,13 +31,9 @@ const PaypalPaymentLegalBlurb = () => (
       id="payment-legal-link-paypal-2"
       elems={{
         paypalPrivacyLink: (
-          <a
-            href="https://www.paypal.com/webapps/mpp/ua/privacy-full"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <LinkExternal href="https://www.paypal.com/webapps/mpp/ua/privacy-full">
             PayPal privacy policy
-          </a>
+          </LinkExternal>
         ),
       }}
     >
@@ -55,13 +52,9 @@ const StripePaymentLegalBlurb = () => (
       id="payment-legal-link-stripe-3"
       elems={{
         stripePrivacyLink: (
-          <a
-            href="https://stripe.com/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <LinkExternal href="https://stripe.com/privacy">
             Stripe privacy policy
-          </a>
+          </LinkExternal>
         ),
       }}
     >
@@ -80,22 +73,14 @@ const DefaultPaymentLegalBlurb = () => (
       id="payment-legal-link-stripe-paypal"
       elems={{
         stripePrivacyLink: (
-          <a
-            href="https://stripe.com/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <LinkExternal href="https://stripe.com/privacy">
             Stripe privacy policy
-          </a>
+          </LinkExternal>
         ),
         paypalPrivacyLink: (
-          <a
-            href="https://www.paypal.com/webapps/mpp/ua/privacy-full"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <LinkExternal href="https://www.paypal.com/webapps/mpp/ua/privacy-full">
             PayPal privacy policy
-          </a>
+          </LinkExternal>
         ),
       }}
     >

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -11,6 +11,8 @@ import { Plan } from '../../store/types';
 import { AppContext } from '../../lib/AppContext';
 import { legalDocsRedirectUrl } from '../../lib/formats';
 
+import LinkExternal from 'fxa-react/components/LinkExternal';
+
 export type TermsAndPrivacyProps = {
   plan: Plan;
   showFXALinks?: boolean;
@@ -27,10 +29,14 @@ export const TermsAndPrivacy = ({
   // TODO: if a plan is not supplied, fall back to default details
   // This mainly happens in ProductUpdateForm where we're updating payment
   // details across *all* plans - are there better URLs to pick in that case?
-  const { termsOfServiceURL, termsOfServiceDownloadURL, privacyNoticeURL } =
-    plan
-      ? productDetailsFromPlan(plan, navigatorLanguages)
-      : DEFAULT_PRODUCT_DETAILS;
+  // This logic assumes that values exist on DEFAULT_PRODUCT_DETAILS and are not undefined
+  const {
+    termsOfServiceURL = DEFAULT_PRODUCT_DETAILS.termsOfServiceURL!,
+    termsOfServiceDownloadURL = DEFAULT_PRODUCT_DETAILS.termsOfServiceDownloadURL!,
+    privacyNoticeURL = DEFAULT_PRODUCT_DETAILS.privacyNoticeURL!,
+  } = plan
+    ? productDetailsFromPlan(plan, navigatorLanguages)
+    : DEFAULT_PRODUCT_DETAILS;
 
   const tosUrl = termsOfServiceDownloadURL
     ? legalDocsRedirectUrl(termsOfServiceDownloadURL)
@@ -39,36 +45,21 @@ export const TermsAndPrivacy = ({
   const productLegalBlurb = (
     <p>
       <Localized id="terms">
-        <a
-          href={termsOfServiceURL}
-          target="_blank"
-          data-testid="terms"
-          rel="noopener noreferrer"
-        >
+        <LinkExternal href={termsOfServiceURL} data-testid="terms">
           Terms of Service
-        </a>
+        </LinkExternal>
       </Localized>
       &nbsp;&nbsp;&nbsp;
       <Localized id="privacy">
-        <a
-          href={privacyNoticeURL}
-          target="_blank"
-          data-testid="privacy"
-          rel="noopener noreferrer"
-        >
+        <LinkExternal href={privacyNoticeURL} data-testid="privacy">
           Privacy Notice
-        </a>
+        </LinkExternal>
       </Localized>
       &nbsp;&nbsp;&nbsp;
       <Localized id="terms-download">
-        <a
-          href={tosUrl}
-          target="_blank"
-          data-testid="terms-download"
-          rel="noopener noreferrer"
-        >
+        <LinkExternal href={tosUrl} data-testid="terms-download">
           Download Terms
-        </a>
+        </LinkExternal>
       </Localized>
     </p>
   );
@@ -78,25 +69,21 @@ export const TermsAndPrivacy = ({
       <p className="legal-heading">Firefox Accounts</p>
       <p data-testid="fxa-legal-links">
         <Localized id="terms">
-          <a
+          <LinkExternal
             href={`${contentServerURL}/legal/terms`}
-            target="_blank"
-            rel="noopener noreferrer"
             data-testid="fxa-terms"
           >
             Terms of Service
-          </a>
+          </LinkExternal>
         </Localized>
         &nbsp;&nbsp;&nbsp;
         <Localized id="privacy">
-          <a
+          <LinkExternal
             href={`${contentServerURL}/legal/privacy`}
-            target="_blank"
-            rel="noopener noreferrer"
             data-testid="fxa-privacy"
           >
             Privacy Notice
-          </a>
+          </LinkExternal>
         </Localized>
       </p>
     </>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -40,6 +40,7 @@ import {
   WebSubscription,
 } from 'fxa-shared/subscriptions/types';
 import SubscriptionIapItem from './SubscriptionIapItem/SubscriptionIapItem';
+import LinkExternal from 'fxa-react/components/LinkExternal';
 
 export type SubscriptionsProps = {
   profile: SelectorReturns['profile'];
@@ -397,30 +398,26 @@ export const Subscriptions = ({
                   </Localized>
                 </p>
                 <Localized
-                  id="manage-pocket-body"
+                  id="manage-pocket-body-2"
                   elems={{
-                    a: (
-                      <a
-                        target="_blank"
-                        rel="noopener noreferrer"
+                    linkExternal: (
+                      <LinkExternal
                         href="https://getpocket.com/premium/manage"
                         data-testid="manage-pocket-link"
                       >
                         click here
-                      </a>
+                      </LinkExternal>
                     ),
                   }}
                 >
                   <p>
                     To manage it,{' '}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
+                    <LinkExternal
                       href="https://getpocket.com/premium/manage"
                       data-testid="manage-pocket-link"
                     >
                       click here
-                    </a>
+                    </LinkExternal>
                     .
                   </p>
                 </Localized>


### PR DESCRIPTION
## Because

- We want to use LinkExternal in payments for all external links

## This pull request

- Replaces a tags with rel="noopener noreferrer” with LinkExternal component

## Issue that this pull request solves

Closes: #12468

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

N/A
