### PR TITLE
chore(storybook) fix broken Security story, add LinkedAccounts to pag…

### DIFF
--- a/packages/fxa-settings/src/components/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.stories.tsx
@@ -8,17 +8,30 @@ import { mockSession } from '../../models/mocks';
 import { getDefault } from '../../lib/config';
 import { Nav } from '.';
 import { AppContext } from 'fxa-settings/src/models';
+import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 
 const account = {
   primaryEmail: {
     email: 'johndope@example.com',
   },
   subscriptions: [{ created: 1, productName: 'x' }],
+  linkedAccounts: [],
 } as any;
+const accountWithLinkedAccounts = Object.assign({}, account, {
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+});
+
 storiesOf('Components/Nav', module)
   .add('basic', () => <Nav />)
   .add('with link to Subscriptions', () => (
     <AppContext.Provider value={{ account, session: mockSession() }}>
+      <Nav />
+    </AppContext.Provider>
+  ))
+  .add('with linked accounts', () => (
+    <AppContext.Provider
+      value={{ account: accountWithLinkedAccounts, session: mockSession() }}
+    >
       <Nav />
     </AppContext.Provider>
   ))

--- a/packages/fxa-settings/src/components/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.tsx
@@ -113,7 +113,7 @@ export const Nav = () => {
         )}
 
         {marketingCommPrefLink && (
-          <li>
+          <li className="mb-5">
             <LinkExternal
               className="font-bold"
               data-testid="nav-link-newsletters"
@@ -121,7 +121,7 @@ export const Nav = () => {
             >
               <Localized id="nav-email-comm">Email Communications</Localized>
               <OpenExternal
-                className="inline-block w-3 h-3 ltr:ml-1 rtl:mr-1 transform rtl:-scale-x-1"
+                className="inline-block w-3 h-3 ml-1"
                 aria-hidden="true"
               />
             </LinkExternal>

--- a/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
@@ -11,6 +11,7 @@ import { isMobileDevice } from '../../lib/utilities';
 import { mockAppContext, mockEmail, MOCK_ACCOUNT } from '../../models/mocks';
 import { MOCK_SERVICES } from '../ConnectedServices/mocks';
 import { AppContext } from 'fxa-settings/src/models';
+import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 
 const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
@@ -26,6 +27,7 @@ storiesOf('Pages/Settings', module)
           recoveryKey: false,
           totp: { exists: false, verified: false },
           attachedClients: SERVICES_NON_MOBILE,
+          linkedAccounts: MOCK_LINKED_ACCOUNTS,
         } as any,
       })}
     >
@@ -42,6 +44,7 @@ storiesOf('Pages/Settings', module)
           displayName: null,
           totp: { exists: true, verified: false },
           attachedClients: SERVICES_NON_MOBILE,
+          linkedAccounts: MOCK_LINKED_ACCOUNTS,
         } as any,
       })}
     >
@@ -62,6 +65,7 @@ storiesOf('Pages/Settings', module)
             mockEmail('johndope2@gmail.com', false),
           ],
           attachedClients: SERVICES_NON_MOBILE,
+          linkedAccounts: MOCK_LINKED_ACCOUNTS,
         } as any,
       })}
     >

--- a/packages/fxa-settings/src/components/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Security/index.stories.tsx
@@ -14,7 +14,11 @@ storiesOf('Components/Security', module)
   .add('default', () => (
     <AppContext.Provider
       value={mockAppContext({
-        account: { recoveryKey: false, totp: { exists: false } } as any,
+        account: {
+          recoveryKey: false,
+          passwordCreated: Date.now(),
+          totp: { exists: false },
+        } as any,
       })}
     >
       <Security />
@@ -25,6 +29,7 @@ storiesOf('Components/Security', module)
       value={mockAppContext({
         account: {
           recoveryKey: true,
+          passwordCreated: Date.now(),
           totp: { verified: true, exists: true },
         } as any,
       })}

--- a/packages/fxa-settings/src/components/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Security/index.test.tsx
@@ -27,8 +27,8 @@ describe('Security', () => {
       </AppContext.Provider>
     );
 
-    expect(await screen.findByText('rk-header')).toBeTruthy;
-    expect(await screen.findByText('tfa-row-header')).toBeTruthy;
+    expect(await screen.findByText('Recovery key')).toBeTruthy;
+    expect(await screen.findByText('Two-step authentication')).toBeTruthy;
 
     const result = await screen.findAllByText('Not Set');
     expect(result).toHaveLength(2);

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
@@ -30,7 +30,7 @@ describe('UnitRowRecoveryKey', () => {
     );
     expect(
       screen.getByTestId('recovery-key-unit-row-header').textContent
-    ).toContain('rk-header');
+    ).toContain('Recovery key');
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
     ).toContain('Enabled');
@@ -51,7 +51,7 @@ describe('UnitRowRecoveryKey', () => {
     );
     expect(
       screen.getByTestId('recovery-key-unit-row-header').textContent
-    ).toContain('rk-header');
+    ).toContain('Recovery key');
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
     ).toContain('Not Set');

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -38,7 +38,7 @@ export const UnitRowRecoveryKey = () => {
 
   return (
     <UnitRow
-      header={l10n.getString('rk-header')}
+      header={l10n.getString('rk-header', null, 'Recovery key')}
       headerId="recovery-key"
       prefixDataTestId="recovery-key"
       headerValueClassName={recoveryKey ? 'text-green-800' : ''}

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -78,7 +78,7 @@ export const UnitRowTwoStepAuth = () => {
 
   return (
     <UnitRow
-      header={l10n.getString('tfa-row-header')}
+      header={l10n.getString('tfa-row-header', null, 'Two-step authentication')}
       headerId="two-step-authentication"
       prefixDataTestId="two-step"
       route={route}


### PR DESCRIPTION
…e settings

fix(storybook) add fallback values for l10n strings

chore(storybook) add examples with linked accounts

fix(storybook) fix incorrect padding in storybook

## Because

- Addresses a few things in storybook that did not match either production or development (or were missing) 
1. Missing default translations resulted in the l10n key showing instead of a translation.
2. Some of the padding didn't match what we would expect (did not align with prod/staging/local.)
3. We didn't have an example of a profile that has linked accounts

## This pull request

- We add the correct fallback/default strings for the elements. 
- The padding didn't match because storybook doesn't give components a value for ltr/rtl, so all rtl/ltr styles are dropped. There are addons for storybook that can offer us this, but we'll have to go through/determine what's safe. Generally speaking however, we don't need those rtl/ltr styles on this page, because the page largely remains the same in these instances.
- We add in examples of a profile with linked accounts.

## Issue that this pull request solves

Closes: #12848 

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
