### PR TITLE
feat(pair): Add button to open Firefox View after completing pairing

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/channels/web.js
+++ b/packages/fxa-content-server/app/scripts/lib/channels/web.js
@@ -38,6 +38,7 @@ const COMMANDS = {
   PAIR_PREFERENCES: 'fxaccounts:pair_preferences',
   PAIR_REQUEST_SUPPLICANT_METADATA: 'fxaccounts:pair_supplicant_metadata',
   PROFILE_CHANGE: 'profile:change',
+  FIREFOX_VIEW: 'fxaccounts:firefox_view',
   /*
     SYNC_PREFERENCES: 'fxaccounts:sync_preferences', // Removed in issue #4250
     */

--- a/packages/fxa-content-server/app/scripts/templates/pair/auth_complete.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/auth_complete.mustache
@@ -8,12 +8,21 @@
 
     <div class="graphic {{ graphicId }}" role="img" aria-label="{{#t}}Successfully connected{{/t}}"></div>
 
-    <h2>{{#t}}You are now syncing with:{{/t}}</h2>
+    <h2 id="device-os">
+      {{#unsafeTranslate}}
+        You are now syncing with: <span>%(deviceFamily)s on %(deviceOS)s</span>
+      {{/unsafeTranslate}}
+    </h2>
 
-    {{{ unsafeDeviceBeingPairedHTML }}}
-
+    <p>{{#t}}Now you can access your open tabs, passwords, and bookmarks on all your devices.{{/t}}</p>
+    
     <div class="button-row">
-      <a href="/settings#connected-services" class="button primary-button">{{#t}}Manage devices{{/t}}</a>
+      {{#hasFirefoxViewSupport}}
+        <a id="open-firefox-view" class="button primary-button">{{#t}}Open Firefox View{{/t}}</a>
+      {{/hasFirefoxViewSupport}}
+      {{^hasFirefoxViewSupport}}
+        <a href="/settings#connected-services" class="button primary-button">{{#t}}Manage devices{{/t}}</a>
+      {{/hasFirefoxViewSupport}}
     </div>
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/pair/auth_complete.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/auth_complete.js
@@ -2,30 +2,75 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import BaseView from '../base';
 import Cocktail from 'cocktail';
 import DeviceBeingPairedMixin from './device-being-paired-mixin';
 import PairingGraphicsMixin from '../mixins/pairing-graphics-mixin';
 import Template from '../../templates/pair/auth_complete.mustache';
+import { assign } from 'underscore';
+import preventDefaultThen from '../decorators/prevent_default_then';
+import WebChannel from '../../lib/channels/web';
+import Constants from '../../lib/constants';
+import FormView from '../form';
 
-class PairAuthCompleteView extends BaseView {
+class PairAuthCompleteView extends FormView {
   template = Template;
 
+  events = assign(this.events, {
+    'click #open-firefox-view': preventDefaultThen('openFirefoxView'),
+  });
+
+  initialize(options) {
+    super.initialize(options);
+    this._notificationChannel = this.createWebchannel();
+  }
+  
+  createWebchannel() {
+    const channel = new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
+    channel.initialize({
+      window: this.window,
+    });
+
+    return channel;
+  }
+  
   beforeRender() {
     return this.invokeBrokerMethod('afterPairAuthComplete');
   }
 
   setInitialContext(context) {
+    const deviceContext = assign({}, this.broker.get('remoteMetaData'));
     const graphicId = this.getGraphicsId();
 
-    context.set({ graphicId });
+    context.set({ 
+      graphicId,
+      deviceFamily: deviceContext.family,
+      deviceOS: deviceContext.OS,
+      hasFirefoxViewSupport: this._hasFirefoxViewSupport()
+    });
+  }
+
+  openFirefoxView() {
+    const channel = this._notificationChannel;
+    return channel.send(channel.COMMANDS.FIREFOX_VIEW, {
+      // TODO: What is the correct entrypoint value?
+      entryPoint: "preferences"
+    });
+  }
+
+  _hasFirefoxViewSupport() {
+    const uap = this.getUserAgent();
+    const browserVersion = uap.browser.version;
+
+    // Currently, only supported in FF Nightly
+    // For local testing, override this to true
+    return uap.isFirefoxDesktop() && browserVersion >= 104;
   }
 }
 
 Cocktail.mixin(
   PairAuthCompleteView,
   DeviceBeingPairedMixin(),
-  PairingGraphicsMixin
+  PairingGraphicsMixin,
 );
 
 export default PairAuthCompleteView;

--- a/packages/fxa-content-server/app/tests/spec/lib/channels/web.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/channels/web.js
@@ -54,7 +54,7 @@ describe('lib/channels/web', () => {
       window: windowMock,
     });
 
-    assert.lengthOf(Object.keys(channel.COMMANDS), 16);
+    assert.lengthOf(Object.keys(channel.COMMANDS), 17);
     assert.ok(channel.COMMANDS.CAN_LINK_ACCOUNT);
     assert.ok(channel.COMMANDS.CHANGE_PASSWORD);
     assert.ok(channel.COMMANDS.DELETE);
@@ -71,6 +71,7 @@ describe('lib/channels/web', () => {
     assert.ok(channel.COMMANDS.PAIR_PREFERENCES);
     assert.ok(channel.COMMANDS.PAIR_REQUEST_SUPPLICANT_METADATA);
     assert.ok(channel.COMMANDS.PROFILE_CHANGE);
+    assert.ok(channel.COMMANDS.FIREFOX_VIEW);
   });
 
   describe('send', () => {

--- a/packages/fxa-content-server/app/tests/spec/views/pair/auth_complete.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/auth_complete.js
@@ -85,15 +85,8 @@ describe('views/pair/auth_complete', () => {
           view.$el.find('#pair-auth-complete-header').text(),
           'Device connected'
         );
-        assert.equal(view.$el.find('.family-os').text(), 'Firefox on Windows');
-        assert.equal(
-          view.$el.find('.location').text().trim(),
-          'Toronto, Ontario, Canada (estimated)'
-        );
-        assert.equal(
-          view.$el.find('.ip-address').text(),
-          'IP address: 1.1.1.1'
-        );
+        assert.include(view.$el.find('#device-os').text(), 'Firefox on Windows');
+
         assert.ok(
           view.$el.find('.graphic-connect-another-device-hearts').length
         );

--- a/packages/fxa-content-server/tests/functional/pairing.js
+++ b/packages/fxa-content-server/tests/functional/pairing.js
@@ -162,6 +162,7 @@ registerSuite('pairing', {
 
           .then(switchToWindow(1))
           .then(testElementExists(selectors.PAIRING.COMPLETE))
+
           .getCurrentUrl()
           .then(function (redirectResult) {
             assert.ok(

--- a/packages/fxa-content-server/tests/tools/firefox_profile_creator.js
+++ b/packages/fxa-content-server/tests/tools/firefox_profile_creator.js
@@ -114,6 +114,8 @@ if (profile) {
   // show the js console in devtools
   myProfile.setPreference('devtools.toolbox.selectedTool', 'webconsole');
   myProfile.setPreference('devtools.webconsole.persistlog', true);
+  
+  myProfile.setPreference('browser.tabs.firefox-view', true);
 
   myProfile.updatePreferences();
 

--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -113,7 +113,8 @@ const fxaProfile = {
   "app.update.silent": false,
   "app.update.staging.enabled": false,
   // allow webchannel url, strips slash from content-server origin.
-  "webchannel.allowObject.urlWhitelist": fxaEnv.content.slice(0, -1)
+  "webchannel.allowObject.urlWhitelist": fxaEnv.content.slice(0, -1),
+  "browser.tabs.firefox-view": true,
 };
 
 // Configuration for local sync development


### PR DESCRIPTION
## Because

- Firefox View wants to be integrated into the pairing flow

## This pull request

- At the end of the pairing flow, the user is shown a button to continue to Firefox view

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5321

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="517" alt="Screen Shot 2022-06-30 at 1 23 47 PM" src="https://user-images.githubusercontent.com/1295288/176743039-7f4234d3-5827-4e23-897a-e1b31e86af05.png">

## Other information

To test this you need to be running the latest FF Nightly build and set the pref `browser.tabs.firefox-view=true`. It is kind of difficult to test but you should be able to run the `yarn test-pairing` from content-server directory.
