### PR TITLE
Fxa 5501

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/cannot_create_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/cannot_create_account.mustache
@@ -5,7 +5,7 @@
 
   <section class="cannot-create-account-content">
     <p>
-      {{#unsafeTranslate}}You must meet certain age requirements to create a Firefox&nbsp;Account.{{/unsafeTranslate}}
+      {{#unsafeTranslate}}You must meet certain age requirements to create a Firefox&nbsp;account.{{/unsafeTranslate}}
     </p>
     <p class="links">
       <a class="ftc" href="https://www.ftc.gov/tips-advice/business-center/privacy-and-security/children%27s-privacy" {{#isSync}} target="_blank"{{/isSync}}>{{#t}}Learn more{{/t}}</a>

--- a/packages/fxa-content-server/app/scripts/templates/partial/coppa-age-input.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/coppa-age-input.mustache
@@ -1,4 +1,4 @@
 <div id="coppa" class="input-row input-row-age">
   <input type="number" pattern="\d*" id="age" placeholder="{{#t}}How old are you?{{/t}}" min="0" max="130" value="{{ age }}" {{#required}}required{{/required}} />
-  <p>{{#t}}You need to be at least 13 years old to create an account.{{/t}}</p>
+  <p>{{#t}}You must be over 13 to create an account.{{/t}}</p>
 </div>


### PR DESCRIPTION
## Because

- We have new copy for the age check when a user creates an account

## This pull request

- Updates copy

## Issue that this pull request solves

Closes: #13569
Closes: #13573

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before (signup screen):
<img width="468" alt="Screen Shot 2022-07-14 at 3 01 19 PM" src="https://user-images.githubusercontent.com/11150372/179096399-e8f1deea-cd85-4076-a65d-22f4b3f40e52.png">

After (signup screen):
<img width="459" alt="Screen Shot 2022-07-14 at 3 03 02 PM" src="https://user-images.githubusercontent.com/11150372/179096371-88c2ebc4-8e6c-4108-9eb3-e7336b5d3e6b.png">

Before (age error screen -- see incorrect capitalization of "Firefox Accounts" ):
<img width="541" alt="Screen Shot 2022-07-14 at 3 08 46 PM" src="https://user-images.githubusercontent.com/11150372/179097117-85d7acbb-49b5-4404-b3cf-26ea0e48c4ae.png">

After (age error screen -- see correct capitalization of "Firefox accounts" ):
<img width="599" alt="Screen Shot 2022-07-14 at 3 09 31 PM" src="https://user-images.githubusercontent.com/11150372/179097075-07109ff8-9ca0-4866-8f89-7ffcb05b3a96.png">

## Other information (Optional)

Any other information that is important to this pull request.
