### PR TITLE
fix(admin-server): make subscription mgmt link optional

### DIFF
--- a/packages/fxa-admin-server/src/gql/model/moz-subscription.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/moz-subscription.model.ts
@@ -25,7 +25,7 @@ export class MozSubscription {
   @Field()
   public latestInvoice!: string;
 
-  @Field()
+  @Field({ nullable: true })
   public manageSubscriptionLink?: string;
 
   @Field()

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -120,7 +120,7 @@ export interface MozSubscription {
     cancelAtPeriodEnd: boolean;
     endedAt?: Nullable<number>;
     latestInvoice: string;
-    manageSubscriptionLink: string;
+    manageSubscriptionLink?: Nullable<string>;
     planId: string;
     productName: string;
     productId: string;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -115,7 +115,7 @@ type MozSubscription {
   cancelAtPeriodEnd: Boolean!
   endedAt: Float
   latestInvoice: String!
-  manageSubscriptionLink: String!
+  manageSubscriptionLink: String
   planId: String!
   productName: String!
   productId: String!


### PR DESCRIPTION
Because:
 - the manage subscription link is optional

This commit:
 - make the management subscription link optional for the GraphQL
   response

