### PR TITLE
fix(content): failing tests checking page url

### DIFF
--- a/packages/fxa-content-server/tests/server/l10n-entrained.js
+++ b/packages/fxa-content-server/tests/server/l10n-entrained.js
@@ -99,7 +99,11 @@ function routeTest(route, expectedStatusCode, requestOptions) {
         assert.equal(res.statusCode, expectedStatusCode);
         checkHeaders(routes, route, res);
 
-        return extractAndCheckUrls(res, testName);
+        return extractAndCheckUrls(
+          res,
+          testName,
+          requestOptions.headers['Accept-Language']
+        );
       })
       .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22717,6 +22717,7 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
+    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.2
     fxa-shared: "workspace:*"
     googleapis: ^102.0.0


### PR DESCRIPTION
## Because

- Tests that were testing the URLs on the signin page were failing,
  because the fetch on URL https://www.mozilla.org/about/ was missing
  the accept-language header.

## This pull request

- Adds the accept-lanugage header to the failing tests.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
