### PR TITLE
Fxa 5322

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -1,7 +1,7 @@
 <div id="main-content" class="card confirm-signup">
     <header>
         <h1 id="fxa-confirm-signup-code-header">
-            {{#t}}Enter verification code{{/t}}
+            {{#t}}Enter confirmation code{{/t}}
             <span class="description">
                 {{#t}}for your Firefox account{{/t}}
             </span>
@@ -21,10 +21,10 @@
                 <input type="text" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
             </div>
             <div class="button-row">
-                <button id="submit-btn" type="submit">{{#t}}Verify{{/t}}</button>
+                <button id="submit-btn" type="submit">{{#t}}Confirm{{/t}}</button>
             </div>
             <div class="links">
-                <span class="delayed-fadein">{{#t}}Code expired?{{/t}}</span>&nbsp;<a id="resend" class="delayed-fadein" href="#">{{#t}}Email new code.{{/t}}</a>
+                <span class="delayed-fadein faint">{{#t}}Code expired?{{/t}}</span>&nbsp;<a id="resend" class="delayed-fadein" href="#">{{#t}}Email new code.{{/t}}</a>
             </div>
         </form>
     </section>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -1,16 +1,16 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-signin-code-header">{{#t}}Authorize this sign-in{{/t}}</h1>
+    <h1 id="fxa-signin-code-header">{{#unsafeTranslate}}Enter confirmation code<span class="description">for your Firefox account</span>{{/unsafeTranslate}}</h1>
   </header>
 
   <section>
     <div class="error"></div>
     <div class="success"></div>
 
-    <div class="graphic graphic-mail">{{#t}}Authorize this sign-in{{/t}}</div>
+    <div class="graphic graphic-mail">{{#t}}Enter confirmation{{/t}}</div>
 
     <p class="verification-email-message">
-    {{#t}}Check your email for the code sent to %(email)s.{{/t}}
+    {{#t}}Enter the code that was sent to %(email)s within 5 minutes{{/t}}
     </p>
 
     <form novalidate>
@@ -20,14 +20,13 @@
       </div>
 
       <div class="button-row">
-        <button type="submit" class="use-logged-in">{{#t}}Continue{{/t}}</button>
+        <button type="submit" class="use-logged-in">{{#t}}Confirm{{/t}}</button>
       </div>
 
     </form>
 
     <div class="links">
-        <a id="resend" class="left delayed-fadein" href="#">{{#t}}Need another code? Resend{{/t}}</a>
-        <a href="{{{ escapedSupportLink }}}" id="support-link" class="delayed-fadein right" target="_blank">{{#t}}Why is this happening?{{/t}}</a>
+      <span class="delayed-fadein faint">{{#t}}Code expired?{{/t}}</span><a id="resend" class="left delayed-fadein" href="#">{{#t}}Email new code{{/t}}</a>
     </div>
   </section>
 </div>

--- a/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
@@ -88,7 +88,7 @@ describe('views/confirm_signup_code', () => {
     it('renders the view', () => {
       assert.include(
         view.$(Selectors.HEADER).text(),
-        'Enter verification code',
+        'Enter confirmation code',
         'has header'
       );
       assert.include(


### PR DESCRIPTION
## Because

- We have new copy for the Signup Confirmation page, and the Signin Confirmation page! 

## This pull request

- Updates copy for the appropriate pages

## Issue that this pull request solves

Closes: # Couldn't find the issue, pinged to request

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before (Signup):
<img width="591" alt="Screen Shot 2022-07-14 at 2 06 22 PM" src="https://user-images.githubusercontent.com/11150372/179086092-8519ce55-b341-45e2-9a41-585225cb396a.png">



After (Signup):
<img width="527" alt="Screen Shot 2022-07-14 at 2 02 56 PM" src="https://user-images.githubusercontent.com/11150372/179085952-e020c804-6048-4ea1-8d10-ed42e72d1c35.png">

Before (Signin):
<img width="603" alt="Screen Shot 2022-07-14 at 2 15 10 PM" src="https://user-images.githubusercontent.com/11150372/179087437-6e621b96-a3f6-45bd-aaed-44b4d9066376.png">

After (Signin):
<img width="634" alt="Screen Shot 2022-07-14 at 2 11 27 PM" src="https://user-images.githubusercontent.com/11150372/179086933-e20182d9-07b3-4d98-bc99-028b1d3a5a51.png">


