### PR TITLE
chore(payments): Missing markup in payment-confirm string

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -165,8 +165,6 @@ payment-confirm-with-legal-links-year = { $intervalCount ->
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 
-payment-confirm = I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } per { $interval }</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-
 ##
 
 payment-cancel-btn = Cancel

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
@@ -71,11 +71,7 @@ describe('components/PaymentConsentCheckbox', () => {
 
   describe('Legal', () => {
     describe('rendering the legal checkbox Localized component', () => {
-      function runTests(
-        plan: Plan,
-        expectedMsgId: string,
-        expectedMsg: string
-      ) {
+      function runTests(plan: Plan, expectedMsgId: string) {
         const props = { plan };
 
         const testRenderer = TestRenderer.create(<WrapCheckbox {...props} />);
@@ -87,87 +83,100 @@ describe('components/PaymentConsentCheckbox', () => {
         expect(legalCheckbox.props.vars.intervalCount).toBe(
           plan.interval_count
         );
-        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+
+        expect(legalCheckbox.props.children.props.children[0]).toBe(
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method '
+        );
+        expect(
+          legalCheckbox.props.children.props.children[1].props.children
+        ).toMatch(
+          /\$\d+[.]\d{2}[ ][daily|every 6 days|weekly|every 6 weeks|monthly|every 6 months|yearly|every 6 years]/
+        );
+        expect(legalCheckbox.props.children.props.children[2]).toBe(
+          ', according to'
+        );
+        expect(legalCheckbox.props.children.props.children[3]).toBe(' ');
+        expect(legalCheckbox.props.children.props.children[4].props.href).toBe(
+          'https://www.mozilla.org/about/legal/terms/firefox-private-network'
+        );
+        expect(
+          legalCheckbox.props.children.props.children[4].props.children
+        ).toBe('Terms of Service');
+        expect(legalCheckbox.props.children.props.children[5]).toBe(' and');
+        expect(legalCheckbox.props.children.props.children[6]).toBe(' ');
+        expect(legalCheckbox.props.children.props.children[7].props.href).toBe(
+          'https://www.mozilla.org/privacy/firefox-private-network'
+        );
+        expect(
+          legalCheckbox.props.children.props.children[7].props.children
+        ).toBe('Privacy Notice');
+        expect(legalCheckbox.props.children.props.children[8]).toBe(
+          ', until I cancel my subscription.'
+        );
       }
 
       it('renders Localized for daily plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_daily';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-day';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for 6 days plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6days';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-day';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for weekly plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_weekly';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-week';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for 6 weeks plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6weeks';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-week';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for monthly plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_monthly';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-month';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for 6 months plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6months';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-month';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for yearly plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_yearly';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-year';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
 
       it('renders Localized for years plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6years';
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'payment-confirm-with-legal-links-year';
-        const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-        runTests(plan, expectedMsgId, expectedMsg);
+        runTests(plan, expectedMsgId);
       });
     });
 

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
@@ -1,10 +1,7 @@
 import React, { useContext } from 'react';
 import { Checkbox } from '../fields';
 import { Plan } from '../../store/types';
-import {
-  getDefaultPaymentConfirmText,
-  getLocalizedCurrency,
-} from '../../lib/formats';
+import { formatPlanPricing, getLocalizedCurrency } from '../../lib/formats';
 import { urlsFromProductConfig } from 'fxa-shared/subscriptions/configuration/helpers';
 import AppContext from '../../lib/AppContext';
 import { Localized } from '@fluent/react';
@@ -26,6 +23,13 @@ export const PaymentConsentCheckbox = ({
     config.featureFlags.useFirestoreProductConfigs
   );
 
+  const planPricing = formatPlanPricing(
+    plan.amount,
+    plan.currency,
+    plan.interval,
+    plan.interval_count
+  );
+
   return (
     <Localized
       id={`payment-confirm-with-legal-links-${plan.interval}`}
@@ -40,12 +44,11 @@ export const PaymentConsentCheckbox = ({
       }}
     >
       <Checkbox name="confirm" data-testid="confirm" onClick={onClick} required>
-        {getDefaultPaymentConfirmText(
-          plan.amount,
-          plan.currency,
-          plan.interval,
-          plan.interval_count
-        )}
+        I authorize Mozilla, maker of Firefox products, to charge my payment
+        method <strong>{planPricing}</strong>, according to{' '}
+        <a href={termsOfService}>Terms of Service</a> and{' '}
+        <a href={privacyNotice}>Privacy Notice</a>, until I cancel my
+        subscription.
       </Checkbox>
     </Localized>
   );

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -94,7 +94,7 @@ describe('components/PaymentMethodHeader', () => {
         MOCK_PLANS.find((p) => p.plan_id === 'plan_daily') || MOCK_PLANS[0];
       const props = { plan, onClick: () => {} };
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method $5.00 daily, according to Terms of Service and Privacy Notice, until I cancel my subscription.';
 
       const { findByTestId } = render(<PaymentMethodHeader {...props} />);
 

--- a/packages/fxa-payments-server/src/lib/formats.ts
+++ b/packages/fxa-payments-server/src/lib/formats.ts
@@ -151,22 +151,6 @@ export function formatPlanPricing(
   }
 }
 
-export function getDefaultPaymentConfirmText(
-  amount: number | null,
-  currency: string,
-  interval: PlanInterval,
-  intervalCount: number
-): string {
-  const planPricing = formatPlanPricing(
-    amount,
-    currency,
-    interval,
-    intervalCount
-  );
-
-  return `I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${planPricing}</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.`;
-}
-
 export const legalDocsRedirectUrl = (docUrl: string): string =>
   `/legal-docs?url=${encodeURI(docUrl)}`;
 


### PR DESCRIPTION
## Because

- This variable is not being used anywhere. The linter is broken on localization files.

## This pull request

- Removes the unused variable

## Issue that this pull request solves

Closes: # 12726

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
