### PR TITLE
fix(swagger): Revise API docs for redocusaurus support

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -11,6 +11,7 @@ const TAGS_ACCOUNT = {
 
 const ACCOUNT_CREATE_POST = {
   ...TAGS_ACCOUNT,
+  description: '/account/create',
   notes: [
     dedent`
       Creates a user account. The client provides the email address with which this account will be associated and a stretched password. Stretching is detailed on the [**onepw**](https://github.com/mozilla/fxa-auth-server/wiki/onepw-protocol#creating-the-account) wiki page.
@@ -37,6 +38,7 @@ const ACCOUNT_CREATE_POST = {
 
 const ACCOUNT_LOGIN_POST = {
   ...TAGS_ACCOUNT,
+  description: '/account/login',
   notes: [
     'Obtain a `sessionToken` and, optionally, a `keyFetchToken` if `keys=true`.',
   ],
@@ -68,10 +70,10 @@ const ACCOUNT_LOGIN_POST = {
 
 const ACCOUNT_STATUS_GET = {
   ...TAGS_ACCOUNT,
-  description: '🔒🔓 sessionToken',
+  description: '/account/status',
   notes: [
     dedent`
-      🔒🔓 Optionally HAWK-authenticated with session token
+      🔒🔓 Optionally authenticated with session token
 
       Gets the status of an account.
     `,
@@ -92,6 +94,7 @@ const ACCOUNT_STATUS_GET = {
 
 const ACCOUNT_STATUS_POST = {
   ...TAGS_ACCOUNT,
+  description: '/account/status',
   notes: [
     'Gets the status of an account without exposing user data through query params. This endpoint is rate limited by [**fxa-customs-server**](https://github.com/mozilla/fxa/tree/main/packages/fxa-customs-server).',
   ],
@@ -99,10 +102,10 @@ const ACCOUNT_STATUS_POST = {
 
 const ACCOUNT_PROFILE_GET = {
   ...TAGS_ACCOUNT,
-  description: '🔒 sessionToken, oauthToken',
+  description: '/account/profile',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token or HAWK-authenticated with session token
+      🔒 Authenticated with OAuth bearer token or authenticated with session token
 
       Get the email and locale of a user.
 
@@ -118,10 +121,10 @@ const ACCOUNT_PROFILE_GET = {
 
 const ACCOUNT_KEYS_GET = {
   ...TAGS_ACCOUNT,
-  description: '🔒 keyFetchToken',
+  description: '/account/keys',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with key fetch token
+      🔒 Authenticated with key fetch token
 
       Get the base-16 bundle of encrypted \`kA|wrapKb\`. The return value must be decrypted with a key derived from \`keyFetchToken\`, then \`wrapKb\` must be further decrypted with a key derived from the user's password.
 
@@ -146,7 +149,7 @@ const ACCOUNT_KEYS_GET = {
 
 const ACCOUNT_UNLOCK_RESEND_CODE_POST = {
   ...TAGS_ACCOUNT,
-  description: 'deprecated',
+  description: '/account/unlock/resend_code',
   notes: ['This endpoint is deprecated.'],
   plugins: {
     'hapi-swagger': {
@@ -165,7 +168,7 @@ const ACCOUNT_UNLOCK_RESEND_CODE_POST = {
 
 const ACCOUNT_UNLOCK_VERIFY_CODE_POST = {
   ...TAGS_ACCOUNT,
-  description: 'deprecated',
+  description: '/account/unlock/verify_code',
   notes: ['This endpoint is deprecated.'],
   plugins: {
     'hapi-swagger': {
@@ -184,10 +187,10 @@ const ACCOUNT_UNLOCK_VERIFY_CODE_POST = {
 
 const ACCOUNT_RESET_POST = {
   ...TAGS_ACCOUNT,
-  description: '🔒 accountResetToken',
+  description: '/account/reset',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with account reset token
+      🔒 Authenticated with account reset token
 
       This sets the account password and resets \`wrapKb\` to a new random value.
 
@@ -212,10 +215,10 @@ const ACCOUNT_RESET_POST = {
 
 const ACCOUNT_DESTROY_POST = {
   ...TAGS_ACCOUNT,
-  description: '🔒🔓 sessionToken',
+  description: '/account/destroy',
   notes: [
     dedent`
-      🔒🔓 Optionally HAWK-authenticated with session token
+      🔒🔓 Optionally authenticated with session token
 
       Deletes an account. All stored data is erased. The client should seek user confirmation first. The client should erase data stored on any attached services before deleting the user's account data.
     `,

--- a/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
@@ -11,10 +11,10 @@ const TAGS_DEVICES_AND_SESSIONS = {
 
 const ACCOUNT_ATTACHED_CLIENTS_GET = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken',
+  description: '/account/attached_clients',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token.
+      🔒 Authenticated with session token
 
       Returns an array listing all the clients connected to the authenticated user's account, including devices, OAuth clients, and web sessions.
 
@@ -32,10 +32,10 @@ const ACCOUNT_ATTACHED_CLIENTS_GET = {
 
 const ACCOUNT_ATTACHED_CLIENT_DESTROY_POST = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken',
+  description: '/account/attached_client/destroy',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token.
+      🔒 Authenticated with session token
 
       Destroy all tokens held by a connected client, disconnecting it from the user's account.
 
@@ -46,10 +46,10 @@ const ACCOUNT_ATTACHED_CLIENT_DESTROY_POST = {
 
 const ACCOUNT_DEVICE_POST = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken, refreshToken',
+  description: '/account/device',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token or authenticated with OAuth refresh token
+      🔒 Authenticated with session token or OAuth refresh token
 
       Creates or updates the [**device registration**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) record associated with the auth token used for this request. At least one of \`name\`, \`type\`, \`pushCallback\` or the tuple \`{ pushCallback, pushPublicKey, pushAuthKey }\` must be present. Beware that if you provide \`pushCallback\` without the pair \`{ pushPublicKey, pushAuthKey }\`, both of those keys will be reset to the empty string.
 
@@ -76,10 +76,10 @@ const ACCOUNT_DEVICE_POST = {
 
 const ACCOUNT_DEVICE_COMMANDS_GET = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken, refreshToken',
+  description: '/account/device/commands',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token or authenticated with OAuth refresh token.
+      🔒 Authenticated with session token or authenticated with OAuth refresh token.
 
       Fetches commands enqueued for the current device by prior calls to \`/account/devices/invoke_command\`. The device can page through the enqueued commands by using the \`index\` and \`limit\` parameters.
 
@@ -90,10 +90,10 @@ const ACCOUNT_DEVICE_COMMANDS_GET = {
 
 const ACCOUNT_DEVICES_INVOKE_COMMAND_POST = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken, refreshToken',
+  description: '/account/devices/invoke_command',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token or authenticated with OAuth refresh token.
+      🔒 Authenticated with session token or authenticated with OAuth refresh token.
 
       Enqueues a command to be invoked on a target device.
 
@@ -116,10 +116,10 @@ const ACCOUNT_DEVICES_INVOKE_COMMAND_POST = {
 
 const ACCOUNT_DEVICES_NOTIFY_POST = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken, refreshToken',
+  description: '/account/devices/notify',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token or authenticated with OAuth refresh token.
+      🔒 Authenticated with session token or authenticated with OAuth refresh token.
 
       Notifies a set of devices associated with the user's account of an event by sending a browser push notification. A typical use case would be to send a notification to another device after sending a tab with Sync, so it can sync too and display the tab in a timely manner.
     `,
@@ -146,10 +146,10 @@ const ACCOUNT_DEVICES_NOTIFY_POST = {
 
 const ACCOUNT_DEVICES_GET = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken, refreshToken',
+  description: '/account/devices',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token or authenticated with OAuth refresh token.
+      🔒 Authenticated with session token or authenticated with OAuth refresh token.
 
       Returns an array of registered device objects for the authenticated user.
     `,
@@ -158,12 +158,12 @@ const ACCOUNT_DEVICES_GET = {
 
 const ACCOUNT_SESSIONS_GET = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: 'deprecated (🔒 sessionToken)',
+  description: '/account/sessions',
   notes: [
     dedent`
       [**DEPRECATED**]: Please use [**/account/attached_clients**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#get-accountattached_clients) instead.
 
-      🔒 HAWK-authenticated with session token.
+      🔒 Authenticated with session token.
 
       Returns an array of session objects for the authenticated user.
     `,
@@ -177,10 +177,10 @@ const ACCOUNT_SESSIONS_GET = {
 
 const ACCOUNT_DEVICE_DESTROY_POST = {
   ...TAGS_DEVICES_AND_SESSIONS,
-  description: '🔒 sessionToken, refreshToken',
+  description: '/account/device/destroy',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token or authenticated with OAuth refresh token
+      🔒 Authenticated with session token or authenticated with OAuth refresh token
 
       Destroys a device record and the associated \`sessionToken\` for the authenticated user.
     `,

--- a/packages/fxa-auth-server/docs/swagger/emails-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/emails-api.ts
@@ -11,15 +11,16 @@ const TAGS_EMAILS = {
 
 const EMAILS_REMINDERS_CAD_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/emails/reminders/cad',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const RECOVERY_EMAIL_STATUS_GET = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email/status',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Returns the 'verified' status for the account's recovery email address.
 
@@ -44,10 +45,10 @@ const RECOVERY_EMAIL_STATUS_GET = {
 
 const RECOVERY_EMAIL_RESEND_CODE_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email/resend_code',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Re-sends a verification code to the account's recovery email address. The code is first sent when the account is created, but if the user thinks the message was lost or accidentally deleted, they can request a new message to be sent via this endpoint. The new message will contain the same code as the original message. When this code is provided to \`/v1/recovery_email/verify_code\`, the email will be marked as 'verified'.
 
@@ -70,6 +71,7 @@ const RECOVERY_EMAIL_RESEND_CODE_POST = {
 
 const RECOVERY_EMAIL_VERIFY_CODE_POST = {
   ...TAGS_EMAILS,
+  description: '/recovery_email/verify_code',
   notes: [
     dedent`
       Verify tokens and/or recovery emails for an account. If a valid token code is detected, the account email and tokens will be set to verified. If a valid email code is detected, the email will be marked as verified.
@@ -93,10 +95,10 @@ const RECOVERY_EMAIL_VERIFY_CODE_POST = {
 
 const RECOVERY_EMAILS_GET = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_emails',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Returns an array of objects containing details of the email addresses associated with the logged-in user. Currently, the primary email address is always the one from the \`accounts\` table.
     `,
@@ -105,10 +107,10 @@ const RECOVERY_EMAILS_GET = {
 
 const RECOVERY_EMAIL_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
       Add a secondary email address to the logged-in account. The created address will be unverified and will not replace the primary email address.
     `,
   ],
@@ -132,10 +134,10 @@ const RECOVERY_EMAIL_POST = {
 
 const RECOVERY_EMAIL_DESTROY_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email/destroy',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Delete an email address associated with the logged-in user.
     `,
@@ -156,10 +158,10 @@ const RECOVERY_EMAIL_DESTROY_POST = {
 
 const RECOVERY_EMAIL_SET_PRIMARY_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email/set_primary',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       This endpoint changes a user's primary email address. This email address must belong to the user and be verified.
     `,
@@ -182,10 +184,10 @@ const RECOVERY_EMAIL_SET_PRIMARY_POST = {
 
 const RECOVERY_EMAIL_SECONDARY_RESEND_CODE_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email/secondary/resend_code',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       This endpoint resend the otp verification to verify the secondary email.
     `,
@@ -207,10 +209,10 @@ const RECOVERY_EMAIL_SECONDARY_RESEND_CODE_POST = {
 
 const RECOVERY_EMAIL_SECONDARY_VERIFY_CODE_POST = {
   ...TAGS_EMAILS,
-  description: '🔒 sessionToken',
+  description: '/recovery_email/secondary/verify_code',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       This endpoint verifies a secondary email using a time based (otp) code.
     `,

--- a/packages/fxa-auth-server/docs/swagger/misc-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/misc-api.ts
@@ -10,90 +10,115 @@ const TAGS_MISC = {
 
 const ACCOUNT_STUB_POST = {
   ...TAGS_MISC,
+  description: '/account/stub',
 };
 
 const ACCOUNT_FINISH_SETUP_POST = {
   ...TAGS_MISC,
+  description: '/account/finish_setup',
 };
 
 const ACCOUNT_GET = {
   ...TAGS_MISC,
-  description: '🔒 sessionToken',
+  description: '/account',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const ACCOUNT_LOCK_POST = {
   ...TAGS_MISC,
+  description: '/account/lock',
 };
 
 const ACCOUNT_SESSIONS_LOCATIONS_GET = {
   ...TAGS_MISC,
-  description: '🔒 supportPanelSecret',
+  description: '/account/sessions/locations',
+  notes: ['🔒 Authenticated with support panel secret'],
 };
 
 const NEWSLETTERS_POST = {
   ...TAGS_MISC,
-  description: '🔒 sessionToken, oauthToken',
+  description: '/newsletters',
+  notes: [
+    '🔒 Authenticated with OAuth bearer token or authenticated with session token',
+  ],
 };
 
 const SUPPORT_TICKET_POST = {
   ...TAGS_MISC,
-  description: '🔒 supportSecret, oauthToken',
+  description: '/support/ticket',
+  notes: [
+    '🔒 Authenticated with support secret or authenticated with OAuth bearer token',
+  ],
 };
 
 const WELLKNOWN_BROWSERID_GET = {
   ...TAGS_MISC,
+  description: '/.well-known/browserid',
 };
 
 const WELLKNOWN_PUBLIC_KEYS = {
   ...TAGS_MISC,
+  description: '/.well-known/public-keys',
 };
 
 const AUTHORIZATION_GET = {
   ...TAGS_MISC,
+  description: '/authorization',
 };
 
 const AUTHORIZATION_POST = {
   ...TAGS_MISC,
+  description: '/authorization',
 };
 
 const DESTROY_POST = {
   ...TAGS_MISC,
+  description: '/destroy',
 };
 
 const AUTHORIZED_CLIENTS_DESTROY_POST = {
   ...TAGS_MISC,
+  description: '/authorized-clients/destroy',
 };
 
 const AUTHORIZED_CLIENTS_POST = {
   ...TAGS_MISC,
+  description: '/authorized_clients',
 };
 
 const CLIENT_CLIENTID_GET = {
   ...TAGS_MISC,
+  description: '/oauth/client/{client_id}',
 };
 
 const OAUTH_ID_TOKEN_VERIFY_POST = {
   ...TAGS_MISC,
+  description: '/oauth/id-token-verify',
 };
 
 const INTROSPECT_POST = {
   ...TAGS_MISC,
+  description: '/introspect',
 };
 
 const JWKS_GET = {
   ...TAGS_MISC,
+  description: '/jwks',
 };
 
 const KEY_DATA_POST = {
   ...TAGS_MISC,
+  description: '/key-data',
 };
 
 const TOKEN_POST = {
   ...TAGS_MISC,
+  description: '/token',
 };
 
 const VERIFY_POST = {
   ...TAGS_MISC,
+  description: '/verify',
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/oauth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-api.ts
@@ -11,10 +11,10 @@ const TAGS_OAUTH = {
 
 const OAUTH_AUTHORIZATION_POST = {
   ...TAGS_OAUTH,
-  description: '🔒 sessionToken',
+  description: '/oauth/authorization',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Authorize a new OAuth client connection to the user's account, returning a short-lived authentication code that the client can exchange for access tokens at the OAuth token endpoint.
 
@@ -25,6 +25,7 @@ const OAUTH_AUTHORIZATION_POST = {
 
 const OAUTH_DESTROY_POST = {
   ...TAGS_OAUTH,
+  description: '/oauth/destroy',
   notes: [
     dedent`
       Destroy an OAuth access token or refresh token.
@@ -54,10 +55,10 @@ const OAUTH_DESTROY_POST = {
 
 const ACCOUNT_SCOPED_KEY_DATA_POST = {
   ...TAGS_OAUTH,
-  description: '🔒 sessionToken',
+  description: '/account/scoped-key-data',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Query for the information required to derive scoped encryption keys requested by the specified OAuth client.
     `,
@@ -66,10 +67,10 @@ const ACCOUNT_SCOPED_KEY_DATA_POST = {
 
 const OAUTH_TOKEN_POST = {
   ...TAGS_OAUTH,
-  description: '🔒🔓 sessionToken',
+  description: '/oauth/token',
   notes: [
     dedent`
-      🔒🔓 Optionally HAWK-authenticated with session token
+      🔒🔓 Optionally authenticated with session token
 
       Grant new OAuth tokens for use by a connected client, using one of the following grant types:
         - \`grant_type=authorization_code\`: A single-use code obtained via OAuth redirect flow.

--- a/packages/fxa-auth-server/docs/swagger/password-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/password-api.ts
@@ -11,6 +11,7 @@ const TAGS_PASSWORD = {
 
 const PASSWORD_CHANGE_START_POST = {
   ...TAGS_PASSWORD,
+  description: '/password/change/start',
   notes: [
     'Begin the "change password" process. Returns a single-use `passwordChangeToken`, to be sent to `POST /password/change/finish`. Also returns a single-use `keyFetchToken`.',
   ],
@@ -30,10 +31,10 @@ const PASSWORD_CHANGE_START_POST = {
 
 const PASSWORD_CHANGE_FINISH_POST = {
   ...TAGS_PASSWORD,
-  description: '🔒 passwordChangeToken',
+  description: '/password/change/finish',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with password change token
+      🔒 Authenticated with password change token
 
       Change the password and update \`wrapKb\`. Optionally returns \`sessionToken\` and \`keyFetchToken\`.
     `,
@@ -54,6 +55,7 @@ const PASSWORD_CHANGE_FINISH_POST = {
 
 const PASSWORD_FORGOT_SEND_CODE_POST = {
   ...TAGS_PASSWORD,
+  description: '/password/forgot/send_code',
   notes: [
     dedent`
       Requests a 'reset password' code to be sent to the user's recovery email. The user should type this code into the agent, which will then submit it to \`POST /password/forgot/verify_code\`.
@@ -81,10 +83,10 @@ const PASSWORD_FORGOT_SEND_CODE_POST = {
 
 const PASSWORD_FORGOT_RESEND_CODE_POST = {
   ...TAGS_PASSWORD,
-  description: '🔒 passwordForgotToken',
+  description: '/password/forgot/resend_code',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with password forgot token
+      🔒 Authenticated with password forgot token
 
       Resends the email from \`POST /password/forgot/send_code\`, for use when the original email has been lost or accidentally deleted.
 
@@ -95,10 +97,10 @@ const PASSWORD_FORGOT_RESEND_CODE_POST = {
 
 const PASSWORD_FORGOT_VERIFY_CODE_POST = {
   ...TAGS_PASSWORD,
-  description: '🔒 passwordForgotToken',
+  description: '/password/forgot/verify_code',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with password forgot token
+      🔒 Authenticated with password forgot token
 
       The code returned by \`POST /v1/password/forgot/send_code\` should be submitted to this endpoint with the \`passwordForgotToken\`. For successful requests, the server will return \`accountResetToken\`, to be submitted in requests to \`POST /account/reset\` to reset the account password and \`wrapKb\`.
     `,
@@ -119,10 +121,10 @@ const PASSWORD_FORGOT_VERIFY_CODE_POST = {
 
 const PASSWORD_FORGOT_STATUS_GET = {
   ...TAGS_PASSWORD,
-  description: '🔒 passwordForgotToken',
+  description: '/password/forgot/status',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with password forgot token
+      🔒 Authenticated with password forgot token
 
       Returns the status of a \`passwordForgotToken\`. Success responses indicate the token has not yet been consumed. For consumed or expired tokens, an HTTP \`401\` response with \`errno: 110\` will be returned.
     `,
@@ -131,10 +133,10 @@ const PASSWORD_FORGOT_STATUS_GET = {
 
 const PASSWORD_CREATE_POST = {
   ...TAGS_PASSWORD,
-  description: '🔒 sessionToken',
+  description: '/password/create',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Creates a new password for the user associated with the session token. Creating a new password will generate new encryption key.
     `,

--- a/packages/fxa-auth-server/docs/swagger/recovery-codes-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-codes-api.ts
@@ -11,10 +11,10 @@ const TAGS_RECOVERY_CODE = {
 
 const RECOVERYCODES_GET = {
   ...TAGS_RECOVERY_CODE,
-  description: '🔒 sessionToken',
+  description: '/recoveryCodes',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Return new recovery codes while removing old ones.
     `,
@@ -23,15 +23,15 @@ const RECOVERYCODES_GET = {
 
 const RECOVERY_CODES_PUT = {
   ...TAGS_RECOVERY_CODE,
-  description: '🔒 sessionToken',
-  tags: TAGS.RECOVERY_CODES,
+  description: '/recoveryCodes',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const SESSION_VERIFY_RECOVERYCODE_POST = {
-  description: '🔒 sessionToken',
+  description: '/session/verify/recoveryCode',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Verify a session using a recovery code.
     `,

--- a/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
@@ -11,10 +11,10 @@ const TAGS_RECOVERY_KEY = {
 
 const RECOVERYKEY_POST = {
   ...TAGS_RECOVERY_KEY,
-  description: '🔒 sessionToken',
+  description: '/recoveryKey',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Creates a new recovery key for a user. Recovery keys are one-time-use tokens that can be used to recover the user's kB if they forget their password. For more details, see the [**recovery keys**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/recovery_keys.md) docs.
     `,
@@ -23,34 +23,35 @@ const RECOVERYKEY_POST = {
 
 const RECOVERYKEY_RECOVERYKEYID_GET = {
   ...TAGS_RECOVERY_KEY,
-  description: '🔒 accountResetToken',
+  description: '/recoveryKey/{recoveryKeyId}',
   notes: [
-    '🔒 HAWK-authenticated with account reset token',
+    '🔒 Authenticated with account reset token',
     'Retrieve the account recovery data associated with the given recovery key.',
   ],
 };
 
 const RECOVERYKEY_EXISTS_POST = {
   ...TAGS_RECOVERY_KEY,
-  description: '🔒🔓 sessionToken',
+  description: '/recoveryKey/exists',
   notes: [
-    '🔒🔓 Optionally HAWK-authenticated with session token',
+    '🔒🔓 Optionally authenticated with session token',
     'This route checks to see if given user has setup an account recovery key. When used during the password reset flow, an email can be provided (instead of a sessionToken) to check for the status. However, when using an email, the request is rate limited.',
   ],
 };
 
 const RECOVERYKEY_DELETE = {
   ...TAGS_RECOVERY_KEY,
-  description: '🔒 sessionToken',
+  description: '/recoveryKey',
   notes: [
-    '🔒 HAWK-authenticated with session token',
+    '🔒 Authenticated with session token',
     "This route remove an account's recovery key. When the key is removed, it can no longer be used to restore an account's kB.",
   ],
 };
 
 const RECOVERYKEY_VERIFY_POST = {
   ...TAGS_RECOVERY_KEY,
-  description: '🔒 sessionToken',
+  description: '/recoveryKey/verify',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/security-events-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/security-events-api.ts
@@ -11,10 +11,10 @@ const TAGS_SECURITY_EVENTS = {
 
 const SECURITYEVENTS_GET = {
   ...TAGS_SECURITY_EVENTS,
-  description: '🔒 securityEvents',
+  description: '/securityEvents',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Returns a list of all security events for a signed in account having \`account.create\`, \`account.login\`, \`account.reset\` events.
     `,
@@ -23,10 +23,10 @@ const SECURITYEVENTS_GET = {
 
 const SECURITYEVENTS_DELETE = {
   ...TAGS_SECURITY_EVENTS,
-  description: '🔒 securityEvents',
+  description: '/securityEvents',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Deletes all the security events of a signed in account.
     `,

--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -11,10 +11,10 @@ const TAGS_SESSION = {
 
 const SESSION_DESTROY_POST = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/destroy',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Destroys the current session and invalidates \`sessionToken\`, to be called when a user signs out. To sign back in, a call must be made to \`POST /account/login\` to obtain a new \`sessionToken\`.
     `,
@@ -35,10 +35,10 @@ const SESSION_DESTROY_POST = {
 
 const SESSION_REAUTH_POST = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/reauth',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Re-authenticate an existing session token. This is equivalent to calling \`/account/login\`, but it re-uses an existing session token rather than generating a new one, allowing the caller to maintain session state such as verification and device registration.
     `,
@@ -65,10 +65,10 @@ const SESSION_REAUTH_POST = {
 
 const SESSION_STATUS_GET = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/status',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Returns a success response if the session token is valid.
     `,
@@ -77,10 +77,10 @@ const SESSION_STATUS_GET = {
 
 const SESSION_DUPLICATE_POST = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/duplicate',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Create a new \`sessionToken\` that duplicates the current session. It will have the same verification status as the current session, but will have a distinct verification code.
     `,
@@ -89,17 +89,20 @@ const SESSION_DUPLICATE_POST = {
 
 const SESSION_VERIFY_CODE_POST = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/verify_code',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const SESSION_RESEND_CODE_POST = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/resend_code',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const SESSION_VERIFY_SEND_PUSH_POST = {
   ...TAGS_SESSION,
-  description: '🔒 sessionToken',
+  description: '/session/verify/send_push',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/sign-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/sign-api.ts
@@ -11,10 +11,10 @@ const TAGS_SIGN = {
 
 const CERTIFICATE_SIGN_POST = {
   ...TAGS_SIGN,
-  description: '🔒 sessionToken',
+  description: '/certificate/sign',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Sign a BrowserID public key. The server is given a public key and returns a signed certificate using the same JWT-like mechanism as a BrowserID primary IdP would (see [**browserid-certifier**](https://github.com/mozilla/browserid-certifier) for details). The signed certificate includes a \`principal.email\` property to indicate the Firefox Account identifier (a UUID at the account server's primary domain) and is stamped with an expiry time based on the \`duration\` parameter.
 

--- a/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
@@ -11,15 +11,16 @@ const TAGS_SUBSCRIPTIONS = {
 
 const OAUTH_SUBSCRIPTIONS_IAP_PLANS_APPNAME_GET = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/iap/plans/{appName}',
   notes: ['Returns available plans for In-App Purchase clients.'],
 };
 
 const OAUTH_SUBSCRIPTIONS_IAP_PLAYTOKEN_APPNAME_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/iap/play-token/{appName}',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Validate and store a Play Store Puchase Token for the given user. Returns token validity.
     `,
@@ -28,10 +29,10 @@ const OAUTH_SUBSCRIPTIONS_IAP_PLAYTOKEN_APPNAME_POST = {
 
 const OAUTH_SUBSCRIPTIONS_PLANS_GET = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/plans',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Returns a list of available subscription plans.
     `,
@@ -40,10 +41,10 @@ const OAUTH_SUBSCRIPTIONS_PLANS_GET = {
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_GET = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/active',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Returns a list of active subscriptions for the user.
     `,
@@ -52,10 +53,10 @@ const OAUTH_SUBSCRIPTIONS_ACTIVE_GET = {
 
 const OAUTH_SUBSCRIPTIONS_CUSTOMER_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/customer',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Create a new customer object for use with subscription payments.
     `,
@@ -64,10 +65,10 @@ const OAUTH_SUBSCRIPTIONS_CUSTOMER_POST = {
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_NEW_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/active/new',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Subscribe the user to a price using a payment method id.
     `,
@@ -76,10 +77,10 @@ const OAUTH_SUBSCRIPTIONS_ACTIVE_NEW_POST = {
 
 const OAUTH_SUBSCRIPTIONS_INVOICE_RETRY_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: 'oauth/subscriptions/invoice/retry',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Retry an incomplete subscription invoice with a new payment method id.
     `,
@@ -88,10 +89,10 @@ const OAUTH_SUBSCRIPTIONS_INVOICE_RETRY_POST = {
 
 const OAUTH_SUBSCRIPTIONS_SETUPINTENT_CREATE_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/setupintent/create',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Create a new setup intent for attaching a new payment method to the user.
     `,
@@ -100,10 +101,10 @@ const OAUTH_SUBSCRIPTIONS_SETUPINTENT_CREATE_POST = {
 
 const OAUTH_SUBSCRIPTIONS_PAYMENTMETHOD_DEFAULT_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/paymentmethod/default',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Update a user's default payment method for invoices to the attached payment method id.
     `,
@@ -112,10 +113,10 @@ const OAUTH_SUBSCRIPTIONS_PAYMENTMETHOD_DEFAULT_POST = {
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_SUBSCRIPTIONID_DELETE = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/active/{subscriptionid}',
   notes: [
     dedent`
-      🔒 authenticated with OAuth bearer token
+      🔒 Authenticated with OAuth bearer token
 
       Cancel an active subscription for the user.
     `,
@@ -124,68 +125,84 @@ const OAUTH_SUBSCRIPTIONS_ACTIVE_SUBSCRIPTIONID_DELETE = {
 
 const OAUTH_SUBSCRIPTIONS_PAYPAL_CHECKOUT_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/paypal-checkout',
 };
 
 const OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_BILLING_AND_SUBSCRIPTIONS_GET = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description:
+    '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_IAP_RTDN_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/iap/rtdn',
 };
 
 const OAUTH_SUBSCRIPTIONS_CLIENTS_GET = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/clients',
 };
 
 const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/invoice/preview',
 };
 
 const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_SUBSEQUENT_GET = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/invoice/preview-subsequent',
 };
 
 const OAUTH_SUBSCRIPTIONS_COUPON_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/coupon',
 };
 
 const OAUTH_SUBSCRIPTIONS_PAYMENTMETHOD_FAILED_DETACH_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/paymentmethod/failed/detach',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_PRODUCTNAME_GET = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/productname',
 };
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_SUBSCRIPTIONID_PUT = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/active/{subscriptionId}',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_REACTIVATE_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/reactivate',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_NEW_PAYPAL_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/active/new-paypal',
 };
 
 const OAUTH_SUBSCRIPTIONS_PAYMENTMETHOD_BILLING_AGREEMENT_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/paymentmethod/billing-agreement',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_STRIPE_EVENT_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/stripe/event',
 };
 
 const OAUTH_SUPPORTPANEL_SUBSCRIPTIONS_GET = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 supportPanelSecret',
+  description: '/oauth/support-panel/subscriptions',
+  notes: ['🔒 Authenticated with support panel secret'],
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/swagger-options.ts
+++ b/packages/fxa-auth-server/docs/swagger/swagger-options.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import dedent from 'dedent';
+import TAGS from './swagger-tags';
 
 export const swaggerOptions = {
   info: {
@@ -24,5 +25,55 @@ export const swaggerOptions = {
   },
   basePath: '/v1',
   schemes: ['https'],
+  tags: [
+    {
+      name: TAGS.ACCOUNT[1],
+    },
+    {
+      name: TAGS.DEVICES_AND_SESSIONS[1],
+    },
+    {
+      name: TAGS.EMAILS[1],
+    },
+    {
+      name: TAGS.MISCELLANEOUS[1],
+    },
+    {
+      name: TAGS.OAUTH[1],
+    },
+    {
+      name: TAGS.PASSWORD[1],
+    },
+    {
+      name: TAGS.RECOVERY_CODES[1],
+    },
+    {
+      name: TAGS.RECOVERY_KEY[1],
+    },
+    {
+      name: TAGS.SECURITY_EVENTS[1],
+    },
+    {
+      name: TAGS.SESSION[1],
+    },
+    {
+      name: TAGS.SIGN[1],
+    },
+    {
+      name: TAGS.SUBSCRIPTIONS[1],
+    },
+    {
+      name: TAGS.THIRD_PARTY_AUTH[1],
+    },
+    {
+      name: TAGS.TOTP[1],
+    },
+    {
+      name: TAGS.UNBLOCK_CODES[1],
+    },
+    {
+      name: TAGS.UTIL[1],
+    },
+  ],
   grouping: 'tags',
 };

--- a/packages/fxa-auth-server/docs/swagger/third-party-auth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/third-party-auth-api.ts
@@ -10,11 +10,13 @@ const TAGS_THIRD_PARTY_AUTH = {
 
 const LINKED_ACCOUNT_LOGIN_POST = {
   ...TAGS_THIRD_PARTY_AUTH,
+  description: '/linked_account/login',
 };
 
 const LINKED_ACCOUNT_UNLINK_POST = {
-  description: '🔒 sessionToken',
   ...TAGS_THIRD_PARTY_AUTH,
+  description: '/linked_account/unlink',
+  notes: ['🔒 Authenticated with session token'],
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/totp-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/totp-api.ts
@@ -11,10 +11,10 @@ const TAGS_TOTP = {
 
 const TOTP_CREATE_POST = {
   ...TAGS_TOTP,
-  description: '🔒 sessionToken',
+  description: '/totp/create',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Create a new randomly generated TOTP token for a user if they do not currently have one.
     `,
@@ -23,10 +23,10 @@ const TOTP_CREATE_POST = {
 
 const TOTP_DESTROY_POST = {
   ...TAGS_TOTP,
-  description: '🔒 sessionToken',
+  description: '/totp/destroy',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Deletes the current TOTP token for the user.
     `,
@@ -35,10 +35,10 @@ const TOTP_DESTROY_POST = {
 
 const TOTP_EXISTS_GET = {
   ...TAGS_TOTP,
-  description: '🔒 sessionToken',
+  description: '/totp/exists',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Checks to see if the user has a TOTP token.
     `,
@@ -47,10 +47,10 @@ const TOTP_EXISTS_GET = {
 
 const SESSION_VERIFY_TOTP_POST = {
   ...TAGS_TOTP,
-  description: '🔒 sessionToken',
+  description: '/session/verifiy/totp',
   notes: [
     dedent`
-      🔒 HAWK-authenticated with session token
+      🔒 Authenticated with session token
 
       Verifies the current session if the passed TOTP code is valid.
     `,

--- a/packages/fxa-auth-server/docs/swagger/unblock-codes-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/unblock-codes-api.ts
@@ -10,6 +10,7 @@ const TAGS_UNBLOCK_CODES = {
 
 const ACCOUNT_LOGIN_SEND_UNBLOCK_CODE_POST = {
   ...TAGS_UNBLOCK_CODES,
+  description: '/account/login/send_unblock_code',
   notes: [
     'Send an unblock code via email to reset rate-limiting for an account.',
   ],
@@ -17,6 +18,7 @@ const ACCOUNT_LOGIN_SEND_UNBLOCK_CODE_POST = {
 
 const ACCOUNT_LOGIN_REJECT_UNBLOCK_CODE_POST = {
   ...TAGS_UNBLOCK_CODES,
+  description: '/account/login/reject_unblock_code',
   notes: [
     'Used to reject and report unblock codes that were not requested by the user.',
   ],

--- a/packages/fxa-auth-server/docs/swagger/util-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/util-api.ts
@@ -10,6 +10,7 @@ const TAGS_UTIL = {
 
 const GET_RANDOM_BYTES_POST = {
   ...TAGS_UTIL,
+  description: '/get_random_bytes',
   notes: [
     'Get 32 bytes of random data. This should be combined with locally-sourced entropy when creating salts, etc.',
   ],
@@ -17,10 +18,12 @@ const GET_RANDOM_BYTES_POST = {
 
 const VERIFY_EMAIL_GET = {
   ...TAGS_UTIL,
+  description: '/verify_email',
 };
 
 const COMPLETE_RESET_PASSWORD_GET = {
   ...TAGS_UTIL,
+  description: '/complete_reset_password',
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1576,43 +1576,36 @@ export const accountRoutes = (
             keys: isA.boolean().optional().description(DESCRIPTION.keys),
             service: validators.service.description(DESCRIPTION.service),
           }),
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.email),
-              authPW: validators.authPW.description(DESCRIPTION.authPW),
-              service: validators.service.description(DESCRIPTION.service),
-              redirectTo: validators
-                .redirectTo(config.smtp.redirectDomain)
-                .optional()
-                .description(DESCRIPTION.redirectTo),
-              resume: isA
-                .string()
-                .max(2048)
-                .optional()
-                .description(DESCRIPTION.resume),
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-              style: isA.string().allow(['trailhead']).optional(),
-              verificationMethod: validators.verificationMethod.optional(),
-              // preVerified is not available in production mode.
-              ...(!(config as any).isProduction && {
-                preVerified: isA.boolean(),
-              }),
-            })
-            .label('Account.create_payload'),
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            authPW: validators.authPW.description(DESCRIPTION.authPW),
+            service: validators.service.description(DESCRIPTION.service),
+            redirectTo: validators
+              .redirectTo(config.smtp.redirectDomain)
+              .optional()
+              .description(DESCRIPTION.redirectTo),
+            resume: isA
+              .string()
+              .max(2048)
+              .optional()
+              .description(DESCRIPTION.resume),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+            style: isA.string().allow(['trailhead']).optional(),
+            verificationMethod: validators.verificationMethod.optional(),
+            // preVerified is not available in production mode.
+            ...(!(config as any).isProduction && {
+              preVerified: isA.boolean(),
+            }),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              uid: isA.string().regex(HEX_STRING).required(),
-              sessionToken: isA.string().regex(HEX_STRING).required(),
-              keyFetchToken: isA.string().regex(HEX_STRING).optional(),
-              authAt: isA.number().integer().description(DESCRIPTION.authAt),
-              verificationMethod: validators.verificationMethod.optional(),
-            })
-            .label('Account.create_response'),
+          schema: isA.object({
+            uid: isA.string().regex(HEX_STRING).required(),
+            sessionToken: isA.string().regex(HEX_STRING).required(),
+            keyFetchToken: isA.string().regex(HEX_STRING).optional(),
+            authAt: isA.number().integer().description(DESCRIPTION.authAt),
+            verificationMethod: validators.verificationMethod.optional(),
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.accountCreate(request),
@@ -1623,13 +1616,11 @@ export const accountRoutes = (
       options: {
         ...MISC_DOCS.ACCOUNT_STUB_POST,
         validate: {
-          payload: isA
-            .object({
-              email: validators.email().required(),
-              clientId: validators.clientId.required(),
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-            })
-            .label('Account.stub_payload'),
+          payload: isA.object({
+            email: validators.email().required(),
+            clientId: validators.clientId.required(),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.accountStub(request),
@@ -1640,12 +1631,10 @@ export const accountRoutes = (
       options: {
         ...MISC_DOCS.ACCOUNT_FINISH_SETUP_POST,
         validate: {
-          payload: isA
-            .object({
-              token: validators.jwt,
-              authPW: validators.authPW,
-            })
-            .label('Account.finishSetup_payload'),
+          payload: isA.object({
+            token: validators.jwt,
+            authPW: validators.authPW,
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.finishSetup(request),
@@ -1674,56 +1663,49 @@ export const accountRoutes = (
               .optional()
               .description(DESCRIPTION.verificationMethod),
           }),
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.email),
-              authPW: validators.authPW.description(DESCRIPTION.authPW),
-              service: validators.service.description(DESCRIPTION.service),
-              redirectTo: validators
-                .redirectTo(config.smtp.redirectDomain)
-                .optional(),
-              resume: isA.string().optional().description(DESCRIPTION.resume),
-              reason: isA
-                .string()
-                .max(16)
-                .optional()
-                .description(DESCRIPTION.reason),
-              unblockCode: signinUtils.validators.UNBLOCK_CODE.description(
-                DESCRIPTION.unblockCode
-              ),
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-              originalLoginEmail: validators
-                .email()
-                .optional()
-                .description(DESCRIPTION.originalLoginEmail),
-              verificationMethod: validators.verificationMethod
-                .optional()
-                .description(DESCRIPTION.verificationMethod),
-            })
-            .label('Account.login_payload'),
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            authPW: validators.authPW.description(DESCRIPTION.authPW),
+            service: validators.service.description(DESCRIPTION.service),
+            redirectTo: validators
+              .redirectTo(config.smtp.redirectDomain)
+              .optional(),
+            resume: isA.string().optional().description(DESCRIPTION.resume),
+            reason: isA
+              .string()
+              .max(16)
+              .optional()
+              .description(DESCRIPTION.reason),
+            unblockCode: signinUtils.validators.UNBLOCK_CODE.description(
+              DESCRIPTION.unblockCode
+            ),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+            originalLoginEmail: validators
+              .email()
+              .optional()
+              .description(DESCRIPTION.originalLoginEmail),
+            verificationMethod: validators.verificationMethod
+              .optional()
+              .description(DESCRIPTION.verificationMethod),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              uid: isA.string().regex(HEX_STRING).required(),
-              sessionToken: isA.string().regex(HEX_STRING).required(),
-              keyFetchToken: isA.string().regex(HEX_STRING).optional(),
-              verificationMethod: isA
-                .string()
-                .optional()
-                .description(DESCRIPTION.verificationMethod),
-              verificationReason: isA
-                .string()
-                .optional()
-                .description(DESCRIPTION.verificationReason),
-              verified: isA.boolean().required(),
-              authAt: isA.number().integer().description(DESCRIPTION.authAt),
-              metricsEnabled: isA.boolean().required(),
-            })
-            .label('Account.login_response'),
+          schema: isA.object({
+            uid: isA.string().regex(HEX_STRING).required(),
+            sessionToken: isA.string().regex(HEX_STRING).required(),
+            keyFetchToken: isA.string().regex(HEX_STRING).optional(),
+            verificationMethod: isA
+              .string()
+              .optional()
+              .description(DESCRIPTION.verificationMethod),
+            verificationReason: isA
+              .string()
+              .optional()
+              .description(DESCRIPTION.verificationReason),
+            verified: isA.boolean().required(),
+            authAt: isA.number().integer().description(DESCRIPTION.authAt),
+            metricsEnabled: isA.boolean().required(),
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.login(request),
@@ -1751,20 +1733,16 @@ export const accountRoutes = (
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_STATUS_POST,
         validate: {
-          payload: isA
-            .object({
-              email: validators.email().required(),
-              checkDomain: isA.optional(),
-            })
-            .label('AccountStatusCheck_payload'),
+          payload: isA.object({
+            email: validators.email().required(),
+            checkDomain: isA.optional(),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              exists: isA.boolean().required(),
-              invalidDomain: isA.boolean().optional(),
-            })
-            .label('AccountStausCheck_response'),
+          schema: isA.object({
+            exists: isA.boolean().required(),
+            invalidDomain: isA.boolean().optional(),
+          }),
         },
       },
       handler: (request: AuthRequest) =>
@@ -1779,20 +1757,18 @@ export const accountRoutes = (
           strategies: ['sessionToken', 'oauthToken'],
         },
         response: {
-          schema: isA
-            .object({
-              email: isA.string().optional(),
-              locale: isA.string().optional().allow(null),
-              authenticationMethods: isA
-                .array()
-                .items(isA.string().required())
-                .optional(),
-              authenticatorAssuranceLevel: isA.number().min(0),
-              subscriptionsByClientId: isA.object().unknown(true).optional(),
-              profileChangedAt: isA.number().min(0),
-              metricsEnabled: isA.boolean().optional(),
-            })
-            .label('Account.profile_response'),
+          schema: isA.object({
+            email: isA.string().optional(),
+            locale: isA.string().optional().allow(null),
+            authenticationMethods: isA
+              .array()
+              .items(isA.string().required())
+              .optional(),
+            authenticatorAssuranceLevel: isA.number().min(0),
+            subscriptionsByClientId: isA.object().unknown(true).optional(),
+            profileChangedAt: isA.number().min(0),
+            metricsEnabled: isA.boolean().optional(),
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.profile(request),
@@ -1806,14 +1782,12 @@ export const accountRoutes = (
           strategy: 'keyFetchTokenWithVerificationStatus',
         },
         response: {
-          schema: isA
-            .object({
-              bundle: isA
-                .string()
-                .regex(HEX_STRING)
-                .description(DESCRIPTION.bundle),
-            })
-            .label('Account.keys_response'),
+          schema: isA.object({
+            bundle: isA
+              .string()
+              .regex(HEX_STRING)
+              .description(DESCRIPTION.bundle),
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.keys(request),
@@ -1869,8 +1843,7 @@ export const accountRoutes = (
                 .optional()
                 .description(DESCRIPTION.sessionToken),
             })
-            .and('wrapKb', 'recoveryKeyId')
-            .label('Account.reset_payload'),
+            .and('wrapKb', 'recoveryKeyId'),
         },
       },
       handler: (request: AuthRequest) => accountHandler.reset(request),
@@ -1885,15 +1858,10 @@ export const accountRoutes = (
           strategy: 'sessionToken',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.email),
-              authPW: validators.authPW.description(DESCRIPTION.authPW),
-            })
-            .label('Account.destroy_payload'),
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            authPW: validators.authPW.description(DESCRIPTION.authPW),
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.destroy(request),
@@ -1907,24 +1875,21 @@ export const accountRoutes = (
           strategy: 'sessionToken',
         },
         response: {
-          schema: isA
-            .object({
-              // This endpoint is evolving, it's not just for subscriptions.
-              // Ultimately we want it to become a one-stop shop for all of
-              // the account data needed by the settings screen, so that we
-              // can drastically reduce how many requests are made to the
-              // backend. Discussion in:
-              //
-              // https://github.com/mozilla/fxa/issues/1808
-              subscriptions: isA
-                .array()
-                .items(
-                  validators.subscriptionsSubscriptionValidator,
-                  validators.subscriptionsGooglePlaySubscriptionValidator,
-                  validators.subscriptionsAppStoreSubscriptionValidator
-                ),
-            })
-            .label('Account.subscriptions'),
+          schema: isA.object({
+            // This endpoint is evolving, it's not just for subscriptions.
+            // Ultimately we want it to become a one-stop shop for all of
+            // the account data needed by the settings screen, so that we
+            // can drastically reduce how many requests are made to the
+            // backend. Discussion in:
+            //
+            // https://github.com/mozilla/fxa/issues/1808
+            subscriptions: isA
+              .array()
+              .items(
+                validators.subscriptionsSubscriptionValidator,
+                validators.subscriptionsGooglePlaySubscriptionValidator
+              ),
+          }),
         },
       },
       handler: (request: AuthRequest) => accountHandler.getAccount(request),

--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -27,54 +27,41 @@ module.exports = (log, db, devices, clientUtils) => {
           strategy: 'sessionToken',
         },
         response: {
-          schema: isA
-            .array()
-            .items(
-              isA
-                .object({
-                  clientId: isA
-                    .string()
-                    .regex(HEX_STRING)
-                    .allow(null)
-                    .required(),
-                  deviceId: DEVICES_SCHEMA.id.allow(null).required(),
-                  sessionTokenId: isA
-                    .string()
-                    .regex(HEX_STRING)
-                    .allow(null)
-                    .required(),
-                  refreshTokenId: isA
-                    .string()
-                    .regex(HEX_STRING)
-                    .allow(null)
-                    .required(),
-                  isCurrentSession: isA.boolean().required(),
-                  deviceType: DEVICES_SCHEMA.type.allow(null).required(),
-                  name: DEVICES_SCHEMA.nameResponse
-                    .allow('')
-                    .allow(null)
-                    .required(),
-                  createdTime: isA.number().min(0).required().allow(null),
-                  createdTimeFormatted: isA.string().optional().allow(''),
-                  lastAccessTime: isA.number().min(0).required().allow(null),
-                  lastAccessTimeFormatted: isA.string().optional().allow(''),
-                  approximateLastAccessTime: isA.number().min(0).optional(),
-                  approximateLastAccessTimeFormatted: isA
-                    .string()
-                    .optional()
-                    .allow(''),
-                  scope: isA
-                    .array()
-                    .items(validators.scope)
-                    .required()
-                    .allow(null),
-                  location: DEVICES_SCHEMA.location,
-                  userAgent: isA.string().max(255).required().allow(''),
-                  os: isA.string().max(255).allow('').allow(null),
-                })
-                .label('Account.attachedClient_model')
-            )
-            .label('Account.attachedClients_response'),
+          schema: isA.array().items(
+            isA.object({
+              clientId: isA.string().regex(HEX_STRING).allow(null).required(),
+              deviceId: DEVICES_SCHEMA.id.allow(null).required(),
+              sessionTokenId: isA
+                .string()
+                .regex(HEX_STRING)
+                .allow(null)
+                .required(),
+              refreshTokenId: isA
+                .string()
+                .regex(HEX_STRING)
+                .allow(null)
+                .required(),
+              isCurrentSession: isA.boolean().required(),
+              deviceType: DEVICES_SCHEMA.type.allow(null).required(),
+              name: DEVICES_SCHEMA.nameResponse
+                .allow('')
+                .allow(null)
+                .required(),
+              createdTime: isA.number().min(0).required().allow(null),
+              createdTimeFormatted: isA.string().optional().allow(''),
+              lastAccessTime: isA.number().min(0).required().allow(null),
+              lastAccessTimeFormatted: isA.string().optional().allow(''),
+              approximateLastAccessTime: isA.number().min(0).optional(),
+              approximateLastAccessTimeFormatted: isA
+                .string()
+                .optional()
+                .allow(''),
+              scope: isA.array().items(validators.scope).required().allow(null),
+              location: DEVICES_SCHEMA.location,
+              userAgent: isA.string().max(255).required().allow(''),
+              os: isA.string().max(255).allow('').allow(null),
+            })
+          ),
         },
       },
       handler: async function (request) {
@@ -127,8 +114,7 @@ module.exports = (log, db, devices, clientUtils) => {
               deviceId: DEVICES_SCHEMA.id.allow(null).optional(),
             })
             .or('clientId', 'sessionTokenId', 'refreshTokenId', 'deviceId')
-            .with('refreshTokenId', ['clientId'])
-            .label('Account.attachedClientDestroy_payload'),
+            .with('refreshTokenId', ['clientId']),
         },
         response: {
           schema: {},

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -116,8 +116,7 @@ module.exports = (
               // We accept but ignore it.
               capabilities: isA.array().length(0).optional(),
             })
-            .and('pushCallback', 'pushPublicKey', 'pushAuthKey')
-            .label('Account.device_payload'),
+            .and('pushCallback', 'pushPublicKey', 'pushAuthKey'),
         },
         response: {
           schema: isA
@@ -133,8 +132,7 @@ module.exports = (
                 DEVICES_SCHEMA.pushEndpointExpired.optional(),
               availableCommands: DEVICES_SCHEMA.availableCommands.optional(),
             })
-            .and('pushCallback', 'pushPublicKey', 'pushAuthKey')
-            .label('Account.device_response'),
+            .and('pushCallback', 'pushPublicKey', 'pushAuthKey'),
         },
       },
       handler: async function (request) {
@@ -221,24 +219,21 @@ module.exports = (
               messages: isA
                 .array()
                 .items(
-                  isA
-                    .object({
-                      index: isA.number().required(),
-                      data: isA
-                        .object({
-                          command: isA.string().max(255).required(),
-                          payload: isA.object().required(),
-                          sender: DEVICES_SCHEMA.id.optional(),
-                        })
-                        .required(),
-                    })
-                    .label('message')
+                  isA.object({
+                    index: isA.number().required(),
+                    data: isA
+                      .object({
+                        command: isA.string().max(255).required(),
+                        payload: isA.object().required(),
+                        sender: DEVICES_SCHEMA.id.optional(),
+                      })
+                      .required(),
+                  })
                 )
                 .optional()
                 .description(DESCRIPTION.messages),
             })
-            .and('last', 'messages')
-            .label('Account.deviceCommands_response'),
+            .and('last', 'messages'),
         },
       },
       handler: async function (request) {
@@ -284,31 +279,27 @@ module.exports = (
           strategies: ['sessionToken', 'refreshToken'],
         },
         validate: {
-          payload: isA
-            .object({
-              target: DEVICES_SCHEMA.id
-                .required()
-                .description(DESCRIPTION.target),
-              command: isA.string().required().description(DESCRIPTION.command),
-              payload: isA.object().required().description(DESCRIPTION.payload),
-              ttl: isA
-                .number()
-                .integer()
-                .min(0)
-                .max(10000000)
-                .optional()
-                .description(DESCRIPTION.ttl),
-            })
-            .label('Account.invokeDeviceCommand_payload'),
+          payload: isA.object({
+            target: DEVICES_SCHEMA.id
+              .required()
+              .description(DESCRIPTION.target),
+            command: isA.string().required().description(DESCRIPTION.command),
+            payload: isA.object().required().description(DESCRIPTION.payload),
+            ttl: isA
+              .number()
+              .integer()
+              .min(0)
+              .max(10000000)
+              .optional()
+              .description(DESCRIPTION.ttl),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              enqueued: isA.boolean().optional(),
-              notified: isA.boolean().optional(),
-              notifyError: isA.string().optional(),
-            })
-            .label('Account.invokeDeviceCommand_response'),
+          schema: isA.object({
+            enqueued: isA.boolean().optional(),
+            notified: isA.boolean().optional(),
+            notifyError: isA.string().optional(),
+          }),
         },
       },
       handler: async function (request) {
@@ -406,35 +397,33 @@ module.exports = (
         },
         validate: {
           payload: isA.alternatives().try(
-            isA
-              .object({
-                to: isA
-                  .string()
-                  .valid('all')
-                  .required()
-                  .description(DESCRIPTION.to),
-                _endpointAction: isA.string().valid('accountVerify').optional(),
-                excluded: isA
-                  .array()
-                  .items(isA.string().length(32).regex(HEX_STRING))
-                  .optional()
-                  .description(DESCRIPTION.excluded),
-                payload: isA
-                  .object()
-                  .when('_endpointAction', {
-                    is: 'accountVerify',
-                    then: isA.required(),
-                    otherwise: isA.required(),
-                  })
-                  .description(DESCRIPTION.pushPayload),
-                TTL: isA
-                  .number()
-                  .integer()
-                  .min(0)
-                  .optional()
-                  .description(DESCRIPTION.ttlPushNotification),
-              })
-              .label('Account.devicesNotify_payload'),
+            isA.object({
+              to: isA
+                .string()
+                .valid('all')
+                .required()
+                .description(DESCRIPTION.to),
+              _endpointAction: isA.string().valid('accountVerify').optional(),
+              excluded: isA
+                .array()
+                .items(isA.string().length(32).regex(HEX_STRING))
+                .optional()
+                .description(DESCRIPTION.excluded),
+              payload: isA
+                .object()
+                .when('_endpointAction', {
+                  is: 'accountVerify',
+                  then: isA.required(),
+                  otherwise: isA.required(),
+                })
+                .description(DESCRIPTION.pushPayload),
+              TTL: isA
+                .number()
+                .integer()
+                .min(0)
+                .optional()
+                .description(DESCRIPTION.ttlPushNotification),
+            }),
             isA.object({
               to: isA
                 .array()
@@ -549,41 +538,34 @@ module.exports = (
           strategies: ['sessionToken', 'refreshToken'],
         },
         response: {
-          schema: isA
-            .array()
-            .items(
-              isA
-                .object({
-                  id: DEVICES_SCHEMA.id.required(),
-                  isCurrentDevice: isA.boolean().required(),
-                  lastAccessTime: isA.number().min(0).required().allow(null),
-                  lastAccessTimeFormatted: isA.string().optional().allow(''),
-                  approximateLastAccessTime: isA.number().min(0).optional(),
-                  approximateLastAccessTimeFormatted: isA
-                    .string()
-                    .optional()
-                    .allow(''),
-                  location: DEVICES_SCHEMA.location,
-                  name: DEVICES_SCHEMA.nameResponse.allow('').required(),
-                  type: DEVICES_SCHEMA.type.required(),
-                  pushCallback: DEVICES_SCHEMA.pushCallback
-                    .allow(null)
-                    .optional(),
-                  pushPublicKey: DEVICES_SCHEMA.pushPublicKey
-                    .allow(null)
-                    .optional(),
-                  pushAuthKey: DEVICES_SCHEMA.pushAuthKey
-                    .allow(null)
-                    .optional(),
-                  pushEndpointExpired:
-                    DEVICES_SCHEMA.pushEndpointExpired.optional(),
-                  availableCommands:
-                    DEVICES_SCHEMA.availableCommands.optional(),
-                })
-                .and('pushPublicKey', 'pushAuthKey')
-                .label('Account.device_model')
-            )
-            .label('Account.devices_response'),
+          schema: isA.array().items(
+            isA
+              .object({
+                id: DEVICES_SCHEMA.id.required(),
+                isCurrentDevice: isA.boolean().required(),
+                lastAccessTime: isA.number().min(0).required().allow(null),
+                lastAccessTimeFormatted: isA.string().optional().allow(''),
+                approximateLastAccessTime: isA.number().min(0).optional(),
+                approximateLastAccessTimeFormatted: isA
+                  .string()
+                  .optional()
+                  .allow(''),
+                location: DEVICES_SCHEMA.location,
+                name: DEVICES_SCHEMA.nameResponse.allow('').required(),
+                type: DEVICES_SCHEMA.type.required(),
+                pushCallback: DEVICES_SCHEMA.pushCallback
+                  .allow(null)
+                  .optional(),
+                pushPublicKey: DEVICES_SCHEMA.pushPublicKey
+                  .allow(null)
+                  .optional(),
+                pushAuthKey: DEVICES_SCHEMA.pushAuthKey.allow(null).optional(),
+                pushEndpointExpired:
+                  DEVICES_SCHEMA.pushEndpointExpired.optional(),
+                availableCommands: DEVICES_SCHEMA.availableCommands.optional(),
+              })
+              .and('pushPublicKey', 'pushAuthKey')
+          ),
         },
       },
       handler: async function (request) {
@@ -669,51 +651,46 @@ module.exports = (
           ],
         },
         response: {
-          schema: isA
-            .array()
-            .items(
-              isA
-                .object({
-                  id: isA.string().regex(HEX_STRING).required(),
-                  lastAccessTime: isA.number().min(0).required().allow(null),
-                  lastAccessTimeFormatted: isA.string().optional().allow(''),
-                  approximateLastAccessTime: isA.number().min(0).optional(),
-                  approximateLastAccessTimeFormatted: isA
-                    .string()
-                    .optional()
-                    .allow(''),
-                  createdTime: isA.number().min(0).required().allow(null),
-                  createdTimeFormatted: isA.string().optional().allow(''),
-                  location: DEVICES_SCHEMA.location,
-                  userAgent: isA.string().max(255).required().allow(''),
-                  os: isA.string().max(255).allow('').allow(null),
-                  deviceId: DEVICES_SCHEMA.id.allow(null).required(),
-                  deviceName: DEVICES_SCHEMA.nameResponse
-                    .allow('')
-                    .allow(null)
-                    .required(),
-                  deviceAvailableCommands: DEVICES_SCHEMA.availableCommands
-                    .allow(null)
-                    .required(),
-                  deviceType: DEVICES_SCHEMA.type.allow(null).required(),
-                  deviceCallbackURL: DEVICES_SCHEMA.pushCallback
-                    .allow(null)
-                    .required(),
-                  deviceCallbackPublicKey: DEVICES_SCHEMA.pushPublicKey
-                    .allow(null)
-                    .required(),
-                  deviceCallbackAuthKey: DEVICES_SCHEMA.pushAuthKey
-                    .allow(null)
-                    .required(),
-                  deviceCallbackIsExpired: DEVICES_SCHEMA.pushEndpointExpired
-                    .allow(null)
-                    .required(),
-                  isDevice: isA.boolean().required(),
-                  isCurrentDevice: isA.boolean().required(),
-                })
-                .label('Account.session_model')
-            )
-            .label('Account.session_response'),
+          schema: isA.array().items(
+            isA.object({
+              id: isA.string().regex(HEX_STRING).required(),
+              lastAccessTime: isA.number().min(0).required().allow(null),
+              lastAccessTimeFormatted: isA.string().optional().allow(''),
+              approximateLastAccessTime: isA.number().min(0).optional(),
+              approximateLastAccessTimeFormatted: isA
+                .string()
+                .optional()
+                .allow(''),
+              createdTime: isA.number().min(0).required().allow(null),
+              createdTimeFormatted: isA.string().optional().allow(''),
+              location: DEVICES_SCHEMA.location,
+              userAgent: isA.string().max(255).required().allow(''),
+              os: isA.string().max(255).allow('').allow(null),
+              deviceId: DEVICES_SCHEMA.id.allow(null).required(),
+              deviceName: DEVICES_SCHEMA.nameResponse
+                .allow('')
+                .allow(null)
+                .required(),
+              deviceAvailableCommands: DEVICES_SCHEMA.availableCommands
+                .allow(null)
+                .required(),
+              deviceType: DEVICES_SCHEMA.type.allow(null).required(),
+              deviceCallbackURL: DEVICES_SCHEMA.pushCallback
+                .allow(null)
+                .required(),
+              deviceCallbackPublicKey: DEVICES_SCHEMA.pushPublicKey
+                .allow(null)
+                .required(),
+              deviceCallbackAuthKey: DEVICES_SCHEMA.pushAuthKey
+                .allow(null)
+                .required(),
+              deviceCallbackIsExpired: DEVICES_SCHEMA.pushEndpointExpired
+                .allow(null)
+                .required(),
+              isDevice: isA.boolean().required(),
+              isCurrentDevice: isA.boolean().required(),
+            })
+          ),
         },
       },
       handler: async function (request) {
@@ -778,11 +755,9 @@ module.exports = (
           strategies: ['sessionToken', 'refreshToken'],
         },
         validate: {
-          payload: isA
-            .object({
-              id: DEVICES_SCHEMA.id.required(),
-            })
-            .label('Account.deviceDestroy_payload'),
+          payload: isA.object({
+            id: DEVICES_SCHEMA.id.required(),
+          }),
         },
         response: {
           schema: {},
@@ -809,21 +784,16 @@ module.exports = (
           },
         },
         response: {
-          schema: isA
-            .array()
-            .items(
-              isA
-                .object({
-                  city: isA.string().required().allow(null),
-                  state: isA.string().required().allow(null),
-                  stateCode: isA.string().required().allow(null),
-                  country: isA.string().required().allow(null),
-                  countryCode: isA.string().required().allow(null),
-                  lastAccessTime: isA.number().required(),
-                })
-                .label('Account.sessionsLocation')
-            )
-            .label('Account.sessionsLocations_response'),
+          schema: isA.array().items(
+            isA.object({
+              city: isA.string().required().allow(null),
+              state: isA.string().required().allow(null),
+              stateCode: isA.string().required().allow(null),
+              country: isA.string().required().allow(null),
+              countryCode: isA.string().required().allow(null),
+              lastAccessTime: isA.number().required(),
+            })
+          ),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -112,16 +112,14 @@ module.exports = (
           },
         },
         response: {
-          schema: isA
-            .object({
-              // There's code in the handler that checks for a valid email,
-              // no point adding overhead by doing it again here.
-              email: isA.string().required(),
-              verified: isA.boolean().required(),
-              sessionVerified: isA.boolean().optional(),
-              emailVerified: isA.boolean().optional(),
-            })
-            .label('Account.RecoveryEmailStatus_response'),
+          schema: isA.object({
+            // There's code in the handler that checks for a valid email,
+            // no point adding overhead by doing it again here.
+            email: isA.string().required(),
+            verified: isA.boolean().required(),
+            sessionVerified: isA.boolean().optional(),
+            emailVerified: isA.boolean().optional(),
+          }),
         },
       },
       handler: async function (request) {
@@ -218,27 +216,25 @@ module.exports = (
               .allow(['upgradeSession'])
               .optional(),
           }),
-          payload: isA
-            .object({
-              email: validators.email().optional(),
-              service: validators.service.description(DESCRIPTION.service),
-              redirectTo: validators
-                .redirectTo(config.smtp.redirectDomain)
-                .optional(),
-              resume: isA
-                .string()
-                .max(2048)
-                .optional()
-                .description(DESCRIPTION.resume),
-              style: isA.string().allow(['trailhead']).optional(),
-              type: isA
-                .string()
-                .max(32)
-                .alphanum()
-                .allow(['upgradeSession'])
-                .optional(),
-            })
-            .label('Account.RecoveryEmailResend_payload'),
+          payload: isA.object({
+            email: validators.email().optional(),
+            service: validators.service.description(DESCRIPTION.service),
+            redirectTo: validators
+              .redirectTo(config.smtp.redirectDomain)
+              .optional(),
+            resume: isA
+              .string()
+              .max(2048)
+              .optional()
+              .description(DESCRIPTION.resume),
+            style: isA.string().allow(['trailhead']).optional(),
+            type: isA
+              .string()
+              .max(32)
+              .alphanum()
+              .allow(['upgradeSession'])
+              .optional(),
+          }),
         },
       },
       handler: async function (request) {
@@ -374,28 +370,26 @@ module.exports = (
       options: {
         ...EMAILS_DOCS.RECOVERY_EMAIL_VERIFY_CODE_POST,
         validate: {
-          payload: isA
-            .object({
-              uid: isA.string().max(32).regex(HEX_STRING).required(),
-              code: isA.string().min(32).max(32).regex(HEX_STRING).required(),
-              service: validators.service.description(DESCRIPTION.service),
-              reminder: isA
-                .string()
-                .regex(REMINDER_PATTERN)
-                .optional()
-                .description(DESCRIPTION.reminder),
-              type: isA
-                .string()
-                .max(32)
-                .alphanum()
-                .optional()
-                .description(DESCRIPTION.type),
-              style: isA.string().allow(['trailhead']).optional(),
-              // The `marketingOptIn` is safe to remove after train-167+
-              marketingOptIn: isA.boolean().optional(),
-              newsletters: validators.newsletters,
-            })
-            .label('Account.RecoveryEmailVerify_payload'),
+          payload: isA.object({
+            uid: isA.string().max(32).regex(HEX_STRING).required(),
+            code: isA.string().min(32).max(32).regex(HEX_STRING).required(),
+            service: validators.service.description(DESCRIPTION.service),
+            reminder: isA
+              .string()
+              .regex(REMINDER_PATTERN)
+              .optional()
+              .description(DESCRIPTION.reminder),
+            type: isA
+              .string()
+              .max(32)
+              .alphanum()
+              .optional()
+              .description(DESCRIPTION.type),
+            style: isA.string().allow(['trailhead']).optional(),
+            // The `marketingOptIn` is safe to remove after train-167+
+            marketingOptIn: isA.boolean().optional(),
+            newsletters: validators.newsletters,
+          }),
         },
       },
       handler: async function (request) {
@@ -519,18 +513,13 @@ module.exports = (
           strategy: 'sessionToken',
         },
         response: {
-          schema: isA
-            .array()
-            .items(
-              isA
-                .object({
-                  verified: isA.boolean().required(),
-                  isPrimary: isA.boolean().required(),
-                  email: validators.email().required(),
-                })
-                .label('Account.RecoveryEmail')
-            )
-            .label('Account.RecoveryEmailEmails_response'),
+          schema: isA.array().items(
+            isA.object({
+              verified: isA.boolean().required(),
+              isPrimary: isA.boolean().required(),
+              email: validators.email().required(),
+            })
+          ),
         },
       },
       handler: async function (request) {
@@ -557,14 +546,12 @@ module.exports = (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.emailAdd),
-            })
-            .label('Account.RecoveryEmailCreate_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailAdd),
+          }),
         },
         response: {},
       },
@@ -710,14 +697,12 @@ module.exports = (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.emailDelete),
-            })
-            .label('Account.RecoveryEmailDestroy_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailDelete),
+          }),
         },
         response: {},
       },
@@ -774,14 +759,12 @@ module.exports = (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.emailNewPrimary),
-            })
-            .label('Account.RecoveryEmailSetPrimary_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailNewPrimary),
+          }),
         },
         response: {},
       },
@@ -885,14 +868,12 @@ module.exports = (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .description(DESCRIPTION.emailSecondaryVerify)
-                .required(),
-            })
-            .label('Account.RecoveryEmailSecondaryResend_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .description(DESCRIPTION.emailSecondaryVerify)
+              .required(),
+          }),
         },
         response: {},
       },
@@ -972,20 +953,18 @@ module.exports = (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.emailSecondaryVerify),
-              code: isA
-                .string()
-                .max(32)
-                .regex(validators.DIGITS)
-                .description(DESCRIPTION.code)
-                .required(),
-            })
-            .label('Account.RecoveryEmailSecondaryVerify_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailSecondaryVerify),
+            code: isA
+              .string()
+              .max(32)
+              .regex(validators.DIGITS)
+              .description(DESCRIPTION.code)
+              .required(),
+          }),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -316,7 +316,7 @@ export const linkedAccountRoutes = (
             provider: validators.thirdPartyProvider,
             code: validators.thirdPartyOAuthCode,
             metricsContext: METRICS_CONTEXT_SCHEMA,
-          }).label('LinkedAccount.login_payload'),
+          }),
         },
       },
       handler: async (request: AuthRequest) =>
@@ -333,7 +333,7 @@ export const linkedAccountRoutes = (
         validate: {
           payload: Joi.object({
             provider: validators.thirdPartyProvider,
-          }).label('LinkedAccount.unlink_payload'),
+          }),
         },
       },
       handler: (request: AuthRequest) => handler.unlinkAccount(request),

--- a/packages/fxa-auth-server/lib/routes/newsletters.js
+++ b/packages/fxa-auth-server/lib/routes/newsletters.js
@@ -25,7 +25,7 @@ module.exports = (log, db) => {
         validate: {
           payload: Joi.object({
             newsletters: validators.newsletters.required(),
-          }).label('Newsletters_payload'),
+          }),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -265,7 +265,7 @@ module.exports = ({ log, oauthDB, config }) => {
               then: Joi.optional(),
               otherwise: Joi.forbidden(),
             }),
-          }).label('Authorization_payload'),
+          }),
         },
         response: {
           schema: Joi.object()
@@ -286,8 +286,7 @@ module.exports = ({ log, oauthDB, config }) => {
               'expires_in',
             ])
             .with('code', ['state', 'redirect'])
-            .without('code', ['access_token'])
-            .label('Authorization_response'),
+            .without('code', ['access_token']),
         },
         handler: function (req) {
           // Refuse to generate new codes or tokens for disabled clients.
@@ -348,16 +347,14 @@ module.exports = ({ log, oauthDB, config }) => {
               .description(DESCRIPTION.acrValues),
             assertion: Joi.forbidden(),
             resource: Joi.forbidden(),
-          })
-            .and('code_challenge', 'code_challenge_method')
-            .label('Oauth.authorization_payload'),
+          }).and('code_challenge', 'code_challenge_method'),
         },
         response: {
           schema: Joi.object({
             redirect: Joi.string(),
             code: Joi.string(),
             state: Joi.string().max(512),
-          }).label('Oauth.authorization_response'),
+          }),
         },
       },
       handler: async function (req) {

--- a/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/destroy.js
@@ -19,7 +19,7 @@ module.exports = () => ({
         client_id: validators.clientId,
         refresh_token_id: validators.token.optional(),
         assertion: validators.assertion,
-      }).label('AuthorizedClients.destroy_payload'),
+      }),
     },
     handler: async function (req) {
       const claims = await verifyAssertion(req.payload.assertion);

--- a/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/list.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorized-clients/list.js
@@ -18,21 +18,19 @@ module.exports = () => ({
     validate: {
       payload: Joi.object({
         assertion: validators.assertion.required(),
-      }).label('AuthorizedClients_payload'),
+      }),
     },
     response: {
-      schema: Joi.array()
-        .items(
-          Joi.object({
-            client_id: validators.clientId,
-            refresh_token_id: validators.token.optional(),
-            client_name: Joi.string().required(),
-            created_time: Joi.number().min(0).required(),
-            last_access_time: Joi.number().min(0).required().allow(null),
-            scope: Joi.array().items(Joi.string()).required(),
-          }).label('AuthorizedClient')
-        )
-        .label('AuthorizedClients_response'),
+      schema: Joi.array().items(
+        Joi.object({
+          client_id: validators.clientId,
+          refresh_token_id: validators.token.optional(),
+          client_name: Joi.string().required(),
+          created_time: Joi.number().min(0).required(),
+          last_access_time: Joi.number().min(0).required().allow(null),
+          scope: Joi.array().items(Joi.string()).required(),
+        })
+      ),
     },
     handler: async function (req) {
       const claims = await verifyAssertion(req.payload.assertion);

--- a/packages/fxa-auth-server/lib/routes/oauth/client/get.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/client/get.js
@@ -27,7 +27,7 @@ module.exports = ({ log, oauthDB }) => ({
         trusted: Joi.boolean().required(),
         image_uri: Joi.any(),
         redirect_uri: Joi.string().required().allow(''),
-      }).label('Oauth.clientId_response'),
+      }),
     },
     handler: async function requestInfoEndpoint(req) {
       const params = req.params;

--- a/packages/fxa-auth-server/lib/routes/oauth/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/destroy.js
@@ -89,8 +89,7 @@ module.exports = ({ log, oauthDB }) => {
               refresh_token_id: validators.token,
             })
             .rename('token', 'access_token')
-            .xor('access_token', 'refresh_token', 'refresh_token_id')
-            .label('Destroy_payload'),
+            .xor('access_token', 'refresh_token', 'refresh_token_id'),
         },
         handler: destroyHandler,
       },
@@ -118,7 +117,7 @@ module.exports = ({ log, oauthDB }) => {
               .max(64)
               .optional()
               .description(DESCRIPTION.tokenTypeHint),
-          }).label('oauth.destroy_payload'),
+          }),
         },
         response: {},
       },

--- a/packages/fxa-auth-server/lib/routes/oauth/id_token_verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/id_token_verify.js
@@ -17,7 +17,7 @@ module.exports = () => ({
         client_id: Joi.string().required(),
         id_token: Joi.string().required(),
         expiry_grace_period: Joi.number().default(0),
-      }).label('Oauth.idTokenVerify_payload'),
+      }),
     },
     response: {
       schema: Joi.object()
@@ -33,8 +33,7 @@ module.exports = () => ({
           iat: Joi.number().optional(),
           iss: Joi.string().optional(),
           sub: Joi.string().optional(),
-        })
-        .label('Oauth.idTokenVerify_response'),
+        }),
     },
   },
   handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/oauth/introspect.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/introspect.js
@@ -13,7 +13,7 @@ const MISC_DOCS = require('../../../docs/swagger/misc-api').default;
 const PAYLOAD_SCHEMA = Joi.object({
   token: Joi.string().required(),
   token_type_hint: Joi.string().equal(['access_token', 'refresh_token']),
-}).label('Introspect_payload');
+});
 
 // The "token introspection" endpoint, per https://tools.ietf.org/html/rfc7662
 
@@ -27,21 +27,19 @@ module.exports = ({ oauthDB }) => ({
       payload: PAYLOAD_SCHEMA.options({ stripUnknown: true }),
     },
     response: {
-      schema: Joi.object()
-        .keys({
-          // https://tools.ietf.org/html/rfc7662#section-2.2
-          active: Joi.boolean().required(),
-          scope: validators.scope.optional(),
-          client_id: validators.clientId.optional(),
-          token_type: Joi.string().equal(['access_token', 'refresh_token']),
-          exp: Joi.number().optional(),
-          iat: Joi.number().optional(),
-          sub: Joi.string().optional(),
-          iss: Joi.string().optional(),
-          jti: Joi.string().optional(),
-          'fxa-lastUsedAt': Joi.number().optional(),
-        })
-        .label('Introspect_response'),
+      schema: Joi.object().keys({
+        // https://tools.ietf.org/html/rfc7662#section-2.2
+        active: Joi.boolean().required(),
+        scope: validators.scope.optional(),
+        client_id: validators.clientId.optional(),
+        token_type: Joi.string().equal(['access_token', 'refresh_token']),
+        exp: Joi.number().optional(),
+        iat: Joi.number().optional(),
+        sub: Joi.string().optional(),
+        iss: Joi.string().optional(),
+        jti: Joi.string().optional(),
+        'fxa-lastUsedAt': Joi.number().optional(),
+      }),
     },
     handler: async function introspectEndpoint(req) {
       const tokenTypeHint = req.payload.token_type_hint;

--- a/packages/fxa-auth-server/lib/routes/oauth/key_data.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/key_data.js
@@ -105,7 +105,7 @@ module.exports = ({ log, oauthDB }) => {
             client_id: validators.clientId,
             assertion: validators.assertion.required(),
             scope: validators.scope.required(),
-          }).label('KeyData_payload'),
+          }),
         },
         response: {
           schema: Joi.object().pattern(/^/, [
@@ -133,7 +133,7 @@ module.exports = ({ log, oauthDB }) => {
             client_id: validators.clientId.required(),
             scope: validators.scope.required(),
             assertion: Joi.forbidden(),
-          }).label('Oauth.scopedKeyData_payload'),
+          }),
         },
         response: {
           schema: Joi.object().pattern(
@@ -142,7 +142,7 @@ module.exports = ({ log, oauthDB }) => {
               identifier: validators.scope.required(),
               keyRotationSecret: validators.hexString.length(64).required(),
               keyRotationTimestamp: Joi.number().required(),
-            }).label('Oauth.scopedKeyData_response')
+            })
           ),
         },
       },

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -364,24 +364,20 @@ module.exports = ({ log, oauthDB, db, mailer, devices }) => {
           // with FxA OAuth. Sometimes, they will send other parameters that
           // we don't use, such as `response_type`, or something else. Instead
           // of giving an error here, we can just ignore them.
-          payload: PAYLOAD_SCHEMA.options({ stripUnknown: true }).label(
-            'Token_payload'
-          ),
+          payload: PAYLOAD_SCHEMA.options({ stripUnknown: true }),
         },
         response: {
-          schema: Joi.object()
-            .keys({
-              access_token: validators.accessToken.required(),
-              refresh_token: validators.token,
-              id_token: validators.assertion,
-              session_token_id: validators.sessionTokenId.optional(),
-              scope: validators.scope.required(),
-              token_type: Joi.string().valid('bearer').required(),
-              expires_in: Joi.number().max(MAX_TTL_S).required(),
-              auth_at: Joi.number(),
-              keys_jwe: validators.jwe.optional(),
-            })
-            .label('Token_response'),
+          schema: Joi.object().keys({
+            access_token: validators.accessToken.required(),
+            refresh_token: validators.token,
+            id_token: validators.assertion,
+            session_token_id: validators.sessionTokenId.optional(),
+            scope: validators.scope.required(),
+            token_type: Joi.string().valid('bearer').required(),
+            expires_in: Joi.number().max(MAX_TTL_S).required(),
+            auth_at: Joi.number(),
+            keys_jwe: validators.jwe.optional(),
+          }),
         },
         handler: tokenHandler,
       },
@@ -427,9 +423,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices }) => {
               resource: validators.resourceUrl
                 .optional()
                 .description(DESCRIPTION.resource),
-            })
-              .xor('client_secret', 'code_verifier')
-              .label('Oauth.token_authorizationCode'),
+            }).xor('client_secret', 'code_verifier'),
             // refresh token
             Joi.object({
               grant_type: Joi.string().valid('refresh_token').required(),
@@ -442,7 +436,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices }) => {
               ttl: Joi.number().positive().optional(),
               ppid_seed: validators.ppidSeed.optional(),
               resource: validators.resourceUrl.optional(),
-            }).label('Oauth.token_refreshToken'),
+            }),
             // credentials
             Joi.object({
               grant_type: Joi.string()
@@ -458,7 +452,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices }) => {
               ttl: Joi.number().positive().optional(),
               resource: validators.resourceUrl.optional(),
               assertion: Joi.forbidden(),
-            }).label('Oauth.token_fxaCredentials')
+            })
           ),
         },
         response: {
@@ -485,7 +479,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices }) => {
                 .description(DESCRIPTION.expiresIn),
               auth_at: Joi.number().required().description(DESCRIPTION.authAt),
               keys_jwe: validators.jwe.optional(),
-            }).label('Oauth.token_response'),
+            }),
             // refresh token
             Joi.object({
               access_token: validators.accessToken.required(),

--- a/packages/fxa-auth-server/lib/routes/oauth/verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/verify.js
@@ -17,7 +17,7 @@ module.exports = ({ log }) => ({
     validate: {
       payload: Joi.object({
         token: validators.accessToken.required(),
-      }).label('Verify_payload'),
+      }),
     },
     response: {
       schema: Joi.object({
@@ -26,7 +26,7 @@ module.exports = ({ log }) => ({
         scope: Joi.array(),
         generation: Joi.number().min(0),
         profile_changed_at: Joi.number().min(0),
-      }).label('Verify_response'),
+      }),
     },
     handler: async function verify(req) {
       const info = await token.verify(req.payload.token);

--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -46,15 +46,10 @@ module.exports = function (
       options: {
         ...PASSWORD_DOCS.PASSWORD_CHANGE_START_POST,
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.email),
-              oldAuthPW: validators.authPW.description(DESCRIPTION.authPW),
-            })
-            .label('Password.changeStart_payload'),
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            oldAuthPW: validators.authPW.description(DESCRIPTION.authPW),
+          }),
         },
       },
       handler: async function (request) {
@@ -142,19 +137,17 @@ module.exports = function (
           query: isA.object({
             keys: isA.boolean().optional().description(DESCRIPTION.queryKeys),
           }),
-          payload: isA
-            .object({
-              authPW: validators.authPW.description(DESCRIPTION.authPW),
-              wrapKb: validators.wrapKb.description(DESCRIPTION.wrapKb),
-              sessionToken: isA
-                .string()
-                .min(64)
-                .max(64)
-                .regex(HEX_STRING)
-                .optional()
-                .description(DESCRIPTION.sessionToken),
-            })
-            .label('Password.changeFinish_payload'),
+          payload: isA.object({
+            authPW: validators.authPW.description(DESCRIPTION.authPW),
+            wrapKb: validators.wrapKb.description(DESCRIPTION.wrapKb),
+            sessionToken: isA
+              .string()
+              .min(64)
+              .max(64)
+              .regex(HEX_STRING)
+              .optional()
+              .description(DESCRIPTION.sessionToken),
+          }),
         },
       },
       handler: async function (request) {
@@ -436,35 +429,31 @@ module.exports = function (
             service: validators.service.description(DESCRIPTION.serviceRP),
             keys: isA.boolean().optional(),
           }),
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.emailRecovery),
-              service: validators.service.description(DESCRIPTION.serviceRP),
-              redirectTo: validators
-                .redirectTo(redirectDomain)
-                .optional()
-                .description(DESCRIPTION.redirectTo),
-              resume: isA
-                .string()
-                .max(2048)
-                .optional()
-                .description(DESCRIPTION.resume),
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-            })
-            .label('Password.forgotSend_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailRecovery),
+            service: validators.service.description(DESCRIPTION.serviceRP),
+            redirectTo: validators
+              .redirectTo(redirectDomain)
+              .optional()
+              .description(DESCRIPTION.redirectTo),
+            resume: isA
+              .string()
+              .max(2048)
+              .optional()
+              .description(DESCRIPTION.resume),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              passwordForgotToken: isA.string(),
-              ttl: isA.number(),
-              codeLength: isA.number(),
-              tries: isA.number(),
-            })
-            .label('Password.forgotSend_response'),
+          schema: isA.object({
+            passwordForgotToken: isA.string(),
+            ttl: isA.number(),
+            codeLength: isA.number(),
+            tries: isA.number(),
+          }),
         },
       },
       handler: async function (request) {
@@ -567,34 +556,30 @@ module.exports = function (
           query: isA.object({
             service: validators.service.description(DESCRIPTION.serviceRP),
           }),
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.emailRecovery),
-              service: validators.service.description(DESCRIPTION.serviceRP),
-              redirectTo: validators
-                .redirectTo(redirectDomain)
-                .optional()
-                .description(DESCRIPTION.redirectTo),
-              resume: isA
-                .string()
-                .max(2048)
-                .optional()
-                .description(DESCRIPTION.resume),
-            })
-            .label('Password.forgotResend_payload'),
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailRecovery),
+            service: validators.service.description(DESCRIPTION.serviceRP),
+            redirectTo: validators
+              .redirectTo(redirectDomain)
+              .optional()
+              .description(DESCRIPTION.redirectTo),
+            resume: isA
+              .string()
+              .max(2048)
+              .optional()
+              .description(DESCRIPTION.resume),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              passwordForgotToken: isA.string(),
-              ttl: isA.number(),
-              codeLength: isA.number(),
-              tries: isA.number(),
-            })
-            .label('Password.forgotResend_response'),
+          schema: isA.object({
+            passwordForgotToken: isA.string(),
+            ttl: isA.number(),
+            codeLength: isA.number(),
+            tries: isA.number(),
+          }),
         },
       },
       handler: async function (request) {
@@ -673,25 +658,21 @@ module.exports = function (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              code: isA
-                .string()
-                .min(32)
-                .max(32)
-                .regex(HEX_STRING)
-                .required()
-                .description(DESCRIPTION.codeRecovery),
-              accountResetWithRecoveryKey: isA.boolean().optional(),
-            })
-            .label('Password.forgotVerify_payload'),
+          payload: isA.object({
+            code: isA
+              .string()
+              .min(32)
+              .max(32)
+              .regex(HEX_STRING)
+              .required()
+              .description(DESCRIPTION.codeRecovery),
+            accountResetWithRecoveryKey: isA.boolean().optional(),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              accountResetToken: isA.string(),
-            })
-            .label('Password.forgotVerify_response'),
+          schema: isA.object({
+            accountResetToken: isA.string(),
+          }),
         },
       },
       handler: async function (request) {
@@ -831,12 +812,10 @@ module.exports = function (
           strategy: 'passwordForgotToken',
         },
         response: {
-          schema: isA
-            .object({
-              tries: isA.number(),
-              ttl: isA.number(),
-            })
-            .label('Password.forgotStatus_response'),
+          schema: isA.object({
+            tries: isA.number(),
+            ttl: isA.number(),
+          }),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -17,10 +17,10 @@ module.exports = (log, db, config, customs, mailer) => {
   const RECOVERY_CODE_COUNT = (codeConfig && codeConfig.count) || 8;
 
   // Validate recovery codes
-  const recoveryCodesSchema = validators
-    .recoveryCodes(RECOVERY_CODE_COUNT, RECOVERY_CODE_SANE_MAX_LENGTH)
-    .label('replaceRecoveryCodes_response');
-
+  const recoveryCodesSchema = validators.recoveryCodes(
+    RECOVERY_CODE_COUNT,
+    RECOVERY_CODE_SANE_MAX_LENGTH
+  );
   return [
     {
       method: 'GET',
@@ -84,11 +84,9 @@ module.exports = (log, db, config, customs, mailer) => {
           payload: recoveryCodesSchema,
         },
         response: {
-          schema: isA
-            .object({
-              success: isA.boolean(),
-            })
-            .label('success'),
+          schema: isA.object({
+            success: isA.boolean(),
+          }),
         },
       },
       async handler(request) {
@@ -138,23 +136,19 @@ module.exports = (log, db, config, customs, mailer) => {
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              // Validation here is done with BASE_36 superset to be backwards compatible...
-              // Ideally all recovery codes are Crockford Base32.
-              code: validators.recoveryCode(
-                RECOVERY_CODE_SANE_MAX_LENGTH,
-                validators.BASE_36
-              ),
-            })
-            .label('session.verify.recoveryCode_payload'),
+          payload: isA.object({
+            // Validation here is done with BASE_36 superset to be backwards compatible...
+            // Ideally all recovery codes are Crockford Base32.
+            code: validators.recoveryCode(
+              RECOVERY_CODE_SANE_MAX_LENGTH,
+              validators.BASE_36
+            ),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              remaining: isA.number(),
-            })
-            .label('session.verify.recoveryCode_response'),
+          schema: isA.object({
+            remaining: isA.number(),
+          }),
         },
       },
       async handler(request) {

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -24,17 +24,15 @@ module.exports = (log, db, Password, verifierVersion, customs, mailer) => {
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              recoveryKeyId: validators.recoveryKeyId.description(
-                DESCRIPTION.recoveryKeyId
-              ),
-              recoveryData: validators.recoveryData.description(
-                DESCRIPTION.recoveryData
-              ),
-              enabled: isA.boolean().default(true),
-            })
-            .label('createRecoveryKey_payload'),
+          payload: isA.object({
+            recoveryKeyId: validators.recoveryKeyId.description(
+              DESCRIPTION.recoveryKeyId
+            ),
+            recoveryData: validators.recoveryData.description(
+              DESCRIPTION.recoveryData
+            ),
+            enabled: isA.boolean().default(true),
+          }),
         },
       },
       handler: async function (request) {
@@ -175,11 +173,9 @@ module.exports = (log, db, Password, verifierVersion, customs, mailer) => {
           strategy: 'accountResetToken',
         },
         validate: {
-          params: isA
-            .object({
-              recoveryKeyId: validators.recoveryKeyId,
-            })
-            .label('getRecoveryKey_params'),
+          params: isA.object({
+            recoveryKeyId: validators.recoveryKeyId,
+          }),
         },
       },
       handler: async function (request) {
@@ -205,18 +201,14 @@ module.exports = (log, db, Password, verifierVersion, customs, mailer) => {
           strategy: 'sessionToken',
         },
         validate: {
-          payload: isA
-            .object({
-              email: validators.email().optional(),
-            })
-            .label('recoveryKeysExists_payload'),
+          payload: isA.object({
+            email: validators.email().optional(),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              exists: isA.boolean().required(),
-            })
-            .label('recoveryKeyExists_response'),
+          schema: isA.object({
+            exists: isA.boolean().required(),
+          }),
         },
       },
       async handler(request) {

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -57,8 +57,7 @@ module.exports = function (
                 .optional()
                 .description(DESCRIPTION.customSessionToken),
             })
-            .allow(null)
-            .label('Session.destroy_payload'),
+            .allow(null),
         },
       },
       handler: async function (request) {
@@ -112,35 +111,31 @@ module.exports = function (
             service: validators.service,
             verificationMethod: validators.verificationMethod.optional(),
           }),
-          payload: isA
-            .object({
-              email: validators.email().required(),
-              authPW: validators.authPW,
-              service: validators.service,
-              redirectTo: validators
-                .redirectTo(config.smtp.redirectDomain)
-                .optional(),
-              resume: isA.string().optional(),
-              reason: isA.string().max(16).optional(),
-              unblockCode: signinUtils.validators.UNBLOCK_CODE,
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-              originalLoginEmail: validators.email().optional(),
-              verificationMethod: validators.verificationMethod.optional(),
-            })
-            .label('Session.reauth_payload'),
+          payload: isA.object({
+            email: validators.email().required(),
+            authPW: validators.authPW,
+            service: validators.service,
+            redirectTo: validators
+              .redirectTo(config.smtp.redirectDomain)
+              .optional(),
+            resume: isA.string().optional(),
+            reason: isA.string().max(16).optional(),
+            unblockCode: signinUtils.validators.UNBLOCK_CODE,
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+            originalLoginEmail: validators.email().optional(),
+            verificationMethod: validators.verificationMethod.optional(),
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              uid: isA.string().regex(HEX_STRING).required(),
-              keyFetchToken: isA.string().regex(HEX_STRING).optional(),
-              verificationMethod: isA.string().optional(),
-              verificationReason: isA.string().optional(),
-              verified: isA.boolean().required(),
-              authAt: isA.number().integer(),
-              metricsEnabled: isA.boolean().required(),
-            })
-            .label('Session.reauth_response'),
+          schema: isA.object({
+            uid: isA.string().regex(HEX_STRING).required(),
+            keyFetchToken: isA.string().regex(HEX_STRING).optional(),
+            verificationMethod: isA.string().optional(),
+            verificationReason: isA.string().optional(),
+            verified: isA.boolean().required(),
+            authAt: isA.number().integer(),
+            metricsEnabled: isA.boolean().required(),
+          }),
         },
       },
       handler: async function (request) {
@@ -257,12 +252,10 @@ module.exports = function (
           strategy: 'sessionToken',
         },
         response: {
-          schema: isA
-            .object({
-              state: isA.string().required(),
-              uid: isA.string().regex(HEX_STRING).required(),
-            })
-            .label('Session.status_response'),
+          schema: isA.object({
+            state: isA.string().required(),
+            uid: isA.string().regex(HEX_STRING).required(),
+          }),
         },
       },
       handler: async function (request) {
@@ -284,11 +277,9 @@ module.exports = function (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              reason: isA.string().max(16).optional(),
-            })
-            .label('Session.duplicate_payload'),
+          payload: isA.object({
+            reason: isA.string().max(16).optional(),
+          }),
         },
       },
       handler: async function (request) {
@@ -352,16 +343,14 @@ module.exports = function (
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              code: validators.DIGITS,
-              service: validators.service,
-              scopes: validators.scopes,
-              // The `marketingOptIn` is safe to remove after train-167+
-              marketingOptIn: isA.boolean().optional(),
-              newsletters: validators.newsletters,
-            })
-            .label('Session.verifyCode_payload'),
+          payload: isA.object({
+            code: validators.DIGITS,
+            service: validators.service,
+            scopes: validators.scopes,
+            // The `marketingOptIn` is safe to remove after train-167+
+            marketingOptIn: isA.boolean().optional(),
+            newsletters: validators.newsletters,
+          }),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/sign.js
+++ b/packages/fxa-auth-server/lib/routes/sign.js
@@ -27,30 +27,28 @@ module.exports = (log, signer, db, domain, devices) => {
           query: isA.object({
             service: validators.service.optional(),
           }),
-          payload: isA
-            .object({
-              publicKey: isA
-                .object({
-                  algorithm: isA.string().valid('RS', 'DS').required(),
-                  n: isA.string(),
-                  e: isA.string(),
-                  y: isA.string(),
-                  p: isA.string(),
-                  q: isA.string(),
-                  g: isA.string(),
-                  version: isA.string(),
-                })
-                .required()
-                .description(DESCRIPTION.publicKey),
-              duration: isA
-                .number()
-                .integer()
-                .min(0)
-                .max(24 * HOUR)
-                .required()
-                .description(DESCRIPTION.duration),
-            })
-            .label('Sign.cert_payload'),
+          payload: isA.object({
+            publicKey: isA
+              .object({
+                algorithm: isA.string().valid('RS', 'DS').required(),
+                n: isA.string(),
+                e: isA.string(),
+                y: isA.string(),
+                p: isA.string(),
+                q: isA.string(),
+                g: isA.string(),
+                version: isA.string(),
+              })
+              .required()
+              .description(DESCRIPTION.publicKey),
+            duration: isA
+              .number()
+              .integer()
+              .min(0)
+              .max(24 * HOUR)
+              .required()
+              .description(DESCRIPTION.duration),
+          }),
         },
       },
       handler: async function certificateSign(request) {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -790,18 +790,12 @@ export const stripeRoutes = (
           strategy: 'subscriptionsSecret',
         },
         response: {
-          schema: isA
-            .array()
-            .items(
-              isA
-                .object()
-                .keys({
-                  clientId: isA.string(),
-                  capabilities: isA.array().items(isA.string()),
-                })
-                .label('subscriptionClient')
-            )
-            .label('subscriptionsClient_response') as any,
+          schema: isA.array().items(
+            isA.object().keys({
+              clientId: isA.string(),
+              capabilities: isA.array().items(isA.string()),
+            })
+          ) as any,
         },
       },
       handler: (request: AuthRequest) => stripeHandler.getClients(request),
@@ -814,7 +808,6 @@ export const stripeRoutes = (
         response: {
           schema: isA
             .array()
-            .label('OauthSubscriptionsPlans')
             .items(validators.subscriptionsPlanValidator) as any,
         },
       },
@@ -832,7 +825,6 @@ export const stripeRoutes = (
         response: {
           schema: isA
             .array()
-            .label('OauthSubscriptionsActive')
             .items(validators.activeSubscriptionValidator) as any,
         },
       },
@@ -918,9 +910,7 @@ export const stripeRoutes = (
         ...SUBSCRIPTIONS_DOCS.OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_POST,
         auth: false,
         response: {
-          schema: invoiceDTO.firstInvoicePreviewSchema.label(
-            'OauthSubscriptionsInvoicePreview_response'
-          ) as any,
+          schema: invoiceDTO.firstInvoicePreviewSchema as any,
         },
         validate: {
           payload: {
@@ -941,9 +931,7 @@ export const stripeRoutes = (
           strategy: 'oauthToken',
         },
         response: {
-          schema: invoiceDTO.subsequentInvoicePreviewsSchema.label(
-            'OauthSubscriptionsInvoicePreviewSubsequent_response'
-          ) as any,
+          schema: invoiceDTO.subsequentInvoicePreviewsSchema as any,
         },
       },
       handler: (request: AuthRequest) =>
@@ -956,9 +944,7 @@ export const stripeRoutes = (
         ...SUBSCRIPTIONS_DOCS.OAUTH_SUBSCRIPTIONS_COUPON_POST,
         auth: false,
         response: {
-          schema: couponDTO.couponDetailsSchema.label(
-            'OauthSubscriptionsCoupon_response'
-          ) as any,
+          schema: couponDTO.couponDetailsSchema as any,
         },
         validate: {
           payload: {
@@ -1038,11 +1024,9 @@ export const stripeRoutes = (
       options: {
         ...SUBSCRIPTIONS_DOCS.OAUTH_SUBSCRIPTIONS_PRODUCTNAME_GET,
         response: {
-          schema: isA
-            .object({
-              product_name: isA.string().required(),
-            })
-            .label('Product Name') as any,
+          schema: isA.object({
+            product_name: isA.string().required(),
+          }) as any,
         },
         validate: {
           query: {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
@@ -63,31 +63,25 @@ export const supportRoutes = (
           maxBytes: config.support.ticketPayloadLimit,
         },
         validate: {
-          payload: isA
-            .object()
-            .keys({
-              email: email().optional(),
-              productName: isA.string().required(),
-              productPlatform: isA.string().optional(),
-              productVersion: isA.string().optional(),
-              topic: isA.string().required(),
-              app: isA.string().allow('').optional(),
-              subject: isA.string().allow('').optional(),
-              message: isA.string().required(),
-              product: isA.string().allow('').optional(),
-              category: isA.string().allow('').optional(),
-            })
-            .label('SupportTicket_payload') as any,
+          payload: isA.object().keys({
+            email: email().optional(),
+            productName: isA.string().required(),
+            productPlatform: isA.string().optional(),
+            productVersion: isA.string().optional(),
+            topic: isA.string().required(),
+            app: isA.string().allow('').optional(),
+            subject: isA.string().allow('').optional(),
+            message: isA.string().required(),
+            product: isA.string().allow('').optional(),
+            category: isA.string().allow('').optional(),
+          }) as any,
         },
         response: {
-          schema: isA
-            .object()
-            .keys({
-              success: isA.bool().required(),
-              ticket: isA.number().optional(),
-              error: isA.string().optional(),
-            })
-            .label('SupportTicket_response') as any,
+          schema: isA.object().keys({
+            success: isA.bool().required(),
+            ticket: isA.number().optional(),
+            error: isA.string().optional(),
+          }) as any,
         },
       },
       handler: async function (

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -39,20 +39,16 @@ module.exports = (log, db, mailer, customs, config) => {
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-            })
-            .label('totp.create_payload'),
+          payload: isA.object({
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              qrCodeUrl: isA.string().required(),
-              secret: isA.string().required(),
-              recoveryCodes: isA.array().items(isA.string()).required(),
-            })
-            .label('totp.create_response'),
+          schema: isA.object({
+            qrCodeUrl: isA.string().required(),
+            secret: isA.string().required(),
+            recoveryCodes: isA.array().items(isA.string()).required(),
+          }),
         },
       },
       handler: async function (request) {
@@ -202,12 +198,10 @@ module.exports = (log, db, mailer, customs, config) => {
           strategy: 'sessionToken',
         },
         response: {
-          schema: isA
-            .object({
-              exists: isA.boolean(),
-              verified: isA.boolean(),
-            })
-            .label('totp.exists_response'),
+          schema: isA.object({
+            exists: isA.boolean(),
+            verified: isA.boolean(),
+          }),
         },
       },
       handler: async function (request) {
@@ -243,24 +237,20 @@ module.exports = (log, db, mailer, customs, config) => {
           payload: 'required',
         },
         validate: {
-          payload: isA
-            .object({
-              code: isA
-                .string()
-                .max(32)
-                .regex(validators.DIGITS)
-                .required()
-                .description(DESCRIPTION.codeTotp),
-              service: validators.service,
-            })
-            .label('session.verify.totp_payload'),
+          payload: isA.object({
+            code: isA
+              .string()
+              .max(32)
+              .regex(validators.DIGITS)
+              .required()
+              .description(DESCRIPTION.codeTotp),
+            service: validators.service,
+          }),
         },
         response: {
-          schema: isA
-            .object({
-              success: isA.boolean().required(),
-            })
-            .label('session.verify.totp_response'),
+          schema: isA.object({
+            success: isA.boolean().required(),
+          }),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/unblock-codes.js
+++ b/packages/fxa-auth-server/lib/routes/unblock-codes.js
@@ -24,15 +24,10 @@ module.exports = (log, db, mailer, config, customs) => {
       options: {
         ...UNBLOCK_CODES_DOCS.ACCOUNT_LOGIN_SEND_UNBLOCK_CODE_POST,
         validate: {
-          payload: isA
-            .object({
-              email: validators
-                .email()
-                .required()
-                .description(DESCRIPTION.email),
-              metricsContext: METRICS_CONTEXT_SCHEMA,
-            })
-            .label('Account.SendUnblockCode_payload'),
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
         },
       },
       handler: async function (request) {
@@ -87,22 +82,20 @@ module.exports = (log, db, mailer, config, customs) => {
       options: {
         ...UNBLOCK_CODES_DOCS.ACCOUNT_LOGIN_REJECT_UNBLOCK_CODE_POST,
         validate: {
-          payload: isA
-            .object({
-              uid: isA
-                .string()
-                .max(32)
-                .regex(HEX_STRING)
-                .required()
-                .description(DESCRIPTION.uid),
-              unblockCode: isA
-                .string()
-                .regex(BASE_36)
-                .length(unblockCodeLen)
-                .required()
-                .description(DESCRIPTION.unblockCode),
-            })
-            .label('Account.RejectUnblockCode_payload'),
+          payload: isA.object({
+            uid: isA
+              .string()
+              .max(32)
+              .regex(HEX_STRING)
+              .required()
+              .description(DESCRIPTION.uid),
+            unblockCode: isA
+              .string()
+              .regex(BASE_36)
+              .length(unblockCodeLen)
+              .required()
+              .description(DESCRIPTION.unblockCode),
+          }),
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -326,15 +326,13 @@ module.exports.subscriptionPaymentCountryCode = isA
   .allow(null);
 
 // This is fxa-auth-db-mysql's perspective on an active subscription
-module.exports.activeSubscriptionValidator = isA
-  .object({
-    uid: isA.string().required(),
-    subscriptionId: module.exports.subscriptionsSubscriptionId.required(),
-    productId: module.exports.subscriptionsProductId.required(),
-    createdAt: isA.number().required(),
-    cancelledAt: isA.alternatives(isA.number(), isA.any().allow(null)),
-  })
-  .label('Active subscription');
+module.exports.activeSubscriptionValidator = isA.object({
+  uid: isA.string().required(),
+  subscriptionId: module.exports.subscriptionsSubscriptionId.required(),
+  productId: module.exports.subscriptionsProductId.required(),
+  createdAt: isA.number().required(),
+  cancelledAt: isA.alternatives(isA.number(), isA.any().allow(null)),
+});
 
 module.exports.subscriptionsSetupIntent = isA
   .object({
@@ -380,65 +378,57 @@ module.exports.subscriptionsInvoicePIExpandedValidator = isA
   })
   .unknown(true);
 
-module.exports.subscriptionsSubscriptionValidator = isA
-  .object({
-    _subscription_type: MozillaSubscriptionTypes.WEB,
-    created: isA.number().required(),
-    current_period_end: isA.number().required(),
-    current_period_start: isA.number().required(),
-    cancel_at_period_end: isA.boolean().required(),
-    end_at: isA.alternatives(isA.number(), isA.any().allow(null)),
-    failure_code: isA.string().optional(),
-    failure_message: isA.string().optional(),
-    latest_invoice: isA.string().required(),
-    plan_id: module.exports.subscriptionsPlanId.required(),
-    product_id: module.exports.subscriptionsProductId.required(),
-    product_name: isA.string().required(),
-    status: isA.string().required(),
-    subscription_id: module.exports.subscriptionsSubscriptionId.required(),
-    promotion_code: isA.string().optional().allow(null),
-    promotion_duration: isA.string().optional().allow(null),
-    promotion_end: isA.number().optional().allow(null),
-  })
-  .label('Subscription');
+module.exports.subscriptionsSubscriptionValidator = isA.object({
+  _subscription_type: MozillaSubscriptionTypes.WEB,
+  created: isA.number().required(),
+  current_period_end: isA.number().required(),
+  current_period_start: isA.number().required(),
+  cancel_at_period_end: isA.boolean().required(),
+  end_at: isA.alternatives(isA.number(), isA.any().allow(null)),
+  failure_code: isA.string().optional(),
+  failure_message: isA.string().optional(),
+  latest_invoice: isA.string().required(),
+  plan_id: module.exports.subscriptionsPlanId.required(),
+  product_id: module.exports.subscriptionsProductId.required(),
+  product_name: isA.string().required(),
+  status: isA.string().required(),
+  subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+  promotion_code: isA.string().optional().allow(null),
+  promotion_duration: isA.string().optional().allow(null),
+  promotion_end: isA.number().optional().allow(null),
+});
 
 // This is support-panel's perspective on a subscription
-module.exports.subscriptionsWebSubscriptionSupportValidator = isA
-  .object({
-    created: isA.number().required(),
-    current_period_end: isA.number().required(),
-    current_period_start: isA.number().required(),
-    plan_changed: isA.alternatives(isA.number(), isA.any().allow(null)),
-    previous_product: isA.alternatives(isA.string(), isA.any().allow(null)),
-    product_name: isA.string().required(),
-    status: isA.string().required(),
-    subscription_id: module.exports.subscriptionsSubscriptionId.required(),
-  })
-  .label('Web Subscription Support');
+module.exports.subscriptionsWebSubscriptionSupportValidator = isA.object({
+  created: isA.number().required(),
+  current_period_end: isA.number().required(),
+  current_period_start: isA.number().required(),
+  plan_changed: isA.alternatives(isA.number(), isA.any().allow(null)),
+  previous_product: isA.alternatives(isA.string(), isA.any().allow(null)),
+  product_name: isA.string().required(),
+  status: isA.string().required(),
+  subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+});
 
-module.exports.subscriptionsPlaySubscriptionSupportValidator = isA
-  .object({
-    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-    auto_renewing: isA.bool().required(),
-    cancel_reason: isA.number().optional(),
-    expiry_time_millis: isA.number().required(),
-    package_name: isA.string().optional(),
-    sku: isA.string().optional(),
-    product_id: isA.string().optional(),
-    product_name: isA.string().required(),
-  })
-  .label('Play Subscription Support');
+module.exports.subscriptionsPlaySubscriptionSupportValidator = isA.object({
+  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  auto_renewing: isA.bool().required(),
+  cancel_reason: isA.number().optional(),
+  expiry_time_millis: isA.number().required(),
+  package_name: isA.string().optional(),
+  sku: isA.string().optional(),
+  product_id: isA.string().optional(),
+  product_name: isA.string().required(),
+});
 
-module.exports.subscriptionsSubscriptionSupportValidator = isA
-  .object({
-    [MozillaSubscriptionTypes.WEB]: isA
-      .array()
-      .items(module.exports.subscriptionsWebSubscriptionSupportValidator),
-    [MozillaSubscriptionTypes.IAP_GOOGLE]: isA
-      .array()
-      .items(module.exports.subscriptionsPlaySubscriptionSupportValidator),
-  })
-  .label('OauthSupportPanelSubscriptions_responses');
+module.exports.subscriptionsSubscriptionSupportValidator = isA.object({
+  [MozillaSubscriptionTypes.WEB]: isA
+    .array()
+    .items(module.exports.subscriptionsWebSubscriptionSupportValidator),
+  [MozillaSubscriptionTypes.IAP_GOOGLE]: isA
+    .array()
+    .items(module.exports.subscriptionsPlaySubscriptionSupportValidator),
+});
 
 module.exports.subscriptionsSubscriptionListValidator = isA.object({
   subscriptions: isA
@@ -527,49 +517,45 @@ module.exports.subscriptionProductMetadataValidator = {
   },
 };
 
-module.exports.subscriptionsPlanValidator = isA
-  .object({
-    plan_id: module.exports.subscriptionsPlanId.required(),
-    plan_metadata: module.exports.subscriptionPlanMetadataValidator.optional(),
-    product_id: module.exports.subscriptionsProductId.required(),
-    product_name: isA.string().required(),
-    plan_name: isA.string().allow('').optional(),
-    product_metadata:
-      module.exports.subscriptionProductMetadataBaseValidator.optional(),
-    interval: isA.string().required(),
-    interval_count: isA.number().required(),
-    amount: isA.number().required(),
-    currency: isA.string().required(),
-    configuration: minimalConfigSchema
-      .keys(productConfigJoiKeys)
-      .keys(planConfigJoiKeys)
-      .optional()
-      .allow(null),
-  })
-  .label('Subscriptions Plan');
+module.exports.subscriptionsPlanValidator = isA.object({
+  plan_id: module.exports.subscriptionsPlanId.required(),
+  plan_metadata: module.exports.subscriptionPlanMetadataValidator.optional(),
+  product_id: module.exports.subscriptionsProductId.required(),
+  product_name: isA.string().required(),
+  plan_name: isA.string().allow('').optional(),
+  product_metadata:
+    module.exports.subscriptionProductMetadataBaseValidator.optional(),
+  interval: isA.string().required(),
+  interval_count: isA.number().required(),
+  amount: isA.number().required(),
+  currency: isA.string().required(),
+  configuration: minimalConfigSchema
+    .keys(productConfigJoiKeys)
+    .keys(planConfigJoiKeys)
+    .optional()
+    .allow(null),
+});
 
-module.exports.subscriptionsCustomerValidator = isA
-  .object({
-    customerId: isA.string().optional(),
-    billing_name: isA
-      .alternatives(isA.string(), isA.any().allow(null))
-      .optional(),
-    exp_month: isA.number().optional(),
-    exp_year: isA.number().optional(),
-    last4: isA.string().optional(),
-    payment_provider: isA.string().optional(),
-    payment_type: isA.string().optional(),
-    paypal_payment_error: isA.string().optional(),
-    brand: isA.string().optional(),
-    billing_agreement_id: isA
-      .alternatives(isA.string(), isA.any().allow(null))
-      .optional(),
-    subscriptions: isA
-      .array()
-      .items(module.exports.subscriptionsSubscriptionValidator)
-      .optional(),
-  })
-  .label('Subscriptions Customer');
+module.exports.subscriptionsCustomerValidator = isA.object({
+  customerId: isA.string().optional(),
+  billing_name: isA
+    .alternatives(isA.string(), isA.any().allow(null))
+    .optional(),
+  exp_month: isA.number().optional(),
+  exp_year: isA.number().optional(),
+  last4: isA.string().optional(),
+  payment_provider: isA.string().optional(),
+  payment_type: isA.string().optional(),
+  paypal_payment_error: isA.string().optional(),
+  brand: isA.string().optional(),
+  billing_agreement_id: isA
+    .alternatives(isA.string(), isA.any().allow(null))
+    .optional(),
+  subscriptions: isA
+    .array()
+    .items(module.exports.subscriptionsSubscriptionValidator)
+    .optional(),
+});
 
 module.exports.subscriptionsStripeIntentValidator = isA
   .object({
@@ -587,8 +573,7 @@ module.exports.subscriptionsStripeIntentValidator = isA
     }),
     status: isA.string().required(),
   })
-  .unknown(true)
-  .label('Subscriptions Stripe Intent');
+  .unknown(true);
 
 module.exports.subscriptionsStripeSourceValidator = isA
   .object({
@@ -654,7 +639,6 @@ module.exports.subscriptionsStripeSubscriptionValidator = isA
       .optional(),
     status: isA.string().required(),
   })
-  .label('Stripe_subscription')
   .unknown(true);
 
 module.exports.subscriptionsGooglePlaySubscriptionValidator =
@@ -708,8 +692,7 @@ module.exports.subscriptionsMozillaSubscriptionsValidator = isA
       )
       .required(),
   })
-  .unknown(true)
-  .label('mozSubscriptionsValidator_response');
+  .unknown(true);
 
 module.exports.ppidSeed = isA.number().integer().min(0).max(1024);
 


### PR DESCRIPTION
## Because:

* values set for description and notes in hapi-swagger are converted to values for summary and description, respectively, in the autogenerated swagger.json file. This causes endpoints to be mislabeled with redocusaurus

## This commit:

* revises the values of description and notes for all endpoints in the API docs
* removes mention of HAWK as it is no longer utilized
* adds `tags` array to `swagger-options.ts` to allow redocusaurus to sort tags alphabetically
* removes `.label()` as redocusaurus does not utilize it

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
BEFORE
<img width="1698" alt="Screen Shot 2022-05-18 at 2 34 03 PM" src="https://user-images.githubusercontent.com/28129806/169119314-9b5eefc6-b00a-4d70-9b61-64bbe7dee9a6.png">

AFTER
<img width="1694" alt="Screen Shot 2022-05-18 at 2 31 26 PM" src="https://user-images.githubusercontent.com/28129806/169118779-2b2e85f2-1889-4297-8faa-58d4caf568a1.png">