### PR TITLE
fix(auth): update existing type

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -123,8 +123,8 @@ export type BillingAddressOptions = {
   state: string;
 };
 
-export type PaymentBillingDetails = ReturnType<
-  StripeHelper['extractBillingDetails']
+export type PaymentBillingDetails = Awaited<
+  ReturnType<StripeHelper['extractBillingDetails']>
 > & {
   paypal_payment_error?: PaypalPaymentError;
   billing_agreement_id?: string;


### PR DESCRIPTION
Because:

* A StripeHelper method that had its retun type used elsewhere became
  an async method and the ReturnType became a Promise. This caused a
  different methods type checking to fail as a Promise cannot be
  embedded in a Promise being returned.

This commit:

* Updates the type declaration to handle the method signature change.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
