### PR TITLE
task(admin-panel): Add info about locked accounts

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -49,14 +49,15 @@ let accountResponse: AccountProps = {
   ],
   createdAt: 1589467100316,
   disabledAt: null,
+  lockedAt: null,
   emailBounces: [
     {
       bounceSubType: BounceSubType.NoEmail,
       bounceType: BounceType.Permanent,
       createdAt: 556061927,
-      diagnosticCode: "",
-      email: "bloop@mozilla.com",
-      templateName: "subscriptionsPaymentProviderCancelled"
+      diagnosticCode: '',
+      email: 'bloop@mozilla.com',
+      templateName: 'subscriptionsPaymentProviderCancelled',
     },
   ],
   onCleared() {},
@@ -199,13 +200,45 @@ it('displays the account', async () => {
   );
 
   expect(getByTestId('account-section')).toBeInTheDocument();
-  expect(getByTestId('verified-status')).toHaveTextContent('verified');
+  expect(getByTestId('account-verified-status')).toHaveTextContent('verified');
   expect(getByTestId('email-label')).toHaveTextContent(
     accountResponse.emails![0].email
   );
-  expect(getByTestId('uid-label')).toHaveTextContent(accountResponse.uid);
-  expect(getByTestId('createdat-label')).toHaveTextContent(
+  expect(getByTestId('account-uid')).toHaveTextContent(accountResponse.uid);
+  expect(getByTestId('account-created-at')).toHaveTextContent(
     accountResponse.createdAt.toString()
+  );
+});
+
+it('displays when account is disabled', async () => {
+  const disabledAccount = {
+    ...accountResponse,
+    disabledAt: accountResponse.createdAt + 1000 * 60 * 60,
+  };
+  const { getByTestId } = render(
+    <MockedProvider>
+      <Account {...disabledAccount} />
+    </MockedProvider>
+  );
+
+  expect(getByTestId('account-disabled-at')).toHaveTextContent(
+    (disabledAccount.disabledAt || '').toString()
+  );
+});
+
+it('displays when account is locked', async () => {
+  const lockedAccount = {
+    ...accountResponse,
+    lockedAt: accountResponse.createdAt + 1000 * 60 * 60,
+  };
+  const { getByTestId } = render(
+    <MockedProvider>
+      <Account {...lockedAccount} />
+    </MockedProvider>
+  );
+
+  expect(getByTestId('account-locked-at')).toHaveTextContent(
+    (lockedAccount.lockedAt || '').toString()
   );
 });
 
@@ -216,7 +249,9 @@ it('displays the unverified account', async () => {
       <Account {...accountResponse} />
     </MockedProvider>
   );
-  expect(getByTestId('verified-status')).toHaveTextContent('not verified');
+  expect(getByTestId('account-verified-status')).toHaveTextContent(
+    'not verified'
+  );
 });
 
 it('displays the bounce type description', async () => {
@@ -224,7 +259,7 @@ it('displays the bounce type description', async () => {
     <MockedProvider>
       <Account {...accountResponse} />
     </MockedProvider>
-  )
+  );
   expect(getByTestId('bounce-description')).toBeInTheDocument();
 });
 

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -311,6 +311,7 @@ export const Account = ({
   emails,
   createdAt,
   disabledAt,
+  lockedAt,
   emailBounces,
   totp,
   recoveryKeys,
@@ -321,7 +322,9 @@ export const Account = ({
   securityEvents,
   linkedAccounts,
 }: AccountProps) => {
-  const date = dateFormat(new Date(createdAt), DATE_FORMAT);
+  const createdAtDate = dateFormat(new Date(createdAt), DATE_FORMAT);
+  const disabledAtDate = dateFormat(new Date(disabledAt || 0), DATE_FORMAT);
+  const lockedAtDate = dateFormat(new Date(lockedAt || 0), DATE_FORMAT);
   const primaryEmail = emails!.find((email) => email.isPrimary)!;
   const secondaryEmails = emails!.filter((email) => !email.isPrimary);
   return (
@@ -337,27 +340,66 @@ export const Account = ({
               {primaryEmail.email}
             </span>
           </h3>
-          <span
-            data-testid="verified-status"
-            className={
-              primaryEmail.isVerified
-                ? 'account-enabled-verified'
-                : 'account-disabled-unverified'
-            }
-          >
-            {primaryEmail.isVerified ? 'verified' : 'not verified'}
-          </span>
         </li>
         <li className="account-li">
-          <div data-testid="uid-label">
-            uid: <span>{uid}</span>
-          </div>
-          <div className="text-right">
-            created at: <span data-testid="createdat-label">{createdAt}</span>
-            <br />
-            {date}
-            <br />
-          </div>
+          <h3 className="account-header">Account Details</h3>
+        </li>
+        <li className="account-li account-border-info">
+          <ul>
+            <table className="pt-1" aria-label="account details">
+              <tbody>
+                <ResultTableRow label="uid" value={uid} testId="account-uid" />
+                <ResultTableRow
+                  label="Status"
+                  testId="account-verified-status"
+                  value={
+                    <span
+                      className={
+                        primaryEmail.isVerified
+                          ? 'account-enabled-verified'
+                          : 'account-disabled-unverified'
+                      }
+                    >
+                      {primaryEmail.isVerified ? 'verified' : 'not verified'}
+                    </span>
+                  }
+                />
+                <ResultTableRow
+                  label="Created At"
+                  value={
+                    <>
+                      {createdAtDate} ({createdAt})
+                    </>
+                  }
+                  testId="account-created-at"
+                />
+                {lockedAt != null && (
+                  <ResultTableRow
+                    label="Locked At"
+                    className="bg-yellow-100"
+                    value={
+                      <>
+                        {lockedAtDate} ({lockedAt})
+                      </>
+                    }
+                    testId="account-locked-at"
+                  />
+                )}
+                {disabledAt != null && (
+                  <ResultTableRow
+                    label="Disabled At"
+                    className="bg-yellow-100"
+                    value={
+                      <>
+                        {disabledAtDate} ({disabledAt})
+                      </>
+                    }
+                    testId="account-disabled-at"
+                  />
+                )}
+              </tbody>
+            </table>
+          </ul>
         </li>
 
         <li className="account-li">
@@ -539,7 +581,7 @@ export const Account = ({
             </table>
           </>
         ) : (
-          <div data-testid="acccount-security-events">
+          <div data-testid="account-security-events">
             No account history to display.
           </div>
         )}
@@ -884,13 +926,15 @@ const ResultTableRow = ({
   label,
   value,
   testId,
+  className,
 }: {
   label: string;
   value: any;
   testId: string;
+  className?: string;
 }) => {
   return (
-    <tr>
+    <tr className={className || ''}>
       <td className="account-label">
         <span>{label}</span>
       </td>

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
@@ -44,6 +44,7 @@ function exampleAccountResponse(email: string): MockedResponse {
           ],
           createdAt: chance.timestamp(),
           disabledAt: null,
+          lockedAt: null,
           emailBounces: [exampleBounce(email), exampleBounce(email)],
           totp: [
             {
@@ -110,6 +111,7 @@ function exampleNoResultsAccountResponse(email: string): MockedResponse {
           ],
           createdAt: chance.timestamp(),
           disabledAt: null,
+          lockedAt: null,
           emailBounces: [],
           totp: [],
           recoveryKeys: [],

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -12,6 +12,7 @@ const ACCOUNT_SCHEMA = `
   uid
   createdAt
   disabledAt
+  lockedAt
   emails {
     email
     isVerified

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -39,6 +39,7 @@ const ACCOUNT_COLUMNS = [
   'emailVerified',
   'createdAt',
   'disabledAt',
+  'lockedAt',
 ];
 const EMAIL_COLUMNS = [
   'createdAt',

--- a/packages/fxa-admin-server/src/gql/model/account.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/account.model.ts
@@ -29,6 +29,9 @@ export class Account {
   @Field({ nullable: true })
   public disabledAt?: number;
 
+  @Field({ nullable: true })
+  public lockedAt?: number;
+
   @Field((type) => [Email], { nullable: true })
   public emails!: Email[];
 

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -134,6 +134,7 @@ export interface Account {
     emailVerified: boolean;
     createdAt: number;
     disabledAt?: Nullable<number>;
+    lockedAt?: Nullable<number>;
     emails?: Nullable<Email[]>;
     emailBounces?: Nullable<EmailBounce[]>;
     totp?: Nullable<Totp[]>;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -129,6 +129,7 @@ type Account {
   emailVerified: Boolean!
   createdAt: Float!
   disabledAt: Float
+  lockedAt: Float
   emails: [Email!]
   emailBounces: [EmailBounce!]
   totp: [Totp!]

--- a/yarn.lock
+++ b/yarn.lock
@@ -22717,6 +22717,7 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
+    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.2
     fxa-shared: "workspace:*"
     googleapis: ^102.0.0


### PR DESCRIPTION
## Because

- Knowing if an account is locked is useful for support.

## This pull request

- Pulls the lockedAccount field from the database, and shows when an account is locked in the UI.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
