### PR TITLE
fix(auth): firestore processor didnt ignore proper errors

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -3014,7 +3014,12 @@ export class StripeHelper extends StripeHelperBase {
         }
       }
     } catch (err) {
-      if (err.name === FirestoreStripeError.STRIPE_CUSTOMER_DELETED) {
+      if (
+        [
+          FirestoreStripeError.STRIPE_CUSTOMER_DELETED,
+          FirestoreStripeError.FIRESTORE_CUSTOMER_NOT_FOUND,
+        ].includes(err.name)
+      ) {
         // We cannot back-fill Firestore with records for deleted customers
         // as they're missing necessary metadata for us to know which user
         // the customer belongs to.


### PR DESCRIPTION
Because:

* The firestore processor failed to find existing records for deleted
  customers nor could it create them as we don't store deleted
  customers.

This commit:

* Catches both the stripe customer deleted error and the lack of a
  firestore record from the same error case.

Closes #13591

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
