### PR TITLE
fix(configs): Build shared projects on `yarn start`

### DIFF
--- a/_scripts/pm2-all.sh
+++ b/_scripts/pm2-all.sh
@@ -11,6 +11,15 @@ fi
 
 mkdir -p artifacts
 
+echo "building shared fxa projects..."
+if ! yarn workspaces foreach --verbose --include fxa-auth-client --include fxa-react --include fxa-shared run build > artifacts/build-shared.log;
+then
+  echo -e "\n###########################################################\n"
+  echo "# fxa couldn't build shared projects. see ./artifacts/build-shared.log for details"
+  echo -e "\n###########################################################\n"
+  exit 1
+fi
+
 echo "${COMMAND} fxa services..."
 if yarn workspaces foreach --topological-dev --verbose --exclude fxa-dev-launcher --exclude fxa run "$COMMAND" > artifacts/start.log;
 then


### PR DESCRIPTION
## Because

- `fxa-auth-client` doesn't get updated if no deps changed
- Might be a better way to do this, ~~but it worked locally for me~~

## This pull request

- Updates `yarn start` to build shared or dependent code (fxa-shared, fxa-auth-client, fxa-react)
- ~~I tried doing `yarn workspaces foreach run build` but that builds everything and took 15mins~~

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12903

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
