### PR TITLE
fix(sign-in/up): Display new Sync copy on force_auth and Sync mobile

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -163,6 +163,10 @@ var OAuthRelier = Relier.extend({
     return true;
   },
 
+  isSync() {
+    return this.get('serviceName') === Constants.RELIER_SYNC_SERVICE_NAME;
+  },
+
   _isVerificationFlow() {
     return !!this.getSearchParam('code');
   },

--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -1,8 +1,15 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-force-auth-header">
-      <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-      {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{#isSync}}
+        {{#unsafeTranslate}}
+          Enter your password <span class="description">for your Firefox account</span>
+        {{/unsafeTranslate}}
+      {{/isSync}}
+      {{^isSync}}
+        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
+        {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{/isSync}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -2,10 +2,9 @@
   <header>
     <h1 id="fxa-signin-password-header">
       {{#isPasswordNeeded}}
-        {{#t}}Enter your password{{/t}}
-        <span class="description">
-          {{#t}}for your Firefox account{{/t}}
-        </span>
+        {{#unsafeTranslate}}
+          Enter your password <span class="description">for your Firefox account</span>
+        {{/unsafeTranslate}}
       {{/isPasswordNeeded}}
       {{^isPasswordNeeded}}
         {{#t}}Sign in{{/t}}

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -38,9 +38,8 @@ describe('models/reliers/oauth', () => {
   var SCOPE = 'profile:email profile:uid';
   var SCOPE_OLDSYNC = 'https://identity.mozilla.com/apps/oldsync';
   var SCOPE_PROFILE = Constants.OAUTH_TRUSTED_PROFILE_SCOPE;
-  var SCOPE_PROFILE_EXPANDED = Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION.join(
-    ' '
-  );
+  var SCOPE_PROFILE_EXPANDED =
+    Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION.join(' ');
   var PERMISSIONS = ['profile:email', 'profile:uid'];
   var SCOPE_WITH_EXTRAS = 'profile:email profile:uid profile:non_whitelisted';
   var SCOPE_WITH_OPENID = 'profile:email profile:uid openid';
@@ -656,6 +655,16 @@ describe('models/reliers/oauth', () => {
       it('returns `false`', () => {
         assert.isFalse(relier.isTrusted());
       });
+    });
+  });
+
+  describe('isSync', () => {
+    it('returns `true` when serviceName matches sync', () => {
+      relier.set('serviceName', Constants.RELIER_SYNC_SERVICE_NAME);
+      assert.isTrue(relier.isSync());
+    });
+    it('returns `false` when serviceName does not match sync', () => {
+      assert.isFalse(relier.isSync());
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -186,16 +186,38 @@ describe('/views/force_auth', function () {
     });
 
     describe('with service=sync', function () {
-      it('has the service title', function () {
+      it('shows expected text', function () {
         relier.set({
-          serviceName: 'Firefox Sync',
+          uid: TestHelpers.createUid(),
+        });
+        sinon.stub(relier, 'isSync').callsFake(() => true);
+
+        return view.render().then(() => {
+          assert.include(
+            view.$(Selectors.HEADER).text(),
+            'Enter your password'
+          );
+
+          assert.include(
+            view.$(Selectors.SUB_HEADER_SYNC).text(),
+            'for your Firefox account'
+          );
+        });
+      });
+    });
+
+    describe('with non-sync Service', function () {
+      it('shows expected text', function () {
+        relier.set({
+          serviceName: 'Monitor',
           uid: TestHelpers.createUid(),
         });
 
         return view.render().then(() => {
-          assert.equal(
+          assert.include(view.$(Selectors.HEADER).text(), 'Sign in');
+          assert.include(
             view.$(Selectors.SUB_HEADER).text(),
-            'Continue to Firefox Sync'
+            'Continue to Monitor'
           );
         });
       });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/service-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/service-mixin.js
@@ -81,6 +81,13 @@ describe('views/mixins/service-mixin', () => {
       view.setInitialContext(context);
       assert.equal(context.get('serviceName'), subscriptionProductName);
     });
+
+    it('sets isSync', () => {
+      relier.set('serviceName', Constants.RELIER_SYNC_SERVICE_NAME);
+      const context = new Backbone.Model({});
+      view.setInitialContext(context);
+      assert.equal(context.get('isSync'), true);
+    });
   });
 
   describe('render', () => {

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -416,6 +416,7 @@ module.exports = {
     LINK_RESET_PASSWORD: '.reset-password',
     PASSWORD: 'input[type=password]',
     SUB_HEADER: '#fxa-force-auth-header .service',
+    SUB_HEADER_SYNC: '#fxa-force-auth-header .description',
   },
   INLINE_TOTP: {
     HEADER: '#fxa-inline-totp-setup',


### PR DESCRIPTION
Because:
* New Sync copy was not displayed on the force_auth page, or when tapping 'Sign in to Sync' through mobile FF browser

This commit:
* Updates force_auth mustache accordingly
* Tweaks the service mixin to also check for serviceName
* Places 'Enter your password for your Firefox account' in one string for l10n on sign_in_password

fixes #13424
fixes #13425