### PR TITLE
fix(admin-panel): Fix slow autocomplete in account search

### DIFF
--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -110,7 +110,7 @@ export class AccountResolver {
       .query()
       .select(ACCOUNT_COLUMNS.map((c) => 'accounts.' + c))
       .innerJoin('emails', 'emails.uid', 'accounts.uid')
-      .where('emails.normalizedEmail', email)
+      .where('emails.normalizedEmail', email.toLocaleLowerCase())
       .first();
   }
 
@@ -120,7 +120,7 @@ export class AccountResolver {
     return this.db.emails
       .query()
       .select(EMAIL_COLUMNS)
-      .where('email', 'like', `${search}%`)
+      .where('normalizedEmail', 'like', `${search.toLowerCase()}%`)
       .limit(10);
   }
 
@@ -130,7 +130,7 @@ export class AccountResolver {
   public async unverifyEmail(@Args('email') email: string) {
     const result = await this.db.emails
       .query()
-      .where('email', email)
+      .where('normalizedEmail', 'like', `${email.toLowerCase()}%`)
       .update({
         isVerified: false,
         verifiedAt: null as any, // same as null


### PR DESCRIPTION
## Because

- Auto complete during account search was very slow

## This pull request

- Uses the normalizedEmail column which is optimized for search.
- Also fixes an unlikely but possible non-lowercased email query in accountByEmail.

## Issue that this pull request solves

Closes: #12346

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

