### PR TITLE
chore(fxa-profile-server) remove mkdirp

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -192,7 +192,6 @@
     "lodash.pick": "4.4.0",
     "mailparser": "0.6.1",
     "mjml-browser": "^4.12.0",
-    "mkdirp": "0.5.1",
     "mocha": "^9.1.2",
     "mocha-junit-reporter": "^2.0.2",
     "moment": "^2.29.2",

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -24,7 +24,6 @@ const config = require('../config').getProperties();
 const createSenders = require('../lib/senders');
 const fs = require('fs');
 const log = require('../lib/log')({});
-const mkdirp = require('mkdirp');
 const path = require('path');
 
 const OUTPUT_DIRECTORY = path.join(__dirname, '..', '.mail_output');
@@ -208,7 +207,7 @@ function getMessageTypesToWrite(mailer) {
 }
 
 function ensureTargetDirectoryExists() {
-  mkdirp.sync(OUTPUT_DIRECTORY);
+  fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 }
 
 module.exports.OUTPUT_DIRECTORY = OUTPUT_DIRECTORY;

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.js
@@ -10,7 +10,6 @@ const { promisify } = require('util');
 const { assert } = require('chai');
 const cp = require('child_process');
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const mocks = require(`${ROOT_DIR}/test/mocks`);
 const path = require('path');
 const rimraf = require('rimraf');
@@ -83,7 +82,7 @@ describe('scripts/bulk-mailer', function () {
 
   before(() => {
     rimraf.sync(OUTPUT_DIRECTORY);
-    mkdirp.sync(OUTPUT_DIRECTORY);
+    fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 
     return TestServer.start(config)
       .then((s) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22430,7 +22430,6 @@ fsevents@~2.1.1:
     memcached: ^2.2.2
     mjml: ^4.12.0
     mjml-browser: ^4.12.0
-    mkdirp: 0.5.1
     mocha: ^9.1.2
     mocha-junit-reporter: ^2.0.2
     moment: ^2.29.2


### PR DESCRIPTION
## Because

- mkdirp recursively creates directories, which can now be handled by `fs.mkdirSync`. Credit for the fix goes to [this PR](https://github.com/mozilla/fxa/pull/13452)! Thank you @vbudhram (and @pdehaan for pointing it out to me!)

## This pull request

- Removes the `mkdirp` package and replaces our use of it with `fs.mkdirSync`

## Issue that this pull request solves

Closes: #13434 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## To test:
I ran tests for the package first on main (to verify that all tests pass before I change anything) and then after removing the dependency and replacing it with `fs`
