### PR TITLE
Updated upload-assets-to-cdn workflow to use github context for slack…

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -53,6 +53,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: 'CLV3KMZ8B'
-          slack-message: "New assets have been uploaded to CDN: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
+          slack-message: "New assets have been uploaded to CDN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Because

- env contexts not working as expected 

## This pull request

- Using the `github` context for server_url, repository and run_id. 

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

- The github context has been tested in a private repository action. 
