### PR TITLE
feat(subscriptions): add feature flag for Stripe Tax

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -900,6 +900,14 @@ const conf = convict({
       format: String,
       doc: 'Stripe API key for direct Stripe integration',
     },
+    stripeAutomaticTax: {
+      enabled: {
+        default: false,
+        doc: 'Whether to enable automatic tax for Stripe',
+        env: 'SUBSCRIPTIONS_STRIPE_AUTOMATIC_TAX',
+        format: Boolean,
+      },
+    },
     stripeWebhookPayloadLimit: {
       default: 1048576,
       env: 'STRIPE_WEBHOOK_PAYLOAD_LIMIT',

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -17,6 +17,12 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED',
       format: Boolean,
     },
+    useStripeAutomaticTax: {
+      default: false,
+      doc: 'Feature flag on whether Stripe automatic tax is enabled',
+      env: 'SUBSCRIPTIONS_STRIPE_TAX_ENABLED',
+      format: Boolean,
+    },
   },
   amplitude: {
     enabled: {


### PR DESCRIPTION
## Because

- we want a feature flag to control whether or not stripe should
  automatically calculate tax for a customer and subscriptions

## This pull request

- add a feature flag to configs in auth and payment servers

## Issue that this pull request solves

Closes: #13315

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).