### PR TITLE
chore(deps): bump jquery-modal from 0.7.1 to 0.9.2

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -100,7 +100,7 @@
     "i18n-abide": "0.0.26",
     "joi": "17.4.0",
     "jquery": "3.6.0",
-    "jquery-modal": "https://github.com/mozilla-fxa/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503",
+    "jquery-modal": "0.9.2",
     "jquery-simulate": "1.0.2",
     "jquery-ui": "1.13.1",
     "jquery-ui-touch-punch-amd": "1.0.1",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -141,7 +141,7 @@
     "hot-shots": "^9.0.0",
     "intl-pluralrules": "^1.3.1",
     "joi": "17.4.0",
-    "jquery-modal": "https://github.com/mozilla-fxa/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503",
+    "jquery-modal": "0.9.2",
     "morgan": "^1.10.0",
     "mozlog": "^3.0.2",
     "nocache": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22473,7 +22473,7 @@ fsevents@~2.1.1:
     intern: ^4.10.1
     joi: 17.4.0
     jquery: 3.6.0
-    jquery-modal: "https://github.com/mozilla-fxa/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503"
+    jquery-modal: 0.9.2
     jquery-simulate: 1.0.2
     jquery-ui: 1.13.1
     jquery-ui-touch-punch-amd: 1.0.1
@@ -22883,7 +22883,7 @@ fsevents@~2.1.1:
     intl-pluralrules: ^1.3.1
     jest: 27.5.1
     joi: 17.4.0
-    jquery-modal: "https://github.com/mozilla-fxa/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503"
+    jquery-modal: 0.9.2
     morgan: ^1.10.0
     mozlog: ^3.0.2
     nocache: ^3.0.4
@@ -28651,10 +28651,10 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"jquery-modal@https://github.com/mozilla-fxa/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503":
-  version: 0.7.1
-  resolution: "jquery-modal@https://github.com/mozilla-fxa/jquery-modal.git#commit=0576775d1b4590314b114386019f4c7421c77503"
-  checksum: 3896bd67f9e8baedcb067bed117b1b4cec52d3ac8bd31be24a5a97a7c1f930bb581e1a1150571a68b6dd4680b14933ee5aebafd93935e5299afac89eda950cd2
+"jquery-modal@npm:0.9.2":
+  version: 0.9.2
+  resolution: "jquery-modal@npm:0.9.2"
+  checksum: f9de23d6e696acb400cbc0f3614cf9ce91254f3d07db0b885ed9e17920e31036bc3e155988edaf990f90394b863c9a201da156c4ef4dbfd72a84779ee855e453
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix https://mozilla-hub.atlassian.net/browse/FXA-5279