### PR TITLE
feat(devices): adds filter query parameter to get_devices api

### DIFF
--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -29,7 +29,10 @@ module.exports = (log, db, devices, clientUtils) => {
         },
         validate: {
           query: isA.object({
-            filterIdleDevicesTimestamp: isA.number().description(DESCRIPTIONS.filterIdleDevicesTimestamp).optional()
+            filterIdleDevicesTimestamp: isA
+              .number()
+              .description(DESCRIPTIONS.filterIdleDevicesTimestamp)
+              .optional(),
           }),
         },
         response: {
@@ -87,19 +90,20 @@ module.exports = (log, db, devices, clientUtils) => {
           },
           deviceList: async () => {
             let devices = await request.app.devices;
-            
-            // To help reduce duplicate devices and help improve send tab 
-            // performance a client can request to filter device last access 
+
+            // To help reduce duplicate devices
+            // a client can request to filter device last access
             // time by a specified number of days. For reference, Sync currently
-            // considers devices that have been accessed in the last 21 days to 
+            // considers devices that have been accessed in the last 21 days to
             // be active.
-            const idleDeviceTimestamp = request.query.filterIdleDevicesTimestamp;
+            const idleDeviceTimestamp =
+              request.query.filterIdleDevicesTimestamp;
             if (idleDeviceTimestamp) {
               devices = devices.filter((device) => {
                 return device.lastAccessTime > idleDeviceTimestamp;
               });
             }
-            
+
             return devices;
           },
           oauthClients: async () => {


### PR DESCRIPTION
## Because

- We want to be able to filter idle/outdated send tab targets, and those are returned from the `/devices` api

## This pull request

- Adds the same `filterIdleDevicesTimestamp` query parameter that was added in #12879 to the GET `/devices` api

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
