### PR TITLE
fix(a11y): add a11y to modal close button svg

### DIFF
--- a/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
@@ -49,7 +49,12 @@ export const DialogMessage = ({
                 aria-label="Close modal"
                 onClick={onDismiss as () => void}
               >
-                <CloseIcon role="img" className="close-icon" />
+                <CloseIcon
+                  role="img"
+                  className="close-icon"
+                  aria-hidden="true"
+                  focusable="false"
+                />
               </button>
             </Localized>
           )}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -262,7 +262,12 @@ export const Subscriptions = ({
               aria-label="Close modal"
               onClick={hideSuccessAlert}
             >
-              <CloseIcon role="img" className="close-icon close-alert-bar" />
+              <CloseIcon
+                role="img"
+                className="close-icon close-alert-bar"
+                aria-hidden="true"
+                focusable="false"
+              />
             </span>
           </Localized>
         </AlertBar>


### PR DESCRIPTION
## Because

- We want ensure all user interactions meet accessibility standards

## This pull request

- Adds a11y attributes to modal close button svg

## Issue that this pull request solves

Closes: #12921

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

The `<svg>` can be hidden from screen readers since the parent `<button>` already has an aria-label associated with it, and `<svg>` is being used strictly for visual purposes.
