### PR TITLE
chore(l10n): replace references to master with main in l10n automation

### DIFF
--- a/_scripts/clone-l10n.sh
+++ b/_scripts/clone-l10n.sh
@@ -77,7 +77,7 @@ else
     FXA_L10N_REPO="${FXA_L10N_REPO:-https://github.com/mozilla/fxa-content-server-l10n.git}"
 
     # branch name
-    FXA_L10N_BRANCH="${FXA_L10N_BRANCH:-master}"
+    FXA_L10N_BRANCH="${FXA_L10N_BRANCH:-main}"
 
     # number of commits to truncate the history for specific commit checkout
     FXA_L10N_DEPTH="${FXA_L10N_DEPTH:-1000}"

--- a/packages/fxa-content-server/grunttasks/replace.js
+++ b/packages/fxa-content-server/grunttasks/replace.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
           // such as `    [`, this creates a <code> block when parsed by remarkable
           // to avoid that we remove the indent spaces
 
-          // ref: https://github.com/mozilla/legal-docs/blob/master/en/firefox_privacy_notice.md
+          // ref: https://github.com/mozilla/legal-docs/blob/main/en/firefox_privacy_notice.md
           from: /^ {4}/gm,
           to: '',
         },

--- a/packages/fxa-content-server/locale/README.md
+++ b/packages/fxa-content-server/locale/README.md
@@ -62,7 +62,7 @@ Then run `merge_po.sh` from within fxa-content-server-l10n:
 ./scripts/merge_po.sh locale
 ```
 
-Commit the merged .po files to master and enjoy.
+Commit the merged .po files and enjoy.
 
 ## Updating translations
 

--- a/packages/fxa-shared/l10n/determineLocale.ts
+++ b/packages/fxa-shared/l10n/determineLocale.ts
@@ -6,13 +6,13 @@ import { parseAcceptLanguage } from './parseAcceptLanguage';
 /**
  * Given a set of supported languages and an accept-language http header value, this resolves language that fits best.
  * @param acceptLanguage - The accept-language http header value
- * @param supportedLanguages - optional set of supported langauges. Defaults to master list held in ./supportedLanguages.json
+ * @param supportedLanguages - optional set of supported languages. Defaults to main list held in ./supportedLanguages.json
  * @returns The best fitting locale
  */
 export function determineLocale(
   acceptLanguage: string,
   supportedLanguages?: string[]
 ) {
-  // Returns languages in order of precendence, so we can just grab the first one.
+  // Returns languages in order of precedence, so we can just grab the first one.
   return parseAcceptLanguage(acceptLanguage, supportedLanguages)[0];
 }


### PR DESCRIPTION
## Because

* The fxa-content-server-l10n is still using master as default branch, and we want to update it to main.

## This pull request

* Updates references from master to main in automation
* Fixes or removes master references in docs
* Fixes a few typos

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Landing for this pull request needs to be coordinated (so, early morning US time). Once ready to merge, I'll need to:
- [x] Switch the default branch to main in the l10n repository
- [x] Merge this [pull request](https://github.com/mozilla/fxa-content-server-l10n/pull/629) in the l10n repository
- [x] Stop and restart sync in Pontoon to pick up the new default branch
