### PR TITLE
chore(repo): set l10n drivers as owners of .ftl files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @mozilla/fxa-devs
+
+*.ftl @mozilla/fxa-l10n


### PR DESCRIPTION
## Because

- localization team should be notified for changes to Fluent files, so that review can happen during development instead of after landing

## This pull request

- updates CODEOWNERS with l10n project owners

## Additional note
Both flod (@flodolo ) and I (@bcolsson) may also need to be added as contributor to this repository. According to the docs we believe "read" access should be enough (or would we need "write"?).