### PR TITLE
refactor(payments): update NewUserEmailForm to utilize Tailwind

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
@@ -1,27 +1,6 @@
 @import '../../../../fxa-content-server/app/styles/variables';
 
 .new-user-email-form {
-    position: relative;
-
-    .sign-in-copy {
-        color: $grey-50;
-        font-weight: 400;
-        margin-top: -8px;
-        margin-left: 24px;
-
-        a {
-            color: $grey-50;
-            text-decoration: underline;
-        }
-    }
-
-    .label-text {
-        font-weight: 600;
-        font-size: 15px;
-        color: $grey-50;
-        display: inline-block;
-    }
-
     .input-row--checkbox {
         margin: 24px 0 5px;
 
@@ -30,10 +9,4 @@
             margin-left: 8px;
         }
     }
-}
-
-.assurance-copy {
-    display: flex;
-    justify-content: center;
-    align-items: center;
 }

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
 import { NewUserEmailForm } from './index';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'components/NewUserEmailForm',
+  component: NewUserEmailForm,
+} as Meta;
 
 const WrapNewUserEmailForm = ({
   accountExistsReturnValue,
@@ -14,7 +19,7 @@ const WrapNewUserEmailForm = ({
   const [, setInvalidEmailDomain] = useState(false);
   const [, setEmailsMatch] = useState(false);
   return (
-    <div style={{ display: 'flex' }}>
+    <div className="flex">
       <NewUserEmailForm
         signInURL={
           'https://localhost:3031/subscriptions/products/productId?plan=planId&signin=yes'
@@ -37,22 +42,32 @@ const WrapNewUserEmailForm = ({
   );
 };
 
-storiesOf('components/NewUserEmailForm', module)
-  .add('default', () => (
+const storyWithContext = (
+  accountExistsReturnValue: boolean,
+  invalidDomain: boolean,
+  storyName?: string
+) => {
+  const story = () => (
     <WrapNewUserEmailForm
-      accountExistsReturnValue={false}
-      invalidDomain={false}
+      accountExistsReturnValue={accountExistsReturnValue}
+      invalidDomain={invalidDomain}
     />
-  ))
-  .add('existing account', () => (
-    <WrapNewUserEmailForm
-      accountExistsReturnValue={true}
-      invalidDomain={false}
-    />
-  ))
-  .add('invalid email domain', () => (
-    <WrapNewUserEmailForm
-      accountExistsReturnValue={false}
-      invalidDomain={true}
-    />
-  ));
+  );
+
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const Default = storyWithContext(false, false, 'default');
+
+export const ExistingAccount = storyWithContext(
+  true,
+  false,
+  'existing account'
+);
+
+export const InvalidEmailDomain = storyWithContext(
+  false,
+  true,
+  'invalid email domain'
+);

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -96,7 +96,7 @@ export const NewUserEmailForm = ({
         }}
       >
         <p
-          className="sign-in-copy font-normal -mt-2 ml-6 text-grey-400"
+          className="font-normal -mt-2 ml-6 text-grey-400"
           data-testid="sign-in-copy"
         >
           Already have a Firefox account?{' '}

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -78,22 +78,30 @@ export const NewUserEmailForm = ({
     <Form
       data-testid="new-user-email-form"
       validator={validator}
-      className="new-user-email-form"
+      className="new-user-email-form relative"
       {...{ onChange }}
     >
       <Localized
         id="new-user-sign-in-link"
         elems={{
           a: (
-            <a onClick={onClickSignInButton} href={signInURL}>
+            <a
+              className="underline text-grey-400 hover:text-grey-400"
+              onClick={onClickSignInButton}
+              href={signInURL}
+            >
               Sign in
             </a>
           ),
         }}
       >
-        <p className="sign-in-copy" data-testid="sign-in-copy">
+        <p
+          className="sign-in-copy font-normal -mt-2 ml-6 text-grey-400"
+          data-testid="sign-in-copy"
+        >
           Already have a Firefox account?{' '}
           <a
+            className="underline text-grey-400 hover:text-grey-400"
             data-testid="sign-in-link"
             onClick={onClickSignInButton}
             href={signInURL}
@@ -158,7 +166,10 @@ export const NewUserEmailForm = ({
         </Checkbox>
       </Localized>
 
-      <div className="assurance-copy" data-testid="assurance-copy">
+      <div
+        className="flex justify-center items-center"
+        data-testid="assurance-copy"
+      >
         <img src={shieldIcon} alt="shield" />
         <Localized id="new-user-subscribe-product-assurance">
           <p>

--- a/packages/fxa-payments-server/src/components/fields/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.test.tsx
@@ -62,14 +62,14 @@ describe('FieldGroup', () => {
 
 describe('Field', () => {
   it('renders a label when available', () => {
-    const { container } = render(
+    const { queryByTestId } = render(
       <TestForm>
         <Field fieldType="input" name="foo" label="This is a label">
           <p>Hi mom</p>
         </Field>
       </TestForm>
     );
-    const label = container.querySelector('label .label-text');
+    const label = queryByTestId('input-label-text');
     expect(label).not.toBeNull();
     expect(label?.textContent).toEqual('This is a label');
   });

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -93,7 +93,14 @@ export const Field = ({
   return (
     <div className={className} data-field-name={name}>
       <label>
-        {label && <span className="label-text">{label}</span>}
+        {label && (
+          <span
+            data-testid="input-label-text"
+            className="font-medium text-sm text-grey-400 block mb-2 text-left"
+          >
+            {label}
+          </span>
+        )}
         {tooltip && tooltipParentRef && validator.getError(name) && (
           <Tooltip parentRef={tooltipParentRef}>
             {validator.getError(name)}


### PR DESCRIPTION
## Because

- We want to convert to Tailwind across fxa for consistency and to improve overall maintenance
- We want to improve responsiveness and UI/UX
- We want to improve accessibility

## This pull request

* Replaces all CSS/SCSS with Tailwind utility classes with the exception of:
  * `.input-row--checkbox` and `label input[type="checkbox"]`, which are custom style settings and apply to elements found in the `fields` component
* Removes the styles from `.scss` file that are specific to the `NewUserEmailForm` component with the exception of classes mentioned above
* Reworks Storybook files

## Issue that this pull request solves

Closes: #13585

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Tweaks made to `fields` component to use Tailwind (applies to all of `fxa-payments-server`), namely `.label-text` on text input and applicable tests.