### PR TITLE
fix(lint): Tweak some stylelint configs and fix content-server issues

### DIFF
--- a/_dev/.stylelintrc
+++ b/_dev/.stylelintrc
@@ -1,12 +1,12 @@
 {
   "ignoreFiles": [
-    "../packages/fxa-content-server/**"
+    "../packages/**/tailwind.out.scss"
   ],
   "extends": "stylelint-config-prettier",
   "rules": {
     "declaration-empty-line-before": "never",
     "selector-max-id": [
-      0,
+      2,
       {
         "message": "Using ID selectors is discouraged",
         "severity": "warning"
@@ -16,16 +16,20 @@
       true,
       {
         "ignoreAtRules": [
-          "tailwind",
+          "at-root",
+          "each",
+          "else",
+          "error",
+          "extend",
           "function",
           "if",
-          "each",
           "include",
+          "layer",
           "mixin",
-          "use",
-          "extend",
+          "return",
           "screen",
-          "layer"
+          "tailwind",
+          "use"
         ]
       }
     ]

--- a/_dev/.stylelintrc
+++ b/_dev/.stylelintrc
@@ -26,6 +26,7 @@
           "include",
           "layer",
           "mixin",
+          "responsive",
           "return",
           "screen",
           "tailwind",

--- a/packages/fxa-content-server/app/styles/_mixins.scss
+++ b/packages/fxa-content-server/app/styles/_mixins.scss
@@ -125,7 +125,6 @@
 
 @mixin message-box($background-color, $text-color) {
   @include body10();
-
   background: $background-color;
   border-radius: 4px;
   color: $text-color;

--- a/packages/fxa-content-server/app/styles/_state.scss
+++ b/packages/fxa-content-server/app/styles/_state.scss
@@ -26,7 +26,6 @@
 
 .success {
   @include message-box($success-background-color, $success-text-color);
-
   display: none;
   margin-bottom: 10px;
 }

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -1,7 +1,6 @@
 #main-content::before {
   $firefox-standalone-logo-size-large: 82px;
   $firefox-standalone-logo-size-small: 56px;
-
   background-image: image-url('firefox-logo.svg');
   background-position: center center;
   background-repeat: no-repeat;

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -162,7 +162,6 @@ hr {
     display: flex;
     flex-direction: row;
 
-    /* stylelint-disable no-descending-specificity */
     input[type="checkbox"] {
       flex: 0 0 18px;
       margin-right: 16px;
@@ -173,7 +172,6 @@ hr {
         background-image: url("images/check.svg");
       }
     }
-    /* stylelint-enable no-descending-specificity */
 
     .label-text {
       display: block;

--- a/packages/fxa-settings/src/styles/drop-down-menu.scss
+++ b/packages/fxa-settings/src/styles/drop-down-menu.scss
@@ -4,21 +4,18 @@
 
 @tailwind screens;
 
-/* stylelint-disable */
 @responsive {
-    .drop-down-menu {
-      @apply w-64 bg-white absolute shadow-md rounded-lg;
-    }
-    .drop-down-menu::before {
-      content: '';
-      @apply caret-top absolute -top-3;
-    }
-    [dir=ltr] .drop-down-menu::before {
-      @apply left-55;
-    }
-    [dir=rtl] .drop-down-menu::before {
-      @apply right-55;
-    }
-
+  .drop-down-menu {
+    @apply w-64 bg-white absolute shadow-md rounded-lg;
   }
-  /* stylelint-enable */
+  .drop-down-menu::before {
+    content: "";
+    @apply caret-top absolute -top-3;
+  }
+  [dir="ltr"] .drop-down-menu::before {
+    @apply left-55;
+  }
+  [dir="rtl"] .drop-down-menu::before {
+    @apply right-55;
+  }
+}


### PR DESCRIPTION
## Because

- Stylelint had some errors/warnings. Now it doesn't.

## This pull request

- Ignores generated Tailwind files. FACT.
- Unignores fxa-content-server files. FACT.
- Fixes existing errors/warnings. FACT.
- Temporarily [famous last words] the `selector-max-id` rule by letting us have two ID selectors. FACT.
- Gets us closer to solving all the world's issues; one linter at a time. FACT-_ish_.

## This pull request DOESN'T

- Enforce additional stylelint rules, per https://github.com/mozilla/fxa/issues/11762#issuecomment-1023447957, although I'm still strongly in "Team Let's Do That in the Future" camp.

## Issue that this pull request solves

Closes: #13239 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
