### PR TITLE
chore(payments): fix flaky test with date matching

### DIFF
--- a/packages/fxa-payments-server/src/lib/coupon.test.ts
+++ b/packages/fxa-payments-server/src/lib/coupon.test.ts
@@ -5,6 +5,8 @@ import {
   incDateByMonth,
 } from './coupon';
 
+const getTimeInSeconds = (date: Date) => Math.floor(date.getTime() / 1000);
+
 describe('lib/coupon', () => {
   describe('incDateByMonth', () => {
     const incrementMonth = 1;
@@ -15,6 +17,7 @@ describe('lib/coupon', () => {
       );
       const actual = incDateByMonth(incrementMonth);
       expect(actual).toEqual(expected);
+      expect(getTimeInSeconds(actual)).toEqual(getTimeInSeconds(expected));
     });
 
     it('should incremenet input date by specified amount', () => {
@@ -62,7 +65,7 @@ describe('lib/coupon', () => {
       const incrementValue = 2;
       const expected = incDateByMonth(incrementValue);
       const actual = incDateByInterval(incrementValue, 'month');
-      expect(actual).toEqual(expected);
+      expect(getTimeInSeconds(actual)).toEqual(getTimeInSeconds(expected));
     });
 
     it('should return the input date if incorrect interval is provided', () => {


### PR DESCRIPTION
## Because

- Tests for functions that manipulate the current date, are flaky since
  the expected date in test doesn't always match the date used in the
  function.

## This pull request

- For these tests match on the date by seconds instead of miliseconds.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).