### PR TITLE
style(payments): add bottom margin to subscriptions page

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -85,7 +85,7 @@ export const SettingsLayout = ({ children }: { children: ReactNode }) => {
           {breadcrumbs}
         </div>
 
-        <div id="fxa-settings">
+        <div id="fxa-settings" className="mb-12">
           <div id="fxa-settings-content" className="card">
             {children}
           </div>


### PR DESCRIPTION
## Because

- We want to improve UX and a11y
- White space improves user focus and readability, delineates sections, and reduces noise, especially with before footer content

## This pull request

- Adds margin bottom to subscriptions card, consistent with the amount of space after the last card in Account Settings

## Issue that this pull request solves

Closes: #8952

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

N/A
