### PR TITLE
[WIP] 3rd party auth sets avatar

### DIFF
--- a/packages/fxa-auth-server/lib/profile/client.js
+++ b/packages/fxa-auth-server/lib/profile/client.js
@@ -12,8 +12,8 @@ const PATH_PREFIX = '/v1';
 // Very generic validator, because there's not really a useful response
 // here other than that it didn't fail in error
 const DeleteCacheResponse = isA.any();
-
 const UpdateDisplayNameResponse = isA.any();
+const UpdateAvatarWithUrlResponse = isA.any();
 
 module.exports = function (log, config, statsd) {
   const ProfileAPI = createBackendServiceAPI(
@@ -42,7 +42,20 @@ module.exports = function (log, config, statsd) {
             name: isA.string().required(),
           },
           response: UpdateDisplayNameResponse,
-        }
+        },
+      },
+      updateAvatarWithUrl: {
+        path: `${PATH_PREFIX}/_avatar/:uid`,
+        method: 'POST',
+        validate: {
+          params: {
+            uid: isA.string().required(),
+          },
+          payload: {
+            imageUrl: isA.string().required(),
+          },
+          response: UpdateAvatarWithUrlResponse,
+        },
       },
     },
     statsd
@@ -68,7 +81,19 @@ module.exports = function (log, config, statsd) {
       try {
         return await api.updateDisplayName(uid, { name: name });
       } catch (err) {
-        log.error('profile.updateDisplayName.failed', { uid, name, err});
+        log.error('profile.updateDisplayName.failed', { uid, name, err });
+        throw err;
+      }
+    },
+    async updateAvatarWithUrl(uid, imageUrl) {
+      try {
+        return await api.updateAvatarWithUrl(uid, { imageUrl });
+      } catch (err) {
+        log.error('profile.updateAvatarWithUrl.failed', {
+          uid,
+          imageUrl,
+          err,
+        });
         throw err;
       }
     },

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -68,6 +68,7 @@ export interface AuthRequest extends Request {
 export interface ProfileClient {
   deleteCache(uid: string): Promise<void>;
   updateDisplayName(uid: string, name: string): Promise<void>;
+  updateAvatarWithUrl(uid: string, imageUrl: string): Promise<void>;
 }
 
 // Container token types

--- a/packages/fxa-profile-server/lib/img-workers.js
+++ b/packages/fxa-profile-server/lib/img-workers.js
@@ -10,9 +10,24 @@ const AppError = require('./error');
 const config = require('./config');
 const logger = require('./logging')('img_workers');
 const request = require('./request');
+const https = require('https');
 
 const WORKER_URL = config.get('worker.url');
 const ACCEPT_ENCODING_HEADER = 'identity';
+
+exports.download = function download(url) {
+  return new P(function(resolve, reject) {
+    try {
+      https.get(url, (stream) => {
+        resolve(stream);
+      })
+    } catch (err) {
+      logger.error('download.network.error', err);
+      reject(AppError.processingError(err));
+      return;
+    }
+  });
+};
 
 exports.upload = function upload(id, payload, headers) {
   return new P(function(resolve, reject) {

--- a/packages/fxa-profile-server/lib/routes/avatar/upload-from-auth-server.js
+++ b/packages/fxa-profile-server/lib/routes/avatar/upload-from-auth-server.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const assert = require('assert');
+
+const Joi = require('joi');
+
+const config = require('../../config');
+const db = require('../../db');
+const hex = require('buf').to.hex;
+const img = require('../../img');
+const notifyProfileUpdated = require('../../updates-queue');
+const workers = require('z../../img-workers');
+const avatarShared = require('./_shared');
+
+const FXA_PROVIDER = 'fxa';
+const FXA_URL_TEMPLATE = config.get('img.url');
+assert(
+  FXA_URL_TEMPLATE.includes('{id}'),
+  'img.url must contain the string "{id}"'
+);
+const DEFAULT_AVATAR_ID = config.get('img.defaultAvatarId');
+assert.strictEqual(DEFAULT_AVATAR_ID.length, 32, 'img.defaultAvatarId');
+
+module.exports = {
+  auth: {
+    strategy: 'secretBearerToken',
+  },
+  validate: {
+    payload: {
+      imageUrl: Joi.string()
+      // I think this max is probably too small.
+      // also we could have a "valid url" regex
+        .max(256)
+        .required()
+    },
+    params: {
+      uid: Joi.string(),
+    }
+  },
+  handler: async function uploadFromUrl(req, h) {
+    const { imageUrl } = req.payload;
+    const { uid } = req.params;
+  //   // now, we download the file from that url so that we can send it to the server.
+    const imageStream = await workers.download(imageUrl);
+    return req.server.methods.profileCache.drop(uid).then(() => {
+      const id = img.id();
+
+      // precaution to avoid the default id from being overwritten
+      assert.notStrictEqual(id, DEFAULT_AVATAR_ID, "New image ID must not equal default avatar ID.");
+      const url = avatarShared.fxaUrl(id);
+
+      // Since the original avatar upload route sent the file in the original req as a stream, these
+      // content headers could be reused in the img worker upload method. since we instead pass in a url
+      // (and derive the stream from it), we need to modify our headers for the upload method.
+      const updatedHeaders = req.headers;
+      updatedHeaders['content-length'] = imageStream.length;
+      updatedHeaders['content-type'] = 'image/png';
+
+      return workers
+        .upload(id, imageStream, updatedHeaders)
+        .then(function save() {
+          return db.addAvatar(id, uid, url, FXA_PROVIDER);
+        })
+        .then(function uploadDone() {
+          notifyProfileUpdated(uid); // Don't wait on promise
+          return h.response({ url, id: hex(id) }).code(201);
+        });
+    });
+  },
+};

--- a/packages/fxa-profile-server/lib/routing.js
+++ b/packages/fxa-profile-server/lib/routing.js
@@ -69,6 +69,13 @@ module.exports = [
     path: v('/avatar/upload'),
     config: require('./routes/avatar/upload'),
   },
+      // This is an internal-only route that allows us to set profile avatar from the auth server
+
+  {
+    method: 'POST',
+    path: v('/_avatar/{uid}'),
+    config: require('./routes/avatar/upload-from-auth-server'),
+  },
   {
     method: 'DELETE',
     path: v('/avatar/{id?}'),

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -917,6 +917,18 @@ describe('api', function () {
     });
 
     describe('upload', function () {
+      const EXPECTED_TOKEN = 'thisisnotthedefault';
+
+    let origSecretBearerToken = null;
+
+    before(function () {
+      origSecretBearerToken = config.get('secretBearerToken');
+      config.set('secretBearerToken', EXPECTED_TOKEN);
+    });
+
+    after(function () {
+      config.set('secretBearerToken', origSecretBearerToken);
+    });
       it('should upload a new avatar', function () {
         this.slow(5000);
         this.timeout(10000);
@@ -953,6 +965,21 @@ describe('api', function () {
               assert.equal(res.statusCode, 200);
             });
           });
+      });
+
+      it('should upload an avatar from a url, using secretBearerToken', function () {
+        return Server.api
+        .post({
+          url: `/_avatar/${uid}`,
+          payload: { imageUrl: 'www.exampleImage.com' },
+          headers: {
+            authorization: 'Bearer ' + EXPECTED_TOKEN,
+          },
+        }).then(function (res) {
+          assert.equal(res.statusCode, 201);
+          assert(res.result.url);
+          assert(res.result.id);
+        })
       });
 
       it('should fail with an error if image cannot be identified', function () {
@@ -1434,7 +1461,7 @@ describe('api', function () {
       });
 
       it('should post a new display name via secretBearerToken', function () {
-        var NAME = 'Spock';
+        const NAME = 'Spock';
         return Server.api
           .post({
             url: '/_display_name/' + USERID,


### PR DESCRIPTION
## NB: This is a WIP and not ready for detailed review

## Because

- When a user creates a new Firefox account through 3rd party auth, we get data (sometimes including a url to the stored image for a user's avatar) back from the 3rd party authenticator. We want to use that data to set a default avatar for the user.

## This pull request

- creates a new route on the profile server for updating an avatar via a request that sends an image url in the payload, and a uid in the params. It also authenticates via secretBearerToken (necessary since the request is coming from the auth server.)
- adds a reference to that route to the auth server's profile client. 
- hits the new route from the auth server after authenticating via a 3rd party and passes in the avatar url which was returned by the 3rd party authenticator
- adds a test to the profile server for the new route 
- adds a method onto the profile server's image worker to allow for downloading the 3rd party avatar from the given url (so as to then upload it to fxa servers) 

## Issue that this pull request solves

Closes: #12506

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
