### PR TITLE
fix(metrics): Flush metrics before completing sign-in

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -57,7 +57,9 @@ export default {
       return this.completeSignIn();
     }
 
-    this.logViewEvent('thirdPartyAuth');
+    if (this.isInThirdPartyAuthExperiment()) {
+      this.logViewEvent('thirdPartyAuth');
+    }
   },
 
   clearStoredParams() {
@@ -188,6 +190,8 @@ export default {
         this.clearStoredParams();
 
         this.logFlowEvent(`${provider}.signin-complete`);
+        
+        this.metrics.flush();
 
         return this.signIn(updatedAccount);
       })

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
@@ -9,6 +9,8 @@ import Relier from 'models/reliers/base';
 import sinon from 'sinon';
 import ThirdPartyAuthMixin from 'views/mixins/third-party-auth-mixin';
 import Notifier from 'lib/channels/notifier';
+import Metrics from 'lib/metrics';
+import SentryMetrics from 'lib/sentry';
 import WindowMock from '../../../mocks/window';
 import Storage from 'lib/storage';
 import User from 'models/user';
@@ -34,6 +36,8 @@ describe('views/mixins/third-party-auth-mixin', function () {
   let notifier;
   let mockForm;
   let mockInput;
+  let metrics;
+  let sentryMetrics;
 
   beforeEach(async () => {
     relier = new Relier();
@@ -63,15 +67,18 @@ describe('views/mixins/third-party-auth-mixin', function () {
     });
     notifier = new Notifier();
     user = new User();
-
+    sentryMetrics = new SentryMetrics();
+    metrics = new Metrics({ notifier, sentryMetrics });
     view = new View({
       config,
       relier,
       notifier,
+      metrics,
       window: windowMock,
       user,
     });
     sinon.spy(notifier, 'trigger');
+    sinon.stub(view, 'isInThirdPartyAuthExperiment').callsFake(() => true);
     await view.render();
   });
 


### PR DESCRIPTION
## Because

- We were dropping the third party complete flow events when it redirected

## This pull request

- Flushes those metrics so that it gets logged correctly
- Only logs the top of funnel `enter-email.thirdPartyAuth` if user is in experiment

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/13379

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
