### PR TITLE
feat(payments): add Apple App Store Subscriptions to Subscription Management Page

### DIFF
--- a/packages/fxa-payments-server/src/lib/formats.ts
+++ b/packages/fxa-payments-server/src/lib/formats.ts
@@ -161,7 +161,6 @@ export const getIapSubscriptionManagementUrl = (s: IapSubscription) => {
         s.sku
       )}&package=${encodeURIComponent(s.package_name)}`;
     case MozillaSubscriptionTypes.IAP_APPLE:
-      // TODO Need actual link
-      return 'https://apple.com';
+      return 'https://apps.apple.com/account/subscriptions';
   }
 };

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/SubscriptionIapItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/SubscriptionIapItem.tsx
@@ -101,17 +101,56 @@ const AppleSubscriptionIapItem = (
   productName: string,
   customerSubscription: AppStoreSubscription
 ) => {
+  const { auto_renewing, expiry_time_millis } = customerSubscription;
+
+  let nextBill, expiresOn, nextBillDate;
+  // TODO - Remove expiry_time_millis check pending https://developer.apple.com/forums/thread/705730
+  if (expiry_time_millis) {
+    nextBillDate = getLocalizedDateString(expiry_time_millis / 1000, true);
+    nextBill = `Next billed on ${nextBillDate}`;
+    expiresOn = `Expires on ${nextBillDate}`;
+  }
+
+  const appStoreLink = getIapSubscriptionManagementUrl(customerSubscription);
+
   return (
     <div className="settings-unit">
       <div className="subscription" data-testid="subscription-item">
         <header>
           <h2>{productName}</h2>
         </header>
-        <div>
+        <div className={'with-settings-button'}>
           <div className="iap-details" data-testid="iap-details">
             <Localized id={'sub-iap-item-apple-purchase'}>
               <div className="iap-type">Apple: In-App purchase</div>
             </Localized>
+            {!!expiry_time_millis &&
+              (auto_renewing ? (
+                <Localized
+                  id="sub-next-bill"
+                  vars={{ date: nextBillDate as string }}
+                >
+                  <div>{nextBill}</div>
+                </Localized>
+              ) : (
+                <Localized
+                  id="sub-expires-on"
+                  vars={{ date: nextBillDate as string }}
+                >
+                  <div>{expiresOn}</div>
+                </Localized>
+              ))}
+          </div>
+          <div className="action">
+            <LinkExternal
+              data-testid="manage-iap-subscription-button"
+              className="settings-button"
+              href={appStoreLink}
+            >
+              <Localized id="sub-iap-item-manage-button">
+                <span data-testid="manage-iap-button">Manage</span>
+              </Localized>
+            </LinkExternal>
           </div>
         </div>
       </div>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/index.test.tsx
@@ -17,6 +17,8 @@ import SubscriptionIapItem, {
 } from './SubscriptionIapItem';
 import { PickPartial } from '../../../lib/types';
 
+const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
+
 const appleSubscription: IapSubscription = {
   _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
   product_id: SELECTED_PLAN.product_id,
@@ -92,6 +94,54 @@ describe('routes/Subscriptions/SubscriptionIapItem', () => {
     expect(iapDetailsEle).toBeInTheDocument();
     expect(iapDetailsEle).toHaveTextContent('Apple');
     const manageButton = queryByTestId('manage-iap-subscription-button');
-    expect(manageButton).toBeNull();
+    expect(manageButton).toBeInTheDocument();
+  });
+
+  it('renders an App store subscription with no expiration data', async () => {
+    const subscription = deepCopy(appleSubscription);
+
+    const { findByTestId } = render(
+      <Subject customerSubscription={subscription as AppleSubscription} />
+    );
+    const subscriptionItemEle = await findByTestId('subscription-item');
+    expect(subscriptionItemEle).toBeInTheDocument();
+    const iapDetailsEle = await findByTestId('iap-details');
+    expect(iapDetailsEle).toBeInTheDocument();
+    expect(iapDetailsEle).not.toHaveTextContent('Expires');
+    expect(iapDetailsEle).not.toHaveTextContent('Next');
+  });
+
+  it('renders an App store subscription with expiration data and auto renew', async () => {
+    const subscription = deepCopy(appleSubscription);
+    subscription.expiry_time_millis = 1656759852811;
+    subscription.auto_renewing = true;
+
+    const { findByTestId } = render(
+      <Subject customerSubscription={subscription as AppleSubscription} />
+    );
+    const subscriptionItemEle = await findByTestId('subscription-item');
+    expect(subscriptionItemEle).toBeInTheDocument();
+    const iapDetailsEle = await findByTestId('iap-details');
+    expect(iapDetailsEle).toBeInTheDocument();
+    expect(iapDetailsEle).not.toHaveTextContent('Expires');
+    expect(iapDetailsEle).toHaveTextContent('Next');
+    expect(iapDetailsEle).toHaveTextContent('07/02/2022');
+  });
+
+  it('renders an App store subscription with expiration data and no auto renew', async () => {
+    const subscription = deepCopy(appleSubscription);
+    subscription.expiry_time_millis = 1656759852811;
+    subscription.auto_renewing = false;
+
+    const { findByTestId } = render(
+      <Subject customerSubscription={subscription as AppleSubscription} />
+    );
+    const subscriptionItemEle = await findByTestId('subscription-item');
+    expect(subscriptionItemEle).toBeInTheDocument();
+    const iapDetailsEle = await findByTestId('iap-details');
+    expect(iapDetailsEle).toBeInTheDocument();
+    expect(iapDetailsEle).toHaveTextContent('Expires');
+    expect(iapDetailsEle).not.toHaveTextContent('Next');
+    expect(iapDetailsEle).toHaveTextContent('07/02/2022');
   });
 });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -15,11 +15,7 @@ import { QueryParams } from '../../lib/types';
 import { APIError } from '../../lib/apiClient';
 import { FetchState, Profile } from '../../store/types';
 import { linkTo } from '@storybook/addon-links';
-import {
-  CUSTOMER,
-  FILTERED_SETUP_INTENT,
-  IAP_APPLE_SUBSCRIPTION,
-} from '../../lib/mock-data';
+import { CUSTOMER, FILTERED_SETUP_INTENT } from '../../lib/mock-data';
 import {
   IapSubscription,
   MozillaSubscriptionTypes,
@@ -69,15 +65,24 @@ function setupVariantStories(
         }}
       />
     ))
-    .add('subscribed with Apple IAP', () => (
+    .add('subscribed with Apple IAP - Auto Rewew w/ Expiration', () => (
       <SubscriptionsRoute
         routeProps={{
-          ...subscribedIapProps,
-          customerSubscriptions: [
-            {
-              ...IAP_APPLE_SUBSCRIPTION,
-            },
-          ],
+          ...subscribedIapPropsAppleExpiry,
+        }}
+      />
+    ))
+    .add('subscribed with Apple IAP - No Auto Renew w/ Expiration', () => (
+      <SubscriptionsRoute
+        routeProps={{
+          ...subscribedIapPropsAppleNoRenew,
+        }}
+      />
+    ))
+    .add('subscribed with Apple IAP - No expiration', () => (
+      <SubscriptionsRoute
+        routeProps={{
+          ...subscribedIapPropsAppleNoExpiry,
         }}
       />
     ))
@@ -409,6 +414,44 @@ const subscribedIapProps = {
   ] as IapSubscription[],
 };
 
+const subscribedIapPropsAppleBase = {
+  ...subscribedProps.customerSubscriptions![0],
+  _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+  app_store_product_id: 'wow',
+  bundle_id: 'hmm',
+};
+
+const subscribedIapPropsAppleExpiry = {
+  ...subscribedProps,
+  customerSubscriptions: [
+    {
+      ...subscribedIapPropsAppleBase,
+      auto_renewing: true,
+      expiry_time_millis: 1656759852811,
+    },
+  ] as IapSubscription[],
+};
+
+const subscribedIapPropsAppleNoRenew = {
+  ...subscribedProps,
+  customerSubscriptions: [
+    {
+      ...subscribedIapPropsAppleBase,
+      auto_renewing: false,
+      expiry_time_millis: Date.now(),
+    },
+  ] as IapSubscription[],
+};
+
+const subscribedIapPropsAppleNoExpiry = {
+  ...subscribedProps,
+  customerSubscriptions: [
+    {
+      ...subscribedIapPropsAppleBase,
+      auto_renewing: true,
+    },
+  ] as IapSubscription[],
+};
 // TODO: Move to some shared lib?
 const wait = (delay: number) =>
   new Promise((resolve) => setTimeout(resolve, delay));


### PR DESCRIPTION
Because:

* We want to be able to view apple app store subs on the subs management page

This commit:

* Adds Apple IAP subscription items to sub management page

Closes #11940

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).