### PR TITLE
fix(a11y): updates a11y on dropdown bento menu

### DIFF
--- a/packages/fxa-settings/src/components/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.test.tsx
@@ -3,41 +3,39 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import BentoMenu from '.';
 
 describe('BentoMenu', () => {
+  const dropDownId = 'drop-down-bento-menu';
+
   it('renders and toggles as expected with default values', () => {
     render(<BentoMenu />);
 
     const toggleButton = screen.getByTestId('drop-down-bento-menu-toggle');
-    const dropDown = screen.queryByTestId('drop-down-bento-menu');
 
     expect(toggleButton).toHaveAttribute('title', 'Firefox Bento Menu');
-    expect(toggleButton).toHaveAttribute(
-      'aria-controls',
-      'drop-down-bento-menu'
-    );
+    expect(toggleButton).toHaveAttribute('aria-label', 'Firefox Bento Menu');
+    expect(toggleButton).toHaveAttribute('aria-haspopup', 'menu');
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(dropDown).not.toBeInTheDocument();
+    expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
 
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
-    expect(dropDown).toBeInTheDocument;
+    expect(screen.queryByTestId(dropDownId)).toBeInTheDocument();
 
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-    expect(dropDown).not.toBeInTheDocument();
+    expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 
   it('closes on esc keypress', () => {
     render(<BentoMenu />);
-    const dropDown = screen.queryByTestId('drop-down-bento-menu');
 
     fireEvent.click(screen.getByTestId('drop-down-bento-menu-toggle'));
-    expect(dropDown).toBeInTheDocument;
+    expect(screen.queryByTestId(dropDownId)).toBeInTheDocument();
     fireEvent.keyDown(window, { key: 'Escape' });
-    expect(dropDown).not.toBeInTheDocument();
+    expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 
   it('closes on click outside', () => {
@@ -48,11 +46,10 @@ describe('BentoMenu', () => {
         </div>
       </div>
     );
-    const dropDown = screen.queryByTestId('drop-down-bento-menu');
 
     fireEvent.click(screen.getByTestId('drop-down-bento-menu-toggle'));
-    expect(dropDown).toBeInTheDocument;
+    expect(screen.queryByTestId(dropDownId)).toBeInTheDocument();
     fireEvent.click(container);
-    expect(dropDown).not.toBeInTheDocument();
+    expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/components/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.tsx
@@ -27,18 +27,24 @@ export const BentoMenu = () => {
   const dropDownId = 'drop-down-bento-menu';
   const iconClassNames = 'inline-block w-5 -mb-1 ltr:pr-1 rtl:pl-1';
   const { l10n } = useLocalization();
+  const bentoMenuTitle = l10n.getString(
+    'bento-menu-title',
+    null,
+    'Firefox Bento Menu'
+  );
 
   return (
     <div className="relative self-center flex" ref={bentoMenuInsideRef}>
       <button
         onClick={toggleRevealed}
         data-testid="drop-down-bento-menu-toggle"
-        title={l10n.getString('bento-menu-title', null, 'Firefox Bento Menu')}
-        aria-expanded={isRevealed}
-        aria-controls={dropDownId}
+        title={bentoMenuTitle}
+        aria-label={bentoMenuTitle}
+        aria-expanded={!!isRevealed}
+        aria-haspopup="menu"
         className="rounded p-1 w-7 mx-2 border-transparent hover:bg-grey-200 transition-standard desktop:mx-8"
       >
-        <BentoIcon className="cursor-pointer" />
+        <BentoIcon />
       </button>
 
       {isRevealed && (
@@ -47,10 +53,11 @@ export const BentoMenu = () => {
           data-testid={dropDownId}
           className={`w-full h-full fixed top-0 ltr:left-0 rtl:right-0 bg-white z-10
                       mobileLandscape:h-auto mobileLandscape:drop-down-menu mobileLandscape:top-10 mobileLandscape:ltr:-left-52 mobileLandscape:rtl:-right-52 desktop:ltr:-left-50 desktop:rtl:-right-50`}
+          role="menu"
         >
           <div className="flex flex-wrap">
             <div className="flex w-full pt-4 items-center flex-col tablet:w-auto tablet:relative">
-              <button type="button" onClick={closeFn} title="Close">
+              <button onClick={closeFn} title="Close">
                 <CloseIcon
                   width="16"
                   height="16"

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -55,7 +55,8 @@ describe('DropDownAvatarMenu', () => {
     const toggleButton = screen.getByTestId('drop-down-avatar-menu-toggle');
 
     expect(toggleButton).toHaveAttribute('title', 'Firefox account menu');
-    expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
+    expect(toggleButton).toHaveAttribute('aria-label', 'Firefox account menu');
+    expect(toggleButton).toHaveAttribute('aria-haspopup', 'menu');
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
 

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -22,6 +22,11 @@ export const DropDownAvatarMenu = () => {
   const alertBar = useAlertBar();
   const dropDownId = 'drop-down-avatar-menu';
   const { l10n } = useLocalization();
+  const dropDownMenuTitle = l10n.getString(
+    'drop-down-menu-title',
+    null,
+    'Firefox account menu'
+  );
 
   const signOut = async () => {
     if (session.destroy) {
@@ -45,16 +50,12 @@ export const DropDownAvatarMenu = () => {
     <>
       <div className="relative" ref={avatarMenuInsideRef}>
         <button
-          type="button"
           onClick={toggleRevealed}
           data-testid="drop-down-avatar-menu-toggle"
-          title={l10n.getString(
-            'drop-down-menu-title',
-            null,
-            'Firefox account menu'
-          )}
-          aria-expanded={isRevealed}
-          aria-controls={dropDownId}
+          title={dropDownMenuTitle}
+          aria-label={dropDownMenuTitle}
+          aria-expanded={!!isRevealed}
+          aria-haspopup="menu"
           className="rounded-full border-2 border-transparent hover:border-purple-500 focus:border-purple-500 focus:outline-none active:border-purple-700 transition-standard"
         >
           <Avatar className="w-10 rounded-full" />
@@ -64,6 +65,7 @@ export const DropDownAvatarMenu = () => {
             id={dropDownId}
             data-testid={dropDownId}
             className="drop-down-menu ltr:-left-52 rtl:-right-52"
+            role="menu"
           >
             <div className="flex flex-wrap">
               <div className="flex w-full p-4 items-center">


### PR DESCRIPTION
## Because

- We want to ensure all user interactions meet accessibility standards

## This pull request

- Adds aria-label along with title for increased screen reader support
- Replaces aria-controls with aria-haspopup for increased a11y support

## Issue that this pull request solves

Closes: #12915

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
