### PR TITLE
chore(db): upgrade to mysql 8 for local dev

### DIFF
--- a/_scripts/mysql.sh
+++ b/_scripts/mysql.sh
@@ -22,7 +22,7 @@ docker run --rm --name=mydb \
   -e MYSQL_ROOT_HOST=% \
   -e MYSQL_DATABASE=pushbox \
   -p 3306:3306 \
-  mysql/mysql-server:5.7 &
+  mysql/mysql-server:8.0.29 --default-authentication-plugin=mysql_native_password &
 
 cd "$DIR"
 ./check-mysql.sh


### PR DESCRIPTION
Because:
 - we want to upgrade to mysql 8

This commit:
 - upgrade mysql for local dev
 - start mysqld with default auth set to native password for backwards
   compat with the 'mysql' module

Closes: FXA-5583
