### PR TITLE
chore(auth): add profile mock to tests

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -23,13 +23,14 @@ const makeRoutes = function (options = {}, requireMocks) {
   const log = options.log || mocks.mockLog();
   const db = options.db || mocks.mockDB();
   const mailer = options.mailer || mocks.mockMailer();
+  const profile = options.profile || mocks.mockProfile();
 
   const { linkedAccountRoutes } = proxyquire(
     '../../../lib/routes/linked-accounts',
     requireMocks || {}
   );
 
-  return linkedAccountRoutes(log, db, config, mailer);
+  return linkedAccountRoutes(log, db, config, mailer, profile);
 };
 
 function runTest(route, request, assertions) {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -198,7 +198,7 @@ const SUBHUB_METHOD_NAMES = [
   'reactivateSubscription',
 ];
 
-const PROFILE_METHOD_NAMES = ['deleteCache'];
+const PROFILE_METHOD_NAMES = ['deleteCache', 'updateDisplayName'];
 
 module.exports = {
   MOCK_PUSH_KEY:


### PR DESCRIPTION
## Because

- Profile Client was added to the linked accounts route.

## This pull request

- Adds a profile mock to the linked account routes tests to prevent some
  tests from failing.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Without this fix, these are the tests that fail for me.
![image](https://user-images.githubusercontent.com/10620585/170287232-8dc8ffbc-71a5-4135-b535-c84920880e31.png)

## Other information (Optional)

Any other information that is important to this pull request.
