### PR TITLE
 fix(admin-panel): Fix remote group resolution

### DIFF
--- a/packages/fxa-admin-panel/interfaces/index.ts
+++ b/packages/fxa-admin-panel/interfaces/index.ts
@@ -4,7 +4,7 @@
 
 import { IncomingHttpHeaders } from 'http';
 import { USER_EMAIL_HEADER, USER_GROUP_HEADER } from '../constants';
-import { IGroup } from 'fxa-shared/guards';
+import { AdminPanelGuard, IGroup } from 'fxa-shared/guards';
 
 export interface IUserInfo {
   group: IGroup;
@@ -17,6 +17,7 @@ export interface IServerInfo {
 
 export interface IClientConfig {
   env: string;
+  guard: AdminPanelGuard;
   user: IUserInfo;
   servers: {
     admin: IServerInfo;

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -5,6 +5,7 @@
 import convict from 'convict';
 import fs from 'fs';
 import path from 'path';
+import { GuardConfig } from 'fxa-shared/guards';
 
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
@@ -179,6 +180,7 @@ const conf = convict({
       format: String,
     },
   },
+  ...GuardConfig,
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-admin-panel/server/lib/client-config/index.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.ts
@@ -12,12 +12,15 @@ import {
   USER_GROUP_HEADER,
   SERVER_CONFIG_PLACEHOLDER,
 } from '../../../constants';
-import { guard } from 'fxa-shared/guards';
+import { AdminPanelGuard } from 'fxa-shared/guards';
 import log from '../logging';
+
+const guard = new AdminPanelGuard(config.get('guard.env'));
 
 /** Client Config Defaults provided by env */
 const defaultConfig: IClientConfig = {
   env: config.get('env'),
+  guard,
   user: {
     group: guard.getBestGroup(config.get('user.group')),
     email: config.get('user.email'),

--- a/packages/fxa-admin-panel/src/App.test.tsx
+++ b/packages/fxa-admin-panel/src/App.test.tsx
@@ -6,10 +6,16 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 import { mockConfigBuilder } from './lib/config';
-import { AdminPanelGroup, guard } from 'fxa-shared/guards';
+import {
+  AdminPanelEnv,
+  AdminPanelGroup,
+  AdminPanelGuard,
+} from 'fxa-shared/guards';
 
 it('renders without imploding', () => {
+  const guard = new AdminPanelGuard(AdminPanelEnv.Prod);
   const config = mockConfigBuilder({
+    guard,
     user: {
       email: 'hello@mozilla.com',
       group: guard.getGroup(AdminPanelGroup.SupportAgentProd),

--- a/packages/fxa-admin-panel/src/App.tsx
+++ b/packages/fxa-admin-panel/src/App.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from 'react';
 import { UserContext } from './hooks/UserContext';
+import { GuardContext } from './hooks/GuardContext';
 import { Route, Routes, BrowserRouter, Navigate } from 'react-router-dom';
 import AppLayout from './components/AppLayout';
 import AccountSearch from './components/AccountSearch';
@@ -11,31 +12,34 @@ import Permissions from './components/Permissions';
 import AdminLogs from './components/AdminLogs';
 import SiteStatus from './components/SiteStatus';
 import { IClientConfig, IUserInfo } from '../interfaces';
-import { AdminPanelFeature, guard } from 'fxa-shared/guards';
+import { AdminPanelFeature, AdminPanelGuard } from 'fxa-shared/guards';
 
 const App = ({ config }: { config: IClientConfig }) => {
+  const [guard, setGuard] = useState<AdminPanelGuard>(config.guard);
   const [user, setUser] = useState<IUserInfo>(config.user);
   return (
     <BrowserRouter>
-      <UserContext.Provider value={{ user, setUser }}>
-        <AppLayout>
-          <Routes>
-            {guard.allow(AdminPanelFeature.AccountLogs, user.group) && (
-              <Route path="/admin-logs" element={<AdminLogs />} />
-            )}
-            {guard.allow(AdminPanelFeature.SiteStatus, user.group) && (
-              <Route path="/site-status" element={<SiteStatus />} />
-            )}
-            {guard.allow(AdminPanelFeature.AccountSearch, user.group) && (
-              <Route path="/account-search" element={<AccountSearch />} />
-            )}
-            {guard.allow(AdminPanelFeature.AccountSearch, user.group) && (
-              <Route path="/" element={<Navigate to="/account-search" />} />
-            )}
-            <Route path="/permissions" element={<Permissions />} />
-          </Routes>
-        </AppLayout>
-      </UserContext.Provider>
+      <GuardContext.Provider value={{ guard, setGuard }}>
+        <UserContext.Provider value={{ user, setUser }}>
+          <AppLayout>
+            <Routes>
+              {guard.allow(AdminPanelFeature.AccountLogs, user.group) && (
+                <Route path="/admin-logs" element={<AdminLogs />} />
+              )}
+              {guard.allow(AdminPanelFeature.SiteStatus, user.group) && (
+                <Route path="/site-status" element={<SiteStatus />} />
+              )}
+              {guard.allow(AdminPanelFeature.AccountSearch, user.group) && (
+                <Route path="/account-search" element={<AccountSearch />} />
+              )}
+              {guard.allow(AdminPanelFeature.AccountSearch, user.group) && (
+                <Route path="/" element={<Navigate to="/account-search" />} />
+              )}
+              <Route path="/permissions" element={<Permissions />} />
+            </Routes>
+          </AppLayout>
+        </UserContext.Provider>
+      </GuardContext.Provider>
     </BrowserRouter>
   );
 };

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -5,20 +5,28 @@
 import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { Account, AccountProps } from './index';
-import { AdminPanelGroup, guard } from 'fxa-shared/guards';
+import {
+  AdminPanelEnv,
+  AdminPanelGroup,
+  AdminPanelGuard,
+} from 'fxa-shared/guards';
 import { IClientConfig } from '../../../../interfaces';
 import { mockConfigBuilder } from '../../../lib/config';
+
+const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
 
 export const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',
-    group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
+    group: mockGroup,
   },
 });
 
 jest.mock('../../../hooks/UserContext.ts', () => ({
   useUserContext: () => {
     const ctx = {
+      guard: mockGuard,
       user: mockConfig.user,
       setUser: () => {},
     };

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Subscription/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Subscription/index.test.tsx
@@ -26,7 +26,12 @@ it('renders each field as expected', () => {
 
   screen.getByText(subscription.productName);
   screen.getByText(subscription.status);
-  expect(screen.getAllByText('1970-01-19 @', { exact: false })).toHaveLength(4);
+
+  // The date is rendered based on user local time. So depending on the user's clock
+  // the date could land on the 18th or the 19th.
+  expect(screen.getAllByText(/1970-01-1[89] @/, { exact: false })).toHaveLength(
+    4
+  );
   screen.getByText('No');
 
   screen.getByText(subscription.subscriptionId);

--- a/packages/fxa-admin-panel/src/components/Guard/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Guard/index.test.tsx
@@ -6,19 +6,28 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { IClientConfig } from '../../../interfaces';
 import { Guard } from './index';
-import { AdminPanelFeature, AdminPanelGroup, guard } from 'fxa-shared/guards';
+import {
+  AdminPanelEnv,
+  AdminPanelFeature,
+  AdminPanelGroup,
+  AdminPanelGuard,
+} from 'fxa-shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
+
+const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
 
 export const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',
-    group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
+    group: mockGroup,
   },
 });
 
 jest.mock('../../hooks/UserContext.ts', () => ({
   useUserContext: () => {
     const ctx = {
+      guard: mockGuard,
       user: mockConfig.user,
       setUser: () => {},
     };

--- a/packages/fxa-admin-panel/src/components/Guard/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Guard/index.tsx
@@ -4,7 +4,8 @@
 
 import React from 'react';
 import { useUserContext } from '../../hooks/UserContext';
-import { AdminPanelFeature, guard } from 'fxa-shared/guards';
+import { AdminPanelFeature } from 'fxa-shared/guards';
+import { useGuardContext } from '../../hooks/GuardContext';
 
 export type GuardProps = {
   features: AdminPanelFeature[];
@@ -12,6 +13,8 @@ export type GuardProps = {
 
 export const Guard: React.FC<GuardProps> = ({ features, children }) => {
   const { user } = useUserContext();
+  const { guard } = useGuardContext();
+
   return features.some((x) => guard.allow(x, user.group)) ? (
     <>{children}</>
   ) : (

--- a/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.test.tsx
@@ -6,19 +6,27 @@ import React from 'react';
 import { render, RenderResult } from '@testing-library/react';
 import { IClientConfig } from '../../../interfaces';
 import { Permissions } from './index';
-import { AdminPanelGroup, guard } from 'fxa-shared/guards';
+import {
+  AdminPanelEnv,
+  AdminPanelGroup,
+  AdminPanelGuard,
+} from 'fxa-shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
+
+const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
 
 export const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',
-    group: guard.getGroup(AdminPanelGroup.SupportAgentProd),
+    group: mockGroup,
   },
 });
 
 jest.mock('../../hooks/UserContext.ts', () => ({
   useUserContext: () => {
     const ctx = {
+      guard: mockGuard,
       user: mockConfig.user,
       setUser: () => {},
     };
@@ -50,7 +58,7 @@ describe('Permissions', () => {
   });
 
   it('has enabled feature', () => {
-    const enabledFeature = guard
+    const enabledFeature = mockGuard
       .getFeatureFlags(mockConfig.user.group)
       .find((x) => x.enabled);
 
@@ -64,7 +72,7 @@ describe('Permissions', () => {
   });
 
   it('has disabled feature', () => {
-    const disabledFeature = guard
+    const disabledFeature = mockGuard
       .getFeatureFlags(mockConfig.user.group)
       .find((x) => !x.enabled);
 

--- a/packages/fxa-admin-panel/src/components/Permissions/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Permissions/index.tsx
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { guard, IFeatureFlag } from 'fxa-shared/guards';
+import { IFeatureFlag } from 'fxa-shared/guards';
 import { useUserContext } from '../../hooks/UserContext';
+import { useGuardContext } from '../../hooks/GuardContext';
 
 const styleClasses = {
   label: 'px-4 py-2',
@@ -69,6 +70,8 @@ export const PermissionsTable = ({
 
 export const Permissions = () => {
   const { user } = useUserContext();
+  const { guard } = useGuardContext();
+
   const featureFlags: IFeatureFlag[] = guard.getFeatureFlags(user.group);
 
   return (

--- a/packages/fxa-admin-panel/src/hooks/GuardContext.ts
+++ b/packages/fxa-admin-panel/src/hooks/GuardContext.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createContext, useContext } from 'react';
+import { AdminPanelGuard } from 'fxa-shared/guards';
+
+export interface IGuardContext {
+  guard: AdminPanelGuard;
+  setGuard: (guard: AdminPanelGuard) => void;
+}
+
+let _guard = new AdminPanelGuard();
+export const GuardContext = createContext<IGuardContext>({
+  guard: _guard,
+  setGuard: (guard: AdminPanelGuard) => {
+    _guard = guard;
+  },
+});
+
+export const useGuardContext = () => useContext(GuardContext);

--- a/packages/fxa-admin-panel/src/lib/config.ts
+++ b/packages/fxa-admin-panel/src/lib/config.ts
@@ -1,6 +1,11 @@
 // This configuration is a subset of the configuration declared in server/config/index.ts
 
-import { AdminPanelGroup, guard, PermissionLevel } from 'fxa-shared/guards';
+import {
+  AdminPanelGuard,
+  unknownGroup,
+  USER_EMAIL_HEADER,
+  USER_GROUP_HEADER,
+} from 'fxa-shared/guards';
 import { SERVER_CONFIG_PLACEHOLDER } from '../../constants';
 import { IClientConfig } from '../../interfaces';
 
@@ -9,14 +14,19 @@ export const config: IClientConfig = defaultConfig();
 export function defaultUser() {
   return {
     email: 'hello@mozilla.com',
-    group: guard.getGroup(AdminPanelGroup.None),
+    group: unknownGroup,
   };
+}
+
+export function defaultGuard() {
+  return new AdminPanelGuard();
 }
 
 export function defaultConfig(): IClientConfig {
   return {
     env: 'development',
     user: defaultUser(),
+    guard: defaultGuard(),
     servers: {
       admin: {
         url: '',
@@ -34,11 +44,11 @@ export function getExtraHeaders(config: IClientConfig) {
 
   if (process.env.NODE_ENV === 'development') {
     if (config.user.email) {
-      headers['oidc-claim-id-token-email'] = config.user.email;
+      headers[USER_EMAIL_HEADER] = config.user.email;
     }
 
     if (config.user.group) {
-      headers['REMOTE-GROUP'] = config.user.group.header;
+      headers[USER_GROUP_HEADER] = config.user.group.header;
     }
   }
   return headers;

--- a/packages/fxa-admin-server/README.md
+++ b/packages/fxa-admin-server/README.md
@@ -8,12 +8,12 @@ The [GraphQL playground](https://www.apollographql.com/docs/apollo-server/testin
 
 The playground requires an `oidc-claim-id-token-email` authorization header. In production this is supplied through an nginx header after LDAP credentials, which have been verified but in development, a dummy email should be supplied in the bottom left-hand corner of the GQL playground labeled "HTTP Headers":
 
-In addition a `REMOTE-GROUP` header must also be set to indicate the user's LDAP group membership. Again, in production this will be set by nginx, but in development, a dummy value must be supplied.
+In addition a `remote-groups` header must also be set to indicate the user's LDAP group membership. Again, in production this will be set by nginx, but in development, a dummy value must be supplied.
 
 ```
 {
   "oidc-claim-id-token-email": "hello@mozilla.com",
-  "REMOTE-GROUP": "vpn_fxa_admin_panel_prod"
+  "remote-groups": "vpn_fxa_admin_panel_prod"
 }
 ```
 
@@ -28,11 +28,11 @@ Hit the "play" button and the schema and docs will populate.
 
 ## Limiting Access With Remote Groups
 
-The `REMOTE-GROUP` header will ultimately limit access to certain data in the graphql schema. This is controlled via a nestjs guard. The guard is applied by tagging methods in our resolvers with an `@feature(AdminPanelFeature.$FEATURE_NAME)`. Once this is applied, access is restricted based on the feature’s configuration.
+The `remote-groups` header will ultimately limit access to certain data in the graphql schema. This is controlled via a nestjs guard. The guard is applied by tagging methods in our resolvers with an `@feature(AdminPanelFeature.$FEATURE_NAME)`. Once this is applied, access is restricted based on the feature’s configuration.
 
 The underlying configuration for features is shared between the admin-panel and the admin-server and therefore resides in `fxa-shared/guard/AdminPanelGuard`. Currently these permissions are hardcoded since there is no compelling reason for them to change.
 
-During development a remote-group with admin permissions is typically used so that all parts of the graphql schema are accessible. However, it might still be useful to test with a remote group with fewer permissions. This can be accomplished by simply using a different `REMOTE-GROUP` header value.
+During development a remote-group with admin permissions is typically used so that all parts of the graphql schema are accessible. However, it might still be useful to test with a remote group with fewer permissions. This can be accomplished by simply using a different `remote-groups` header value.
 
 If access is insufficient an error field will be returned indicating insufficient permissions. It is important to note that because access is restricted at the field level, there is a possibility a graphql query can partially succeed. In this case, the fields that are accessible will still be returned, but there will also be an error field in the response indicating what part of the query could not be fulfilled.
 

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
@@ -5,9 +5,16 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { USER_GROUP_HEADER, guard, AdminPanelFeature } from 'fxa-shared/guards';
+import {
+  USER_GROUP_HEADER,
+  AdminPanelFeature,
+  AdminPanelGuard,
+} from 'fxa-shared/guards';
 import { FEATURE_KEY } from './user-group-header.decorator';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import config from '../config';
+
+const guard = new AdminPanelGuard(config.get('guard.env'));
 
 @Injectable()
 export class UserGroupGuard implements CanActivate {
@@ -38,6 +45,7 @@ export class UserGroupGuard implements CanActivate {
     this.log?.info('userGroupHeader', { userGroupHeader });
 
     const group = guard.getBestGroup(userGroupHeader);
-    return features.some((x) => guard.allow(x, group));
+    const allowed = features.some((x) => guard.allow(x, group));
+    return allowed;
   }
 }

--- a/packages/fxa-admin-server/src/config.ts
+++ b/packages/fxa-admin-server/src/config.ts
@@ -4,6 +4,7 @@
 import convict from 'convict';
 import fs from 'fs';
 import { makeMySQLConfig, makeRedisConfig } from 'fxa-shared/db/config';
+import { GuardConfig, USER_EMAIL_HEADER } from 'fxa-shared/guards';
 import path from 'path';
 
 convict.addFormats(require('convict-format-with-moment'));
@@ -11,7 +12,7 @@ convict.addFormats(require('convict-format-with-validator'));
 
 const conf = convict({
   authHeader: {
-    default: 'oidc-claim-id-token-email',
+    default: USER_EMAIL_HEADER,
     doc: 'Authentication header that should be logged for the user',
     env: 'AUTH_HEADER',
     format: String,
@@ -159,6 +160,7 @@ const conf = convict({
     default: 'changeme',
     env: 'IP_HMAC_KEY',
   },
+  ...GuardConfig,
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-shared/test/guard/AdminPanelGuard.ts
+++ b/packages/fxa-shared/test/guard/AdminPanelGuard.ts
@@ -3,18 +3,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  guard,
+  AdminPanelEnv,
   AdminPanelFeature,
   AdminPanelGroup,
+  AdminPanelGuard,
+  getGroupsByEnv,
   PermissionLevel,
 } from '../../guards';
 import { expect } from 'chai';
 
 describe('support agents', () => {
   describe('Admin Panel Guard', () => {
+    const guard = new AdminPanelGuard();
+    const stageGuard = new AdminPanelGuard(AdminPanelEnv.Stage);
+    const prodGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+
     it('allows', () => {
       expect(
         guard.allow(AdminPanelFeature.DisableAccount, AdminPanelGroup.AdminProd)
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.DisableAccount,
+          AdminPanelGroup.AdminStage
+        )
+      ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.DisableAccount,
+          AdminPanelGroup.AdminProd
+        )
       ).true;
     });
 
@@ -23,22 +41,82 @@ describe('support agents', () => {
         name: 'Admin',
         header: 'vpn_fxa_admin_panel_prod',
         level: PermissionLevel.Admin,
+        env: AdminPanelEnv.Prod,
       });
       expect(guard.getGroup(AdminPanelGroup.AdminStage)).deep.equal({
         name: 'Admin',
         header: 'vpn_fxa_admin_panel_stage',
         level: PermissionLevel.Admin,
+        env: AdminPanelEnv.Stage,
       });
       expect(guard.getGroup(AdminPanelGroup.SupportAgentProd)).deep.equal({
         name: 'Support',
         header: 'vpn_fxa_supportagent_prod',
         level: PermissionLevel.Support,
+        env: AdminPanelEnv.Prod,
       });
       expect(guard.getGroup(AdminPanelGroup.SupportAgentStage)).deep.equal({
         name: 'Support',
         header: 'vpn_fxa_supportagent_stage',
         level: PermissionLevel.Support,
+        env: AdminPanelEnv.Stage,
       });
+    });
+
+    it('looks up best group', () => {
+      expect(
+        guard.getBestGroup(
+          `${AdminPanelGroup.AdminProd},${AdminPanelGroup.AdminStage},${AdminPanelGroup.SupportAgentProd},${AdminPanelGroup.None}`
+        )
+      ).deep.equal(
+        guard.getGroup(AdminPanelGroup.AdminProd),
+        'production group should take precedence'
+      );
+
+      expect(
+        guard.getBestGroup(
+          `${AdminPanelGroup.AdminStage},${AdminPanelGroup.SupportAgentProd},${AdminPanelGroup.AdminProd},${AdminPanelGroup.None}`
+        )
+      ).deep.equal(
+        guard.getGroup(AdminPanelGroup.AdminProd),
+        'production group should take precedence, order should not matter'
+      );
+
+      expect(
+        stageGuard.getBestGroup(
+          `${AdminPanelGroup.AdminProd},${AdminPanelGroup.SupportAgentStage}`
+        )
+      ).deep.equal(
+        guard.getGroup(AdminPanelGroup.SupportAgentStage),
+        'only stage groups should be considered'
+      );
+
+      expect(
+        stageGuard.getBestGroup(
+          `${AdminPanelGroup.AdminStage},${AdminPanelGroup.AdminProd}`
+        )
+      ).deep.equal(
+        guard.getGroup(AdminPanelGroup.AdminStage),
+        'only stage groups should be considered'
+      );
+
+      expect(
+        prodGuard.getBestGroup(
+          `${AdminPanelGroup.AdminStage},${AdminPanelGroup.AdminProd}`
+        )
+      ).deep.equal(
+        guard.getGroup(AdminPanelGroup.AdminProd),
+        'only production groups should be considered'
+      );
+
+      expect(
+        guard.getBestGroup(
+          `test1, ${AdminPanelGroup.SupportAgentProd}, test2 , ${AdminPanelGroup.AdminProd}, test3`
+        )
+      ).deep.equal(
+        guard.getGroup(AdminPanelGroup.AdminProd),
+        'irrelevant and whitespace groups should have no effect'
+      );
     });
 
     it('denies', () => {
@@ -55,6 +133,36 @@ describe('support agents', () => {
         name: 'Lookup Account By Email/UID',
         level: PermissionLevel.Support,
       });
+    });
+
+    it('gets groups', () => {
+      const groups = getGroupsByEnv();
+      expect(groups[AdminPanelGroup.AdminProd]).to.exist;
+      expect(groups[AdminPanelGroup.SupportAgentProd]).to.exist;
+      expect(groups[AdminPanelGroup.AdminStage]).to.exist;
+      expect(groups[AdminPanelGroup.SupportAgentStage]).to.exist;
+      expect(groups[AdminPanelGroup.None]).to.exist;
+    });
+
+    it('throws on invalid group', () => {
+      expect(() => stageGuard.getGroup(AdminPanelGroup.AdminProd)).throws(
+        `Unknown group ${AdminPanelGroup.AdminProd}`
+      );
+      expect(() =>
+        stageGuard.allow(
+          AdminPanelFeature.DisableAccount,
+          AdminPanelGroup.AdminProd
+        )
+      ).throws(`Unknown group ${AdminPanelGroup.AdminProd}`);
+      expect(() => prodGuard.getGroup(AdminPanelGroup.AdminStage)).throws(
+        `Unknown group ${AdminPanelGroup.AdminStage}`
+      );
+      expect(() =>
+        prodGuard.allow(
+          AdminPanelFeature.DisableAccount,
+          AdminPanelGroup.AdminStage
+        )
+      ).throws(`Unknown group ${AdminPanelGroup.AdminStage}`);
     });
   });
 });

--- a/packages/fxa-shared/test/guard/Guard.ts
+++ b/packages/fxa-shared/test/guard/Guard.ts
@@ -8,6 +8,9 @@ import { expect } from 'chai';
 describe('support agents', () => {
   describe('Guard', () => {
     class TestGuard extends Guard<string, string> {
+      protected envToNum(env?: string): number {
+        return 0;
+      }
       constructor(permissions: Permissions, groups: Groups) {
         super(permissions, groups);
       }


### PR DESCRIPTION
## Because

- The remote group was not resolved correctly which rendered the admin panel useless.

## This pull request

- Targets the correct header, 'remote-groups', which was previously 'REMOTE-GROUP'. This small thing was really the crux of the problem.
- Does some cleanup and removes magic strings for header keys.
- Makes the AdminPanelGuard aware of the current environment. This ended up being the bulk of the changes, and was necessary since user groups are environment specific, and therefore the guard needs to be able to distinguish this. I.e. A user user could be part of an ldap group that has admin privileges on stage, but not part of the ldap group that has admin privileges on prod. 
- Resolves the correct user group for the current environment. For example, when both stage and prod ldap groups are provided in the remote-groups header, we must resolve the group that’s most appropriate for the current environment.
- Introduces a hook for GuardContext. Now that the AdminPanelGuard is aware of the current environment it is essentially contextual and should be accessed from a hook.

## Issue that this pull request solves

Closes: #12744

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

