### PR TITLE
fix(payments): do not report account exist error

### DIFF
--- a/packages/fxa-payments-server/src/lib/account.ts
+++ b/packages/fxa-payments-server/src/lib/account.ts
@@ -6,7 +6,7 @@ import {
   apiCreatePasswordlessAccount,
   updateAPIClientToken,
 } from './apiClient';
-import { GeneralError } from './errors';
+import { AuthServerErrno, GeneralError } from './errors';
 import sentry from './sentry';
 export const FXA_SIGNUP_ERROR: GeneralError = {
   code: 'fxa_account_signup_error',
@@ -26,7 +26,9 @@ export async function handlePasswordlessSignUp({
     });
     updateAPIClientToken(accessToken);
   } catch (e) {
-    sentry.captureException(e);
+    if (e.body?.errno !== AuthServerErrno.ACCOUNT_EXISTS) {
+      sentry.captureException(e);
+    }
     throw FXA_SIGNUP_ERROR;
   }
 }

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -8,6 +8,7 @@ export type GeneralError = {
 
 // ref: fxa-auth-server/lib/error.js
 const AuthServerErrno = {
+  ACCOUNT_EXISTS: 101,
   UNKNOWN_SUBSCRIPTION_CUSTOMER: 176,
   UNKNOWN_SUBSCRIPTION: 177,
   UNKNOWN_SUBSCRIPTION_PLAN: 178,


### PR DESCRIPTION
## Because

- Currently when the stub account creation throws an error that the
  account already exists, it is reported to Sentry.
- Due to recent changes, it has become very difficult for this situation
  to happen, and usually only occurs when non-standard steps are
  performed. For example, the user has 2 tabs open.

## This pull request

- Does not report to Sentry when the Stub Account creation returns with
  and error that the Account already exists.

## Issue that this pull request solves

Closes: #10344

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).