### PR TITLE
chore(tests): Fix uncalled .toBeInTheDocument and .toBeTruthy referen…

### DIFF
--- a/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
@@ -61,9 +61,9 @@ describe('FirestoreService', () => {
     'ignores a duplicate login',
     async () => {
       const result = await service.storeLogin(uid1, 'fx_send');
-      expect(result).toBeTruthy;
+      expect(result).toBeTruthy();
       const result2 = await service.storeLogin(uid1, 'fx_send');
-      expect(result2).toBeFalsy;
+      expect(result2).toBeFalsy();
     },
     TEST_TIMEOUT
   );

--- a/packages/fxa-settings/src/components/ConnectAnotherDevicePromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/ConnectAnotherDevicePromo/index.test.tsx
@@ -12,8 +12,9 @@ describe('Connect another device Promo', () => {
   it('renders "fresh load" <ConnectAnotherDevicePromo/> with correct content', async () => {
     renderWithRouter(<ConnectAnotherDevicePromo />);
 
-    expect(await screen.findByText('Get Firefox on mobile or tablet'))
-      .toBeTruthy;
+    expect(
+      await screen.findByText('Get Firefox on mobile or tablet')
+    ).toBeTruthy();
     expect(await screen.findByTestId('download-link')).toHaveAttribute(
       'href',
       'https://www.mozilla.org/en-US/firefox/mobile/'

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -57,7 +57,7 @@ describe('DropDownAvatarMenu', () => {
     expect(toggleButton).toHaveAttribute('title', 'Firefox account menu');
     expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
 
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
@@ -68,7 +68,7 @@ describe('DropDownAvatarMenu', () => {
 
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
   });
 
   it('renders as expected with avatar url and displayName set', () => {
@@ -94,7 +94,7 @@ describe('DropDownAvatarMenu', () => {
     fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
     expect(dropDown).toBeInTheDocument;
     fireEvent.keyDown(window, { key: 'Escape' });
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
   });
 
   it('closes on click outside', () => {
@@ -112,7 +112,7 @@ describe('DropDownAvatarMenu', () => {
     fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
     expect(dropDown).toBeInTheDocument;
     fireEvent.click(container);
-    expect(dropDown).not.toBeInTheDocument;
+    expect(dropDown).not.toBeInTheDocument();
   });
 
   describe('destroySession', () => {


### PR DESCRIPTION
…ces in tests

## Because

- `.toBeInDocument` should be `.toBeInDocument()`, etc.

## This pull request

- Fixes the errors, but doesn't add ESLint rules to catch future breakages, I'll file that as a separate issue.

## Issue that this pull request solves

Closes: #12868

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
