### PR TITLE
docs(customs): Implement Swagger for API documentation

### DIFF
--- a/packages/fxa-customs-server/.eslintrc
+++ b/packages/fxa-customs-server/.eslintrc
@@ -4,10 +4,12 @@
   "parserOptions": {
     "ecmaFeatures": {
       "globalReturn": true
-    }
+    },
+    "sourceType": "module"
   },
   "rules": {
     "strict": "off",
-    "handle-callback-err": "off"
+    "handle-callback-err": "off",
+    "camelcase": "off"
   }
 }

--- a/packages/fxa-customs-server/docs/swagger/customs-server-api.js
+++ b/packages/fxa-customs-server/docs/swagger/customs-server-api.js
@@ -1,0 +1,353 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const dedent = require('dedent');
+const Joi = require('joi');
+const DESCRIPTIONS = require('./descriptions');
+
+const TAGS_CUSTOMS_SERVER = {
+  tags: ['api'],
+};
+
+const BLOCKEMAIL_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/blockEmail',
+  notes: [
+    dedent`
+      *Not currently used by anyone.*
+
+      Used by internal services to temporarily ban requests associated with a given email address. These bans last for \`config.limits.blockIntervalSeconds\` (default: 24 hours).
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description:
+            'Successful requests will produce a "200 OK" response with an empty JSON object as the body: {}',
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: email is required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/blockEmail" \\\n-d \'{\n  "email": "me@example.com"\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      email: Joi.string().description(DESCRIPTIONS.blockEmail),
+    }),
+  },
+};
+
+const BLOCKIP_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/blockIp',
+  notes: [
+    dedent`
+      *Not currently used by anyone.*
+
+      Used by internal services to temporarily ban requests associated with a given IP address. These bans last for \`config.limits.blockIntervalSeconds\` (default: 24 hours).
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description:
+            'Successful requests will produce a "200 OK" response with an empty JSON object as the body: {}',
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: ip is required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/blockIp" \\\n-d \'{\n  "ip": "192.0.2.1"\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      ip: Joi.string().description('the IP address to ban'),
+    }),
+  },
+};
+
+const CHECK_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/check',
+  notes: [
+    'Called by the auth server before performing an action on its end to check whether or not the action should be blocked. The endpoint is capable of rate-limiting and blocking requests that involve a variety of [actions](https://github.com/mozilla/fxa/blob/main/packages/fxa-customs-server/lib/actions.js).',
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            Successful requests will produce a "200 OK" response with the blocking advice in the JSON body:
+            {
+              "block": true,
+              "retryAfter": 86396
+            }
+            - \`block\` indicates whether or not the action should be blocked and \`retyAfter\` tells the client how long it should wait (in seconds) before attempting this action again.
+          `,
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: email, ip and action are all required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/check" \\\n-d \'{\n  "email": "me@example.com",\n  "ip": "192.0.2.1",\n  "action": "accountCreate"\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      email: Joi.string().description(DESCRIPTIONS.email),
+      ip: Joi.string().description(DESCRIPTIONS.ip),
+      action: Joi.string().description(DESCRIPTIONS.action),
+      headers: Joi.object().optional().description(DESCRIPTIONS.headers),
+      payload: Joi.object().optional().description(DESCRIPTIONS.payload),
+      phoneNumber: Joi.string()
+        .optional()
+        .description(DESCRIPTIONS.phoneNumber),
+    }),
+  },
+};
+
+const CHECK_AUTHENTICATED_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/checkAuthenticated',
+  notes: [
+    'Called by the auth server before performing an authenticated action to check whether or not the action should be blocked.',
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            Successful requests will produce a "200 OK" response with the blocking advice in the JSON body:
+            {
+              "block": true,
+              "retryAfter": 86396
+            }
+            - \`block\` indicates whether or not the action should be blocked and \`retyAfter\` tells the client how long it should wait (in seconds) before attempting this action again.
+          `,
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: action, ip and uid are all required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/checkAuthenticated" \\\n-d \'{\n  "action": "devicesNotify",\n  "ip": "192.0.2.1",\n  "uid": "0b65dd742b5a415487f2108cca597044",\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      action: Joi.string().description(DESCRIPTIONS.action),
+      ip: Joi.string().description(DESCRIPTIONS.ip),
+      uid: Joi.string().description(DESCRIPTIONS.uid),
+    }),
+  },
+};
+
+const CHECKIPONLY_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/checkIpOnly',
+  notes: [
+    'Like [/check](#operation/postCheck), called by the auth server before performing an action on its end to check whether or not the action should be blocked based only on the request IP.',
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            Successful requests will produce a "200 OK" response with the blocking advice in the JSON body:
+            {
+              "block": true,
+              "retryAfter": 86396
+            }
+            - \`block\` indicates whether or not the action should be blocked and \`retyAfter\` tells the client how long it should wait (in seconds) before attempting this action again.
+          `,
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: ip and action are both required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/checkIpOnly" \\\n-d \'{\n  "ip": "192.0.2.1",\n  "action": "accountCreate"\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      email: Joi.string().optional().description(DESCRIPTIONS.email),
+      ip: Joi.string().required().description(DESCRIPTIONS.ip),
+      action: Joi.string().required().description(DESCRIPTIONS.action),
+    }),
+  },
+};
+
+const FAILEDLOGINATTEMPT_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/failedLoginAttempt',
+  notes: [
+    dedent`
+      Called by the auth server to signal to the customs server that a failed login attempt has occured.
+
+      This information is stored by the customs server to enforce some of its policies.
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            Successful requests will produce a "200 OK" response: {}
+
+            - \`lockout\` indicates whether or not the account should be locked out.
+          `,
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: email and ip are both required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/failedLoginAttempt" \\\n-d \'{\n  "email": "me@example.com",\n  "ip": "192.0.2.1",\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      email: Joi.string().description(DESCRIPTIONS.email),
+      ip: Joi.string().description(DESCRIPTIONS.ip),
+      action: Joi.string().optional().description(DESCRIPTIONS.action),
+    }),
+  },
+};
+
+const PASSWORDRESET_POST = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/passwordReset',
+  notes: [
+    dedent`
+      Called by the auth server to signal to the customs server that the password on the account has been successfully reset.
+
+      The customs server uses this information to update its state (expiring bad logins for example).
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description:
+            'Successful requests will produce a "200 OK" response with an empty JSON object as the body: {}',
+        },
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - code MissingParameters: email is required
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n-H "Content-Type: application/json" \\\n"http://localhost:7000/passwordReset" \\\n-d \'{\n  "email": "me@example.com",\n}\'',
+        },
+      ],
+    },
+  },
+  validate: {
+    payload: Joi.object({
+      email: Joi.string().description(DESCRIPTIONS.email),
+    }),
+  },
+};
+
+const GET = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/',
+};
+
+const LIMITS_GET = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/limits',
+};
+
+const ALLOWED_IPS_GET = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/allowedIps',
+};
+
+const ALLOWED_EMAILDOMAINS_GET = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/allowedEmailDomains',
+};
+
+const ALLOWED_PHONENUMBERS_GET = {
+  ...TAGS_CUSTOMS_SERVER,
+  description: '/allowedPhoneNumbers',
+};
+
+module.exports = {
+  BLOCKEMAIL_POST,
+  BLOCKIP_POST,
+  CHECK_POST,
+  CHECK_AUTHENTICATED_POST,
+  CHECKIPONLY_POST,
+  FAILEDLOGINATTEMPT_POST,
+  PASSWORDRESET_POST,
+  GET,
+  LIMITS_GET,
+  ALLOWED_IPS_GET,
+  ALLOWED_EMAILDOMAINS_GET,
+  ALLOWED_PHONENUMBERS_GET,
+};

--- a/packages/fxa-customs-server/docs/swagger/descriptions.js
+++ b/packages/fxa-customs-server/docs/swagger/descriptions.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = {
+  action: 'the name of the action under consideration',
+  blockEmail: 'the email address associated with the account to ban',
+  email: 'the email address associated with the account',
+  headers: 'the forwarded headers of the original request',
+  ip: 'the IP address where the request originates',
+  payload: 'the payload of the original request',
+  phoneNumber: 'optional phone number of request',
+  uid: 'account identifier',
+};

--- a/packages/fxa-customs-server/docs/swagger/swagger-options.js
+++ b/packages/fxa-customs-server/docs/swagger/swagger-options.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const dedent = require('dedent');
+
+module.exports = {
+  info: {
+    title: 'Firefox Accounts Customs Server API Documentation',
+    description: dedent`
+      # Overview
+
+      ## Request Format
+      None of the requests are authenticated. The customs server is an internal service that is running on the same machine as the service that uses it (currently only the auth server) and is listening on localhost.
+
+      ## Response Format
+      All successful requests will produce a response with HTTP status code of "200" and content-type of "application/json". The structure of the response body will depend on the endpoint in question.
+
+      Failures due to invalid behavior from the client will produce a response with HTTP status code of "400" and content-type of "application/json". Failures due to an unexpected situation on the server will produce a response with HTTP status code of "500" and content-type of "application/json".
+
+      ## API Endpoints
+      - [GET /allowedEmailDomains](#operation/getAllowedemaildomains)
+      - [GET /allowedIps](#operation/getAllowedips)
+      - [GET /allowedPhoneNumbers](#operation/getAllowedphonenumbers)
+      - [GET /limits](#operation/getLimits)
+      - [GET /](#operation/get)
+      - [POST /blockEmail](#operation/postBlockemail)
+      - [POST /blockIp](#operation/postBlockip)
+      - [POST /check](#operation/postCheck)
+      - [POST /checkAuthenticated](#operation/postCheckauthenticated)
+      - [POST /checkIpOnly](#operation/postCheckiponly)
+      - [POST /failedLoginAttempt](#operation/postFailedloginattempt)
+      - [POST /passwordReset](#operation/postPasswordreset)
+    `,
+  },
+  basePath: '/',
+  schemes: ['https'],
+  grouping: 'tags',
+  documentationPage: false,
+  swaggerUI: false,
+};

--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -7,7 +7,10 @@
 'use strict';
 
 const Hapi = require('@hapi/hapi');
+const HapiSwagger = require('hapi-swagger');
 const Memcached = require('memcached');
+const swaggerOptions = require('../docs/swagger/swagger-options');
+const API_DOCS = require('../docs/swagger/customs-server-api');
 const packageJson = require('../package.json');
 const blockReasons = require('./block_reasons');
 const P = require('bluebird');
@@ -173,304 +176,124 @@ module.exports = async function createServer(config, log) {
     return lowercaseEmail;
   }
 
+  api.register([
+    {
+      plugin: HapiSwagger,
+      options: swaggerOptions,
+    },
+  ]);
+
   api.route({
     method: 'POST',
     path: '/check',
-    handler: async (req, h) => {
-      let email = req.payload.email;
-      const { ip, action } = req.payload;
-      const headers = req.headers || {};
-      const payload = req.payload.payload || {};
+    options: {
+      handler: async (req, h) => {
+        let email = req.payload.email;
+        const { ip, action } = req.payload;
+        const headers = req.headers || {};
+        const payload = req.payload.payload || {};
 
-      if (!email || !ip || !action) {
-        const err = {
-          code: 'MissingParameters',
-          message: 'email, ip and action are all required',
-        };
-        log.error({ op: 'request.check', email, ip, action, err });
-        return h.response(err).code(400);
-      }
-      email = normalizedEmail(email);
-
-      // Phone number is optional
-      let phoneNumber;
-      if (payload.phoneNumber) {
-        phoneNumber = payload.phoneNumber;
-      }
-
-      async function checkRecords({
-        ipRecord,
-        reputation,
-        emailRecord,
-        ipEmailRecord,
-        smsRecord,
-      }) {
-        if (ipRecord.isBlocked() || ipRecord.isDisabled()) {
-          // a blocked ip should just be ignored completely
-          // it's malicious, it shouldn't penalize emails or allow
-          // (most) escape hatches. just abort!
-          return {
-            block: true,
-            retryAfter: ipRecord.retryAfter(),
+        if (!email || !ip || !action) {
+          const err = {
+            code: 'MissingParameters',
+            message: 'email, ip and action are all required',
           };
+          log.error({ op: 'request.check', email, ip, action, err });
+          return h.response(err).code(400);
+        }
+        email = normalizedEmail(email);
+
+        // Phone number is optional
+        let phoneNumber;
+        if (payload.phoneNumber) {
+          phoneNumber = payload.phoneNumber;
         }
 
-        // Check each record type to see if a retryAfter has been set
-        const wantsUnblock = payload.unblockCode;
-        const blockEmail = emailRecord.update(action, !!wantsUnblock);
-        let blockIpEmail = ipEmailRecord.update(action);
-        const blockIp = ipRecord.update(action, email);
-
-        let blockSMS = 0;
-        if (smsRecord) {
-          blockSMS = smsRecord.update(action);
-        }
-
-        if (blockIpEmail && ipEmailRecord.unblockIfReset(emailRecord.pr)) {
-          blockIpEmail = 0;
-        }
-
-        let retryAfter = [blockEmail, blockIpEmail, blockIp, blockSMS].reduce(
-          max
-        );
-        let block = retryAfter > 0;
-        let suspect = false;
-        let blockReason = null;
-
-        if (block) {
-          blockReason = blockReasons.OTHER;
-        }
-
-        if (
-          requestChecks.treatEveryoneWithSuspicion ||
-          reputationService.isSuspectBelow(reputation) ||
-          ipRecord.isSuspected() ||
-          emailRecord.isSuspected()
-        ) {
-          suspect = true;
-        }
-
-        if (!block && action === 'accountLogin') {
-          // All login requests should include a valid flowId.
-          if (!payload.metricsContext || !payload.metricsContext.flowId) {
-            // Unless they're legacy user-agents that we know will not include it.
-            var isExemptUA = false;
-            var userAgent = headers['user-agent'];
-            isExemptUA = requestChecks.flowIdExemptUserAgentCompiledREs.some(
-              function (re) {
-                return re.test(userAgent);
-              }
-            );
-            // Or unless it's for non-signin-related reasons, e.g. changing password.
-            // We know these requests will not include it.
-            var isExemptRequest = false;
-            if (payload.reason && payload.reason !== 'signin') {
-              isExemptRequest = true;
-            }
-            if (!isExemptUA && !isExemptRequest) {
-              // By default we just treat a missing flowId as suspicious,
-              // but config can change this to a hard block.
-              suspect = true;
-              if (requestChecks.flowIdRequiredOnLogin) {
-                block = true;
-              }
-            }
-          }
-        }
-
-        const canUnblock = emailRecord.canUnblock();
-
-        // IP's that are in blocklist should be blocked
-        // and not return a retryAfter because it is not known
-        // when they would be removed from blocklist
-        if (config.ipBlocklist.enable && blockListManager.contains(ip)) {
-          block = true;
-          blockReason = blockReasons.IP_IN_BLOCKLIST;
-          retryAfter = 0;
-        }
-
-        if (reputationService.isBlockBelow(reputation)) {
-          block = true;
-          retryAfter = ipRecord.retryAfter();
-          blockReason = blockReasons.IP_BAD_REPUTATION;
-        }
-
-        // smsRecord is optional, trying to save an undefined record results in an error
-        const recordsToSave = [
+        async function checkRecords({
           ipRecord,
+          reputation,
           emailRecord,
           ipEmailRecord,
           smsRecord,
-        ].filter((record) => !!record);
-        await setRecords(...recordsToSave);
-        return {
-          block,
-          blockReason,
-          retryAfter,
-          unblock: canUnblock,
-          suspect,
-        };
-      }
-
-      function createResponse(result) {
-        const { block, unblock, suspect, blockReason } = result;
-
-        checkAllowlist(result, ip, email, phoneNumber);
-
-        log.info({
-          op: 'request.check',
-          email,
-          ip,
-          action,
-          block,
-          unblock,
-          suspect,
-        });
-
-        const response = {
-          block: result.block,
-          retryAfter: result.retryAfter,
-          unblock: result.unblock,
-          suspect: result.suspect,
-        };
-
-        if (blockReason) {
-          response['blockReason'] = blockReason;
-        }
-
-        optionallyReportIp(result, ip, action);
-
-        return response;
-      }
-
-      function handleError(err) {
-        log.error({
-          op: 'request.check',
-          email: email,
-          ip: ip,
-          action: action,
-          err: err,
-        });
-
-        // Default is to block request on any server based error
-        return {
-          block: true,
-          retryAfter: limits.rateLimitIntervalSeconds,
-          unblock: false,
-        };
-      }
-
-      return fetchRecords({ ip, email, phoneNumber })
-        .then(checkRecords)
-        .then((result) =>
-          checkUserDefinedRateLimitRules(result, action, email, ip)
-        )
-        .then(createResponse, handleError);
-    },
-  });
-
-  api.route({
-    method: 'POST',
-    path: '/checkAuthenticated',
-    handler: async (req, h) => {
-      var action = req.payload.action;
-      var ip = req.payload.ip;
-      var uid = req.payload.uid;
-
-      if (!action || !ip || !uid) {
-        var err = {
-          code: 'MissingParameters',
-          message: 'action, ip and uid are all required',
-        };
-        log.error({
-          op: 'request.checkAuthenticated',
-          action: action,
-          ip: ip,
-          uid: uid,
-          err: err,
-        });
-        return h.response(err).code(400);
-      }
-
-      return fetchRecords({ uid })
-        .then(({ uidRecord }) => {
-          var retryAfter = uidRecord.addCount(action, uid);
-          return setRecords(uidRecord).then(function () {
-            return {
-              block: retryAfter > 0,
-              retryAfter: retryAfter,
-            };
-          });
-        })
-        .then(
-          function (result) {
-            log.info({ op: 'request.checkAuthenticated', block: result.block });
-
-            if (result.block) {
-              reputationService.report(
-                ip,
-                'fxa:request.checkAuthenticated.block.' + action
-              );
-            }
-
-            return result;
-          },
-          function (err) {
-            log.error({ op: 'request.checkAuthenticated', err: err });
-            // Default is to block request on any server based error
-
-            reputationService.report(
-              ip,
-              'fxa:request.checkAuthenticated.block.' + action
-            );
-
+        }) {
+          if (ipRecord.isBlocked() || ipRecord.isDisabled()) {
+            // a blocked ip should just be ignored completely
+            // it's malicious, it shouldn't penalize emails or allow
+            // (most) escape hatches. just abort!
             return {
               block: true,
-              retryAfter: limits.blockIntervalSeconds,
+              retryAfter: ipRecord.retryAfter(),
             };
           }
-        );
-    },
-  });
 
-  api.route({
-    method: 'POST',
-    path: '/checkIpOnly',
-    handler: async (req, h) => {
-      const action = req.payload.action;
-      const ip = req.payload.ip;
+          // Check each record type to see if a retryAfter has been set
+          const wantsUnblock = payload.unblockCode;
+          const blockEmail = emailRecord.update(action, !!wantsUnblock);
+          let blockIpEmail = ipEmailRecord.update(action);
+          const blockIp = ipRecord.update(action, email);
 
-      if (!action || !ip) {
-        const err = {
-          code: 'MissingParameters',
-          message: 'action and ip are both required',
-        };
-        log.error({
-          op: 'request.checkIpOnly',
-          action: action,
-          ip: ip,
-          err: err,
-        });
-        return h.response(err).code(400);
-      }
-
-      return fetchRecords({ ip })
-        .then(({ ipRecord, reputation }) => {
-          if (ipRecord.isBlocked() || ipRecord.isDisabled()) {
-            return { block: true, retryAfter: ipRecord.retryAfter() };
+          let blockSMS = 0;
+          if (smsRecord) {
+            blockSMS = smsRecord.update(action);
           }
 
-          const suspect =
-            requestChecks.treatEveryoneWithSuspicion ||
-            reputationService.isSuspectBelow(reputation);
-          let retryAfter = ipRecord.update(action);
+          if (blockIpEmail && ipEmailRecord.unblockIfReset(emailRecord.pr)) {
+            blockIpEmail = 0;
+          }
+
+          let retryAfter = [blockEmail, blockIpEmail, blockIp, blockSMS].reduce(
+            max
+          );
           let block = retryAfter > 0;
-          let blockReason;
+          let suspect = false;
+          let blockReason = null;
 
           if (block) {
             blockReason = blockReasons.OTHER;
           }
 
+          if (
+            requestChecks.treatEveryoneWithSuspicion ||
+            reputationService.isSuspectBelow(reputation) ||
+            ipRecord.isSuspected() ||
+            emailRecord.isSuspected()
+          ) {
+            suspect = true;
+          }
+
+          if (!block && action === 'accountLogin') {
+            // All login requests should include a valid flowId.
+            if (!payload.metricsContext || !payload.metricsContext.flowId) {
+              // Unless they're legacy user-agents that we know will not include it.
+              var isExemptUA = false;
+              var userAgent = headers['user-agent'];
+              isExemptUA = requestChecks.flowIdExemptUserAgentCompiledREs.some(
+                function (re) {
+                  return re.test(userAgent);
+                }
+              );
+              // Or unless it's for non-signin-related reasons, e.g. changing password.
+              // We know these requests will not include it.
+              var isExemptRequest = false;
+              if (payload.reason && payload.reason !== 'signin') {
+                isExemptRequest = true;
+              }
+              if (!isExemptUA && !isExemptRequest) {
+                // By default we just treat a missing flowId as suspicious,
+                // but config can change this to a hard block.
+                suspect = true;
+                if (requestChecks.flowIdRequiredOnLogin) {
+                  block = true;
+                }
+              }
+            }
+          }
+
+          const canUnblock = emailRecord.canUnblock();
+
+          // IP's that are in blocklist should be blocked
+          // and not return a retryAfter because it is not known
+          // when they would be removed from blocklist
           if (config.ipBlocklist.enable && blockListManager.contains(ip)) {
             block = true;
             blockReason = blockReasons.IP_IN_BLOCKLIST;
@@ -483,229 +306,461 @@ module.exports = async function createServer(config, log) {
             blockReason = blockReasons.IP_BAD_REPUTATION;
           }
 
-          return setRecords(ipRecord).then(() => ({
+          // smsRecord is optional, trying to save an undefined record results in an error
+          const recordsToSave = [
+            ipRecord,
+            emailRecord,
+            ipEmailRecord,
+            smsRecord,
+          ].filter((record) => !!record);
+          await setRecords(...recordsToSave);
+          return {
             block,
             blockReason,
             retryAfter,
+            unblock: canUnblock,
             suspect,
-          }));
-        })
-        .then(
-          (result) => {
-            checkAllowlist(result, ip);
+          };
+        }
 
-            log.info({
-              op: 'request.checkIpOnly',
-              ip,
-              action,
-              block: result.block,
-              blockReason: result.blockReason,
-              suspect: result.suspect,
+        function createResponse(result) {
+          const { block, unblock, suspect, blockReason } = result;
+
+          checkAllowlist(result, ip, email, phoneNumber);
+
+          log.info({
+            op: 'request.check',
+            email,
+            ip,
+            action,
+            block,
+            unblock,
+            suspect,
+          });
+
+          const response = {
+            block: result.block,
+            retryAfter: result.retryAfter,
+            unblock: result.unblock,
+            suspect: result.suspect,
+          };
+
+          if (blockReason) {
+            response['blockReason'] = blockReason;
+          }
+
+          optionallyReportIp(result, ip, action);
+
+          return response;
+        }
+
+        function handleError(err) {
+          log.error({
+            op: 'request.check',
+            email: email,
+            ip: ip,
+            action: action,
+            err: err,
+          });
+
+          // Default is to block request on any server based error
+          return {
+            block: true,
+            retryAfter: limits.rateLimitIntervalSeconds,
+            unblock: false,
+          };
+        }
+
+        return fetchRecords({ ip, email, phoneNumber })
+          .then(checkRecords)
+          .then((result) =>
+            checkUserDefinedRateLimitRules(result, action, email, ip)
+          )
+          .then(createResponse, handleError);
+      },
+      ...API_DOCS.CHECK_POST,
+    },
+  });
+
+  api.route({
+    method: 'POST',
+    path: '/checkAuthenticated',
+    options: {
+      handler: async (req, h) => {
+        var action = req.payload.action;
+        var ip = req.payload.ip;
+        var uid = req.payload.uid;
+
+        if (!action || !ip || !uid) {
+          var err = {
+            code: 'MissingParameters',
+            message: 'action, ip and uid are all required',
+          };
+          log.error({
+            op: 'request.checkAuthenticated',
+            action: action,
+            ip: ip,
+            uid: uid,
+            err: err,
+          });
+          return h.response(err).code(400);
+        }
+
+        return fetchRecords({ uid })
+          .then(({ uidRecord }) => {
+            var retryAfter = uidRecord.addCount(action, uid);
+            return setRecords(uidRecord).then(function () {
+              return {
+                block: retryAfter > 0,
+                retryAfter: retryAfter,
+              };
             });
+          })
+          .then(
+            function (result) {
+              log.info({
+                op: 'request.checkAuthenticated',
+                block: result.block,
+              });
 
-            const response = {
-              block: result.block,
-              retryAfter: result.retryAfter,
-              suspect: result.suspect,
-            };
+              if (result.block) {
+                reputationService.report(
+                  ip,
+                  'fxa:request.checkAuthenticated.block.' + action
+                );
+              }
 
-            if (result.blockReason) {
-              response['blockReason'] = result.blockReason;
+              return result;
+            },
+            function (err) {
+              log.error({ op: 'request.checkAuthenticated', err: err });
+              // Default is to block request on any server based error
+
+              reputationService.report(
+                ip,
+                'fxa:request.checkAuthenticated.block.' + action
+              );
+
+              return {
+                block: true,
+                retryAfter: limits.blockIntervalSeconds,
+              };
+            }
+          );
+      },
+      ...API_DOCS.CHECK_AUTHENTICATED_POST,
+    },
+  });
+
+  api.route({
+    method: 'POST',
+    path: '/checkIpOnly',
+    options: {
+      handler: async (req, h) => {
+        const action = req.payload.action;
+        const ip = req.payload.ip;
+
+        if (!action || !ip) {
+          const err = {
+            code: 'MissingParameters',
+            message: 'action and ip are both required',
+          };
+          log.error({
+            op: 'request.checkIpOnly',
+            action: action,
+            ip: ip,
+            err: err,
+          });
+          return h.response(err).code(400);
+        }
+
+        return fetchRecords({ ip })
+          .then(({ ipRecord, reputation }) => {
+            if (ipRecord.isBlocked() || ipRecord.isDisabled()) {
+              return { block: true, retryAfter: ipRecord.retryAfter() };
             }
 
-            optionallyReportIp(result, ip, action);
+            const suspect =
+              requestChecks.treatEveryoneWithSuspicion ||
+              reputationService.isSuspectBelow(reputation);
+            let retryAfter = ipRecord.update(action);
+            let block = retryAfter > 0;
+            let blockReason;
 
-            return response;
-          },
-          (err) => {
-            log.error({
-              op: 'request.checkIpOnly',
-              ip: ip,
-              action: action,
-              err: err,
-            });
-            return {
-              block: true,
-              retryAfter: limits.ipRateLimitIntervalSeconds,
-            };
-          }
-        );
+            if (block) {
+              blockReason = blockReasons.OTHER;
+            }
+
+            if (config.ipBlocklist.enable && blockListManager.contains(ip)) {
+              block = true;
+              blockReason = blockReasons.IP_IN_BLOCKLIST;
+              retryAfter = 0;
+            }
+
+            if (reputationService.isBlockBelow(reputation)) {
+              block = true;
+              retryAfter = ipRecord.retryAfter();
+              blockReason = blockReasons.IP_BAD_REPUTATION;
+            }
+
+            return setRecords(ipRecord).then(() => ({
+              block,
+              blockReason,
+              retryAfter,
+              suspect,
+            }));
+          })
+          .then(
+            (result) => {
+              checkAllowlist(result, ip);
+
+              log.info({
+                op: 'request.checkIpOnly',
+                ip,
+                action,
+                block: result.block,
+                blockReason: result.blockReason,
+                suspect: result.suspect,
+              });
+
+              const response = {
+                block: result.block,
+                retryAfter: result.retryAfter,
+                suspect: result.suspect,
+              };
+
+              if (result.blockReason) {
+                response['blockReason'] = result.blockReason;
+              }
+
+              optionallyReportIp(result, ip, action);
+
+              return response;
+            },
+            (err) => {
+              log.error({
+                op: 'request.checkIpOnly',
+                ip: ip,
+                action: action,
+                err: err,
+              });
+              return {
+                block: true,
+                retryAfter: limits.ipRateLimitIntervalSeconds,
+              };
+            }
+          );
+      },
+      ...API_DOCS.CHECKIPONLY_POST,
     },
   });
 
   api.route({
     method: 'POST',
     path: '/failedLoginAttempt',
-    handler: async (req, h) => {
-      let email = req.payload.email;
-      const ip = req.payload.ip;
-      const errno = Number(req.payload.errno) || 999;
-      if (!email || !ip) {
-        const err = {
-          code: 'MissingParameters',
-          message: 'email and ip are both required',
-        };
-        log.error({
-          op: 'request.failedLoginAttempt',
-          email: email,
-          ip: ip,
-          err: err,
-        });
-        return h.response(err).code(400);
-      }
-      email = normalizedEmail(email);
+    options: {
+      handler: async (req, h) => {
+        let email = req.payload.email;
+        const ip = req.payload.ip;
+        const errno = Number(req.payload.errno) || 999;
+        if (!email || !ip) {
+          const err = {
+            code: 'MissingParameters',
+            message: 'email and ip are both required',
+          };
+          log.error({
+            op: 'request.failedLoginAttempt',
+            email: email,
+            ip: ip,
+            err: err,
+          });
+          return h.response(err).code(400);
+        }
+        email = normalizedEmail(email);
 
-      return fetchRecords({ ip, email })
-        .then(function ({ ipRecord, emailRecord, ipEmailRecord }) {
-          ipRecord.addBadLogin({ email: email, errno: errno });
-          ipEmailRecord.addBadLogin();
-          emailRecord.addBadLogin();
+        return fetchRecords({ ip, email })
+          .then(function ({ ipRecord, emailRecord, ipEmailRecord }) {
+            ipRecord.addBadLogin({ email: email, errno: errno });
+            ipEmailRecord.addBadLogin();
+            emailRecord.addBadLogin();
 
-          if (ipRecord.isOverBadLogins()) {
-            reputationService.report(
-              ip,
-              'fxa:request.failedLoginAttempt.isOverBadLogins'
+            if (ipRecord.isOverBadLogins()) {
+              reputationService.report(
+                ip,
+                'fxa:request.failedLoginAttempt.isOverBadLogins'
+              );
+            }
+
+            return setRecords(ipRecord, emailRecord, ipEmailRecord).then(
+              function () {
+                return {};
+              }
             );
-          }
-
-          return setRecords(ipRecord, emailRecord, ipEmailRecord).then(
-            function () {
-              return {};
+          })
+          .then(
+            function (result) {
+              log.info({
+                op: 'request.failedLoginAttempt',
+                email: email,
+                ip: ip,
+                errno: errno,
+              });
+              return result;
+            },
+            function (err) {
+              log.error({
+                op: 'request.failedLoginAttempt',
+                email: email,
+                ip: ip,
+                err: err,
+              });
+              return h.response(err).code(500);
             }
           );
-        })
-        .then(
-          function (result) {
-            log.info({
-              op: 'request.failedLoginAttempt',
-              email: email,
-              ip: ip,
-              errno: errno,
-            });
-            return result;
-          },
-          function (err) {
-            log.error({
-              op: 'request.failedLoginAttempt',
-              email: email,
-              ip: ip,
-              err: err,
-            });
-            return h.response(err).code(500);
-          }
-        );
+      },
+      ...API_DOCS.FAILEDLOGINATTEMPT_POST,
     },
   });
 
   api.route({
     method: 'POST',
     path: '/passwordReset',
-    handler: async (req, h) => {
-      var email = req.payload.email;
-      if (!email) {
-        const err = { code: 'MissingParameters', message: 'email is required' };
-        log.error({ op: 'request.passwordReset', email: email, err: err });
-        return h.response(err).code(400);
-      }
-      email = normalizedEmail(email);
+    options: {
+      handler: async (req, h) => {
+        var email = req.payload.email;
+        if (!email) {
+          const err = {
+            code: 'MissingParameters',
+            message: 'email is required',
+          };
+          log.error({ op: 'request.passwordReset', email: email, err: err });
+          return h.response(err).code(400);
+        }
+        email = normalizedEmail(email);
 
-      const { emailRecord } = await fetchRecords({ email });
-      emailRecord.passwordReset();
+        const { emailRecord } = await fetchRecords({ email });
+        emailRecord.passwordReset();
 
-      try {
-        await setRecords(emailRecord);
-        return {};
-      } catch (err) {
-        logError(err);
-        return h.response(err).code(500);
-      }
+        try {
+          await setRecords(emailRecord);
+          return {};
+        } catch (err) {
+          logError(err);
+          return h.response(err).code(500);
+        }
+      },
+      ...API_DOCS.PASSWORDRESET_POST,
     },
   });
 
   api.route({
     method: 'POST',
     path: '/blockEmail',
-    handler: async (req, h) => {
-      var email = req.payload.email;
-      if (!email) {
-        const err = { code: 'MissingParameters', message: 'email is required' };
-        log.error({ op: 'request.blockEmail', email: email, err: err });
-        return h.response(err).code(400);
-      }
-      email = normalizedEmail(email);
-
-      return handleBan({ ban: { email: email } })
-        .then(function () {
-          log.info({ op: 'request.blockEmail', email: email });
-          return {};
-        })
-        .catch(function (err) {
+    options: {
+      handler: async (req, h) => {
+        var email = req.payload.email;
+        if (!email) {
+          const err = {
+            code: 'MissingParameters',
+            message: 'email is required',
+          };
           log.error({ op: 'request.blockEmail', email: email, err: err });
-          return h.response(err).code(500);
-        });
+          return h.response(err).code(400);
+        }
+        email = normalizedEmail(email);
+
+        return handleBan({ ban: { email: email } })
+          .then(function () {
+            log.info({ op: 'request.blockEmail', email: email });
+            return {};
+          })
+          .catch(function (err) {
+            log.error({ op: 'request.blockEmail', email: email, err: err });
+            return h.response(err).code(500);
+          });
+      },
+      ...API_DOCS.BLOCKEMAIL_POST,
     },
   });
 
   api.route({
     method: 'POST',
     path: '/blockIp',
-    handler: async (req, h) => {
-      var ip = req.payload.ip;
-      if (!ip) {
-        const err = { code: 'MissingParameters', message: 'ip is required' };
-        log.error({ op: 'request.blockIp', ip: ip, err: err });
-        return h.response(err).code(400);
-      }
+    options: {
+      handler: async (req, h) => {
+        var ip = req.payload.ip;
+        if (!ip) {
+          const err = { code: 'MissingParameters', message: 'ip is required' };
+          log.error({ op: 'request.blockIp', ip: ip, err: err });
+          return h.response(err).code(400);
+        }
 
-      try {
-        await handleBan({ ban: { ip: ip } });
-        reputationService.report(ip, 'fxa:request.blockIp');
-        log.info({ op: 'request.blockIp', ip: ip });
-        return {};
-      } catch (err) {
-        log.error({ op: 'request.blockIp', ip: ip, err: err });
-        return h.response(err).code(500);
-      }
+        try {
+          await handleBan({ ban: { ip: ip } });
+          reputationService.report(ip, 'fxa:request.blockIp');
+          log.info({ op: 'request.blockIp', ip: ip });
+          return {};
+        } catch (err) {
+          log.error({ op: 'request.blockIp', ip: ip, err: err });
+          return h.response(err).code(500);
+        }
+      },
+      ...API_DOCS.BLOCKIP_POST,
     },
   });
 
   api.route({
     method: 'GET',
     path: '/',
-    handler: async () => {
-      return { version: packageJson.version };
+    options: {
+      handler: async () => {
+        return { version: packageJson.version };
+      },
+      ...API_DOCS.GET,
     },
   });
 
   api.route({
     method: 'GET',
     path: '/limits',
-    handler: async () => {
-      return limits;
+    options: {
+      handler: async () => {
+        return limits;
+      },
+      ...API_DOCS.LIMITS_GET,
     },
   });
 
   api.route({
     method: 'GET',
     path: '/allowedIPs',
-    handler: async () => {
-      return Object.keys(allowedIPs.ips);
+    options: {
+      handler: async () => {
+        return Object.keys(allowedIPs.ips);
+      },
+      ...API_DOCS.ALLOWED_IPS_GET,
     },
   });
 
   api.route({
     method: 'GET',
     path: '/allowedEmailDomains',
-    handler: async () => {
-      return Object.keys(allowedEmailDomains.domains);
+    options: {
+      handler: async () => {
+        return Object.keys(allowedEmailDomains.domains);
+      },
+      ...API_DOCS.ALLOWED_EMAILDOMAINS_GET,
     },
   });
 
   api.route({
     method: 'GET',
     path: '/allowedPhoneNumbers',
-    handler: async () => {
-      return allowedPhoneNumbers.toJSON();
+    options: {
+      handler: async () => {
+        return allowedPhoneNumbers.toJSON();
+      },
+      ...API_DOCS.ALLOWED_PHONENUMBERS_GET,
     },
   });
 

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -33,14 +33,18 @@
     "convict": "^6.2.3",
     "convict-format-with-moment": "^6.2.0",
     "convict-format-with-validator": "^6.2.0",
+    "dedent": "^0.7.0",
     "deep-equal": "2.0.5",
+    "hapi-swagger": "^14.5.5",
     "ip": "^1.1.8",
     "ip-reputation-js-client": "^6.0.4",
+    "joi": "^17.6.0",
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.2",
     "memcached": "^2.2.2"
   },
   "devDependencies": {
+    "@types/dedent": "^0",
     "audit-filter": "^0.5.0",
     "chai": "^4.3.6",
     "eslint": "^7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apidevtools/json-schema-ref-parser@npm:^9.0.6":
+  version: 9.0.9
+  resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
+  dependencies:
+    "@jsdevtools/ono": ^7.1.3
+    "@types/json-schema": ^7.0.6
+    call-me-maybe: ^1.0.1
+    js-yaml: ^4.1.0
+  checksum: b21f6bdd37d2942c3967ee77569bc74fadd1b922f688daf5ef85057789a2c3a7f4afc473aa2f3a93ec950dabb6ef365f8bd9cf51e4e062a1ee1e59b989f8f9b4
+  languageName: node
+  linkType: hard
+
+"@apidevtools/openapi-schemas@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "@apidevtools/openapi-schemas@npm:2.1.0"
+  checksum: 4a8f64935b9049ef21e41fa4b188f39f6bc3f5291cebd451701db1115451ccb246a739e46cc5ce9ecdec781671431db40db7851acdac84a990a45756e0f32de3
+  languageName: node
+  linkType: hard
+
+"@apidevtools/swagger-methods@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@apidevtools/swagger-methods@npm:3.0.2"
+  checksum: d06b1ac5c1956613c4c6be695612ef860cd4e962b93a509ca551735a328a856cae1e33399cac1dcbf8333ba22b231746f3586074769ef0e172cf549ec9e7eaae
+  languageName: node
+  linkType: hard
+
+"@apidevtools/swagger-parser@npm:10.0.3":
+  version: 10.0.3
+  resolution: "@apidevtools/swagger-parser@npm:10.0.3"
+  dependencies:
+    "@apidevtools/json-schema-ref-parser": ^9.0.6
+    "@apidevtools/openapi-schemas": ^2.0.4
+    "@apidevtools/swagger-methods": ^3.0.2
+    "@jsdevtools/ono": ^7.1.3
+    call-me-maybe: ^1.0.1
+    z-schema: ^5.0.1
+  peerDependencies:
+    openapi-types: ">=7"
+  checksum: 580a86d4c2a667e825dae80d2ed115c282e6210e3cb0ffc39b3bf5fc5b4fcb576cce3fc3d0519b6c4de8fa617ab0dbee1adeac134d0c1364e0a0f7d394b28796
+  languageName: node
+  linkType: hard
+
 "@apollo/client@npm:^3.4.5":
   version: 3.4.5
   resolution: "@apollo/client@npm:3.4.5"
@@ -4990,6 +5032,13 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: e38254e830472248ca10a6ed1ae75af5e8514f0680245a5e7b53bc3c030fd8691d4d3115d80595b45d3badead68269769ed47ecbbdd67db1343a11f05700e75a
+  languageName: node
+  linkType: hard
+
+"@jsdevtools/ono@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "@jsdevtools/ono@npm:7.1.3"
+  checksum: 2297fcd472ba810bffe8519d2249171132844c7174f3a16634f9260761c8c78bc0428a4190b5b6d72d45673c13918ab9844d706c3ed4ef8f62ab11a2627a08ad
   languageName: node
   linkType: hard
 
@@ -9917,6 +9966,13 @@ __metadata:
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
   checksum: 259d0e25f11a21ba5c708f7ea47196bd396e379fddb79c76f9f4f62c945879dc21657904914313ec2754e443c5018ea8372362f323f30e0792897fdb2098a705
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.6":
+  version: 7.0.11
+  resolution: "@types/json-schema@npm:7.0.11"
+  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
   languageName: node
   linkType: hard
 
@@ -23009,6 +23065,7 @@ fsevents@~2.1.1:
     "@hapi/hapi": ^20.2.1
     "@hapi/hoek": ^10.0.0
     "@sentry/node": ^6.19.1
+    "@types/dedent": ^0
     audit-filter: ^0.5.0
     bl: 5.0.0
     bluebird: ^3.7.2
@@ -23017,6 +23074,7 @@ fsevents@~2.1.1:
     convict: ^6.2.3
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
+    dedent: ^0.7.0
     deep-equal: 2.0.5
     eslint: ^7.32.0
     eslint-plugin-fxa: ^2.0.2
@@ -23025,8 +23083,10 @@ fsevents@~2.1.1:
     grunt-cli: ^1.4.3
     grunt-copyright: 0.3.0
     grunt-eslint: ^23.0.0
+    hapi-swagger: ^14.5.5
     ip: ^1.1.8
     ip-reputation-js-client: ^6.0.4
+    joi: ^17.6.0
     load-grunt-tasks: ^5.1.0
     lodash.isequal: 4.5.0
     lodash.merge: 4.6.2
@@ -25184,6 +25244,24 @@ fsevents@~2.1.1:
     "@hapi/hapi": ^20.2.2
     joi: 17.x
   checksum: 390f3fe99f2c649f89fd6f4a79dbc1a7696c0c6c9f900a5d0e04c062b3e4619dc1c496b8ad3ddc31715ffb95862a3d4e34af2b04e72a275f817a4970af1cde52
+  languageName: node
+  linkType: hard
+
+"hapi-swagger@npm:^14.5.5":
+  version: 14.5.5
+  resolution: "hapi-swagger@npm:14.5.5"
+  dependencies:
+    "@hapi/boom": ^9.1.4
+    "@hapi/hoek": ^9.3.0
+    handlebars: ^4.7.7
+    http-status: ^1.5.2
+    json-schema-ref-parser: ^6.1.0
+    swagger-parser: ^10.0.3
+    swagger-ui-dist: ^4.11.1
+  peerDependencies:
+    "@hapi/hapi": ^20.2.2
+    joi: 17.x
+  checksum: 61192237354ec755bf5b85b1f80205beb3d817ba1459c225c4b9eadb47c19633758e15f6ea508f39d387fbecd894d595b94bfb16a22a7e2d53308ce08050deee
   languageName: node
   linkType: hard
 
@@ -29073,7 +29151,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.3.0":
+"joi@npm:^17.3.0, joi@npm:^17.6.0":
   version: 17.6.0
   resolution: "joi@npm:17.6.0"
   dependencies:
@@ -42017,6 +42095,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"swagger-parser@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "swagger-parser@npm:10.0.3"
+  dependencies:
+    "@apidevtools/swagger-parser": 10.0.3
+  checksum: bd99d94543b9bdc6bf062ea211f70d4fa004e6e8ce97ee47a388a046f3cc2839e7349970e8a0b11136b55a674e1cc7b0bbdfbe4fb40adf0c68bc70736eedb8b7
+  languageName: node
+  linkType: hard
+
 "swagger-schema-official@npm:2.0.0-bab6bed":
   version: 2.0.0-bab6bed
   resolution: "swagger-schema-official@npm:2.0.0-bab6bed"
@@ -46191,6 +46278,23 @@ resolve@^2.0.0-next.3:
   bin:
     z-schema: ./bin/z-schema
   checksum: 7ce44ca3c548421b9041a08bacbe47657532c8d0e54250672b1e65b287339cfd3ba38a3405176e1965e3efa88c9fb00bfbf52558f2e36c2af6415372cdf3289b
+  languageName: node
+  linkType: hard
+
+"z-schema@npm:^5.0.1":
+  version: 5.0.3
+  resolution: "z-schema@npm:5.0.3"
+  dependencies:
+    commander: ^2.20.3
+    lodash.get: ^4.4.2
+    lodash.isequal: ^4.5.0
+    validator: ^13.7.0
+  dependenciesMeta:
+    commander:
+      optional: true
+  bin:
+    z-schema: bin/z-schema
+  checksum: eb6c2c3c2878c4c333fd3755703616c8f846158da0154f60f81f188c3c4ce7ad5b8ff5ce570d6372d4803fb5c8c9d97b4e54becdd5a832b1a31240d149b87191
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- we want to auto-generate the [current Customs Server API doc](https://github.com/mozilla/fxa/blob/main/packages/fxa-customs-server/docs/api.md)

## This pull request

- generates the Swagger JSON file that will later be added to Ecosystem Platform

## To view Swagger JSON file
- start FxA stack
- `npm start` fxa-customs-server
- Go to [http://localhost:7000/swagger.json](http://localhost:7000/swagger.json)

## Issue that this pull request solves

Closes: #12963

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots
- While this PR only generates the JSON file that will be added to Ecosystem Platform, when the JSON file is added to Ecosystem Platform, the generated API documentation will look as follows: 
<img width="1645" alt="Screen Shot 2022-07-18 at 6 23 28 PM" src="https://user-images.githubusercontent.com/28129806/179627456-ba62f0e2-656a-4285-a032-200fb03a57b3.png">
<img width="1652" alt="Screen Shot 2022-07-18 at 6 23 39 PM" src="https://user-images.githubusercontent.com/28129806/179627475-16f25107-4d61-438e-9c45-292a355f3a25.png">
<img width="1655" alt="Screen Shot 2022-07-18 at 6 23 49 PM" src="https://user-images.githubusercontent.com/28129806/179627488-6a4f4de0-06ec-421e-a026-3146e6bb78c1.png">
<img width="1654" alt="Screen Shot 2022-07-18 at 6 23 59 PM" src="https://user-images.githubusercontent.com/28129806/179627498-e10939de-d553-4fe8-ac35-849589c43956.png">
<img width="1653" alt="Screen Shot 2022-07-18 at 6 24 16 PM" src="https://user-images.githubusercontent.com/28129806/179627510-28e53d52-ce43-47e6-87e9-afbeca4cad50.png">
<img width="827" alt="Screen Shot 2022-07-18 at 6 24 29 PM" src="https://user-images.githubusercontent.com/28129806/179627519-b5e562fd-0cca-45c9-8838-93d83cf146b6.png">
<img width="1647" alt="Screen Shot 2022-07-18 at 6 24 39 PM" src="https://user-images.githubusercontent.com/28129806/179627527-6bdc994a-e24a-4c9a-9d9d-3a90903e3887.png">


