### PR TITLE
fix(styles): use a bg img instead of img tag for green check

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
@@ -2,12 +2,7 @@
   <header class="hidden" id="fxa-connect-another-device-header"><h1>{{#t}}Connect another device{{/t}}</h1></header>
   {{#showSuccessMessage}}
     {{#isSignedIn}}
-      <h2 id="fxa-connected-heading" class="mb-10"><img
-      src="/images/circle-check.svg"
-      role="presentation"
-      alt=""
-      class="align-middle mr-3"
-      />{{#t}}Firefox account connected{{/t}}</h2>
+      <h2 id="fxa-connected-heading" class="mb-10 py-1.5 pl-10 bg-no-repeat bg-center bg-[center_left_40px]">{{#t}}Firefox account connected{{/t}}</h2>
     {{/isSignedIn}}
     {{^isSignedIn}}
       {{#isSignUp}}

--- a/packages/fxa-content-server/app/styles/_modules.scss
+++ b/packages/fxa-content-server/app/styles/_modules.scss
@@ -19,3 +19,4 @@
 @import 'modules/support';
 @import 'modules/chosen';
 @import 'modules/security-events';
+@import 'modules/cad';

--- a/packages/fxa-content-server/app/styles/modules/_cad.scss
+++ b/packages/fxa-content-server/app/styles/modules/_cad.scss
@@ -1,0 +1,3 @@
+#fxa-connected-heading {
+  background-image: image-url('circle-check.svg');
+}


### PR DESCRIPTION
Because:
 - using an img tag in content-server doesn't Just Work due to the way
   it is built and bundled

This commit:
 - switch to using a background image
