### PR TITLE
refactor(event-broker): Remove typesafe-joi dependency

### DIFF
--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -35,7 +35,6 @@
     "@google-cloud/pubsub": "^2.18.4",
     "@grpc/grpc-js": "^1.1.3",
     "@hapi/hoek": "^10.0.0",
-    "@hapi/joi": "^15.1.1",
     "@nestjs/common": "^8.4.5",
     "@nestjs/config": "^2.0.0",
     "@nestjs/core": "^8.4.5",
@@ -69,7 +68,6 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "sqs-consumer": "^5.7.0",
-    "typesafe-joi": "^2.1.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
+++ b/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as Sentry from '@sentry/node';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
-import joi from 'typesafe-joi';
+import joi from 'joi';
 
 import * as dto from './sqs.dto';
 

--- a/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
+++ b/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import joi from 'typesafe-joi';
+import joi from 'joi';
 
 // Event strings
 export const DELETE_EVENT = 'delete';
@@ -91,10 +91,48 @@ export const PROFILE_CHANGE_SCHEMA = joi
   .unknown(true)
   .required();
 
-export type deleteSchema = joi.Literal<typeof DELETE_SCHEMA>;
-export type loginSchema = joi.Literal<typeof LOGIN_SCHEMA>;
-export type passwordSchema = joi.Literal<typeof PASSWORD_CHANGE_SCHEMA>;
-export type profileSchema = joi.Literal<typeof PROFILE_CHANGE_SCHEMA>;
-export type subscriptionUpdateSchema = joi.Literal<
-  typeof SUBSCRIPTION_UPDATE_SCHEMA
->;
+export type deleteSchema = {
+  event: typeof DELETE_EVENT;
+  timestamp?: number;
+  ts: number;
+  uid: string;
+};
+
+export type loginSchema = {
+  clientId: string;
+  deviceCount: number;
+  email: string;
+  event: typeof LOGIN_EVENT;
+  service?: string;
+  timestamp?: number;
+  ts: number;
+  uid: string;
+  userAgent?: string;
+};
+
+export type passwordSchema = {
+  event: typeof PASSWORD_CHANGE_EVENT | typeof PASSWORD_RESET_EVENT;
+  timestamp?: number;
+  ts: number;
+  uid: string;
+};
+
+export type profileSchema = {
+  event: typeof PRIMARY_EMAIL_EVENT | typeof PROFILE_CHANGE_EVENT;
+  timestamp?: number;
+  ts: number;
+  uid: string;
+  email?: string;
+};
+
+export type productCapability = string;
+
+export type subscriptionUpdateSchema = {
+  event: typeof SUBSCRIPTION_UPDATE_EVENT;
+  eventCreatedAt: number;
+  isActive: boolean;
+  productCapabilities: Array<productCapability>;
+  timestamp?: number;
+  ts: number;
+  uid: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,7 +4074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hapi/joi@npm:^15.1.0, @hapi/joi@npm:^15.1.1":
+"@hapi/joi@npm:^15.1.0":
   version: 15.1.1
   resolution: "@hapi/joi@npm:15.1.1"
   dependencies:
@@ -9578,22 +9578,6 @@ __metadata:
     "@types/node": "*"
     joi: ^17.3.0
   checksum: 6a8c02367a946b66c5decccee98ae14dbbc68ab022f613eab31d055501da89f265755019f940d62da9072c5f8355d3a9f027635f8d354e9b7d572265885afb81
-  languageName: node
-  linkType: hard
-
-"@types/hapi__joi@npm:*":
-  version: 17.1.6
-  resolution: "@types/hapi__joi@npm:17.1.6"
-  checksum: 03d062e1f0122d177e9c45798c99a0bfd1559519443c1df982c4c8431ba0bb4079c4fea3b61aa7f9abc275872af2c28dacc12869f40e2c86fc17b54465d15898
-  languageName: node
-  linkType: hard
-
-"@types/hapi__joi@npm:^15.0.1":
-  version: 15.0.4
-  resolution: "@types/hapi__joi@npm:15.0.4"
-  dependencies:
-    "@types/hapi__joi": "*"
-  checksum: 711a3b63685b1b4b6d94f94348d306318e402fbec24e278e8529b725d5c6b9c817e4d01a5327f07a56e6b2d138e20171ea1cec8309328015118c34b92c91cb1b
   languageName: node
   linkType: hard
 
@@ -22602,7 +22586,6 @@ fsevents@~2.1.1:
     "@google-cloud/pubsub": ^2.18.4
     "@grpc/grpc-js": ^1.1.3
     "@hapi/hoek": ^10.0.0
-    "@hapi/joi": ^15.1.1
     "@nestjs/cli": ^8.2.5
     "@nestjs/common": ^8.4.5
     "@nestjs/config": ^2.0.0
@@ -22668,7 +22651,6 @@ fsevents@~2.1.1:
     ts-jest: ^27.1.4
     ts-loader: ^8.4.0
     tsconfig-paths: ^4.0.0
-    typesafe-joi: ^2.1.0
     typesafe-node-firestore: ^1.4.0
     typescript: ^4.5.2
     uuid: ^8.3.2
@@ -42601,19 +42583,6 @@ resolve@^2.0.0-next.3:
   version: 0.8.0
   resolution: "typedi@npm:0.8.0"
   checksum: f6fc275672945953aa3486582273a89bcf4e6c0808810a1f21332f4725d0493d1fb74fef8cdb7bc700ec8aa9c36db9a070d6a2f88c8639037185f0d78b988692
-  languageName: node
-  linkType: hard
-
-"typesafe-joi@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "typesafe-joi@npm:2.1.0"
-  dependencies:
-    "@types/hapi__joi": ^15.0.1
-    "@types/node": "*"
-  peerDependencies:
-    "@hapi/joi": ^15.0.1
-    typescript: ">=3.0.0"
-  checksum: ee2382e31d45315c21cbd7a99d611a7cb6aaf1a7709561c25e860c6387f92e1e0aefb262c0066f1d4360bf75e3ab1d2dc6ff29c60eb7b9f54c924ca870538f94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- the `typesafe-joi` dependency utilizes `@hapi/joi` v15.x, which is deprecated

## This pull request

- revises `joi<Literal>`s to regular Typescript

## Issue that this pull request solves

Closes: #13021

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
