### PR TITLE
fix(functional-test): fix broken smoke test for add-ons displaying in…

### DIFF
--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -68,7 +68,7 @@ test.describe('severity-3 #smoke', () => {
     await settings.goto();
     const services = await settings.connectedServices.services();
     const names = services.map((s) => s.name);
-    expect(names).toContainEqual('Add-ons');
+    expect(names?.some((x) => /^Add-ons/.test(x))).toBeTruthy();
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293352


### PR DESCRIPTION

## Because:
- A smoke test was failing on production
- Some extra tooltip text was added that interfered with the test.

## This commit:
- Relaxes the test a bit and just checks that the term 'Add-ons' is present in the connected services section.
