### PR TITLE
fix(l10n): add fallback text for payment and subscription errors

### DIFF
--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -13,7 +13,7 @@ import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import sentryMetrics from './lib/sentry';
 import { QueryParams } from './lib/types';
 import { Config } from './lib/config';
-import { getErrorMessage } from './lib/errors';
+import { getErrorMessageId } from './lib/errors';
 import { Store } from './store';
 import { AppContext, AppContextType } from './lib/AppContext';
 
@@ -193,7 +193,7 @@ export const AppErrorDialog = ({ error: { message } }: { error: Error }) => {
             General application error
           </h4>
         </Localized>
-        <Localized id={getErrorMessage({ code: 'api_connection_error' })}>
+        <Localized id={getErrorMessageId({ code: 'api_connection_error' })}>
           <p id={ariaDescribedBy}>
             {' '}
             Something went wrong. Please try again later.

--- a/packages/fxa-payments-server/src/components/CouponForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.test.tsx
@@ -6,10 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import CouponForm, {
-  checkPromotionCode,
-  CouponErrorMessageType,
-} from './index';
+import { CouponForm, checkPromotionCode } from './index';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { defaultAppContext, AppContext } from '../../lib/AppContext';
 import {
@@ -19,6 +16,10 @@ import {
   COUPON_DETAILS_VALID,
   SELECTED_PLAN,
 } from '../../lib/mock-data';
+import {
+  getFallbackTextByFluentId,
+  CouponErrorMessageType,
+} from '../../lib/errors';
 
 import {
   coupon_REJECTED,
@@ -124,8 +125,13 @@ describe('CouponForm', () => {
       };
 
       const { queryByTestId, getByTestId } = subject();
-      fireEvent.change(getByTestId('coupon-input'), { target: { value: 'a' } });
-      fireEvent.click(getByTestId('coupon-button'));
+
+      await waitFor(() => {
+        fireEvent.change(getByTestId('coupon-input'), {
+          target: { value: 'a' },
+        });
+        fireEvent.click(getByTestId('coupon-button'));
+      });
 
       await waitFor(() => {
         expect(queryByTestId('coupon-error')).toBeInTheDocument();
@@ -134,12 +140,16 @@ describe('CouponForm', () => {
 
       const couponError = getByTestId('coupon-error');
 
-      expect(couponError).toHaveTextContent(CouponErrorMessageType.Invalid);
+      expect(couponError).toHaveTextContent(
+        getFallbackTextByFluentId(CouponErrorMessageType.Invalid)
+      );
 
-      fireEvent.change(getByTestId('coupon-input'), {
-        target: { value: 'again' },
+      await waitFor(() => {
+        fireEvent.change(getByTestId('coupon-input'), {
+          target: { value: 'again' },
+        });
+        fireEvent.click(getByTestId('coupon-button'));
       });
-      fireEvent.click(getByTestId('coupon-button'));
 
       await waitFor(() => {
         expect(queryByTestId('coupon-error')).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -23,18 +23,15 @@ import { APIError, apiRetrieveCouponDetails } from '../../lib/apiClient';
 import { useCallbackOnce } from '../../lib/hooks';
 import AppContext from '../../lib/AppContext';
 
+import {
+  getFallbackTextByFluentId,
+  CouponErrorMessageType,
+} from '../../lib/errors';
 class CouponError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'CouponError';
   }
-}
-
-export enum CouponErrorMessageType {
-  Expired = 'coupon-error-expired',
-  LimitReached = 'coupon-error-limit-reached',
-  Invalid = 'coupon-error-invalid',
-  Generic = 'coupon-error-generic',
 }
 
 /*
@@ -242,7 +239,7 @@ export const CouponForm = ({
       {error && (
         <Localized id={error}>
           <div className="text-red-700 mt-4" data-testid="coupon-error">
-            {error}
+            {getFallbackTextByFluentId(error)}
           </div>
         </Localized>
       )}

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -3,7 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { Localized } from '@fluent/react';
 import { StripeError } from '@stripe/stripe-js';
 
-import { getErrorMessage, GeneralError } from '../../lib/errors';
+import {
+  getErrorMessageId,
+  GeneralError,
+  getFallbackTextByFluentId,
+} from '../../lib/errors';
 import errorIcon from '../../images/error.svg';
 import SubscriptionTitle, { SubscriptionTitleType } from '../SubscriptionTitle';
 import TermsAndPrivacy from '../TermsAndPrivacy';
@@ -116,13 +120,13 @@ export const PaymentErrorView = ({
     const l10nIds: string[] = [];
     const errorMessage: any[] = [];
 
-    getErrorMessage(error) === 'iap-upgrade-contact-support'
+    getErrorMessageId(error) === 'iap-upgrade-contact-support'
       ? l10nIds.push(
           'iap-upgrade-already-subscribed',
           'iap-upgrade-no-bundle-support',
           'iap-upgrade-contact-support'
         )
-      : l10nIds.push(getErrorMessage(error));
+      : l10nIds.push(getErrorMessageId(error));
 
     for (const [idx, l10nId] of l10nIds.entries()) {
       errorMessage.push(
@@ -132,7 +136,7 @@ export const PaymentErrorView = ({
           vars={{ productName, ...contentProps }}
         >
           <p className="mb-4" data-testid="error-payment-submission">
-            {l10nId}
+            {getFallbackTextByFluentId(l10nId)}
           </p>
         </Localized>
       );

--- a/packages/fxa-payments-server/src/lib/errors.test.tsx
+++ b/packages/fxa-payments-server/src/lib/errors.test.tsx
@@ -1,28 +1,49 @@
 import '@testing-library/jest-dom/extend-expect';
-import { getErrorMessage, BASIC_ERROR, PAYMENT_ERROR_1 } from './errors';
+import {
+  getFallbackTextByFluentId,
+  getErrorMessageId,
+  BASIC_ERROR,
+  PAYMENT_ERROR_1,
+} from './errors';
 
-it('returns the basic error text if undefined error type', () => {
-  expect(getErrorMessage(undefined)).toEqual(BASIC_ERROR);
-});
+describe('lib/errors', () => {
+  it('returns the basic error id if undefined error type', () => {
+    expect(getErrorMessageId(undefined)).toEqual(BASIC_ERROR);
+  });
 
-it('returns the basic error text if not predefined error type', () => {
-  expect(getErrorMessage({ code: 'NON_PREDEFINED_ERROR' })).toEqual(
-    BASIC_ERROR
-  );
-});
+  it('returns the basic error id if not predefined error type', () => {
+    expect(getErrorMessageId({ code: 'NON_PREDEFINED_ERROR' })).toEqual(
+      BASIC_ERROR
+    );
+  });
 
-it('returns the payment error text for the correct error type', () => {
-  expect(getErrorMessage({ code: 'approve_with_id' })).toEqual(PAYMENT_ERROR_1);
-});
+  it('returns the payment error id for the correct error type', () => {
+    expect(getErrorMessageId({ code: 'approve_with_id' })).toEqual(
+      PAYMENT_ERROR_1
+    );
+  });
 
-it('returns the payment error text for setup intent authentication failure', () => {
-  expect(
-    getErrorMessage({ code: 'setup_intent_authentication_failure' })
-  ).toEqual(PAYMENT_ERROR_1);
-});
+  it('returns the payment error id for setup intent authentication failure', () => {
+    expect(
+      getErrorMessageId({ code: 'setup_intent_authentication_failure' })
+    ).toEqual(PAYMENT_ERROR_1);
+  });
 
-it('returns payment error based on message if that is what is available in error map', () => {
-  expect(getErrorMessage({ code: 'test', message: 'approve_with_id' })).toEqual(
-    PAYMENT_ERROR_1
-  );
+  it('returns payment error id based on message if that is what is available in error map', () => {
+    expect(
+      getErrorMessageId({ code: 'test', message: 'approve_with_id' })
+    ).toEqual(PAYMENT_ERROR_1);
+  });
+
+  it('returns generic error message if provided error id is undefined', () => {
+    expect(getFallbackTextByFluentId(undefined)).toEqual(
+      'Something went wrong. Please try again later.'
+    );
+  });
+
+  it('returns generic error message if provided error id does not match any key in dictionary', () => {
+    expect(getFallbackTextByFluentId('foo-bar')).toEqual(
+      'Something went wrong. Please try again later.'
+    );
+  });
 });

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -45,7 +45,7 @@ import {
 
 import { FXA_NEWSLETTER_SIGNUP_ERROR } from '../../lib/newsletter';
 import { FXA_SIGNUP_ERROR } from '../../lib/account';
-import { getErrorMessage } from '../../lib/errors';
+import { getErrorMessageId, getFallbackTextByFluentId } from '../../lib/errors';
 
 import {
   updateAPIClientToken,
@@ -324,7 +324,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(FXA_SIGNUP_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(FXA_SIGNUP_ERROR))
       );
     });
 
@@ -355,7 +355,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_STRIPE_CARD_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(MOCK_STRIPE_CARD_ERROR))
       );
     });
 
@@ -385,7 +385,9 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
+        getFallbackTextByFluentId(
+          getErrorMessageId(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
+        )
       );
     });
 
@@ -415,7 +417,9 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
+        getFallbackTextByFluentId(
+          getErrorMessageId(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
+        )
       );
     });
 
@@ -438,7 +442,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_CURRENCY_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(MOCK_CURRENCY_ERROR))
       );
     });
 
@@ -593,7 +597,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(FXA_SIGNUP_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(FXA_SIGNUP_ERROR))
       );
     });
 
@@ -629,7 +633,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_GENERAL_PAYPAL_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(MOCK_GENERAL_PAYPAL_ERROR))
       );
     });
 
@@ -659,7 +663,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_GENERAL_PAYPAL_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(MOCK_GENERAL_PAYPAL_ERROR))
       );
     });
 
@@ -689,7 +693,7 @@ describe('routes/Checkout', () => {
       const paymentErrorComponent = screen.getByTestId('payment-error');
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
-        getErrorMessage(MOCK_GENERAL_PAYPAL_ERROR)
+        getFallbackTextByFluentId(getErrorMessageId(MOCK_GENERAL_PAYPAL_ERROR))
       );
     });
     describe('newsletter', () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -39,6 +39,7 @@ import {
   mockStripeElementOnChangeFns,
 } from '../../../lib/test-utils';
 import { PickPartial } from '../../../lib/types';
+import { getFallbackTextByFluentId } from '../../../lib/errors';
 
 jest.mock('../../../lib/hooks', () => {
   const refreshNonceMock = jest.fn().mockImplementation(Math.random);
@@ -909,7 +910,9 @@ describe('routes/Product/SubscriptionCreate', () => {
         code: 'card_declined',
       });
       await commonSetup();
-      expect(screen.getByText('card-error')).toBeInTheDocument();
+      expect(
+        screen.getByText(getFallbackTextByFluentId('card-error'))
+      ).toBeInTheDocument();
     });
 
     it('reports incorrect cvc', async () => {
@@ -917,7 +920,9 @@ describe('routes/Product/SubscriptionCreate', () => {
         code: 'incorrect_cvc',
       });
       await commonSetup();
-      expect(screen.getByText('card-error')).toBeInTheDocument();
+      expect(
+        screen.getByText(getFallbackTextByFluentId('card-error'))
+      ).toBeInTheDocument();
     });
 
     it('reports expired card', async () => {
@@ -925,7 +930,9 @@ describe('routes/Product/SubscriptionCreate', () => {
         code: 'expired_card',
       });
       await commonSetup();
-      expect(screen.getByText('expired-card-error')).toBeInTheDocument();
+      expect(
+        screen.getByText(getFallbackTextByFluentId('expired-card-error'))
+      ).toBeInTheDocument();
     });
 
     it('reports processing errors', async () => {
@@ -933,7 +940,9 @@ describe('routes/Product/SubscriptionCreate', () => {
         code: 'processing_error',
       });
       await commonSetup();
-      expect(screen.getByText('payment-error-1')).toBeInTheDocument();
+      expect(
+        screen.getByText(getFallbackTextByFluentId('payment-error-1'))
+      ).toBeInTheDocument();
     });
 
     it('reports stolen card error', async () => {
@@ -941,7 +950,9 @@ describe('routes/Product/SubscriptionCreate', () => {
         code: 'stolen_card',
       });
       await commonSetup();
-      expect(screen.getByText('payment-error-2')).toBeInTheDocument();
+      expect(
+        screen.getByText(getFallbackTextByFluentId('payment-error-2'))
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -21,6 +21,7 @@ import { CUSTOMER, FILTERED_SETUP_INTENT, PLAN } from '../../lib/mock-data';
 
 import { PickPartial } from '../../lib/types';
 import { defaultConfig } from '../../lib/config';
+import { getFallbackTextByFluentId } from '../../lib/errors';
 import {
   PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
   PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
@@ -103,12 +104,16 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
 
   it('renders valid expiration date', async () => {
     render(<Subject />);
-    expect(screen.queryByTestId('card-expiration-date')).toHaveTextContent('Expires February 2099');
+    expect(screen.queryByTestId('card-expiration-date')).toHaveTextContent(
+      'Expires February 2099'
+    );
   });
 
   it('does not render expiration date if date is invalid', async () => {
-    render(<Subject customer={{...CUSTOMER, exp_month: undefined}} />);
-    expect(screen.queryByTestId('card-expiration-date')).not.toBeInTheDocument();
+    render(<Subject customer={{ ...CUSTOMER, exp_month: undefined }} />);
+    expect(
+      screen.queryByTestId('card-expiration-date')
+    ).not.toBeInTheDocument();
   });
 
   it('reveals the payment update form on clicking Change button', async () => {
@@ -369,7 +374,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
-    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFallbackTextByFluentId('basic-error-message'))
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
     expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
     expect(stripeOverride.confirmCardSetup).not.toHaveBeenCalled();
@@ -391,7 +398,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
-    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFallbackTextByFluentId('basic-error-message'))
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
     expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
     expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
@@ -415,7 +424,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
-    expect(screen.getByText('expired-card-error')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFallbackTextByFluentId('expired-card-error'))
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
     expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
     expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
@@ -437,7 +448,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
-    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFallbackTextByFluentId('basic-error-message'))
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
     expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
     expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
@@ -461,7 +474,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
-    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFallbackTextByFluentId('basic-error-message'))
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
     expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
     expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
@@ -485,7 +500,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
-    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFallbackTextByFluentId('basic-error-message'))
+    ).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
     expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
     expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -10,7 +10,7 @@ import { Stripe, StripeCardElement, StripeError } from '@stripe/stripe-js';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 
 import { useNonce, usePaypalButtonSetup } from '../../lib/hooks';
-import { getErrorMessage } from '../../lib/errors';
+import { getFallbackTextByFluentId, getErrorMessageId } from '../../lib/errors';
 import { AppContext } from '../../lib/AppContext';
 import { Customer, Plan } from '../../store/types';
 
@@ -302,9 +302,9 @@ export const PaymentUpdateForm = ({
           <>
             <ErrorMessage isVisible={!!paymentError}>
               {paymentError && (
-                <Localized id={getErrorMessage(paymentError)}>
+                <Localized id={getErrorMessageId(paymentError)}>
                   <p data-testid="error-payment-submission">
-                    {getErrorMessage(paymentError)}
+                    {getFallbackTextByFluentId(getErrorMessageId(paymentError))}
                   </p>
                 </Localized>
               )}


### PR DESCRIPTION
## Because

- We want to ensure users know what the error is by providing clear fallback text instead of error ids, in the event that localization fails

## This pull request

- Adds a dictionary for fallback error messages in `errors.ts`.
- Adds a function in `errors.ts` that takes in a fluent id and returns corresponding text from aforementioned dictionary. Returns basic error message if id is undefined or not in dictionary.
- Updates templates that use the id with the text returned from the aforementioned function.
- Updates and includes some new tests

## Issue that this pull request solves

Closes: #13045

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

As per comment threads below, also updates variable and function names to remove confusion as to whether they return the error id or message.
