### PR TITLE
fix(a11y): remove duplicate ids in Connected Services

### DIFF
--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -107,8 +107,10 @@ export class TotpRow extends UnitRow {
 
 export class ConnectedServicesRow extends UnitRow {
   async services() {
-    await this.page.waitForSelector('#service');
-    const elements = await this.page.$$('#service');
+    await this.page.waitForSelector('[data-testid=settings-connected-service]');
+    const elements = await this.page.$$(
+      '[data-testid=settings-connected-service]'
+    );
     return Promise.all(
       elements.map((el) => ConnectedService.create(el, this.page))
     );

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -219,6 +219,7 @@ const SETTINGS = {
     MENU: '[data-testid=nav-link-connected-services]',
     REFRESH_BUTTON: '[data-testid=connected-services-refresh]',
     HEADER: '[data-testid=settings-connected-services]',
+    SERVICE: '[data-testid=settings-connected-service]',
     SIGN_OUT: '[data-testid=connected-service-sign-out]',
   },
   FOOTER: {

--- a/packages/fxa-content-server/tests/functional/settings/connected_services_oauth_clients.js
+++ b/packages/fxa-content-server/tests/functional/settings/connected_services_oauth_clients.js
@@ -10,6 +10,7 @@ const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
 const selectors = require('../lib/selectors');
 const FunctionalHelpers = require('../lib/helpers');
 const { createEmail } = FunctionalHelpers;
+const connectedServices = selectors.SETTINGS.CONNECTED_SERVICES;
 
 describe('connected services: oauth clients', () => {
   let email;
@@ -61,14 +62,8 @@ describe('connected services: oauth clients', () => {
     await testElementExists(selectors['123DONE'].AUTHENTICATED);
 
     // client is listed
-    await openPage(
-      config.fxaSettingsV2Root,
-      selectors.SETTINGS.CONNECTED_SERVICES.HEADER
-    );
-    await testElementTextInclude(
-      selectors.SETTINGS.CONNECTED_SERVICES.HEADER,
-      '123Done'
-    );
+    await openPage(config.fxaSettingsV2Root, connectedServices.HEADER);
+    await testElementTextInclude(connectedServices.HEADER, '123Done');
 
     await openTab(config.fxaUntrustedOauthApp);
     await switchToWindow(1);
@@ -80,24 +75,23 @@ describe('connected services: oauth clients', () => {
     await click(selectors.OAUTH_PERMISSIONS.SUBMIT);
     await testElementExists(selectors['123DONE'].AUTHENTICATED);
     await closeCurrentWindow();
+
     // refresh the list
-    await click(selectors.SETTINGS.CONNECTED_SERVICES.REFRESH_BUTTON);
-    await testElementTextInclude(
-      selectors.SETTINGS.CONNECTED_SERVICES.HEADER,
-      '321Done'
-    );
+    await click(connectedServices.REFRESH_BUTTON);
+    await testElementTextInclude(connectedServices.HEADER, '321Done');
 
     // disconnect
     await click(
-      // the current lack of unique ids make the positional selector here necessary
-      `${selectors.SETTINGS.CONNECTED_SERVICES.HEADER} #service:nth-child(3) ${selectors.SETTINGS.CONNECTED_SERVICES.SIGN_OUT}`
+      `${connectedServices.SERVICE}[data-name^="123"] ${connectedServices.SIGN_OUT}`
     );
     await pollUntilGoneByQSA(
-      `${selectors.SETTINGS.CONNECTED_SERVICES.HEADER} #service:nth-child(4) ${selectors.SETTINGS.CONNECTED_SERVICES.SIGN_OUT}`
+      `${connectedServices.SERVICE}[data-name^="123"] ${connectedServices.SIGN_OUT}`
     );
-    await click(selectors.SETTINGS.CONNECTED_SERVICES.REFRESH_BUTTON);
+
+    // refresh to confirm app and its tokens are gone
+    await click(connectedServices.REFRESH_BUTTON);
     await noSuchElement(
-      `${selectors.SETTINGS.CONNECTED_SERVICES.HEADER} #service:nth-child(4) ${selectors.SETTINGS.CONNECTED_SERVICES.SIGN_OUT}`
+      `${connectedServices.SERVICE}[data-name^="123"] ${connectedServices.SIGN_OUT}`
     );
   });
 
@@ -110,10 +104,7 @@ describe('connected services: oauth clients', () => {
     await testElementExists(selectors['123DONE'].AUTHENTICATED);
     const oldUrl = `${config.fxaSettingsV2Root}/clients`;
     // page is redirected and client list is shown
-    await openPage(oldUrl, selectors.SETTINGS.CONNECTED_SERVICES.HEADER);
-    await testElementTextInclude(
-      selectors.SETTINGS.CONNECTED_SERVICES.HEADER,
-      '123Done'
-    );
+    await openPage(oldUrl, connectedServices.HEADER);
+    await testElementTextInclude(connectedServices.HEADER, '123Done');
   });
 });

--- a/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
@@ -91,7 +91,6 @@ export function Service({
   return (
     <div
       className="my-1"
-      id="service"
       data-testid="settings-connected-service"
       data-name={name}
     >


### PR DESCRIPTION
## Because

- We want to ensure we are standards-compliant with both the web and a11y
- An id is an element's unique identifier and should not be duplicated

## This pull request

- Removes the id attribute and adds an additional class
- Updates tests to target the class

## Issue that this pull request solves

Closes: #12916

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
