### PR TITLE
fix(auth): ignore replaced purchases

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
@@ -58,8 +58,8 @@ export class PlayPubsubHandler {
       return {};
     }
 
-    if (!purchase.userId) {
-      // Purchase is not associated with a user, nothing else can be done.
+    if (!purchase.userId || purchase.replacedByAnotherPurchase) {
+      // Purchase is not associated with a user or was replaced, nothing else can be done.
       return {};
     }
     const uid = purchase.userId;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
@@ -135,5 +135,16 @@ describe('PlayPubsubHandler', () => {
       );
       assert.notCalled(db.account);
     });
+
+    it('replaced purchase', async () => {
+      mockPurchase.userId = 'invalid';
+      mockPurchase.replacedByAnotherPurchase = true;
+      const result = await playPubsubHandlerInstance.rtdn(mockRequest);
+      assert.deepEqual(result, {});
+      assert.notCalled(
+        mockPlayBilling.purchaseManager.processDeveloperNotification
+      );
+      assert.notCalled(db.account);
+    });
   });
 });


### PR DESCRIPTION
Because:

* We can get RTDN messages for purchases that were replaced by newer
  purchases.

This commit:

* Ignores purchases that were replaced as they're no longer active.

Closes #13656

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
