### PR TITLE
fix(content): Show the download firefox page after sign in from browser menu

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -789,11 +789,14 @@ const Account = Backbone.Model.extend(
         options.newsletters = newsletters;
       }
 
-      return this._fxaClient.sessionVerifyCode(
-        this.get('sessionToken'),
-        code,
-        options
-      );
+      return this._fxaClient
+        .sessionVerifyCode(this.get('sessionToken'), code, options)
+        .then(() => {
+          // If the promise resolves without error, then the code was correct and the
+          // verified flag can be set to true. If verified is not set, the user will
+          // likely be directed to the signin.
+          this.set('verified', true);
+        });
     },
 
     /**

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -54,12 +54,20 @@ export default {
         );
       }
 
-      const type = this.model.get('type');
-      this.navigate('connect_another_device', {
-        account,
-        showSuccessMessage: true,
-        type,
-      });
+      // If we can pair, just jump straight to this screen. Otherwise
+      // fall back to previous generic CAD screen.
+      if (this.isEligibleForPairing()) {
+        this.navigate('pair', {
+          account,
+        });
+      } else {
+        const type = this.model.get('type');
+        this.navigate('connect_another_device', {
+          account,
+          showSuccessMessage: true,
+          type,
+        });
+      }
     });
   },
 
@@ -105,5 +113,5 @@ export default {
    */
   replaceCurrentPageWithPairScreen() {
     this.navigate('/pair', {});
-  }
+  },
 };

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -460,6 +460,7 @@ module.exports = {
     PAIR_FAILURE: '#fxa-pair-failure-header',
     START_PAIRING: '#start-pairing',
     SUPP_SUBMIT: '#supp-approve-btn',
+    CONNECT_ANOTHER_QR_CODE: '.graphic-connect-another-device-qr-code',
   },
   PAYMENTS: {
     HEADER: '.accepted-cards',

--- a/packages/fxa-content-server/tests/functional/pairing.js
+++ b/packages/fxa-content-server/tests/functional/pairing.js
@@ -20,6 +20,7 @@ const GOOD_CLIENT_ID = '3c49430b43dfba77';
 const GOOD_PAIR_URL = `${config.fxaContentRoot}pair/supp?response_type=code&client_id=${GOOD_CLIENT_ID}&redirect_uri=${REDIRECT_HOST}oauth%2Fsuccess%2F3c49430b43dfba77&scope=profile%2Bhttps%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync&state=foo&code_challenge_method=S256&code_challenge=IpOAcntLUmKITcxI_rDqMvFTeC9n_g0B8_Pj2yWZp7w&access_type=offline&keys_jwk=eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImlmcWY2U1pwMlM0ZjA5c3VhS093dmNsbWJxUm8zZXdGY0pvRURpYnc4MTQiLCJ5IjoiSE9LTXh5c1FseExqRGttUjZZbFpaY1Y4MFZBdk9nSWo1ZHRVaWJmYy1qTSJ9`; //eslint-disable-line  max-len
 const BAD_PAIR_URL = `${config.fxaContentRoot}pair/supp?response_type=code&client_id=${BAD_CLIENT_ID}&redirect_uri=${BAD_OAUTH_REDIRECT}&scope=profile%2Bhttps%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync&state=foo&code_challenge_method=S256&code_challenge=IpOAcntLUmKITcxI_rDqMvFTeC9n_g0B8_Pj2yWZp7w&access_type=offline&keys_jwk=eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImlmcWY2U1pwMlM0ZjA5c3VhS093dmNsbWJxUm8zZXdGY0pvRURpYnc4MTQiLCJ5IjoiSE9LTXh5c1FseExqRGttUjZZbFpaY1Y4MFZBdk9nSWo1ZHRVaWJmYy1qTSJ9`; //eslint-disable-line  max-len
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
+const DESKTOP_SIGNUP_URL = `${config.fxaContentRoot}signup?context=fx_desktop_v3&entrypoint=fxa_app_menu&service=sync`;
 
 const PASSWORD = 'PASSWORD123123';
 let email;
@@ -257,6 +258,27 @@ registerSuite('pairing', {
             'Invalid pairing client'
           )
         );
+    },
+
+    'it shows qr code after sign in from fx desktop pre': function () {
+      email = createEmail();
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(DESKTOP_SIGNUP_URL))
+        .then(() =>
+          this.remote.findAllByCssSelector(
+            selectors.SIGNIN_PASSWORD.LINK_USE_DIFFERENT
+          )
+        )
+        .then((r) => r[0]?.click())
+        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+        .then(click(selectors.ENTER_EMAIL.SUBMIT))
+        .then(() => this.remote.sleep(100))
+        .then(() => this.remote.acceptAlert())
+        .catch(() => {})
+        .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
+        .then(click(selectors.SIGNIN_PASSWORD.SUBMIT, selectors.PAIRING.HEADER))
+        .then(testElementExists(selectors.PAIRING.CONNECT_ANOTHER_QR_CODE));
     },
   },
 });


### PR DESCRIPTION
## Because

- After signing in from the browser's hamburger menu, we were not seeing the Download Firefox mobile page.

## This pull request

- Removes the `showSuccessMesssage: true` on navigation. This flag was causing the pairing success page to be displayed instead of the download firefox page.

## Issue that this pull request solves

Closes: #13447

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
