### PR TITLE
fix(fxa-shared): add missing type declarations for AppendedAppStore/P…

### DIFF
--- a/packages/fxa-shared/payments/iap/apple-app-store/types/index.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/types/index.ts
@@ -1,4 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { IapExtraStripeInfo } from '../../../../dto/auth/payments/iap-subscription';
+import { AppStoreSubscriptionPurchase } from '../subscription-purchase';
+
+export type AppendedAppStoreSubscriptionPurchase =
+  AppStoreSubscriptionPurchase & IapExtraStripeInfo;
+
 export { PurchaseQueryError, PurchaseUpdateError } from './errors';

--- a/packages/fxa-shared/payments/iap/google-play/types/index.ts
+++ b/packages/fxa-shared/payments/iap/google-play/types/index.ts
@@ -1,6 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { IapExtraStripeInfo } from '../../../../dto/auth/payments/iap-subscription';
+import { PlayStoreSubscriptionPurchase } from '../subscription-purchase';
+
+export type AppendedPlayStoreSubscriptionPurchase =
+  PlayStoreSubscriptionPurchase & IapExtraStripeInfo;
+
 export * from './errors';
 export * from './notifications';
 export * from './purchases';


### PR DESCRIPTION
…layStoreSubscriptionPurchase

TS error introduced by PR #12890. #12823 will fix these types of errors permanently.

Closes: # No issue

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).