### PR TITLE
chore(build): Point at the Github changelog

### DIFF
--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Other changes

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### New features

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### New features

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### New features

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 No changes.

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Other changes

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Other changes

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Other changes

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### New features

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Other changes

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Bug fixes

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### Bug fixes

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### New features

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## Deprecation notice
+
+Changes are now documented at https://github.com/mozilla/fxa/releases
+
 ## 1.236.0
 
 ### New features


### PR DESCRIPTION
Because:

* We're leveraging Github's release infrastructure to track release
  notes now

This commit:

* Changes the release script to point to Github

Closes FXA-5496