### PR TITLE
task(settings): Disable 2FA and Recovery Code actions when account has no password

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -32,7 +32,7 @@ type AppProps = {
 
 export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
   const config = useConfig();
-  const { metricsEnabled } = useAccount();
+  const { metricsEnabled, hasPassword } = useAccount();
 
   useEffect(() => {
     if (config.metrics.navTiming.enabled && metricsEnabled) {
@@ -76,11 +76,31 @@ export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
             <PageDisplayName path="/display_name" />
             <PageAvatar path="/avatar" />
             <PageChangePassword path="/change_password" />
-            <PageRecoveryKeyAdd path="/account_recovery" />
+            {hasPassword ? (
+              <PageRecoveryKeyAdd path="/account_recovery" />
+            ) : (
+              <Redirect from="/account_recovery" to="/settings" noThrow />
+            )}
             <PageSecondaryEmailAdd path="/emails" />
             <PageSecondaryEmailVerify path="/emails/verify" />
-            <PageTwoStepAuthentication path="/two_step_authentication" />
-            <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+            {hasPassword ? (
+              <PageTwoStepAuthentication path="/two_step_authentication" />
+            ) : (
+              <Redirect
+                from="/two_step_authentication"
+                to="/settings"
+                noThrow
+              />
+            )}
+            {hasPassword ? (
+              <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+            ) : (
+              <Redirect
+                from="/two_step_authentication/replace_codes"
+                to="/settings"
+                noThrow
+              />
+            )}
             <PageDeleteAccount path="/delete_account" />
             <Redirect
               from="/clients"

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -81,6 +81,8 @@ type UnitRowProps = {
   hideCtaText?: boolean;
   prefixDataTestId?: string;
   isLevelWithRefreshButton?: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
 };
 
 export const UnitRow = ({
@@ -105,6 +107,8 @@ export const UnitRow = ({
   hideCtaText,
   prefixDataTestId = '',
   isLevelWithRefreshButton = false,
+  disabled = false,
+  disabledReason = '',
 }: UnitRowProps & RouteComponentProps) => {
   const { l10n } = useLocalization();
   const localizedCtaAdd = l10n.getString(
@@ -124,6 +128,10 @@ export const UnitRow = ({
     secondaryCtaText ||
     l10n.getString('row-defaults-action-disable', null, 'Disable');
   ctaText = ctaText || (headerValue ? localizedCtaChange : localizedCtaAdd);
+
+  if (disabled) {
+    ctaText = l10n.getString('row-defaults-action-disable', null, 'Disable');
+  }
 
   const location = useLocation();
   const multiButton = !!(route || secondaryCtaRoute);
@@ -158,46 +166,67 @@ export const UnitRow = ({
 
       <div className="unit-row-actions">
         <div className="flex items-center">
-          {!hideCtaText && route && (
-            <Link
+          {disabled ? (
+            <button
               className={classNames(
                 'cta-neutral cta-base transition-standard rtl:ml-1',
                 isLevelWithRefreshButton && 'mobileLandscape:mr-9'
               )}
               data-testid={formatDataTestId('unit-row-route')}
-              to={`${route}${location.search}`}
+              title={disabledReason}
+              disabled={disabled}
             >
-              {ctaText}
-            </Link>
-          )}
+              {' '}
+              Disabled{' '}
+            </button>
+          ) : (
+            <>
+              {!hideCtaText && route && (
+                <Link
+                  className={classNames(
+                    'cta-neutral cta-base transition-standard rtl:ml-1',
+                    isLevelWithRefreshButton && 'mobileLandscape:mr-9'
+                  )}
+                  data-testid={formatDataTestId('unit-row-route')}
+                  to={`${route}${location.search}`}
+                >
+                  {ctaText}
+                </Link>
+              )}
 
-          {revealModal && (
-            <ModalButton
-              {...{ revealModal, ctaText, alertBarRevealed, prefixDataTestId }}
-            />
-          )}
+              {revealModal && (
+                <ModalButton
+                  {...{
+                    revealModal,
+                    ctaText,
+                    alertBarRevealed,
+                    prefixDataTestId,
+                  }}
+                />
+              )}
 
-          {secondaryCtaRoute && (
-            <Link
-              className="cta-neutral cta-base transition-standard ltr:mr-1 rtl:ml-1"
-              data-testid={formatDataTestId('unit-row-route')}
-              to={`${secondaryCtaRoute}${location.search}`}
-            >
-              {secondaryCtaText}
-            </Link>
-          )}
+              {secondaryCtaRoute && (
+                <Link
+                  className="cta-neutral cta-base transition-standard ltr:mr-1 rtl:ml-1"
+                  data-testid={formatDataTestId('unit-row-route')}
+                  to={`${secondaryCtaRoute}${location.search}`}
+                >
+                  {secondaryCtaText}
+                </Link>
+              )}
 
-          {revealSecondaryModal && (
-            <ModalButton
-              leftSpaced={multiButton}
-              revealModal={revealSecondaryModal}
-              ctaText={secondaryCtaText}
-              className={secondaryButtonClassName}
-              alertBarRevealed={alertBarRevealed}
-              prefixDataTestId={secondaryButtonTestId}
-            />
+              {revealSecondaryModal && (
+                <ModalButton
+                  leftSpaced={multiButton}
+                  revealModal={revealSecondaryModal}
+                  ctaText={secondaryCtaText}
+                  className={secondaryButtonClassName}
+                  alertBarRevealed={alertBarRevealed}
+                  prefixDataTestId={secondaryButtonTestId}
+                />
+              )}
+            </>
           )}
-
           {actionContent}
         </div>
       </div>

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -129,10 +129,6 @@ export const UnitRow = ({
     l10n.getString('row-defaults-action-disable', null, 'Disable');
   ctaText = ctaText || (headerValue ? localizedCtaChange : localizedCtaAdd);
 
-  if (disabled) {
-    ctaText = l10n.getString('row-defaults-action-disable', null, 'Disable');
-  }
-
   const location = useLocation();
   const multiButton = !!(route || secondaryCtaRoute);
 
@@ -176,8 +172,7 @@ export const UnitRow = ({
               title={disabledReason}
               disabled={disabled}
             >
-              {' '}
-              Disabled{' '}
+              {!hideCtaText && ctaText}
             </button>
           ) : (
             <>

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
@@ -74,14 +74,14 @@ describe('UnitRowRecoveryKey', () => {
 
     expect(
       screen.getByTestId('recovery-key-unit-row-route').textContent
-    ).toContain('Disabled');
+    ).toContain('Create');
 
     expect(
       screen
         .getByTestId('recovery-key-unit-row-route')
         .attributes.getNamedItem('title')?.value
     ).toEqual(
-      'Set a password to use Sync and certain account security features.'
+      'Set a password to use Firefox Sync and certain account security features.'
     );
   });
 

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
@@ -16,6 +16,7 @@ import { Account, AppContext } from '../../models';
 import * as Metrics from '../../lib/metrics';
 
 const account = {
+  hasPassword: true,
   recoveryKey: true,
   deleteRecoveryKey: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
@@ -40,6 +41,7 @@ describe('UnitRowRecoveryKey', () => {
 
   it('renders when recovery key is not set', () => {
     const account = {
+      hasPassword: true,
       recoveryKey: false,
     } as unknown as Account;
     renderWithRouter(
@@ -58,8 +60,34 @@ describe('UnitRowRecoveryKey', () => {
     ).toContain('Create');
   });
 
+  it('renders disabled state when account has no password', () => {
+    const account = {
+      hasPassword: false,
+      recoveryKey: false,
+    } as unknown as Account;
+
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <UnitRowRecoveryKey />
+      </AppContext.Provider>
+    );
+
+    expect(
+      screen.getByTestId('recovery-key-unit-row-route').textContent
+    ).toContain('Disabled');
+
+    expect(
+      screen
+        .getByTestId('recovery-key-unit-row-route')
+        .attributes.getNamedItem('title')?.value
+    ).toEqual(
+      'Set a password to use Sync and certain account security features.'
+    );
+  });
+
   it('can be refreshed', async () => {
     const account = {
+      hasPassword: true,
       recoveryKey: false,
       refresh: jest.fn(),
     } as unknown as Account;
@@ -98,6 +126,7 @@ describe('UnitRowRecoveryKey', () => {
 
     const removeRecoveryKey = async (process = false) => {
       const account = {
+        hasPassword: true,
         recoveryKey: true,
       } as unknown as Account;
 

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -54,6 +54,12 @@ export const UnitRowRecoveryKey = () => {
           ? l10n.getString('rk-action-remove', null, 'Remove')
           : l10n.getString('rk-action-create', null, 'Create')
       }
+      disabled={!account.hasPassword}
+      disabledReason={l10n.getString(
+        'rk-no-pwd-action-disabled-reason',
+        null,
+        'Set a password to use Sync and certain account security features.'
+      )}
       alertBarRevealed
       headerContent={
         <ButtonIconReload
@@ -68,7 +74,7 @@ export const UnitRowRecoveryKey = () => {
           title={l10n.getString('rk-refresh-key')}
           classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
           testId="recovery-key-refresh"
-          disabled={account.loading}
+          disabled={account.loading || !account.hasPassword}
           onClick={() => account.refresh('recovery')}
         />
       }

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -56,9 +56,9 @@ export const UnitRowRecoveryKey = () => {
       }
       disabled={!account.hasPassword}
       disabledReason={l10n.getString(
-        'rk-no-pwd-action-disabled-reason',
+        'security-set-password',
         null,
-        'Set a password to use Sync and certain account security features.'
+        'Set a password to use Firefox Sync and certain account security features.'
       )}
       alertBarRevealed
       headerContent={

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
@@ -128,14 +128,14 @@ describe('UnitRowTwoStepAuth', () => {
     );
 
     expect(screen.getByTestId('two-step-unit-row-route').textContent).toContain(
-      'Disabled'
+      'Add'
     );
     expect(
       screen
         .getByTestId('two-step-unit-row-route')
         .attributes.getNamedItem('title')?.value
     ).toEqual(
-      'Set a password to use Sync and certain account security features.'
+      'Set a password to use Firefox Sync and certain account security features.'
     );
   });
 });

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
@@ -10,6 +10,7 @@ import { Account, AppContext } from '../../models';
 
 jest.mock('../../models/AlertBarInfo');
 const account = {
+  hasPassword: true,
   totp: { exists: true, verified: true },
   disableTwoStepAuth: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
@@ -50,6 +51,7 @@ describe('UnitRowTwoStepAuth', () => {
 
   it('renders when Two-step authentication is not enabled', () => {
     const account = {
+      hasPassword: true,
       totp: { exists: false, verified: false },
     } as unknown as Account;
     renderWithRouter(
@@ -70,6 +72,7 @@ describe('UnitRowTwoStepAuth', () => {
 
   it('can be refreshed', async () => {
     const account = {
+      hasPassword: true,
       totp: { exists: false, verified: false },
       refresh: jest.fn(),
     } as unknown as Account;
@@ -110,5 +113,29 @@ describe('UnitRowTwoStepAuth', () => {
     });
 
     expect(context.alertBarInfo?.success).toBeCalledTimes(1);
+  });
+
+  it('renders disabled state when account has no password', async () => {
+    const account = {
+      hasPassword: false,
+      totp: { exists: false, verified: false },
+    } as unknown as Account;
+
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <UnitRowTwoStepAuth />
+      </AppContext.Provider>
+    );
+
+    expect(screen.getByTestId('two-step-unit-row-route').textContent).toContain(
+      'Disabled'
+    );
+    expect(
+      screen
+        .getByTestId('two-step-unit-row-route')
+        .attributes.getNamedItem('title')?.value
+    ).toEqual(
+      'Set a password to use Sync and certain account security features.'
+    );
   });
 });

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -93,13 +93,19 @@ export const UnitRowTwoStepAuth = () => {
           />
         </Localized>
       }
+      disabled={!account.hasPassword}
+      disabledReason={l10n.getString(
+        'rk-action-disabled-reason',
+        null,
+        'Set a password to use Sync and certain account security features.'
+      )}
       actionContent={
         <Localized id="tfa-row-button-refresh" attrs={{ title: true }}>
           <ButtonIconReload
             title="Refresh two-step authentication"
             classNames="hidden ltr:ml-1 rtl:mr-1 mobileLandscape:inline-block"
             testId="two-step-refresh"
-            disabled={account.loading}
+            disabled={account.loading || !account.hasPassword}
             onClick={() => account.refresh('totp')}
           />
         </Localized>

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -95,9 +95,9 @@ export const UnitRowTwoStepAuth = () => {
       }
       disabled={!account.hasPassword}
       disabledReason={l10n.getString(
-        'rk-action-disabled-reason',
+        'security-set-password',
         null,
-        'Set a password to use Sync and certain account security features.'
+        'Set a password to use Firefox Sync and certain account security features.'
       )}
       actionContent={
         <Localized id="tfa-row-button-refresh" attrs={{ title: true }}>

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -53,6 +53,7 @@ export interface AccountData {
   };
   accountCreated: number;
   passwordCreated: number;
+  hasPassword: boolean;
   recoveryKey: boolean;
   metricsEnabled: boolean;
   primaryEmail: Email;
@@ -271,6 +272,18 @@ export class Account implements AccountData {
 
   get passwordCreated() {
     return this.data.passwordCreated;
+  }
+
+  get hasPassword() {
+    // This might be requested before account data is ready,
+    // so default to disabled until we can get a proper read
+    try {
+      return (
+        this.data?.passwordCreated != null && this.data.passwordCreated > 0
+      );
+    } catch {
+      return false;
+    }
   }
 
   get recoveryKey() {

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -24,6 +24,7 @@ export const MOCK_ACCOUNT: AccountData = {
   },
   accountCreated: 123456789,
   passwordCreated: 123456789,
+  hasPassword: true,
   recoveryKey: true,
   metricsEnabled: true,
   attachedClients: [],


### PR DESCRIPTION
## Because
- With third party oauth, we might enter into a state where the user has authenticated, but has not supplied a password yet. In this case, setting up recovery codes or 2FA isn’t applicable.

## This pull request
- Introduces hasPassword flag on account model
- Guards routes associated to 2FA and recovery codes in the event the account does not have a password
- Disables 2FA and recovery code action buttons in the event a user’s account has no password set.
- Provides a tooltip hint on the disabled action button that a password must be set in order to use certain features or sync.

## Issue that this pull request solves

Closes: #12774

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/167507719-8d032338-a5af-4e27-914c-67fecf570e62.png)


## Other Information

To test this state, login with a third party oauth account (apple or google) for the first time. This will result in a state where you have been authenticated, but haven't set a password yet.

