### PR TITLE
fix(auth): pass Product/Plan Metadata to Email Sender

### DIFF
--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -152,6 +152,7 @@ export class SubscriptionReminders {
           // Using invoice prefix instead of plan to accomodate `yarn write-emails`.
           invoiceTotalInCents: amount,
           invoiceTotalCurrency: currency,
+          productMetadata: formattedSubscription.productMetadata,
         }
       );
       await this.updateSentEmail(uid, emailParams);

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2789,7 +2789,8 @@ module.exports = function (log, config, bounces) {
       privacyNoticeDownloadURL = this.privacyUrl,
     } = productDetailsFromPlan(
       {
-        product_metadata: message.productMetadata,
+        product_metadata:
+          message.productMetadata || message.subscription?.productMetadata,
       },
       determineLocale(message.acceptLanguage)
     );

--- a/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
+++ b/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
@@ -254,7 +254,11 @@ describe('SubscriptionReminders', () => {
         },
       };
       reminder.alreadySentEmail = sandbox.fake.resolves(false);
-      const account = { emails: [], email: 'testo@test.test', locale: 'NZ' };
+      const account = {
+        emails: [],
+        email: 'testo@test.test',
+        locale: 'NZ',
+      };
       reminder.db.account = sandbox.fake.resolves(account);
       mockLog.info = sandbox.fake.returns({});
       mockStripeHelper.formatSubscriptionForEmail = sandbox.fake.resolves({});
@@ -264,8 +268,15 @@ describe('SubscriptionReminders', () => {
         interval_count: longPlan1.interval_count,
         interval: longPlan1.interval,
       });
+      const formattedSubscription = {
+        id: 'subscriptionId',
+        productMetadata: {
+          privacyUrl: 'http://privacy',
+          termsOfServiceUrl: 'http://tos',
+        },
+      };
       reminder.mailer.sendSubscriptionRenewalReminderEmail =
-        sandbox.fake.resolves({});
+        sandbox.fake.resolves(formattedSubscription);
       reminder.updateSentEmail = sandbox.fake.resolves({});
       const realDateNow = Date.now.bind(global.Date);
       Date.now = sinon.fake(() => MOCK_DATETIME_MS);
@@ -305,12 +316,13 @@ describe('SubscriptionReminders', () => {
           acceptLanguage: account.locale,
           uid: 'uid',
           email: 'testo@test.test',
-          subscription: {},
+          subscription: formattedSubscription,
           reminderLength: 14,
           planIntervalCount: 1,
           planInterval: 'month',
           invoiceTotalInCents: 499,
           invoiceTotalCurrency: 'usd',
+          productMetadata: formattedSubscription.productMetadata,
         }
       );
       sinon.assert.calledOnceWithExactly(


### PR DESCRIPTION
Because:

* The email sender defaults to the VPN's privacy and ToS links in the email footer, we need to pass the product/plan specific metadata

This commit:

* passes the metadata from the formattedSubscription object to the message received by the email sender

Closes #12655

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).