### PR TITLE
fix(redirect): Increase redirectTo validator max length

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -189,7 +189,7 @@ module.exports.isValidEmailAddress = function (value) {
 module.exports.redirectTo = function redirectTo(base) {
   const validator = isA
     .string()
-    .max(768)
+    .max(2048)
     .custom((value) => {
       let hostnameRegex = '';
       if (base) {

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -361,9 +361,9 @@ describe('lib/routes/validators:', () => {
       assert.equal(res.value, 'https://mozilla.com%2Eevil.com');
     });
 
-    it('rejects if over 768 characters', () => {
+    it('rejects if over 2048 characters', () => {
       const res = v.validate(
-        `https://example.com/path${new Array(768).fill('a').join('')}`
+        `https://example.com/${new Array(2048).fill('a').join('')}`
       );
       assert.ok(res.error);
     });


### PR DESCRIPTION
Because:
* The error 'invalid parameter redirectTo' is occuring due to the domain and needed URL/campaign parameters for subscription purchases exceeding the 512 length

This commit:
* Increases the max length from 768 to 2048. A previous commit increased this to 768 but we determined we should increase it further.