### PR TITLE
fix(a11y): add missing landmarks to Subscriptions page

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -53,18 +53,22 @@ export const SettingsLayout = ({ children }: { children: ReactNode }) => {
   const { config } = useContext(AppContext);
   const homeURL = `${config.servers.content.url}/settings`;
   let breadcrumbs = (
-    <ol className="breadcrumbs" data-testid="breadcrumbs">
-      <li>
-        <Localized id="settings-home">
-          <a href={homeURL}>Account Home</a>
-        </Localized>
-      </li>
-      <li>
-        <Localized id="settings-subscriptions-title">
-          <a href="/subscriptions">Subscriptions</a>
-        </Localized>
-      </li>
-    </ol>
+    <nav aria-label="breadcrumbs" data-testid="breadcrumbs">
+      <ol className="breadcrumbs">
+        <li>
+          <Localized id="settings-home">
+            <a href={homeURL}>Account Home</a>
+          </Localized>
+        </li>
+        <li>
+          <Localized id="settings-subscriptions-title">
+            <a href="/subscriptions" aria-current="location">
+              Subscriptions
+            </a>
+          </Localized>
+        </li>
+      </ol>
+    </nav>
   );
 
   return (

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -206,7 +206,7 @@ export const PaymentUpdateForm = ({
     .format('MMMM YYYY');
 
   return (
-    <div className="settings-unit">
+    <section className="settings-unit" aria-labelledby="payment-information">
       <div className="payment-update" data-testid="payment-update">
         {stripeSubmitInProgress && (
           <AlertBar className="alert alertPending">
@@ -264,7 +264,7 @@ export const PaymentUpdateForm = ({
           </DialogMessage>
         )}
 
-        <header>
+        <header id="payment-information">
           <h2 className="billing-title">
             <Localized id="sub-update-payment-title">
               <span className="title">Payment information</span>
@@ -311,7 +311,7 @@ export const PaymentUpdateForm = ({
           </>
         )}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -44,6 +44,11 @@ export const SubscriptionItem = ({
   const paymentProvider: PaymentProvider | undefined =
     customer?.payment_provider;
   const promotionCode = customerSubscription.promotion_code;
+  // labelId is used as the landmark identifier for each product section
+  // if no plan exists, this would result in "subscription-undefined"
+  // however, the existence of plan is checked in the following line,
+  // preventing any mislabelled landmarks from ever getting used
+  const labelId = 'subscription-' + plan?.product_id;
 
   if (!plan) {
     // TODO: This really shouldn't happen, would mean the user has a
@@ -79,9 +84,9 @@ export const SubscriptionItem = ({
   }
 
   return (
-    <div className="settings-unit">
+    <section className="settings-unit" aria-labelledby={labelId}>
       <div className="subscription" data-testid="subscription-item">
-        <header>
+        <header id={labelId}>
           <h2>{plan.product_name}</h2>
         </header>
 
@@ -113,7 +118,7 @@ export const SubscriptionItem = ({
           </>
         )}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -312,9 +312,15 @@ export const Subscriptions = ({
 
       <div className="child-views" data-testid="subscription-management-loaded">
         <div className="settings-child-view support">
-          <div className="settings-unit">
+          <section
+            className="settings-unit"
+            aria-labelledby="subscriptions-support"
+          >
             <div className="settings-unit-stub">
-              <header className="settings-unit-summary">
+              <header
+                id="subscriptions-support"
+                className="settings-unit-summary"
+              >
                 <Localized id="settings-subscriptions-title">
                   <h2>Subscriptions</h2>
                 </Localized>
@@ -329,7 +335,7 @@ export const Subscriptions = ({
                 </Localized>
               </button>
             </div>
-          </div>
+          </section>
 
           {customer.result && showPaymentUpdateForm && (
             <PaymentUpdateForm
@@ -391,13 +397,13 @@ export const Subscriptions = ({
                 ))
             )}
 
-          <div className="settings-unit">
+          <section className="settings-unit" aria-labelledby="pocket-external">
             <div className="subscription pocket-external">
               <div>
                 <PocketIcon className="pocket-icon" />
               </div>
               <div>
-                <p data-testid="manage-pocket-title">
+                <p id="pocket-external" data-testid="manage-pocket-title">
                   <Localized id="manage-pocket-title">
                     <b>Looking for your Pocket Premium subscription?</b>
                   </Localized>
@@ -428,7 +434,7 @@ export const Subscriptions = ({
                 </Localized>
               </div>
             </div>
-          </div>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Because

* We want to ensure that our pages meet accessibility standards

## This pull request

* Adds landmarks to the following areas:
  1. Breadcrumbs
  2. Subscriptions/Contact Support row
  3. Payment information row
  4. Subscription item row(s)
  5. Pocket external row

## Issue that this pull request solves

Closes: #12920

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
