### PR TITLE
refactor(email): Revise cadReminderSecond email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -45,7 +45,7 @@
   "postAddAccountRecovery": 6,
   "postRemoveAccountRecovery": 6,
   "cadReminderFirst": 2,
-  "cadReminderSecond": 2,
+  "cadReminderSecond": 3,
   "subscriptionAccountReminderFirst": 2,
   "subscriptionAccountReminderSecond": 2
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/en.ftl
@@ -1,4 +1,5 @@
-cadReminderSecond-subject = Final Reminder: Complete Sync Setup
+cadReminderSecond-subject-2 = Don’t miss out! Let’s finish your sync setup
 cadReminderSecond-action = Sync another device
-cadReminderSecond-title = Last reminder to sync devices!
-cadReminderSecond-description = Syncing another device with { -brand-firefox } privately keeps your bookmarks, passwords and other { -brand-firefox } data the same everywhere you use { -brand-firefox }.
+cadReminderSecond-title-2 = Don’t forget to sync!
+cadReminderSecond-description-sync = Sync your bookmarks, passwords, open tabs and more — everywhere you use { -brand-firefox }.
+cadReminderSecond-description-plus = Plus, your data is always encrypted. Only you and devices you approve can see it.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "cadReminderSecond-subject",
-    "message": "Final Reminder: Complete Sync Setup"
+    "id": "cadReminderSecond-subject-2",
+    "message": "Don’t miss out! Let’s finish your sync setup"
   },
   "action": {
     "id": "cadReminderSecond-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="cadReminderSecond-title">Last reminder to sync devices!</span>
+      <span data-l10n-id="cadReminderSecond-title-2">Don’t forget to sync!</span>
     </mj-text>
     <mj-image width="240px" css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
   </mj-column>
@@ -14,7 +14,11 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="cadReminderSecond-description">Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.</span>
+      <span data-l10n-id="cadReminderSecond-description-sync">Sync your bookmarks, passwords, open tabs and more — everywhere you use Firefox.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="cadReminderSecond-description-plus">Plus, your data is always encrypted. Only you and devices you approve can see it.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'cadReminderSecond',
-  'Sent 72 hours after a user clicks "send me a reminder" on the connect another device page. At the time of writing, it cannot be triggered in staging (FXA-4515).',
+  'Sent 72 hours after a user clicks "send me a reminder" on the connect another device page.',
   cadReminderFirst.CadReminderDefault.args.variables
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.txt
@@ -1,6 +1,8 @@
-cadReminderSecond-title = "Last reminder to sync devices!"
+cadReminderSecond-title-2 = "Don’t forget to sync!"
 
-cadReminderSecond-description = "Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox."
+cadReminderSecond-description-sync = "Sync your bookmarks, passwords, open tabs and more — everywhere you use Firefox."
+
+cadReminderSecond-description-plus = "Plus, your data is always encrypted. Only you and devices you approve can see it."
 
 <%- link %>
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -240,7 +240,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       {...x, productName: undefined})}],
 
   ['cadReminderSecondEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Final Reminder: Complete Sync Setup' }],
+    ['subject', { test: 'equal', expected: 'Don’t miss out! Let’s finish your sync setup' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-second', 'connect-device') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderSecond') }],
@@ -248,8 +248,9 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.cadReminderSecond }],
     ])],
     ['html', [
-      { test: 'include', expected: 'Last reminder to sync devices!' },
-      { test: 'include', expected: 'Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: 'Don’t forget to sync!' },
+      { test: 'include', expected: 'Sync your bookmarks, passwords, open tabs and more — everywhere you use Firefox.' },
+      { test: 'include', expected: 'Plus, your data is always encrypted. Only you and devices you approve can see it.' },
       { test: 'include', expected: decodeUrl(configHref('syncUrl', 'cad-reminder-second', 'connect-device')) },
       { test: 'include', expected: decodeUrl(config.smtp.androidUrl) },
       { test: 'include', expected: decodeUrl(config.smtp.iosUrl) },
@@ -259,8 +260,9 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: 'alt="Devices"' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Last reminder to sync devices!' },
-      { test: 'include', expected: 'Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: 'Don’t forget to sync!' },
+      { test: 'include', expected: 'Sync your bookmarks, passwords, open tabs and more — everywhere you use Firefox.' },
+      { test: 'include', expected: 'Plus, your data is always encrypted. Only you and devices you approve can see it.' },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-second', 'privacy')}` },
       { test: 'include', expected: config.smtp.syncUrl },
       { test: 'notInclude', expected: config.smtp.androidUrl },


### PR DESCRIPTION
## Because

- we are updating email copy

## This pull request

- updates the email copy for cadReminderSecond:
  - [x] description in Storybook: Sent 72 hours after a user clicks "send me a reminder" on the connect another device page (new)
  - [x] updates the email subject: Don’t miss out! Let’s finish your sync setup
  - [x] updates the email body in HTML and TXT: 
  ```
        Don’t forget to sync!
        [image]
        Sync your bookmarks, passwords, open tabs and more – everywhere you use Firefox.
        Plus, your data is always encrypted. Only you and devices you approve can see it.
  ```

## Issue that this pull request solves

Closes: #13041 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before
<img width="1323" alt="Screen Shot 2022-06-09 at 8 56 23 AM" src="https://user-images.githubusercontent.com/28129806/172852488-44d3132d-95a4-4a34-bed9-27d3db9687d7.png">

After
<img width="1313" alt="Screen Shot 2022-06-09 at 8 46 19 AM" src="https://user-images.githubusercontent.com/28129806/172852519-3c4f4bd2-e792-4181-bf34-61b0ce6e47a8.png">
