### PR TITLE
chore(lint): Tweak ESLint config for fxa-admin-panel

### DIFF
--- a/packages/fxa-admin-panel/.eslintrc.json
+++ b/packages/fxa-admin-panel/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "react-app",
+    "react-app/jest"
+  ]
+}

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -10,7 +10,7 @@
     "build": "npm-run-all build:client build:server",
     "eject": "react-scripts eject",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
-    "lint": "eslint .",
+    "lint": "eslint . .storybook",
     "restart": "tsc --build ../fxa-react && npm run build-postcss && pm2 restart pm2.config.js",
     "start": "tsc --build ../fxa-react && npm run build-postcss && pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
@@ -19,12 +19,6 @@
     "test:frontend": "SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=/ INLINE_RUNTIME_CHUNK=false rescripts test --coverage --verbose",
     "test:server": "jest --runInBand --coverage --verbose --config server/jest.config.js --forceExit",
     "test": "CI=true npm-run-all test:frontend test:server"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Because

- the .storybook/ folder wasn't getting linted.

## This pull request

- Moves the ESLint config from package.json into .eslintrc.json
- Explicitly lints .storybook/ as well (I guess ESLint ignores hidden files/folders by default)

## Issue that this pull request solves



## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
