### PR TITLE
style(settings): fix alignment of headers on Settings page

### DIFF
--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -186,7 +186,7 @@ export const ConnectedServices = () => {
 
   return (
     <section className="mt-11" data-testid="settings-connected-services">
-      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4 relative">
+      <h2 className="font-header font-bold mobileLandscape:ltr:ml-6 mobileLandscape:rtl:ml-6 ltr:ml-4 rtl:mr-4 mb-4 relative">
         <span id="connected-services" className="nav-anchor"></span>
         <Localized id="cs-heading">Connected Services</Localized>
       </h2>

--- a/packages/fxa-settings/src/components/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/DataCollection/index.tsx
@@ -54,7 +54,7 @@ export const DataCollection = () => {
 
   return (
     <section className="mt-11" data-testid="settings-data-collection">
-      <h2 className="font-header font-bold relative ltr:ml-4 rtl:mr-4 mb-4">
+      <h2 className="font-header font-bold mobileLandscape:ltr:ml-6 mobileLandscape:rtl:ml-6 ltr:ml-4 rtl:mr-4 mb-4 relative">
         <span id="data-collection" className="nav-anchor" />
         {localizedHeader}
       </h2>


### PR DESCRIPTION
## Because

- We want to maintain consistent design and UX throughout the site

## This pull request

- Updates h2 classes to align all headers

## Issue that this pull request solves

Closes: #9324

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

Also corrected alignment for "Data Collection and Use"
