### PR TITLE
test(functional_tests): increase default timeout value for flaky tests

### DIFF
--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -19,6 +19,7 @@ test.describe('severity-1', () => {
     credentials,
     pages: { page, login, settings, secondaryEmail },
   }) => {
+    test.slow();
     await settings.goto();
     await settings.secondaryEmail.clickAdd();
     const newEmail = `blocked${Math.floor(

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -26,6 +26,7 @@ test.describe('severity-1 #smoke', () => {
     credentials,
     pages: { settings, deleteAccount, page },
   }) => {
+    test.slow();
     await settings.goto();
     await settings.clickDeleteAccount();
     await deleteAccount.checkAllBoxes();

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -26,7 +26,7 @@ test.describe('severity-1 #smoke', () => {
     credentials,
     pages: { settings, deleteAccount, page },
   }) => {
-    test.slow();
+    test.slow(); 
     await settings.goto();
     await settings.clickDeleteAccount();
     await deleteAccount.checkAllBoxes();


### PR DESCRIPTION
## Because
These two tests : `change email and unblock`,  `delete account` were the flakiest and failed every now and then with a timeout error.

## This pull request
I increased the default timeout value from 30s to 90s using `test.slow()`. I am going to monitor these tests and if the issue reoccurs I will do another fix then. But for now, looks like this will resolve the issue.

## Issue that this pull request solves
Resolves the timeout error for these two tests

Closes: #13324  

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@mozilla/fxa-devs please review! Thanks! :)
