### PR TITLE
bug(fxa-admin-server): Tests weren't running on the first invocation.

### DIFF
--- a/packages/fxa-admin-server/src/database/database.service.spec.ts
+++ b/packages/fxa-admin-server/src/database/database.service.spec.ts
@@ -9,10 +9,21 @@ import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import config, { AppConfig } from '../config';
 import { DatabaseService } from './database.service';
+import { testDatabaseSetup } from 'fxa-shared/test/db/helpers';
+import { Knex } from 'knex';
 
 describe('DatabaseService', () => {
   let service: DatabaseService;
   let logger: any;
+  let knex: Knex;
+
+  beforeAll(async () => {
+    knex = await testDatabaseSetup();
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
+  });
 
   beforeEach(async () => {
     const MockConfig: Provider = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22717,7 +22717,6 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
-    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.2
     fxa-shared: "workspace:*"
     googleapis: ^102.0.0


### PR DESCRIPTION
## Because

- On a fresh startup, the fxa-admin-server tests would fail the first time they were run.

## This pull request

- Ensures the database is setup prior to running the tests in database.service.spec.ts

## Issue that this pull request solves

Closes: #13711

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other Information

This can be validated by dropping the fxa.testAdmin database on your local mysql db. Then run the admin server tests. Without this patch, the tests will pretty consistently fail. With this patch, the issue is resolved.
