### PR TITLE
fix(auth): ensure /app-store-notification endpoint returns 200s

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/purchase-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/purchase-manager.js
@@ -245,6 +245,24 @@ describe('PurchaseManager', () => {
       assert.deepEqual(result, mockSubscriptionWithNotificationProps);
     });
 
+    it('adds only notificationType to the purchase if notificationSubtype is undefined when passed in', async () => {
+      mockPurchaseDoc.data = sinon.fake.returns({});
+      mockPurchaseDoc.exists = true;
+      const notificationType = 'foo';
+      const notificationSubtype = undefined;
+      const mockSubscriptionWithNotificationProp = {
+        ...mockSubscription,
+        latestNotificationType: notificationType,
+      };
+      const result = await purchaseManager.querySubscriptionPurchase(
+        mockBundleId,
+        mockOriginalTransactionId,
+        notificationType,
+        notificationSubtype
+      );
+      assert.deepEqual(result, mockSubscriptionWithNotificationProp);
+    });
+
     it('throws unexpected library error', async () => {
       mockPurchaseDoc.ref.set = sinon.fake.rejects(new Error('test'));
       try {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
@@ -162,7 +162,9 @@ describe('AppleIapHandler', () => {
         userId: 'test1234',
       };
       mockRequest = {
-        payload: {},
+        payload: {
+          signedPayload: 'base64 encoded string',
+        },
       };
       appleIap.purchaseManager = {
         decodeNotificationPayload: sinon.fake.resolves({
@@ -178,7 +180,10 @@ describe('AppleIapHandler', () => {
     it('handles a notification that requires profile updating', async () => {
       const result = await appleIapHandler.processNotification(mockRequest);
       assert.deepEqual(result, {});
-      assert.calledOnce(appleIap.purchaseManager.decodeNotificationPayload);
+      assert.calledOnceWithExactly(
+        appleIap.purchaseManager.decodeNotificationPayload,
+        mockRequest.payload.signedPayload
+      );
       assert.calledOnce(appleIap.purchaseManager.getSubscriptionPurchase);
       assert.calledOnce(appleIap.purchaseManager.processNotification);
       assert.calledOnce(mockCapabilityService.iapUpdate);

--- a/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
@@ -93,10 +93,10 @@ export class PurchaseManager {
       // triggered by a notification
       if (triggerNotificationType !== undefined) {
         subscriptionPurchase.latestNotificationType = triggerNotificationType;
-        // This may be `undefined`, but we assign regardless to clear any previous
-        // notification's subtype value.
-        subscriptionPurchase.latestNotificationSubtype =
-          triggerNotificationSubtype;
+        if (triggerNotificationSubtype !== undefined) {
+          subscriptionPurchase.latestNotificationSubtype =
+            triggerNotificationSubtype;
+        }
       }
 
       // Convert subscriptionPurchase object to a format that to be stored in Firestore


### PR DESCRIPTION
Because:

The auth server is erroring on App Store Server notifications for several reasons:
1. App Store Server notification request payloads are larger than our default request payload max size.
2. Request payload validation was failing.
3. decodeNotificationPayload was being passed request.payload (object) instead of request.payload.signedPayload (string).
4. undefined is not a valid data type to store in Firestore.

This commit:

Fixes the route configuration and handler to ensure we respond with a 200:
1. Increases maxBytes on this endpoint to be 2x as large as the expected payload.
2. Updates Hapi request payload validation for the endpoint to reflect the expected payload structure.
3. Passes in the signed payload to decodeNotificationPayload.
4. Only adds latestNotificationSubtype to the Firestore object if its defined for document updates.

Closes #13426

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).