### PR TITLE
task(admin-panel): Move subscriptions above connected services

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -461,6 +461,26 @@ export const Account = ({
           </li>
         )}
 
+        <>
+          <li className="account-li">
+            <h3 className="account-header">Subscriptions</h3>
+          </li>
+          {subscriptions && subscriptions.length > 0 ? (
+            <>
+              {subscriptions.map((subscription) => (
+                <Subscription
+                  key={subscription.subscriptionId}
+                  {...subscription}
+                />
+              ))}
+            </>
+          ) : (
+            <li className="account-li account-border-info">
+              This account doesn't have any subscriptions.
+            </li>
+          )}
+        </>
+
         <Guard features={[AdminPanelFeature.ConnectedServices]}>
           <li className="account-li">
             <h3 className="account-header">Connected Services</h3>
@@ -485,29 +505,6 @@ export const Account = ({
             </li>
           )}
         </Guard>
-
-        {/* Temporary check for fake hard-coded value until we fetch actual subscriptions in FXA-4237 */}
-        {subscriptions && (
-          <>
-            <li className="account-li">
-              <h3 className="account-header">Subscriptions</h3>
-            </li>
-            {subscriptions && subscriptions.length > 0 ? (
-              <>
-                {subscriptions.map((subscription) => (
-                  <Subscription
-                    key={subscription.subscriptionId}
-                    {...subscription}
-                  />
-                ))}
-              </>
-            ) : (
-              <li className="account-li account-border-info">
-                This account doesn't have any subscriptions.
-              </li>
-            )}
-          </>
-        )}
       </ul>
 
       <hr className="border-grey-50 mb-4" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -22717,6 +22717,7 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
+    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.2
     fxa-shared: "workspace:*"
     googleapis: ^102.0.0


### PR DESCRIPTION
## Because

- List of connected services can be really long, and support mostly cares about connected services.

## This pull request

- Places the subscription section above the connected services section.

## Issue that this pull request solves

Closes: #13304

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/180096149-1b759acb-ad9b-46bf-ada4-ab122b8bff49.png)

