### PR TITLE
fix(auth): populate ua info in session token for linked account session

### DIFF
--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -228,6 +228,12 @@ export class LinkedAccountHandler {
       verifierSetAt: accountRecord.verifierSetAt,
       mustVerify: false,
       tokenVerificationCodeExpiresAt: Date.now() + this.tokenCodeLifetime,
+      uaBrowser: request.app.ua.browser,
+      uaBrowserVersion: request.app.ua.browserVersion,
+      uaOS: request.app.ua.os,
+      uaOSVersion: request.app.ua.osVersion,
+      uaDeviceType: request.app.ua.deviceType,
+      uaFormFactor: request.app.ua.formFactor,
     };
 
     const sessionToken = await this.db.createSessionToken(sessionTokenOptions);

--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -178,7 +178,27 @@ describe('/linked_account', () => {
             GOOGLE_PROVIDER
           )
         );
-        assert.isTrue(mockDB.createSessionToken.calledOnce);
+        assert.isTrue(
+          mockDB.createSessionToken.calledOnceWith(
+            sinon.match({
+              uid: 'fxauid',
+              email: mockGoogleUser.email,
+              mustVerify: false,
+              uaBrowser: 'Firefox',
+              uaBrowserVersion: '57.0',
+              uaOS: 'Mac OS X',
+              uaOSVersion: '10.13',
+              uaDeviceType: null,
+              uaFormFactor: null,
+            })
+          )
+        );
+        assert.isTrue(
+          mockDB.createSessionToken.calledOnceWith(
+            sinon.match.has('tokenVerificationCodeExpiresAt')
+          )
+        );
+
         assert.equal(result.uid, UID);
         assert.ok(result.sessionToken);
       });


### PR DESCRIPTION
## Because

- When using third party sign in, connected services section was missing info for the session.

## This pull request

- Makes sure the session token is populated with user agent info.

## Issue that this pull request solves

Closes: #12008

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
![image](https://user-images.githubusercontent.com/94418270/167219134-dacf6173-a7ea-40c7-b3d1-1cee24843caa.png)

After Fix:
![image](https://user-images.githubusercontent.com/94418270/167219173-ea466779-ac6e-4c82-94f3-5d4d9b1db872.png)

