### PR TITLE
fix(email): Revise footer to add conditional for account finish setup

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -80,18 +80,20 @@
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;
 
               <a href="<%- subscriptionPrivacyUrl %>" class="footer-link" data-l10n-id="subplat-privacy-notice">Privacy notice</a>
-              &nbsp;&nbsp;&bull;&nbsp;&nbsp;
             <% } %>
 
-            <% if (locals.isCancellationEmail) { %>
-              <a href="<%- reactivateSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-reactivate">Reactivate subscription</a>
+            <% if (!locals.isFinishSetup) { %>
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-            <% } else { %>
-              <a href="<%- cancelSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-cancel">Cancel subscription</a>
-              &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-            <% } %>
+              <% if (locals.isCancellationEmail) { %>
+                <a href="<%- reactivateSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-reactivate">Reactivate subscription</a>
+                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+              <% } else { %>
+                <a href="<%- cancelSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-cancel">Cancel subscription</a>
+                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+              <% } %>
 
-            <a href="<%- updateBillingUrl %>" class="footer-link" data-l10n-id="subplat-update-billing">Update billing information</a>
+              <a href="<%- updateBillingUrl %>" class="footer-link" data-l10n-id="subplat-update-billing">Update billing information</a>
+            <% } %>
           </mj-text>
         <% } else { %>
           <mj-text css-class="footer-text">

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -11,6 +11,7 @@ subplat-privacy-plaintext = "Privacy notice:"
 <%- subscriptionPrivacyUrl %>
 <% } %>
 
+<% if (!locals.isFinishSetup) { %>
 <% if (locals.isCancellationEmail) { %>
 subplat-reactivate-plaintext = "Reactivate subscription:"
 <%- reactivateSubscriptionUrl %>
@@ -21,6 +22,7 @@ subplat-cancel-plaintext = "Cancel subscription:"
 
 subplat-update-billing-plaintext = "Update billing information:"
 <%- updateBillingUrl %>
+<% } %>
 <% } else { %>
 subplat-privacy-policy-plaintext = "Mozilla Privacy Policy:"
 <%- privacyUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/index.stories.ts
@@ -17,6 +17,7 @@ const createStory = subplatStoryWithProps(
     icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     link: 'http://localhost:3030/post_verify/finish_account_setup/set_password',
     subscriptionSupportUrl: 'http://localhost:3030/support',
+    isFinishSetup: true,
   }
 );
 


### PR DESCRIPTION
## Because

- the `subscriptionAccountFinishSetup` email encourages users to create a password, but has "Cancel subscription" and "Update billing information" links in the footer, which redirects users to a Sign In page when they do not have a password yet and causes an Invalid redirectTo alert.

## This pull request

- removes the footer links in the HTML and TXT emails, per confirmation from Legal

## Issue that this pull request solves

Closes: #12108

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before 
<img width="1254" alt="Screen Shot 2022-06-14 at 10 14 56 AM" src="https://user-images.githubusercontent.com/28129806/173599350-1a040151-e8c6-435b-a461-07d0f6b3c97a.png">

After
<img width="1353" alt="Screen Shot 2022-06-13 at 3 55 43 PM" src="https://user-images.githubusercontent.com/28129806/173436077-e81953f6-ffbd-4ab0-af70-a8adc557614c.png">

