### PR TITLE
fix(auth-server): Fix "Expires Invalid Date" for cc info on Subscription Management

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2094,12 +2094,12 @@ export class StripeHelper extends StripeHelperBase {
           brand,
         };
       } else {
-        const pm = await this.expandResource<Stripe.PaymentMethod>(
+        const paymentMethod = await this.expandResource<Stripe.PaymentMethod>(
           customer.default_source,
           PAYMENT_METHOD_RESOURCE
         );
-        console.log('code pm', pm);
-        const { brand, exp_month, exp_year, funding, last4 } = pm.card!;
+        const { brand, exp_month, exp_year, funding, last4 } =
+          paymentMethod.card!;
         return {
           billing_name: customer.name,
           payment_provider: paymentProvider,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -6176,7 +6176,7 @@ describe('StripeHelper', () => {
       id: sourceId,
       brand: 'visa',
       exp_month: 8,
-      exp_year: 2022,
+      exp_year: new Date().getFullYear(),
       funding: 'credit',
       last4: '4242',
     };

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -101,6 +101,16 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     expect(screen.queryByTestId('paymentForm')).not.toBeInTheDocument();
   });
 
+  it('renders valid expiration date', async () => {
+    render(<Subject />);
+    expect(screen.queryByTestId('card-expiration-date')).toHaveTextContent('Expires February 2099');
+  });
+
+  it('does not render expiration date if date is invalid', async () => {
+    render(<Subject customer={{...CUSTOMER, exp_month: undefined}} />);
+    expect(screen.queryByTestId('card-expiration-date')).not.toBeInTheDocument();
+  });
+
   it('reveals the payment update form on clicking Change button', async () => {
     render(<Subject />);
     expect(screen.queryByTestId('payment-update')).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -200,7 +200,7 @@ export const PaymentUpdateForm = ({
   const onFormEngaged = useCallback(() => Amplitude.updatePaymentEngaged(), []);
 
   // https://github.com/iamkun/dayjs/issues/639
-  const expirationDate = dayjs()
+  const expirationDate = exp_month && exp_year && dayjs()
     .set('month', Number(exp_month) - 1)
     .set('year', Number(exp_year))
     .format('MMMM YYYY');


### PR DESCRIPTION
## Because

- "Expires Invalid Date" appears as we no longer pull `customer.sources` due to Stripe changes. We should be looking at `customer.default_source` and then pulling that payment method to get the card.

## This pull request

- checks `customer.default_source` for card information

## Issue that this pull request solves

Closes: #10150

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
