### PR TITLE
fix(fxa-admin-panel) use clearer icons to indicate permission status

### DIFF
--- a/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
@@ -60,7 +60,7 @@ describe('Permissions', () => {
     ).toEqual(enabledFeature?.name);
     expect(
       getByTestId(`permissions-row-${enabledFeature?.id}-val`).textContent
-    ).toEqual('✓');
+    ).toEqual('✅');
   });
 
   it('has disabled feature', () => {
@@ -74,6 +74,6 @@ describe('Permissions', () => {
     ).toEqual(disabledFeature?.name);
     expect(
       getByTestId(`permissions-row-${disabledFeature?.id}-val`).textContent
-    ).toEqual('x');
+    ).toEqual('❌');
   });
 });

--- a/packages/fxa-admin-panel/src/components/Permissions/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.tsx
@@ -37,7 +37,7 @@ export const PermissionRow = ({ flag }: { flag: IFeatureFlag }) => {
       {...{
         testId,
         label: flag.name,
-        val: flag.enabled ? '✓' : 'x',
+        val: flag.enabled ? '✅' : '❌',
       }}
     ></LabelValRow>
   );


### PR DESCRIPTION
## Because

- Currently, a user can be confused as to whether they have a given permission or not, because the negative symbol is `x`. We use clearer positive/negative symbols to indicate permission status.

## This pull request

- Replaces the symbols with more vivid unicode symbols (`U+2705`:  ✅ and `U-274C`: ❌)

## Issue that this pull request solves

Closes: #12743 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before (user has permissions):
<img width="370" alt="Screen Shot 2022-05-10 at 10 19 33 AM" src="https://user-images.githubusercontent.com/11150372/167686226-9be86e70-006b-4cb7-8961-feba7a35f1db.png">

Before (user does not have permissions):
<img width="349" alt="Screen Shot 2022-05-10 at 10 18 42 AM" src="https://user-images.githubusercontent.com/11150372/167686250-fbf91857-d600-4ae4-9d3a-cdec53171ed3.png">

After (user has permissions):
<img width="349" alt="Screen Shot 2022-05-10 at 10 19 42 AM" src="https://user-images.githubusercontent.com/11150372/167686273-33b04297-9f44-4d33-b201-f0a6c61039ae.png">

After (user does not have permissions):
<img width="366" alt="Screen Shot 2022-05-10 at 10 18 55 AM" src="https://user-images.githubusercontent.com/11150372/167686285-be2c904c-4323-4748-b4d2-2794118b96b2.png">

To test:
With the `fxa-admin-panel` app running in local, visit `http://localhost:8091/permissions` and observe the permissions for your user. I don't know how to change the permissions for the logged in user, but to view the opposite of whatever permissions you're seeing, switch the values in the ternary [here](https://github.com/mozilla/fxa/blob/main/packages/fxa-admin-panel/src/components/Permissions/index.tsx#L40) like so: `val: flag.enabled ? '❌' : '✅',`

