### PR TITLE
feat(l10n): remove sr-LATN support. Fix FXA-5126

### DIFF
--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -61,7 +61,6 @@
   "sl",
   "sq",
   "sr",
-  "sr-LATN",
   "su",
   "sv",
   "sv-SE",


### PR DESCRIPTION
## Because

- we don't need to support sr-LATN anymore

## This pull request

- removes it

## Issue that this pull request solves

Closes: #12950
