### PR TITLE
Don't treat Firefox Sync as a feature name

### DIFF
--- a/packages/fxa-settings/src/components/App/en-US.ftl
+++ b/packages/fxa-settings/src/components/App/en-US.ftl
@@ -20,7 +20,6 @@
 # “Account” can be localized, “Firefox” must be treated as a brand.
 # This is used to refer to a user's account, e.g. "update your Firefox account ..."
 -product-firefox-account = Firefox account
--product-firefox-sync = Firefox Sync
 product-mozilla-vpn = Mozilla VPN
 product-pocket = Pocket
 product-firefox-monitor = Firefox Monitor

--- a/packages/fxa-settings/src/components/Security/en-US.ftl
+++ b/packages/fxa-settings/src/components/Security/en-US.ftl
@@ -9,4 +9,4 @@ security-password =
 security-password-created-date = Created { $date }
 security-not-set = Not Set
 security-action-create = Create
-security-set-password = Set a password to use { -product-firefox-sync } and certain account security features.
+security-set-password = Set a password to sync and use certain account security features.

--- a/packages/fxa-settings/src/components/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Security/index.tsx
@@ -62,7 +62,7 @@ export const Security = () => {
             ) : (
               <Localized id="security-set-password">
                 <p className="text-sm mt-3">
-                  Set a password to use Firefox Sync and certain account
+                  Set a password to sync and use certain account
                   security features.
                 </p>
               </Localized>

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
@@ -85,7 +85,7 @@ describe('UnitRowRecoveryKey', () => {
         .getByTestId('recovery-key-unit-row-route')
         .attributes.getNamedItem('title')?.value
     ).toEqual(
-      'Set a password to use Firefox Sync and certain account security features.'
+      'Set a password to sync and use certain account security features.'
     );
   });
 

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -70,7 +70,7 @@ export const UnitRowRecoveryKey = () => {
       disabledReason={l10n.getString(
         'security-set-password',
         null,
-        'Set a password to use Firefox Sync and certain account security features.'
+        'Set a password to sync and use certain account security features.'
       )}
       alertBarRevealed
       headerContent={

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
@@ -135,7 +135,7 @@ describe('UnitRowTwoStepAuth', () => {
         .getByTestId('two-step-unit-row-route')
         .attributes.getNamedItem('title')?.value
     ).toEqual(
-      'Set a password to use Firefox Sync and certain account security features.'
+      'Set a password to sync and use certain account security features.'
     );
   });
 });

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -97,7 +97,7 @@ export const UnitRowTwoStepAuth = () => {
       disabledReason={l10n.getString(
         'security-set-password',
         null,
-        'Set a password to use Firefox Sync and certain account security features.'
+        'Set a password to sync and use certain account security features.'
       )}
       actionContent={
         <Localized id="tfa-row-button-refresh" attrs={{ title: true }}>


### PR DESCRIPTION
Firefox Sync should not be treated as a feature name anymore (starting with Firefox 89)
 https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=FIREFOX&title=Word+List#WordList-sync