### PR TITLE
style(settings): remove extra white-space before and after "Resend verification code" text

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -218,7 +218,7 @@ export const UnitRowSecondaryEmail = () => {
                 elems={{
                   button: (
                     <button
-                      className="link-blue mx-1"
+                      className="link-blue"
                       data-testid="secondary-email-resend-code-button"
                       onClick={() => {
                         resendEmailCode(email);
@@ -228,7 +228,7 @@ export const UnitRowSecondaryEmail = () => {
                 }}
               >
                 <p className="text-xs mt-3 text-grey-400">
-                  Verification needed.
+                  Verification needed.{' '}
                   <button
                     className="link-blue"
                     data-testid="secondary-email-resend-code-button"
@@ -237,7 +237,7 @@ export const UnitRowSecondaryEmail = () => {
                     }}
                   >
                     Resend verification code
-                  </button>
+                  </button>{' '}
                   if it's not in your inbox or spam folder.
                 </p>
               </Localized>


### PR DESCRIPTION
## Because

- we want to maintain consistent design and UX throughout the site

## This pull request

- removes extra whitespace and adds explicit space to fallback text

## Issue that this pull request solves

Closes: #10585

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

N/A

Any other information that is important to this pull request.

This issue was caused by a combination of localization settings that have since been corrected, and how inexplicit space is treated in browsers across operating systems after being compiled (particularly in Windows).
