### PR TITLE
chore(strings): fix comment issue in fxa-settings ftl file

### DIFF
--- a/packages/fxa-settings/src/components/ConnectedServices/en-US.ftl
+++ b/packages/fxa-settings/src/components/ConnectedServices/en-US.ftl
@@ -18,11 +18,13 @@ cs-refresh-button =
 cs-missing-device-help = Missing or duplicate items?
 
 cs-disconnect-sync-heading = Disconnect from Sync
-# This string is used in a modal dialog when the user starts the disconnect from
-# Sync process.
-# Variables:
-#   $device (String) - the name of a device using Firefox Accounts
-#                      (for example: "Firefox Nightly on Google Pixel 4a")
+
+## This string is used in a modal dialog when the user starts the disconnect from
+## Sync process.
+## Variables:
+##   $device (String) - the name of a device using Firefox Accounts
+##                      (for example: "Firefox Nightly on Google Pixel 4a")
+
 cs-disconnect-sync-content-2 = Your browsing data will remain on { $device },
   but it will no longer sync with your account.
 cs-disconnect-sync-reason-2 = What’s the main reason for disconnecting { $device }?


### PR DESCRIPTION
## Because

- Current comment is single message only so localizers will be unable to see comment for all applicable strings where variable is used

## This pull request

- Changes existing comment from single message only  to group-level comment

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
