### PR TITLE
feat(auth): restore expandResource prior behavior

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5650,7 +5650,8 @@ describe('StripeHelper', () => {
       assert.hasAllKeys(result, customer);
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
-        customer.id
+        customer.id,
+        true
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveCustomerSubscriptions,
@@ -5672,7 +5673,8 @@ describe('StripeHelper', () => {
       assert.deepEqual(result.subscriptions.data, []);
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
-        customer.id
+        customer.id,
+        true
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveCustomerSubscriptions,
@@ -5691,7 +5693,8 @@ describe('StripeHelper', () => {
       assert.deepEqual(result, subscription1);
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveAndFetchSubscription,
-        subscription1.id
+        subscription1.id,
+        true
       );
     });
 
@@ -5738,7 +5741,8 @@ describe('StripeHelper', () => {
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
-        invoicePaidSubscriptionCreate.customer
+        invoicePaidSubscriptionCreate.customer,
+        true
       );
     });
   });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -438,7 +438,7 @@ describe('StripeWebhookHandler', () => {
           assert.isTrue(scopeContextSpy.calledOnce, 'Expected to call Sentry');
         });
 
-        it('does not call sentry or expand resourche for event payment_method.detached', async () => {
+        it('does not call sentry or expand resource for event payment_method.detached', async () => {
           const event = deepCopy(subscriptionCreated);
           event.type = 'payment_method.detached';
           StripeWebhookHandlerInstance.stripeHelper.constructWebhookEvent.returns(
@@ -1152,6 +1152,30 @@ describe('StripeWebhookHandler', () => {
         assert.isUndefined(result);
         assert.notCalled(
           StripeWebhookHandlerInstance.stripeHelper.expandResource
+        );
+      });
+
+      it('returns with customer.deleted', async () => {
+        const paymentMethodUpdatedEvent = deepCopy(eventPaymentMethodUpdated);
+        const customer = deepCopy(customerFixture);
+        customer.deleted = true;
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.resolves(
+          customer
+        );
+        const result =
+          await StripeWebhookHandlerInstance.handlePaymentMethodUpdated(
+            {},
+            paymentMethodUpdatedEvent
+          );
+        assert.isUndefined(result);
+        assert.calledWith(
+          StripeWebhookHandlerInstance.stripeHelper.expandResource,
+          paymentMethodUpdatedEvent.data.object.customer,
+          CUSTOMER_RESOURCE
+        );
+        assert.notCalled(
+          StripeWebhookHandlerInstance.stripeHelper
+            .updateCustomerPaymentMethodTaxRates
         );
       });
 


### PR DESCRIPTION
Because:

* We've had a variety of bugs related to expandResource behavior
  changing after Firestore caching was added. New errors were thrown
  that calling code did not expect.

This commit:

* Restores the prior expandResource behavior, and if the object cannot
  be cached, instead returns it as it previously did.

Closes #12380

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
