### PR TITLE
fix(graphql): Fix graphql playground

### DIFF
--- a/packages/fxa-graphql-api/README.md
+++ b/packages/fxa-graphql-api/README.md
@@ -15,7 +15,7 @@ Add this as a property of a JSON object with an `authorization` key in the botto
 
 ```
 {
-  "authorization": "d4a62a0f58efb0e9c7d17b579434f2a56cad10503033874002ddd507a503cea5"
+  "authorization": "Bearer d4a62a0f58efb0e9c7d17b579434f2a56cad10503033874002ddd507a503cea5"
 }
 ```
 

--- a/packages/fxa-graphql-api/src/gql/gql.module.ts
+++ b/packages/fxa-graphql-api/src/gql/gql.module.ts
@@ -71,9 +71,9 @@ export class GqlModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply((req: Request, res: Response, next: Function) => {
-        if (!req.is('application/json') && !req.is('multipart/form-data')) {
+        if (config.env !== 'development' && !req.is('application/json') && !req.is('multipart/form-data')) {
           return next(
-            new HttpException('Request content type is not supported.', 415)
+           new HttpException('Request content type is not supported.', 415),
           );
         }
         next();


### PR DESCRIPTION
## Because

- Graphql playground broke

## This pull request

- Only applies security headers when in prod and not development

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9101

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
