### PR TITLE
fix(apple): Generate JWT for client secret on each request

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -150,12 +150,30 @@ const conf = convict({
       format: String,
       doc: 'Apple auth client secret',
     },
+    keyId: {
+      default: '',
+      env: 'APPLE_AUTH_KEY_ID',
+      format: String,
+      doc: 'Apple auth key id',
+    },
     redirectUri: {
       default:
         'https://localhost.dev:3030/post_verify/third_party_auth/callback',
       env: 'APPLE_AUTH_REDIRECT_URI',
       format: String,
       doc: 'Apple auth redirect uri',
+    },
+    privateKey: {
+      default: '',
+      env: 'APPLE_AUTH_PRIVATE_KEY',
+      format: String,
+      doc: 'Apple auth private key',
+    },
+    teamId: {
+      default: '',
+      env: 'APPLE_AUTH_TEAM_ID',
+      format: String,
+      doc: 'Apple auth team id',
     },
     tokenEndpoint: {
       default: 'https://appleid.apple.com/auth/token',

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -96,6 +96,7 @@
     "i18n-iso-countries": "^7.4.0",
     "inert": "^5.1.3",
     "ioredis": "^4.28.2",
+    "jose": "^4.8.1",
     "jsdom": "^19.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22485,6 +22485,7 @@ fsevents@~2.1.1:
     i18n-iso-countries: ^7.4.0
     inert: ^5.1.3
     ioredis: ^4.28.2
+    jose: ^4.8.1
     jsdom: ^19.0.0
     jsonwebtoken: ^8.5.1
     jsxgettext-recursive-next: 1.1.0
@@ -28870,6 +28871,13 @@ fsevents@~2.1.1:
   version: 4.6.1
   resolution: "jose@npm:4.6.1"
   checksum: f701b41ef385e819a2a6369f2c63277ed51694bac4c0dac211e58f71a7b902b5c42cb0fbaf922e5a14d6f02219f0cb4e1128147f6cbd003f9f6abb7b8f7b91e5
+  languageName: node
+  linkType: hard
+
+"jose@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "jose@npm:4.8.1"
+  checksum: c3e239ccbb07863c28250aedea3e734e4a3b26abc1cbf6acf333381db5ef31e5d1eeced791299076f13b24f41b4b463a7a1e4eaa0079ae0febf9bfd60acb555a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* Apple only requires the generated token to be updated every six months

This commit:

* Generates the JWT for the client secret on each request as a better approach

Closes #12391

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

