### PR TITLE
fix(content): Add verify endpoint to well-known list

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/get-openid-configuration.js
+++ b/packages/fxa-content-server/server/lib/routes/get-openid-configuration.js
@@ -13,6 +13,7 @@ const jwksEndpoint = config.get('oauth_url') + '/v1/jwks';
 const revocationEndpoint = config.get('oauth_url') + '/v1/destroy';
 const tokenEndpoint = config.get('oauth_url') + '/v1/token';
 const userInfoEndpoint = config.get('profile_url') + '/v1/profile';
+const verifyEndpoint = config.get('oauth_url') + '/v1/verify';
 
 const openidConfig = {
   /*eslint-disable camelcase */
@@ -23,6 +24,7 @@ const openidConfig = {
   revocation_endpoint: revocationEndpoint,
   token_endpoint: tokenEndpoint,
   userinfo_endpoint: userInfoEndpoint,
+  verify_endpoint: verifyEndpoint,
 };
 
 const c = config.get('openid_configuration');

--- a/packages/fxa-content-server/tests/server/routes/get-openid-configuration.js
+++ b/packages/fxa-content-server/tests/server/routes/get-openid-configuration.js
@@ -12,21 +12,20 @@ var suite = {
   tests: {},
 };
 
-suite.tests[
-  '#options /.well-known/openid-configuration - CORS enabled'
-] = function () {
-  const dfd = this.async(intern._config.asyncTimeout);
+suite.tests['#options /.well-known/openid-configuration - CORS enabled'] =
+  function () {
+    const dfd = this.async(intern._config.asyncTimeout);
 
-  got(serverUrl + '/.well-known/openid-configuration', { method: 'options' })
-    .then(function (res) {
-      assert.equal(res.statusCode, 204);
-      assert.equal(res.headers['access-control-allow-origin'], '*');
-      assert.equal(res.headers['access-control-allow-methods'], 'GET');
-    })
-    .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
+    got(serverUrl + '/.well-known/openid-configuration', { method: 'options' })
+      .then(function (res) {
+        assert.equal(res.statusCode, 204);
+        assert.equal(res.headers['access-control-allow-origin'], '*');
+        assert.equal(res.headers['access-control-allow-methods'], 'GET');
+      })
+      .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
 
-  return dfd;
-};
+    return dfd;
+  };
 
 suite.tests[
   '#get /.well-known/openid-configuration - returns a JSON doc with expected values'
@@ -43,7 +42,7 @@ suite.tests[
       assert.equal(res.headers['access-control-allow-origin'], '*');
 
       var result = JSON.parse(res.body);
-      assert.equal(Object.keys(result).length, 13);
+      assert.equal(Object.keys(result).length, 14);
       assert.containsAllKeys(result, [
         'authorization_endpoint',
         'introspection_endpoint',
@@ -52,6 +51,7 @@ suite.tests[
         'revocation_endpoint',
         'token_endpoint',
         'userinfo_endpoint',
+        'verify_endpoint',
       ]);
       assert.deepEqual(result.claims_supported, openIdConfig.claims_supported);
       assert.deepEqual(


### PR DESCRIPTION
## Because

- The /v1/verify end point was not included in the /.well-known/openid-configration response.

## This pull request

- Adds the /v1/verify endpoint to the openid-configration

## Issue that this pull request solves

Closes: #13185

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

