### PR TITLE
chore(storybook) update storybook format and add ltr/rtl support

### DIFF
--- a/packages/fxa-settings/.storybook/main.js
+++ b/packages/fxa-settings/.storybook/main.js
@@ -4,5 +4,9 @@
 
 module.exports = {
   stories: ['./design-guide/main.stories.tsx', '../src/**/*.stories.tsx'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links'],
+  addons: [
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    'storybook-addon-rtl',
+  ],
 };

--- a/packages/fxa-settings/.storybook/preview.js
+++ b/packages/fxa-settings/.storybook/preview.js
@@ -5,3 +5,6 @@
 import '../src/styles/tailwind.out';
 import '../src/styles/fonts';
 import './design-guide/design-guide';
+import { initializeRTL } from 'storybook-addon-rtl';
+
+initializeRTL();

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -122,6 +122,7 @@
     "pm2": "^5.1.2",
     "postcss-cli": "^7.1.1",
     "react-test-renderer": "^17.0.2",
+    "storybook-addon-rtl": "^0.4.2",
     "style-loader": "^1.3.0",
     "tailwindcss": "^1.9.1",
     "webpack": "^4.43.0",

--- a/packages/fxa-settings/src/components/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.stories.tsx
@@ -3,33 +3,72 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { mockSession } from '../../models/mocks';
-import { getDefault } from '../../lib/config';
+import { LocationProvider } from '@reach/router';
+import { getDefault, Config } from '../../lib/config';
 import { Nav } from '.';
 import { AppContext } from 'fxa-settings/src/models';
+import { mockAppContext } from '../../models/mocks';
+import { Account } from '../../models/Account';
+import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'Components/Nav',
+  component: Nav,
+} as Meta;
 
 const account = {
   primaryEmail: {
     email: 'johndope@example.com',
   },
   subscriptions: [{ created: 1, productName: 'x' }],
-} as any;
-storiesOf('Components/Nav', module)
-  .add('basic', () => <Nav />)
-  .add('with link to Subscriptions', () => (
-    <AppContext.Provider value={{ account, session: mockSession() }}>
-      <Nav />
-    </AppContext.Provider>
-  ))
-  .add('without link to Newsletters', () => {
-    const config = Object.assign({}, getDefault(), {
-      marketingEmailPreferencesUrl: '',
-    });
+  linkedAccounts: [],
+} as unknown as Account;
 
-    return (
-      <AppContext.Provider value={{ account, session: mockSession(), config }}>
+const accountWithLinkedAccounts = {
+  ...account,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+};
+
+const configWithoutNewsletterLink = {
+  ...getDefault(),
+  marketingEmailPreferencesUrl: '',
+};
+
+const storyWithContext = (
+  account: Partial<Account>,
+  storyName?: string,
+  config?: Config,
+) => {
+  const context = config
+    ? { account: account as Account, config: config }
+    : { account: account as Account };
+
+  const story = () => (
+    <LocationProvider>
+      <AppContext.Provider value={mockAppContext(context)}>
         <Nav />
       </AppContext.Provider>
-    );
-  });
+    </LocationProvider>
+  );
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const Basic = () => <Nav />;
+
+export const WithLinkToSubscriptions = storyWithContext(
+  account,
+  'with link to Subscriptions'
+);
+
+export const WithLinkedAccounts = storyWithContext(
+  accountWithLinkedAccounts,
+  'with linked accounts'
+);
+
+export const WithoutNewsletterLink = storyWithContext(
+  account,
+  'without link to Newsletters',
+  configWithoutNewsletterLink
+);

--- a/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
@@ -3,70 +3,89 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { Account } from '../../models/Account';
+
 import { PageSettings } from '.';
+import { Config } from '../../lib/config';
+
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 import { isMobileDevice } from '../../lib/utilities';
 import { mockAppContext, mockEmail, MOCK_ACCOUNT } from '../../models/mocks';
 import { MOCK_SERVICES } from '../ConnectedServices/mocks';
 import { AppContext } from 'fxa-settings/src/models';
+import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
+import { Meta } from '@storybook/react';
+
 
 const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
-storiesOf('Pages/Settings', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('cold start', () => (
-    <AppContext.Provider
-      value={mockAppContext({
-        account: {
-          ...MOCK_ACCOUNT,
-          displayName: null,
-          avatar: { id: null, url: null },
-          recoveryKey: false,
-          totp: { exists: false, verified: false },
-          attachedClients: SERVICES_NON_MOBILE,
-        } as any,
-      })}
-    >
-      <AppLayout>
-        <PageSettings />
-      </AppLayout>
-    </AppContext.Provider>
-  ))
-  .add('partially filled out', () => (
-    <AppContext.Provider
-      value={mockAppContext({
-        account: {
-          ...MOCK_ACCOUNT,
-          displayName: null,
-          totp: { exists: true, verified: false },
-          attachedClients: SERVICES_NON_MOBILE,
-        } as any,
-      })}
-    >
-      <AppLayout>
-        <PageSettings />
-      </AppLayout>
-    </AppContext.Provider>
-  ))
+export default {
+  title: 'Pages/Settings',
+  component: PageSettings,
+} as Meta;
 
-  .add('completely filled out', () => (
-    <AppContext.Provider
-      value={mockAppContext({
-        account: {
-          ...MOCK_ACCOUNT,
-          subscriptions: [{ created: 1, productName: 'x' }],
-          emails: [
-            mockEmail('johndope@example.com'),
-            mockEmail('johndope2@gmail.com', false),
-          ],
-          attachedClients: SERVICES_NON_MOBILE,
-        } as any,
-      })}
-    >
-      <AppLayout>
-        <PageSettings />
-      </AppLayout>
-    </AppContext.Provider>
-  ));
+const coldStartAccount = {
+  ...MOCK_ACCOUNT,
+  displayName: null,
+  avatar: { id: null, url: null },
+  recoveryKey: false,
+  totp: { exists: false, verified: false },
+  attachedClients: [SERVICES_NON_MOBILE[0]],
+} as unknown as Account;
+
+const partiallyFilledOutAccount = {
+  ...MOCK_ACCOUNT,
+  displayName: null,
+  totp: { exists: true, verified: false },
+  attachedClients: SERVICES_NON_MOBILE,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+} as unknown as Account;
+
+const completelyFilledOutAccount = {
+  ...MOCK_ACCOUNT,
+  subscriptions: [{ created: 1, productName: 'x' }],
+  emails: [
+    mockEmail('johndope@example.com'),
+    mockEmail('johndope2@gmail.com', false),
+  ],
+  attachedClients: SERVICES_NON_MOBILE,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+}
+
+const storyWithContext = (
+  account: Partial<Account>,
+  storyName?: string,
+  config?: Config,
+) => {
+  const context = config
+    ? { account: account as Account, config: config }
+    : { account: account as Account };
+
+  const story = () => (
+    <LocationProvider>
+      <AppContext.Provider value={mockAppContext(context)}>
+        <AppLayout>
+          <PageSettings/>
+        </AppLayout>
+      </AppContext.Provider>
+    </LocationProvider>
+  );
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const ColdStart = storyWithContext(
+  coldStartAccount,
+  'cold start',
+);
+
+export const PartiallyFilledOut = storyWithContext(
+  partiallyFilledOutAccount,
+  'partially filled out',
+);
+
+export const CompletelyFilledOut = storyWithContext(
+  completelyFilledOutAccount,
+  'completely filled out',
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,6 +493,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.18.2":
+  version: 7.18.2
+  resolution: "@babel/generator@npm:7.18.2"
+  dependencies:
+    "@babel/types": ^7.18.2
+    "@jridgewell/gen-mapping": ^0.3.0
+    jsesc: ^2.5.1
+  checksum: d0661e95532ddd97566d41fec26355a7b28d1cbc4df95fe80cc084c413342935911b48db20910708db39714844ddd614f61c2ec4cca3fb10181418bdcaa2e7a3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-annotate-as-pure@npm:7.16.0"
@@ -688,6 +699,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-environment-visitor@npm:^7.18.2":
+  version: 7.18.2
+  resolution: "@babel/helper-environment-visitor@npm:7.18.2"
+  checksum: 1a9c8726fad454a082d077952a90f17188e92eabb3de236cb4782c49b39e3f69c327e272b965e9a20ff8abf37d30d03ffa6fd7974625a6c23946f70f7527f5e9
+  languageName: node
+  linkType: hard
+
 "@babel/helper-explode-assignable-expression@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-explode-assignable-expression@npm:7.16.0"
@@ -725,6 +743,16 @@ __metadata:
     "@babel/template": ^7.16.7
     "@babel/types": ^7.16.7
   checksum: fc77cbe7b10cfa2a262d7a37dca575c037f20419dfe0c5d9317f589599ca24beb5f5c1057748011159149eaec47fe32338c6c6412376fcded68200df470161e1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.17.9":
+  version: 7.17.9
+  resolution: "@babel/helper-function-name@npm:7.17.9"
+  dependencies:
+    "@babel/template": ^7.16.7
+    "@babel/types": ^7.17.0
+  checksum: a59b2e5af56d8f43b9b0019939a43774754beb7cb01a211809ca8031c71890999d07739e955343135ec566c4d8ff725435f1f60fb0af3bb546837c1f9f84f496
   languageName: node
   linkType: hard
 
@@ -1084,6 +1112,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 1771808491982cc47baa888a997aef6b58308e3844c8c00f730f8fd97defe57d32cdbf46075cd49aaee310fa31f3d2c80a0d41b41a4ee0ff336ee09e2ff6c222
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.18.0":
+  version: 7.18.4
+  resolution: "@babel/parser@npm:7.18.4"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: e05b2dc720c4b200e088258f3c2a2de5041c140444edc38181d1217b10074e881a7133162c5b62356061f26279f08df5a06ec14c5842996ee8601ad03c57a44f
   languageName: node
   linkType: hard
 
@@ -3090,6 +3127,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.0.0":
+  version: 7.18.2
+  resolution: "@babel/traverse@npm:7.18.2"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.18.2
+    "@babel/helper-environment-visitor": ^7.18.2
+    "@babel/helper-function-name": ^7.17.9
+    "@babel/helper-hoist-variables": ^7.16.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/parser": ^7.18.0
+    "@babel/types": ^7.18.2
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: e21c2d550bf610406cf21ef6fbec525cb1d80b9d6d71af67552478a24ee371203cb4025b23b110ae7288a62a874ad5898daad19ad23daa95dfc8ab47a47a092f
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.12.1, @babel/traverse@npm:^7.12.11, @babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.5, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.2":
   version: 7.16.5
   resolution: "@babel/traverse@npm:7.16.5"
@@ -3171,6 +3226,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.16.7
     to-fast-properties: ^2.0.0
   checksum: 12e5a287986fe557188e87b2c5202223f1dc83d9239a196ab936fdb9f8c1eb0be717ff19f934b5fad4e29a75586d5798f74bed209bccea1c20376b9952056f0e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.18.2":
+  version: 7.18.4
+  resolution: "@babel/types@npm:7.18.4"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.16.7
+    to-fast-properties: ^2.0.0
+  checksum: 85df59beb99c1b95e9e41590442f2ffa1e5b1b558d025489db40c9f7c906bd03a17da26c3ec486e5800e80af27c42ca7eee9506d9212ab17766d2d68d30fbf52
   languageName: node
   linkType: hard
 
@@ -3317,7 +3382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/is-prop-valid@npm:0.8.8, @emotion/is-prop-valid@npm:^0.8.6":
+"@emotion/is-prop-valid@npm:0.8.8, @emotion/is-prop-valid@npm:^0.8.1, @emotion/is-prop-valid@npm:^0.8.6":
   version: 0.8.8
   resolution: "@emotion/is-prop-valid@npm:0.8.8"
   dependencies:
@@ -3451,7 +3516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/unitless@npm:0.7.5, @emotion/unitless@npm:^0.7.5":
+"@emotion/unitless@npm:0.7.5, @emotion/unitless@npm:^0.7.0, @emotion/unitless@npm:^0.7.5":
   version: 0.7.5
   resolution: "@emotion/unitless@npm:0.7.5"
   checksum: f976e5345b53fae9414a7b2e7a949aa6b52f8bdbcc84458b1ddc0729e77ba1d1dfdff9960e0da60183877873d3a631fa24d9695dd714ed94bcd3ba5196586a6b
@@ -4799,10 +4864,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "@jridgewell/gen-mapping@npm:0.3.1"
+  dependencies:
+    "@jridgewell/set-array": ^1.0.0
+    "@jridgewell/sourcemap-codec": ^1.4.10
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: e9e7bb3335dea9e60872089761d4e8e089597360cdb1af90370e9d53b7d67232c1e0a3ab65fbfef4fc785745193fbc56bff9f3a6cab6c6ce3f15e12b4191f86b
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.0.5
   resolution: "@jridgewell/resolve-uri@npm:3.0.5"
   checksum: 1ee652b693da7979ac4007926cc3f0a32b657ffeb913e111f44e5b67153d94a2f28a1d560101cc0cf8087625468293a69a00f634a2914e1a6d0817ba2039a913
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@jridgewell/set-array@npm:1.1.1"
+  checksum: cc5d91e0381c347e3edee4ca90b3c292df9e6e55f29acbe0dd97de8651b4730e9ab761406fd572effa79972a0edc55647b627f8c72315e276d959508853d9bf2
   languageName: node
   linkType: hard
 
@@ -4820,6 +4903,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: 0f1f807e33a23280c538574028af30f8173d7622704799b0d97fcfcacc45864e348ba40692488bb9afb606a21a14ac955fbe0bba02a6e0f021e52869f0fd2d65
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.13
+  resolution: "@jridgewell/trace-mapping@npm:0.3.13"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: e38254e830472248ca10a6ed1ae75af5e8514f0680245a5e7b53bc3c030fd8691d4d3115d80595b45d3badead68269769ed47ecbbdd67db1343a11f05700e75a
   languageName: node
   linkType: hard
 
@@ -7545,6 +7638,15 @@ __metadata:
   dependencies:
     core-js: ^3.8.2
   checksum: a10620f3f6b6e0dd22951c3c2287482bdb3e53c98b4b482f142aa2e979ae993a9ee626686a7320f97ce2fe82dcb5afec037346abfda4f33c2f612b1cd83c74a2
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:^6.3.7":
+  version: 6.5.6
+  resolution: "@storybook/core-events@npm:6.5.6"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: b198f61552e55148c9db9caa6ced9f93a5bdd44c22f0b6333e4c03c0fccabcfde01c591225e88db937928244f2155e8b83f3c462c6df5bee135b340159f653bd
   languageName: node
   linkType: hard
 
@@ -13663,6 +13765,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-styled-components@npm:>= 1":
+  version: 2.0.7
+  resolution: "babel-plugin-styled-components@npm:2.0.7"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.16.0
+    "@babel/helper-module-imports": ^7.16.0
+    babel-plugin-syntax-jsx: ^6.18.0
+    lodash: ^4.17.11
+    picomatch: ^2.3.0
+  peerDependencies:
+    styled-components: ">= 2"
+  checksum: 80b06b10db02d749432a0ac43a5feedd686f6b648628d7433a39b1844260b2b7c72431f6e705c82636ee025fcfd4f6c32fc05677e44033b8a39ddcd4488b3147
+  languageName: node
+  linkType: hard
+
 "babel-plugin-syntax-async-functions@npm:^6.8.0":
   version: 6.13.0
   resolution: "babel-plugin-syntax-async-functions@npm:6.13.0"
@@ -15520,6 +15637,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelize@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "camelize@npm:1.0.0"
+  checksum: 769f8d10071f57b974d9a51dc02f589dd7fb07ea6a7ecde1a57b52ae68657ba61fe85c60d50661b76c7dbb76b6474fbfd3356aee33cf5f025cd7fd6fb2811b73
+  languageName: node
+  linkType: hard
+
 "caniuse-api@npm:^3.0.0":
   version: 3.0.0
   resolution: "caniuse-api@npm:3.0.0"
@@ -17311,6 +17435,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-color-keywords@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "css-color-keywords@npm:1.0.0"
+  checksum: 8f125e3ad477bd03c77b533044bd9e8a6f7c0da52d49bbc0bbe38327b3829d6ba04d368ca49dd9ff3b667d2fc8f1698d891c198bbf8feade1a5501bf5a296408
+  languageName: node
+  linkType: hard
+
 "css-color-names@npm:0.0.4, css-color-names@npm:^0.0.4":
   version: 0.0.4
   resolution: "css-color-names@npm:0.0.4"
@@ -17470,6 +17601,17 @@ __metadata:
     fastparse: ^1.1.2
     regexpu-core: ^4.6.0
   checksum: 9ea7dde5a4a01b9b47d823a572ee7e7b6f4599250b9238224ca13c31c8e9bc168b188f20282f591ac7db6f56f4c9f69944289f1d8377b4f4923d0783335da500
+  languageName: node
+  linkType: hard
+
+"css-to-react-native@npm:^2.2.2":
+  version: 2.3.2
+  resolution: "css-to-react-native@npm:2.3.2"
+  dependencies:
+    camelize: ^1.0.0
+    css-color-keywords: ^1.0.0
+    postcss-value-parser: ^3.3.0
+  checksum: 0cc6ea2e519614c8d4e1e8e3872344b137f8bd091f0b21335037adbaa894b600b2cdb10b14d7f9f4047f6465dcd14daff10fd7ddbfa4f2ac300093687a9f0046
   languageName: node
   linkType: hard
 
@@ -23147,6 +23289,7 @@ fsevents@~2.1.1:
     react-scripts: ^4.0.3
     react-test-renderer: ^17.0.2
     react-webcam: ^7.0.0
+    storybook-addon-rtl: ^0.4.2
     style-loader: ^1.3.0
     subscriptions-transport-ws: ^0.11.0
     tailwindcss: ^1.9.1
@@ -27207,6 +27350,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"is-what@npm:^3.3.1":
+  version: 3.14.1
+  resolution: "is-what@npm:3.14.1"
+  checksum: a9a6ce92d33799f1ae0916c7afb6f8128a23ce9d28bd69d9ec3ec88910e7a1f68432e6236c3c8a4d544cf0b864675e5d828437efde60ee0cf8102061d395c1df
+  languageName: node
+  linkType: hard
+
 "is-whitespace-character@npm:^1.0.0":
   version: 1.0.4
   resolution: "is-whitespace-character@npm:1.0.4"
@@ -30917,6 +31067,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "memoize-one@npm:5.2.1"
+  checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
+  languageName: node
+  linkType: hard
+
 "memoizerific@npm:^1.11.3":
   version: 1.11.3
   resolution: "memoizerific@npm:1.11.3"
@@ -30977,6 +31134,15 @@ fsevents@~2.1.1:
     type-fest: ^0.18.0
     yargs-parser: ^20.2.3
   checksum: 99799c47247f4daeee178e3124f6ef6f84bde2ba3f37652865d5d8f8b8adcf9eedfc551dd043e2455cd8206545fd848e269c0c5ab6b594680a0ad4d3617c9639
+  languageName: node
+  linkType: hard
+
+"merge-anything@npm:^2.2.4":
+  version: 2.4.4
+  resolution: "merge-anything@npm:2.4.4"
+  dependencies:
+    is-what: ^3.3.1
+  checksum: 90df106bf7dd57763c0e349ea31c10d140513ccbfc09d4b2b99ccfab1ee7a0c23daa34ae611e9deedacddf6ed1b44bd4eca8f15f07d820686db2cdb10e143284
   languageName: node
   linkType: hard
 
@@ -36141,6 +36307,17 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"prop-types@npm:^15.5.4":
+  version: 15.8.1
+  resolution: "prop-types@npm:15.8.1"
+  dependencies:
+    loose-envify: ^1.4.0
+    object-assign: ^4.1.1
+    react-is: ^16.13.1
+  checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
 "propagate@npm:^2.0.0":
   version: 2.0.1
   resolution: "propagate@npm:2.0.1"
@@ -37017,7 +37194,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.7.0, react-is@npm:^16.8.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -40345,6 +40522,21 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"storybook-addon-rtl@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "storybook-addon-rtl@npm:0.4.2"
+  dependencies:
+    "@storybook/core-events": ^6.3.7
+    prop-types: ^15.7.2
+    styled-components: ^4.4.1
+  peerDependencies:
+    "@storybook/addons": ">=3.1.6 < 7.0.0"
+    react: "*"
+    react-dom: "*"
+  checksum: 6d70d5106c47ab1cf4579da47316500baaec42c2f1d7eff257009598d40ad0ee1145e9cd3a887edfc6d46fe363abbd753fc18e209e492422679a5b0bdaa27a49
+  languageName: node
+  linkType: hard
+
 "stream-browserify@npm:^2.0.0, stream-browserify@npm:^2.0.1":
   version: 2.0.2
   resolution: "stream-browserify@npm:2.0.2"
@@ -40813,6 +41005,30 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"styled-components@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "styled-components@npm:4.4.1"
+  dependencies:
+    "@babel/helper-module-imports": ^7.0.0
+    "@babel/traverse": ^7.0.0
+    "@emotion/is-prop-valid": ^0.8.1
+    "@emotion/unitless": ^0.7.0
+    babel-plugin-styled-components: ">= 1"
+    css-to-react-native: ^2.2.2
+    memoize-one: ^5.0.0
+    merge-anything: ^2.2.4
+    prop-types: ^15.5.4
+    react-is: ^16.6.0
+    stylis: ^3.5.0
+    stylis-rule-sheet: ^0.0.10
+    supports-color: ^5.5.0
+  peerDependencies:
+    react: ">= 16.3.0"
+    react-dom: ">= 16.3.0"
+  checksum: df137c7f621b4250cb40e0cd915275a01d2cef0f5104314a9b8fd7fe4127787f789ca9331b958164203f847e796b03e6e315dbdd6f526b4e4d484f39077950c6
+  languageName: node
+  linkType: hard
+
 "stylehacks@npm:^4.0.0":
   version: 4.0.3
   resolution: "stylehacks@npm:4.0.3"
@@ -40894,10 +41110,26 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"stylis-rule-sheet@npm:^0.0.10":
+  version: 0.0.10
+  resolution: "stylis-rule-sheet@npm:0.0.10"
+  peerDependencies:
+    stylis: ^3.5.0
+  checksum: 97ad016c64ecce8d4b2c2c1c3cf3260de3c0e2b151e78f90ded6cc1bfcca536625a77277af16a9c8a241236a9e4fd5b70d88dfa32e9b48afaddb8f102a95582d
+  languageName: node
+  linkType: hard
+
 "stylis@npm:4.0.13":
   version: 4.0.13
   resolution: "stylis@npm:4.0.13"
   checksum: 8ea7a87028b6383c6a982231c4b5b6150031ce028e0fdaf7b2ace82253d28a8af50cc5a9da8a421d3c7c4441592f393086e332795add672aa4a825f0fe3713a3
+  languageName: node
+  linkType: hard
+
+"stylis@npm:^3.5.0":
+  version: 3.5.4
+  resolution: "stylis@npm:3.5.4"
+  checksum: 3673a748ad236219bd77ca9c0a8730b8726812e612cbc844aa6f029f13666a10cf2825a5f8d41f05e8af02b5987d31b7d3ebe995e4b42e0255366fec23489b77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
chore(storybook) add LinkedAccounts to stories

chore(storybook) refactor nav stories

fix(storybook) use addon to get ltr/rtl in storybook

## Because

- Styles in storybook did not match what we were seeing in prod/local/staging. Also, some cases were missing from demos of the Settings page and nav.

## This pull request

- Adds in additional cases (specifically, an account with Linked Accounts) and also adds a storybook addon to enable ltr/rtl specific styles

## Issue that this pull request solves

Closes: #12848 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before (no linked accounts stories):
![Screen Shot 2022-05-17 at 11 50 19 AM](https://user-images.githubusercontent.com/11150372/168888293-69ca5540-9225-445a-9789-a90698981e27.png)

After (with linked accounts stories):
![Screen Shot 2022-05-17 at 11 44 23 AM](https://user-images.githubusercontent.com/11150372/168888159-4b790b1c-7b80-4ec4-b6ff-c4a12ecc86f7.png)

Before (without rtl/ltr addon):
![Screen Shot 2022-05-17 at 11 46 32 AM](https://user-images.githubusercontent.com/11150372/168888066-00369e12-6675-45c7-833d-f3a5d32eced5.png)
![Screen Shot 2022-05-17 at 11 46 43 AM](https://user-images.githubusercontent.com/11150372/168888068-830cacc2-5c29-47c9-bd34-a6c2a6723028.png)

After (with rtl/ltr addon):
![Screen Shot 2022-05-17 at 11 44 28 AM](https://user-images.githubusercontent.com/11150372/168888028-c72c43b2-6371-456d-8c28-3debecc55cf4.png)
![Screen Shot 2022-05-17 at 11 44 57 AM](https://user-images.githubusercontent.com/11150372/168888031-614c26f0-4fb5-429c-8d49-a9d04ad0fa25.png)

## Other information (Optional)

The reason why the styles in storybook looked wrong, even thought they looked fine when rendered outside of storybook, is because some of our styles were only being applied in the case of (under the hood in our CSS), the property selectors `[dir='rtl']` or `[dir='ltr']` being true. Storybook doesn't have a value for that property available out of the box, so those styles were not being applied. Adding in the `storybook-addon-rtl` addon, and calling `initializeRTL()` in `preview.js` provided that property and fixed the styles. Long-term there is probably future work to be done regularizing some of the styles (so that similar elements have similar styles) and possibly adding a knob so that users can toggle the rtl/ltr in Storybook, but that feels outside of the scope of this ticket.

## Testing
Elements where you can see the rtl/ltr fixes in storybook are: the `Checkbox` story, and the space between the `Email Communications` label and its associated "link" button, visible in the "basic" story under the `Nav` story.
