### PR TITLE
bug(auth-server): Fix token-pruner.complete metric

### DIFF
--- a/packages/fxa-shared/test/db/models/auth/prune-token.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/prune-token.spec.ts
@@ -141,17 +141,13 @@ describe('PruneTokens', () => {
       setTimeout(resolve, pruneInterval + maxJitter)
     );
 
-    expect(statsd.increment.calledWith('PruneTokens.Start')).to.be.true;
-    expect(statsd.increment.calledWith('PruneTokens.Error')).to.be.false;
+    expect(statsd.increment.calledWith('prune-tokens.start')).to.be.true;
+    expect(statsd.increment.calledWith('prune-tokens.error')).to.be.false;
     expect(
-      statsd.increment.calledWith('PruneTokens.Complete', {
-        '@unblockCodesDeleted': 0,
-        '@signInCodesDeleted': 0,
-        '@accountResetTokensDeleted': 0,
-        '@passwordForgotTokensDeleted': 0,
-        '@passwordChangeTokensDeleted': 0,
-        '@sessionTokensDeleted': 1,
-      })
+      statsd.increment.calledWith(
+        'prune-tokens.complete.session-tokens-deleted',
+        1
+      )
     ).to.be.true;
   });
 
@@ -190,7 +186,7 @@ describe('PruneTokens', () => {
 
     await pruneTokens.prune(1, 1);
 
-    expect(statsd.increment.calledWith('PruneTokens.Error')).to.be.true;
-    expect(log.error.calledWith('TokenPruner')).to.be.true;
+    expect(statsd.increment.calledWith('prune-tokens.error')).to.be.true;
+    expect(log.error.calledWith('prune-tokens')).to.be.true;
   });
 });


### PR DESCRIPTION
## Because

- The prune-tokens.complete metric wasn't being recorded.

## This pull request

- Records individual stats for each result type as opposed to using an increment with a 'Tag'
- Renames metrics to prune-tokens. This casing is more inline with the way other metrics are recorded.

## Issue that this pull request solves

Closes: #13718

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

