### PR TITLE
style(content): fix alignment of "Firefox Relay" icon on sign-in page

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -100,11 +100,7 @@
 
         &.logo-relay {
           background-image: image-url('graphic-logo-relay.svg');
-          background-position-x: -5px;
-
-          html[dir='rtl'] & {
-            background-position-x: 5px;
-          }
+          background-position-x: -15px;
         }
 
         &.logo-monitor {


### PR DESCRIPTION
## Because

- We want to maintain consistent design and UX throughout the site

## This pull request

- Updates styles for Firefox Relay icon position

## Issue that this pull request solves

Closes: #11310

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

N/A
