### PR TITLE
fix(admin-panel): Fix link to 'Manage Subscriptions' 

### DIFF
--- a/packages/fxa-admin-server/pm2.config.js
+++ b/packages/fxa-admin-server/pm2.config.js
@@ -17,7 +17,7 @@ module.exports = {
       max_restarts: '1',
       min_uptime: '2m',
       env: {
-        CONFIG_FILES: 'src/config/secrets.json',
+        CONFIG_FILES: 'secrets.json',
         PATH,
         NODE_ENV: 'development',
         TS_NODE_TRANSPILE_ONLY: 'true',

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -12,12 +12,6 @@ convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
 
 const conf = convict({
-  returnUrl: {
-    default: 'https://fxa-admin-panel.prod.mozaws.net/account-search',
-    doc: 'A url that a user can be redirected back to after completing a remote work flow.',
-    env: 'ADMIN_PANEL_RETURN_URL',
-    format: String,
-  },
   authHeader: {
     default: USER_EMAIL_HEADER,
     doc: 'Authentication header that should be logged for the user',
@@ -529,17 +523,16 @@ const conf = convict({
   },
 });
 
-// handle configuration files.  you can specify a CSV list of configuration
-// files to process, which will be overlayed in order, in the CONFIG_FILES
-// environment variable.
-
-// Need to move two dirs up as we're in the compiled directory now
-const configDir = path.dirname(path.dirname(__dirname));
-let envConfig = path.join(configDir, 'config', `${conf.get('env')}.json`);
-envConfig = `${envConfig},${process.env.CONFIG_FILES || ''}`;
-
-const files = envConfig.split(',').filter(fs.existsSync);
-conf.loadFile(files);
+const configDir = path.join(__dirname, 'config');
+const envConfig = path.join(configDir, `${conf.get('env')}.json`);
+const configFiles =
+  process.env.CONFIG_FILES?.split(',')
+    .map((x) => path.join(configDir, x))
+    .join(',') || '';
+const existingConfigFiles = `${envConfig},${configFiles}`
+  .split(',')
+  .filter(fs.existsSync);
+conf.loadFile(existingConfigFiles);
 conf.validate();
 const Config = conf;
 

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.spec.ts
@@ -15,7 +15,6 @@ import {
   MockMetricsFactory,
   MockStripeFactory,
 } from '../mocks';
-import { FirestoreFactory } from './firestore.service';
 import {
   iapPurchaseToPlan,
   StripePaymentConfigManagerService,
@@ -98,18 +97,12 @@ describe('Stripe Service', () => {
   let service: StripeService;
 
   const mockLookupLatestInvoice = jest.fn();
-  const mockCreateManageSubscriptionLink = jest.fn();
   const MockStripeFactory: Provider = {
     provide: 'STRIPE',
     useFactory: () => {
       return {
         invoices: {
           retrieve: mockLookupLatestInvoice,
-        },
-        billingPortal: {
-          sessions: {
-            create: mockCreateManageSubscriptionLink,
-          },
         },
         on: jest.fn(),
       };
@@ -128,7 +121,6 @@ describe('Stripe Service', () => {
 
   beforeEach(async () => {
     mockLookupLatestInvoice.mockClear();
-    mockCreateManageSubscriptionLink.mockClear();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StripeService,
@@ -189,21 +181,11 @@ describe('Stripe Service', () => {
 
   it('creates manage subscription link', async () => {
     const customerId = 'customer-123';
-    const returnUrl = 'http://fxa-admin-panel/account-search';
-    const manageSessionUrl = 'http://www.foo.bar/manage-session';
-    mockCreateManageSubscriptionLink.mockImplementation(async () => ({
-      url: manageSessionUrl,
-    }));
+    const manageSessionUrl =
+      'https://dashboard.stripe.com/customers/customer-123';
 
-    const result1 = await service.createManageSubscriptionLink(
-      customerId,
-      returnUrl
-    );
+    const result1 = await service.createManageSubscriptionLink(customerId);
 
-    expect(mockCreateManageSubscriptionLink).toBeCalledWith({
-      customer: customerId,
-      return_url: returnUrl,
-    });
     expect(result1).toEqual(manageSessionUrl);
   });
 

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -82,6 +82,7 @@ export class StripeFirestoreService extends StripeFirestore {
 
 @Injectable()
 export class StripeService extends StripeHelper {
+  protected readonly isTestingApi: boolean;
   public override readonly stripe: Stripe;
   protected override readonly stripeFirestore: StripeFirestore;
   protected override readonly paymentConfigManager?:
@@ -104,6 +105,7 @@ export class StripeService extends StripeHelper {
     };
     super(config, metrics, logger);
 
+    this.isTestingApi = /sk_test/.test(config.subscriptions.stripeApiKey);
     this.stripe = stripe;
     this.stripeFirestore = stripeFirestore;
     this.paymentConfigManager = paymentConfigManager;
@@ -137,21 +139,16 @@ export class StripeService extends StripeHelper {
   }
 
   /**
-   * Starts a management session for the customer's subscriptions.
+   * Links to customer's stripe dashboard
    * @param customer - stripe customer
+   * @returns link to stripe dashboard
    */
   public async createManageSubscriptionLink(
-    customer: string | Stripe.Customer | Stripe.DeletedCustomer,
-    returnUrl: string
+    customer: string | Stripe.Customer | Stripe.DeletedCustomer
   ) {
     let customerId = typeof customer === 'string' ? customer : customer.id;
-
-    const resp = await this.stripe.billingPortal.sessions.create({
-      customer: customerId,
-      return_url: returnUrl,
-    });
-
-    return resp.url;
+    let test = this.isTestingApi ? 'test/' : '';
+    return `https://dashboard.stripe.com/${test}customers/${customerId}`;
   }
 }
 export type SkuKey =

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
@@ -71,8 +71,8 @@ describe('Subscription Service', () => {
   const productId = 'product-123';
   const productName = 'product 123';
   const subscriptionId = 'subscription-123';
-  const manageSubscriptionLink = 'http://foo.bar/manage-session/123';
-  const returnUrl = 'http://foo.bar/account-search';
+  const manageSubscriptionLink =
+    'https://dashboard.stripe.com/test/customers/customer-123';
   const latestInvoice = 'invoice-123';
   const currentPeriodStart = created;
   const currentPeriodEnd = addDays(created, 30);
@@ -104,7 +104,6 @@ describe('Subscription Service', () => {
     mockConfigOverrides['featureFlags.subscriptions.appStore'] = true;
     mockConfigOverrides['featureFlags.subscriptions.playStore'] = true;
     mockConfigOverrides['featureFlags.subscriptions.stripe'] = true;
-    mockConfigOverrides['returnUrl'] = returnUrl;
 
     mockAllAbbrevPlans.mockClear();
     mockFetchCustomers.mockClear();
@@ -214,10 +213,7 @@ describe('Subscription Service', () => {
     ]);
     expect(mockAllAbbrevPlans).toBeCalledTimes(1);
     expect(mockFetchCustomers).toBeCalledWith(uid, ['subscriptions']);
-    expect(mockCreateManageSubscriptionLink).toBeCalledWith(
-      customerId,
-      returnUrl
-    );
+    expect(mockCreateManageSubscriptionLink).toBeCalledWith(customerId);
     expect(mockAppStoreGetSubscriptions).toBeCalledWith(uid);
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
   });

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
@@ -36,11 +36,6 @@ export class SubscriptionsService {
     return this.configService.get('featureFlags.subscriptions.stripe');
   }
 
-  /** A return URL that stripe can redirect to after a user completes a workflow. */
-  protected get returnUrl() {
-    return this.configService.get('returnUrl');
-  }
-
   /**
    * Create new SubscriptionService instance
    * @param logger - logging module
@@ -111,8 +106,7 @@ export class SubscriptionsService {
 
       const manageSubscriptionLink =
         await this.stripeService.createManageSubscriptionLink(
-          subscription.customer,
-          this.returnUrl
+          subscription.customer
         );
 
       yield StripeFormatter.toMozSubscription(


### PR DESCRIPTION
## Because

- The link to the customer portal session was unnecessary.
- We can link directly to the customer dashboard instead.

## This pull request

- Switches link to point directly at the stripe customer dashboard.
- Updates tests.
- Fixes issue loading the current env's .json config file.

## Issue that this pull request solves

Closes: #13245

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

