### PR TITLE
fix(settings): Fixes en-GB strings showing up en-US strings should be…

### DIFF
--- a/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
@@ -18,12 +18,10 @@ describe('<AppLocalizationProvider/>', () => {
   const locales = ['en-GB', 'en-US', 'es-ES'];
   const bundles = ['greetings', 'farewells'];
   function waitUntilTranslated() {
-    return waitUntil(
-      () => {
-        // @ts-ignore
-        return AppLocalizationProvider.prototype.render.callCount === 2
-      }
-    );
+    return waitUntil(() => {
+      // @ts-ignore
+      return AppLocalizationProvider.prototype.render.callCount === 2;
+    });
   }
 
   beforeAll(() => {
@@ -44,7 +42,7 @@ describe('<AppLocalizationProvider/>', () => {
 
   afterEach(() => {
     // @ts-ignore
-    AppLocalizationProvider.prototype.render.restore()
+    AppLocalizationProvider.prototype.render.restore();
     cleanup();
   });
 
@@ -82,7 +80,7 @@ describe('<AppLocalizationProvider/>', () => {
     await waitUntilTranslated();
 
     // Ensure we fall back to en-US if our locale is missing that string.
-    expect(getByTestId('result')).toHaveTextContent('HolaGoodbye');
+    expect(getByTestId('result')).toHaveTextContent('Holauntranslated');
   });
 
   it('translate to de', async () => {
@@ -102,7 +100,7 @@ describe('<AppLocalizationProvider/>', () => {
 
     // Ensure we fall back to en-US strings if we don't have translations for
     // any of the userLocales.
-    expect(getByTestId('result')).toHaveTextContent('HelloGoodbye');
+    expect(getByTestId('result')).toHaveTextContent('untranslated');
   });
 
   it('fallback to text content', async () => {
@@ -129,10 +127,7 @@ describe('<AppLocalizationProvider/>', () => {
     const { getByTestId } = render(
       <AppLocalizationProvider bundles={bundles} userLocales={['en-NZ']}>
         <main data-testid="result">
-          <Localized
-            id="hello"
-            vars={{ amount: '$US123.00' }}
-          >
+          <Localized id="hello" vars={{ amount: '$US123.00' }}>
             <div>untranslated</div>
           </Localized>
         </main>

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -3,11 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FluentBundle, FluentResource } from '@fluent/bundle';
-import { negotiateLanguages } from '@fluent/langneg';
 import { LocalizationProvider, ReactLocalization } from '@fluent/react';
 import React, { Component } from 'react';
-import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
 import { EN_GB_LOCALES } from 'fxa-shared/l10n/otherLanguages';
+import { parseAcceptLanguage } from 'fxa-shared/l10n/parseAcceptLanguage';
 
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {
@@ -96,13 +95,7 @@ export default class AppLocalizationProvider extends Component<Props, State> {
   async componentDidMount() {
     const { baseDir, userLocales, bundles } = this.state;
 
-    const currentLocales = negotiateLanguages(
-      [...userLocales],
-      [...EN_GB_LOCALES, ...availableLocales],
-      {
-        defaultLocale: 'en-US',
-      }
-    );
+    const currentLocales = parseAcceptLanguage(userLocales.join(', '));
 
     const bundleGenerator = await createFluentBundleGenerator(
       baseDir,


### PR DESCRIPTION
## Because

- British spellings like 'authorised' were being reported by US users on the settings page.

## This pull request

- Reuses the routine for parsing language strings used on the server side.
- Adjusts one tests that was incorrect. Placeholder text should be displayed if no language can be resolved.

## Issue that this pull request solves

Closes: #12276 
Closes: #12307 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


