### PR TITLE
fix(admin-panel): Fix 404 errors on direct navigation to a page

### DIFF
--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -162,12 +162,14 @@ if (proxyUrl) {
     { encoding: 'utf-8' }
   );
 
-  ['/', '/account-search'].forEach((route) => {
-    // FIXME: should set ETag, Not-Modified:
-    app.get(route, (req, res) => {
-      res.send(ClientConfig.injectIntoHtml(STATIC_INDEX_HTML, req.headers));
-    });
-  });
+  ['/', '/account-search', '/relying-parties', '/permissions'].forEach(
+    (route) => {
+      // FIXME: should set ETag, Not-Modified:
+      app.get(route, (req, res) => {
+        res.send(ClientConfig.injectIntoHtml(STATIC_INDEX_HTML, req.headers));
+      });
+    }
+  );
 
   logger.info('static.directory', { directory: STATIC_DIRECTORY });
   app.use(


### PR DESCRIPTION
## Because
- A request to /permissions or /relying-parties was returning a 404.

## This pull request
- Adds missing routes to the server so these pages can be served.

## Issue that this pull request solves

Closes: #12745

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was not reproducible locally, because the local server uses a slightly different routing mechanism. 
