### PR TITLE
fix(strings): Add default string for delete account checkbox

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -20,12 +20,12 @@ type FormData = {
   password: string;
 };
 
-const checkboxLabels = [
-  'delete-account-chk-box-1-v2',
-  'delete-account-chk-box-2',
-  'delete-account-chk-box-3',
-  'delete-account-chk-box-4',
-];
+const checkboxLabels: Record<string, string> = {
+  'delete-account-chk-box-1-v2': 'Any paid subscriptions you have will be canceled (Except Pocket)',
+  'delete-account-chk-box-2': 'You may lose saved information and features within Mozilla products',
+  'delete-account-chk-box-3': 'Reactivating with this email may not restore your saved information',
+  'delete-account-chk-box-4': 'Any extensions and themes that you published to addons.mozilla.org will be deleted',
+};
 
 export const PageDeleteAccount = (_: RouteComponentProps) => {
   usePageViewEvent('settings.delete-account');
@@ -46,7 +46,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
     l10n.getString('delete-account-step-1-2', null, 'Step 1 of 2')
   );
   const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
-  const allBoxesChecked = checkboxLabels.every((element) =>
+  const allBoxesChecked = Object.keys(checkboxLabels).every((element) =>
     checkedBoxes.includes(element)
   );
   const navigate = useNavigate();
@@ -143,12 +143,12 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
             </Localized>
             <form>
               <ul className="mt-4 text-xs">
-                {checkboxLabels.map((label, i) => (
+                {Object.keys(checkboxLabels).map((label, i) => (
                   <li className="py-2" key={i}>
                     <Localized id={label} attrs={{ label: true }}>
                       <Checkbox
                         data-testid="required-confirm"
-                        label={label}
+                        label={l10n.getString(label, null, checkboxLabels[label])}
                         onChange={handleConfirmChange(label)}
                       />
                     </Localized>


### PR DESCRIPTION
## Because

- These were not being translated

## This pull request

- Adds defaults for the checkboxes

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12900

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="438" alt="Screen Shot 2022-05-17 at 3 09 03 PM" src="https://user-images.githubusercontent.com/1295288/168891691-48008253-c211-4e5f-bea8-0a742982aee9.png">

## Other information (Optional)

This will need to be uplifted to train 232, cc @chenba 
