### PR TITLE
fix(redirect): Increase redirectTo validator max length

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -189,7 +189,7 @@ module.exports.isValidEmailAddress = function (value) {
 module.exports.redirectTo = function redirectTo(base) {
   const validator = isA
     .string()
-    .max(512)
+    .max(768)
     .custom((value) => {
       let hostnameRegex = '';
       if (base) {

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -360,6 +360,13 @@ describe('lib/routes/validators:', () => {
       assert.ok(res.error);
       assert.equal(res.value, 'https://mozilla.com%2Eevil.com');
     });
+
+    it('rejects if over 768 characters', () => {
+      const res = v.validate(
+        `https://example.com/path${new Array(768).fill('a').join('')}`
+      );
+      assert.ok(res.error);
+    });
   });
 
   describe('subscriptionPlanMetadataValidator', () => {


### PR DESCRIPTION
Because:
* The error 'invalid parameter redirectTo' is occuring due to the domain and needed URL/campaign parameters for subscription purchases exceeding the 512 length

This comit:
* Increases the max length from 512 to 768

fixes #13605

---

Went down some rabbit holes on this one, see [this Slack thread](https://mozilla.slack.com/archives/CLV3KMZ8B/p1657641413971839).

I'm open to suggestions on what this max length should be, we're hitting this bug since the current `redirectTo` shown in the ticket is 528 chars. We're not referencing `768` anywhere else, our relevant max lengths are `512` or `1024`, but I have a hard time believing we'll exceed 200+ more characters when most of our param length comes from flow params.