### PR TITLE
feat(auth): copy paypal name into stripe record

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/client.ts
@@ -113,6 +113,8 @@ type BAUpdateData = {
   BILLINGAGREEMENTSTATUS: string;
   EMAIL: string;
   PAYERSTATUS: string;
+  FIRSTNAME: string;
+  LASTNAME: string;
 };
 
 type BillToAddressData = {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -442,9 +442,9 @@ export class PayPalHandler extends StripeWebhookHandler {
           locationDetails.state = stateNames[country][state];
         }
       }
-      this.stripeHelper.updateCustomerBillingAddress(
-        accountCustomer.stripeCustomerId,
-        {
+      this.stripeHelper.updateCustomerBillingAddress({
+        customerId: accountCustomer.stripeCustomerId,
+        options: {
           city: agreementDetails.city,
           country: agreementDetails.countryCode,
           line1: agreementDetails.street,
@@ -452,8 +452,9 @@ export class PayPalHandler extends StripeWebhookHandler {
           postalCode: agreementDetails.zip,
           state: agreementDetails.state,
           ...locationDetails,
-        }
-      );
+        },
+        name: `${agreementDetails.firstName} ${agreementDetails.lastName}`,
+      });
     }
 
     // Verify sourceCountry and plan currency are a valid combination.

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -581,6 +581,26 @@ describe('PayPalHelper', () => {
     });
   });
 
+  describe('updateStripeNameFromBA', () => {
+    it('updates the name on the stripe customer', async () => {
+      mockStripeHelper.updateCustomerBillingAddress = sinon.fake.resolves({});
+      paypalHelper.agreementDetails = sinon.fake.resolves({
+        firstName: 'Test',
+        lastName: 'User',
+      });
+      const result = await paypalHelper.updateStripeNameFromBA(
+        mockCustomer,
+        'mock-agreement-id'
+      );
+      assert.deepEqual(result, {});
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.updateCustomerBillingAddress,
+        { customerId: mockCustomer.id, name: 'Test User' }
+      );
+      sinon.assert.calledOnce(paypalHelper.metrics.increment);
+    });
+  });
+
   describe('processZeroInvoice', () => {
     it('finalize invoice that with no amount set to zero', async () => {
       mockStripeHelper.finalizeInvoice = sinon.fake.resolves({});

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2458,17 +2458,17 @@ describe('StripeHelper', () => {
       stripeFirestore.insertCustomerRecordWithBackfill = sandbox
         .stub()
         .resolves({});
-      const result = await stripeHelper.updateCustomerBillingAddress(
-        customer1.id,
-        {
+      const result = await stripeHelper.updateCustomerBillingAddress({
+        customerId: customer1.id,
+        options: {
           city: 'city',
           country: 'US',
           line1: 'street address',
           line2: undefined,
           postalCode: '12345',
           state: 'CA',
-        }
-      );
+        },
+      });
       assert.deepEqual(result, { metadata: {} });
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.customers.update,
@@ -6291,8 +6291,7 @@ describe('StripeHelper', () => {
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.updateCustomerBillingAddress,
-        customer1.id,
-        expectedAddressArg
+        { customerId: customer1.id, options: expectedAddressArg }
       );
     });
 
@@ -6339,8 +6338,7 @@ describe('StripeHelper', () => {
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.updateCustomerBillingAddress,
-        customer1.id,
-        expectedAddressArg
+        { customerId: customer1.id, options: expectedAddressArg }
       );
       sinon.assert.calledOnce(Sentry.withScope);
       sinon.assert.calledOnceWithExactly(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -205,6 +205,8 @@ describe('subscriptions payPalRoutes', () => {
       stripeHelper.findPlanById = sinon.fake.resolves(plan);
       payPalHelper.createBillingAgreement = sinon.fake.resolves('B-test');
       payPalHelper.agreementDetails = sinon.fake.resolves({
+        firstName: 'Test',
+        lastName: 'User',
         countryCode: 'CA',
       });
       stripeHelper.customerTaxId = sinon.fake.returns(undefined);
@@ -410,14 +412,17 @@ describe('subscriptions payPalRoutes', () => {
         );
         sinon.assert.calledOnceWithExactly(
           stripeHelper.updateCustomerBillingAddress,
-          accountCustomer.stripeCustomerId,
           {
-            city: undefined,
-            country: 'CA',
-            line1: undefined,
-            line2: undefined,
-            postalCode: undefined,
-            state: 'ON',
+            customerId: accountCustomer.stripeCustomerId,
+            options: {
+              city: undefined,
+              country: 'CA',
+              line1: undefined,
+              line2: undefined,
+              postalCode: undefined,
+              state: 'ON',
+            },
+            name: 'Test User',
           }
         );
       });
@@ -461,14 +466,17 @@ describe('subscriptions payPalRoutes', () => {
         );
         sinon.assert.calledOnceWithExactly(
           stripeHelper.updateCustomerBillingAddress,
-          accountCustomer.stripeCustomerId,
           {
-            city: undefined,
-            country: 'CA',
-            line1: undefined,
-            line2: undefined,
-            postalCode: undefined,
-            state: undefined,
+            customerId: accountCustomer.stripeCustomerId,
+            options: {
+              city: undefined,
+              country: 'CA',
+              line1: undefined,
+              line2: undefined,
+              postalCode: undefined,
+              state: undefined,
+            },
+            name: 'Test User',
           }
         );
       });
@@ -495,14 +503,17 @@ describe('subscriptions payPalRoutes', () => {
         );
         sinon.assert.calledOnceWithExactly(
           stripeHelper.updateCustomerBillingAddress,
-          accountCustomer.stripeCustomerId,
           {
-            city: undefined,
-            country: 'CA',
-            line1: undefined,
-            line2: undefined,
-            postalCode: undefined,
-            state: undefined,
+            customerId: accountCustomer.stripeCustomerId,
+            options: {
+              city: undefined,
+              country: 'CA',
+              line1: undefined,
+              line2: undefined,
+              postalCode: undefined,
+              state: undefined,
+            },
+            name: 'Test User',
           }
         );
       });
@@ -529,6 +540,8 @@ describe('subscriptions payPalRoutes', () => {
 
       it('should throw an error if planCurrency does not match billingAgreement country', async () => {
         payPalHelper.agreementDetails = sinon.fake.resolves({
+          firstName: 'Test',
+          lastName: 'User',
           countryCode: 'AS',
         });
         try {
@@ -549,14 +562,17 @@ describe('subscriptions payPalRoutes', () => {
         );
         sinon.assert.calledOnceWithExactly(
           stripeHelper.updateCustomerBillingAddress,
-          accountCustomer.stripeCustomerId,
           {
-            city: undefined,
-            country: 'AS',
-            line1: undefined,
-            line2: undefined,
-            postalCode: undefined,
-            state: undefined,
+            customerId: accountCustomer.stripeCustomerId,
+            options: {
+              city: undefined,
+              country: 'AS',
+              line1: undefined,
+              line2: undefined,
+              postalCode: undefined,
+              state: undefined,
+            },
+            name: 'Test User',
           }
         );
       });
@@ -582,14 +598,17 @@ describe('subscriptions payPalRoutes', () => {
         );
         sinon.assert.calledOnceWithExactly(
           stripeHelper.updateCustomerBillingAddress,
-          accountCustomer.stripeCustomerId,
           {
-            city: undefined,
-            country: 'CA',
-            line1: undefined,
-            line2: undefined,
-            postalCode: undefined,
-            state: undefined,
+            customerId: accountCustomer.stripeCustomerId,
+            options: {
+              city: undefined,
+              country: 'CA',
+              line1: undefined,
+              line2: undefined,
+              postalCode: undefined,
+              state: undefined,
+            },
+            name: 'Test User',
           }
         );
       });
@@ -781,6 +800,8 @@ describe('subscriptions payPalRoutes', () => {
       stripeHelper.findPlanById = sinon.fake.resolves(plan);
       payPalHelper.createBillingAgreement = sinon.fake.resolves('B-test');
       payPalHelper.agreementDetails = sinon.fake.resolves({
+        firstName: 'Test',
+        lastName: 'User',
         countryCode: 'CA',
       });
       stripeHelper.updateCustomerPaypalAgreement =
@@ -811,14 +832,17 @@ describe('subscriptions payPalRoutes', () => {
       sinon.assert.calledOnce(payPalHelper.processInvoice);
       sinon.assert.calledOnceWithExactly(
         stripeHelper.updateCustomerBillingAddress,
-        accountCustomer.stripeCustomerId,
         {
-          city: undefined,
-          country: 'CA',
-          line1: undefined,
-          line2: undefined,
-          postalCode: undefined,
-          state: 'ON',
+          customerId: accountCustomer.stripeCustomerId,
+          options: {
+            city: undefined,
+            country: 'CA',
+            line1: undefined,
+            line2: undefined,
+            postalCode: undefined,
+            state: 'ON',
+          },
+          name: 'Test User',
         }
       );
     });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -1090,6 +1090,12 @@ describe('StripeWebhookHandler', () => {
           true
         );
         StripeWebhookHandlerInstance.stripeHelper.finalizeInvoice.resolves({});
+        StripeWebhookHandlerInstance.stripeHelper.getCustomerPaypalAgreement.returns(
+          'test-ba'
+        );
+        StripeWebhookHandlerInstance.paypalHelper.updateStripeNameFromBA.resolves(
+          {}
+        );
         const result =
           await StripeWebhookHandlerInstance.handleInvoiceCreatedEvent(
             {},
@@ -1103,6 +1109,15 @@ describe('StripeWebhookHandler', () => {
         assert.calledWith(
           StripeWebhookHandlerInstance.stripeHelper.finalizeInvoice,
           invoiceCreatedEvent.data.object
+        );
+        assert.calledWith(
+          StripeWebhookHandlerInstance.paypalHelper.updateStripeNameFromBA,
+          {},
+          'test-ba'
+        );
+        assert.calledWith(
+          StripeWebhookHandlerInstance.stripeHelper.getCustomerPaypalAgreement,
+          {}
         );
       });
     });

--- a/packages/fxa-shared/payments/stripe-firestore.ts
+++ b/packages/fxa-shared/payments/stripe-firestore.ts
@@ -163,7 +163,10 @@ export class StripeFirestore {
     }
 
     if (typeof invoice.subscription !== 'string') {
-      throw new Error(`Invoice ${invoice.id} has no subscription id.`);
+      // We can only insert invoices with a subscription for caching, but we
+      // shouldn't throw errors just because we can't cache non-subscription invoices.
+      // TODO: Cache non-subscription invoices.
+      return invoice;
     }
 
     return customerSnap.docs[0].ref


### PR DESCRIPTION
Because:

* We need to retain the user name on our billing records.

This commit:

* Copies the first/laast name into the Stripe billing record for PayPal
  users.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
