### PR TITLE
chore(fxa-profile-server): upgrade eslint

### DIFF
--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -43,7 +43,7 @@
     "@types/sharp": "^0",
     "audit-filter": "^0.5.0",
     "commander": "2.9.0",
-    "eslint": "^7.32.0",
+    "eslint": "^8.18.0",
     "eslint-plugin-fxa": "^2.0.2",
     "insist": "1.0.1",
     "mkdirp": "0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23071,7 +23071,7 @@ fsevents@~2.1.1:
     convict: ^6.2.3
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
-    eslint: ^7.32.0
+    eslint: ^8.18.0
     eslint-plugin-fxa: ^2.0.2
     fxa-shared: "workspace:*"
     insist: 1.0.1


### PR DESCRIPTION
## Because

- We want to update dependencies in our packages

## This pull request

- Upgrades eslint from ^7.32.0 to ^8.18.0

## Issue that this pull request solves

Closes: #13433 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
All tests pass. Eslint runs successfully and outputs no new errors. 

## To test
Pull down these changes. After rebuilding/restarting, run `yarn workspace fxa-profile-server lint` to verify that no new errors are thrown. If you want to make double sure that lint is in fact running properly, go to `packages/fxa-profile-server/.eslintrc` and add a `"camelcase": 2` to the array of rules, then run the above command again. You should now see a list of non-camelcase var names output.
