### PR TITLE
fix(fxa-content-server): strict casing for email validation

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -176,7 +176,9 @@ class IndexView extends FormView {
   _isEmailFirefoxDomain(email) {
     // "@firefox" or "@firefox.com" email addresses are not valid
     // at this time, therefore block the attempt.
-    return /@firefox(\.com)?$/.test(email);
+    // the added 'i' disallows uppercase letters
+    const firefoxMail = new RegExp("@firefox(\\.com)?$", 'i');
+    return firefoxMail.test(email);
   }
 
   _hasEmailBounced() {


### PR DESCRIPTION
## Because

- Fix for [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1773161)
- See discussion and proposed solution [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1777876) 

## This pull request

- Adds a check to ensure all characters are lowercase in email validation

## Issue that this pull request solves

Closes: #13690

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before (logging in with *@firefox.com)
<img width="623" alt="Screen Shot 2022-07-25 at 9 58 37 AM" src="https://user-images.githubusercontent.com/11150372/180834307-05d35eb2-77f1-4850-bd2f-8574343e152d.png">

Before (logging in with *@FiReFoX.com)
(successfully lets you into the password step): 
<img width="633" alt="Screen Shot 2022-07-25 at 9 59 02 AM" src="https://user-images.githubusercontent.com/11150372/180834353-a83292df-1755-44f4-8023-f02d402ba53f.png">

After (logging in with *@firefox.com) 
(shows desired behavior remains after changes):
<img width="577" alt="Screen Shot 2022-07-25 at 9 59 23 AM" src="https://user-images.githubusercontent.com/11150372/180834373-8d9d0cec-99f1-4c43-8bf7-4084539ae6d4.png">

After (logging in with *@FiReFoX.com)
(does not pass thru to password step):
<img width="590" alt="Screen Shot 2022-07-25 at 9 59 34 AM" src="https://user-images.githubusercontent.com/11150372/180834416-2e28cb63-30cf-428d-83f1-316acb90175a.png">


## Other information (Optional)

Any other information that is important to this pull request.
