### PR TITLE
fix(a11y): ARIA nodes should have an accessible name

### DIFF
--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactNode, useContext, useEffect } from 'react';
+import React, { ReactNode, useContext } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { loadStripe } from '@stripe/stripe-js';
 import { StripeProvider } from 'react-stripe-elements';
@@ -176,16 +176,23 @@ export class AppErrorBoundary extends React.Component {
 
 export const AppErrorDialog = ({ error: { message } }: { error: Error }) => {
   const { locationReload } = useContext(AppContext);
+  const ariaLabelledBy = "general-application-error-header";
+  const ariaDescribedBy = "general-application-error-description";
   // TODO: Not displaying the actual error message to the user, just logging it.
   // Most of these errors will probably be failure to load Stripe widgets.
   return (
     <SettingsLayout>
-      <DialogMessage className="dialog-error" onDismiss={locationReload}>
+      <DialogMessage
+        className="dialog-error"
+        onDismiss={locationReload}
+        headerId={ariaLabelledBy}
+        descId={ariaDescribedBy}
+      >
         <Localized id="general-error-heading">
-          <h4 data-testid="error-loading-app">General application error</h4>
+          <h4 id={ariaLabelledBy} data-testid="error-loading-app">General application error</h4>
         </Localized>
         <Localized id={getErrorMessage({ code: 'api_connection_error' })}>
-          <p>Something went wrong. Please try again later.</p>
+          <p id={ariaDescribedBy}> Something went wrong. Please try again later.</p>
         </Localized>
       </DialogMessage>
     </SettingsLayout>

--- a/packages/fxa-payments-server/src/components/AlertBar/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/AlertBar/index.stories.tsx
@@ -3,5 +3,12 @@ import { storiesOf } from '@storybook/react';
 import { AlertBar } from './index';
 
 storiesOf('components/AlertBar', module).add('basic', () => (
-  <AlertBar className="alert">This is an alert.</AlertBar>
+  <AlertBar
+    className="alert"
+    dataTestId="alert-bar"
+    headerId="alert-bar-header"
+    localizedId="alert-bar"
+  >
+    This is an alert.
+  </AlertBar>
 ));

--- a/packages/fxa-payments-server/src/components/AlertBar/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/AlertBar/index.test.tsx
@@ -8,18 +8,29 @@ afterEach(cleanup);
 
 it('renders as expected', () => {
   const { queryByTestId } = render(
-    <AlertBar>
-      <div data-testid="children">Hi mom</div>
+    <AlertBar
+      dataTestId="children"
+      headerId="alert-bar-header"
+      localizedId="alert-bar"
+    >
+      <div id="alert-bar-header">Message for mom</div>
     </AlertBar>
   );
   expect(queryByTestId('alert-container')).toHaveClass('alert');
+  expect(queryByTestId('alert-container')).toHaveAttribute('aria-labelledby', "alert-bar-header");
+  expect(queryByTestId('alert-container')).toHaveAttribute('role', "dialog");
   expect(queryByTestId('children')).toBeInTheDocument();
 });
 
 it('accepts an alternate className', () => {
   const { queryByTestId } = render(
-    <AlertBar className="foo">
-      <div data-testid="children">Hi mom</div>
+    <AlertBar
+      className="foo"
+      dataTestId="children"
+      headerId="alternate-alert-bar-header"
+      localizedId="alert-bar"
+    >
+      <div id="alternate-alert-bar-header">Hi mom</div>
     </AlertBar>
   );
   expect(queryByTestId('alert-container')).not.toHaveClass('alert');

--- a/packages/fxa-payments-server/src/components/AlertBar/index.tsx
+++ b/packages/fxa-payments-server/src/components/AlertBar/index.tsx
@@ -3,20 +3,69 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-
+import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
+import { Localized } from '@fluent/react';
 import Portal from 'fxa-react/components/Portal';
 import './index.scss';
 
 type AlertBarProps = {
+  actionButton?: any;
+  checked?: boolean;
   children: any;
   className?: string;
+  dataTestId: string;
+  elems?: boolean;
+  headerId: string;
+  localizedId: string;
+  onClick?: Function;
 };
 
-export const AlertBar = ({ children, className = 'alert' }: AlertBarProps) => {
+export const AlertBar = ({
+  actionButton,
+  checked,
+  children,
+  className = 'alert',
+  dataTestId,
+  elems,
+  headerId,
+  localizedId,
+  onClick,
+}: AlertBarProps) => {
   return (
     <Portal id="top-bar">
-      <div data-testid="alert-container" className={className}>
-        {children}
+      <div
+        aria-labelledby={headerId}
+        className={className}
+        data-testid="alert-container"
+        role="dialog"
+      >
+        <Localized id={localizedId} elems={elems ? { div: actionButton } : undefined}>
+          <span
+            id={headerId}
+            data-testid={dataTestId}
+            className={checked ? "checked" : undefined}
+          >
+            {children}
+          </span>
+        </Localized>
+
+        {onClick && <Localized id="close-aria">
+            <span
+              data-testid="clear-success-alert"
+              className="close"
+              aria-label="Close modal"
+              onClick={() => onClick()}
+              role="button"
+            >
+              <CloseIcon
+                role="img"
+                className="close-icon close-alert-bar"
+                aria-hidden="true"
+                focusable="false"
+              />
+            </span>
+          </Localized>
+        }
       </div>
     </Portal>
   );

--- a/packages/fxa-payments-server/src/components/DialogMessage/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.stories.tsx
@@ -16,9 +16,13 @@ storiesOf('components/DialogMessage', module)
       <DialogToggle>
         {({ dialogShown, hideDialog }) =>
           dialogShown && (
-            <DialogMessage onDismiss={hideDialog}>
-              <h4>This is a basic dialog</h4>
-              <p>Content goes in here.</p>
+            <DialogMessage
+              onDismiss={hideDialog}
+              headerId="basic-header"
+              descId="basic-description"
+            >
+              <h4 id="basic-header">This is a basic dialog</h4>
+              <p id="basic-description">Content goes in here.</p>
             </DialogMessage>
           )
         }
@@ -30,9 +34,14 @@ storiesOf('components/DialogMessage', module)
       <DialogToggle>
         {({ dialogShown, hideDialog }) =>
           dialogShown && (
-            <DialogMessage className="dialog-error" onDismiss={hideDialog}>
-              <h4>This is an error dialog</h4>
-              <p>Content goes in here.</p>
+            <DialogMessage
+              className="dialog-error"
+              onDismiss={hideDialog}
+              headerId="error-header"
+              descId="error-description"
+            >
+              <h4 id="error-header">This is an error dialog</h4>
+              <p id="error-description">Content goes in here.</p>
             </DialogMessage>
           )
         }
@@ -41,9 +50,12 @@ storiesOf('components/DialogMessage', module)
   ))
   .add('without onDismiss', () => (
     <MockPage>
-      <DialogMessage>
-        <h4>This is a basic dialog</h4>
-        <p>Content goes in here.</p>
+      <DialogMessage
+        headerId="basic-no-dismiss-header"
+        descId="basic-no-dismiss-description"
+      >
+        <h4 id="basic-no-dismiss-header">This is a basic dialog</h4>
+        <p id="basic-no-dismiss-description">Content goes in here.</p>
       </DialogMessage>
     </MockPage>
   ));

--- a/packages/fxa-payments-server/src/components/DialogMessage/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.test.tsx
@@ -12,20 +12,41 @@ afterEach(cleanup);
 
 it('renders as expected', () => {
   const onDismiss = jest.fn();
+  const ariaLabelledBy = "message-header";
+  const ariaDescribedBy = "message-description";
   const { queryByTestId } = render(
-    <DialogMessage onDismiss={onDismiss}>
-      <div data-testid="children">Hi mom</div>
+    <DialogMessage
+      onDismiss={onDismiss}
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+    >
+      <div id={ariaLabelledBy} data-testid="children">Message for Mom</div>
+      <p id={ariaDescribedBy}>Hi mom</p>
     </DialogMessage>
   );
   expect(queryByTestId('dialog-message-container')).toHaveClass('blocker');
   expect(queryByTestId('children')).toBeInTheDocument();
+  expect(queryByTestId('dialog-message-information')).toHaveAttribute('aria-labelledby', ariaLabelledBy);
+  expect(queryByTestId('dialog-message-information')).toHaveAttribute('aria-describedby', ariaDescribedBy);
+  expect(queryByTestId('dialog-message-information')).toHaveAttribute(
+    'role',
+    'dialog'
+  );
 });
 
 it('accepts an alternate className', () => {
   const onDismiss = jest.fn();
+  const ariaLabelledBy = "barquux-message-header";
+  const ariaDescribedBy = "barquux-message-description";
   const { queryByTestId } = render(
-    <DialogMessage onDismiss={onDismiss} className="barquux">
-      <div data-testid="children">Hi mom</div>
+    <DialogMessage
+      onDismiss={onDismiss}
+      className="barquux"
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+    >
+      <div id={ariaLabelledBy} data-testid="children">Message for Mom</div>
+      <p id={ariaDescribedBy}>Hi mom</p>
     </DialogMessage>
   );
   expect(queryByTestId('dialog-message-content')).toHaveClass('barquux');
@@ -33,9 +54,16 @@ it('accepts an alternate className', () => {
 
 it('calls onDismiss on click outside', () => {
   const onDismiss = jest.fn();
+  const ariaLabelledBy = "dismiss-message-header";
+  const ariaDescribedBy = "dismiss-message-description";
   const { container, getByTestId } = render(
-    <DialogMessage onDismiss={onDismiss}>
-      <div data-testid="children">Hi mom</div>
+    <DialogMessage
+      onDismiss={onDismiss}
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+    >
+      <div id={ariaLabelledBy} data-testid="children">Message for Mom</div>
+      <p id={ariaDescribedBy}>Hi mom</p>
     </DialogMessage>
   );
   fireEvent.click(getByTestId('dialog-message-content'));
@@ -45,9 +73,12 @@ it('calls onDismiss on click outside', () => {
 });
 
 it('hides the close button when onDismiss is not supplied', () => {
+  const ariaLabelledBy = "dismiss-header";
+  const ariaDescribedBy = "dismiss-description";
   const { queryByTestId } = render(
-    <DialogMessage>
-      <div data-testid="children">Hi mom</div>
+    <DialogMessage headerId={ariaLabelledBy} descId={ariaDescribedBy}>
+      <div id={ariaLabelledBy} data-testid="children">Message for Mom</div>
+      <p id={ariaDescribedBy}>Hi mom</p>
     </DialogMessage>
   );
   expect(queryByTestId('dialog-dismiss')).not.toBeInTheDocument();

--- a/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
@@ -16,6 +16,8 @@ type DialogMessageProps = {
   className?: string;
   onDismiss?: Function;
   children: ReactNode;
+  headerId: string;
+  descId: string;
   'data-testid'?: string;
 };
 
@@ -26,6 +28,8 @@ export const DialogMessage = ({
   className = '',
   onDismiss,
   children,
+  headerId,
+  descId,
   'data-testid': testid = 'dialog-message-container',
 }: DialogMessageProps) => {
   const dialogInsideRef = useClickOutsideEffect<HTMLDivElement>(
@@ -58,7 +62,15 @@ export const DialogMessage = ({
               </button>
             </Localized>
           )}
-          <div className="message">{children}</div>
+          <div
+            aria-labelledby={headerId}
+            aria-describedby={descId}
+            className="message"
+            data-testid="dialog-message-information"
+            role="dialog"
+          >
+            {children}
+          </div>
         </div>
       </div>
     </Portal>

--- a/packages/fxa-payments-server/src/components/FetchErrorDialogMessage.tsx
+++ b/packages/fxa-payments-server/src/components/FetchErrorDialogMessage.tsx
@@ -3,6 +3,9 @@ import { FetchState } from '../store/types';
 import { APIError } from '../lib/apiClient';
 import DialogMessage from './DialogMessage';
 
+const ariaLabelledBy = "fetch-error-header";
+const ariaDescribedBy = "fetch-error-description";
+
 const FetchErrorDialogMessage = ({
   title,
   testid = '',
@@ -14,10 +17,15 @@ const FetchErrorDialogMessage = ({
   fetchState: FetchState<any, APIError>;
   onDismiss?: Function;
 }) => (
-  <DialogMessage className="dialog-error" onDismiss={onDismiss}>
-    <h4 data-testid={testid}>{title}</h4>
+  <DialogMessage
+    className="dialog-error"
+    onDismiss={onDismiss}
+    headerId={ariaLabelledBy}
+    descId={ariaDescribedBy}
+  >
+    <h4 id={ariaLabelledBy} data-testid={testid}>{title}</h4>
     {fetchState.error && fetchState.error.message && (
-      <p>{fetchState.error.message}</p>
+      <p id={ariaDescribedBy}>{fetchState.error.message}</p>
     )}
   </DialogMessage>
 );

--- a/packages/fxa-payments-server/src/components/PlanErrorDialog/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanErrorDialog/index.tsx
@@ -15,6 +15,9 @@ export const PlanErrorDialog = ({
   locationReload,
   plans,
 }: PlanErrorDialogProps) => {
+  const ariaLabelledBy = "plan-error-header";
+  const ariaDescribedBy = "plan-error-description";
+
   if (!plans.result || plans.error !== null) {
     return (
       <Localized id="product-plan-error">
@@ -29,12 +32,16 @@ export const PlanErrorDialog = ({
   }
 
   return (
-    <DialogMessage className="dialog-error">
+    <DialogMessage
+      className="dialog-error"
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+    >
       <Localized id="product-plan-not-found">
-        <h4>Plan not found</h4>
+        <h4 id={ariaLabelledBy}>Plan not found</h4>
       </Localized>
       <Localized id="product-no-such-plan">
-        <p data-testid="no-such-plan-error">No such plan for this product.</p>
+        <p id={ariaDescribedBy} data-testid="no-such-plan-error">No such plan for this product.</p>
       </Localized>
     </DialogMessage>
   );

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -68,16 +68,18 @@ import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { useParams } from 'react-router-dom';
 
 const PaypalButton = React.lazy(() => import('../../components/PayPalButton'));
+const ariaLabelledBy = "newsletter-error-alert-bar-header";
 
 const NewsletterErrorAlertBar = () => {
   return (
-    <AlertBar className="alert newsletter-error">
-      <Localized id="newsletter-signup-error">
-        <span data-testid="newsletter-signup-error-message">
-          You're not signed up for product update emails. You can try again in
-          your account settings.
-        </span>
-      </Localized>
+    <AlertBar
+      className="alert newsletter-error"
+      dataTestId="newsletter-signup-error-message"
+      headerId={ariaLabelledBy}
+      localizedId="newsletter-signup-error"
+    >
+      You’re not signed up for product update emails. You can try again in
+      your account settings.
     </AlertBar>
   );
 };

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -50,6 +50,8 @@ export const SubscriptionUpgrade = ({
   resetUpdateSubscriptionPlan,
   updateSubscriptionPlanStatus,
 }: SubscriptionUpgradeProps) => {
+  const ariaLabelledBy = "error-plan-change-failed-header";
+  const ariaDescribedBy = "error-plan-change-failed-description";
   const validator = useValidatorState();
 
   const inProgress = updateSubscriptionPlanStatus.loading;
@@ -101,11 +103,19 @@ export const SubscriptionUpgrade = ({
         <DialogMessage
           className="dialog-error"
           onDismiss={resetUpdateSubscriptionPlan}
+          headerId={ariaLabelledBy}
+          descId={ariaDescribedBy}
         >
           <Localized id="sub-change-failed">
-            <h4 data-testid="error-plan-update-failed">Plan change failed</h4>
+            <h4
+            id={ariaLabelledBy}
+            data-testid="error-plan-update-failed"
+          >
+            Plan change failed</h4>
           </Localized>
-          <p>{updateSubscriptionPlanStatus.error.message}</p>
+          <p id={ariaDescribedBy}>
+            {updateSubscriptionPlanStatus.error.message}
+          </p>
         </DialogMessage>
       )}
       <Header {...{ profile }} />

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -105,29 +105,40 @@ export const PaymentUpdateForm = ({
     />
   );
 
+  const alertPendingAriaLabelledBy = "alert-pending-header";
+
+  const alertErrorAriaLabelledBy = "alert-error-header";
+
+  const ariaLabelledBy = "error-invalid-billing-info-header";
+  const ariaDescribedBy = "error-invalid-billing-info-description";
+
   const billingAgreementErrorAlertBarContent = () => (
-    <Localized
-      id="sub-route-missing-billing-agreement-payment-alert"
-      elems={{ div: actionButton }}
+    <AlertBar
+      actionButton={actionButton}
+      className="alert alertError"
+      dataTestId="invalid-payment-error"
+      elems
+      headerId={alertErrorAriaLabelledBy}
+      localizedId="sub-route-missing-billing-agreement-payment-alert"
     >
-      <span>
         Invalid payment information; there is an error with your account.{' '}
         {actionButton}
-      </span>
-    </Localized>
+    </AlertBar>
   );
 
   const fundingSourceErrorAlertBarContent = () => (
-    <Localized
-      id="sub-route-funding-source-payment-alert"
-      elems={{ div: actionButton }}
+    <AlertBar
+      actionButton={actionButton}
+      className="alert alertError"
+      dataTestId="invalid-payment-error-pending"
+      elems
+      headerId={alertErrorAriaLabelledBy}
+      localizedId="sub-route-funding-source-payment-alert"
     >
-      <span>
-        Invalid payment information; there is an error with your account. This
-        alert may take some time to clear after you successfully update your
-        information. {actionButton}
-      </span>
-    </Localized>
+      Invalid payment information; there is an error with your account. This
+      alert may take some time to clear after you successfully update your
+      information. {actionButton}
+    </AlertBar>
   );
 
   const getPaypalErrorAlertBarContent = () => {
@@ -209,17 +220,18 @@ export const PaymentUpdateForm = ({
     <section className="settings-unit" aria-labelledby="payment-information">
       <div className="payment-update" data-testid="payment-update">
         {stripeSubmitInProgress && (
-          <AlertBar className="alert alertPending">
-            <Localized id="sub-route-idx-updating">
-              <span>Updating billing information...</span>
-            </Localized>
+          <AlertBar
+            className="alert alertPending"
+            dataTestId="alert-pending"
+            headerId={alertPendingAriaLabelledBy}
+            localizedId="sub-route-idx-updating"
+          >
+            Updating billing information…
           </AlertBar>
         )}
 
         {!transactionInProgress && paypal_payment_error && (
-          <AlertBar className="alert alertError">
-            {getPaypalErrorAlertBarContent()}
-          </AlertBar>
+          getPaypalErrorAlertBarContent()
         )}
 
         {transactionInProgress && (
@@ -231,13 +243,15 @@ export const PaymentUpdateForm = ({
             data-testid="billing-info-modal"
             onDismiss={hideFixPaymentModal}
             className="billing-info-modal"
+            headerId={ariaLabelledBy}
+            descId={ariaDescribedBy}
           >
             <img id="error-icon" src={errorIcon} alt="error icon" />
             <Localized id="sub-route-payment-modal-heading">
-              <h2>Invalid billing information</h2>
+              <h2 id={ariaLabelledBy}>Invalid billing information</h2>
             </Localized>
             <Localized id="sub-route-payment-modal-message">
-              <p>
+              <p id={ariaDescribedBy}>
                 There seems to be an error with your PayPal account, we need you
                 to take the necessary steps to resolve this payment issue.
               </p>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -15,21 +15,29 @@ import LoadingSpinner from '../../../components/LoadingSpinner';
 import { useHandleConfirmationDialog } from '../../../lib/hooks';
 import AppContext from '../../../lib/AppContext';
 
-const ConfirmationDialogErrorContent = () => (
+const ConfirmationDialogErrorContent = ({
+  headerId,
+  descId
+}: {
+  headerId: string;
+  descId: string;
+}) => (
   <>
     <Localized id="general-error-heading">
-      <h4 data-testid="reactivate-confirm-error-loading">
+      <h4 id={headerId} data-testid="reactivate-confirm-error-loading">
         General application error
       </h4>
     </Localized>
     <Localized id="basic-error-message">
-      <p>Something went wrong. Please try again later.</p>
+      <p id={descId}>Something went wrong. Please try again later.</p>
     </Localized>
   </>
 );
 
 const ConfirmationDialogContent = ({
   onConfirm,
+  headerId,
+  descId,
   periodEndDate,
   currency,
   productName,
@@ -39,6 +47,8 @@ const ConfirmationDialogContent = ({
   webIconURL,
 }: {
   onConfirm: () => void;
+  headerId: string;
+  descId: string;
   periodEndDate: number;
   currency: string;
   productName: string;
@@ -67,7 +77,7 @@ const ConfirmationDialogContent = ({
           name: productName,
         }}
       >
-        <h4>Want to keep using {productName}?</h4>
+        <h4 id={headerId}>Want to keep using {productName}?</h4>
       </Localized>
       {last4 && (
         <Localized
@@ -79,9 +89,9 @@ const ConfirmationDialogContent = ({
             endDate: getLocalizedDate(periodEndDate),
           }}
         >
-          <p>
+          <p id={descId}>
             Your access to {productName} will continue, and your billing cycle
-            and payment will stay the same. Your next charge will be
+            and payment will stay the same. Your next charge will be{' '}
             {getLocalizedCurrencyString(amount, currency)} to the card ending in{' '}
             {last4} on {getLocalizedDateString(periodEndDate)}.
           </p>
@@ -147,16 +157,34 @@ const ConfirmationDialog = ({
     plan
   );
 
+  const ariaLabelledByError = "error-content-header";
+  const ariaDescribedByError = "error-content-description";
+
+  const ariaLabelledByConfirmation = "confirmation-content-header";
+  const ariaDescribedByConfirmation = "confirmation-content-description";
+
+  const ariaLabelledBy = !loading && error ? ariaLabelledByError : ariaLabelledByConfirmation;
+  const ariaDescribedBy = !loading && !error ? ariaDescribedByError : ariaDescribedByConfirmation;
+
   return (
-    <DialogMessage onDismiss={onDismiss}>
+    <DialogMessage
+      onDismiss={onDismiss}
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+    >
       {!loading ? (
         <>
           {/* TO DO: display card type, IE 'to the Visa card ending...' */}
           {error ? (
-            <ConfirmationDialogErrorContent />
+            <ConfirmationDialogErrorContent
+              headerId={ariaLabelledBy}
+              descId={ariaDescribedBy}
+            />
           ) : (
             <ConfirmationDialogContent
               onConfirm={onConfirm}
+              headerId={ariaLabelledBy}
+              descId={ariaDescribedBy}
               periodEndDate={periodEndDate}
               currency={plan.currency}
               productName={plan.product_name}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
@@ -21,6 +21,9 @@ const SuccessDialog = ({
     config.featureFlags.useFirestoreProductConfigs
   );
 
+  const ariaLabelledBy = "reactivate-subscription-success-header";
+  const ariaDescribedBy = "reactivate-subscription-success-description";
+
   const setWebIconBackground = webIconBackground
     ? { background: webIconBackground }
     : '';
@@ -29,8 +32,10 @@ const SuccessDialog = ({
     <DialogMessage
       onDismiss={onDismiss}
       data-testid="reactivate-subscription-success-dialog"
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
     >
-      <div className="dialog-icon" style={{ ...setWebIconBackground }}>
+      <div id={ariaLabelledBy} className="dialog-icon" style={{ ...setWebIconBackground }}>
         <img
           alt={productName}
           src={webIcon || fpnImage}
@@ -39,6 +44,7 @@ const SuccessDialog = ({
         />
       </div>
       <p
+        id={ariaDescribedBy}
         data-testid="reactivate-subscription-success"
         className="reactivate-subscription-success"
       >

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -51,15 +51,22 @@ export const SubscriptionItem = ({
   const labelId = 'subscription-' + plan?.product_id;
 
   if (!plan) {
+    const ariaLabelledBy = "error-product-plan-not-found-header";
+    const ariaDescribedBy = "error-product-plan-not-found-description";
     // TODO: This really shouldn't happen, would mean the user has a
     // subscription to a plan that no longer exists in API results.
     return (
-      <DialogMessage className="dialog-error" onDismiss={locationReload}>
+      <DialogMessage
+        className="dialog-error"
+        onDismiss={locationReload}
+        headerId={ariaLabelledBy}
+        descId={ariaDescribedBy}
+      >
         <Localized id="product-plan-not-found">
-          <h4 data-testid="error-subhub-missing-plan">Plan not found</h4>
+          <h4 id={ariaLabelledBy} data-testid="error-subhub-missing-plan">Plan not found</h4>
         </Localized>
         <Localized id="sub-item-no-such-plan">
-          <p>No such plan for this subscription.</p>
+          <p id={ariaDescribedBy}>No such plan for this subscription.</p>
         </Localized>
       </DialogMessage>
     );
@@ -69,15 +76,22 @@ export const SubscriptionItem = ({
     customerSubscription.cancel_at_period_end === false &&
     !((total || total === 0) && period_start)
   ) {
+    const ariaLabelledBy = "invoice-not-found-header";
+    const ariaDescribedBy = "invoice-not-found-description";
     return (
-      <DialogMessage className="dialog-error" onDismiss={locationReload}>
+      <DialogMessage
+        className="dialog-error"
+        onDismiss={locationReload}
+        headerId={ariaLabelledBy}
+        descId={ariaDescribedBy}
+      >
         <Localized id="invoice-not-found">
-          <h4 data-testid="error-subhub-missing-subsequent-invoice">
+          <h4 id={ariaLabelledBy} data-testid="error-subhub-missing-subsequent-invoice">
             Subsequent invoice not found
           </h4>
         </Localized>
         <Localized id="sub-item-no-such-subsequent-invoice">
-          <p>Subsequent invoice not found for this subscription.</p>
+          <p id={ariaDescribedBy}>Subsequent invoice not found for this subscription.</p>
         </Localized>
       </DialogMessage>
     );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -23,7 +23,6 @@ import AlertBar from '../../components/AlertBar';
 import DialogMessage from '../../components/DialogMessage';
 import FetchErrorDialogMessage from '../../components/FetchErrorDialogMessage';
 import { LoadingOverlay } from '../../components/LoadingOverlay';
-import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
 import { ReactComponent as PocketIcon } from '../../images/pocket-icon.svg';
 import { getLocalizedDate, getLocalizedDateString } from '../../lib/formats';
 
@@ -233,6 +232,12 @@ export const Subscriptions = ({
   const planId =
     activeWebSubscription && (activeWebSubscription as WebSubscription).plan_id;
 
+  const ariaLabelledByReactivateSubscription = "error-subscription-reactivation-failed-header";
+  const ariaDescribedByReactivateSubscription = "error-subscription-reactivation-failed-description";
+
+  const ariaLabelledByCancellationStatus = "error-cancellation-failed-header";
+  const ariaDescribedByCancellationStatus = "error-cancellation-failed-description";
+
   return (
     <div className="subscription-management" onClick={onAnyClick}>
       {customerSubscriptions && cancelSubscriptionStatus.result !== null && (
@@ -248,28 +253,15 @@ export const Subscriptions = ({
       )}
 
       {showPaymentSuccessAlert && (
-        <AlertBar className="alert alertSuccess alertCenter">
-          <Localized id="sub-billing-update-success">
-            <span data-testid="success-billing-update" className="checked">
-              Your billing information has been updated successfully
-            </span>
-          </Localized>
-
-          <Localized id="close-aria">
-            <span
-              data-testid="clear-success-alert"
-              className="close"
-              aria-label="Close modal"
-              onClick={hideSuccessAlert}
-            >
-              <CloseIcon
-                role="img"
-                className="close-icon close-alert-bar"
-                aria-hidden="true"
-                focusable="false"
-              />
-            </span>
-          </Localized>
+        <AlertBar
+          checked
+          className="alert alertSuccess alertCenter"
+          dataTestId="success-billing-update"
+          headerId="success-billing-update-header"
+          localizedId="sub-billing-update-success"
+          onClick={hideSuccessAlert}
+        >
+          Your billing information has been updated successfully
         </AlertBar>
       )}
 
@@ -277,13 +269,17 @@ export const Subscriptions = ({
         <DialogMessage
           className="dialog-error"
           onDismiss={resetReactivateSubscription}
+          headerId={ariaLabelledByReactivateSubscription}
+          descId={ariaDescribedByReactivateSubscription}
         >
           <Localized id="sub-route-idx-reactivating">
-            <h4 data-testid="error-reactivation">
+            <h4 id={ariaLabelledByReactivateSubscription} data-testid="error-reactivation">
               Reactivating subscription failed
             </h4>
           </Localized>
-          <p>{reactivateSubscriptionStatus.error.message}</p>
+          <p id={ariaDescribedByReactivateSubscription}>
+            {reactivateSubscriptionStatus.error.message}
+          </p>
         </DialogMessage>
       )}
 
@@ -298,13 +294,17 @@ export const Subscriptions = ({
         <DialogMessage
           className="dialog-error"
           onDismiss={resetCancelSubscription}
+          headerId={ariaLabelledByCancellationStatus}
+          descId={ariaDescribedByCancellationStatus}
         >
           <Localized id="sub-route-idx-cancel-failed">
-            <h4 data-testid="error-cancellation">
+            <h4 id={ariaLabelledByCancellationStatus} data-testid="error-cancellation">
               Cancelling subscription failed
             </h4>
           </Localized>
-          <p>{cancelSubscriptionStatus.error.message}</p>
+          <p id={ariaDescribedByCancellationStatus}>
+            {cancelSubscriptionStatus.error.message}
+          </p>
         </DialogMessage>
       )}
 
@@ -479,12 +479,18 @@ const CancellationDialogMessage = ({
     subscriptionId,
     customerSubscriptions
   );
+  const ariaLabelledBy = "subscription-cancellation-header";
+  const ariaDescribedBy = "subscription-cancellation-description";
   const plan = planForId(customerSubscription!.plan_id, plans) as Plan;
 
   return (
-    <DialogMessage onDismiss={resetCancelSubscription}>
+    <DialogMessage
+      onDismiss={resetCancelSubscription}
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+    >
       <Localized id="sub-route-idx-cancel-msg-title">
-        <h4 data-testid="cancellation-message-title">
+        <h4 id={ariaLabelledBy} data-testid="cancellation-message-title">
           We're sorry to see you go
         </h4>
       </Localized>
@@ -495,7 +501,7 @@ const CancellationDialogMessage = ({
           date: getLocalizedDate(customerSubscription!.current_period_end),
         }}
       >
-        <p>
+        <p id={ariaDescribedBy}>
           Your {plan.product_name} subscription has been cancelled.
           <br />
           You will still have access to {plan.product_name} until{' '}

--- a/packages/fxa-react/components/Portal/index.test.tsx
+++ b/packages/fxa-react/components/Portal/index.test.tsx
@@ -14,10 +14,6 @@ it('renders children in a new element outside original DOM parent', () => {
   expect(screen.getByTestId('portal-parent')).not.toContainElement(childrenEl);
   const containerParent = container.parentNode as ParentNode;
   expect(containerParent.querySelector('#foo')).toContainElement(childrenEl);
-  expect(containerParent.querySelector('#foo')).toHaveAttribute(
-    'role',
-    'dialog'
-  );
 });
 
 it('renders multiple instances with the same ID to the same DOM parent', () => {
@@ -55,8 +51,9 @@ it('applies a11y improvements when id is set to "modal"', () => {
   const descId = 'some-desc-id';
 
   render(
-    <Portal id="modal" {...{ headerId, descId }}>
-      <div>Hi mom</div>
+    <Portal id="modal">
+      <div id={headerId}>Message for mom</div>
+      <p id={descId}>Hi mom</p>
     </Portal>
   );
 
@@ -74,6 +71,4 @@ it('applies a11y improvements when id is set to "modal"', () => {
   expect(adjacentToRoot.classList).toContain('pointer-events-none');
 
   expect(modal).not.toHaveAttribute('aria-hidden', 'true');
-  expect(modal).toHaveAttribute('aria-labelledby', headerId);
-  expect(modal).toHaveAttribute('aria-describedby', descId);
 });

--- a/packages/fxa-react/components/Portal/index.tsx
+++ b/packages/fxa-react/components/Portal/index.tsx
@@ -5,8 +5,6 @@ import './index.scss';
 
 type PortalProps = {
   id: string;
-  headerId?: string;
-  descId?: string;
   children: React.ReactNode;
 };
 
@@ -30,8 +28,6 @@ const resetA11yOnAdjacentElementsAndBody = (els: NodeListOf<HTMLElement>) => {
 
 const Portal = ({
   id,
-  headerId = '',
-  descId = '',
   children,
 }: PortalProps): React.ReactPortal | null => {
   let el = document.getElementById(id);
@@ -41,13 +37,7 @@ const Portal = ({
     el.setAttribute('id', id);
     document.body.appendChild(el);
 
-    if (id !== 'alert-bar-portal') {
-      el.setAttribute('role', 'dialog');
-    }
-
     if (id === 'modal') {
-      el.setAttribute('aria-labelledby', headerId);
-      el.setAttribute('aria-describedby', descId);
       setA11yOnAdjacentElementsAndBody(
         document.querySelectorAll(TOP_LEVEL_NONMODAL_DIVS_SELECTOR)
       );

--- a/packages/fxa-settings/src/components/Modal/index.test.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.test.tsx
@@ -9,8 +9,11 @@ import { renderWithRouter } from '../../models/mocks';
 
 it('renders as expected', () => {
   const onDismiss = jest.fn();
+  const ariaLabelledBy="modal-header";
+  const ariaDescribedBy="modal-description";
+
   renderWithRouter(
-    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
+    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
       <div data-testid="children">Hi mom</div>
     </Modal>
   );
@@ -19,18 +22,26 @@ it('renders as expected', () => {
     'title',
     'Close'
   );
+  expect(screen.getByTestId('modal-information')).toHaveAttribute('aria-labelledby', ariaLabelledBy);
+  expect(screen.getByTestId('modal-information')).toHaveAttribute('aria-describedby', ariaDescribedBy);
+  expect(screen.getByTestId('modal-information')).toHaveAttribute('role', "dialog")
 });
 
 it('renders confirm button as a link if route is passed', () => {
+  const ariaLabelledBy="modal-with-confirm-header";
+  const ariaDescribedBy="modal-with-confirm-description";
   const route = '/some/route';
   const onDismiss = jest.fn();
-  const { container } = renderWithRouter(
+  renderWithRouter(
     <Modal
-      headerId="some-header"
-      descId="some-description"
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
       {...{ route, onDismiss }}
     >
-      <div data-testid="children">Hi mom</div>
+      <div data-testid="children">
+        <h4 id={ariaLabelledBy}>Message for mom</h4>
+        <p id={ariaDescribedBy}>Hi mom</p>
+      </div>
     </Modal>
   );
 
@@ -40,14 +51,19 @@ it('renders confirm button as a link if route is passed', () => {
 });
 
 it('does not render the cancel button if hasCancelButton is set to false', () => {
+  const ariaLabelledBy="no-cancel-modal-header"
+  const ariaDescribedBy="no-cancel-modal-description"
   const onDismiss = jest.fn();
   renderWithRouter(
     <Modal
-      headerId="some-header"
-      descId="some-description"
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
       {...{ hasCancelButton: false, onDismiss }}
     >
-      <div data-testid="children">Hi mom</div>
+      <div data-testid="children">
+        <h4 id={ariaLabelledBy}>Message for mom</h4>
+        <p id={ariaDescribedBy}>Hi mom</p>
+      </div>
     </Modal>
   );
   expect(document.activeElement).toBe(screen.getByTestId('modal-tab-fence'));
@@ -56,15 +72,20 @@ it('does not render the cancel button if hasCancelButton is set to false', () =>
 });
 
 it('accepts an alternate className', () => {
+  const ariaLabelledBy="barquux-modal-header";
+  const ariaDescribedBy="barquux-modal-description";
   const onDismiss = jest.fn();
   renderWithRouter(
     <Modal
-      headerId="some-header"
-      descId="some-description"
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
       {...{ onDismiss }}
       className="barquux"
     >
-      <div data-testid="children">Hi mom</div>
+      <div data-testid="children">
+        <h4 id={ariaLabelledBy}>Message for mom</h4>
+        <p id={ariaDescribedBy}>Hi mom</p>
+      </div>
     </Modal>
   );
   expect(screen.queryByTestId('modal-content-container')).toHaveClass(
@@ -73,10 +94,15 @@ it('accepts an alternate className', () => {
 });
 
 it('calls onDismiss on click outside', () => {
+  const ariaLabelledBy="some-modal-header";
+  const ariaDescribedBy="some-modal-description";
   const onDismiss = jest.fn();
   const { container } = renderWithRouter(
-    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
-      <div data-testid="children">Hi mom</div>
+    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+      <div data-testid="children">
+        <h4 id={ariaLabelledBy}>Message for mom</h4>
+        <p id={ariaDescribedBy}>Hi mom</p>
+      </div>
     </Modal>
   );
   fireEvent.click(screen.getByTestId('modal-content-container'));
@@ -86,10 +112,15 @@ it('calls onDismiss on click outside', () => {
 });
 
 it('calls onDismiss on esc key press', () => {
+  const ariaLabelledBy="use-esc-modal-header";
+  const ariaDescribedBy="use-esc-modal-description";
   const onDismiss = jest.fn();
   renderWithRouter(
-    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
-      <div data-testid="children">Hi mom</div>
+    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+      <div data-testid="children">
+        <h4 id={ariaLabelledBy}>Message for mom</h4>
+        <p id={ariaDescribedBy}>Hi mom</p>
+      </div>
     </Modal>
   );
   fireEvent.keyDown(window, { key: 'Escape' });
@@ -97,10 +128,15 @@ it('calls onDismiss on esc key press', () => {
 });
 
 it('shifts focus to the tab fence when opened', () => {
+  const ariaLabelledBy="tab-focus-modal-header";
+  const ariaDescribedBy="tab-focus-modal-description";
   const onDismiss = jest.fn();
   renderWithRouter(
-    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
-      <div data-testid="children">Hi mom</div>
+    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+      <div data-testid="children">
+        <h4 id={ariaLabelledBy}>Message for mom</h4>
+        <p id={ariaDescribedBy}>Hi mom</p>
+      </div>
     </Modal>
   );
   expect(document.activeElement).toBe(screen.getByTestId('modal-tab-fence'));

--- a/packages/fxa-settings/src/components/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.tsx
@@ -47,7 +47,7 @@ export const Modal = ({
   useEscKeydownEffect(onDismiss);
 
   return (
-    <Portal id="modal" {...{ headerId, descId }}>
+    <Portal id="modal">
       <div
         data-testid={testid}
         className="flex flex-col justify-center fixed inset-0 z-50 w-full px-2 h-full bg-black bg-opacity-75"
@@ -76,8 +76,15 @@ export const Modal = ({
             </button>
           </div>
 
-          <div className="px-6 tablet:px-10 pb-10">
-            <div>{children}</div>
+          <div
+            aria-describedby={descId}
+            aria-labelledby={headerId}
+            className="px-6 tablet:px-10 pb-10"
+            data-testid="modal-information"
+            role="dialog"
+          >
+            {children}
+
             {hasButtons && (
               <div className="flex justify-center mx-auto mt-6 max-w-64">
                 {hasCancelButton && (


### PR DESCRIPTION
## Because

- we are missing ARIA attributes within `<div class="portal" id="dialogs" role="dialog">` DOM elements

## This pull request

- [x] updates `AlertBar` and `DialogMessage` components to add aria-labelledby and aria-describedby attributes
- [x] updates components using `AlertBar` and `DialogMessage` component to include aria-labelledby and aria-describedby attributes
- [x] updates `Portal` component as `modal` is no longer the only id that contain aria attributes
- [x] adds tests to check that aria attributes are also passed when id is set to `dialogs` or `top-bar`

## Issue that this pull request solves

Closes: #12922

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots
- `id` set to `dialogs`
<img width="1576" alt="Screen Shot 2022-07-05 at 8 28 28 PM" src="https://user-images.githubusercontent.com/28129806/177437952-29476b51-e8e3-4008-a01a-a64cf1998d6f.png">

- `id` set to `modal`
<img width="1579" alt="Screen Shot 2022-07-05 at 8 29 35 PM" src="https://user-images.githubusercontent.com/28129806/177438063-7bb882db-c406-4cec-a0d8-18055d05d137.png">

- `id` set to `top-bar`
<img width="1587" alt="Screen Shot 2022-07-05 at 8 26 37 PM" src="https://user-images.githubusercontent.com/28129806/177437836-aaeda5ea-e496-4fc4-95e0-0ad0b508fcd3.png">

