### PR TITLE
fix(fxa-content-server): remove blank space

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -212,7 +212,7 @@
     color: $grey-70;
     font-size: 13px;
     margin: 0;
-    padding: 90px 0 0 0 !important;
+    padding: 0 !important;
     text-align: center;
 
     .ip-address {


### PR DESCRIPTION
## Because

- There was an (unexpected) blank space in the page after we added an image to the pairing confirmation page. This removes that space.

## This pull request

- Removes the top padding from the "device being paired" element, since there's an image there now. 

## Issue that this pull request solves

Closes: #13448 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="514" alt="Screen Shot 2022-07-11 at 4 59 15 PM" src="https://user-images.githubusercontent.com/11150372/178357296-ebb80723-104d-4231-92b4-81e2610e0043.png">

After:
<img width="503" alt="Screen Shot 2022-07-11 at 4 47 05 PM" src="https://user-images.githubusercontent.com/11150372/178356886-66e24b05-fb3d-4150-af98-ce1bc3775a84.png">

What it would look like in a view without an image:
<img width="553" alt="Screen Shot 2022-07-11 at 4 47 22 PM" src="https://user-images.githubusercontent.com/11150372/178356906-7a44dfad-0c8b-4afb-be30-e6ec001d2f92.png">


## Other information (Optional)
To test:
Testing these changes is legitimately difficult, since we have no known way to see this view in local. To test these changes, go through the sync flow until you reach the appropriate page (either in stage or prod.)Then, open the dev tools, and select the "device being paired" element (with the information about your IP address etc.) Go through the css styles in the dev tools until you find `.pair-auth .client`, and change the `padding`value to `0`per the changes in this PR. Styles should appear as expected. Changes will be tested again in staging before going to prod. 

_Regarding possible side effects:_ 
I wanted to make sure that these changes wouldn't bleed out into other views unexpectedly. I searched in the templates/partials of `fxa-content-server` and found that this specific issue (an element with a class of `.client`contained by a parent element with a class of `.pair-auth` was isolated to the `pair` views. The `client` class only shows up in the `device-being-paired`mixin. While that mixin is present on many of those views, I tested what those views would look like if there were no image present, and it seems preferable to the current state of affairs (having the white blank space in between the device-being-paired element and the header.)

_Changes I didn't make in this PR and want to keep for the future:_
I had some thoughts about things we could clean up in this CSS. I have a suspicion that those `!important`tags are in place (on `.pair_auth .client` and `&.pair_auth_complete .client` in opposition to each other, so we could probably clean them up with some more digging, but that would require a deeper understanding of the styles as a whole, so I think it's worth saving that type of refactor for when we convert these away from being sass.