### PR TITLE
FXA-5452-create-two-versions-of-the-pair-screen-based-on-entry-point

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -6,8 +6,13 @@
   <section>
     <div class="error"></div>
 
-    <div class="graphic graphic-connect-another-device-qr-code" role="img" aria-label="{{#t}}Get Firefox on your phone or tablet{{/t}}"></div>
-    <p>{{#t}}Hold your phone's camera over the code to scan.{{/t}}<br>{{#unsafeTranslate}}Or, send yourself a <a href="https://www.mozilla.org/firefox/mobile/get-app/" class="download-firefox-mobile">download link.</a>{{/unsafeTranslate}}</p>
+    {{#showQrCode}}
+      <div class="graphic graphic-connect-another-device-qr-code" role="img" aria-label="{{#t}}Get Firefox on your phone or tablet{{/t}}"></div>
+      <p>{{#t}}Hold your phone's camera over the code to scan.{{/t}}<br>{{#unsafeTranslate}}Or, send yourself a <a href="https://www.mozilla.org/firefox/mobile/get-app/" class="download-firefox-mobile">download link.</a>{{/unsafeTranslate}}</p>
+    {{/showQrCode}}
+    {{^showQrCode}}
+      <div class="graphic {{graphicId}}" role="img" aria-label="{{#t}}Get Firefox on your phone or tablet{{/t}}"></div>
+    {{/showQrCode}}
 
     <form novalidate>
       <div class="button-row">

--- a/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
@@ -10,9 +10,11 @@
  */
 
 import UserAgentMixin from '../../lib/user-agent-mixin';
+import Constants from '../../lib/constants';
+import UrlMixin from '../../lib/url-mixin';
 
 export default {
-  dependsOn: [UserAgentMixin],
+  dependsOn: [UserAgentMixin, UrlMixin],
 
   /**
    * Returns graphicId 'graphic-connect-another-device-hearts' if the
@@ -28,5 +30,15 @@ export default {
       return 'graphic-connect-another-device-hearts';
     }
     return 'graphic-connect-another-device';
+  },
+
+  /**
+   * Returns true if the we believe the current entry points merits that we show the user
+   * a QR code that can be used download firefox on a mobile device.
+   */
+  showDownloadFirefoxQrCode() {
+    return (
+      this.getSearchParam('entrypoint') === Constants.FIREFOX_MENU_ENTRYPOINT
+    );
   },
 };

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -45,10 +45,13 @@ class PairIndexView extends FormView {
   }
 
   setInitialContext(context) {
+    // Check the entrypoint. If we aren't in a entrypoint=fxa_app_menu context, then don't show QR code.
     const graphicId = this.getGraphicsId();
+    const showQrCode = this.showDownloadFirefoxQrCode();
 
     context.set({
       graphicId,
+      showQrCode,
     });
   }
 }

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
@@ -41,4 +41,16 @@ describe('views/mixins/pairing-graphics-mixin', function () {
       );
     });
   });
+
+  describe('showDownloadFirefoxQrCode', () => {
+    it('returns true if entry point is app menu', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => 'fxa_app_menu');
+      assert.equal(view.showDownloadFirefoxQrCode(), true);
+    });
+
+    it('returns false if entry point is not app menu', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => undefined);
+      assert.equal(view.showDownloadFirefoxQrCode(), false);
+    });
+  });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -165,6 +165,22 @@ describe('views/pair/index', () => {
         assert.isTrue(view.navigateAway.calledOnce);
       });
     });
+
+    it('shows qr code', () => {
+      sinon.stub(view, 'showDownloadFirefoxQrCode').callsFake(() => true);
+      return view.render().then(() => {
+        const qrCode = view.$el.find('.graphic-connect-another-device-qr-code');
+        assert.equal(qrCode.length, 1);
+      });
+    });
+
+    it('does not show qr code', () => {
+      sinon.stub(view, 'showDownloadFirefoxQrCode').callsFake(() => false);
+      return view.render().then(() => {
+        const qrCode = view.$el.find('.graphic-connect-another-device-qr-code');
+        assert.equal(qrCode.length, 0);
+      });
+    });
   });
 
   describe('submit', () => {


### PR DESCRIPTION
## Because

- We only want to show the download qr code if the entrypoint query param is fxa_app_menu.

## This pull request

- Hides the QR code in favor of the default pair graphic when the entrypoint query parameter is not fxa_app_menu.

## Issue that this pull request solves

Closes: #13488

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/178369556-a5d4e863-c244-4800-9896-5a7b4a691936.png)

![image](https://user-images.githubusercontent.com/94418270/178369593-a45a19d3-0d1a-47a3-a344-6de48f66fa94.png)

## Other information (Optional)

There was some discussion in the initial ticket surrounding whether or not the _entrypoint=fxa_app_menu_ would be set when coming from Firefox View. I am moving forward with the assumption that this will be set in firefox view.
