### PR TITLE
Using context property syntax for variables in slack notifcation

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -52,6 +52,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: 'CLV3KMZ8B'
-          slack-message: "New assets have been uploaded to CDN: ${{ GITHUB_SERVER_URL }}/${{ GITHUB_REPOSITORY }}/actions/runs/${{ GITHUB_RUN_ID }}"
+          slack-message: "New assets have been uploaded to CDN: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Because

- Environment variables were not being consumed properly with `$VARNAME` syntax. 
- Partially moved to context property syntax `${{ VARNAME }}` but the context was missing `${{ env.VARNAME }}`

## This pull request

- Adds the context to the environment variables used in the slack notification for the cdn-upload workflow 

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
