### PR TITLE
chore(settings): remove period in one-line alert bar copy

### DIFF
--- a/packages/fxa-settings/src/components/ConnectedServices/en-US.ftl
+++ b/packages/fxa-settings/src/components/ConnectedServices/en-US.ftl
@@ -9,7 +9,7 @@ cs-cannot-disconnect = Client not found, unable to disconnect
 # Variables:
 #   $service (String) - the name of a device or service that uses Firefox Accounts
 #                       (for example: "Firefox Lockwise")
-cs-logged-out = Logged out of { $service }.
+cs-logged-out-2 = Logged out of { $service }
 
 cs-refresh-button =
   .title = Refresh connected services

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -129,9 +129,9 @@ export const ConnectedServices = () => {
           const name = client.name;
           alertBar.success(
             l10n.getString(
-              'cs-logged-out',
+              'cs-logged-out-2',
               { service: name },
-              `Logged out of ${name}.`
+              `Logged out of ${name}`
             )
           );
           clearDisconnectingState();

--- a/packages/fxa-settings/src/components/DataCollection/en-US.ftl
+++ b/packages/fxa-settings/src/components/DataCollection/en-US.ftl
@@ -5,5 +5,5 @@ dc-subheader = Help improve { -product-firefox-accounts }
 dc-subheader-content = Allow { -product-firefox-accounts } to send technical and interaction data to { -brand-mozilla }.
 dc-opt-out-success = Opt out successful. { -product-firefox-accounts } won’t send technical or interaction data to { -brand-mozilla }.
 dc-opt-in-success = Thanks! Sharing this data helps us improve { -product-firefox-accounts }.
-dc-opt-in-out-error = Sorry, there was a problem changing your data collection preference.
+dc-opt-in-out-error-2 = Sorry, there was a problem changing your data collection preference
 dc-learn-more = Learn more

--- a/packages/fxa-settings/src/components/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/DataCollection/index.tsx
@@ -42,9 +42,9 @@ export const DataCollection = () => {
     } catch (err) {
       alertBar.error(
         l10n.getString(
-          'dc-opt-in-out-error',
+          'dc-opt-in-out-error-2',
           null,
-          'Sorry, there was a problem changing your data collection preference.'
+          'Sorry, there was a problem changing your data collection preference'
         )
       );
     } finally {

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/en-US.ftl
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/en-US.ftl
@@ -7,4 +7,4 @@ drop-down-menu-title = { -product-firefox-account } menu
 drop-down-menu-signed-in-as = <signin>Signed in as</signin><user>{ $user }</user>
 drop-down-menu-sign-out = Sign out
 
-drop-down-menu-sign-out-error = Sorry, there was a problem signing you out.
+drop-down-menu-sign-out-error-2 = Sorry, there was a problem signing you out

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -32,9 +32,9 @@ export const DropDownAvatarMenu = () => {
       } catch (e) {
         alertBar.error(
           l10n.getString(
-            'drop-down-menu-sign-out-error',
+            'drop-down-menu-sign-out-error-2',
             null,
-            'Sorry, there was a problem signing you out.'
+            'Sorry, there was a problem signing you out'
           )
         );
       }

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/en-US.ftl
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/en-US.ftl
@@ -1,9 +1,9 @@
 ## Two Step Authentication - replace recovery code
 
-tfa-replace-code-error = There was a problem replacing your recovery codes.
+tfa-replace-code-error-2 = There was a problem replacing your recovery codes
 tfa-replace-code-success = New codes have been created. Save these one-time use
   codes in a safe place — you’ll need them to access your account if you don’t
   have your mobile device.
-tfa-replace-code-success-alert = Account recovery codes updated.
+tfa-replace-code-success-alert-2 = Account recovery codes updated
 tfa-replace-code-1-2 = Step 1 of 2
 tfa-replace-code-2-2 = Step 2 of 2

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -36,9 +36,9 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertSuccessAndGoHome = () => {
     alertBar.success(
       l10n.getString(
-        'tfa-replace-code-success-alert',
+        'tfa-replace-code-success-alert-2',
         null,
-        'Account recovery codes updated.'
+        'Account recovery codes updated'
       )
     );
     navigate(HomePath + '#two-step-authentication', { replace: true });
@@ -54,9 +54,9 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
     } catch (e) {
       alertBar.error(
         l10n.getString(
-          'tfa-replace-code-error',
+          'tfa-replace-code-error-2',
           null,
-          'There was a problem replacing your recovery codes.'
+          'There was a problem replacing your recovery codes'
         )
       );
     }
@@ -80,9 +80,9 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
     } catch (e) {
       alertBar.error(
         l10n.getString(
-          'tfa-replace-code-error',
+          'tfa-replace-code-error-2',
           null,
-          'There was a problem creating your recovery codes.'
+          'There was a problem creating your recovery codes'
         )
       );
     }

--- a/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
@@ -39,9 +39,9 @@ export const RemovePhotoBtn = () => {
     } catch (err) {
       alertBar.error(
         l10n.getString(
-          'avatar-page-delete-error-2',
+          'avatar-page-delete-error-3',
           null,
-          'There was a problem deleting your profile picture.'
+          'There was a problem deleting your profile picture'
         )
       );
     }

--- a/packages/fxa-settings/src/components/PageAvatar/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageAvatar/en-US.ftl
@@ -24,8 +24,8 @@ avatar-page-rotate-button =
 avatar-page-camera-error = Could not initialize camera
 avatar-page-new-avatar =
   .alt = new profile picture
-avatar-page-file-upload-error-2 = There was a problem uploading your profile picture.
-avatar-page-delete-error-2 = There was a problem deleting your profile picture.
-avatar-page-image-too-large-error = The image file size is too large to be uploaded.
+avatar-page-file-upload-error-3 = There was a problem uploading your profile picture
+avatar-page-delete-error-3 = There was a problem deleting your profile picture
+avatar-page-image-too-large-error-2 = The image file size is too large to be uploaded
 
 ##

--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -54,9 +54,9 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
   const onFileError = useCallback(() => {
     alertBar.error(
       l10n.getString(
-        'avatar-page-file-upload-error-2',
+        'avatar-page-file-upload-error-3',
         null,
-        'There was a problem uploading your profile picture.'
+        'There was a problem uploading your profile picture'
       )
     );
   }, [alertBar, l10n]);
@@ -180,9 +180,9 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
     if (img && img.size > PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE) {
       alertBar.error(
         l10n.getString(
-          'avatar-page-image-too-large-error',
+          'avatar-page-image-too-large-error-2',
           null,
-          'The image file size is too large to be uploaded.'
+          'The image file size is too large to be uploaded'
         )
       );
       resetAllState();

--- a/packages/fxa-settings/src/components/PageChangePassword/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageChangePassword/en-US.ftl
@@ -21,6 +21,6 @@ pw-change-new-password =
 pw-change-confirm-password =
   .label = Confirm new password
 
-pw-change-success-alert = Password updated.
+pw-change-success-alert-2 = Password updated
 
 ##

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -53,7 +53,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const { l10n } = useLocalization();
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
-      l10n.getString('pw-change-success-alert', null, 'Password updated.')
+      l10n.getString('pw-change-success-alert-2', null, 'Password updated')
     );
     navigate(HomePath + '#password', { replace: true });
   }, [alertBar, l10n, navigate]);

--- a/packages/fxa-settings/src/components/PageCreatePassword/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageCreatePassword/en-US.ftl
@@ -3,7 +3,7 @@
 pw-create-header =
   .title = Create password
 
-pw-create-success-alert = Password set.
-pw-create-error = Sorry, there was a problem setting your password.
+pw-create-success-alert-2 = Password set
+pw-create-error-2 = Sorry, there was a problem setting your password
 
 ##

--- a/packages/fxa-settings/src/components/PageCreatePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageCreatePassword/index.test.tsx
@@ -139,7 +139,7 @@ describe('PageCreatePassword', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(alertBarInfo.error).toHaveBeenCalledTimes(1);
     expect(alertBarInfo.error).toHaveBeenCalledWith(
-      'Sorry, there was a problem setting your password.'
+      'Sorry, there was a problem setting your password'
     );
   });
 
@@ -150,6 +150,6 @@ describe('PageCreatePassword', () => {
       replace: true,
     });
     expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
-    expect(alertBarInfo.success).toHaveBeenCalledWith('Password set.');
+    expect(alertBarInfo.success).toHaveBeenCalledWith('Password set');
   });
 });

--- a/packages/fxa-settings/src/components/PageCreatePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageCreatePassword/index.tsx
@@ -43,7 +43,7 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
 
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
-      l10n.getString('pw-create-success-alert', null, 'Password set.')
+      l10n.getString('pw-create-success-alert-2', null, 'Password set')
     );
     navigate(HomePath + '#password', { replace: true });
   }, [alertBar, l10n, navigate]);
@@ -59,9 +59,9 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
         logViewEvent(settingsViewName, 'create-password.fail');
         alertBar.error(
           l10n.getString(
-            'pw-create-error',
+            'pw-create-error-2',
             null,
-            'Sorry, there was a problem setting your password.'
+            'Sorry, there was a problem setting your password'
           )
         );
       }

--- a/packages/fxa-settings/src/components/PageDisplayName/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDisplayName/en-US.ftl
@@ -8,8 +8,8 @@ display-name-input =
 submit-display-name = Save
 cancel-display-name = Cancel
 
-display-name-update-error = There was a problem updating your display name.
+display-name-update-error-2 = There was a problem updating your display name
 
-display-name-success-alert = Display name updated.
+display-name-success-alert-2 = Display name updated
 
 ##

--- a/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
@@ -74,7 +74,7 @@ it('navigates back to settings home and shows a success message on a successful 
   await submitDisplayName('John Hope');
   expect(window.location.pathname).toBe(HomePath);
   expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
-  expect(alertBarInfo.success).toHaveBeenCalledWith('Display name updated.');
+  expect(alertBarInfo.success).toHaveBeenCalledWith('Display name updated');
 });
 
 it('displays a general error in the alert bar', async () => {

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -11,9 +11,9 @@ import { HomePath } from '../../constants';
 import { Localized, useLocalization } from '@fluent/react';
 import { useAccount, useAlertBar } from '../../models';
 
-const validateDisplayName = (currentDisplayName: string) => (
-  newDisplayName: string
-) => newDisplayName !== currentDisplayName && newDisplayName.length <= 256;
+const validateDisplayName =
+  (currentDisplayName: string) => (newDisplayName: string) =>
+    newDisplayName !== currentDisplayName && newDisplayName.length <= 256;
 
 export const PageDisplayName = (_: RouteComponentProps) => {
   const account = useAccount();
@@ -23,9 +23,9 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
       l10n.getString(
-        'display-name-success-alert',
+        'display-name-success-alert-2',
         null,
-        'Display name updated.'
+        'Display name updated'
       )
     );
     navigate(HomePath + '#display-name', { replace: true });
@@ -53,9 +53,9 @@ export const PageDisplayName = (_: RouteComponentProps) => {
         } else {
           alertBar.error(
             l10n.getString(
-              'display-name-update-error',
+              'display-name-update-error-2',
               null,
-              'There was a problem updating your display name.'
+              'There was a problem updating your display name'
             )
           );
         }

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/en-US.ftl
@@ -10,4 +10,4 @@ recovery-key-page-title =
   .title = Recovery key
 recovery-key-step-1 = Step 1 of 2
 recovery-key-step-2 = Step 2 of 2
-recovery-key-success-alert = Recovery key created.
+recovery-key-success-alert-2 = Recovery key created

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -43,9 +43,9 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
   const alertSuccessAndGoHome = () => {
     alertBar.success(
       l10n.getString(
-        'recovery-key-success-alert',
+        'recovery-key-success-alert-2',
         null,
-        'Recovery key created.'
+        'Recovery key created'
       )
     );
     navigate(HomePath + '#recovery-key', { replace: true });

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
@@ -1,7 +1,7 @@
 ## Add secondary email page
 
 add-secondary-email-step-1 = Step 1 of 2
-add-secondary-email-error = There was a problem creating this email.
+add-secondary-email-error-2 = There was a problem creating this email
 add-secondary-email-page-title =
   .title = Secondary email
 add-secondary-email-enter-address =

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -45,9 +45,9 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
         } else {
           alertBar.error(
             l10n.getString(
-              'add-secondary-email-error',
+              'add-secondary-email-error-2',
               null,
-              'There was a problem creating this email.'
+              'There was a problem creating this email'
             )
           );
         }

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
@@ -1,7 +1,7 @@
 ## Verify secondary email page
 
 add-secondary-email-step-2 = Step 2 of 2
-verify-secondary-email-error = There was a problem sending the verification code.
+verify-secondary-email-error-2 = There was a problem sending the verification code
 verify-secondary-email-page-title =
   .title = Secondary email
 verify-secondary-email-verification-code =
@@ -15,6 +15,6 @@ verify-secondary-email-please-enter-code = Please enter the verification code th
 # This string is a confirmation message shown after verifying an email.
 # Variables:
 #   $email (String) - the user's email address, which does not need translation.
-verify-secondary-email-success-alert = { $email } successfully added.
+verify-secondary-email-success-alert-2 = { $email } successfully added
 
 ##

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
@@ -93,7 +93,7 @@ describe('PageSecondaryEmailVerify', () => {
     expect(history.location.pathname).toEqual('/settings#secondary-email');
     expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
     expect(alertBarInfo.success).toHaveBeenCalledWith(
-      'johndope@example.com successfully added.'
+      'johndope@example.com successfully added'
     );
   });
 });

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -34,9 +34,9 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
     (email: string) => {
       alertBar.success(
         l10n.getString(
-          'verify-secondary-email-success-alert',
+          'verify-secondary-email-success-alert-2',
           { email },
-          `${email} successfully added.`
+          `${email} successfully added`
         )
       );
       navigate(HomePath + '#secondary-email', { replace: true });
@@ -68,9 +68,9 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         } else {
           alertBar.error(
             l10n.getString(
-              'verify-secondary-email-error',
+              'verify-secondary-email-error-2',
               null,
-              'There was a problem sending the verification code.'
+              'There was a problem sending the verification code'
             )
           );
         }

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/en-US.ftl
@@ -12,7 +12,7 @@ tfa-button-finish = Finish
 
 tfa-incorrect-totp = Incorrect two-step authentication code
 tfa-cannot-retrieve-code = There was a problem retrieving your code.
-tfa-cannot-verify-code = There was a problem verifying your recovery code.
+tfa-cannot-verify-code-2 = There was a problem verifying your recovery code
 tfa-incorrect-recovery-code = Incorrect recovery code
 tfa-enabled = Two-step authentication enabled
 

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -100,9 +100,9 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
         } else {
           alertBar.error(
             l10n.getString(
-              'tfa-cannot-verify-code',
+              'tfa-cannot-verify-code-2',
               null,
-              'There was a problem verifying your recovery code.'
+              'There was a problem verifying your recovery code'
             )
           );
         }

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/en-US.ftl
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/en-US.ftl
@@ -6,14 +6,14 @@ rk-not-set = Not Set
 rk-action-create = Create
 rk-action-remove = Remove
 rk-cannot-refresh = Sorry, there was a problem refreshing the recovery key.
-rk-key-removed = Account recovery key removed.
+rk-key-removed-2 = Account recovery key removed
 rk-cannot-remove-key = Your account recovery key could not be removed.
 rk-refresh-key = Refresh recovery key
 rk-content-explain = Restore your information when you forget your password.
 rk-content-reset-data = Why does resetting my password reset my data?
-rk-cannot-verify-session-2 = Sorry, there was a problem verifying your session.
+rk-cannot-verify-session-3 = Sorry, there was a problem verifying your session
 rk-remove-modal-heading = Remove recovery key?
 rk-remove-modal-content = In the event you reset your password, you won’t be
   able to use your recovery key to access your data. You can’t undo this action.
 rk-refresh-error = Sorry, there was a problem refreshing the recovery key.
-rk-remove-error = Your account recovery key could not be removed.
+rk-remove-error-2 = Your account recovery key could not be removed

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -26,16 +26,16 @@ export const UnitRowRecoveryKey = () => {
       await account.deleteRecoveryKey();
       hideModal();
       alertBar.success(
-        l10n.getString('rk-key-removed', null, 'Account recovery key removed.')
+        l10n.getString('rk-key-removed-2', null, 'Account recovery key removed')
       );
       logViewEvent('flow.settings.account-recovery', 'confirm-revoke.success');
     } catch (e) {
       hideModal();
       alertBar.error(
         l10n.getString(
-          'rk-remove-error',
+          'rk-remove-error-2',
           null,
-          'Your account recovery key could not be removed.'
+          'Your account recovery key could not be removed'
         )
       );
       logViewEvent('flow.settings.account-recovery', 'confirm-revoke.fail');
@@ -111,9 +111,9 @@ export const UnitRowRecoveryKey = () => {
             hideModal();
             alertBar.error(
               l10n.getString(
-                'rk-cannot-verify-session-2',
+                'rk-cannot-verify-session-3',
                 null,
-                'Sorry, there was a problem verifying your session.'
+                'Sorry, there was a problem verifying your session'
               ),
               error
             );

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/en-US.ftl
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/en-US.ftl
@@ -3,19 +3,19 @@
 se-heading = Secondary email
   .header = Secondary email
 se-cannot-refresh-email = Sorry, there was a problem refreshing that email.
-se-cannot-resend-code = Sorry, there was a problem re-sending the verification code.
+se-cannot-resend-code-2 = Sorry, there was a problem re-sending the verification code
 # This string is used in a notification message near the top of the page.
 # Variables:
 #   $email (String) - the user's email address, which does not need translation.
-se-set-primary-successful = { $email } is now your primary email.
-se-set-primary-error = Sorry, there was a problem changing your primary email.
+se-set-primary-successful-2 = { $email } is now your primary email
+se-set-primary-error-2 = Sorry, there was a problem changing your primary email
 # This string is used in a notification message near the top of the page.
 # Variables:
 #   $email (String) - the user's email address, which does not need translation.
-se-delete-email-successful = { $email } successfully deleted.
-se-delete-email-error = Sorry, there was a problem deleting this email.
-se-verify-session = You’ll need to verify your current session to perform this action.
-se-verify-session-error = Sorry, there was a problem verifying your session.
+se-delete-email-successful-2 = { $email } successfully deleted
+se-delete-email-error-2 = Sorry, there was a problem deleting this email
+se-verify-session-2 = You’ll need to verify your current session to perform this action
+se-verify-session-error-2 = Sorry, there was a problem verifying your session
 # Button to remove the secondary email
 se-remove-email =
   .title = Remove email

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -37,9 +37,9 @@ export const UnitRowSecondaryEmail = () => {
       } catch (e) {
         alertBar.error(
           l10n.getString(
-            'se-cannot-resend-code',
+            'se-cannot-resend-code-2',
             null,
-            'Sorry, there was a problem re-sending the verification code.'
+            'Sorry, there was a problem re-sending the verification code'
           )
         );
       }
@@ -53,17 +53,17 @@ export const UnitRowSecondaryEmail = () => {
         await account.makeEmailPrimary(email);
         alertBar.success(
           l10n.getString(
-            'se-set-primary-successful',
+            'se-set-primary-successful-2',
             { email },
-            `${email} is now your primary email.`
+            `${email} is now your primary email`
           )
         );
       } catch (e) {
         alertBar.error(
           l10n.getString(
-            'se-set-primary-error',
+            'se-set-primary-error-2',
             null,
-            'Sorry, there was a problem changing your primary email.'
+            'Sorry, there was a problem changing your primary email'
           )
         );
       }
@@ -77,17 +77,17 @@ export const UnitRowSecondaryEmail = () => {
         await account.deleteSecondaryEmail(email);
         alertBar.success(
           l10n.getString(
-            'se-delete-email-successful',
+            'se-delete-email-successful-2',
             { email },
-            `${email} successfully deleted.`
+            `${email} successfully deleted`
           )
         );
       } catch (e) {
         alertBar.error(
           l10n.getString(
-            'se-delete-email-error',
+            'se-delete-email-error-2',
             null,
-            `Sorry, there was a problem deleting this email.`
+            `Sorry, there was a problem deleting this email`
           )
         );
       }
@@ -103,9 +103,9 @@ export const UnitRowSecondaryEmail = () => {
             setQueuedAction(undefined);
             alertBar.info(
               l10n.getString(
-                'se-verify-session',
+                'se-verify-session-2',
                 null,
-                "You'll need to verify your current session to perform this action."
+                "You'll need to verify your current session to perform this action"
               )
             );
           }}
@@ -113,9 +113,9 @@ export const UnitRowSecondaryEmail = () => {
             setQueuedAction(undefined);
             alertBar.error(
               l10n.getString(
-                'se-verify-session-error',
+                'se-verify-session-error-2',
                 null,
-                'Sorry, there was a problem verifying your session.'
+                'Sorry, there was a problem verifying your session'
               ),
               error
             );

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/en-US.ftl
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/en-US.ftl
@@ -1,7 +1,7 @@
 ## Two Step Auth sub-section on Settings main page
 
 tfa-row-header = Two-step authentication
-tfa-row-disabled = Two-step authentication disabled.
+tfa-row-disabled-2 = Two-step authentication disabled
 tfa-row-enabled = Enabled
 tfa-row-not-set = Not Set
 tfa-row-action-add = Add
@@ -13,13 +13,13 @@ tfa-row-cannot-refresh = Sorry, there was a problem refreshing two-step
   authentication.
 tfa-row-content-explain = Prevent someone else from logging in by requiring a
   unique code only you have access to.
-tfa-row-cannot-verify-session-2 = Sorry, there was a problem verifying your session.
+tfa-row-cannot-verify-session-3 = Sorry, there was a problem verifying your session
 
 tfa-row-disable-modal-heading = Disable two-step authentication?
 tfa-row-disable-modal-confirm = Disable
 tfa-row-disable-modal-explain = You won’t be able to undo this action. You also
   have the option of <linkExternal>replacing your recovery codes</linkExternal>.
-tfa-row-cannot-disable = Two-step authentication could not be disabled.
+tfa-row-cannot-disable-2 = Two-step authentication could not be disabled
 
 tfa-row-change-modal-heading = Change recovery codes?
 tfa-row-change-modal-confirm = Change

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -33,18 +33,18 @@ export const UnitRowTwoStepAuth = () => {
       hideModal();
       alertBar.success(
         l10n.getString(
-          'tfa-row-disabled',
+          'tfa-row-disabled-2',
           null,
-          'Two-step authentication disabled.'
+          'Two-step authentication disabled'
         )
       );
     } catch (e) {
       hideModal();
       alertBar.error(
         l10n.getString(
-          'tfa-row-cannot-disable',
+          'tfa-row-cannot-disable-2',
           null,
-          'Two-step authentication could not be disabled.'
+          'Two-step authentication could not be disabled'
         )
       );
     }
@@ -182,9 +182,9 @@ export const UnitRowTwoStepAuth = () => {
             hideModal();
             alertBar.error(
               l10n.getString(
-                'tfa-row-cannot-verify-session-2',
+                'tfa-row-cannot-verify-session-3',
                 null,
-                'Sorry, there was a problem verifying your session.'
+                'Sorry, there was a problem verifying your session'
               ),
               error
             );


### PR DESCRIPTION
## Because

- We want to maintain consistency of alert bar copy in account settings

## This pull request

- Removes the period from one line alert bar messages

## Issue that this pull request solves

Closes: #9253

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

N/A
