### PR TITLE
style(settings): remove extra white-space before and after "Resend verification code" text

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -218,7 +218,7 @@ export const UnitRowSecondaryEmail = () => {
                 elems={{
                   button: (
                     <button
-                      className="link-blue mx-1"
+                      className="link-blue"
                       data-testid="secondary-email-resend-code-button"
                       onClick={() => {
                         resendEmailCode(email);


### PR DESCRIPTION
## Because

- We want to maintain consistent design and UX throughout the site

## This pull request

- Removes tailwind class adding extra white-space

## Issue that this pull request solves

Closes: #10585

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

N/A
