### PR TITLE
chore(db): Cleanup and remove `tokenVerificationCode`

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1477,12 +1477,12 @@ const conf = convict({
     },
     tokenVerificationCode: {
       codeLength: {
-        doc: 'Number of digits to make up a token code',
+        doc: '(Deprecated) Number of digits to make up a token code',
         default: 6,
         env: 'SIGNIN_TOKEN_CODE_LENGTH',
       },
       codeLifetime: {
-        doc: 'How long code should be valid for',
+        doc: '(Deprecated) How long code should be valid for',
         format: 'duration',
         default: '20 minutes',
         env: 'SIGNIN_TOKEN_CODE_LIFETIME',

--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -746,20 +746,6 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     await RawSessionToken.verify(tokenId, verificationMethod);
   };
 
-  DB.prototype.verifyTokenCode = async function (code, accountData) {
-    log.trace('DB.verifyTokenCode', { code });
-    try {
-      await BaseToken.verifyTokenCode(accountData.uid, code);
-    } catch (err) {
-      if (isExpiredTokenVerificationCodeError(err)) {
-        throw error.expiredTokenVerficationCode();
-      } else if (isNotFoundError(err)) {
-        throw error.invalidTokenVerficationCode();
-      }
-      throw err;
-    }
-  };
-
   DB.prototype.forgotPasswordVerified = async function (passwordForgotToken) {
     const { id, uid } = passwordForgotToken;
     log.trace('DB.forgotPasswordVerified', { uid });
@@ -1086,8 +1072,4 @@ function isEmailAlreadyExistsError(err) {
 
 function isEmailDeletePrimaryError(err) {
   return err.statusCode === 400 && err.errno === 136;
-}
-
-function isExpiredTokenVerificationCodeError(err) {
-  return err.statusCode === 400 && err.errno === 137;
 }

--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -149,7 +149,7 @@ export class SubscriptionReminders {
           reminderLength: this.reminderDuration.as('days'),
           planIntervalCount: interval_count,
           planInterval: interval,
-          // Using invoice prefix instead of plan to accomodate `yarn write-emails`.
+          // Using invoice prefix instead of plan to accommodate `yarn write-emails`.
           invoiceTotalInCents: amount,
           invoiceTotalCurrency: currency,
           productMetadata: formattedSubscription.productMetadata,

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -20,13 +20,10 @@ const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
 const error = require('../error');
 
-const MS_ONE_HOUR = 1000 * 60 * 60;
-
 const appleAud = 'https://appleid.apple.com';
 
 export class LinkedAccountHandler {
   private googleAuthClient?: OAuth2Client;
-  private tokenCodeLifetime: number;
 
   constructor(
     private log: AuthLogger,
@@ -35,10 +32,6 @@ export class LinkedAccountHandler {
     private mailer: any,
     private profile: ProfileClient,
   ) {
-    const tokenCodeConfig = config.signinConfirmation.tokenVerificationCode;
-    this.tokenCodeLifetime =
-      (tokenCodeConfig?.codeLifetime as unknown as number) ?? MS_ONE_HOUR;
-
     if (config.googleAuthConfig && config.googleAuthConfig.clientId) {
       this.googleAuthClient = new OAuth2Client(
         config.googleAuthConfig.clientId
@@ -274,7 +267,6 @@ export class LinkedAccountHandler {
       emailVerified: accountRecord.primaryEmail.isVerified,
       verifierSetAt: accountRecord.verifierSetAt,
       mustVerify: false,
-      tokenVerificationCodeExpiresAt: Date.now() + this.tokenCodeLifetime,
       uaBrowser: request.app.ua.browser,
       uaBrowserVersion: request.app.ua.browserVersion,
       uaOS: request.app.ua.os,

--- a/packages/fxa-auth-server/lib/tokens/session_token.js
+++ b/packages/fxa-auth-server/lib/tokens/session_token.js
@@ -43,11 +43,7 @@ module.exports = (log, Token, config) => {
       // Tokens are considered verified if no tokenVerificationId exists
       this.tokenVerificationId = details.tokenVerificationId || null;
       this.tokenVerified = this.tokenVerificationId ? false : true;
-
-      this.tokenVerificationCode = details.tokenVerificationCode || null;
-      this.tokenVerificationCodeExpiresAt =
-        details.tokenVerificationCodeExpiresAt || null;
-
+      
       this.verificationMethod = details.verificationMethod || null;
       this.verificationMethodValue = VERIFICATION_METHODS.get(
         this.verificationMethod
@@ -87,17 +83,6 @@ module.exports = (log, Token, config) => {
         newVerificationState.tokenVerificationId = await random.hex(
           this.tokenVerificationId.length / 2
         );
-      }
-
-      if (this.tokenVerificationCode) {
-        // Using expiresAt=0 here prevents the new token from being verified via email code.
-        // That's OK, because we don't send them a new email with the new verification code
-        // unless they explicitly ask us to resend it, and resend only handles email links
-        // rather than email codes.
-        newVerificationState.tokenVerificationCode = await random.hex(
-          this.tokenVerificationCode.length / 2
-        );
-        newVerificationState.tokenVerificationCodeExpiresAt = 0;
       }
 
       // Copy all other details from the original sessionToken.

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -299,10 +299,6 @@ module.exports = (config) => {
     return this.api.recoveryEmailSecondaryResendCode(this.sessionToken, email);
   };
 
-  Client.prototype.verifyTokenCode = function (code, options) {
-    return this.api.verifyTokenCode(this.sessionToken, code, options);
-  };
-
   Client.prototype.emailStatus = function () {
     const o = this.sessionToken ? Promise.resolve(null) : this.login();
     return o.then(() => {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -48,8 +48,6 @@ const makeRoutes = function (options = {}, requireMocks) {
   };
   config.lastAccessTimeUpdates = {};
   config.signinConfirmation = config.signinConfirmation || {};
-  config.signinConfirmation.tokenVerificationCode =
-    config.signinConfirmation.tokenVerificationCode || {};
   config.signinUnblock = config.signinUnblock || {};
   config.secondaryEmail = config.secondaryEmail || {};
 
@@ -526,7 +524,6 @@ describe('deleteAccountIfUnverified', () => {
   const mockConfig = {};
   mockConfig.oauth = {};
   mockConfig.signinConfirmation = {};
-  mockConfig.signinConfirmation.tokenVerificationCode = {};
   mockConfig.signinConfirmation.skipForEmailAddresses = [];
   const emailRecord = {
     isPrimary: true,
@@ -1602,11 +1599,7 @@ describe('/account/login', () => {
     securityHistory: {
       ipProfiling: {},
     },
-    signinConfirmation: {
-      tokenVerificationCode: {
-        codeLength: 8,
-      },
-    },
+    signinConfirmation: {},
     signinUnblock: {
       codeLifetime: 1000,
     },

--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -17,8 +17,6 @@ const APPLE_PROVIDER = 'apple';
 const makeRoutes = function (options = {}, requireMocks) {
   const config = options.config || {};
   config.signinConfirmation = config.signinConfirmation || {};
-  config.signinConfirmation.tokenVerificationCode =
-    config.signinConfirmation.tokenVerificationCode || {};
 
   const log = options.log || mocks.mockLog();
   const db = options.db || mocks.mockDB();
@@ -192,11 +190,6 @@ describe('/linked_account', () => {
               uaDeviceType: null,
               uaFormFactor: null,
             })
-          )
-        );
-        assert.isTrue(
-          mockDB.createSessionToken.calledOnceWith(
-            sinon.match.has('tokenVerificationCodeExpiresAt')
           )
         );
 

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -641,38 +641,7 @@ describe('/session/reauth', () => {
       }
     );
   });
-
-  it('reflects the requested verificationMethod in the response body', () => {
-    signinUtils.checkPassword = sinon.spy(() => {
-      return Promise.resolve(true);
-    });
-    request.auth.credentials.emailVerified = true;
-    request.auth.credentials.tokenVerified = false;
-    request.auth.credentials.tokenVerificationId = 'myCoolId';
-    request.auth.credentials.tokenVerificationCode = 'myAwesomerCode';
-    request.auth.credentials.tokenVerificationCodeExpiresAt =
-      Date.now() + 10000;
-    request.payload.verificationMethod = 'email-2fa';
-    return runTest(route, request).then((res) => {
-      assert.ok(res);
-      assert.equal(
-        res.verified,
-        false,
-        'result reports the session as unverified'
-      );
-      assert.equal(
-        res.verificationReason,
-        'login',
-        'result reports the verificationReason as "login"'
-      );
-      assert.equal(
-        res.verificationMethod,
-        'email-2fa',
-        'result reports the verificationReason as requested'
-      );
-    });
-  });
-
+  
   it('can refuse reauth for selected OAuth clients', async () => {
     const route = getRoute(
       makeRoutes({
@@ -860,7 +829,7 @@ describe('/session/duplicate', () => {
       const sessionTokenOptions = db.createSessionToken.args[0][0];
       assert.equal(
         Object.keys(sessionTokenOptions).length,
-        38,
+        36,
         'was called with correct number of options'
       );
       assert.equal(
@@ -907,16 +876,6 @@ describe('/session/duplicate', () => {
         'db.createSessionToken called with correct tokenVerificationId'
       );
       assert.equal(
-        sessionTokenOptions.tokenVerificationCode,
-        undefined,
-        'db.createSessionToken called with correct tokenVerificationCode'
-      );
-      assert.equal(
-        sessionTokenOptions.tokenVerificationCodeExpiresAt,
-        undefined,
-        'db.createSessionToken called with correct tokenVerificationCodeExpiresAt'
-      );
-      assert.equal(
         sessionTokenOptions.uaBrowser,
         'Chrome',
         'db.createSessionToken called with correct uaBrowser'
@@ -952,9 +911,6 @@ describe('/session/duplicate', () => {
   it('correctly generates new codes for unverified sessions', () => {
     request.auth.credentials.tokenVerified = false;
     request.auth.credentials.tokenVerificationId = 'myCoolId';
-    request.auth.credentials.tokenVerificationCode = 'myAwesomerCode';
-    request.auth.credentials.tokenVerificationCodeExpiresAt =
-      Date.now() + 10000;
     return runTest(route, request).then((res) => {
       assert.equal(
         Object.keys(res).length,
@@ -996,7 +952,7 @@ describe('/session/duplicate', () => {
       const sessionTokenOptions = db.createSessionToken.args[0][0];
       assert.equal(
         Object.keys(sessionTokenOptions).length,
-        38,
+        36,
         'was called with correct number of options'
       );
       assert.equal(
@@ -1045,20 +1001,6 @@ describe('/session/duplicate', () => {
         sessionTokenOptions.tokenVerificationId,
         'myCoolId',
         'db.createSessionToken called with a new tokenVerificationId'
-      );
-      assert.ok(
-        sessionTokenOptions.tokenVerificationCode,
-        'db.createSessionToken called with a truthy tokenVerificationCode'
-      );
-      assert.notEqual(
-        sessionTokenOptions.tokenVerificationCode,
-        'myAwesomerCode',
-        'db.createSessionToken called with a new tokenVerificationCode'
-      );
-      assert.equal(
-        sessionTokenOptions.tokenVerificationCodeExpiresAt,
-        0,
-        'db.createSessionToken called with correct tokenVerificationCodeExpiresAt'
       );
       assert.equal(
         sessionTokenOptions.uaBrowser,

--- a/packages/fxa-auth-server/test/local/routes/utils/signin.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signin.js
@@ -967,7 +967,6 @@ describe('sendSigninNotifications', () => {
     beforeEach(() => {
       sessionToken.tokenVerified = false;
       sessionToken.tokenVerificationId = 'tokenVerifyCode';
-      sessionToken.tokenVerificationCode = 'tokenVerifyShortCode';
       sessionToken.mustVerify = true;
     });
 

--- a/packages/fxa-auth-server/test/local/tokens/session_token.js
+++ b/packages/fxa-auth-server/test/local/tokens/session_token.js
@@ -113,15 +113,10 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
   });
 
   it('copy token state works', async () => {
-    TOKEN.tokenVerificationCode = 'foo';
     TOKEN.tokenVerificationId = 'bar';
     const token = await SessionToken.create(TOKEN);
     const newState = await token.copyTokenState();
     assert.notEqual(token.tokenVerificationId, newState.tokenVerificationId);
-    assert.notEqual(
-      token.tokenVerificationCode,
-      newState.tokenVerificationCode
-    );
     assert.equal(token.data, newState.data);
     assert.equal(token.id, newState.id);
     assert.equal(token.uid, newState.uid);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -96,7 +96,6 @@ const DB_METHOD_NAMES = [
   'updateTotpToken',
   'verifyEmail',
   'verifyTokens',
-  'verifyTokenCode',
   'verifyTokensWithMethod',
   'createAccountSubscription',
   'getAccountSubscription',
@@ -544,12 +543,6 @@ function mockDB(data, errors) {
       return Promise.resolve(res);
     }),
     verifyTokens: optionallyThrow(errors, 'verifyTokens'),
-    verifyTokenCode: sinon.spy(() => {
-      if (errors.verifyTokenCode) {
-        return Promise.reject(errors.verifyTokenCode);
-      }
-      return Promise.resolve({});
-    }),
     replaceRecoveryCodes: sinon.spy(() => {
       return Promise.resolve(['12312312', '12312312']);
     }),

--- a/packages/fxa-content-server/app/scripts/views/push/confirm_login.js
+++ b/packages/fxa-content-server/app/scripts/views/push/confirm_login.js
@@ -44,9 +44,6 @@ class ConfirmPushLoginView extends FormView {
   changePassword() {}
 
   submit() {
-    // TODO: Unfortunately, we need to use `/recovery_email/verify_code`
-    // endpoint to verify our tokenVerificationCode because that code
-    // is linked directly to a specific session.
     const account = this.getSignedInAccount();
     return account
       .verifySignUp(this.code)

--- a/packages/fxa-shared/db/models/auth/base-auth.ts
+++ b/packages/fxa-shared/db/models/auth/base-auth.ts
@@ -63,7 +63,6 @@ export enum Proc {
   UpsertAvailableCommands = 'upsertAvailableCommand_1',
   VerifyEmail = 'verifyEmail_9',
   VerifyToken = 'verifyToken_3',
-  VerifyTokenCode = 'verifyTokenCode_2',
   VerifyTokenWithMethod = 'verifyTokensWithMethod_3',
 }
 

--- a/packages/fxa-shared/db/models/auth/base-token.ts
+++ b/packages/fxa-shared/db/models/auth/base-token.ts
@@ -20,19 +20,4 @@ export class BaseToken extends BaseAuthModel {
       throw convertError(e);
     }
   }
-
-  static async verifyTokenCode(uid: string, code: string) {
-    try {
-      const { status } = await BaseToken.callProcedure(
-        Proc.VerifyTokenCode,
-        BaseAuthModel.sha256(code),
-        uuidTransformer.to(uid)
-      );
-      if (status.affectedRows < 1) {
-        throw notFound();
-      }
-    } catch (e) {
-      throw convertError(e);
-    }
-  }
 }

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -113,8 +113,6 @@ export class SessionToken extends BaseToken {
     uaFormFactor,
     tokenVerificationId,
     mustVerify,
-    tokenVerificationCode,
-    tokenVerificationCodeExpiresAt,
   }: Pick<
     SessionToken,
     | 'uid'
@@ -130,8 +128,6 @@ export class SessionToken extends BaseToken {
   > & {
     id: string;
     data: string;
-    tokenVerificationCode?: string;
-    tokenVerificationCodeExpiresAt: number;
   }) {
     return this.callProcedure(
       Proc.CreateSessionToken,
@@ -147,10 +143,8 @@ export class SessionToken extends BaseToken {
       uaFormFactor ?? null,
       uuidTransformer.to(tokenVerificationId),
       !!mustVerify,
-      tokenVerificationCode
-        ? BaseAuthModel.sha256(tokenVerificationCode)
-        : null,
-      tokenVerificationCodeExpiresAt ?? null
+      null, // we no longer set token verification code
+      null // we no longer set token verification code expiresAt
     );
   }
 


### PR DESCRIPTION
## Because

- We no longer use `tokenVerificationCode` to verify sessions
- Note that in orginal issue we called out removing `tokenVerificationId`, however this is still being used to verify sessions

## This pull request

- Removing references and code that use this value
- Stop writing this value to the database

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/12489

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
