### PR TITLE
fix(a11y): update a11y attrs on check img

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
@@ -4,7 +4,8 @@
     {{#isSignedIn}}
       <h2 id="fxa-connected-heading" class="mb-10"><img
       src="/images/circle-check.svg"
-      alt="a check symbol within a circle, indicating a successful result"
+      role="presentation"
+      alt=""
       class="align-middle mr-3"
       />{{#t}}Firefox account connected{{/t}}</h2>
     {{/isSignedIn}}


### PR DESCRIPTION
## Because

- A decorative image needs appropriate A11y attributes
