### PR TITLE
docs(swagger): Follow-up Swagger items

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -11,7 +11,7 @@ Services ecosystem.
 
 [Detailed design document](https://github.com/mozilla/fxa-auth-server/wiki/onepw-protocol)
 
-[Detailed API spec](docs/api.md)
+[Detailed API spec](https://mozilla.github.io/ecosystem-platform/api)
 
 [Guidelines for Contributing](CONTRIBUTING.md)
 

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -1,1 +1,0 @@
-# [Firefox Accounts Authentication Server API](https://mozilla.github.io/ecosystem-platform/api#tag/Auth-Server-API-Overview)

--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -14,7 +14,7 @@ const ACCOUNT_CREATE_POST = {
   description: '/account/create',
   notes: [
     dedent`
-      Creates a user account. The client provides the email address with which this account will be associated and a stretched password. Stretching is detailed on the [onepw](https://github.com/mozilla/fxa-auth-server/wiki/onepw-protocol#creating-the-account) wiki page.
+      Creates a user account. The client provides the email address with which this account will be associated and a stretched password. Stretching is detailed on the [onepw](https://mozilla.github.io/ecosystem-platform/explanation/onepw-protocol#client-side-key-stretching) wiki page.
 
       This endpoint may send a verification email to the user. Callers may optionally provide the \`service\` parameter to indicate which service they are acting on behalf of. This is an opaque alphanumeric token that will be embedded in the verification link as a query parameter.
 
@@ -54,7 +54,7 @@ const ACCOUNT_LOGIN_POST = {
             - \`errno: 127\` - Invalid unblock code
             - \`errno: 142\` - Sign in with this email type is not currently supported
             - \`errno: 149\` - This email can not currently be used to login
-            - \`errno: 160\` - This request requires two step authentication enabled on your account.
+            - \`errno: 160\` - This request requires two step authentication enabled on your account
           `,
         },
         422: {

--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -14,7 +14,7 @@ const ACCOUNT_CREATE_POST = {
   description: '/account/create',
   notes: [
     dedent`
-      Creates a user account. The client provides the email address with which this account will be associated and a stretched password. Stretching is detailed on the [**onepw**](https://github.com/mozilla/fxa-auth-server/wiki/onepw-protocol#creating-the-account) wiki page.
+      Creates a user account. The client provides the email address with which this account will be associated and a stretched password. Stretching is detailed on the [onepw](https://github.com/mozilla/fxa-auth-server/wiki/onepw-protocol#creating-the-account) wiki page.
 
       This endpoint may send a verification email to the user. Callers may optionally provide the \`service\` parameter to indicate which service they are acting on behalf of. This is an opaque alphanumeric token that will be embedded in the verification link as a query parameter.
 
@@ -27,8 +27,8 @@ const ACCOUNT_CREATE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 101\` - Account already exists
-            \`errno: 144\` - Email already exists
+            - \`errno: 101\` - Account already exists
+            - \`errno: 144\` - Email already exists
           `,
         },
       },
@@ -48,19 +48,19 @@ const ACCOUNT_LOGIN_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 102\` - Unknown account
-            \`errno: 103\` - Incorrect password
-            \`errno: 125\` - The request was blocked for security reasons
-            \`errno: 127\` - Invalid unblock code
-            \`errno: 142\` - Sign in with this email type is not currently supported
-            \`errno: 149\` - This email can not currently be used to login
-            \`errno: 160\` - This request requires two step authentication enabled on your account.
+            - \`errno: 102\` - Unknown account
+            - \`errno: 103\` - Incorrect password
+            - \`errno: 125\` - The request was blocked for security reasons
+            - \`errno: 127\` - Invalid unblock code
+            - \`errno: 142\` - Sign in with this email type is not currently supported
+            - \`errno: 149\` - This email can not currently be used to login
+            - \`errno: 160\` - This request requires two step authentication enabled on your account.
           `,
         },
         422: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 151\` - Failed to send email
+            - \`errno: 151\` - Failed to send email
           `,
         },
       },
@@ -84,7 +84,7 @@ const ACCOUNT_STATUS_GET = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 108\` - Missing parameter in request body
+            - \`errno: 108\` - Missing parameter in request body
           `,
         },
       },
@@ -96,7 +96,7 @@ const ACCOUNT_STATUS_POST = {
   ...TAGS_ACCOUNT,
   description: '/account/status',
   notes: [
-    'Gets the status of an account without exposing user data through query params. This endpoint is rate limited by [**fxa-customs-server**](https://github.com/mozilla/fxa/tree/main/packages/fxa-customs-server).',
+    'Gets the status of an account without exposing user data through query params. This endpoint is rate limited by [fxa-customs-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-customs-server).',
   ],
 };
 
@@ -139,7 +139,7 @@ const ACCOUNT_KEYS_GET = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 104\` - Unverified account
+            - \`errno: 104\` - Unverified account
           `,
         },
       },
@@ -158,7 +158,7 @@ const ACCOUNT_UNLOCK_RESEND_CODE_POST = {
         410: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 116\` - This endpoint is no longer supported
+            - \`errno: 116\` - This endpoint is no longer supported
           `,
         },
       },
@@ -177,7 +177,7 @@ const ACCOUNT_UNLOCK_VERIFY_CODE_POST = {
         410: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 116\` - This endpoint is no longer supported
+            - \`errno: 116\` - This endpoint is no longer supported
           `,
         },
       },
@@ -205,7 +205,7 @@ const ACCOUNT_RESET_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 108\` - Missing parameter in request body
+            - \`errno: 108\` - Missing parameter in request body
           `,
         },
       },
@@ -229,8 +229,8 @@ const ACCOUNT_DESTROY_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 103\` - Incorrect password
-            \`errno: 138\` - Unverified session
+            - \`errno: 103\` - Incorrect password
+            - \`errno: 138\` - Unverified session
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
@@ -41,6 +41,7 @@ export const AUTH_SERVER_API_DESCRIPTION = {
 
     For example:
 
+    \`\`\`js
         {
           "code": 400,  // Matches the HTTP status code
           "errno": 107, // Stable application-level error number
@@ -48,6 +49,7 @@ export const AUTH_SERVER_API_DESCRIPTION = {
           "message": "Invalid parameter in request body", // Specific error message
           "info": "https://docs.dev.lcip.og/errors/1234"  // Link to more information
         }
+    \`\`\`
 
     Responses for some errors may include additional parameters.
 
@@ -279,6 +281,7 @@ export const AUTH_SERVER_API_DESCRIPTION = {
     should suspend making further requests
     for 30 seconds:
 
+    \`\`\`js
         HTTP/1.1 503 Service Unavailable
         Retry-After: 30
         Content-Type: application/json
@@ -292,5 +295,6 @@ export const AUTH_SERVER_API_DESCRIPTION = {
             "retryAfter": 30,
             "retryAfterLocalized": "in a few seconds"
         }
+  \`\`\`
   `,
 };

--- a/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
@@ -19,8 +19,6 @@ export const AUTH_SERVER_API_DESCRIPTION = {
     - The URL embeds a version identifier \`v1\`.
       Future revisions of this API may introduce new version numbers.
     - The base URI of the server may be configured on a per-client basis:
-      - For a list of development servers
-        see [Firefox Accounts deployments on MDN](https://developer.mozilla.org/en-US/Firefox_Accounts#Firefox_Accounts_deployments).
       - The canonical URL for Mozilla's hosted Firefox Accounts server
         is \`https://api.accounts.firefox.com/v1\`.
 
@@ -43,13 +41,13 @@ export const AUTH_SERVER_API_DESCRIPTION = {
 
     For example:
 
-    > \`{\`<br/>
-    >   \`"code": 400,\`  // Matches the HTTP status code<br/>
-    >   \`"errno": 107,\` // Stable application-level error number<br/>
-    >   \`"error": "Bad Request",\` // String description of the error type<br/>
-    >   \`"message": "Invalid parameter in request body",\` // Specific error message<br/>
-    >   \`"info": "https://docs.dev.lcip.og/errors/1234"\`  // Link to more information<br/>
-    > \`}\`
+        {
+          "code": 400,  // Matches the HTTP status code
+          "errno": 107, // Stable application-level error number
+          "error": "Bad Request", // String description of the error type
+          "message": "Invalid parameter in request body", // Specific error message
+          "info": "https://docs.dev.lcip.og/errors/1234"  // Link to more information
+        }
 
     Responses for some errors may include additional parameters.
 
@@ -281,18 +279,18 @@ export const AUTH_SERVER_API_DESCRIPTION = {
     should suspend making further requests
     for 30 seconds:
 
-    > \`HTTP/1.1 503 Service Unavailable\`<br/>
-    > \`Retry-After: 30\`<br/>
-    > \`Content-Type: application/json\`
-    >
-    > \`{\`<br/>
-    >     \`"code": 503,\`<br/>
-    >     \`"errno": 201,\`<br/>
-    >     \`"error": "Service Unavailable",\`<br/>
-    >     \`"message": "Service unavailable",\`<br/>
-    >     \`"info": "https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format",\`<br/>
-    >     \`"retryAfter": 30,\`<br/>
-    >     \`"retryAfterLocalized": "in a few seconds"\`<br/>
-    > \`}\`
+        HTTP/1.1 503 Service Unavailable
+        Retry-After: 30
+        Content-Type: application/json
+
+        {
+            "code": 503,
+            "errno": 201,
+            "error": "Service Unavailable",
+            "message": "Service unavailable",
+            "info": "https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format",
+            "retryAfter": 30,
+            "retryAfterLocalized": "in a few seconds"
+        }
   `,
 };

--- a/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
@@ -25,8 +25,8 @@ const ACCOUNT_ATTACHED_CLIENTS_GET = {
       - \`refreshTokenId\`: The id of the OAuth \`refreshToken\` held by that client, if any.
       - \`deviceId\`: The id of the client's device record, if it has registered one.
 
-      These identifiers can be passed to [**/account/attached_client/destroy**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#post-accountattached_clientdestroy) in order to disconnect the client.
-      
+      These identifiers can be passed to [/account/attached_client/destroy](#tag/Devices-and-Sessions/operation/getAccountAttached_clients) in order to disconnect the client.
+
       This endpoint returns a maximum 500 last used devices and sessions.
     `,
   ],
@@ -41,7 +41,7 @@ const ACCOUNT_ATTACHED_CLIENT_DESTROY_POST = {
 
       Destroy all tokens held by a connected client, disconnecting it from the user's account.
 
-      This endpoint is designed to be used in conjunction with [**/account/attached_clients**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#get-accountattached_clients). It accepts as the request body an object in the same format as returned by that endpoing, and will disconnect that client from the user's account.
+      This endpoint is designed to be used in conjunction with [/account/attached_clients](#tag/Devices-and-Sessions/operation/getAccountAttached_clients). It accepts as the request body an object in the same format as returned by that endpoing, and will disconnect that client from the user's account.
     `,
   ],
 };
@@ -53,7 +53,7 @@ const ACCOUNT_DEVICE_POST = {
     dedent`
       🔒 Authenticated with session token or OAuth refresh token
 
-      Creates or updates the [**device registration**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) record associated with the auth token used for this request. At least one of \`name\`, \`type\`, \`pushCallback\` or the tuple \`{ pushCallback, pushPublicKey, pushAuthKey }\` must be present. Beware that if you provide \`pushCallback\` without the pair \`{ pushPublicKey, pushAuthKey }\`, both of those keys will be reset to the empty string.
+      Creates or updates the [device registration](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) record associated with the auth token used for this request. At least one of \`name\`, \`type\`, \`pushCallback\` or the tuple \`{ pushCallback, pushPublicKey, pushAuthKey }\` must be present. Beware that if you provide \`pushCallback\` without the pair \`{ pushPublicKey, pushAuthKey }\`, both of those keys will be reset to the empty string.
 
       \`pushEndpointExpired\` will be reset to false on update if the tuple \`{ pushCallback, pushPublicKey, pushAuthKey }\` is specified.
 
@@ -64,12 +64,16 @@ const ACCOUNT_DEVICE_POST = {
     'hapi-swagger': {
       responses: {
         400: {
-          description:
-            'Failing requests may be caused by the following errors (this is not an exhaustive list): \n `errno: 107` - Invalid parameter in request body',
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 107\` - Invalid parameter in request body
+          `
         },
         503: {
-          description:
-            'Failing requests may be caused by the following errors (this is not an exhaustive list): \n `errno: 202` - Feature not enabled',
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 202\` - Feature not enabled
+          `
         },
       },
     },
@@ -83,9 +87,9 @@ const ACCOUNT_DEVICE_COMMANDS_GET = {
     dedent`
       🔒 Authenticated with session token or authenticated with OAuth refresh token.
 
-      Fetches commands enqueued for the current device by prior calls to \`/account/devices/invoke_command\`. The device can page through the enqueued commands by using the \`index\` and \`limit\` parameters.
+      Fetches commands enqueued for the current device by prior calls to [/account/devices/invoke_command](#tag/Devices-and-Sessions/operation/postAccountDevicesInvoke_command). The device can page through the enqueued commands by using the \`index\` and \`limit\` parameters.
 
-      For more details, see the [**device registration**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) docs.
+      For more details, see the [device registration](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) docs.
     `,
   ],
 };
@@ -99,7 +103,7 @@ const ACCOUNT_DEVICES_INVOKE_COMMAND_POST = {
 
       Enqueues a command to be invoked on a target device.
 
-      For more details, see the [**device registration**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) docs.
+      For more details, see the [device registration](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md) docs.
     `,
   ],
   plugins: {
@@ -108,7 +112,7 @@ const ACCOUNT_DEVICES_INVOKE_COMMAND_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 157\` - Unavailable device command
+            - \`errno: 157\` - Unavailable device command
           `,
         },
       },
@@ -132,13 +136,13 @@ const ACCOUNT_DEVICES_NOTIFY_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 107\` - Invalid parameter in request body
+            - \`errno: 107\` - Invalid parameter in request body
           `,
         },
         503: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 202\` - Feature not enabled
+            - \`errno: 202\` - Feature not enabled
           `,
         },
       },
@@ -163,7 +167,7 @@ const ACCOUNT_SESSIONS_GET = {
   description: '/account/sessions',
   notes: [
     dedent`
-      [**DEPRECATED**]: Please use [**/account/attached_clients**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#get-accountattached_clients) instead.
+      [**DEPRECATED**]: Please use [/account/attached_clients](#tag/Devices-and-Sessions/operation/getAccountAttached_clients) instead.
 
       🔒 Authenticated with session token.
 

--- a/packages/fxa-auth-server/docs/swagger/emails-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/emails-api.ts
@@ -85,7 +85,7 @@ const RECOVERY_EMAIL_VERIFY_CODE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            - \`errno: 105\` - Invalid verification code'
+            - \`errno: 105\` - Invalid verification code
           `,
         },
       },
@@ -199,7 +199,7 @@ const RECOVERY_EMAIL_SECONDARY_RESEND_CODE_POST = {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
             - \`errno: 138\` - Unverified session
-            - \`errno: 150\` - Can not resend code for email that does not belong to the account
+            - \`errno: 150\` - Can not resend email code to an email that does not belong to this account
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/emails-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/emails-api.ts
@@ -35,7 +35,7 @@ const RECOVERY_EMAIL_STATUS_GET = {
         401: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 110\` - Invalid authentication token in request signature
+            - \`errno: 110\` - Invalid authentication token in request signature
           `,
         },
       },
@@ -61,7 +61,7 @@ const RECOVERY_EMAIL_RESEND_CODE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 150\` - Can not resend email code to an email that does not belong to this account
+            - \`errno: 150\` - Can not resend email code to an email that does not belong to this account
           `,
         },
       },
@@ -85,7 +85,7 @@ const RECOVERY_EMAIL_VERIFY_CODE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 105\` - Invalid verification code'
+            - \`errno: 105\` - Invalid verification code'
           `,
         },
       },
@@ -120,11 +120,11 @@ const RECOVERY_EMAIL_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 104\` - Unverified account
-            \`errno: 138\` - Unverified session
-            \`errno: 139\` - Can not add secondary email that is same as your primary
-            \`errno: 140\` - Email already exists
-            \`errno: 141\` - Email already exists
+            - \`errno: 104\` - Unverified account
+            - \`errno: 138\` - Unverified session
+            - \`errno: 139\` - Can not add secondary email that is same as your primary
+            - \`errno: 140\` - Email already exists
+            - \`errno: 141\` - Email already exists
           `,
         },
       },
@@ -148,7 +148,7 @@ const RECOVERY_EMAIL_DESTROY_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 138\` - Unverified session
+            - \`errno: 138\` - Unverified session
           `,
         },
       },
@@ -172,9 +172,9 @@ const RECOVERY_EMAIL_SET_PRIMARY_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 138\` - Unverified session
-            \`errno: 147\` - Can not change primary email to an unverified email
-            \`errno: 148\` - Can not change primary email to an email that does not belong to this account
+            - \`errno: 138\` - Unverified session
+            - \`errno: 147\` - Can not change primary email to an unverified email
+            - \`errno: 148\` - Can not change primary email to an email that does not belong to this account
           `,
         },
       },
@@ -198,8 +198,8 @@ const RECOVERY_EMAIL_SECONDARY_RESEND_CODE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 138\` - Unverified session
-            \`errno: 150\` - Can not resend code for email that does not belong to the account
+            - \`errno: 138\` - Unverified session
+            - \`errno: 150\` - Can not resend code for email that does not belong to the account
           `,
         },
       },
@@ -223,8 +223,8 @@ const RECOVERY_EMAIL_SECONDARY_VERIFY_CODE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 138\` - Unverified session
-            \`errno: 105\` - Invalid verification code
+            - \`errno: 138\` - Unverified session
+            - \`errno: 105\` - Invalid verification code
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/oauth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-api.ts
@@ -42,7 +42,7 @@ const OAUTH_DESTROY_POST = {
         401: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            - \`errno: 171\` - Incorrect client secret.
+            - \`errno: 171\` - Incorrect client secret
           `,
         },
         500: {
@@ -89,13 +89,13 @@ const OAUTH_TOKEN_POST = {
         401: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            - \`errno: 110\` - Invalid authentication token in request signature.
+            - \`errno: 110\` - Invalid authentication token in request signature
           `,
         },
         500: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            - \`errno: 998\` - An internal validation check failed.
+            - \`errno: 998\` - An internal validation check failed
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/oauth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-api.ts
@@ -36,16 +36,19 @@ const OAUTH_DESTROY_POST = {
   plugins: {
     'hapi-swagger': {
       responses: {
+        200: {
+          description: 'No information is returned in the response body.'
+        },
         401: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 171\` - Incorrect client secret.
+            - \`errno: 171\` - Incorrect client secret.
           `,
         },
         500: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 162\` - Unknown client id.
+            - \`errno: 162\` - Unknown client id.
           `,
         },
       },
@@ -77,7 +80,7 @@ const OAUTH_TOKEN_POST = {
         - \`grant_type=refresh_token\`: A refresh token issued by a previous call to this endpoint.
         - \`grant_type=fxa-credentials\`: Directly grant tokens using an FxA sessionToken.
 
-      This is the "token endpoint" as defined in RFC6749, and behaves like the oauth-server /token endpoint except that the \`fxa-credentials\` grant can be authenticated directly with a sessionToken rather than with a BrowserID assertion.
+      This is the "token endpoint" as defined in RFC6749, and behaves like the [oauth-server /token endpoint](#tag/OAuth-Server-API-Overview/operation/postToken) except that the \`fxa-credentials\` grant can be authenticated directly with a sessionToken rather than with a BrowserID assertion.
     `,
   ],
   plugins: {
@@ -86,13 +89,13 @@ const OAUTH_TOKEN_POST = {
         401: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 110\` - Invalid authentication token in request signature.
+            - \`errno: 110\` - Invalid authentication token in request signature.
           `,
         },
         500: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 998\` - An internal validation check failed.
+            - \`errno: 998\` - An internal validation check failed.
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/oauth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-server-api.ts
@@ -18,13 +18,16 @@ const OAUTH_SERVER_API_DESCRIPTION = {
       ## Errors
       Invalid requests will return 4XX responses. Internal failures will return 5XX. Both will include JSON responses describing the error.
 
-      **Example error:** \n
-            {
-              "code": 400, // matches the HTTP status code
-              "errno": 101, // stable application-level error number
-              "error": "Bad Request", // string description of error type
-              "message": "Unknown client"
-            }
+      **Example error:**
+
+      \`\`\`js
+          {
+            "code": 400, // matches the HTTP status code
+            "errno": 101, // stable application-level error number
+            "error": "Bad Request", // string description of error type
+            "message": "Unknown client"
+          }
+      \`\`\`
 
       The currently-defined error responses are:
 
@@ -104,10 +107,13 @@ const AUTHORIZATION_POST = {
           description: dedent`
             A valid request will return a 200 response, with JSON containing the \`redirect\` to follow.
             <br />
-            **Example:** \n
-                { \n
-                  "redirect": "https://example.domain/path?foo=bar&code=4ab433e31ef3a7cf7c20590f047987922b5c9ceb1faff56f0f8164df053dd94c&state=1234" \n
+            **Example:**
+
+            \`\`\`js
+                {
+                  "redirect": "https://example.domain/path?foo=bar&code=4ab433e31ef3a7cf7c20590f047987922b5c9ceb1faff56f0f8164df053dd94c&state=1234"
                 }
+            \`\`\`
 
             **Implicit Grant** \\n If requesting an implicit grant (token), the response will match the [/v1/token][token] response.
           `,
@@ -194,32 +200,34 @@ const AUTHORIZED_CLIENTS_POST = {
 
             For clients that only use access tokens, all active access tokens are combined into a single entry in the list, and the \`refresh_token_id\` field will not be present.
 
-            **Example:** \n
-                [ \n
-                  { \n
-                    "client_id": "5901bd09376fadaa", \n
-                    "refresh_token_id": "6e8c38f6a9c27dc0e4df698dc3e3e8b101ad6d79e87842b1ca96ad9b3cd8ed28", \n
-                    "name": "Example Sync Client", \n
-                    "created_time": 1528334748000, \n
-                    "last_access_time": 1528334748000, \n
-                    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"] \n
-                  }, \n
-                  { \n
-                    "client_id": "5901bd09376fadaa", \n
-                    "refresh_token_id": "eb5e17f246a6b0937356412118ea12b67a638232d6b376e2511cf38a0c4eecf9", \n
-                    "name": "Example Sync Client", \n
-                    "created_time": 1528334748000, \n
-                    "last_access_time": 1528334834000, \n
-                    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"] \n
-                  }, \n
-                  { \n
-                    "client_id": "23d10a14f474ca41", \n
-                    "name": "Example Website", \n
-                    "created_time": 1328334748000, \n
-                    "last_access_time": 1476677854037, \n
-                    "scope": ["profile:email", "profile:uid"] \n
-                  } \n
+            **Example:**
+            \`\`\` js
+                [
+                  {
+                    "client_id": "5901bd09376fadaa",
+                    "refresh_token_id": "6e8c38f6a9c27dc0e4df698dc3e3e8b101ad6d79e87842b1ca96ad9b3cd8ed28",
+                    "name": "Example Sync Client",
+                    "created_time": 1528334748000,
+                    "last_access_time": 1528334748000,
+                    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"]
+                  },
+                  {
+                    "client_id": "5901bd09376fadaa",
+                    "refresh_token_id": "eb5e17f246a6b0937356412118ea12b67a638232d6b376e2511cf38a0c4eecf9",
+                    "name": "Example Sync Client",
+                    "created_time": 1528334748000,
+                    "last_access_time": 1528334834000,
+                    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"]
+                  },
+                  {
+                    "client_id": "23d10a14f474ca41",
+                    "name": "Example Website",
+                    "created_time": 1328334748000,
+                    "last_access_time": 1476677854037,
+                    "scope": ["profile:email", "profile:uid"]
+                  }
                 ]
+            \`\`\`
           `
         }
       },
@@ -247,13 +255,15 @@ const CLIENT_CLIENTID_GET = {
           description: dedent`
             A valid 200 response will be a JSON blob.
             <br />
-            **Example:** \n
-                { \n
-                  "name": "Where's My Fox", \n
-                  "image_uri": "https://mozilla.org/firefox.png", \n
-                  "redirect_uri": "https://wheres.my.firefox.com/oauth", \n
-                  "trusted": true \n
+            **Example:**
+            \`\`\` js
+                {
+                  "name": "Where's My Fox",
+                  "image_uri": "https://mozilla.org/firefox.png",
+                  "redirect_uri": "https://wheres.my.firefox.com/oauth",
+                  "trusted": true
                 }
+            \`\`\`
           `,
         }
       },
@@ -285,17 +295,19 @@ const INTROSPECT_POST = {
           description: dedent`
             A valid request will return a JSON response.
             <br />
-            **Example** \n
-                { \n
-                  "active": true, \n
-                  "scope": "profile https://identity.mozilla.com/account/subscriptions", \n
-                  "client_id": "59cceb6f8c32317c", \n
-                  "token_type": "access_token", \n
-                  "iat": 1566535888243, \n
-                  "sub": "913fe9395bb946b48c1521d7beb2cb24", \n
-                  "jti": "5ae05d8fe413a749e0f4eb3c495a1c526fb52c85ca5fde516df5dd77d41f7b5b", \n
-                  "exp": 1566537688243 \n
+            **Example:**
+            \`\`\` js
+                {
+                  "active": true,
+                  "scope": "profile https://identity.mozilla.com/account/subscriptions",
+                  "client_id": "59cceb6f8c32317c",
+                  "token_type": "access_token",
+                  "iat": 1566535888243,
+                  "sub": "913fe9395bb946b48c1521d7beb2cb24",
+                  "jti": "5ae05d8fe413a749e0f4eb3c495a1c526fb52c85ca5fde516df5dd77d41f7b5b",
+                  "exp": 1566537688243
                 }
+            \`\`\`
           `,
         },
       },
@@ -323,17 +335,19 @@ const JWKS_GET = {
           description: dedent`
             A valid response will return JSON of the \`keys\`.
             <br />
-            **Example:** \n
-                { \n
-                  "keys": [ \n
-                    "alg": "RS256", \n
-                    "use": "sig", \n
-                    "kty": "RSA", \n
-                    "kid": "2015.12.02-1", \n
-                    "n":"xaQHsKpu1KSK-YEMoLzZS7Xxciy3esGrhrrqW_JBrq3IRmeGLaqlE80zcpIVnStyp9tbet2niYTemt8ug591YWO5Y-S0EgQyFTxnGjzNOvAL6Cd2iGie9QeSehfFLNyRPdQiadYw07fw-h5gweMpVJs8nTgS-Bcorlw9JQM6Il1cUpbP0Lt-F_5qrzlaOiTEAAb4JGOusVh0n-MZfKt7w0mikauMH5KfhflwQDn4YTzRkWJzlldXr1Cs0ZkYzOwS4Hcoku7vd6lqCUO0GgZvkuvCFqdVKzpa4CGboNdfIjcGVF4f1CTQaQ0ao51cwLzq1pgi5aWYhVH7lJcm6O_BQw", \n
-                    "e":"AQAC" \n
-                  ] \n
+            **Example:**
+            \`\`\` js
+                {
+                  "keys": [
+                    "alg": "RS256",
+                    "use": "sig",
+                    "kty": "RSA",
+                    "kid": "2015.12.02-1",
+                    "n":"xaQHsKpu1KSK-YEMoLzZS7Xxciy3esGrhrrqW_JBrq3IRmeGLaqlE80zcpIVnStyp9tbet2niYTemt8ug591YWO5Y-S0EgQyFTxnGjzNOvAL6Cd2iGie9QeSehfFLNyRPdQiadYw07fw-h5gweMpVJs8nTgS-Bcorlw9JQM6Il1cUpbP0Lt-F_5qrzlaOiTEAAb4JGOusVh0n-MZfKt7w0mikauMH5KfhflwQDn4YTzRkWJzlldXr1Cs0ZkYzOwS4Hcoku7vd6lqCUO0GgZvkuvCFqdVKzpa4CGboNdfIjcGVF4f1CTQaQ0ao51cwLzq1pgi5aWYhVH7lJcm6O_BQw",
+                    "e":"AQAC"
+                  ]
                 }
+            \`\`\`
           `,
         },
       },
@@ -359,14 +373,16 @@ const KEY_DATA_POST = {
           description: dedent`
             A valid response will return JSON the scoped key information for every scope that has scoped keys.
             <br />
-            **Example** \n
-                { \n
-                  "https://identity.mozilla.com/apps/sample-scope-can-scope-key": { \n
-                    "identifier": "https://identity.mozilla.com/apps/sample-scope-can-scope-key", \n
-                    "keyRotationSecret": "0000000000000000000000000000000000000000000000000000000000000000", \n
-                    "keyRotationTimestamp": 1506970363512 \n
-                  } \n
+            **Example:**
+            \`\`\` js
+                {
+                  "https://identity.mozilla.com/apps/sample-scope-can-scope-key": {
+                    "identifier": "https://identity.mozilla.com/apps/sample-scope-can-scope-key",
+                    "keyRotationSecret": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "keyRotationTimestamp": 1506970363512
+                  }
                 }
+            \`\`\`
           `
         }
       },
@@ -404,15 +420,17 @@ const TOKEN_POST = {
           description: dedent`
             A valid request will return a JSON response.
             <br />
-            **Example:** \n
-                {\n
-                  "access_token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0", \n
-                  "scope": "profile:email profile:avatar", \n
-                  "token_type": "bearer", \n
-                  "expires_in": 3600, \n
-                  "refresh_token": "58d59cc97c3ca183b3a87a65eec6f93d5be051415b53afbf8491cc4c45dbb0c6", \n
-                  "auth_at": 1422336613 \n
+            **Example:**
+            \`\`\` js
+                {
+                  "access_token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0",
+                  "scope": "profile:email profile:avatar",
+                  "token_type": "bearer",
+                  "expires_in": 3600,
+                  "refresh_token": "58d59cc97c3ca183b3a87a65eec6f93d5be051415b53afbf8491cc4c45dbb0c6",
+                  "auth_at": 1422336613
                 }
+            \`\`\`
           `
         }
       },
@@ -442,12 +460,14 @@ const VERIFY_POST = {
 
             - Note: \`email\` of the respective user has been **REMOVED**.
 
-            **Example:** \n
-                { \n
-                  "user": "5901bd09376fadaa076afacef5251b6a", \n
-                  "client_id": "45defeda038a1c92", \n
-                  "scope": ["profile:email", "profile:avatar"], \n
+            **Example:**
+            \`\`\` js
+                {
+                  "user": "5901bd09376fadaa076afacef5251b6a",
+                  "client_id": "45defeda038a1c92",
+                  "scope": ["profile:email", "profile:avatar"],
                 }
+            \`\`\`
           `
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/oauth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-server-api.ts
@@ -18,13 +18,13 @@ const OAUTH_SERVER_API_DESCRIPTION = {
       ## Errors
       Invalid requests will return 4XX responses. Internal failures will return 5XX. Both will include JSON responses describing the error.
 
-      **Example error:**
-      > {<br/>
-      >  \`"code": 400,\` // matches the HTTP status code<br/>
-      >  \`"errno": 101,\` // stable application-level error number<br/>
-      >  \`"error": "Bad Request",\` // string description of error type<br/>
-      >  \`"message": "Unknown client"\`<br/>
-      > }
+      **Example error:** \n
+            {
+              "code": 400, // matches the HTTP status code
+              "errno": 101, // stable application-level error number
+              "error": "Bad Request", // string description of error type
+              "message": "Unknown client"
+            }
 
       The currently-defined error responses are:
 
@@ -79,30 +79,78 @@ const AUTHORIZATION_GET = {
   notes: [
     'This endpoint starts the OAuth flow. A client redirects the user agent to this url. This endpoint will then redirect to the appropriate content-server page.',
   ],
+  plugins: {
+    'hapi-swagger': {
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v "https://oauth.accounts.firefox.com/v1/authorization?client_id=5901bd09376fadaa&state=1234&scope=profile:email&action=signup"',
+        },
+      ],
+    },
+  },
 };
 
 const AUTHORIZATION_POST = {
   ...TAGS_OAUTH_SERVER,
   description: '/v1/authorization',
-  notes: [
-    dedent`
-      This endpoint should be used by the fxa-content-server, requesting that we supply a short-lived code (currently 15 minutes) that will be sent back to the client. This code will be traded for a token at the [token][] endpoint.
-
-      Note:
-
-      Responses
-
-      Implicit Grant - If requesting an implicit grant (token), the response will match the [/v1/token][token] response.
-    `,
+  notes: ['This endpoint should be used by the fxa-content-server, requesting that we supply a short-lived code (currently 15 minutes) that will be sent back to the client. This code will be traded for a token at the [token][] endpoint.',
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid request will return a 200 response, with JSON containing the \`redirect\` to follow.
+            <br />
+            **Example:** \n
+                { \n
+                  "redirect": "https://example.domain/path?foo=bar&code=4ab433e31ef3a7cf7c20590f047987922b5c9ceb1faff56f0f8164df053dd94c&state=1234" \n
+                }
+
+            **Implicit Grant** \\n If requesting an implicit grant (token), the response will match the [/v1/token][token] response.
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n -X POST \\\n -H "Content-Type: application/json" \\\n "https://oauth.accounts.firefox.com/v1/authorization" \\\n -d \'{\n  "client_id": "5901bd09376fadaa",\n  "assertion": "<assertion>",\n  "state": "1234",\n  "scope": "profile:email"\n}\'',
+        },
+      ],
+    },
+  },
 };
 
 const DESTROY_POST = {
   ...TAGS_OAUTH_SERVER,
   description: '/v1/destroy',
   notes: [
-    'After a client is done using a token, the responsible thing to do is to destroy the token afterwards. A client can use this route to do so.',
+    dedent`
+      After a client is done using a token, the responsible thing to do is to destroy the token afterwards. A client can use this route to do so.
+
+      **Request Parameters**
+      - \`token|access_token|refresh_token|refresh_token_id\`: The hex string access token. By default, \`token\` is assumed to be the access token.
+    `,
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: 'A valid request will return an empty response, with a 200 status code.',
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n -X POST \\\n -H "Content-Type: application/json" \\\n "https://oauth.accounts.firefox.com/v1/destroy" \\\n -d \'{\n  "token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0"\n}\'',
+        },
+      ],
+    },
+  },
 };
 
 const AUTHORIZED_CLIENTS_DESTROY_POST = {
@@ -111,24 +159,79 @@ const AUTHORIZED_CLIENTS_DESTROY_POST = {
   notes: [
     `This endpoint revokes tokens granted to a given client. It must be authenticated with an identity assertion for the user's account.`,
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: 'A valid 200 response will return an empty JSON object.'
+        }
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -X POST \\\n "https://oauth.accounts.firefox.com/v1/authorized-clients/destroy \\\n -H \'cache-control: no-cache\' \\\n -H \'content-type: application/json\' \\\n -d \'{\n  "client_id": "5901bd09376fadaa",\n  "refresh_token_id": "6e8c38f6a9c27dc0e4df698dc3e3e8b101ad6d79e87842b1ca96ad9b3cd8ed28",\n  "assertion": "eyJhbGciOiJSUzI1NiJ9.eyJwdWJsaWMta2V5Ijp7Imt0eSI6IlJTQSIsIm4iOiJvWmdsNkpwM0Iwcm5BVXppNThrdS1iT0RvR3ZuUGNnWU1UdXQ1WkpyQkJiazBCdWU4VUlRQ0dnYVdrYU5Xb29INkktMUZ6SXU0VFpZYnNqWGJ1c2JRRlQxOGREUkN6VVRubFlXdVZXUzhoSWhKc3lhZHJwSHJOVkI1VndmSlRKZVgwTjFpczBXcU1qdUdOc2VMLXluYnFjOVhueElncFJaai05QnZqY2ZKYXNOUTNZdHR3VHZVaFJOLVFGNWgxQkY1MnA2QmdOTVBvWmQ5MC1EU0xydlpseXp6MEh0Q2tFZnNsc013czVkR0ExTlZ1dEwtcGVDeU50VTFzOEtFaDlzcGxXeF9lQlFybTlYQU1kYXp5ZWR6VUpJU1UyMjZmQzhEUHh5c0ZreXpCbjlDQnFDQUpTNjQzTGFydUVDaS1rMGhKOWFmM2JXTmJnWmpSNVJ2NXF4THciLCJlIjoiQVFBQiJ9LCJwcmluY2lwYWwiOnsiZW1haWwiOiIwNjIxMzM0YzIwNjRjNmYzNmJlOGFkOWE0N2M1NTliY2FwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9LCJpYXQiOjE1MDY5Njk2OTU0MzksImV4cCI6MTUwNjk2OTY5NjQzOSwiZnhhLXZlcmlmaWVkRW1haWwiOiIzMjM2NzJiZUBtb3ppbGxhLmNvbSIsImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.hFZd5zFheXOFrXKkJvw6Vpv2l7ctlxuBTvuh5f_jLPAjZoJ9ri-vaJjL_WYBFUvS2xHzfx3-ldxLddyTKwCDAJeB_NkOFL_WJSrMet9C7_Z1hH9HmydeXIT82xJmhrwzW-WOO4ibQvRbocEFiNujynKsg1gS8v0iiYjIX-0cXCrlkxkbVx_8EXJFKDDOGzK9v7Zq6D7gkhP-CHEaNYaTHMn65tLQtBS6snGdaXlxoGHMWmDL6STbnJzWa7sa4QwHf-AgT1rUkQQAUHNa_XLZ0FEzqiCPctMadlihiUZL2V6vxIDBS4mHUF4qj0FvIMJflivDnJVkRNijDuP-h-Lh_A~eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJvYXV0aC5meGEiLCJleHAiOjE1MDY5Njk2OTY0MzksImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.M5xyk3RffucgaavjbUm7Eqnt47hzeGbGa2VR3jnVEIlRHfz5S25Qf3ngejwee7XECvIywbaKWeijXFOwS-EkB-7qP1gl4oNJjPmbnCk7S1lgckLWvdMIU-HLGKjrN6Mw76__LzvAbsusSeGmsvTCIVuOJ49Xs3tC1fLyB_re0QNpCcS6AUnJ1KOxIMEM3Om7ysNO5F_AqcD3PwlEti5lbwSk8iP5TWL12C2Nkb_6Hxze_mA1NZNAHOips9bF2J7oy1hqGoMYj1XYZrsyjpPWEuZQATAPlKSjbh1hq-UtDeT7DlwEmIbIUd3JA8qh1MkHKGgavd4fIMap0IPmr9rs4A",\n}\'',
+        },
+      ],
+    }
+  }
 };
 
 const AUTHORIZED_CLIENTS_POST = {
   ...TAGS_OAUTH_SERVER,
-  description: '/v1/authorized_clients',
+  description: '/v1/authorized-clients',
   notes: [
-    dedent`
-      This endpoint returns a list of all OAuth client instances connected to the user's account, including the the scopes granted to each client instance and the time at which it was last active, if available. It must be authenticated with an identity assertion for the user's account
-
-      Note:
-
-      Responses
-
-      For clients that use refresh tokens, each refresh token is taken to represent a separate instance of that client and is returned as a separate entry in the list, with the \`refresh_token_id\` field distinguishing each.
-
-      For clients that only use access tokens, all active access tokens are combined into a single entry in the list, and the \`refresh_token_id\` field will not be present.
-    `,
+    "This endpoint returns a list of all OAuth client instances connected to the user's account, including the the scopes granted to each client instance and the time at which it was last active, if available. It must be authenticated with an identity assertion for the user's account.",
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid 200 response will be a JSON array.
+
+            For clients that use refresh tokens, each refresh token is taken to represent a separate instance of that client and is returned as a separate entry in the list, with the \`refresh_token_id\` field distinguishing each.
+
+            For clients that only use access tokens, all active access tokens are combined into a single entry in the list, and the \`refresh_token_id\` field will not be present.
+
+            **Example:** \n
+                [ \n
+                  { \n
+                    "client_id": "5901bd09376fadaa", \n
+                    "refresh_token_id": "6e8c38f6a9c27dc0e4df698dc3e3e8b101ad6d79e87842b1ca96ad9b3cd8ed28", \n
+                    "name": "Example Sync Client", \n
+                    "created_time": 1528334748000, \n
+                    "last_access_time": 1528334748000, \n
+                    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"] \n
+                  }, \n
+                  { \n
+                    "client_id": "5901bd09376fadaa", \n
+                    "refresh_token_id": "eb5e17f246a6b0937356412118ea12b67a638232d6b376e2511cf38a0c4eecf9", \n
+                    "name": "Example Sync Client", \n
+                    "created_time": 1528334748000, \n
+                    "last_access_time": 1528334834000, \n
+                    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"] \n
+                  }, \n
+                  { \n
+                    "client_id": "23d10a14f474ca41", \n
+                    "name": "Example Website", \n
+                    "created_time": 1328334748000, \n
+                    "last_access_time": 1476677854037, \n
+                    "scope": ["profile:email", "profile:uid"] \n
+                  } \n
+                ]
+          `
+        }
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -X POST \\\n "https://oauth.accounts.firefox.com/v1/authorized-clients" \\\n -H \'cache-control: no-cache\' \\\n -H "Content-Type: application/json" \\\n -d \'{\n  "assertion": "eyJhbGciOiJSUzI1NiJ9.eyJwdWJsaWMta2V5Ijp7Imt0eSI6IlJTQSIsIm4iOiJvWmdsNkpwM0Iwcm5BVXppNThrdS1iT0RvR3ZuUGNnWU1UdXQ1WkpyQkJiazBCdWU4VUlRQ0dnYVdrYU5Xb29INkktMUZ6SXU0VFpZYnNqWGJ1c2JRRlQxOGREUkN6VVRubFlXdVZXUzhoSWhKc3lhZHJwSHJOVkI1VndmSlRKZVgwTjFpczBXcU1qdUdOc2VMLXluYnFjOVhueElncFJaai05QnZqY2ZKYXNOUTNZdHR3VHZVaFJOLVFGNWgxQkY1MnA2QmdOTVBvWmQ5MC1EU0xydlpseXp6MEh0Q2tFZnNsc013czVkR0ExTlZ1dEwtcGVDeU50VTFzOEtFaDlzcGxXeF9lQlFybTlYQU1kYXp5ZWR6VUpJU1UyMjZmQzhEUHh5c0ZreXpCbjlDQnFDQUpTNjQzTGFydUVDaS1rMGhKOWFmM2JXTmJnWmpSNVJ2NXF4THciLCJlIjoiQVFBQiJ9LCJwcmluY2lwYWwiOnsiZW1haWwiOiIwNjIxMzM0YzIwNjRjNmYzNmJlOGFkOWE0N2M1NTliY2FwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9LCJpYXQiOjE1MDY5Njk2OTU0MzksImV4cCI6MTUwNjk2OTY5NjQzOSwiZnhhLXZlcmlmaWVkRW1haWwiOiIzMjM2NzJiZUBtb3ppbGxhLmNvbSIsImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.hFZd5zFheXOFrXKkJvw6Vpv2l7ctlxuBTvuh5f_jLPAjZoJ9ri-vaJjL_WYBFUvS2xHzfx3-ldxLddyTKwCDAJeB_NkOFL_WJSrMet9C7_Z1hH9HmydeXIT82xJmhrwzW-WOO4ibQvRbocEFiNujynKsg1gS8v0iiYjIX-0cXCrlkxkbVx_8EXJFKDDOGzK9v7Zq6D7gkhP-CHEaNYaTHMn65tLQtBS6snGdaXlxoGHMWmDL6STbnJzWa7sa4QwHf-AgT1rUkQQAUHNa_XLZ0FEzqiCPctMadlihiUZL2V6vxIDBS4mHUF4qj0FvIMJflivDnJVkRNijDuP-h-Lh_A~eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJvYXV0aC5meGEiLCJleHAiOjE1MDY5Njk2OTY0MzksImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.M5xyk3RffucgaavjbUm7Eqnt47hzeGbGa2VR3jnVEIlRHfz5S25Qf3ngejwee7XECvIywbaKWeijXFOwS-EkB-7qP1gl4oNJjPmbnCk7S1lgckLWvdMIU-HLGKjrN6Mw76__LzvAbsusSeGmsvTCIVuOJ49Xs3tC1fLyB_re0QNpCcS6AUnJ1KOxIMEM3Om7ysNO5F_AqcD3PwlEti5lbwSk8iP5TWL12C2Nkb_6Hxze_mA1NZNAHOips9bF2J7oy1hqGoMYj1XYZrsyjpPWEuZQATAPlKSjbh1hq-UtDeT7DlwEmIbIUd3JA8qh1MkHKGgavd4fIMap0IPmr9rs4A"\n}\'',
+        },
+      ],
+    }
+  }
 };
 
 const CLIENT_CLIENTID_GET = {
@@ -137,6 +240,32 @@ const CLIENT_CLIENTID_GET = {
   notes: [
     'This endpoint is for the fxa-content-server to retrieve information about a client to show in its user interface.',
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid 200 response will be a JSON blob.
+            <br />
+            **Example:** \n
+                { \n
+                  "name": "Where's My Fox", \n
+                  "image_uri": "https://mozilla.org/firefox.png", \n
+                  "redirect_uri": "https://wheres.my.firefox.com/oauth", \n
+                  "trusted": true \n
+                }
+          `,
+        }
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v "http://oauth.accounts.firefox.com/v1/client/5901bd09376fadaa"',
+        },
+      ],
+    },
+  },
 };
 
 const INTROSPECT_POST = {
@@ -149,6 +278,36 @@ const INTROSPECT_POST = {
       If the token has attribute \`active: false\`, none of the other attributes in the response will have content
     `,
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid request will return a JSON response.
+            <br />
+            **Example** \n
+                { \n
+                  "active": true, \n
+                  "scope": "profile https://identity.mozilla.com/account/subscriptions", \n
+                  "client_id": "59cceb6f8c32317c", \n
+                  "token_type": "access_token", \n
+                  "iat": 1566535888243, \n
+                  "sub": "913fe9395bb946b48c1521d7beb2cb24", \n
+                  "jti": "5ae05d8fe413a749e0f4eb3c495a1c526fb52c85ca5fde516df5dd77d41f7b5b", \n
+                  "exp": 1566537688243 \n
+                }
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -X POST \\\n -H "Content-Type: application/json" \\\n "https://oauth.accounts.firefox.com/v1/introspect" \\\n -d \'{\n  "token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0"\n}\'',
+        },
+      ],
+    },
+  },
 };
 
 const JWKS_GET = {
@@ -157,12 +316,69 @@ const JWKS_GET = {
   notes: [
     'This endpoint returns the [JWKs](https://datatracker.ietf.org/doc/html/rfc7517) that are used for signing OpenID Connect id tokens.',
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid response will return JSON of the \`keys\`.
+            <br />
+            **Example:** \n
+                { \n
+                  "keys": [ \n
+                    "alg": "RS256", \n
+                    "use": "sig", \n
+                    "kty": "RSA", \n
+                    "kid": "2015.12.02-1", \n
+                    "n":"xaQHsKpu1KSK-YEMoLzZS7Xxciy3esGrhrrqW_JBrq3IRmeGLaqlE80zcpIVnStyp9tbet2niYTemt8ug591YWO5Y-S0EgQyFTxnGjzNOvAL6Cd2iGie9QeSehfFLNyRPdQiadYw07fw-h5gweMpVJs8nTgS-Bcorlw9JQM6Il1cUpbP0Lt-F_5qrzlaOiTEAAb4JGOusVh0n-MZfKt7w0mikauMH5KfhflwQDn4YTzRkWJzlldXr1Cs0ZkYzOwS4Hcoku7vd6lqCUO0GgZvkuvCFqdVKzpa4CGboNdfIjcGVF4f1CTQaQ0ao51cwLzq1pgi5aWYhVH7lJcm6O_BQw", \n
+                    "e":"AQAC" \n
+                  ] \n
+                }
+          `,
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v "http://oauth.accounts.firefox.com/v1/jwks"',
+        },
+      ],
+    },
+  },
 };
 
 const KEY_DATA_POST = {
   ...TAGS_OAUTH_SERVER,
   description: '/v1/key-data',
   notes: ['This endpoint returns the required scoped key metadata.'],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid response will return JSON the scoped key information for every scope that has scoped keys.
+            <br />
+            **Example** \n
+                { \n
+                  "https://identity.mozilla.com/apps/sample-scope-can-scope-key": { \n
+                    "identifier": "https://identity.mozilla.com/apps/sample-scope-can-scope-key", \n
+                    "keyRotationSecret": "0000000000000000000000000000000000000000000000000000000000000000", \n
+                    "keyRotationTimestamp": 1506970363512 \n
+                  } \n
+                }
+          `
+        }
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -X POST \\\n "https://oauth.accounts.firefox.com/v1/key-data" \\\n  -H \'cache-control: no-cache\' \\\n  -H \'content-type: application/json\' \\\n  -d \'{\n   "client_id": "5901bd09376fadaa",\n   "assertion": "eyJhbGciOiJSUzI1NiJ9.eyJwdWJsaWMta2V5Ijp7Imt0eSI6IlJTQSIsIm4iOiJvWmdsNkpwM0Iwcm5BVXppNThrdS1iT0RvR3ZuUGNnWU1UdXQ1WkpyQkJiazBCdWU4VUlRQ0dnYVdrYU5Xb29INkktMUZ6SXU0VFpZYnNqWGJ1c2JRRlQxOGREUkN6VVRubFlXdVZXUzhoSWhKc3lhZHJwSHJOVkI1VndmSlRKZVgwTjFpczBXcU1qdUdOc2VMLXluYnFjOVhueElncFJaai05QnZqY2ZKYXNOUTNZdHR3VHZVaFJOLVFGNWgxQkY1MnA2QmdOTVBvWmQ5MC1EU0xydlpseXp6MEh0Q2tFZnNsc013czVkR0ExTlZ1dEwtcGVDeU50VTFzOEtFaDlzcGxXeF9lQlFybTlYQU1kYXp5ZWR6VUpJU1UyMjZmQzhEUHh5c0ZreXpCbjlDQnFDQUpTNjQzTGFydUVDaS1rMGhKOWFmM2JXTmJnWmpSNVJ2NXF4THciLCJlIjoiQVFBQiJ9LCJwcmluY2lwYWwiOnsiZW1haWwiOiIwNjIxMzM0YzIwNjRjNmYzNmJlOGFkOWE0N2M1NTliY2FwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9LCJpYXQiOjE1MDY5Njk2OTU0MzksImV4cCI6MTUwNjk2OTY5NjQzOSwiZnhhLXZlcmlmaWVkRW1haWwiOiIzMjM2NzJiZUBtb3ppbGxhLmNvbSIsImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.hFZd5zFheXOFrXKkJvw6Vpv2l7ctlxuBTvuh5f_jLPAjZoJ9ri-vaJjL_WYBFUvS2xHzfx3-ldxLddyTKwCDAJeB_NkOFL_WJSrMet9C7_Z1hH9HmydeXIT82xJmhrwzW-WOO4ibQvRbocEFiNujynKsg1gS8v0iiYjIX-0cXCrlkxkbVx_8EXJFKDDOGzK9v7Zq6D7gkhP-CHEaNYaTHMn65tLQtBS6snGdaXlxoGHMWmDL6STbnJzWa7sa4QwHf-AgT1rUkQQAUHNa_XLZ0FEzqiCPctMadlihiUZL2V6vxIDBS4mHUF4qj0FvIMJflivDnJVkRNijDuP-h-Lh_A~eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJvYXV0aC5meGEiLCJleHAiOjE1MDY5Njk2OTY0MzksImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.M5xyk3RffucgaavjbUm7Eqnt47hzeGbGa2VR3jnVEIlRHfz5S25Qf3ngejwee7XECvIywbaKWeijXFOwS-EkB-7qP1gl4oNJjPmbnCk7S1lgckLWvdMIU-HLGKjrN6Mw76__LzvAbsusSeGmsvTCIVuOJ49Xs3tC1fLyB_re0QNpCcS6AUnJ1KOxIMEM3Om7ysNO5F_AqcD3PwlEti5lbwSk8iP5TWL12C2Nkb_6Hxze_mA1NZNAHOips9bF2J7oy1hqGoMYj1XYZrsyjpPWEuZQATAPlKSjbh1hq-UtDeT7DlwEmIbIUd3JA8qh1MkHKGgavd4fIMap0IPmr9rs4A",\n   "scope": "https://identity.mozilla.com/apps/sample-scope-can-scope-key"\n}\'',
+        },
+      ],
+    },
+  },
 };
 
 const TOKEN_POST = {
@@ -181,6 +397,34 @@ const TOKEN_POST = {
       **WARNING**: Do not include \`scope\` unless you want to downgrade it.
     `,
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid request will return a JSON response.
+            <br />
+            **Example:** \n
+                {\n
+                  "access_token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0", \n
+                  "scope": "profile:email profile:avatar", \n
+                  "token_type": "bearer", \n
+                  "expires_in": 3600, \n
+                  "refresh_token": "58d59cc97c3ca183b3a87a65eec6f93d5be051415b53afbf8491cc4c45dbb0c6", \n
+                  "auth_at": 1422336613 \n
+                }
+          `
+        }
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n -X POST \\\n -H "Content-Type: application/json" \\\n "https://oauth.accounts.firefox.com/v1/token" \\\n -d \'{\n  "client_id": "5901bd09376fadaa",\n  "client_secret": "20c6882ef864d75ad1587c38f9d733c80751d2cbc8614e30202dc3d1d25301ff",\n  "ttl": 3600,\n  "grant_type": "authorization_code",\n  "code": "4ab433e31ef3a7cf7c20590f047987922b5c9ceb1faff56f0f8164df053dd94c"\n}\'',
+        },
+      ],
+    },
+  },
 };
 
 const VERIFY_POST = {
@@ -189,6 +433,33 @@ const VERIFY_POST = {
   notes: [
     'Attached services can post tokens to this endpoint to learn about which user and scopes are permitted for the token.',
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        200: {
+          description: dedent`
+            A valid request will return a JSON response.
+
+            - Note: \`email\` of the respective user has been **REMOVED**.
+
+            **Example:** \n
+                { \n
+                  "user": "5901bd09376fadaa076afacef5251b6a", \n
+                  "client_id": "45defeda038a1c92", \n
+                  "scope": ["profile:email", "profile:avatar"], \n
+                }
+          `
+        },
+      },
+      'x-codeSamples': [
+        {
+          lang: 'JavaScript',
+          source:
+            'curl -v \\\n -X POST \\\n -H "Content-Type: application/json" \\\n "https://oauth.accounts.firefox.com/v1/verify" \\\n -d \'{\n  "token": "558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0"\n}\'',
+        },
+      ],
+    },
+  },
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/password-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/password-api.ts
@@ -21,7 +21,7 @@ const PASSWORD_CHANGE_START_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 103\` - Incorrect password
+            - \`errno: 103\` - Incorrect password
           `,
         },
       },
@@ -45,7 +45,7 @@ const PASSWORD_CHANGE_FINISH_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 138\` - Unverified session
+            - \`errno: 138\` - Unverified session
           `,
         },
       },
@@ -73,8 +73,10 @@ const PASSWORD_FORGOT_SEND_CODE_POST = {
     'hapi-swagger': {
       responses: {
         400: {
-          description:
-            'Failing requests may be caused by the following errors (this is not an exhaustive list): \n `errno: 145` - Reset password with this email type is not currently supported',
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 145\` - Reset password with this email type is not currently supported
+          `
         },
       },
     },
@@ -111,7 +113,7 @@ const PASSWORD_FORGOT_VERIFY_CODE_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 105\` - Invalid verification code
+            - \`errno: 105\` - Invalid verification code
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
@@ -16,7 +16,7 @@ const RECOVERYKEY_POST = {
     dedent`
       🔒 Authenticated with session token
 
-      Creates a new recovery key for a user. Recovery keys are one-time-use tokens that can be used to recover the user's kB if they forget their password. For more details, see the [**recovery keys**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/recovery_keys.md) docs.
+      Creates a new recovery key for a user. Recovery keys are one-time-use tokens that can be used to recover the user's kB if they forget their password. For more details, see the [recovery keys](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/recovery_keys.md) docs.
     `,
   ],
 };

--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -25,7 +25,7 @@ const SESSION_DESTROY_POST = {
         401: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 110\` - Invalid authentication token in request signature
+            - \`errno: 110\` - Invalid authentication token in request signature
           `,
         },
       },
@@ -49,13 +49,13 @@ const SESSION_REAUTH_POST = {
         400: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
-            \`errno: 102\` - Unknown account
-            \`errno: 103\` - Incorrect password
-            \`errno: 125\` - The request was blocked for security reasons
-            \`errno: 127\` - Invalid unblock code
-            \`errno: 142\` - Sign in with this email type is not currently supported
-            \`errno: 149\` - This email can not currently be used to login
-            \`errno: 160\` - This request requires two-step authentication enabled on your account
+            - \`errno: 102\` - Unknown account
+            - \`errno: 103\` - Incorrect password
+            - \`errno: 125\` - The request was blocked for security reasons
+            - \`errno: 127\` - Invalid unblock code
+            - \`errno: 142\` - Sign in with this email type is not currently supported
+            - \`errno: 149\` - This email can not currently be used to login
+            - \`errno: 160\` - This request requires two-step authentication enabled on your account
           `,
         },
       },

--- a/packages/fxa-auth-server/docs/swagger/sign-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/sign-api.ts
@@ -16,7 +16,7 @@ const CERTIFICATE_SIGN_POST = {
     dedent`
       🔒 Authenticated with session token
 
-      Sign a BrowserID public key. The server is given a public key and returns a signed certificate using the same JWT-like mechanism as a BrowserID primary IdP would (see [**browserid-certifier**](https://github.com/mozilla/browserid-certifier) for details). The signed certificate includes a \`principal.email\` property to indicate the Firefox Account identifier (a UUID at the account server's primary domain) and is stamped with an expiry time based on the \`duration\` parameter.
+      Sign a BrowserID public key. The server is given a public key and returns a signed certificate using the same JWT-like mechanism as a BrowserID primary IdP would (see [browserid-certifier](https://github.com/mozilla/browserid-certifier) for details). The signed certificate includes a \`principal.email\` property to indicate the Firefox Account identifier (a UUID at the account server's primary domain) and is stamped with an expiry time based on the \`duration\` parameter.
 
       This request will fail unless the primary email address for the account has been verified.
 
@@ -43,8 +43,12 @@ const CERTIFICATE_SIGN_POST = {
     'hapi-swagger': {
       responses: {
         400: {
-          description:
-            'Failing requests may be caused by the following errors (this is not an exhaustive list): \n `errno: 104` - Unverified account \n `errno: 108` - Missing parameter in request body \n `errno: 138` - Unverified session',
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 104\` - Unverified account
+            - \`errno: 108\` - Missing parameter in request body
+            - \`errno: 138\` - Unverified session
+          `
         },
       },
     },

--- a/packages/fxa-auth-server/docs/swagger/swagger-options.ts
+++ b/packages/fxa-auth-server/docs/swagger/swagger-options.ts
@@ -55,4 +55,6 @@ export const swaggerOptions = {
     },
   ],
   grouping: 'tags',
+  documentationPage: false,
+  swaggerUI: false,
 };

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -22,6 +22,8 @@ module.exports = (log, config, db, mailer, devices) => {
     'Retrieve metadata about the specified OAuth client, such as its display name and redirect URI.',
   ];
   clientGetAlias.config.tags = ['api', 'Oauth'];
+  // Prevents hapi-swagger from including /v1/client/{client_id}'s response example
+  clientGetAlias.config.plugins = {};
   routes.push(clientGetAlias);
 
   routes.forEach((r) => {

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -7,8 +7,6 @@
 const fs = require('fs');
 const Hapi = require('@hapi/hapi');
 const HapiSwagger = require('hapi-swagger');
-const Inert = require('@hapi/inert');
-const Vision = require('@hapi/vision');
 const path = require('path');
 const url = require('url');
 const userAgent = require('./userAgent');
@@ -448,8 +446,6 @@ async function create(log, error, config, routes, db, statsd) {
 
   // register all plugins and Swagger configuration
   await server.register([
-    Inert,
-    Vision,
     {
       plugin: HapiSwagger,
       options: swaggerOptions,

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -63,8 +63,6 @@
     "@hapi/hapi": "^20.2.1",
     "@hapi/hawk": "^8.0.0",
     "@hapi/hoek": "^10.0.0",
-    "@hapi/inert": "^6.0.5",
-    "@hapi/vision": "^6.1.0",
     "@sentry/integrations": "^6.19.1",
     "@sentry/node": "^6.19.1",
     "@type-cacheable/core": "^10.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4175,7 +4175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hapi/inert@npm:6.0.5, @hapi/inert@npm:^6.0.5":
+"@hapi/inert@npm:6.0.5":
   version: 6.0.5
   resolution: "@hapi/inert@npm:6.0.5"
   dependencies:
@@ -4379,18 +4379,6 @@ __metadata:
   dependencies:
     "@hapi/hoek": 9.x.x
   checksum: ddee101b4d4b01153d2eb51cd180c889297805f5117b7061088a2f1de29b71684c956fa1ff3c1575572992bfd485a60dee9376b03ffdbd0adbd861222a31f30a
-  languageName: node
-  linkType: hard
-
-"@hapi/vision@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@hapi/vision@npm:6.1.0"
-  dependencies:
-    "@hapi/boom": 9.x.x
-    "@hapi/bounce": 2.x.x
-    "@hapi/hoek": 9.x.x
-    "@hapi/validate": 1.x.x
-  checksum: 3e38ea9a0b29849c98ce9ba92b200c6912f60d47768140cb371f05593b4bf34ad4544d3e48e38b57831b22e47f8778cf5877f8a5e7d895566b1d2b8cc82a1535
   languageName: node
   linkType: hard
 
@@ -22828,8 +22816,6 @@ fsevents@~2.1.1:
     "@hapi/hapi": ^20.2.1
     "@hapi/hawk": ^8.0.0
     "@hapi/hoek": ^10.0.0
-    "@hapi/inert": ^6.0.5
-    "@hapi/vision": ^6.1.0
     "@sentry/integrations": ^6.19.1
     "@sentry/node": ^6.19.1
     "@storybook/addon-controls": ^6.5.9


### PR DESCRIPTION
## Because

- we are only utilizing hapi-swagger to auto-generate the JSON file, which is then added to Ecosystem Platform. Since we are not using hapi-swagger's UI to display the documentation page, we can remove `@hapi/inert` and `@hapi/vision` dependencies.
- we had examples in the initial OAuth Server API doc that were not included in the current API doc
- the list of errno's for responses in Auth Server API were not spaced out correctly

## This pull request

- [x] Remove Inert and Vision dependencies
- [x] Add examples to routes in OAuth Server API doc
- [x] Bullet the list of errno's in responses sections in Auth Server API doc
- [x] Updated the links in Auth Server to API doc in Ecosystem Platform

## Issue that this pull request solves

Closes: #13667

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
- OAuth Server
<img width="1574" alt="Screen Shot 2022-07-20 at 7 09 19 PM" src="https://user-images.githubusercontent.com/28129806/180097705-06051cf0-711a-4336-82b1-4f3c3e061609.png">

<img width="1566" alt="Screen Shot 2022-07-20 at 7 09 55 PM" src="https://user-images.githubusercontent.com/28129806/180097753-a550fc52-58bb-4078-a5e7-3a61ee0c8fe7.png">

<img width="1567" alt="Screen Shot 2022-07-20 at 7 10 19 PM" src="https://user-images.githubusercontent.com/28129806/180097805-aa01f6d0-a09d-4037-b5b4-c6c739c0f928.png">

<img width="1572" alt="Screen Shot 2022-07-20 at 7 10 42 PM" src="https://user-images.githubusercontent.com/28129806/180097843-60137a2c-9d04-4508-95ed-9b4ec2a7b914.png">

<img width="1579" alt="Screen Shot 2022-07-20 at 7 11 04 PM" src="https://user-images.githubusercontent.com/28129806/180097884-ff3b8d98-68dd-4440-b7d1-122f406d4e77.png">

<img width="1573" alt="Screen Shot 2022-07-20 at 7 11 16 PM" src="https://user-images.githubusercontent.com/28129806/180097905-89861715-863f-497a-a4cd-2b4621124bb3.png">

<img width="1570" alt="Screen Shot 2022-07-20 at 7 11 35 PM" src="https://user-images.githubusercontent.com/28129806/180097927-353c8acd-ed96-434f-b2a5-254c7bf9f019.png">

- Updated list of errno in Auth Server API
<img width="1556" alt="Screen Shot 2022-07-20 at 7 12 29 PM" src="https://user-images.githubusercontent.com/28129806/180098012-d9fdf022-0cd2-4385-b6d5-2cb5177a93a4.png">