### PR TITLE
Revert "chore(deps-dev): bump @testing-library/user-event from 14.2.0 to 14.2.1"

### DIFF
--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -49,7 +49,7 @@
     "@testing-library/dom": "^8.11.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
-    "@testing-library/user-event": "^14.2.1",
+    "@testing-library/user-event": "^14.2.0",
     "@types/camelcase": "5.2.0",
     "@types/classnames": "^2.3.1",
     "@types/file-loader": "^5.0.0",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -94,7 +94,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.0",
-    "@testing-library/user-event": "^14.2.1",
+    "@testing-library/user-event": "^14.2.0",
     "@types/babel__core": "7.1.14",
     "@types/classnames": "^2.3.1",
     "@types/jest": "^26.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9093,12 +9093,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^14.2.1":
-  version: 14.2.1
-  resolution: "@testing-library/user-event@npm:14.2.1"
+"@testing-library/user-event@npm:^14.2.0":
+  version: 14.2.0
+  resolution: "@testing-library/user-event@npm:14.2.0"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 661d61a52a3ec954fe21d799f8203f0eaa7c43ea4f2c1b5916f3bb34a3609a8d7ac3dfaff5247c4511aed7ce122883c297bf59e9ffe086e375f42c98596802b9
+  checksum: b34f19bbfe938d03778831b9c083d451c53f983f6f6c0db05a572b71ba5323c4125097bb4b8c97595bc9b946610d2c2f65cf1e113f047eed7a3078f28a1027e2
   languageName: node
   linkType: hard
 
@@ -23493,7 +23493,7 @@ fsevents@~2.1.1:
     "@testing-library/dom": ^8.11.2
     "@testing-library/jest-dom": ^5.16.4
     "@testing-library/react": ^12.1.5
-    "@testing-library/user-event": ^14.2.1
+    "@testing-library/user-event": ^14.2.0
     "@types/camelcase": 5.2.0
     "@types/classnames": ^2.3.1
     "@types/file-loader": ^5.0.0
@@ -23562,7 +23562,7 @@ fsevents@~2.1.1:
     "@testing-library/jest-dom": ^5.16.4
     "@testing-library/react": ^12.1.5
     "@testing-library/react-hooks": ^8.0.0
-    "@testing-library/user-event": ^14.2.1
+    "@testing-library/user-event": ^14.2.0
     "@types/babel__core": 7.1.14
     "@types/classnames": ^2.3.1
     "@types/jest": ^26.0.23


### PR DESCRIPTION
Reverts mozilla/fxa#13509 - failed `deploy-packages`