### PR TITLE
feat(payments): autofill coupon when valid query string parameter is provided

### DIFF
--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
   useEffect,
   useState,
+  useContext,
 } from 'react';
 
 import {
@@ -20,6 +21,7 @@ import {
 } from '../../lib/amplitude';
 import { APIError, apiRetrieveCouponDetails } from '../../lib/apiClient';
 import { useCallbackOnce } from '../../lib/hooks';
+import AppContext from '../../lib/AppContext';
 
 class CouponError extends Error {
   constructor(message: string) {
@@ -107,8 +109,30 @@ export const CouponForm = ({
   );
   const [error, setError] = useState<CouponErrorMessageType | null>(null);
   const [checkingCoupon, setCheckingCoupon] = useState(false);
+  const { queryParams } = useContext(AppContext);
 
   const onFormMounted = useCallback(() => couponMounted({ planId }), [planId]);
+
+  // check if coupon code was included in URL
+  // if true and valid, apply coupon code on page load
+  useEffect(() => {
+    (async () => {
+      if (queryParams.coupon) {
+        try {
+          setCheckingCoupon(true);
+          const coupon = await checkPromotionCode(planId, queryParams.coupon);
+          setHasCoupon(true);
+          setCoupon(coupon);
+          setPromotionCode(coupon.promotionCode);
+        } catch (err) {
+          setCoupon(undefined);
+        } finally {
+          setCheckingCoupon(false);
+        }
+      }
+    })();
+  }, [queryParams, planId, setCoupon]);
+
   useEffect(() => {
     onFormMounted();
   }, [onFormMounted, planId]);

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -1,5 +1,6 @@
 export interface QueryParams {
   plan?: string;
+  coupon?: string;
   device_id?: string;
   flow_id?: string;
   flow_begin_time?: number;


### PR DESCRIPTION
## Because

- We want to streamline the coupon payment flow and improve UX

## This pull request

- Parses the provided URL for a coupon parameter
- Authenticates and applies discount code on load if valid

## Issue that this pull request solves

Closes: #13550

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
