### PR TITLE
feat(auth): log unhandled paypal ipn

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -179,11 +179,7 @@ export class PayPalNotificationHandler extends PayPalHandler {
         }
       }
       if (!IPN_EXCLUDED.includes(payload.txn_type)) {
-        reportSentryError(
-          new Error('Unhandled Ipn message: ' + payload.txn_type),
-          request
-        );
-        this.log.debug('Unhandled Ipn message', { payload });
+        this.log.info('Unhandled Ipn message', { payload });
       }
     } catch (err) {
       reportSentryError(err, request);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -163,7 +163,7 @@ describe('PayPalNotificationHandler', () => {
       assert.deepEqual(result, false);
       sinon.assert.calledOnce(paypalHelper.verifyIpnMessage);
       sinon.assert.calledOnce(paypalHelper.extractIpnMessage);
-      sinon.assert.calledWithExactly(log.debug, 'Unhandled Ipn message', {
+      sinon.assert.calledWithExactly(log.info, 'Unhandled Ipn message', {
         payload: ipnMessage,
       });
     });


### PR DESCRIPTION
Because:

* We don't want to flag Sentry on every IPN message we intentionally
  don't handle.
* Without seeing full payloads, it's hard to determine whether we should
  handle a message or not.

This commit:

* Removes the sentry flagging of unhandled message types.
* Changes logging of the event to record them in production.

Closes FXA-4976.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
