### PR TITLE
feat(auth): ignore missing account for api calls

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -472,7 +472,10 @@ export class StripeWebhookHandler extends StripeHandler {
       return;
     }
     const account = await Account.findByUid(uid, { include: ['emails'] });
-    if (!account) {
+    // If the request has a request id, it means that our API triggered this so
+    // we can safely ignore the account not existing as this is typically due to
+    // us deleting the account in FxA.
+    if (!account && !event.request.id) {
       reportSentryError(
         new Error(`Cannot load account for customerId: ${customer.id}`),
         request

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -549,6 +549,7 @@ describe('StripeWebhookHandler', () => {
           {
             data: { object: customerFixture },
             type: 'customer.updated',
+            request: {},
           }
         );
         assert.calledOnce(sentryModule.reportSentryError);
@@ -566,6 +567,25 @@ describe('StripeWebhookHandler', () => {
           {
             data: { object: customer },
             type: 'customer.updated',
+          }
+        );
+        assert.notCalled(sentryModule.reportSentryError);
+      });
+
+      it('does not report error with no customer if the account does not exist but it was an api call', async () => {
+        const authDbModule = require('fxa-shared/db/models/auth');
+        const sentryModule = require('../../../../lib/sentry');
+        sandbox.stub(sentryModule, 'reportSentryError').returns({});
+        sandbox.stub(authDbModule.Account, 'findByUid').resolves(null);
+        const customer = deepCopy(customerFixture);
+        await StripeWebhookHandlerInstance.handleCustomerUpdatedEvent(
+          {},
+          {
+            data: { object: customer },
+            type: 'customer.updated',
+            request: {
+              id: 'someid',
+            },
           }
         );
         assert.notCalled(sentryModule.reportSentryError);


### PR DESCRIPTION
Because:

* We can safely ignore the account not existing for customer updates that
  we trigger via API calls.

This commit:

* Updates the webhook handling code to not report sentry errors if the
  webhook event is a result of our API call.

Closes #12996

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
