### PR TITLE
fix(test): Fix broken reminders test

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
+++ b/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
@@ -261,13 +261,6 @@ describe('SubscriptionReminders', () => {
       };
       reminder.db.account = sandbox.fake.resolves(account);
       mockLog.info = sandbox.fake.returns({});
-      mockStripeHelper.formatSubscriptionForEmail = sandbox.fake.resolves({});
-      mockStripeHelper.findPlanById = sandbox.fake.resolves({
-        amount: longPlan1.amount,
-        currency: longPlan1.currency,
-        interval_count: longPlan1.interval_count,
-        interval: longPlan1.interval,
-      });
       const formattedSubscription = {
         id: 'subscriptionId',
         productMetadata: {
@@ -275,8 +268,15 @@ describe('SubscriptionReminders', () => {
           termsOfServiceUrl: 'http://tos',
         },
       };
+      mockStripeHelper.formatSubscriptionForEmail = sandbox.fake.resolves(formattedSubscription);
+      mockStripeHelper.findPlanById = sandbox.fake.resolves({
+        amount: longPlan1.amount,
+        currency: longPlan1.currency,
+        interval_count: longPlan1.interval_count,
+        interval: longPlan1.interval,
+      });
       reminder.mailer.sendSubscriptionRenewalReminderEmail =
-        sandbox.fake.resolves(formattedSubscription);
+        sandbox.fake.resolves(true);
       reminder.updateSentEmail = sandbox.fake.resolves({});
       const realDateNow = Date.now.bind(global.Date);
       Date.now = sinon.fake(() => MOCK_DATETIME_MS);


### PR DESCRIPTION
## Because

- This test was failing and somehow caused out of memory error, which unfortunatley was showing as all tests passed on auth-server
- I haven't dug into the why this would happen since the test itself seems pretty normal?

## This pull request

- Fixes the test

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/13024

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
