### PR TITLE
chore(build): switch to python3 in builder docker deps

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -10,8 +10,8 @@ RUN set -x \
         app
 RUN apt-get update && apt-get install -y \
     git-core \
-    python-setuptools \
-    python-dev \
+    python3-setuptools \
+    python3-dev \
     build-essential \
     zip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Because

- our deploy-packages job is failing now due to python 2 not 3 being installed
