### PR TITLE
chore(ci): Set up linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: FxA Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+    - run: yarn install --frozen-lockfile
+    - run: npx eslint . --config _dev/.eslintrc --ext .js
+

--- a/_dev/.eslintrc
+++ b/_dev/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": ["plugin:fxa/recommended"],
+  "ignorePatterns": ["**/123done/static/components/*.js", "**/dist/**"],
   "plugins": ["fxa"],
   "parserOptions": {
     "ecmaVersion": "2020"

--- a/packages/fxa-customs-server/test/remote/too_many_bad_logins.js
+++ b/packages/fxa-customs-server/test/remote/too_many_bad_logins.js
@@ -162,6 +162,7 @@ test('too many failed logins from the same email', async (t) => {
   await Promise.delay(1000);
 
   // Attempt to login again, not rate limited
+  // eslint-disable-next-line no-unused-vars
   [req, res, obj] = await client.postAsync('/check', {
     email: TEST_EMAIL,
     ip: IP0,


### PR DESCRIPTION
In our triage this morning we talked about setting up eslint in Github Actions.  I volunteered to do it since I saw the action, but it turns out everyone uses setup-node now.  So, that's what this uses.

This has in-line annotations automatically, eg. 
![image](https://user-images.githubusercontent.com/80098/167502328-1801d418-b64f-4e39-b464-b9af1977277a.png)

This would be a first step and if we like it we could enable the style linters and whatever else.  Anyway, feedback welcome.