### PR TITLE
chore(fxa-profile-server): upgrade commander

### DIFF
--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/sharp": "^0",
     "audit-filter": "^0.5.0",
-    "commander": "2.9.0",
+    "commander": "9.3.0",
     "eslint": "^8.18.0",
     "eslint-plugin-fxa": "^2.0.2",
     "insist": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16518,15 +16518,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:2.9.0":
-  version: 2.9.0
-  resolution: "commander@npm:2.9.0"
-  dependencies:
-    graceful-readlink: ">= 1.0.0"
-  checksum: 37939b6866ae190784fa946ea5b926dfe713731064c746e818642ac59e28f513b54e88e35d8c34b4d24d063cb465977dca2efd2ec974f91e495c743fcb2ae7a2
-  languageName: node
-  linkType: hard
-
 "commander@npm:4.0.1":
   version: 4.0.1
   resolution: "commander@npm:4.0.1"
@@ -16545,6 +16536,13 @@ __metadata:
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
   checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
+  languageName: node
+  linkType: hard
+
+"commander@npm:9.3.0":
+  version: 9.3.0
+  resolution: "commander@npm:9.3.0"
+  checksum: d421ce66fee25792a1470c69aa8d1b86434bf873a96483aa92c8267f81a6f20c6f7c426f5e82f88ac50a8ec4855d3f2787aebcdef8aa559e1080a2337a95a217
   languageName: node
   linkType: hard
 
@@ -23056,7 +23054,7 @@ fsevents@~2.1.1:
     bluebird: ^3.7.2
     buf: 0.1.1
     checksum: 1.0.0
-    commander: 2.9.0
+    commander: 9.3.0
     compute-cluster: 0.0.9
     convict: ^6.2.3
     convict-format-with-moment: ^6.2.0


### PR DESCRIPTION
## Because

- Our version of `commander` is significantly behind and needs to be updated

## This pull request

- Updates `commander`

## Issue that this pull request solves

Closes: #13432 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
As far as I could tell, `commander` is only used within our tests on the `fxa-profile-server`. To test the success of these changes, I ran `yarn workspace fxa-profile-server test` before introducing changes, verified that there were no failed tests under those circumstances, updated the version of `commander`, ran `yarn workspace fxa-profile-server install`, rebuilt the package, and then re-ran the testing command. There were no failed tests.
