### PR TITLE
fix(bug): Fix change password not redirecting on pairing allow page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/auth_allow.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/auth_allow.mustache
@@ -17,7 +17,7 @@
       <div class="button-row">
         <button type="submit" id="auth-approve-btn">{{#t}}Yes, approve device{{/t}}</button>
       </div>
-      <p>{{#unsafeTranslate}}If this wasn’t you, <a href="/settings/change_password" id="change-password">change your passsword</a> {{/unsafeTranslate}}</p>
+      <p>{{#unsafeTranslate}}If this wasn’t you, <a id="change-password">change your password</a> {{/unsafeTranslate}}</p>
     </form>
   </section>
   </div>

--- a/packages/fxa-content-server/app/scripts/views/pair/auth_allow.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/auth_allow.js
@@ -7,9 +7,15 @@ import DeviceBeingPairedMixin from './device-being-paired-mixin';
 import PairingTotpMixin from './pairing-totp-mixin';
 import FormView from '../form';
 import Template from '../../templates/pair/auth_allow.mustache';
+import { assign } from 'underscore';
+import preventDefaultThen from '../decorators/prevent_default_then';
 
 class PairAuthAllowView extends FormView {
   template = Template;
+
+  events = assign(this.events, {
+    'click #change-password': preventDefaultThen('changePassword'),
+  });
 
   setInitialContext(context) {
     context.set({
@@ -25,6 +31,10 @@ class PairAuthAllowView extends FormView {
 
   submit() {
     return this.invokeBrokerMethod('afterPairAuthAllow');
+  }
+  
+  changePassword() {
+    this.navigateAway('/settings/change_password');
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/views/pair/auth_allow.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/auth_allow.js
@@ -30,7 +30,7 @@ const MOCK_ACCOUNT_PROFILE = {
   email: MOCK_EMAIL,
 };
 
-describe('views/pair/auth_allow', () => {
+describe ('views/pair/auth_allow', () => {
   let account;
   let broker;
   let config;
@@ -93,7 +93,7 @@ describe('views/pair/auth_allow', () => {
 
   describe('render', () => {
     const HEADER_TEXT = 'Did you just sign in to Firefox?';
-    it('renders, can submit and navigate to change password', () => {
+    it('renders and can submit', () => {
       sinon.stub(view, 'invokeBrokerMethod').callsFake(() => {});
       sinon.spy(view, 'replaceCurrentPage');
       return view.render().then(() => {
@@ -125,6 +125,16 @@ describe('views/pair/auth_allow', () => {
       });
     });
 
+    it('can change password', async () => {
+      sinon.spy(view, 'navigateAway');
+      
+      await view.render();
+      
+      view.$('#change-password').click();
+      
+      assert.isTrue(view.navigateAway.calledOnceWith('/settings/change_password'));
+    });
+    
     it('handles errors', (done) => {
       sinon.spy(view, 'displayError');
       view.initialize();


### PR DESCRIPTION
## Because

- The change password button did not redirect
- The way our current backbone app is setup we have to do the redirecting from within the controller and not view

## This pull request

- Instead of using an href, we perform redirect in controller for view

## Issue that this pull request solves

Closes: #13449 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that this is targetd on branc train-235 and will be a point release.
