### PR TITLE
fix(settings): Add default text to several l10n.getString calls

### DIFF
--- a/packages/fxa-react/components/Footer/index.test.tsx
+++ b/packages/fxa-react/components/Footer/index.test.tsx
@@ -19,7 +19,7 @@ describe('Footer', () => {
     expect(linkMozilla.firstElementChild).toHaveAttribute('role', 'img');
     expect(linkMozilla.firstElementChild).toHaveAttribute(
       'aria-label',
-      'app-footer-mozilla-logo-label'
+      'Mozilla logo'
     );
     expect(screen.getByTestId('link-privacy')).toHaveAttribute(
       'href',

--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -19,7 +19,11 @@ export const Footer = () => {
         data-testid="link-mozilla"
       >
         <MozLogo
-          aria-label={l10n.getString('app-footer-mozilla-logo-label')}
+          aria-label={l10n.getString(
+            'app-footer-mozilla-logo-label',
+            null,
+            'Mozilla logo'
+          )}
           role="img"
           className="transition-standard w-18 h-auto opacity-75 hover:opacity-100"
         />

--- a/packages/fxa-react/components/Head/index.tsx
+++ b/packages/fxa-react/components/Head/index.tsx
@@ -12,7 +12,11 @@ const Head = ({ title }: { title?: string }) => {
     <Helmet>
       <title>
         {title
-          ? l10n.getString('app-page-title', { title })
+          ? l10n.getString(
+              'app-page-title',
+              { title },
+              `${title} | Firefox Accounts`
+            )
           : l10n.getString('app-default-title', null, 'Firefox Accounts')}
       </title>
     </Helmet>

--- a/packages/fxa-settings/src/components/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.test.tsx
@@ -11,13 +11,15 @@ describe('BentoMenu', () => {
     render(<BentoMenu />);
 
     const toggleButton = screen.getByTestId('drop-down-bento-menu-toggle');
-    const dropDownId = 'drop-down-bento-menu';
-    const dropDown = screen.queryByTestId(dropDownId);
+    const dropDown = screen.queryByTestId('drop-down-bento-menu');
 
-    expect(toggleButton).toHaveAttribute('title', 'bento-menu-title');
-    expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
+    expect(toggleButton).toHaveAttribute('title', 'Firefox Bento Menu');
+    expect(toggleButton).toHaveAttribute(
+      'aria-controls',
+      'drop-down-bento-menu'
+    );
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
 
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
@@ -25,7 +27,7 @@ describe('BentoMenu', () => {
 
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
   });
 
   it('closes on esc keypress', () => {
@@ -35,7 +37,7 @@ describe('BentoMenu', () => {
     fireEvent.click(screen.getByTestId('drop-down-bento-menu-toggle'));
     expect(dropDown).toBeInTheDocument;
     fireEvent.keyDown(window, { key: 'Escape' });
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
   });
 
   it('closes on click outside', () => {
@@ -51,6 +53,6 @@ describe('BentoMenu', () => {
     fireEvent.click(screen.getByTestId('drop-down-bento-menu-toggle'));
     expect(dropDown).toBeInTheDocument;
     fireEvent.click(container);
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/components/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.tsx
@@ -33,7 +33,7 @@ export const BentoMenu = () => {
       <button
         onClick={toggleRevealed}
         data-testid="drop-down-bento-menu-toggle"
-        title={l10n.getString('bento-menu-title')}
+        title={l10n.getString('bento-menu-title', null, 'Firefox Bento Menu')}
         aria-expanded={isRevealed}
         aria-controls={dropDownId}
         className="rounded p-1 w-7 mx-2 border-transparent hover:bg-grey-200 transition-standard desktop:mx-8"

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -54,7 +54,7 @@ describe('DropDownAvatarMenu', () => {
     const dropDownId = 'drop-down-avatar-menu';
     const dropDown = screen.queryByTestId(dropDownId);
 
-    expect(toggleButton).toHaveAttribute('title', 'drop-down-menu-title');
+    expect(toggleButton).toHaveAttribute('title', 'Firefox account menu');
     expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     expect(dropDown).not.toBeInTheDocument;

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -16,9 +16,8 @@ export const DropDownAvatarMenu = () => {
   const session = useSession();
   const [isRevealed, setRevealed] = useState(false);
   const toggleRevealed = () => setRevealed(!isRevealed);
-  const avatarMenuInsideRef = useClickOutsideEffect<HTMLDivElement>(
-    setRevealed
-  );
+  const avatarMenuInsideRef =
+    useClickOutsideEffect<HTMLDivElement>(setRevealed);
   useEscKeydownEffect(setRevealed);
   const alertBar = useAlertBar();
   const dropDownId = 'drop-down-avatar-menu';
@@ -31,7 +30,13 @@ export const DropDownAvatarMenu = () => {
         logViewEvent(settingsViewName, 'signout.success');
         window.location.assign(`${window.location.origin}/signin`);
       } catch (e) {
-        alertBar.error(l10n.getString('drop-down-menu-sign-out-error'));
+        alertBar.error(
+          l10n.getString(
+            'drop-down-menu-sign-out-error',
+            null,
+            'Sorry, there was a problem signing you out.'
+          )
+        );
       }
     }
   };
@@ -43,7 +48,11 @@ export const DropDownAvatarMenu = () => {
           type="button"
           onClick={toggleRevealed}
           data-testid="drop-down-avatar-menu-toggle"
-          title={l10n.getString('drop-down-menu-title')}
+          title={l10n.getString(
+            'drop-down-menu-title',
+            null,
+            'Firefox account menu'
+          )}
           aria-expanded={isRevealed}
           aria-controls={dropDownId}
           className="rounded-full border-2 border-transparent hover:border-purple-500 focus:border-purple-500 focus:outline-none active:border-purple-700 transition-standard"

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -32,7 +32,11 @@ const recoveryCodesPrintTemplate = (
 
 export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
   const { l10n } = useLocalization();
-  const pageTitle = l10n.getString('get-data-trio-title');
+  const pageTitle = l10n.getString(
+    'get-data-trio-title',
+    null,
+    'Recovery Codes'
+  );
   const print = useCallback(() => {
     const printWindow = window.open('', 'Print', 'height=600,width=800')!;
     printWindow.document.write(recoveryCodesPrintTemplate(value, pageTitle));

--- a/packages/fxa-settings/src/components/HeaderLockup/index.test.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.test.tsx
@@ -12,18 +12,24 @@ import HeaderLockup from '.';
 describe('HeaderLockup', () => {
   it('renders as expected', () => {
     render(<HeaderLockup />);
+    const headerHelp = screen.getByTestId('header-help');
+    const headerMenu = screen.getByTestId('header-menu');
 
     expect(screen.getByTestId('header-sumo-link')).toHaveAttribute(
       'href',
       'https://support.mozilla.org'
     );
-    expect(screen.getByTestId('header-help')).toBeInTheDocument();
+    expect(headerHelp).toBeInTheDocument();
+    expect(headerHelp).toHaveAttribute('title', 'Help');
+
     expect(
       screen.getByTestId('drop-down-bento-menu-toggle')
     ).toBeInTheDocument();
     expect(screen.getByTestId('avatar-nondefault')).toBeInTheDocument();
 
-    expect(screen.getByTestId('header-menu')).toBeInTheDocument();
+    expect(headerMenu).toBeInTheDocument();
+    expect(headerMenu).toHaveAttribute('title', 'Site navigation menu');
+
     expect(screen.getByTestId('back-to-top')).toHaveAttribute(
       'title',
       'Back to top'

--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -17,21 +17,18 @@ import Nav from '../Nav';
 export const HeaderLockup = () => {
   const [navRevealedState, setNavState] = useState(false);
   const { l10n } = useLocalization();
+  const localizedHelpText = l10n.getString('header-help', null, 'Help');
+  const localizedMenuText = navRevealedState
+    ? l10n.getString('header-menu-open', null, 'Close menu')
+    : l10n.getString('header-menu-closed', null, 'Site navigation menu');
+
   const left = (
     <>
       <button
         className="desktop:hidden ltr:mr-6 rtl:ml-6 w-8 h-6 self-center"
         data-testid="header-menu"
-        aria-label={
-          navRevealedState
-            ? l10n.getString('header-menu-open')
-            : l10n.getString('header-menu-closed')
-        }
-        title={
-          navRevealedState
-            ? l10n.getString('header-menu-open')
-            : l10n.getString('header-menu-closed')
-        }
+        aria-label={localizedMenuText}
+        title={localizedMenuText}
         aria-haspopup={true}
         aria-expanded={navRevealedState}
         onClick={() => setNavState(!navRevealedState)}
@@ -65,12 +62,12 @@ export const HeaderLockup = () => {
       <div className="rounded border-transparent hover:bg-grey-200 p-1">
         <LinkExternal
           href="https://support.mozilla.org"
-          title={l10n.getString('header-help')}
+          title={localizedHelpText}
           data-testid="header-sumo-link"
         >
           <Help
-            aria-label={l10n.getString('header-help')}
-            title={l10n.getString('header-help')}
+            aria-label={localizedHelpText}
+            title={localizedHelpText}
             role="img"
             className="w-5"
             data-testid="header-help"

--- a/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
@@ -37,7 +37,13 @@ export const RemovePhotoBtn = () => {
       await account.deleteAvatar();
       navigate(HomePath, { replace: true });
     } catch (err) {
-      alertBar.error(l10n.getString('avatar-page-delete-error-2'));
+      alertBar.error(
+        l10n.getString(
+          'avatar-page-delete-error-2',
+          null,
+          'There was a problem deleting your profile picture.'
+        )
+      );
     }
   }, [account, navigate, alertBar, l10n]);
 
@@ -128,13 +134,13 @@ export const AddPhotoBtn = ({
 type ConfirmBtnsProps = {
   onSave: VoidFunction;
   saveEnabled: boolean;
-  saveStringId?: string;
+  localizedSaveText: string;
 };
 
 export const ConfirmBtns = ({
   onSave,
   saveEnabled,
-  saveStringId = 'avatar-page-save-button',
+  localizedSaveText,
 }: ConfirmBtnsProps) => {
   const navigate = useNavigate();
 
@@ -149,14 +155,14 @@ export const ConfirmBtns = ({
           Cancel
         </button>
       </Localized>
-      <Localized id={saveStringId}>
-        <button
-          className="cta-primary mx-2 px-10 w-full max-w-32"
-          onClick={onSave}
-          disabled={!saveEnabled}
-          data-testid="save-button"
-        ></button>
-      </Localized>
+      <button
+        className="cta-primary mx-2 px-10 w-full max-w-32"
+        onClick={onSave}
+        disabled={!saveEnabled}
+        data-testid="save-button"
+      >
+        {localizedSaveText}
+      </button>
     </div>
   );
 };

--- a/packages/fxa-settings/src/components/PageAvatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.test.tsx
@@ -55,6 +55,8 @@ it('PageAddAvatar | render add, take buttons on initial load', async () => {
       <PageAvatar />
     </AppContext.Provider>
   );
+
+  screen.getByText('Save');
   expect(screen.getByTestId('add-photo-btn')).toBeInTheDocument();
   expect(screen.getByTestId('take-photo-btn')).toBeInTheDocument();
 });
@@ -78,7 +80,11 @@ it('PageAddAvatar | renders ConfirmBtns and calls onsave correctly', async () =>
   const onSave = jest.fn();
   renderWithRouter(
     <AppContext.Provider value={mockAppContext({ account })}>
-      <ConfirmBtns onSave={onSave} saveEnabled={true} />
+      <ConfirmBtns
+        onSave={onSave}
+        saveEnabled={true}
+        localizedSaveText="Save"
+      />
     </AppContext.Provider>
   );
 
@@ -96,7 +102,11 @@ it('PageAddAvatar | renders ConfirmBtns with save button disabled when "enabled"
   const onSave = jest.fn();
   renderWithRouter(
     <AppContext.Provider value={mockAppContext({ account })}>
-      <ConfirmBtns onSave={onSave} saveEnabled={false} />
+      <ConfirmBtns
+        onSave={onSave}
+        saveEnabled={false}
+        localizedSaveText="Save"
+      />
     </AppContext.Provider>
   );
 

--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -46,13 +46,29 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
   const { avatar } = useAccount();
   const alertBar = useAlertBar();
   const [saveEnabled, setSaveEnabled] = useState(false);
-  const [saveStringId, setSaveStringId] = useState('avatar-page-save-button');
+
+  const [localizedSaveText, setLocalizedSaveText] = useState(
+    l10n.getString('avatar-page-save-button', null, 'Save')
+  );
+
   const onFileError = useCallback(() => {
-    alertBar.error(l10n.getString('avatar-page-file-upload-error-2'));
+    alertBar.error(
+      l10n.getString(
+        'avatar-page-file-upload-error-2',
+        null,
+        'There was a problem uploading your profile picture.'
+      )
+    );
   }, [alertBar, l10n]);
 
   const onMediaError = useCallback(() => {
-    alertBar.error(l10n.getString('avatar-page-camera-error'));
+    alertBar.error(
+      l10n.getString(
+        'avatar-page-camera-error',
+        null,
+        'Could not initialize camera'
+      )
+    );
   }, [alertBar, l10n]);
 
   const uploadAvatar = useCallback(
@@ -162,10 +178,18 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
     setSaveEnabled(false);
     const img = croppedImgSrc || (await saveCroppedImage());
     if (img && img.size > PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE) {
-      alertBar.error(l10n.getString('avatar-page-image-too-large-error'));
+      alertBar.error(
+        l10n.getString(
+          'avatar-page-image-too-large-error',
+          null,
+          'The image file size is too large to be uploaded.'
+        )
+      );
       resetAllState();
     } else if (img) {
-      setSaveStringId('avatar-page-saving-button');
+      setLocalizedSaveText(
+        l10n.getString('avatar-page-saving-button', null, 'Saving…')
+      );
       uploadAvatar(img);
     }
   }, [
@@ -174,7 +198,7 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
     l10n,
     saveCroppedImage,
     setSaveEnabled,
-    setSaveStringId,
+    setLocalizedSaveText,
     uploadAvatar,
     resetAllState,
   ]);
@@ -184,7 +208,7 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
     <ConfirmBtns
       onSave={save}
       saveEnabled={!capturing && saveEnabled}
-      saveStringId={saveStringId}
+      {...{ localizedSaveText }}
     />
   );
 

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -43,7 +43,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const [errorText, setErrorText] = useState<string>();
   const [confirmed, setConfirmed] = useState<boolean>(false);
   const [subtitleText, setSubtitleText] = useState<string>(
-    l10n.getString('delete-account-step-1-2')
+    l10n.getString('delete-account-step-1-2', null, 'Step 1 of 2')
   );
   const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
   const allBoxesChecked = checkboxLabels.every((element) =>
@@ -56,7 +56,9 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const account = useAccount();
 
   const advanceStep = () => {
-    setSubtitleText(l10n.getString('delete-account-step-2-2'));
+    setSubtitleText(
+      l10n.getString('delete-account-step-2-2', null, 'Step 2 of 2')
+    );
     setConfirmed(true);
 
     logViewEvent('flow.settings.account-delete', 'terms-checked.success');

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -34,7 +34,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
   const [errorText, setErrorText] = useState<string>();
   const { l10n } = useLocalization();
   const [subtitleText, setSubtitleText] = useState<string>(
-    l10n.getString('recovery-key-step-1')
+    l10n.getString('recovery-key-step-1', null, 'Step 1 of 2')
   );
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>();
   const navigate = useNavigate();
@@ -61,7 +61,9 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
             .match(/.{4}/g)!
             .join(' ')
         );
-        setSubtitleText(l10n.getString('recovery-key-step-2'));
+        setSubtitleText(
+          l10n.getString('recovery-key-step-2', null, 'Step 2 of 2')
+        );
         logViewEvent(
           'flow.settings.account-recovery',
           'confirm-password.success'

--- a/packages/fxa-settings/src/components/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Security/index.test.tsx
@@ -27,8 +27,8 @@ describe('Security', () => {
       </AppContext.Provider>
     );
 
-    expect(await screen.findByText('rk-header')).toBeTruthy;
-    expect(await screen.findByText('tfa-row-header')).toBeTruthy;
+    expect(await screen.findByText('Recovery key')).toBeTruthy();
+    expect(await screen.findByText('Two-step authentication')).toBeTruthy();
 
     const result = await screen.findAllByText('Not Set');
     expect(result).toHaveLength(2);

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
@@ -30,13 +30,17 @@ describe('UnitRowRecoveryKey', () => {
     );
     expect(
       screen.getByTestId('recovery-key-unit-row-header').textContent
-    ).toContain('rk-header');
+    ).toContain('Recovery key');
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
     ).toContain('Enabled');
     expect(
       screen.getByTestId('recovery-key-unit-row-modal').textContent
     ).toContain('Remove');
+    expect(screen.getByTestId('recovery-key-refresh')).toHaveAttribute(
+      'title',
+      'Refresh recovery key'
+    );
   });
 
   it('renders when recovery key is not set', () => {
@@ -51,7 +55,7 @@ describe('UnitRowRecoveryKey', () => {
     );
     expect(
       screen.getByTestId('recovery-key-unit-row-header').textContent
-    ).toContain('rk-header');
+    ).toContain('Recovery key');
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
     ).toContain('Not Set');

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -31,14 +31,26 @@ export const UnitRowRecoveryKey = () => {
       logViewEvent('flow.settings.account-recovery', 'confirm-revoke.success');
     } catch (e) {
       hideModal();
-      alertBar.error(l10n.getString('rk-remove-error'));
+      alertBar.error(
+        l10n.getString(
+          'rk-remove-error',
+          null,
+          'Your account recovery key could not be removed.'
+        )
+      );
       logViewEvent('flow.settings.account-recovery', 'confirm-revoke.fail');
     }
   }, [account, hideModal, alertBar, l10n]);
 
+  const localizedRefreshRkText = l10n.getString(
+    'rk-refresh-key',
+    null,
+    'Refresh recovery key'
+  );
+
   return (
     <UnitRow
-      header={l10n.getString('rk-header')}
+      header={l10n.getString('rk-header', null, 'Recovery key')}
       headerId="recovery-key"
       prefixDataTestId="recovery-key"
       headerValueClassName={recoveryKey ? 'text-green-800' : ''}
@@ -63,7 +75,7 @@ export const UnitRowRecoveryKey = () => {
       alertBarRevealed
       headerContent={
         <ButtonIconReload
-          title={l10n.getString('rk-refresh-key')}
+          title={localizedRefreshRkText}
           classNames="mobileLandscape:hidden ltr:ml-1 rtl:mr-1"
           disabled={account.loading}
           onClick={() => account.refresh('recovery')}
@@ -71,7 +83,7 @@ export const UnitRowRecoveryKey = () => {
       }
       actionContent={
         <ButtonIconReload
-          title={l10n.getString('rk-refresh-key')}
+          title={localizedRefreshRkText}
           classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
           testId="recovery-key-refresh"
           disabled={account.loading || !account.hasPassword}

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
@@ -24,7 +24,7 @@ describe('UnitRowTwoStepAuth', () => {
     );
     expect(
       screen.getByTestId('two-step-unit-row-header').textContent
-    ).toContain('tfa-row-header');
+    ).toContain('Two-step authentication');
     expect(
       screen.getByTestId('two-step-unit-row-header-value').textContent
     ).toContain('Enabled');
@@ -61,7 +61,7 @@ describe('UnitRowTwoStepAuth', () => {
     );
     expect(
       screen.getByTestId('two-step-unit-row-header').textContent
-    ).toContain('tfa-row-header');
+    ).toContain('Two-step authentication');
     expect(
       screen.getByTestId('two-step-unit-row-header-value').textContent
     ).toContain('Not Set');

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -78,7 +78,7 @@ export const UnitRowTwoStepAuth = () => {
 
   return (
     <UnitRow
-      header={l10n.getString('tfa-row-header')}
+      header={l10n.getString('tfa-row-header', null, 'Two-step authentication')}
       headerId="two-step-authentication"
       prefixDataTestId="two-step"
       route={route}


### PR DESCRIPTION
Because:
* We must provide fallback text when pulling strings from Fluent since at the moment, we don't deploy en/en-US strings and rely on fallback text

This commit:
* Adds the default text to several l10n.getString calls, updates some tests

fixes #12857
fixes #12858
fixes #12859

---

I started adding tests for all of these and then realized we were missing quite a few and some tests might take a bit longer to write. If you see something in particular feel free to call it out.

At the time of writing, without further investigation I don't know why these ever rendered correctly, we've been relying on fallback text for English for all of our strings and we even had tests to check for FTL IDs rendered rather than the English text. 

This makes me eager to work on [this spike](https://mozilla-hub.atlassian.net/browse/FXA-4477), I think there's some l10n improvements we can make all around.