### PR TITLE
fix(payments): sub management breadcrumb alignment

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -53,7 +53,7 @@ export const SettingsLayout = ({ children }: { children: ReactNode }) => {
   const { config } = useContext(AppContext);
   const homeURL = `${config.servers.content.url}/settings`;
   let breadcrumbs = (
-    <nav aria-label="breadcrumbs" data-testid="breadcrumbs">
+    <nav aria-label="breadcrumbs" data-testid="breadcrumbs" className="w-full">
       <ol className="breadcrumbs">
         <li>
           <Localized id="settings-home">


### PR DESCRIPTION
## Because

- The firefox breadcrumb menu should be left aligned instead of center.

## This pull request

- Left aligns the breadcrumb to match the design and other pages.

## Issue that this pull request solves

Closes: #13557

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
