### PR TITLE
fix(auth): make unknown properties valid for support-panel route

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -389,27 +389,32 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
 });
 
 // This is support-panel's perspective on a subscription
-module.exports.subscriptionsWebSubscriptionSupportValidator = isA.object({
-  created: isA.number().required(),
-  current_period_end: isA.number().required(),
-  current_period_start: isA.number().required(),
-  plan_changed: isA.alternatives(isA.number(), isA.any().allow(null)),
-  previous_product: isA.alternatives(isA.string(), isA.any().allow(null)),
-  product_name: isA.string().required(),
-  status: isA.string().required(),
-  subscription_id: module.exports.subscriptionsSubscriptionId.required(),
-});
+module.exports.subscriptionsWebSubscriptionSupportValidator = isA
+  .object({
+    created: isA.number().required(),
+    current_period_end: isA.number().required(),
+    current_period_start: isA.number().required(),
+    plan_changed: isA.alternatives(isA.number(), isA.any().allow(null)),
+    previous_product: isA.alternatives(isA.string(), isA.any().allow(null)),
+    product_name: isA.string().required(),
+    status: isA.string().required(),
+    subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+  })
+  .unknown(true);
 
-module.exports.subscriptionsPlaySubscriptionSupportValidator = isA.object({
-  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-  auto_renewing: isA.bool().required(),
-  cancel_reason: isA.number().optional(),
-  expiry_time_millis: isA.number().required(),
-  package_name: isA.string().optional(),
-  sku: isA.string().optional(),
-  product_id: isA.string().optional(),
-  product_name: isA.string().required(),
-});
+module.exports.subscriptionsPlaySubscriptionSupportValidator = isA
+  .object({
+    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+    auto_renewing: isA.bool().required(),
+    cancel_reason: isA.number().optional(),
+    expiry_time_millis: isA.number().required(),
+    package_name: isA.string().optional(),
+    price_id: isA.string().optional(),
+    product_id: isA.string().optional(),
+    product_name: isA.string().required(),
+    sku: isA.string().optional(),
+  })
+  .unknown(true);
 
 module.exports.subscriptionsSubscriptionSupportValidator = isA.object({
   [MozillaSubscriptionTypes.WEB]: isA

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -819,6 +819,7 @@ describe('lib/routes/validators:', () => {
       expiry_time_millis: 1591650790000,
       package_name: 'club.foxkeh',
       sku: 'LOL.daily',
+      price_id: 'price_testo',
       product_id: 'prod_testo',
       product_name: 'LOL Daily',
     };
@@ -849,6 +850,18 @@ describe('lib/routes/validators:', () => {
           assert.ok(res.error);
         });
       }
+
+      it('accepts a valid web subscription with unknown properties for the support-panel', () => {
+        const webSubWithExtraProp = {
+          ...webSub,
+          otherId: 1234,
+        };
+        const res =
+          validators.subscriptionsWebSubscriptionSupportValidator.validate(
+            webSubWithExtraProp
+          );
+        assert.ok(!res.error);
+      });
     });
 
     describe('subscriptionsPlaySubscriptionSupportValidator', () => {
@@ -870,6 +883,18 @@ describe('lib/routes/validators:', () => {
           assert.ok(res.error);
         });
       }
+
+      it('accepts a valid play subscription with unknown properties for the support-panel', () => {
+        const playSubWithExtraProp = {
+          ...playSub,
+          otherId: 1234,
+        };
+        const res =
+          validators.subscriptionsPlaySubscriptionSupportValidator.validate(
+            playSubWithExtraProp
+          );
+        assert.ok(!res.error);
+      });
     });
 
     describe('subscriptionsSubscriptionSupportValidator', () => {


### PR DESCRIPTION
Because:

* The fxa-auth-server was returning 500s for the support-panel route due to a response validation error.

This commit:

* Allows unknown properties on the web and Google Play subscription objects returned in the response.
* Adds the missing 'price_id' property as an optional property for Play subscriptions returned by the endpoint.

Closes #12055

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).