### PR TITLE
task(shared): Improve PII filtering

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/reporting.spec.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.spec.ts
@@ -14,46 +14,58 @@ describe('filterObject', () => {
 
   // Test Sentry QueryParams filtering types
   it('should filter array of key/value arrays', () => {
-    const input = [
-      ['foo', uuid.v4().replace(/-/g, '')],
-      ['baz', uuid.v4().replace(/-/g, '')],
-      ['bar', 'fred'],
-    ];
-    const expected = [
-      ['foo', FILTERED],
-      ['baz', FILTERED],
-      ['bar', 'fred'],
-    ];
+    const input = {
+      extra: [
+        ['foo', uuid.v4().replace(/-/g, '')],
+        ['baz', uuid.v4().replace(/-/g, '')],
+        ['bar', 'fred'],
+      ],
+    };
+    const expected = {
+      extra: [
+        ['foo', FILTERED],
+        ['baz', FILTERED],
+        ['bar', 'fred'],
+      ],
+    };
     const output = filterObject(input);
     expect(output).toEqual(expected);
   });
 
   it('should filter an object of key/value pairs', () => {
     const input = {
-      foo: uuid.v4().replace(/-/g, ''),
-      baz: uuid.v4().replace(/-/g, ''),
-      bar: 'fred',
+      extra: {
+        foo: uuid.v4().replace(/-/g, ''),
+        baz: uuid.v4().replace(/-/g, ''),
+        bar: 'fred',
+      },
     };
     const expected = {
-      foo: FILTERED,
-      baz: FILTERED,
-      bar: 'fred',
+      extra: {
+        foo: FILTERED,
+        baz: FILTERED,
+        bar: 'fred',
+      },
     };
     const output = filterObject(input);
     expect(output).toEqual(expected);
   });
 
   it('should skip nested arrays that are not valid key/value arrays', () => {
-    const input = [
-      ['foo', uuid.v4().replace(/-/g, '')],
-      ['bar', 'fred'],
-      ['fizz', 'buzz', 'parrot'],
-    ];
-    const expected = [
-      ['foo', FILTERED],
-      ['bar', 'fred'],
-      ['fizz', 'buzz', 'parrot'],
-    ];
+    const input = {
+      extra: [
+        ['foo', uuid.v4().replace(/-/g, '')],
+        ['bar', 'fred'],
+        ['fizz', 'buzz', 'parrot'],
+      ],
+    };
+    const expected = {
+      extra: [
+        ['foo', FILTERED],
+        ['bar', 'fred'],
+        ['fizz', 'buzz', 'parrot'],
+      ],
+    };
     const output = filterObject(input);
     expect(output).toEqual(expected);
   });

--- a/packages/fxa-shared/nestjs/sentry/reporting.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.ts
@@ -6,15 +6,8 @@ import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
 import * as Sentry from '@sentry/node';
 import { SQS } from 'aws-sdk';
 import { Request } from 'express';
-
-// Matches uid, session, oauth and other common tokens which we would
-// prefer not to include in Sentry reports.
-const TOKENREGEX = /[a-fA-F0-9]{32,}/gi;
-// RFC 5322 generalized email regex, ~ 99.99% accurate.
-const EMAILREGEX =
-  /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/gi;
-const FILTERED = '[Filtered]';
-const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
+import { CommonPiiActions } from '../../sentry/pii-filter-actions';
+import { SentryPiiFilter, SqsMessageFilter } from '../../sentry/pii-filters';
 
 export interface ExtraContext {
   name: string;
@@ -26,85 +19,34 @@ export interface ExtraContext {
  *
  * @param obj Object to filter values on
  */
-export function filterObject<T>(obj: T): T {
-  if (Array.isArray(obj)) {
-    if (obj.length === 2 && typeof obj[1] === 'string') {
-      // Assume a key/value pair.
-      return [
-        obj[0],
-        obj[1].replace(TOKENREGEX, FILTERED).replace(EMAILREGEX, FILTERED),
-      ] as unknown as T;
-    }
-    if (Array.isArray(obj[0])) {
-      // Assume an array of array of key/values and filter each one.
-      return obj.map(filterObject) as unknown as T;
-    }
-  } else if (typeof obj === 'object' && obj) {
-    for (const [key, value] of Object.entries(obj)) {
-      if (typeof value === 'string') {
-        // Typescript can't quite infer that this is the value that was
-        // at that index, so a cast is needed.
-        (obj as any)[key] = value
-          .replace(TOKENREGEX, FILTERED)
-          .replace(EMAILREGEX, FILTERED);
-      }
-    }
-  }
-  return obj;
+export function filterObject(obj: Record<string, any>) {
+  return piiFilter.filter(obj);
 }
 
 /**
- * Filter a sentry event for PII in addition to the default filters.
+ * Filter potential PII from a sentry event.
  *
- * Current replacements:
- *   - A 32-char hex string that typically is a FxA user-id.
- *
- * Data Removed:
- *   - Request body.
- *
- * @param event
+ * - Limits depth data beyond 5 levels
+ * - Filters out pii keys, See CommonPiiActions.piiKeys for more details
+ * - Filters out strings that look like emails addresses
+ * - Filters out strings that look like tokens value (32 char length alphanumeric values)
+ * - Filters out strings that look like ip addresses (v4/v6)
+ * - Filters out urls with user name / password data
+ * @param event A sentry event
+ * @returns a sanitized sentry event
  */
-export function filterSentryEvent(event: Sentry.Event, hint: unknown) {
-  if (event.message) {
-    event.message = event.message.replace(TOKENREGEX, FILTERED);
-  }
-  if (event.breadcrumbs) {
-    for (const bc of event.breadcrumbs) {
-      if (bc.message) {
-        bc.message = bc.message.replace(TOKENREGEX, FILTERED);
-      }
-      if (bc.data) {
-        bc.data = filterObject(bc.data);
-      }
-    }
-  }
-  if (event.request) {
-    if (event.request.url) {
-      event.request.url = event.request.url.replace(TOKENREGEX, FILTERED);
-    }
-    if (event.request.query_string) {
-      if (typeof event.request.query_string === 'string') {
-        event.request.query_string = event.request.query_string.replace(
-          TOKENREGEX,
-          URIENCODEDFILTERED
-        );
-      } else {
-        event.request.query_string = filterObject(event.request.query_string);
-      }
-    }
-    if (event.request.headers) {
-      (event as any).request.headers = filterObject(event.request.headers);
-    }
-    if (event.request.data) {
-      // Remove request data entirely
-      delete event.request.data;
-    }
-  }
-  if (event.tags && event.tags.url) {
-    event.tags.url = (event.tags.url as string).replace(TOKENREGEX, FILTERED);
-  }
-  return event;
+export function filterSentryEvent(event: Sentry.Event, _hint: unknown) {
+  return piiFilter.filter(event);
 }
+const piiFilter = new SentryPiiFilter([
+  CommonPiiActions.depthFilter,
+  CommonPiiActions.piiKeys,
+  CommonPiiActions.emailValues,
+  CommonPiiActions.tokenValues,
+  CommonPiiActions.ipV4Values,
+  CommonPiiActions.ipV6Values,
+  CommonPiiActions.urlUsernamePassword,
+]);
 
 /**
  * Capture a SQS Error to Sentry with additional context.
@@ -115,17 +57,16 @@ export function filterSentryEvent(event: Sentry.Event, hint: unknown) {
 export function captureSqsError(err: Error, message?: SQS.Message): void {
   Sentry.withScope((scope) => {
     if (message?.Body) {
-      if (typeof message.Body === 'string') {
-        message.Body = message.Body.replace(TOKENREGEX, FILTERED).replace(
-          EMAILREGEX,
-          FILTERED
-        );
-      }
+      message = sqsMessageFilter.filter(message);
       scope.setContext('SQS Message', message as Record<string, unknown>);
     }
     Sentry.captureException(err);
   });
 }
+const sqsMessageFilter = new SqsMessageFilter([
+  CommonPiiActions.emailValues,
+  CommonPiiActions.tokenValues,
+]);
 
 /**
  * Report an exception with request and additional optional context objects.

--- a/packages/fxa-shared/sentry/models/pii.ts
+++ b/packages/fxa-shared/sentry/models/pii.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** A general type that holds PII data. */
+export type PiiData = Record<string, any> | string | undefined | null;
+
+/** A general interface for running a filter action on PII Data */
+export interface IAction {
+  /**
+   * Filters a value for PII
+   * @param val - the value to filter
+   */
+  execute<T extends PiiData>(val: T, depth?: number): T;
+}
+
+/** A general interface for top level classes that filter PII data */
+export interface IFilter {
+  filter(event: PiiData): PiiData;
+}
+
+/** Things to check for when scrubbing for PII. */
+export type CheckOnly = 'keys' | 'values' | 'both';

--- a/packages/fxa-shared/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/sentry/pii-filter-actions.ts
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CheckOnly, IAction, PiiData } from './models/pii';
+
+/** Default replacement value */
+export const FILTERED = '[Filtered]';
+export const TRUNCATED = '[Truncated]';
+
+/**
+ * A filter that truncates anything over maxDepth. This is a good first action.
+ */
+export class DepthFilter implements IAction {
+  /**
+   * Maximum Depth
+   * @param maxDepth
+   */
+  constructor(protected readonly maxDepth = 3) {}
+
+  execute<T extends PiiData>(val: T, depth = 1): T {
+    if (depth >= this.maxDepth && val != null && typeof val === 'object') {
+      Object.keys(val)?.forEach((x) => {
+        val[x] = TRUNCATED;
+      });
+    }
+    return val;
+  }
+}
+
+/**
+ * A base class for other PiiFilters. Supports checking keys and values
+ */
+export abstract class PiiFilter implements IAction {
+  /** Flag determining if object values should be checked. */
+  protected get checkValues() {
+    return this.checkOnly === 'values' || this.checkOnly === 'both';
+  }
+
+  /** Flag determining if object keys should be checked. */
+  protected get checkKeys() {
+    return this.checkOnly === 'keys' || this.checkOnly === 'both';
+  }
+
+  /**
+   * Creates a new regex filter action
+   * @param checkOnly - Optional directive indicating what to check, a value, an object key, or both.
+   * @param replaceWith - Optional value indicating what to replace a matched value with.
+   */
+  constructor(
+    public readonly checkOnly: CheckOnly = 'values',
+    public readonly replaceWith = FILTERED
+  ) {}
+
+  /**
+   * Runs the filter
+   * @param val - value to filter on.
+   * @returns a filtered value
+   */
+  public execute<T extends PiiData>(val: T) {
+    if (val == null) {
+      return val;
+    }
+
+    // A string, just update the value.
+    if (typeof val === 'string') {
+      return this.replaceValues(val) as T;
+    } else if (typeof val === 'object') {
+      // Mutate and drill down into object
+      for (const key of Object.keys(val)) {
+        if (this.filterKey(key)) {
+          val[key] = this.replaceWith;
+        } else if (this.filterValue(val[key])) {
+          val[key] = this.replaceValues(val[key]);
+        }
+      }
+    }
+    return val;
+  }
+
+  /**
+   * Indicates if value should be filtered
+   * @param val
+   * @returns
+   */
+  protected filterValue(val: any) {
+    return this.checkValues && typeof val === 'string';
+  }
+
+  /**
+   * Let the sub classes determine how to replace values.
+   * @param val
+   */
+  protected abstract replaceValues(val: string): string;
+
+  /**
+   * Let subclasses determine when an object's key should be filtered out.
+   * @param key
+   */
+  protected abstract filterKey(key: string): boolean;
+}
+
+/**
+ * Uses a regular expression to scrub PII
+ */
+export class PiiRegexFilter extends PiiFilter implements IAction {
+  /**
+   * Creates a new regex filter action
+   * @param regex - regular expression to use for filter
+   * @param checkOnly - Optional directive indicating what to check, a value, an object key, or both.
+   * @param replaceWith - Optional value indicating what to replace a matched value with.
+   */
+  constructor(
+    public readonly regex: RegExp,
+    public readonly checkOnly: CheckOnly = 'values',
+    public readonly replaceWith = FILTERED
+  ) {
+    super(checkOnly, replaceWith);
+  }
+
+  protected override replaceValues(val: string): string {
+    return val.replace(this.regex, this.replaceWith);
+  }
+
+  protected override filterKey(key: string): boolean {
+    const result = this.checkKeys && this.regex.test(key);
+
+    // Tricky edge case. The regex maybe sticky. If so, we need to reset its lastIndex so it does not
+    // affect a subsequent operation.
+    if (this.regex.sticky) {
+      this.regex.lastIndex = 0;
+    }
+    return result;
+  }
+}
+
+/**
+ * Makes sure that if value is a URL it doesn't have identifying info like the username or password portion of the url.
+ */
+export class UrlUsernamePasswordFilter extends PiiFilter {
+  constructor(replaceWith = FILTERED) {
+    super('values', replaceWith);
+  }
+
+  protected override replaceValues(val: string) {
+    const url = tryParseUrl(val);
+    if (url) {
+      if (url.username) {
+        url.username = this.replaceWith;
+      }
+      if (url.password) {
+        url.password = this.replaceWith;
+      }
+      val = decodeURI(url.toString());
+    }
+    return val;
+  }
+
+  protected override filterKey(): boolean {
+    return false;
+  }
+}
+
+/**
+ * Strips emails from data.
+ */
+export class EmailFilter extends PiiRegexFilter {
+  constructor(checkOnly: CheckOnly = 'values', replaceWith = FILTERED) {
+    super(
+      // RFC 5322 generalized email regex, ~ 99.99% accurate.
+      /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/gim,
+      checkOnly,
+      replaceWith
+    );
+  }
+
+  protected override replaceValues(val: string) {
+    const url = tryParseUrl(val);
+    if (url) {
+      if (url.search) {
+        url.search = url.search.replace(this.regex, this.replaceWith);
+      }
+      if (url.pathname) {
+        url.pathname = url.pathname.replace(this.regex, this.replaceWith);
+      }
+      val = decodeURI(url.toString());
+    }
+
+    return val.replace(this.regex, this.replaceWith);
+  }
+
+  protected filterKey(key: string): boolean {
+    return false;
+  }
+}
+
+/** Auxillary method for safely parsing a url. If it can't be parsed returns null. */
+function tryParseUrl(val: string) {
+  try {
+    return new URL(val);
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Some common PII scrubbing actions
+ */
+export const CommonPiiActions = {
+  /**
+   * Limits objects to 5 levels of depth
+   */
+  depthFilter: new DepthFilter(5),
+
+  /**
+   * Makes sure the user name / password is stripped out of the url.
+   */
+  urlUsernamePassword: new UrlUsernamePasswordFilter(),
+
+  /**
+   * Makes sure emails are stripped from data. Uses RFC 5322 generalized email regex, ~ 99.99% accurate.
+   */
+  emailValues: new EmailFilter(),
+
+  /**
+   * Matches IP V6 values
+   */
+  ipV6Values: new PiiRegexFilter(
+    /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))/gim
+  ),
+
+  /**
+   * Matches IPV4 values
+   */
+  ipV4Values: new PiiRegexFilter(
+    /(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}/gim
+  ),
+
+  /**
+   * Looks for keys that commonly contain PII
+   */
+  piiKeys: new PiiRegexFilter(
+    /^oidc-.*|^remote-groups$|^uid$|^email_?|^ip_?|^user$|^user_?(id|name)$/i,
+    'keys'
+  ),
+
+  /**
+   * Matches uid, session, oauth and other common tokens which we would prefer not to include in Sentry reports.
+   */
+  tokenValues: new PiiRegexFilter(/[a-fA-F0-9]{32,}/gim),
+};

--- a/packages/fxa-shared/sentry/pii-filters.ts
+++ b/packages/fxa-shared/sentry/pii-filters.ts
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/node';
+import { SQS } from 'aws-sdk';
+import { ILogger } from '../log';
+import { IAction, PiiData } from './models/pii';
+
+/**
+ * Base class for all filters
+ */
+export abstract class FilterBase {
+  constructor(
+    protected readonly actions: IAction[],
+    protected readonly logger?: ILogger
+  ) {}
+
+  /**
+   * Applies filters to object and drills down into object
+   * @param val - Value to drill into
+   * @param depth - the current depth in the object
+   * @param maxDepth - depth at which to give up
+   * @returns
+   */
+  applyFilters<T extends PiiData>(val: T, depth = 1, maxDepth = 10) {
+    if (depth < maxDepth && val != null) {
+      this.actions.forEach((x) => {
+        try {
+          val = x.execute(val, depth);
+        } catch (err) {
+          this.logger?.error('sentry.filter.error', { err });
+        }
+      });
+
+      if (typeof val === 'object') {
+        Object.values(val).forEach((x) => {
+          this.applyFilters(x, depth + 1, maxDepth);
+        });
+      }
+    }
+    return val;
+  }
+
+  abstract filter(data: PiiData): PiiData;
+}
+
+/**
+ * Defacto Sentry Event Filter. Can be extended and customization as needed.
+ */
+export class SentryPiiFilter extends FilterBase {
+  /**
+   * Creates a new PII Filter for sentry data
+   * @param actions - Set of filters to apply
+   */
+  constructor(actions: IAction[]) {
+    super(actions);
+  }
+
+  /**
+   * Filter PII from all known sentry fields
+   */
+  public filter(event: Sentry.Event) {
+    // Target key parts of sentry event structure
+    this.scrubMessage(event)
+      .scrubBreadCrumbs(event)
+      .scrubRequest(event)
+      .scrubTags(event)
+      .scrubException(event)
+      .scrubExtra(event)
+      .scrubUser(event);
+    return event;
+  }
+
+  protected scrubMessage(event: Sentry.Event) {
+    if (event.message) {
+      event.message = this.applyFilters(event.message);
+    }
+    return this;
+  }
+
+  protected scrubBreadCrumbs(event: Sentry.Event) {
+    for (const bc of event.breadcrumbs || []) {
+      if (bc.message) {
+        bc.message = this.applyFilters(bc.message);
+      }
+      if (bc.data) {
+        bc.data = this.applyFilters(bc.data);
+      }
+    }
+    return this;
+  }
+
+  protected scrubRequest(event: Sentry.Event) {
+    if (event.request?.headers)
+      event.request.headers = this.applyFilters(event.request.headers);
+
+    if (event.request?.data)
+      event.request.data = this.applyFilters(event.request.data);
+
+    if (event.request?.query_string)
+      event.request.query_string = this.applyFilters(
+        event.request.query_string
+      );
+
+    if (event.request?.env)
+      event.request.env = this.applyFilters(event.request.env);
+
+    if (event.request?.url)
+      event.request.url = this.applyFilters(event.request.url);
+
+    if (event.request?.cookies)
+      event.request.cookies = this.applyFilters(event.request.cookies);
+
+    return this;
+  }
+
+  protected scrubTags(event: Sentry.Event) {
+    if (typeof event.tags?.url === 'string') {
+      event.tags.url = this.applyFilters(event.tags.url);
+    }
+    return this;
+  }
+
+  protected scrubException(event: Sentry.Event) {
+    if (event.exception) {
+      event.exception = this.applyFilters(event.exception);
+    }
+    return this;
+  }
+
+  protected scrubExtra(event: Sentry.Event) {
+    if (event.extra) {
+      event.extra = this.applyFilters(event.extra);
+    }
+    return this;
+  }
+
+  protected scrubUser(event: Sentry.Event) {
+    if (event.user) {
+      event.user = this.applyFilters(event.user);
+    }
+    return this;
+  }
+}
+
+/**
+ * Scrubs PII from SQS Messages
+ */
+export class SqsMessageFilter extends FilterBase {
+  /**
+   * Create a new SqsMessageFilter
+   * @param actions
+   */
+  constructor(actions: IAction[]) {
+    super(actions);
+  }
+
+  /**
+   * Filter Body of sqs messages
+   */
+  public filter(event: SQS.Message) {
+    this.filterBody(event);
+    return event;
+  }
+
+  protected filterBody(event: SQS.Message) {
+    event.Body = this.applyFilters(event.Body);
+    return this;
+  }
+}

--- a/packages/fxa-shared/test/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/test/sentry/pii-filter-actions.ts
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from 'chai';
+import * as uuid from 'uuid';
+import {
+  CommonPiiActions,
+  DepthFilter,
+  FILTERED,
+  PiiRegexFilter,
+} from '../../sentry/pii-filter-actions';
+
+describe('pii-filter-actions', () => {
+  describe('DepthFilter', () => {
+    it('only truncates objects', () => {
+      const filter = new DepthFilter(1);
+
+      expect(filter.execute('foo', 1)).to.equal('foo');
+      expect(filter.execute(null, 1)).to.equal(null);
+    });
+
+    it('truncates objects when depth is greater than or equal to max depth', () => {
+      const filter = new DepthFilter(1);
+      expect(filter.execute({ foo: 'bar' }, 1)).to.deep.equal({
+        foo: '[Truncated]',
+      });
+    });
+
+    it('does not truncate if depth is less than max depth ', () => {
+      const filter = new DepthFilter(1);
+      expect(filter.execute({ foo: 'bar' }, 0)).to.deep.equal({ foo: 'bar' });
+    });
+  });
+
+  describe('PiiRegexFilter', () => {
+    it('filters string', () => {
+      const filter = new PiiRegexFilter(/foo/gi, 'values', '[BAR]');
+      const value = filter.execute('test foo regex filter');
+      expect(value).to.equal('test [BAR] regex filter');
+    });
+
+    it('filters object value', () => {
+      const filter1 = new PiiRegexFilter(/foo/gi, 'both', '[BAR]');
+      const filter2 = new PiiRegexFilter(/foo/gi, 'values', '[BAR]');
+
+      const value1 = filter1.execute({
+        item: 'test foo regex filter',
+      });
+      const value2 = filter2.execute({
+        item: 'test foo regex filter',
+      });
+
+      expect(value1.item).to.equal('test [BAR] regex filter');
+      expect(value2.item).to.equal('test [BAR] regex filter');
+    });
+
+    it('filters object key', () => {
+      const filter = new PiiRegexFilter(/foo/gi, 'keys', '[BAR]');
+
+      const value = filter.execute({
+        foo: 'test foo regex filter',
+      });
+
+      expect(value.foo).to.equal('[BAR]');
+    });
+
+    describe('checksOn', () => {
+      it('checks only on values', () => {
+        const filter = new PiiRegexFilter(/foo/gi, 'values', '[BAR]');
+        const value = filter.execute({
+          foo: 'test foo regex filter',
+          bar: 'test foo regex filter',
+        });
+        expect(value.foo).to.equal('test [BAR] regex filter');
+        expect(value.bar).to.equal('test [BAR] regex filter');
+      });
+
+      it('checks only on keys', () => {
+        const filter = new PiiRegexFilter(/foo/gi, 'keys', '[BAR]');
+        const value = filter.execute({
+          foo: 'test foo regex filter',
+          bar: 'test foo regex filter',
+        });
+        expect(value.foo).to.equal('[BAR]');
+        expect(value.bar).to.equal('test foo regex filter');
+      });
+
+      it('checks on keys and values', () => {
+        const filter = new PiiRegexFilter(/foo/gi, 'both', '[BAR]');
+        const value = filter.execute({
+          foo: 'test foo regex filter',
+          bar: 'test foo regex filter',
+        });
+        expect(value.foo).to.equal('[BAR]');
+        expect(value.bar).to.equal('test [BAR] regex filter');
+      });
+    });
+  });
+
+  describe('CommonPiiActions', () => {
+    it('filters emails', () => {
+      const result = CommonPiiActions.emailValues.execute({
+        foo: 'email: test@123.com -- 123@test.com --',
+        bar: '123',
+      });
+
+      expect(result).to.deep.equal({
+        foo: `email: ${FILTERED} -- ${FILTERED} --`,
+        bar: '123',
+      });
+    });
+
+    it('filters email in url', () => {
+      const result = CommonPiiActions.emailValues.execute(
+        'http://foo.bar/?email=foxkey@mozilla.com&key=1'
+      );
+      expect(result).to.equal('http://foo.bar/?[Filtered]&key=1');
+    });
+
+    it('filters username / password from url', () => {
+      const result = CommonPiiActions.urlUsernamePassword.execute(
+        'http://me:wut@foo.bar/'
+      );
+      expect(result).to.equal('http://[Filtered]:[Filtered]@foo.bar/');
+    });
+
+    it('ipv6 values', () => {
+      const result = CommonPiiActions.ipV6Values.execute({
+        foo: 'ipv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334 -- FE80:0000:0000:0000:0202:B3FF:FE1E:8329 --',
+        bar: '123',
+      });
+      expect(result).to.deep.equal({
+        foo: `ipv6: ${FILTERED} -- ${FILTERED} --`,
+        bar: '123',
+      });
+    });
+
+    it('ipv4 values', () => {
+      const result = CommonPiiActions.ipV4Values.execute({
+        foo: '-- 127.0.0.1 -- 10.0.0.1 -- ',
+        bar: '1.2.3',
+      });
+      expect(result).to.deep.equal({
+        foo: `-- ${FILTERED} -- ${FILTERED} -- `,
+        bar: '1.2.3',
+      });
+    });
+
+    it('filters pii keys', () => {
+      const result = CommonPiiActions.piiKeys.execute({
+        'oidc-test': 'foo',
+        'OIDC-TEST': 'foo',
+        'remote-groups': 'foo',
+        'REMOTE-GROUPS': 'foo',
+        email_address: 'foo',
+        email: 'foo',
+        EmailAddress: 'foo',
+        ip: 'foo',
+        ip_addr: 'foo',
+        ip_address: 'foo',
+        IpAddress: 'foo',
+        uid: 'foo',
+        user: 'foo',
+        username: 'foo',
+        user_name: 'foo',
+        UserName: 'foo',
+        userid: 'foo',
+        UserId: 'foo',
+        user_id: 'foo',
+        bar: '123',
+      });
+
+      expect(result).to.deep.equal({
+        'oidc-test': FILTERED,
+        'OIDC-TEST': FILTERED,
+        'remote-groups': FILTERED,
+        'REMOTE-GROUPS': FILTERED,
+        email: FILTERED,
+        email_address: FILTERED,
+        EmailAddress: FILTERED,
+        ip: FILTERED,
+        ip_addr: FILTERED,
+        ip_address: FILTERED,
+        IpAddress: FILTERED,
+        uid: FILTERED,
+        user: FILTERED,
+        username: FILTERED,
+        user_name: FILTERED,
+        UserName: FILTERED,
+        userid: FILTERED,
+        user_id: FILTERED,
+        UserId: FILTERED,
+        bar: '123',
+      });
+    });
+
+    it('filters token values', () => {
+      const token1 = uuid.v4().replace(/-/g, '');
+      const token2 = uuid.v4().replace(/-/g, '');
+      const token3 = uuid.v4().toString();
+      const result = CommonPiiActions.tokenValues.execute({
+        foo: `-- ${token1}\n${token2}--`,
+        bar: token3,
+      });
+
+      expect(result).to.deep.equal({
+        foo: `-- ${FILTERED}\n${FILTERED}--`,
+        bar: token3,
+      });
+    });
+
+    it('filters token value in url', () => {
+      const result = CommonPiiActions.tokenValues.execute(
+        'https://foo.bar/?uid=12345678123456781234567812345678'
+      );
+      expect(result).to.equal('https://foo.bar/?uid=[Filtered]');
+    });
+
+    it('filters multiple multiline token values', () => {
+      const token = '12345678123456781234567812345678';
+      const result = CommonPiiActions.tokenValues.execute(
+        `${token}--${token}\n${token}`
+      );
+      expect(result).to.equal(`${FILTERED}--${FILTERED}\n${FILTERED}`);
+    });
+  });
+});

--- a/packages/fxa-shared/test/sentry/pii-filters.ts
+++ b/packages/fxa-shared/test/sentry/pii-filters.ts
@@ -1,0 +1,256 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/node';
+import { SQS } from 'aws-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ILogger } from '../../log';
+import { IAction, PiiData } from '../../sentry/models/pii';
+import {
+  CommonPiiActions,
+  FILTERED,
+  PiiRegexFilter,
+} from '../../sentry/pii-filter-actions';
+import {
+  FilterBase,
+  SentryPiiFilter,
+  SqsMessageFilter,
+} from '../../sentry/pii-filters';
+
+describe('pii-filters', () => {
+  describe('SentryMessageFilter', () => {
+    const sentryFilter = new SentryPiiFilter([
+      CommonPiiActions.depthFilter,
+      CommonPiiActions.urlUsernamePassword,
+      CommonPiiActions.emailValues,
+      CommonPiiActions.piiKeys,
+      CommonPiiActions.tokenValues,
+      CommonPiiActions.ipV4Values,
+      CommonPiiActions.ipV6Values,
+      new PiiRegexFilter(/foo/gi),
+    ]);
+
+    it('filters empty event', () => {
+      let event: Sentry.Event = {};
+      event = sentryFilter.filter(event);
+      expect(event).to.deep.equal({});
+    });
+
+    it('filters event', () => {
+      let event: Sentry.Event = {
+        message: 'A foo message.',
+        breadcrumbs: [
+          {
+            message: 'A foo breadcrumb',
+            data: {
+              first_name: 'foo',
+              last_name: 'bar',
+            },
+          },
+          {
+            message: 'A fine message',
+          },
+        ],
+        request: {
+          url: 'http://me:123@foo.bar/?email=foxkey@mozilla.com&uid=12345678123456781234567812345678',
+          query_string: {
+            email: 'foo',
+            uid: 'bar',
+          },
+          cookies: {
+            user: 'foo:bar',
+          },
+          env: {
+            key: '--foo',
+          },
+          headers: {
+            foo: 'a foo header',
+            bar: 'a foo bar bar header',
+            'oidc-claim': 'claim1',
+          },
+          data: {
+            info: {
+              email: 'foxkeh@mozilla.com',
+              uid: '12345678123456781234567812345678',
+            },
+            time: new Date(0).getTime(),
+          },
+        },
+        exception: {
+          values: [
+            {
+              value:
+                'Foo bar! A user with email foxkeh@mozilla.clom and ip 127.0.0.1 encountered an err.',
+            },
+          ],
+        },
+        extra: {
+          meta: {
+            email: 'foo@bar.com',
+          },
+          l1: {
+            l2: {
+              l3: {
+                l4: {
+                  l5: {
+                    l6: {
+                      l7: {
+                        l8: {
+                          l9: {
+                            l10: 'bar',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        user: {
+          meta: {
+            email: 'foo@bar.com',
+          },
+          id: 'foo123',
+          ip_address: '127.0.0.1',
+          email: 'foo@bar.com',
+          username: 'foo.bar',
+        },
+        type: 'transaction',
+        spans: undefined, // Not testing, let's be careful not put PII in spans,
+        measurements: undefined, // NA, just numbers
+        debug_meta: undefined, // NA, image data
+        sdkProcessingMetadata: undefined, // NA, not used
+      };
+
+      event = sentryFilter.filter(event);
+
+      expect(event).to.deep.equal({
+        message: 'A [Filtered] message.',
+        breadcrumbs: [
+          {
+            message: 'A [Filtered] breadcrumb',
+            data: {
+              first_name: '[Filtered]',
+              last_name: 'bar',
+            },
+          },
+          {
+            message: 'A fine message',
+          },
+        ],
+        request: {
+          url: 'http://[Filtered]:[Filtered]@[Filtered].bar/?[Filtered]&uid=[Filtered]',
+          query_string: {
+            email: '[Filtered]',
+            uid: '[Filtered]',
+          },
+          cookies: {
+            user: '[Filtered]',
+          },
+          env: {
+            key: '--[Filtered]',
+          },
+          headers: {
+            foo: 'a [Filtered] header',
+            bar: 'a [Filtered] bar bar header',
+            'oidc-claim': '[Filtered]',
+          },
+          data: {
+            info: {
+              email: '[Filtered]',
+              uid: '[Filtered]',
+            },
+            time: new Date(0).getTime(),
+          },
+        },
+        exception: {
+          values: [
+            {
+              value:
+                '[Filtered] bar! A user with email [Filtered] and ip [Filtered] encountered an err.',
+            },
+          ],
+        },
+        extra: {
+          meta: {
+            email: '[Filtered]',
+          },
+          l1: {
+            l2: {
+              l3: {
+                l4: {
+                  l5: '[Truncated]',
+                },
+              },
+            },
+          },
+        },
+        user: {
+          meta: {
+            email: '[Filtered]',
+          },
+          id: '[Filtered]123',
+          ip_address: '[Filtered]',
+          email: '[Filtered]',
+          username: '[Filtered]',
+        },
+        type: 'transaction',
+        spans: undefined, // Not testing, let's be careful not put PII in spans,
+        measurements: undefined, // NA, just numbers
+        debug_meta: undefined, // NA, image data
+        sdkProcessingMetadata: undefined, // NA, not used
+      });
+    });
+  });
+
+  describe('SqsMessageFilter', () => {
+    const sqsFilter = new SqsMessageFilter([new PiiRegexFilter(/foo/gi)]);
+
+    it('filters body', () => {
+      let msg = { Body: 'A message with foo in it.' } as SQS.Message;
+      msg = sqsFilter.filter(msg);
+
+      expect(msg).to.deep.equal({
+        Body: `A message with ${FILTERED} in it.`,
+      });
+    });
+  });
+
+  describe('Deals with Bad Filter', () => {
+    let mockLogger = <ILogger>{
+      error: () => {},
+    };
+    let sandbox = sinon.createSandbox();
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    class BadAction implements IAction {
+      execute<T extends PiiData>(val: T, depth?: number): T {
+        throw new Error('Boom');
+      }
+    }
+
+    class BadFilter extends FilterBase {
+      constructor(logger: ILogger) {
+        super([new BadAction()], logger);
+      }
+
+      filter(data: any): any {
+        return this.applyFilters(data);
+      }
+    }
+
+    it('handles errors and logs them', () => {
+      const errorStub = sandbox.stub(mockLogger, 'error');
+      const badFilter = new BadFilter(mockLogger);
+      badFilter.filter({ foo: 'bar' });
+      expect(errorStub.called).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Because

- We noticed some PII slipping into Sentry events when testing the admin panel.

## This pull request

- Applies to nestjs sentry service.
- Improves the filtering of PII data in sentry events.
- Creates an extensible pattern for adding more filters in the future.
- Checks and scrubs list of known field names that hold PII.
- Retains request body data, but limits data depth, and applies filters to data.
- Fixes issues scrubbing emails from urls. URL is not clobbered by filters anymore.
- Checks and scrubs IP addresses (v4 & v6)
- Checks exception, user, and extra fields on the SentryEvent object for PII.

## Issue that this pull request solves

Closes: #12907

## Checklist

_Put an `x` in the boxes that apply_

- [x ] My commit is GPG signed.
- [x ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This could have been accomplished more directly, but as I was testing I noticed a couple places where coverage for filtering PII could be improved, so I created these utility modules for scrubbing PII. These will also be reusable in other APIs in the future as they aren’t necessarily just for the nestjs sentry service.
