### PR TITLE
chore(deps): bump grunt-po2json from 0.2.0 to 0.3.0

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -87,7 +87,7 @@
     "grunt-contrib-cssmin": "4.0.0",
     "grunt-contrib-htmlmin": "3.1.0",
     "grunt-file-rev": "1.0.2",
-    "grunt-po2json": "https://github.com/mozilla-fxa/grunt-po2json.git#2f415c8ac0435bf8942dc7131c3916ecd1684a46",
+    "grunt-po2json": "0.3.0",
     "grunt-remarkable": "1.1.0",
     "grunt-sri": "0.2.0",
     "grunt-text-replace": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22456,7 +22456,7 @@ fsevents@~2.1.1:
     grunt-htmllint: 0.3.0
     grunt-jsonlint: 2.1.3
     grunt-newer: 1.3.0
-    grunt-po2json: "https://github.com/mozilla-fxa/grunt-po2json.git#2f415c8ac0435bf8942dc7131c3916ecd1684a46"
+    grunt-po2json: 0.3.0
     grunt-remarkable: 1.1.0
     grunt-sri: 0.2.0
     grunt-text-replace: 0.4.0
@@ -24525,14 +24525,14 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"grunt-po2json@https://github.com/mozilla-fxa/grunt-po2json.git#2f415c8ac0435bf8942dc7131c3916ecd1684a46":
-  version: 0.2.0
-  resolution: "grunt-po2json@https://github.com/mozilla-fxa/grunt-po2json.git#commit=2f415c8ac0435bf8942dc7131c3916ecd1684a46"
+"grunt-po2json@npm:0.3.0":
+  version: 0.3.0
+  resolution: "grunt-po2json@npm:0.3.0"
   dependencies:
     po2json: "*"
   peerDependencies:
-    grunt: ">=0.4.1"
-  checksum: 2f275000e9d8554b3d4d42c519f6f7400cd4fd63df5ca5ba5b922e904cfe9af0210c091b259de49b747e23832730751c2815144cf8f79ac8c1ac37a46c55c45d
+    grunt: ~0.4.1
+  checksum: e1cb26de75d07b9dd639aaf0964a5930d06269c64dab839bc2e8f724eacf91cddb4baed0122499070e1295e408822bdee368f6bff6f03dd512cbf10c56a0c0af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Not much has changed since 0.2.0 but no need to maintain our own fork.  Fixes https://github.com/mozilla/fxa/issues/13199