### PR TITLE
feat(payments): rename downloadURL to successActionButtonURL

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -110,7 +110,7 @@ export type FormattedSubscriptionForEmail = {
   planId: string;
   planName: string | null;
   planEmailIconURL: string;
-  planDownloadURL: string;
+  planSuccessActionButtonURL: string;
   productMetadata: Stripe.Metadata;
 };
 
@@ -2354,8 +2354,12 @@ export class StripeHelper extends StripeHelperBase {
     const productMetadata = this.mergeMetadata(plan, abbrevProduct);
     const {
       emailIconURL: planEmailIconURL = '',
-      downloadURL: planDownloadURL = '',
+      downloadURL,
+      successActionButtonURL,
     } = productMetadata;
+
+    const planSuccessActionButtonURL =
+      successActionButtonURL || downloadURL || '';
 
     const { lastFour, cardType } = this.extractCardDetails({
       charge,
@@ -2382,7 +2386,7 @@ export class StripeHelper extends StripeHelperBase {
       planId,
       planName,
       planEmailIconURL,
-      planDownloadURL,
+      planSuccessActionButtonURL,
       productMetadata,
       showPaymentMethod: !!invoiceTotalInCents,
       discountType,
@@ -2410,15 +2414,20 @@ export class StripeHelper extends StripeHelperBase {
     const productMetadata = this.mergeMetadata(plan, abbrevProduct);
     const {
       emailIconURL: planEmailIconURL = '',
-      downloadURL: planDownloadURL = '',
+      downloadURL,
+      successActionButtonURL,
     } = productMetadata;
+
+    const planSuccessActionButtonURL =
+      successActionButtonURL || downloadURL || '';
+
     return {
       productId,
       productName,
       planId,
       planName,
       planEmailIconURL,
-      planDownloadURL,
+      planSuccessActionButtonURL,
       productMetadata,
     };
   }
@@ -2586,7 +2595,6 @@ export class StripeHelper extends StripeHelperBase {
     const {
       productOrder: productOrderNew,
       emailIconURL: productIconURLNew = '',
-      downloadURL: productDownloadURLNew = '',
     } = productNewMetadata;
 
     const baseDetails = {
@@ -2597,7 +2605,6 @@ export class StripeHelper extends StripeHelperBase {
       productIdNew,
       productNameNew,
       productIconURLNew,
-      productDownloadURLNew,
       planIdNew,
       paymentAmountNewInCents,
       paymentAmountNewCurrency,
@@ -2824,7 +2831,6 @@ export class StripeHelper extends StripeHelperBase {
     const {
       productOrder: productOrderOld,
       emailIconURL: productIconURLOld = '',
-      downloadURL: productDownloadURLOld = '',
     } = this.mergeMetadata(planOld, abbrevProductOld);
 
     const updateType =
@@ -2838,7 +2844,6 @@ export class StripeHelper extends StripeHelperBase {
       productIdOld,
       productNameOld,
       productIconURLOld,
-      productDownloadURLOld,
       productPaymentCycleOld:
         planOld.interval ?? baseDetails.productPaymentCycleNew,
       paymentAmountOldInCents,

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -457,7 +457,8 @@ module.exports.subscriptionProductMetadataBaseValidator = isA
   .object({
     webIconURL: isA.string().uri().required(),
     upgradeCTA: isA.string().optional(),
-    downloadURL: isA.string().uri().required(),
+    downloadURL: isA.string().uri(), // TODO - Legacy value. Remove once all Stripe Products have been updated.
+    successActionButtonURL: isA.string().uri(), // TODO - Mark as required, once downloadURL is removed
     appStoreLink: isA.string().uri().optional(),
     playStoreLink: isA.string().uri().optional(),
     productSet: isA.string().optional(),
@@ -477,6 +478,7 @@ module.exports.subscriptionProductMetadataBaseValidator = isA
   .pattern(capabilitiesClientIdPattern, isA.string(), {
     fallthrough: true,
   })
+  .or('downloadURL', 'successActionButtonURL') // TODO - Remove once downloadURL is removed.
   .unknown(true);
 
 module.exports.subscriptionProductMetadataValidator = {

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2650,7 +2650,7 @@ module.exports = function (log, config, bounces) {
       planId,
       productName,
       planEmailIconURL,
-      planDownloadURL,
+      planSuccessActionButtonURL,
       uid,
       appStoreLink,
       playStoreLink,
@@ -2661,7 +2661,7 @@ module.exports = function (log, config, bounces) {
     const query = { plan_id: planId, product_id: productId, uid };
     const template = 'downloadSubscription';
     const links = this._generateLinks(
-      planDownloadURL,
+      planSuccessActionButtonURL,
       message,
       query,
       template,

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
@@ -215,6 +215,16 @@ export class StripeProductsAndPlansConverter {
         urlConfig[key] = value;
       }
     }
+
+    // Support legacy downloadURL, which was renamed to successActionButtonURL
+    // TODO - Remove once all Prod Products have been updated.
+    if (
+      !urlConfig['successActionButton'] &&
+      stripeObject.metadata['downloadURL']
+    ) {
+      urlConfig['successActionButton'] = stripeObject.metadata['downloadURL'];
+    }
+
     return urlConfig;
   }
 

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -112,7 +112,7 @@ function sendMail(mailer, messageToSend) {
     planId: 'plan-example',
     productName: 'Firefox Fortress',
     planEmailIconURL: 'http://placekitten.com/512/512',
-    planDownloadURL: 'http://getfirefox.com/',
+    planSuccessActionButtonURL: 'http://getfirefox.com/',
     planInterval: 'week',
     planIntervalCount: 4,
     playStoreLink: 'https://example.com/play-store',
@@ -159,7 +159,7 @@ function sendMail(mailer, messageToSend) {
     productMetadata,
     providerName: 'Google',
     subscription: {
-      planDownloadURL: 'http://getfirefox.com/',
+      planSuccessActionButtonURL: 'http://getfirefox.com/',
       planEmailIconURL: 'http://placekitten.com/512/512',
       planId: 'plan-example',
       productId: '0123456789abcdef',
@@ -168,7 +168,7 @@ function sendMail(mailer, messageToSend) {
     },
     subscriptions: [
       {
-        planDownloadURL: 'http://getfirefox.com/',
+        planSuccessActionButtonURL: 'http://getfirefox.com/',
         planEmailIconURL: 'http://placekitten.com/512/512',
         planId: 'plan-example',
         productId: '0123456789abcdef',

--- a/packages/fxa-auth-server/test/local/payments/configuration/manager.js
+++ b/packages/fxa-auth-server/test/local/payments/configuration/manager.js
@@ -70,7 +70,7 @@ const productConfig = {
   support: {},
   uiContent: {},
   urls: {
-    download: 'https://download.com',
+    successActionButton: 'https://download.com',
     privacyNotice: 'https://privacy.com',
     termsOfService: 'https://terms.com',
     termsOfServiceDownload: 'https://terms-download.com',

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4439,7 +4439,8 @@ describe('StripeHelper', () => {
     const productId = 'prod_00000000000000';
     const productName = 'Example Product';
     const planEmailIconURL = 'http://example.com/icon';
-    const planDownloadURL = 'http://example.com/download';
+    const downloadURL = 'http://example.com/download';
+    const successActionButtonURL = 'http://example.com/success';
     const sourceId = eventCustomerSourceExpiring.data.object.id;
     const chargeId = 'ch_1GVm24BVqmGyQTMaUhRAfUmA';
     const privacyNoticeURL =
@@ -4455,7 +4456,7 @@ describe('StripeHelper', () => {
       product: productId,
       metadata: {
         emailIconURL: planEmailIconURL,
-        downloadURL: planDownloadURL,
+        successActionButtonURL: successActionButtonURL,
       },
     };
 
@@ -4625,9 +4626,9 @@ describe('StripeHelper', () => {
         planId,
         planName,
         planEmailIconURL,
-        planDownloadURL,
+        planSuccessActionButtonURL: successActionButtonURL,
         productMetadata: {
-          downloadURL: planDownloadURL,
+          successActionButtonURL: successActionButtonURL,
           emailIconURL: planEmailIconURL,
           'product:privacyNoticeURL': privacyNoticeURL,
           'product:termsOfServiceURL': termsOfServiceURL,
@@ -4734,6 +4735,32 @@ describe('StripeHelper', () => {
         assert.deepEqual(result, {
           ...expected,
           nextInvoiceDate: new Date(subscriptionPeriodEnd * 1000),
+        });
+      });
+
+      it('planSuccessActionButton URL, falls back to using downloadURL if successActionButtonURL is not available', async () => {
+        const fixture = deepCopy(invoicePaidSubscriptionCreate);
+        fixture.lines.data[0].plan = {
+          id: planId,
+          nickname: planName,
+          metadata: {
+            ...mockPlan.metadata,
+            successActionButtonURL: undefined,
+            downloadURL,
+          },
+          product: mockProduct,
+        };
+        const result = await stripeHelper.extractInvoiceDetailsForEmail(
+          fixture
+        );
+        assert.deepEqual(result, {
+          ...expected,
+          planSuccessActionButtonURL: downloadURL,
+          productMetadata: {
+            ...expected.productMetadata,
+            successActionButtonURL: undefined,
+            downloadURL,
+          },
         });
       });
 
@@ -4942,9 +4969,9 @@ describe('StripeHelper', () => {
             planId,
             planName,
             planEmailIconURL,
-            planDownloadURL,
+            planSuccessActionButtonURL: successActionButtonURL,
             productMetadata: {
-              downloadURL: planDownloadURL,
+              successActionButtonURL,
               emailIconURL: planEmailIconURL,
               'product:privacyNoticeURL': privacyNoticeURL,
               'product:termsOfServiceURL': termsOfServiceURL,
@@ -5024,8 +5051,6 @@ describe('StripeHelper', () => {
       productNameNew: productName,
       productIconURLNew:
         eventCustomerSubscriptionUpdated.data.object.plan.metadata.emailIconURL,
-      productDownloadURLNew:
-        eventCustomerSubscriptionUpdated.data.object.plan.metadata.downloadURL,
       planIdNew: planId,
       paymentAmountNewCurrency:
         eventCustomerSubscriptionUpdated.data.object.plan.currency,
@@ -5182,7 +5207,6 @@ describe('StripeHelper', () => {
           productIdNew,
           productNameNew,
           productIconURLNew,
-          productDownloadURLNew,
           productMetadata: {
             ...expectedBaseUpdateDetails.productMetadata,
             emailIconURL: productIconURLNew,
@@ -5255,7 +5279,6 @@ describe('StripeHelper', () => {
           productIdOld,
           productNameOld,
           productIconURLOld,
-          productDownloadURLOld,
           productPaymentCycleOld: event.data.previous_attributes.plan.interval,
           paymentAmountOldCurrency:
             event.data.previous_attributes.plan.currency,
@@ -5291,7 +5314,6 @@ describe('StripeHelper', () => {
           productIdNew,
           productNameNew,
           productIconURLNew,
-          productDownloadURLNew,
           productMetadata: {
             ...expectedBaseUpdateDetails.productMetadata,
             emailIconURL: productIconURLNew,

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -96,7 +96,7 @@ const MESSAGE = {
   paymentProratedInCents: 523099.9,
   paymentProratedCurrency: 'usd',
   payment_provider: 'stripe',
-  planDownloadURL: 'http://getfirefox.com/',
+  planSuccessActionButtonURL: 'http://getfirefox.com/',
   planId: 'plan-example',
   planInterval: 'day',
   planIntervalCount: 2,
@@ -1159,7 +1159,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: 'https://www.mozilla.org/privacy/websites/' },
-      { test: 'include', expected: MESSAGE.planDownloadURL },
+      { test: 'include', expected: MESSAGE.planSuccessActionButtonURL },
       { test: 'include', expected: MESSAGE.appStoreLink },
       { test: 'include', expected: MESSAGE.playStoreLink },
       { test: 'include', expected: decodeUrl(configHref('subscriptionPrivacyUrl', 'new-subscription', 'subscription-privacy')) },
@@ -1177,7 +1177,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: MESSAGE.planDownloadURL },
+      { test: 'include', expected: MESSAGE.planSuccessActionButtonURL },
       { test: 'include', expected: configUrl('subscriptionPrivacyUrl', 'new-subscription', 'subscription-privacy') },
       { test: 'include', expected: configUrl('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configUrl('subscriptionTermsUrl', 'new-subscription', 'subscription-terms') },

--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
@@ -201,7 +201,29 @@ describe('StripeProductsAndPlansConverter', () => {
         },
       };
       const expected = {
-        download: 'http://127.0.0.1:8080/',
+        successActionButton: 'http://127.0.0.1:8080/',
+        webIcon: 'https://123done-stage.dev.lcip.org/img/transparent-logo.png',
+        emailIcon:
+          'https://123done-stage.dev.lcip.org/img/transparent-logo.png',
+        appStore: 'https://www.appstore.com',
+        privacyNotice: 'https://www.privacy.wow',
+      };
+      const result = converter.urlMetadataToUrlConfig(testProduct);
+      assert.deepEqual(expected, result);
+    });
+
+    it('transforms the data - without successActionButtonURL', () => {
+      const testProduct = {
+        ...deepCopy(product),
+        metadata: {
+          ...deepCopy(product.metadata),
+          successActionButtonURL: undefined,
+          appStoreLink: 'https://www.appstore.com',
+          'product:privacyNoticeURL': 'https://www.privacy.wow',
+        },
+      };
+      const expected = {
+        successActionButton: 'http://127.0.0.1:8080/legacy/download',
         webIcon: 'https://123done-stage.dev.lcip.org/img/transparent-logo.png',
         emailIcon:
           'https://123done-stage.dev.lcip.org/img/transparent-logo.png',
@@ -240,7 +262,7 @@ describe('StripeProductsAndPlansConverter', () => {
         support: {},
         uiContent: {},
         urls: {
-          download: 'http://127.0.0.1:8080/',
+          successActionButton: 'http://127.0.0.1:8080/',
           privacyNotice: 'http://127.0.0.1:8080/',
           termsOfService: 'http://127.0.0.1:8080/',
           termsOfServiceDownload: 'http://127.0.0.1:8080/',
@@ -282,7 +304,7 @@ describe('StripeProductsAndPlansConverter', () => {
           upgradeCTA: 'hello <a href="http://example.org">world</a>',
         },
         urls: {
-          download: 'https://example.com/download',
+          successActionButton: 'https://example.com/download',
         },
         productOrder: 2,
       };
@@ -387,7 +409,7 @@ describe('StripeProductsAndPlansConverter', () => {
       support: {},
       uiContent: {},
       urls: {
-        download: 'http://127.0.0.1:8080/',
+        successActionButton: 'http://127.0.0.1:8080/',
         privacyNotice: 'http://127.0.0.1:8080/',
         termsOfService: 'http://127.0.0.1:8080/',
         termsOfServiceDownload: 'http://127.0.0.1:8080/',
@@ -421,7 +443,7 @@ describe('StripeProductsAndPlansConverter', () => {
         upgradeCTA: 'hello <a href="http://example.org">world</a>',
       },
       urls: {
-        download: 'https://example.com/download',
+        successActionButton: 'https://example.com/download',
       },
       productOrder: 2,
     };
@@ -444,7 +466,7 @@ describe('StripeProductsAndPlansConverter', () => {
             upgradeCTA: 'hello <a href="http://example.org">world</a>',
           },
           urls: {
-            download: 'https://example.com/download',
+            successActionButton: 'https://example.com/download',
           },
         },
       },

--- a/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
@@ -67,7 +67,8 @@ class SetPassword extends FormView {
       const plan = plans.find((p) => p.product_id === productId);
       const url = new URL(
         plan && plan.product_metadata
-          ? plan.product_metadata.downloadURL
+          ? plan.product_metadata.successActionButtonURL ||
+            plan.product_metadata.downloadURL
           : 'https://mozilla.org'
       );
       url.searchParams.set('email', account.get('email'));

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -84,7 +84,7 @@ describe('SubscriptionSuccess', () => {
         subtitle: 'VPN Subtitle',
       },
       urls: {
-        download: 'https://download.default.locale',
+        successActionButton: 'https://download.default.locale',
       },
     };
     assertRedirectForProduct(
@@ -104,12 +104,12 @@ describe('SubscriptionSuccess', () => {
         subtitle: 'VPN Subtitle',
       },
       urls: {
-        download: 'https://download.default.locale',
+        successActionButton: 'https://download.default.locale',
       },
       locales: {
         fr: {
           urls: {
-            download: 'https://download.default.locale/fr/',
+            successActionButton: 'https://download.default.locale/fr/',
           },
         },
       },

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.tsx
@@ -35,14 +35,16 @@ export const SubscriptionSuccess = ({
     navigatorLanguages,
   } = useContext(AppContext);
 
-  const { download } = urlsFromProductConfig(
+  const { successActionButton } = urlsFromProductConfig(
     plan,
     navigatorLanguages,
     featureFlags.useFirestoreProductConfigs
   );
 
   const productUrl =
-    download || productRedirectURLs[product_id] || defaultProductRedirectURL;
+    successActionButton ||
+    productRedirectURLs[product_id] ||
+    defaultProductRedirectURL;
 
   return (
     <>

--- a/packages/fxa-shared/subscriptions/configuration/base.ts
+++ b/packages/fxa-shared/subscriptions/configuration/base.ts
@@ -13,7 +13,7 @@ const capabilitySchema = joi
   .min(1);
 
 export const UrlConfigKeys = [
-  'download',
+  'successActionButton',
   'webIcon',
   'emailIcon',
   'termsOfService',
@@ -30,7 +30,7 @@ export type UrlConfig = {
 };
 
 const urlsSchema = joi.object({
-  download: joi.string().uri(),
+  successActionButton: joi.string().uri(),
   webIcon: joi.string().uri(),
   emailIcon: joi.string().uri(),
   termsOfService: joi.string().uri(),

--- a/packages/fxa-shared/subscriptions/configuration/helpers.ts
+++ b/packages/fxa-shared/subscriptions/configuration/helpers.ts
@@ -88,8 +88,11 @@ export const urlsFromProductConfig = (
         planMetadataConfig.privacyNoticeDownloadURL ||
         DEFAULT_PRODUCT_DETAILS.privacyNoticeDownloadURL!,
       cancellationSurvey: planMetadataConfig.cancellationSurveyURL,
-      download:
-        plan.product_metadata?.downloadURL || plan.plan_metadata?.downloadURL,
+      successActionButton:
+        plan.product_metadata?.successActionButtonURL ||
+        plan.plan_metadata?.successActionButtonURL ||
+        plan.product_metadata?.downloadURL ||
+        plan.plan_metadata?.downloadURL,
     };
   }
 };

--- a/packages/fxa-shared/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/subscriptions/configuration/product.ts
@@ -30,7 +30,7 @@ const buildProductConfigSchema = (baseSchema: joi.ObjectSchema) =>
       'styles',
       'support',
       'uiContent',
-      'urls.download',
+      'urls.successActionButton',
       'urls.privacyNotice',
       'urls.termsOfService',
       'urls.termsOfServiceDownload',
@@ -41,7 +41,7 @@ const buildProductConfigSchema = (baseSchema: joi.ObjectSchema) =>
 // This type defines the required fields of urls, set by function buildProductConfigSchema.
 // Any change to required fields in urls, should be updated here as well.
 export type ProductConfigUrlConfig = Partial<UrlConfig> & {
-  download: string;
+  successActionButton: string;
   privacyNotice: string;
   termsOfService: string;
   termsOfServiceDownload: string;

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -42,7 +42,8 @@ export const metadataFromPlan = (plan: Plan): ProductMetadata => ({
   webIconURL: null,
   webIconBackground: null,
   upgradeCTA: null,
-  downloadURL: null,
+  downloadURL: null, // TODO - Legacy value. Remove once all Stripe Products have been updated.
+  successActionButtonURL: null,
   'product:termsOfServiceDownloadURL': '',
   'product:termsOfServiceURL': '',
   'product:privacyNoticeURL': '',

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -37,7 +37,8 @@ export interface PlanMetadata {
 export interface ProductMetadata {
   appStoreLink?: string;
   capabilities?: string;
-  downloadURL: string | null;
+  downloadURL: string | null; // TODO - Legacy value. Remove once all Stripe Products have been updated.
+  successActionButtonURL: string | null;
   emailIconURL?: string | null;
   playStoreLink?: string;
   productOrder?: string | null;

--- a/packages/fxa-shared/test/fixtures/stripe/product1.json
+++ b/packages/fxa-shared/test/fixtures/stripe/product1.json
@@ -10,7 +10,8 @@
   "metadata": {
     "capabilities": "testForAllClients, foo",
     "capabilities:dcdb5ae7add825d2": "123donePro,     gogogo",
-    "downloadURL": "http://127.0.0.1:8080/",
+    "successActionButtonURL": "http://127.0.0.1:8080/",
+    "downloadURL": "http://127.0.0.1:8080/legacy/download",
     "webIconURL": "https://123done-stage.dev.lcip.org/img/transparent-logo.png",
     "webIconBackground": "lime",
     "emailIconURL": "https://123done-stage.dev.lcip.org/img/transparent-logo.png",

--- a/packages/fxa-shared/test/subscriptions/configuration/helpers.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/helpers.ts
@@ -68,7 +68,7 @@ const PLAN_WITH_METADATA: Plan = {
 };
 
 const CONFIGURATION_URLS = {
-  download: 'https://download',
+  successActionButton: 'https://download',
   privacyNotice: 'https://privacynotice',
   termsOfService: 'httsp://termsofservice',
   termsOfServiceDownload: 'https://termsofservicedownload',
@@ -90,7 +90,7 @@ const LOCALE_CONFIGURATION_NONE = {
 
 const LOCALE_CONFIGURATION_FR = {
   urls: {
-    download: 'https://download/fr',
+    successActionButton: 'https://download/fr',
     privacyNotice: 'https://privacynotice/fr',
     termsOfService: 'httsp://termsofservice/fr',
     termsOfServiceDownload: 'https://termsofservicedownload/fr',
@@ -107,7 +107,7 @@ const LOCALE_CONFIGURATION_FR = {
 
 const LOCALE_CONFIGURATION_ENUS = {
   urls: {
-    download: 'https://download/enUS',
+    successActionButton: 'https://download/enUS',
     privacyNotice: 'https://privacynotice/enUS',
     termsOfService: 'httsp://termsofservice/enUS',
     termsOfServiceDownload: 'https://termsofservicedownload/enUS',
@@ -210,7 +210,7 @@ describe('subscriptions/configuration/helpers', () => {
         privacyNotice: 'https://example.org/en-US/privacy',
         termsOfServiceDownload: 'https://example.org/en-US/terms/download',
         privacyNoticeDownload: 'https://example.org/en-US/privacy/download',
-        download: undefined,
+        successActionButton: undefined,
         cancellationSurvey: undefined,
       });
     });

--- a/packages/fxa-shared/test/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/plan.ts
@@ -20,7 +20,7 @@ const firestoreObject = {
   },
   support: {},
   uiContent: {},
-  urls: { download: 'gopher://example.gg' },
+  urls: { successActionButton: 'gopher://example.gg' },
 };
 
 const localesObject = {

--- a/packages/fxa-shared/test/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/product.ts
@@ -20,7 +20,7 @@ const firestoreObject = {
   support: {},
   uiContent: {},
   urls: {
-    download: 'https://download.com',
+    successActionButton: 'https://download.com',
     privacyNotice: 'https://privacy.com',
     termsOfService: 'https://terms.com',
     termsOfServiceDownload: 'https://terms-download.com',
@@ -74,7 +74,7 @@ describe('ProductConfig', () => {
 
   it('validates with error on an invalid productConfig', async () => {
     const obj = JSON.parse(JSON.stringify(firestoreObject));
-    delete obj.urls.download;
+    delete obj.urls.successActionButton;
     const result = await ProductConfig.validate(obj, validSchemaValidation);
     assert.isDefined(result.error);
     assert.isUndefined(result.value);

--- a/packages/fxa-shared/test/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/utils.ts
@@ -23,10 +23,10 @@ describe('product configuration util functions', () => {
     termsOfServiceDownload: 'product',
     privacyNotice: 'product',
     privacyNoticeDownload: 'product',
-    download: 'download',
+    successActionButton: 'download',
   };
   const planUrls = {
-    download: 'plan',
+    successActionButton: 'plan',
     emailIcon: 'plan',
     termsOfService: 'plan',
     termsOfServiceDownload: 'plan',
@@ -98,7 +98,7 @@ describe('product configuration util functions', () => {
           webIcon: 'product',
           privacyNotice: 'product',
           privacyNoticeDownload: 'product',
-          download: 'plan',
+          successActionButton: 'plan',
           emailIcon: 'plan',
           termsOfService: 'plan',
           termsOfServiceDownload: 'plan',

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -22,6 +22,7 @@ const NULL_METADATA = {
   webIconBackground: null,
   upgradeCTA: null,
   downloadURL: null,
+  successActionButtonURL: null,
   'product:termsOfServiceURL': '',
   'product:termsOfServiceDownloadURL': '',
   'product:privacyNoticeURL': '',
@@ -45,6 +46,7 @@ const requiredProductMetadata = {
   'product:termsOfServiceDownloadURL': '',
   'product:privacyNoticeURL': '',
   downloadURL: null,
+  successActionButtonURL: null,
   webIconURL: null,
 };
 


### PR DESCRIPTION
## Because

- The button on the success screen allows for a configurable label,
  which means it can be used for more than just downloading the product,
  which makes the configuration field "downloadURL" misleading.

## This pull request

- Adds support for a new configuration field "successActionButtonURL" to
  replace "downloadURL".
- Updates the code to reflect the name change.

## Issue that this pull request solves

Closes: #9338

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional Info

- Document changes can be found in the Pull Request listed below.
  - https://github.com/mozilla/ecosystem-platform/pull/205
- I've added `successActionButtonURL` to all products in Stripe Dev and Staging 