### PR TITLE
fix(docker): pull swagger docs in for customs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 **/coverage
 **/docs
 !packages/fxa-auth-server/docs/swagger
+!packages/fxa-customs-server/docs/swagger
 **/node_modules
 #**/test
 **/tests


### PR DESCRIPTION
Because:
 - customs was failing to start due to missing swagger docs

This commit:
 - let the docs in
