### PR TITLE
fix(auth): Update cadReminderFirst email copy

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -44,7 +44,7 @@
   "passwordResetAccountRecovery": 6,
   "postAddAccountRecovery": 6,
   "postRemoveAccountRecovery": 6,
-  "cadReminderFirst": 2,
+  "cadReminderFirst": 3,
   "cadReminderSecond": 3,
   "subscriptionAccountReminderFirst": 2,
   "subscriptionAccountReminderSecond": 2

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en.ftl
@@ -1,4 +1,7 @@
-cadReminderFirst-subject = Your Friendly Reminder: How To Complete Your Sync Setup
+cadReminderFirst-subject-1 = Reminder! Let’s sync { -brand-firefox }
 cadReminderFirst-action = Sync another device
-cadReminderFirst-title = Here’s your reminder to sync devices.
-cadReminderFirst-description = It takes two to sync. Syncing another device with { -brand-firefox } privately keeps your bookmarks, passwords and other { -brand-firefox } data the same everywhere you use { -brand-firefox }.
+cadReminderFirst-action-plaintext = { cadReminderFirst-action }:
+# In the title of the email, "It takes two to sync", "two" refers to syncing two devices
+cadReminderFirst-title-1 = It takes two to sync
+cadReminderFirst-description-1 = Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use { -brand-firefox }. It’s like having magic in your { -brand-firefox } account!
+cadReminderFirst-description-2 = It only takes a sec to sync.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "cadReminderFirst-subject",
-    "message": "Your Friendly Reminder: How To Complete Your Sync Setup"
+    "id": "cadReminderFirst-subject-1",
+    "message": "Reminder! Let’s sync Firefox"
   },
   "action": {
     "id": "cadReminderFirst-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.mjml
@@ -5,16 +5,17 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="cadReminderFirst-title">Here’s your reminder to sync devices.</span>
+      <span data-l10n-id="cadReminderFirst-title-1">It takes two to sync</span>
     </mj-text>
-    <mj-image width="240px" css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
-  </mj-column>
-</mj-section>
 
-<mj-section>
-  <mj-column>
+    <mj-image width="240px" css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
+
     <mj-text css-class="text-body">
-      <span data-l10n-id="cadReminderFirst-description">It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.</span>
+      <span data-l10n-id="cadReminderFirst-description-1">Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="cadReminderFirst-description-2">It only takes a sec to sync.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.txt
@@ -1,7 +1,10 @@
-cadReminderFirst-title = "Here’s your reminder to sync devices."
+cadReminderFirst-title-1 = "It takes two to sync"
 
-cadReminderFirst-description = "It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox."
+cadReminderFirst-description-1 = "Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!"
 
+cadReminderFirst-description-2 = "It only takes a sec to sync."
+
+cadReminderFirst-action-plaintext = "Sync another device:"
 <%- link %>
 
 <%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -202,7 +202,7 @@ const COMMON_METRICS_OPT_OUT_TESTS: { test: string; expected: string }[] = [
 // prettier-ignore
 const TESTS: [string, any, Record<string, any>?][] = [
   ['cadReminderFirstEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Your Friendly Reminder: How To Complete Your Sync Setup' }],
+    ['subject', { test: 'equal', expected: 'Reminder! Let’s sync Firefox' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-first', 'connect-device') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderFirst') }],
@@ -210,8 +210,9 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.cadReminderFirst }],
     ])],
     ['html', [
-      { test: 'include', expected: "Here’s your reminder to sync devices." },
-      { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: 'It takes two to sync' },
+      { test: 'include', expected: 'Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!' },
+      { test: 'include', expected: 'It only takes a sec to sync.' },
       { test: 'include', expected: decodeUrl(configHref('syncUrl', 'cad-reminder-first', 'connect-device')) },
       { test: 'include', expected: decodeUrl(config.smtp.androidUrl) },
       { test: 'include', expected: decodeUrl(config.smtp.iosUrl) },
@@ -227,8 +228,9 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: config.smtp.firefoxDesktopUrl },
     ]],
     ['text', [
-      { test: 'include', expected: "Here’s your reminder to sync devices." },
-      { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: 'It takes two to sync' },
+      { test: 'include', expected: 'Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!' },
+      { test: 'include', expected: 'It only takes a sec to sync.' },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-first', 'privacy')}` },
       { test: 'include', expected: config.smtp.syncUrl },
       { test: 'notInclude', expected: config.smtp.androidUrl },


### PR DESCRIPTION
## Because

- we are updating email copy

## This pull request

- updates the email copy for cadReminderFirst in HTML and TXT:
  - [x] updates the email subject to `Reminder! Let’s sync Firefox`
  - [x] updates the email title to `It takes two to sync`
  - [x] updates the email body to reflect:
```
[Image](https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png)

Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account! 

It only takes a sec to sync. 

Button: [Sync another device](http://localhost:3030/connect_another_device)

Install Firefox Component

<Footer Component>
``` 

## Issue that this pull request solves

Closes: #13040

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
<img width="1331" alt="Screen Shot 2022-07-11 at 2 21 16 PM" src="https://user-images.githubusercontent.com/28129806/178331711-4c112144-fc3f-41ce-869b-73b0d62a1043.png">

