### PR TITLE
fix(auth): Report actual error to Sentry

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -253,14 +253,11 @@ async function configureSentry(server, config, processName = 'key_server') {
       request.app.sentry.transaction.finish();
     });
 
-    // Sentry handler for hapi errors
-    server.events.on(
-      { name: 'request', channels: 'error' },
-      (request, event) => {
-        const err = (event && event.error) || null;
-        reportSentryError(err, request);
+    server.events.on('request', (request, event, tags) => {
+      if (event?.error && tags?.handler && tags?.error) {
+        reportSentryError(event.error, request);
       }
-    );
+    });
   }
 }
 


### PR DESCRIPTION
## Because

- The error messages going to sentry are often the WError: Internal Server Error, which don't contain enough info.

## This pull request

- Reports the actual error to sentry instead the WError.
- Does this by binding to the server events in a slightly different way.

## Issue that this pull request solves

Closes: #11864

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


