### PR TITLE
fix(fortress): Fix CI tests by temporarily disabling stylelint

### DIFF
--- a/packages/fortress/package.json
+++ b/packages/fortress/package.json
@@ -37,7 +37,7 @@
     "stylelint-config-prettier": "^8.0.2"
   },
   "scripts": {
-    "lint": "npm-run-all --parallel lint:eslint lint:style",
+    "lint": "npm-run-all --parallel lint:eslint",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "lint:style": "stylelint --config ../../_dev/.stylelintrc static/*.css",


### PR DESCRIPTION
## Because

- Stylelint was failing in fortress and blocking release.

## This pull request

- Temporarily removes lint:style from the lint script.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

