### PR TITLE
bug(fxa-admin-server): Tests weren't running on the first invocation.

### DIFF
--- a/packages/fxa-graphql-api/src/database/database.service.spec.ts
+++ b/packages/fxa-graphql-api/src/database/database.service.spec.ts
@@ -8,12 +8,15 @@ import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Account } from 'fxa-shared/db/models/auth';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
-import { Profile } from 'fxa-shared/db/models/profile';
-import { StatsD } from 'hot-shots';
+import { testDatabaseSetup } from 'fxa-shared/test/db/helpers';
 
-describe('DatabaseService', () => {
+describe.only('DatabaseService', () => {
   let service: DatabaseService;
   let logger: any;
+
+  beforeAll(async () => {
+    await testDatabaseSetup();
+  });
 
   beforeEach(async () => {
     const dbConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22717,7 +22717,6 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
-    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.2
     fxa-shared: "workspace:*"
     googleapis: ^102.0.0


### PR DESCRIPTION
## Because

- On a fresh startup, the fxa-admin-server tests would fail the first time they were run.

## This pull request

- Ensures the database is setup prior to running the tests in

## Issue that this pull request solves

Closes: #13711

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


