### PR TITLE
refactor(sign-in/up): Update copy on FxA flow entry screen

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -2,7 +2,7 @@
   <header>
     {{#isSync}}
       <h1 id="fxa-enter-email-header">
-        Sign in to your Firefox account
+        {{#t}}Continue to Firefox accounts{{/t}}
       </h1>
       <p class="sync-description">
         {{#t}}Sync your passwords, tabs, and bookmarks everywhere you use Firefox.{{/t}}
@@ -36,7 +36,9 @@
       </div>
 
       <div class="button-row">
-        <button id="submit-btn" type="submit">{{#t}}Continue{{/t}}</button>
+        <button id="submit-btn" type="submit">
+          {{#t}}Sign up or sign in{{/t}}
+        </button>
       </div>
     </form>
 

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -208,7 +208,7 @@ describe('views/index', () => {
           return view.render().then(() => {
             assert.include(
               view.$(Selectors.HEADER).text(),
-              'Sign in to your Firefox account'
+              'Continue to Firefox accounts'
             );
             assert.include(
               view.$(Selectors.SYNC_DESCRIPTION).text(),


### PR DESCRIPTION
Because:
* We want clearer copy

This commit:
* Displays 'Continue to Firefox accounts' for Sync flow
* Updates the 'Continue' button to read 'Sign up or sign in' for all flows

fixes #13444

---

Confirmed with Vesta that we want to show "Sign up or sign in" on the home page on Sync and non-Sync flows.

<img width="588" alt="image" src="https://user-images.githubusercontent.com/13018240/179066832-66451d7a-729e-4798-a0c9-6ca4d4bc7d4b.png">


<img width="649" alt="image" src="https://user-images.githubusercontent.com/13018240/179066760-749d514c-5045-4008-8777-915e5c8325d5.png">
