### PR TITLE
feat(auth): add body logging for push fail

### DIFF
--- a/packages/fxa-auth-server/lib/push.js
+++ b/packages/fxa-auth-server/lib/push.js
@@ -468,7 +468,11 @@ module.exports = function (log, db, config, statsd) {
               log.warn(LOG_OP_DEVICE_UPDATE_FAILED, { uid, deviceId, err });
             }
           } else {
-            log.error(LOG_OP_PUSH_UNEXPECTED_ERROR, { err });
+            log.error(LOG_OP_PUSH_UNEXPECTED_ERROR, {
+              err,
+              statusCode: err.statusCode,
+              body: err.body,
+            });
             sendErrors[deviceId] = this.reportPushFailure(err, metricsTags);
           }
         }


### PR DESCRIPTION
Because:

* We want to debug push failures using additional information.

This commit:

* Adds status code and the body of the message to the logged
  message.
