### PR TITLE
fix(email): Remove footer links from subscriptionAccountFinishSetup

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1728,6 +1728,7 @@ module.exports = function (log, config, bounces) {
           message.acceptLanguage,
           invoiceDate
         ),
+        isFinishSetup: true,
         nextInvoiceDateOnly: this._constructLocalDateString(
           message.timeZone,
           message.acceptLanguage,

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1252,6 +1252,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId')) },
       { test: 'include', expected: decodeUrl(configHref('subscriptionPrivacyUrl', 'subscription-account-finish-setup', 'subscription-privacy')) },
       { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support')) },
+      { test: 'notInclude', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-account-finish-setup', 'cancel-subscription', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId', 'uid')) },
+      { test: 'notInclude', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-account-finish-setup', 'update-billing', 'email', 'product_name', 'token', 'product_id', 'flowId', 'flowBeginTime', 'deviceId', 'uid'))},
       { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
       { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },


### PR DESCRIPTION
## Because

- QA reported that the "Cancel subscription" and "Update billing information" footer links still appeared in stage

## This pull request

- revises subscriptionAccountFinishSetupEmail to include `isFinishSetup: true`
- adds tests that checks those footer links are not included in this email

## Issue that this pull request solves

Closes: #12108

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information
I also ran `yarn write-emails` to check that the footer links are not included in this email