### PR TITLE
fix(email): remove duplicate Fluent string payment-details

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
@@ -1,5 +1,3 @@
-# COMMENT ABOUT After the colon,
-payment-details = Payment details:
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionAccountFinishSetup-subject = Welcome to { $productName }: Please set your password.


### PR DESCRIPTION
Because:

* `payment-details` are defined in two files
  * packages/fxa-auth-server/lib/senders/emails/partials/paymentPlanDetails/en.ftl
  * packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl


This commit:

* removes the string that is not needed within `subscriptionAccountFinishSetup`. In addition, the string belongs in the `en.ftl` of its partial

Closes #12773

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
