### PR TITLE
feat(auth): update subscriptions endpoint to include Apple IAP

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -380,7 +380,7 @@ export class CapabilityService {
     }
   }
 
-  private async fetchSubscribedPricesFromAppStore(
+  public async fetchSubscribedPricesFromAppStore(
     uid: string
   ): Promise<string[]> {
     if (!this.appleIap) {

--- a/packages/fxa-auth-server/lib/payments/iap/iap-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/iap-formatter.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import * as iapSubscriptionDTO from 'fxa-shared/dto/auth/payments/iap-subscription';
+import { AppendedAppStoreSubscriptionPurchase } from 'fxa-shared/payments/iap/apple-app-store/types';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+
+import { AppendedPlayStoreSubscriptionPurchase } from './google-play/types';
+
+/**
+ * Formats an AppendedPlayStoreSubscriptionPurchase to the PlayStoreSubscription DTO format.
+ */
+export function playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO(
+  purchase: AppendedPlayStoreSubscriptionPurchase
+): iapSubscriptionDTO.PlayStoreSubscription {
+  return {
+    auto_renewing: purchase.autoRenewing,
+    expiry_time_millis: purchase.expiryTimeMillis,
+    package_name: purchase.packageName, // Play Store analog to a Stripe Product id
+    sku: purchase.sku, // Play Store analog to a Stripe Plan id
+    ...(purchase.cancelReason && { cancel_reason: purchase.cancelReason }),
+    price_id: purchase.price_id,
+    product_id: purchase.product_id,
+    product_name: purchase.product_name,
+    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  };
+}
+
+/**
+ * Formats an AppendedAppStoreSubscriptionPurchase to the AppStoreSubscription DTO format.
+ */
+export function appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO(
+  purchase: AppendedAppStoreSubscriptionPurchase
+): iapSubscriptionDTO.AppStoreSubscription {
+  return {
+    // App Store analog to a Stripe Plan id, prepended with app_store to avoid confusion.
+    app_store_product_id: purchase.productId,
+    auto_renewing: !!purchase.autoRenewStatus,
+    bundle_id: purchase.bundleId, // App Store analog to a Stripe Product id
+    // TODO: Should this always be present or just for TransactionType of
+    // "Auto-Renewable Subscription"? See https://developer.apple.com/forums/thread/705730
+    ...(purchase.expiresDate && { expiry_time_millis: purchase.expiresDate }),
+    ...(purchase.hasOwnProperty('isInBillingRetry') && {
+      is_in_billing_retry_period: purchase.isInBillingRetry,
+    }),
+    price_id: purchase.price_id,
+    product_id: purchase.product_id,
+    product_name: purchase.product_name,
+    _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+  };
+}

--- a/packages/fxa-auth-server/lib/payments/iap/types/index.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/types/index.ts
@@ -1,5 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+export interface SubscriptionsService<T> {
+  getSubscriptions: (uid: string) => Promise<T[]>;
+}
 
 export { IapConfig } from './firestore';

--- a/packages/fxa-auth-server/lib/routes/support-panel.ts
+++ b/packages/fxa-auth-server/lib/routes/support-panel.ts
@@ -1,18 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 import { ServerRoute } from '@hapi/hapi';
 import isA from '@hapi/joi';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import { Container } from 'typedi';
+
 import { ConfigType } from '../../config';
+import SUBSCRIPTIONS_DOCS from '../../docs/swagger/subscriptions-api';
 import { PlaySubscriptions } from '../../lib/payments/iap/google-play/subscriptions';
+import { playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO } from '../payments/iap/iap-formatter';
 import { StripeHelper } from '../payments/stripe';
 import { AuthLogger, AuthRequest } from '../types';
 import validators from './validators';
-
-import SUBSCRIPTIONS_DOCS from '../../docs/swagger/subscriptions-api';
 
 export const supportPanelRoutes = ({
   log,
@@ -73,9 +73,9 @@ export class SupportPanelHandler {
   async getSubscriptions(request: AuthRequest) {
     this.log.begin('supportPanelGetSubscriptions', request);
     const { uid } = request.query as Record<string, string>;
-    const iapPlaySubscriptions = await this.playSubscriptions.getSubscriptions(
-      uid
-    );
+    const iapPlaySubscriptions = (
+      await this.playSubscriptions.getSubscriptions(uid)
+    ).map(playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO);
     const customer = await this.stripeHelper.fetchCustomer(uid);
     const webSubscriptions = customer?.subscriptions;
     const formattedWebSubscriptions = webSubscriptions

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -18,6 +18,10 @@ const {
 const {
   planConfigJoiKeys,
 } = require('fxa-shared/subscriptions/configuration/plan');
+const {
+  appStoreSubscriptionSchema,
+  playStoreSubscriptionSchema,
+} = require('fxa-shared/dto/auth/payments/iap-subscription');
 
 // Match any non-empty hex-encoded string.
 const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
@@ -653,17 +657,11 @@ module.exports.subscriptionsStripeSubscriptionValidator = isA
   .label('Stripe_subscription')
   .unknown(true);
 
-module.exports.subscriptionsGooglePlaySubscriptionValidator = isA.object({
-  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-  auto_renewing: isA.bool().required(),
-  cancel_reason: isA.number().optional(),
-  expiry_time_millis: isA.number().required(),
-  package_name: isA.string().required(),
-  product_id: isA.string().required(),
-  product_name: isA.string().required(),
-  price_id: isA.string().required(),
-  sku: isA.string().required(),
-});
+module.exports.subscriptionsGooglePlaySubscriptionValidator =
+  playStoreSubscriptionSchema;
+
+module.exports.subscriptionsAppStoreSubscriptionValidator =
+  appStoreSubscriptionSchema;
 
 module.exports.subscriptionsStripeCustomerValidator = isA
   .object({
@@ -705,7 +703,8 @@ module.exports.subscriptionsMozillaSubscriptionsValidator = isA
       .array()
       .items(
         module.exports.subscriptionsSubscriptionValidator,
-        module.exports.subscriptionsGooglePlaySubscriptionValidator
+        module.exports.subscriptionsGooglePlaySubscriptionValidator,
+        module.exports.subscriptionsAppStoreSubscriptionValidator
       )
       .required(),
   })

--- a/packages/fxa-auth-server/test/local/payments/iap-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/iap-formatter.js
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const { deepCopy } = require('./util');
+const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
+
+const {
+  appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO,
+  playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO,
+} = require('../../../lib/payments/iap/iap-formatter.ts');
+
+const mockExtraStripeInfo = {
+  price_id: 'price_lol',
+  product_id: 'prod_lol',
+  product_name: 'LOL Product',
+};
+
+describe('playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO', () => {
+  const mockPlayStoreSubscriptionPurchase = {
+    kind: 'androidpublisher#subscriptionPurchase',
+    startTimeMillis: `${Date.now() - 10000}`,
+    expiryTimeMillis: `${Date.now() + 10000}`,
+    autoRenewing: true,
+    priceCurrencyCode: 'JPY',
+    priceAmountMicros: '99000000',
+    countryCode: 'JP',
+    developerPayload: '',
+    paymentState: 1,
+    orderId: 'GPA.3313-5503-3858-32549',
+    packageName: 'testPackage',
+    purchaseToken: 'testToken',
+    sku: 'sku',
+    verifiedAt: Date.now(),
+    isEntitlementActive: sinon.fake.returns(true),
+  };
+
+  const mockAppendedPlayStoreSubscriptionPurchase = {
+    ...mockPlayStoreSubscriptionPurchase,
+    ...mockExtraStripeInfo,
+    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  };
+
+  const mockFormattedPlayStoreSubscription = {
+    auto_renewing: mockPlayStoreSubscriptionPurchase.autoRenewing,
+    expiry_time_millis: mockPlayStoreSubscriptionPurchase.expiryTimeMillis,
+    package_name: mockPlayStoreSubscriptionPurchase.packageName,
+    sku: mockPlayStoreSubscriptionPurchase.sku,
+    ...mockExtraStripeInfo,
+    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  };
+
+  it('formats an appended PlayStoreSubscriptionPurchase', () => {
+    const subscription =
+      playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO(
+        deepCopy(mockAppendedPlayStoreSubscriptionPurchase)
+      );
+    assert.deepEqual(subscription, mockFormattedPlayStoreSubscription);
+  });
+
+  it('formats an appended PlayStoreSubscriptionPurchase with optional properties', () => {
+    const appendedSubscriptionWithOptions = deepCopy(
+      mockAppendedPlayStoreSubscriptionPurchase
+    );
+    appendedSubscriptionWithOptions.cancelReason = 1;
+    const subscription =
+      playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO(
+        appendedSubscriptionWithOptions
+      );
+    const expected = deepCopy(mockFormattedPlayStoreSubscription);
+    expected.cancel_reason = appendedSubscriptionWithOptions.cancelReason;
+    assert.deepEqual(subscription, expected);
+  });
+});
+
+describe('appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO', () => {
+  const mockAppStoreSubscriptionPurchase = {
+    autoRenewStatus: 1,
+    productId: 'wow',
+    bundleId: 'hmm',
+    isEntitlementActive: sinon.fake.returns(true),
+  };
+
+  const mockAppendedAppStoreSubscriptionPurchase = {
+    ...mockAppStoreSubscriptionPurchase,
+    ...mockExtraStripeInfo,
+    _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+  };
+
+  const mockFormattedAppStoreSubscription = {
+    _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+    app_store_product_id: 'wow',
+    auto_renewing: true,
+    bundle_id: 'hmm',
+    ...mockExtraStripeInfo,
+  };
+
+  it('formats an appended AppStoreSubscriptionPurchase', () => {
+    const subscription = appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO(
+      deepCopy(mockAppendedAppStoreSubscriptionPurchase)
+    );
+    assert.deepEqual(subscription, mockFormattedAppStoreSubscription);
+  });
+
+  it('formats an appended AppStoreSubscriptionPurchase with optional properties', () => {
+    const appendedSubscriptionWithOptions = deepCopy(
+      mockAppendedAppStoreSubscriptionPurchase
+    );
+    appendedSubscriptionWithOptions.expiresDate = 1234567890;
+    appendedSubscriptionWithOptions.isInBillingRetry = true;
+    const subscription = appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO(
+      appendedSubscriptionWithOptions
+    );
+    const expected = deepCopy(mockFormattedAppStoreSubscription);
+    expected.expiry_time_millis = appendedSubscriptionWithOptions.expiresDate;
+    expected.is_in_billing_retry_period =
+      appendedSubscriptionWithOptions.isInBillingRetry;
+    assert.deepEqual(subscription, expected);
+  });
+});

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -6334,7 +6334,7 @@ describe('StripeHelper', () => {
     });
   });
 
-  describe('Google Play helpers', () => {
+  describe('IAP helpers', () => {
     let subPurchase;
     let productId;
     let priceId;
@@ -6460,38 +6460,61 @@ describe('StripeHelper', () => {
       });
     });
 
-    describe('addPriceInfoToAbbrevPlayPurchases', () => {
-      let mockAbbrevPlayPurchase;
+    describe('addPriceInfoToIapPurchases', () => {
+      let mockPlayPurchase;
+      let mockAppStorePurchase;
 
       beforeEach(() => {
-        mockAbbrevPlayPurchase = {
+        mockPlayPurchase = {
           auto_renewing: true,
           expiry_time_millis: Date.now(),
           package_name: 'org.mozilla.cooking.with.foxkeh',
           sku: 'testSku',
         };
+        mockAppStorePurchase = {
+          autoRenewStatus: 1,
+          productId: 'skydiving.with.foxkeh',
+          bundleId: 'hmm',
+        };
       });
 
-      it('adds matching product info to a subscription purchase', async () => {
+      it('adds matching product info to a Play Store subscription purchase', async () => {
         const expected = {
-          ...mockAbbrevPlayPurchase,
+          ...mockPlayPurchase,
           price_id: priceId,
           product_id: productId,
           product_name: productName,
         };
-        const result = await stripeHelper.addPriceInfoToAbbrevPlayPurchases([
-          mockAbbrevPlayPurchase,
-        ]);
+        const result = await stripeHelper.addPriceInfoToIapPurchases(
+          [mockPlayPurchase],
+          MozillaSubscriptionTypes.IAP_GOOGLE
+        );
         assert.deepEqual([expected], result);
       });
+
+      it('adds matching product info to an App Store subscription purchase', async () => {
+        const expected = {
+          ...mockAppStorePurchase,
+          price_id: priceId,
+          product_id: productId,
+          product_name: productName,
+        };
+        const result = await stripeHelper.addPriceInfoToIapPurchases(
+          [mockAppStorePurchase],
+          MozillaSubscriptionTypes.IAP_APPLE
+        );
+        assert.deepEqual([expected], result);
+      });
+
       it('returns an empty list if no matching product ids are found', async () => {
-        const mockAbbrevPlayPurchase1 = {
-          ...mockAbbrevPlayPurchase,
+        const mockPlayPurchase1 = {
+          ...mockPlayPurchase,
           sku: 'notMatchingSku',
         };
-        const result = await stripeHelper.addPriceInfoToAbbrevPlayPurchases([
-          mockAbbrevPlayPurchase1,
-        ]);
+        const result = await stripeHelper.addPriceInfoToIapPurchases(
+          [mockPlayPurchase1],
+          MozillaSubscriptionTypes.IAP_GOOGLE
+        );
         assert.isEmpty(result);
       });
     });

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3722,14 +3722,43 @@ describe('/account', () => {
   });
 
   describe('Google Play subscriptions', () => {
-    const mockIapSubscription = {
-      auto_renewing: true,
-      expiry_time_millis: Date.now(),
-      package_name: 'org.mozilla.cooking.with.foxkeh',
-      sku: 'org.mozilla.foxkeh.yearly',
+    const mockPlayStoreSubscriptionPurchase = {
+      kind: 'androidpublisher#subscriptionPurchase',
+      startTimeMillis: `${Date.now() - 10000}`,
+      expiryTimeMillis: `${Date.now() + 10000}`,
+      autoRenewing: true,
+      priceCurrencyCode: 'JPY',
+      priceAmountMicros: '99000000',
+      countryCode: 'JP',
+      developerPayload: '',
+      paymentState: 1,
+      orderId: 'GPA.3313-5503-3858-32549',
+      packageName: 'testPackage',
+      purchaseToken: 'testToken',
+      sku: 'sku',
+      verifiedAt: Date.now(),
+      isEntitlementActive: sinon.fake.returns(true),
+    };
+
+    const mockExtraStripeInfo = {
+      price_id: 'price_lol',
+      product_id: 'prod_lol',
+      product_name: 'LOL Product',
+    };
+
+    const mockAppendedPlayStoreSubscriptionPurchase = {
+      ...mockPlayStoreSubscriptionPurchase,
+      ...mockExtraStripeInfo,
       _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-      product_id: 'iap_prod_lol',
-      product_name: 'LOL daily',
+    };
+
+    const mockFormattedPlayStoreSubscription = {
+      auto_renewing: mockPlayStoreSubscriptionPurchase.autoRenewing,
+      expiry_time_millis: mockPlayStoreSubscriptionPurchase.expiryTimeMillis,
+      package_name: mockPlayStoreSubscriptionPurchase.packageName,
+      sku: mockPlayStoreSubscriptionPurchase.sku,
+      ...mockExtraStripeInfo,
+      _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
     };
 
     let subscriptionsEnabled, playSubscriptionsEnabled;
@@ -3753,7 +3782,7 @@ describe('/account', () => {
       mockPlaySubscriptions = mocks.mockPlaySubscriptions(['getSubscriptions']);
       Container.set(PlaySubscriptions, mockPlaySubscriptions);
       mockPlaySubscriptions.getSubscriptions = sinon.spy(async (uid) => [
-        mockIapSubscription,
+        mockAppendedPlayStoreSubscriptionPurchase,
       ]);
     });
 
@@ -3770,7 +3799,7 @@ describe('/account', () => {
             uid
           );
           assert.deepEqual(result, {
-            subscriptions: [mockIapSubscription],
+            subscriptions: [mockFormattedPlayStoreSubscription],
           });
         }
       );
@@ -3798,7 +3827,7 @@ describe('/account', () => {
           assert.equal(mockPlaySubscriptions.getSubscriptions.callCount, 1);
           assert.deepEqual(result, {
             subscriptions: [
-              ...[mockIapSubscription],
+              ...[mockFormattedPlayStoreSubscription],
               ...mockWebSubscriptionsResponse,
             ],
           });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -27,6 +27,12 @@ const buildRoutes = require('../../../../lib/routes/subscriptions');
 const ACCOUNT_LOCALE = 'en-US';
 const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 const { CapabilityService } = require('../../../../lib/payments/capability');
+const {
+  PlaySubscriptions,
+} = require('../../../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../../../lib/payments/iap/apple-app-store/subscriptions');
 const { PlayBilling } = require('../../../../lib/payments/iap/google-play');
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
@@ -127,6 +133,8 @@ describe('subscriptions payPalRoutes', () => {
     profile = {};
     Container.set(CapabilityService, {});
     push = {};
+    Container.set(PlaySubscriptions, {});
+    Container.set(AppStoreSubscriptions, {});
   });
 
   afterEach(() => {

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -10,6 +10,13 @@ const crypto = require('crypto');
 const Client = require('../client')();
 const config = require('../../config').getProperties();
 const mocks = require('../mocks');
+const { default: Container } = require('typedi');
+const {
+  PlaySubscriptions,
+} = require('../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 describe('remote account create', function () {
   this.timeout(30000);
@@ -28,6 +35,9 @@ describe('remote account create', function () {
     const mockStripeHelper = {};
     mockStripeHelper.hasActiveSubscription = async () => Promise.resolve(false);
     mockStripeHelper.removeCustomer = async () => Promise.resolve();
+
+    Container.set(PlaySubscriptions, {});
+    Container.set(AppStoreSubscriptions, {});
 
     server = await TestServer.start(config, false, {
       authServerMockDependencies: {

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -19,6 +19,9 @@ const { AuthLogger } = require('../../lib/types');
 const {
   PlaySubscriptions,
 } = require('../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 const validClients = config.oauthServer.clients.filter(
   (client) => client.trusted && client.canGrant && client.publicClient
@@ -46,6 +49,7 @@ describe('remote subscriptions:', function () {
     let client, server, tokens;
     const mockStripeHelper = {};
     const mockPlaySubscriptions = {};
+    const mockAppStoreSubscriptions = {};
 
     before(async () => {
       config.subscriptions.enabled = true;
@@ -91,6 +95,7 @@ describe('remote subscriptions:', function () {
       mockStripeHelper.fetchCustomer = async (uid, email) => ({});
       Container.set(StripeHelper, mockStripeHelper);
       Container.set(PlaySubscriptions, mockPlaySubscriptions);
+      Container.set(AppStoreSubscriptions, mockAppStoreSubscriptions);
       Container.set(AuthLogger, {});
       Container.remove(CapabilityService);
       Container.set(CapabilityService, new CapabilityService());

--- a/packages/fxa-auth-server/test/remote/token_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_code_tests.js
@@ -9,6 +9,13 @@ const config = require('../../config').getProperties();
 const TestServer = require('../test_server');
 const Client = require('../client')();
 const error = require('../../lib/error');
+const { default: Container } = require('typedi');
+const {
+  PlaySubscriptions,
+} = require('../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 describe('remote tokenCodes', function () {
   let server, client, email, code;
@@ -17,6 +24,9 @@ describe('remote tokenCodes', function () {
   this.timeout(10000);
 
   before(() => {
+    Container.set(PlaySubscriptions, {});
+    Container.set(AppStoreSubscriptions, {});
+
     return TestServer.start(config).then((s) => {
       server = s;
     });

--- a/packages/fxa-auth-server/test/remote/token_expiry_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_expiry_tests.js
@@ -7,6 +7,13 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
+const { default: Container } = require('typedi');
+const {
+  PlaySubscriptions,
+} = require('../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 function fail() {
   throw new Error();
@@ -19,6 +26,9 @@ describe('remote token expiry', function () {
     config = require('../../config').getProperties();
     config.tokenLifetimes.passwordChangeToken = 1;
     config.tokenLifetimes.sessionTokenWithoutDevice = 1;
+
+    Container.set(PlaySubscriptions, {});
+    Container.set(AppStoreSubscriptions, {});
 
     return TestServer.start(config).then((s) => {
       server = s;

--- a/packages/fxa-auth-server/test/remote/totp_tests.js
+++ b/packages/fxa-auth-server/test/remote/totp_tests.js
@@ -10,6 +10,13 @@ const config = require('../../config').getProperties();
 const TestServer = require('../test_server');
 const Client = require('../client')();
 const otplib = require('otplib');
+const { default: Container } = require('typedi');
+const {
+  PlaySubscriptions,
+} = require('../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 describe('remote totp', function () {
   let server, client, email, totpToken, authenticator;
@@ -30,6 +37,9 @@ describe('remote totp', function () {
   before(() => {
     config.securityHistory.ipProfiling = {};
     config.signinConfirmation.skipForNewAccounts.enabled = false;
+
+    Container.set(PlaySubscriptions, {});
+    Container.set(AppStoreSubscriptions, {});
 
     return TestServer.start(config).then((s) => {
       server = s;

--- a/packages/fxa-auth-server/test/remote/verifier_upgrade_tests.js
+++ b/packages/fxa-auth-server/test/remote/verifier_upgrade_tests.js
@@ -23,6 +23,14 @@ const DB = require('../../lib/db')(
   Token.PasswordChangeToken
 );
 
+const { default: Container } = require('typedi');
+const {
+  PlaySubscriptions,
+} = require('../../lib/payments/iap/google-play/subscriptions');
+const {
+  AppStoreSubscriptions,
+} = require('../../lib/payments/iap/apple-app-store/subscriptions');
+
 let client, db, server;
 
 describe('remote verifier upgrade', function () {
@@ -31,6 +39,9 @@ describe('remote verifier upgrade', function () {
   before(async () => {
     config.verifierVersion = 0;
     config.securityHistory.ipProfiling.allowedRecency = 0;
+
+    Container.set(PlaySubscriptions, {});
+    Container.set(AppStoreSubscriptions, {});
 
     server = await TestServer.start(config);
     db = await DB.connect(config);

--- a/packages/fxa-payments-server/src/lib/customer.ts
+++ b/packages/fxa-payments-server/src/lib/customer.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { isIapSubscription } from 'fxa-shared/subscriptions/subscriptions';
+import { isIapSubscription } from 'fxa-shared/subscriptions/type-guards';
 import {
   IapSubscription,
   MozillaSubscription,

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,5 +1,6 @@
 import { PaymentIntent, PaymentMethod } from '@stripe/stripe-js';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { AppStoreSubscription } from 'fxa-shared/dto/auth/payments/iap-subscription';
 import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
@@ -239,8 +240,12 @@ export const IAP_GOOGLE_SUBSCRIPTION = {
   price_id: 'plan_123',
 };
 
-export const IAP_APPLE_SUBSCRIPTION = {
+export const IAP_APPLE_SUBSCRIPTION: AppStoreSubscription = {
   _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+  app_store_product_id: 'wow',
+  auto_renewing: true,
+  bundle_id: 'hmm',
+  price_id: 'price_123',
   product_id: 'prod_123',
   product_name: 'Cooking with Foxkeh',
 };

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -29,7 +29,7 @@ import {
   SubscriptionUpdateEligibility,
   WebSubscription,
 } from 'fxa-shared/subscriptions/types';
-import { isWebSubscription } from 'fxa-shared/subscriptions/subscriptions';
+import { isWebSubscription } from 'fxa-shared/subscriptions/type-guards';
 import { findCustomerIapSubscriptionByProductId } from '../../lib/customer';
 import IapRoadblock from './IapRoadblock';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/SubscriptionIapItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/SubscriptionIapItem.tsx
@@ -6,16 +6,16 @@
 import React from 'react';
 import { Localized } from '@fluent/react';
 
+import { IapSubscription } from 'fxa-shared/subscriptions/types';
 import {
-  AppleSubscription,
-  GooglePlaySubscription,
-  IapSubscription,
-} from 'fxa-shared/subscriptions/types';
+  AppStoreSubscription,
+  PlayStoreSubscription,
+} from 'fxa-shared/dto/auth/payments/iap-subscription';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import {
   isAppleSubscription,
   isGooglePlaySubscription,
-} from 'fxa-shared/subscriptions/subscriptions';
+} from 'fxa-shared/subscriptions/type-guards';
 import {
   getIapSubscriptionManagementUrl,
   getLocalizedDateString,
@@ -43,7 +43,7 @@ export const SubscriptionIapItem = ({
 
 const GooglePlaySubscriptionIapItem = (
   productName: string,
-  customerSubscription: GooglePlaySubscription
+  customerSubscription: PlayStoreSubscription
 ) => {
   const { auto_renewing, expiry_time_millis } = customerSubscription;
 
@@ -99,7 +99,7 @@ const GooglePlaySubscriptionIapItem = (
 
 const AppleSubscriptionIapItem = (
   productName: string,
-  customerSubscription: AppleSubscription
+  customerSubscription: AppStoreSubscription
 ) => {
   return (
     <div className="settings-unit">

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -15,7 +15,11 @@ import { QueryParams } from '../../lib/types';
 import { APIError } from '../../lib/apiClient';
 import { FetchState, Profile } from '../../store/types';
 import { linkTo } from '@storybook/addon-links';
-import { CUSTOMER, FILTERED_SETUP_INTENT } from '../../lib/mock-data';
+import {
+  CUSTOMER,
+  FILTERED_SETUP_INTENT,
+  IAP_APPLE_SUBSCRIPTION,
+} from '../../lib/mock-data';
 import {
   IapSubscription,
   MozillaSubscriptionTypes,
@@ -71,8 +75,7 @@ function setupVariantStories(
           ...subscribedIapProps,
           customerSubscriptions: [
             {
-              ...subscribedProps.customerSubscriptions![0],
-              _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+              ...IAP_APPLE_SUBSCRIPTION,
             },
           ],
         }}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -34,7 +34,7 @@ import PaymentUpdateForm, {
 import {
   isIapSubscription,
   isWebSubscription,
-} from 'fxa-shared/subscriptions/subscriptions';
+} from 'fxa-shared/subscriptions/type-guards';
 import {
   MozillaSubscription,
   WebSubscription,

--- a/packages/fxa-shared/dto/auth/payments/iap-subscription.ts
+++ b/packages/fxa-shared/dto/auth/payments/iap-subscription.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import Stripe from 'stripe';
+import joi from 'typesafe-joi';
+
+import {
+  MozillaSubscriptionTypes,
+  SubscriptionTypes,
+} from '../../../subscriptions/types';
+
+export type IapExtraStripeInfo = {
+  product_id: Stripe.Product['id'];
+  product_name: Stripe.Product['name'];
+  price_id: Stripe.Plan['id'];
+};
+
+export const iapExtraStripeInfoSchema = joi.object({
+  price_id: joi.string().required(),
+  product_id: joi.string().required(),
+  product_name: joi.string().required(),
+});
+
+export type iapExtraStripeInfoSchema = joi.Literal<
+  typeof iapExtraStripeInfoSchema
+>;
+
+export type PlayStoreSubscription = {
+  auto_renewing: boolean;
+  cancel_reason?: number;
+  expiry_time_millis: number;
+  package_name: string;
+  sku: string;
+  _subscription_type: SubscriptionTypes[1];
+} & IapExtraStripeInfo;
+
+export const playStoreSubscriptionSchema = joi
+  .object({
+    auto_renewing: joi.boolean().required(),
+    cancel_reason: joi.number().optional(),
+    expiry_time_millis: joi.number().required(),
+    package_name: joi.string().required(),
+    sku: joi.string().required(),
+    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  })
+  .concat(iapExtraStripeInfoSchema);
+
+export type playStoreSubscriptionSchema = joi.Literal<
+  typeof playStoreSubscriptionSchema
+>;
+
+export type AppStoreSubscription = {
+  app_store_product_id: string;
+  auto_renewing: boolean;
+  bundle_id: string;
+  expiry_time_millis?: number;
+  is_in_billing_retry_period?: boolean;
+  _subscription_type: SubscriptionTypes[2];
+} & IapExtraStripeInfo;
+
+export const appStoreSubscriptionSchema = joi
+  .object({
+    app_store_product_id: joi.string().required(),
+    auto_renewing: joi.boolean().required(),
+    bundle_id: joi.string().required(),
+    expiry_time_millis: joi.number().optional(),
+    is_in_billing_retry_period: joi.boolean().optional(),
+    _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+  })
+  .concat(iapExtraStripeInfoSchema);
+
+export type appStoreSubscriptionSchema = joi.Literal<
+  typeof appStoreSubscriptionSchema
+>;

--- a/packages/fxa-shared/index.ts
+++ b/packages/fxa-shared/index.ts
@@ -1,25 +1,25 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import * as iapSubscription from './dto/auth/payments/iap-subscription';
+import * as invoice from './dto/auth/payments/invoice';
+import * as emailHelpers from './email/helpers';
 import popularDomains from './email/popularDomains.json';
 import BaseGroupingRule from './experiments/base';
+import featureFlags from './feature-flags';
 import { localizeTimestamp } from './l10n/localizeTimestamp';
 import supportedLanguages from './l10n/supportedLanguages.json';
-import scopes from './oauth/scopes';
-import * as emailHelpers from './email/helpers';
-import featureFlags from './feature-flags';
-import {
-  metadataFromPlan,
-  productDetailsFromPlan,
-} from './subscriptions/metadata';
-import * as invoice from './dto/auth/payments/invoice';
-import * as stripe from './subscriptions/stripe';
-import * as subscriptions from './subscriptions/subscriptions';
-
 import amplitude from './metrics/amplitude';
 import flowPerformance from './metrics/flow-performance';
 import navigationTimingSchema from './metrics/navigation-timing-validation';
 import userAgent from './metrics/user-agent';
+import scopes from './oauth/scopes';
+import {
+  metadataFromPlan,
+  productDetailsFromPlan,
+} from './subscriptions/metadata';
+import * as stripe from './subscriptions/stripe';
+import * as subscriptions from './subscriptions/type-guards';
 
 module.exports = {
   email: {
@@ -54,6 +54,7 @@ module.exports = {
   dto: {
     auth: {
       payments: {
+        iapSubscription,
         invoice,
       },
     },

--- a/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
@@ -82,7 +82,7 @@ export class AppStoreSubscriptionPurchase {
   // Response from App Store API server Subscription Status endpoint
   // https://developer.apple.com/documentation/appstoreserverapi/get_all_subscription_statuses
   // IMPORTANT: If adding a new required property, also add it to SUBSCRIPTION_PURCHASE_REQUIRED_PROPERTIES
-  private autoRenewStatus!: AutoRenewStatus;
+  autoRenewStatus!: AutoRenewStatus;
   private autoRenewProductId!: string;
   bundleId!: string; // unique identifier for the iOS app; analogous to a Stripe product id
   private environment!: Environment;
@@ -93,9 +93,9 @@ export class AppStoreSubscriptionPurchase {
   private status!: SubscriptionStatus;
   private type!: TransactionType;
   private expirationIntent?: number;
-  private expiresDate?: number;
+  expiresDate?: number;
   private gracePeriodExpiresDate?: number;
-  private isInBillingRetry?: boolean;
+  isInBillingRetry?: boolean;
   private isUpgraded?: boolean;
   private offerType?: OfferType;
   private offerIdentifier?: string;

--- a/packages/fxa-shared/subscriptions/type-guards.ts
+++ b/packages/fxa-shared/subscriptions/type-guards.ts
@@ -3,13 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  AppleSubscription,
-  GooglePlaySubscription,
   IapSubscription,
   MozillaSubscription,
   MozillaSubscriptionTypes,
   WebSubscription,
 } from './types';
+
+import {
+  AppStoreSubscription,
+  PlayStoreSubscription,
+} from '../dto/auth/payments/iap-subscription';
 
 export const isWebSubscription = (
   s: MozillaSubscription
@@ -23,10 +26,10 @@ export const isIapSubscription = (
 
 export const isGooglePlaySubscription = (
   s: MozillaSubscription
-): s is GooglePlaySubscription =>
+): s is PlayStoreSubscription =>
   s._subscription_type === MozillaSubscriptionTypes.IAP_GOOGLE;
 
 export const isAppleSubscription = (
   s: MozillaSubscription
-): s is AppleSubscription =>
+): s is AppStoreSubscription =>
   s._subscription_type === MozillaSubscriptionTypes.IAP_APPLE;

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -1,4 +1,9 @@
 import { Stripe } from 'stripe';
+
+import {
+  AppStoreSubscription,
+  PlayStoreSubscription,
+} from '../dto/auth/payments/iap-subscription';
 import { PlanConfigurationDtoT } from '../dto/auth/payments/plan-configuration';
 
 export type PlanInterval = Stripe.Plan['interval'];
@@ -130,25 +135,7 @@ export type WebSubscription = Pick<
     promotion_end: number | null;
   };
 
-export interface AbbrevPlayPurchase {
-  auto_renewing: boolean;
-  cancel_reason?: number;
-  expiry_time_millis: number;
-  package_name: string;
-  sku: string;
-}
-export interface GooglePlaySubscription extends AbbrevPlayPurchase {
-  _subscription_type: SubscriptionTypes[1];
-  product_id: Stripe.Product['id'];
-  product_name: Stripe.Product['name'];
-  price_id: Stripe.Plan['id'];
-}
-export type AppleSubscription = {
-  _subscription_type: SubscriptionTypes[2];
-  product_id: Stripe.Product['id'];
-  product_name: Stripe.Product['name'];
-};
-export type IapSubscription = GooglePlaySubscription | AppleSubscription;
+export type IapSubscription = PlayStoreSubscription | AppStoreSubscription;
 export type MozillaSubscription = WebSubscription | IapSubscription;
 
 export const PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT = 'missing_agreement';


### PR DESCRIPTION
Because:

* We want the payments server to know about active Apple IAP subscriptions (e.g. during checkout and for subscription management).

This commit:

* Updates the existing endpoint to also return any active Apple IAP subscriptions.
  - Refactors the PlaySubscriptions module, creating PlayStoreSubscription DTOs and removing AbbrevPlayPurchase and related helpers.
  - Generalizes addPriceInfoToAbbrevPlayPurchases, renaming it to addPriceInfoToIapPurchases.
  - Creates a new AppStoreSubscriptions module, creating AppStoreSubscription DTOs.
  - Renames AppleSubscription to AppStoreSubscription and GooglePlaySubscription to PlayStoreSubscription to keep naming conventions consistent with other modules.

Closes #11941

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
