### PR TITLE
Fix group comments and apostrophes

### DIFF
--- a/packages/fxa-auth-server/lib/l10n/auth.ftl
+++ b/packages/fxa-auth-server/lib/l10n/auth.ftl
@@ -23,9 +23,6 @@
 -google-play = Google Play
 
 ## Non-email strings
+
 session-verify-send-push-title = Logging in to { -product-firefox-accounts }?
 session-verify-send-push-body = Click here to verify it’s you
-
-## Email content
-## Emails do not contain buttons, only links. Emails have a rich HTML version and a plaintext
-## version. The strings are usually identical but sometimes they differ slightly.

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
@@ -1,3 +1,8 @@
+
+## Email content
+## Emails do not contain buttons, only links. Emails have a rich HTML version and a plaintext
+## version. The strings are usually identical but sometimes they differ slightly.
+
 fxa-header-firefox-logo = <img data-l10n-name="fxa-logo" alt="{ -brand-firefox } logo">
 fxa-header-sync-devices-image = <img data-l10n-name="sync-devices-image" alt="Sync devices">
 body-devices-image = <img data-l10n-name="devices-image" alt="Devices">

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -2,7 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-## branding
+## Branding
+
 project-brand = Firefox Accounts
 -brand-name-mozilla = Mozilla
 -brand-name-firefox = Firefox
@@ -12,7 +13,7 @@ project-brand = Firefox Accounts
 -brand-name-apple = Apple
 -brand-name-pocket = Pocket
 
-# the following are not terms because they are not used directly in messages,
+# The following are not terms because they are not used directly in messages,
 # but rather looked up in code and passed into the message as variables.
 brand-name-google-play = { -brand-name-google } Play Store
 # App Store here refers to Apple's App Store not the generic app store.
@@ -21,11 +22,13 @@ brand-name-apple-app-store = App Store
 document =
   .title = Firefox Accounts
 
-## general-aria
+## General aria-label
+
 close-aria =
   .aria-label = Close modal
 
-## app error dialog
+## App error dialog
+
 general-error-heading = General application error
 
 basic-error-message = Something went wrong. Please try again later.
@@ -36,9 +39,9 @@ payment-error-retry-button = Try again
 payment-error-manage-subscription-button = Manage my subscription
 
 country-currency-mismatch = The currency of this subscription is not valid for the country associated with your payment.
-currency-currency-mismatch = Sorry. You can't switch between currencies.
+currency-currency-mismatch = Sorry. You can’t switch between currencies.
 
-no-subscription-change = Sorry. You can't change your subscription plan.
+no-subscription-change = Sorry. You can’t change your subscription plan.
 
 # $mobileAppStore (String) - "Google Play Store" or "App Store", localized when the translation is available.
 iap-already-subscribed = You’re already subscribed through the { $mobileAppStore }.
@@ -47,26 +50,29 @@ expired-card-error = It looks like your credit card has expired. Try another car
 insufficient-funds-error = It looks like your card has insufficient funds. Try another card.
 withdrawal-count-limit-exceeded-error = It looks like this transaction will put you over your credit limit. Try another card.
 charge-exceeds-source-limit = It looks like this transaction will put you over your daily credit limit. Try another card or in 24 hours.
-instant-payouts-unsupported = It looks like your debit card isn't setup for instant payments. Try another debit or credit card.
+instant-payouts-unsupported = It looks like your debit card isn’t setup for instant payments. Try another debit or credit card.
 duplicate-transaction = Hmm. Looks like an identical transaction was just sent. Check your payment history.
 coupon-expired = It looks like that promo code has expired.
 card-error = Your transaction could not be processed. Please verify your credit card information and try again.
 
-##  $productName (String) - The name of the subscribed product.
+# $productName (String) - The name of the subscribed product.
 fxa-account-signup-error-2 = A system error caused your { $productName } sign-up to fail. Your payment method has not been charged. Please try again.
-newsletter-signup-error = You're not signed up for product update emails. You can try again in your account settings.
+newsletter-signup-error = You’re not signed up for product update emails. You can try again in your account settings.
 fxa-post-passwordless-sub-error = Subscription confirmed, but the confirmation page failed to load. Please check your email to set up your account.
 
-## settings
+## Settings
+
 settings-home = Account Home
 settings-subscriptions-title = Subscriptions
 
-## legal footer
+## Legal footer
+
 terms = Terms of Service
 privacy = Privacy Notice
 terms-download = Download Terms
 
 ## Subscription titles
+
 subscription-create-title = Set up your subscription
 subscription-success-title = Subscription confirmation
 subscription-processing-title = Confirming subscription…
@@ -74,30 +80,32 @@ subscription-error-title = Error confirming subscription…
 subscription-noplanchange-title = This subscription plan change is not supported
 subscription-iapsubscribed-title = Already subscribed
 
-##  $productName (String) - The name of the subscribed product.
-##  $amount (Number) - The amount billed. It will be formatted as currency.
-#  $intervalCount (Number) - The interval between payments, in days.
+## $productName (String) - The name of the subscribed product.
+## $amount (Number) - The amount billed. It will be formatted as currency.
+
+# $intervalCount (Number) - The interval between payments, in days.
 day-based-plan-details-amount = { $intervalCount ->
   [one] { $productName } billed { $amount } daily
   *[other] { $productName } billed { $amount } every { $intervalCount } days
 }
-#  $intervalCount (Number) - The interval between payments, in weeks.
+# $intervalCount (Number) - The interval between payments, in weeks.
 week-based-plan-details-amount = { $intervalCount ->
   [one] { $productName } billed { $amount } weekly
   *[other] { $productName } billed { $amount } every { $intervalCount } weeks
 }
-#  $intervalCount (Number) - The interval between payments, in months.
+# $intervalCount (Number) - The interval between payments, in months.
 month-based-plan-details-amount = { $intervalCount ->
   [one] { $productName } billed { $amount } monthly
   *[other] { $productName } billed { $amount } every { $intervalCount } months
 }
-#  $intervalCount (Number) - The interval between payments, in years.
+# $intervalCount (Number) - The interval between payments, in years.
 year-based-plan-details-amount = { $intervalCount ->
   [one] { $productName } billed { $amount } yearly
   *[other] { $productName } billed { $amount } every { $intervalCount } years
 }
 
 ## Product route
+
 product-plan-error =
   .title = Problem loading plans
 product-profile-error =
@@ -107,7 +115,8 @@ product-customer-error =
 product-plan-not-found = Plan not found
 product-no-such-plan = No such plan for this product.
 
-## payment legal blurb
+## Payment legal blurb
+
 payment-legal-copy-stripe-and-paypal-2 = { -brand-name-mozilla } uses { -brand-name-stripe } and { -brand-name-paypal } for secure payment processing.
 payment-legal-link-stripe-paypal = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> &nbsp; <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>
 
@@ -117,7 +126,8 @@ payment-legal-link-paypal-2 = <paypalPrivacyLink>{ -brand-name-paypal } privacy 
 payment-legal-copy-stripe-2 = { -brand-name-mozilla } uses { -brand-name-stripe } for secure payment processing.
 payment-legal-link-stripe-3 = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink>
 
-## payment form
+## Payment form
+
 payment-name =
   .placeholder = Full Name
   .label = Name as it appears on your card
@@ -131,23 +141,25 @@ payment-cvc =
   .label = CVC
 payment-zip =
   .label = ZIP code
+
 ##  $amount (Number) - The amount billed. It will be formatted as currency.
+
 # $intervalCount (Number) - The interval between payments, in days.
 payment-confirm-with-legal-links-day = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
-#  $intervalCount (Number) - The interval between payments, in weeks.
+# $intervalCount (Number) - The interval between payments, in weeks.
 payment-confirm-with-legal-links-week = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
-#  $intervalCount (Number) - The interval between payments, in months.
+# $intervalCount (Number) - The interval between payments, in months.
 payment-confirm-with-legal-links-month = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
-#  $intervalCount (Number) - The interval between payments, in years.
+# $intervalCount (Number) - The interval between payments, in years.
 payment-confirm-with-legal-links-year = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
@@ -156,6 +168,7 @@ payment-confirm-with-legal-links-year = { $intervalCount ->
 payment-confirm = I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } per { $interval }</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 
 ##
+
 payment-cancel-btn = Cancel
 payment-update-btn = Update
 payment-pay-btn = Pay now
@@ -165,16 +178,19 @@ payment-validate-name-error = Please enter your name
 payment-validate-zip-required = Zip code is required
 payment-validate-zip-short = Zip code is too short
 
-## subscription redirect
+## Subscription redirect
+
 sub-redirect-ready = Your subscription is ready
 sub-redirect-copy = Please take a moment to tell us about your experience.
 sub-redirect-skip-survey = No thanks, just take me to my product.
 
-## fields
+## Fields
+
 default-input-error = This field is required
 input-error-is-required = { $label } is required
 
-## subscription upgrade
+## Subscription upgrade
+
 product-plan-change-heading = Review your change
 sub-change-failed = Plan change failed
 sub-update-payment-title = Payment information
@@ -185,6 +201,7 @@ sub-update-copy =
     you’ll be charged the full amount.
 
 ##
+
 sub-change-submit = Confirm change
 sub-change-indicator =
   .aria-label = change indicator
@@ -192,9 +209,10 @@ sub-update-current-plan-label = Current plan
 sub-update-new-plan-label = New plan
 sub-update-total-label = New total
 
-## subscription upgrade plan details
+## Subscription upgrade plan details
 ## $amount (Number) - The amount billed. It will be formatted as currency.
-#  $intervalCount (Number) - The interval between payments, in days.
+
+# $intervalCount (Number) - The interval between payments, in days.
 plan-price-day = { $intervalCount ->
   [one] { $amount } daily
   *[other] { $amount } every { $intervalCount } days
@@ -203,7 +221,7 @@ plan-price-day = { $intervalCount ->
     [one] { $amount } daily
     *[other] { $amount } every { $intervalCount } days
   }
-#  $intervalCount (Number) - The interval between payments, in weeks.
+# $intervalCount (Number) - The interval between payments, in weeks.
 plan-price-week = { $intervalCount ->
   [one] { $amount } weekly
   *[other] { $amount } every { $intervalCount } weeks
@@ -212,7 +230,7 @@ plan-price-week = { $intervalCount ->
     [one] { $amount } weekly
     *[other] { $amount } every { $intervalCount } weeks
   }
-#  $intervalCount (Number) - The interval between payments, in months.
+# $intervalCount (Number) - The interval between payments, in months.
 plan-price-month = { $intervalCount ->
   [one] { $amount } monthly
   *[other] { $amount } every { $intervalCount } months
@@ -221,7 +239,7 @@ plan-price-month = { $intervalCount ->
     [one] { $amount } monthly
     *[other] { $amount } every { $intervalCount } months
   }
-#  $intervalCount (Number) - The interval between payments, in years.
+# $intervalCount (Number) - The interval between payments, in years.
 plan-price-year = { $intervalCount ->
   [one] { $amount } yearly
   *[other] { $amount } every { $intervalCount } years
@@ -231,9 +249,9 @@ plan-price-year = { $intervalCount ->
     *[other] { $amount } every { $intervalCount } years
   }
 
-
-## subscription billing details
+## Subscription billing details
 ## $amount (Number) - The amount billed. It will be formatted as currency.
+
 #  $intervalCount (Number) - The interval between payments, in days.
 sub-plan-price-day = { $intervalCount ->
   [one] { $amount } daily
@@ -254,16 +272,20 @@ sub-plan-price-year = { $intervalCount ->
   [one] { $amount } yearly
   *[other] { $amount } every { $intervalCount } years
 }
+
 ## $date (Date) - The date for the next time a charge will occur.
+
 sub-next-bill = Next billed on { $date }
 sub-expires-on = Expires on { $date }
 
 ##
+
 pay-update-card-exp = Expires { $expirationDate }
 pay-update-change-btn = Change
 
 ## reactivate
 ## $name (String) - The name of the subscribed product.
+
 reactivate-confirm-dialog-header = Want to keep using { $name }?
 # $amount (Number) - The amount billed. It will be formatted as currency.
 # $last (String) - The last 4 digits of the card that will be charged
@@ -280,15 +302,18 @@ reactivate-confirm-without-payment-method-copy =
     and payment will stay the same. Your next charge will be
     { $amount } on { $endDate }.
 reactivate-confirm-button = Resubscribe
-##  $date (Date) - Last day of product access
+
+## $date (Date) - Last day of product access
+
 reactivate-panel-date = You cancelled your subscription on { $date }.
 reactivate-panel-copy = You will lose access to { $name } on <strong>{ $date }</strong>.
-reactivate-success-copy = Thanks! You're all set.
+reactivate-success-copy = Thanks! You’re all set.
 reactivate-success-button = Close
 
-## subscription item
+## Subscription item
 ## $name (String) - The name of the subscribed product.
 ## $period (Date) - The last day of product access
+
 sub-item-missing = Problem loading subscriptions
 sub-item-missing-msg = Please try again later.
 sub-item-no-such-plan = No such plan for this subscription.
@@ -303,19 +328,21 @@ sub-item-cancel-confirm =
 invoice-not-found = Subsequent invoice not found
 sub-item-no-such-subsequent-invoice = Subsequent invoice not found for this subscription.
 
-## subscription iap item
+## Subscription iap item
+
 sub-iap-item-google-purchase = { -brand-name-google }: In-App purchase
 sub-iap-item-apple-purchase = { -brand-name-apple }: In-App purchase
 sub-iap-item-manage-button = Manage
 
 account-activated = Your account is activated, <userEl/>
 
-## subscription route index
+## Subscription route index
+
 sub-route-idx-updating = Updating billing information…
 sub-route-idx-reactivating = Reactivating subscription failed
 sub-route-idx-cancel-failed = Cancelling subscription failed
 sub-route-idx-contact = Contact Support
-sub-route-idx-cancel-msg-title = We're sorry to see you go
+sub-route-idx-cancel-msg-title = We’re sorry to see you go
 # $name (String) - The name of the subscribed product.
 # $date (Date) - Last day of product access
 sub-route-idx-cancel-msg =
@@ -337,20 +364,23 @@ sub-route-missing-billing-agreement-payment-alert = Invalid payment information;
 sub-route-funding-source-payment-alert = Invalid payment information; there is an error with your account. This alert may take some time to clear after you successfully update your information. <div>Manage</div>
 pay-update-manage-btn = Manage
 
-## subscription create
+## Subscription create
+
 sub-guarantee = 30-day money-back guarantee
 pay-with-heading-other = Select payment option
 pay-with-heading-card-or = Or pay with card
 pay-with-heading-card-only = Pay with card
 
-## plan-details
+## Plan details
+
 plan-details-header = Product details
 plan-details-show-button = Show details
 plan-details-hide-button = Hide details
 plan-details-total-label = Total
 plan-details-list-price = List Price
 
-## coupons
+## Coupons
+
 coupon-discount = Discount
 coupon-discount-applied = Discount Reward Applied
 coupon-submit = Apply
@@ -366,28 +396,34 @@ coupon-success-repeating = Your plan will automatically renew after { $couponDur
 coupon-enter-code =
   .placeholder = Enter Code
 
-## payment-processing
+## Payment processing
+
 payment-processing-message = Please wait while we process your payment…
 
-## payment confirmation
+## Payment confirmation
+
 payment-confirmation-alert = Click here to download
-payment-confirmation-mobile-alert = Didn't open app? <a>Click Here</a>
+payment-confirmation-mobile-alert = Didn’t open app? <a>Click Here</a>
 payment-confirmation-thanks-heading = Thank you!
 
-## payment confirmation details
+## Payment confirmation details
 ## $email (string) - The user's email.
 ## $productName (String) - The name of the subscribed product.
+
 payment-confirmation-thanks-subheading = A confirmation email has been sent to { $email } with details on how to get started with { $product_name }.
 payment-confirmation-thanks-heading-account-exists = Thanks, now check your email!
 
 ## $email (string) - The user's email.
-payment-confirmation-thanks-subheading-account-exists = You'll receive an email at { $email } with instructions for setting up your account, as well as your payment details.
+
+payment-confirmation-thanks-subheading-account-exists = You’ll receive an email at { $email } with instructions for setting up your account, as well as your payment details.
 payment-confirmation-order-heading = Order details
 payment-confirmation-invoice-number = Invoice #{ $invoiceNumber }
 payment-confirmation-billing-heading = Billed to
 payment-confirmation-details-heading-2 = Payment information
 payment-confirmation-amount = { $amount } per { $interval }
+
 ## $amount (Number) - The amount billed. It will be formatted as currency.
+
 #  $intervalCount (Number) - The interval between payments, in days.
 payment-confirmation-amount-day = { $intervalCount ->
   [one] { $amount } daily
@@ -412,7 +448,8 @@ payment-confirmation-amount-year = { $intervalCount ->
 payment-confirmation-download-button = Continue to download
 payment-confirmation-cc-card-ending-in = Card ending in { $last4 }
 
-## new user email form
+## New user email form
+
 new-user-sign-in-link = Already have a { -brand-name-firefox } account? <a>Sign in</a>
 new-user-step-1 = 1. Create a { -brand-name-firefox } account
 # "Required" to indicate that the user must use the checkbox below this text to
@@ -422,7 +459,7 @@ new-user-email =
   .label = Enter your email
 new-user-confirm-email =
   .label = Confirm your email
-new-user-subscribe-product-updates = I'd like to receive product updates from { -brand-name-firefox }
+new-user-subscribe-product-updates = I’d like to receive product updates from { -brand-name-firefox }
 new-user-subscribe-product-assurance = We only use your email to create your account. We will never sell it to a third party.
 new-user-email-validate = Email is not valid
 new-user-email-validate-confirm = Emails do not match


### PR DESCRIPTION
Not exactly sure if this is enough, hopefully tests are not looking for specific text.

CC @clouserw 

I tried running a linter on source files, and a few issues:
* Group comment should have a space before and after, and be followed by at least a string. I move the one about "email content" in the following file to avoid that problem.
* Strings should use `’` and not `'`.

