### PR TITLE
fix(content): Allow list missing mozgcp.net

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -548,7 +548,7 @@ const conf = (module.exports = convict({
   redirect_check: {
     allow_list: {
       default:
-        '*.mozilla.org,*.mozilla.com,*.mozaws.net,*.firefox.com,firefox.com,localhost'.split(
+        '*.mozilla.org,*.mozilla.com,*.mozaws.net,*.mozgcp.net,*.firefox.com,firefox.com,localhost'.split(
           ','
         ),
       doc: `A comma separated list of hostname rules to let through on redirects. Rules support wildcards.


### PR DESCRIPTION
## Because

- A bug report was filed where the invalid redirectTo error was triggered

## This pull request

- Adds *.mozgcp.net to the default white list

## Issue that this pull request solves

Closes: #12108

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

