### PR TITLE
style(auth): add space to alt text and underline

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
@@ -47,6 +47,12 @@
   padding: global.$s-5 global.$s-0 !important;
   height: 56px !important;
   display: block !important;
+
+  // overrides the 13px inline font-size default for MJML images
+  // see https://github.com/mozilla/fxa/pull/12956#discussion_r878556004
+  a, img {
+    font-size: global.$s-3 !important;
+  }
 }
 
 .mozilla-logo {


### PR DESCRIPTION
## Because

- We want to maintain consistent design, UX and a11y in emails

## This pull request

- Adds font-size to create whitespace between text and underline

## Issue that this pull request solves

Closes: #12600

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

N/A
