### PR TITLE
chore(package): Remove node/npm engines from fxa-content-server/package.json

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -184,9 +184,5 @@
     "xmlhttprequest": "https://github.com/mozilla-fxa/node-XMLHttpRequest.git#onerror",
     "yargs": "^17.0.1"
   },
-  "engines": {
-    "node": ">=10",
-    "npm": ">=6.4.1"
-  },
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
## Because

- We already have a root [.nvmrc](https://github.com/mozilla/fxa/blob/main/.nvmrc) file, so having similar [but very outdated] information is confusing.

## This pull request

-

## Issue that this pull request solves

Closes: #12895 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
