### PR TITLE
fix(auth): user Sent Unnecessary Finish Setting Up Account Reminder Email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -658,6 +658,7 @@ module.exports = function (log, config, bounces) {
         flowId,
         flowBeginTime,
         deviceId,
+        accountVerified,
       } = message;
 
       log.trace(`mailer.${template}`, { email, uid });
@@ -682,22 +683,24 @@ module.exports = function (log, config, bounces) {
         'X-Link': links.link,
       };
 
-      return this.send({
-        ...message,
-        headers,
-        layout: 'subscription',
-        template,
-        templateValues: {
-          email,
-          ...links,
-          oneClickLink: links.oneClickLink,
-          privacyUrl: links.privacyUrl,
-          termsOfServiceDownloadURL: links.termsOfServiceDownloadURL,
-          supportUrl: links.supportUrl,
-          supportLinkAttributes: links.supportLinkAttributes,
-          reminderShortForm: true,
-        },
-      });
+      if (!accountVerified) {
+        return this.send({
+          ...message,
+          headers,
+          layout: 'subscription',
+          template,
+          templateValues: {
+            email,
+            ...links,
+            oneClickLink: links.oneClickLink,
+            privacyUrl: links.privacyUrl,
+            termsOfServiceDownloadURL: links.termsOfServiceDownloadURL,
+            supportUrl: links.supportUrl,
+            supportLinkAttributes: links.supportLinkAttributes,
+            reminderShortForm: true,
+          },
+        });
+      }
     };
   });
 

--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -182,6 +182,7 @@ async function run() {
             acceptLanguage: account.locale,
             code: account.emailCode,
             email: account.email,
+            accountVerified: account.verifierSetAt > 0,
             token: token,
             flowBeginTime,
             flowId,

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -1595,6 +1595,20 @@ describe('/account/finish_setup', () => {
       assert.equal(err.errno, 110);
     }
   });
+
+  it('removes the reminder if it errors after account is verified', async () => {
+    const { route, mockRequest, subscriptionAccountReminders } = setup({
+      verifierSetAt: Date.now(),
+    });
+
+    try {
+      await runTest(route, mockRequest);
+      assert.fail('should have errored');
+    } catch (err) {
+      assert.equal(err.errno, 110);
+      assert.calledOnce(subscriptionAccountReminders.delete);
+    }
+  });
 });
 
 describe('/account/login', () => {

--- a/packages/fxa-auth-server/test/local/senders/index.js
+++ b/packages/fxa-auth-server/test/local/senders/index.js
@@ -241,7 +241,10 @@ describe('lib/senders/index', () => {
             return email.sendPostAddLinkedAccountEmail(EMAILS, acct, {});
           })
           .then(() => {
-            assert.equal(email._ungatedMailer.postAddLinkedAccountEmail.callCount, 1);
+            assert.equal(
+              email._ungatedMailer.postAddLinkedAccountEmail.callCount,
+              1
+            );
 
             const args =
               email._ungatedMailer.postAddLinkedAccountEmail.getCall(0).args;
@@ -459,6 +462,42 @@ describe('lib/senders/index', () => {
           metricsEnabled: true,
           uid: UID,
         });
+      });
+    });
+
+    describe('subscriptionAccountReminder Emails', () => {
+      it('should send an email if the account is unverified', async () => {
+        const mailer = await createSender(config);
+        await mailer.sendSubscriptionAccountReminderFirstEmail(EMAILS, acct, {
+          email: 'test@test.com',
+          uid: '123',
+          productId: 'abc',
+          productName: 'testProduct',
+          token: 'token',
+          flowId: '456',
+          lowBeginTime: 123,
+          deviceId: 'xyz',
+          accountVerified: false,
+        });
+
+        assert.equal(mailer._ungatedMailer.mailer.sendMail.callCount, 1);
+      });
+
+      it('should not send an email if the account is verified', async () => {
+        const mailer = await createSender(config);
+        await mailer.sendSubscriptionAccountReminderFirstEmail(EMAILS, acct, {
+          email: 'test@test.com',
+          uid: '123',
+          productId: 'abc',
+          productName: 'testProduct',
+          token: 'token',
+          flowId: '456',
+          lowBeginTime: 123,
+          deviceId: 'xyz',
+          accountVerified: true,
+        });
+
+        assert.equal(mailer._ungatedMailer.mailer.sendMail.callCount, 0);
       });
     });
   });


### PR DESCRIPTION
Because:

* users are receiving unnecessary emails after creating a password (likely due to an error occuring after their account is verified but before their reminder is removed OR an issue with not dropping the key from redis)

This commit:

* adds an additional attempt to drop the key from redis if an error occurs after the account is verified and adds a check to see if the account is verified before sending the email

Closes #12802

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
I was not able to reproduce this locally but I think was I able to narrow it down to 2 possible issues that COULD occur: the first that there is an error when the user is finishing setting up their account between where the account is verified and where we drop the key from redis to send out a reminder email OR the second where we fail to drop the key. I added 2 checks in here to hopefully handle either scenario.