### PR TITLE
bug(content-server): Fix qr code screen when user is coming from pref…

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -169,6 +169,8 @@ module.exports = {
   FIREFOX_TOOLBAR_ENTRYPOINT: 'fxa_discoverability_native',
   FIREFOX_MENU_ENTRYPOINT: 'fxa_app_menu',
   FIREFOX_PREFERENCES_ENTRYPOINT: 'preferences',
+  FIREFOX_SYNCED_TABS_ENTRYPOINT: 'synced-tabs',
+  FIREFOX_TABS_SIDEBAR_ENTRYPOINT: 'tabs-sidebar',
 
   // This is compared against all secondary email
   // records, both verified and unverified

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -88,7 +88,9 @@ export default {
       context === Constants.FX_DESKTOP_V3_CONTEXT &&
       (entrypoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT ||
         entrypoint === Constants.FIREFOX_MENU_ENTRYPOINT ||
-        entrypoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT)
+        entrypoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT ||
+        entrypoint === Constants.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
+        entrypoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT)
     ) {
       return true;
     }

--- a/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
@@ -37,8 +37,12 @@ export default {
    * a QR code that can be used download firefox on a mobile device.
    */
   showDownloadFirefoxQrCode() {
+    const entryPoint = this.getSearchParam('entrypoint');
     return (
-      this.getSearchParam('entrypoint') === Constants.FIREFOX_MENU_ENTRYPOINT
+      entryPoint === Constants.FIREFOX_MENU_ENTRYPOINT ||
+      entryPoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT ||
+      entryPoint === Constants.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
+      entryPoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT
     );
   },
 };

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -93,30 +93,34 @@ describe('views/connect_another_device', () => {
       });
     });
 
-    ['fxa_discoverability_native', 'fxa_app_menu', 'preferences'].forEach(
-      (entrypoint) => {
-        describe(`with a Fx desktop user that can pair from ${entrypoint}`, () => {
-          beforeEach(() => {
-            sinon.stub(view, '_isSignedIn').callsFake(() => true);
-            relier.set('entrypoint', entrypoint);
-            relier.set('context', 'fx_desktop_v3');
-            sinon.spy(view, 'navigate');
+    [
+      'fxa_discoverability_native',
+      'fxa_app_menu',
+      'preferences',
+      'synced-tabs',
+      'tabs-sidebar',
+    ].forEach((entrypoint) => {
+      describe(`with a Fx desktop user that can pair from ${entrypoint}`, () => {
+        beforeEach(() => {
+          sinon.stub(view, '_isSignedIn').callsFake(() => true);
+          relier.set('entrypoint', entrypoint);
+          relier.set('context', 'fx_desktop_v3');
+          sinon.spy(view, 'navigate');
 
-            windowMock.navigator.userAgent =
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+          windowMock.navigator.userAgent =
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
 
-            return view.render().then(() => {
-              view.afterVisible();
-            });
-          });
-
-          it('shows pairing', () => {
-            assert.isTrue(view._isSignedIn.called);
-            assert.isTrue(view.navigate.calledWith('/pair'));
+          return view.render().then(() => {
+            view.afterVisible();
           });
         });
-      }
-    );
+
+        it('shows pairing', () => {
+          assert.isTrue(view._isSignedIn.called);
+          assert.isTrue(view.navigate.calledWith('/pair'));
+        });
+      });
+    });
 
     describe('with a fennec user that is signed in', () => {
       beforeEach(() => {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
@@ -48,6 +48,21 @@ describe('views/mixins/pairing-graphics-mixin', function () {
       assert.equal(view.showDownloadFirefoxQrCode(), true);
     });
 
+    it('returns true if entry point is preferences', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => 'preferences');
+      assert.equal(view.showDownloadFirefoxQrCode(), true);
+    });
+
+    it('returns true if entry point is synced-tabs', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => 'synced-tabs');
+      assert.equal(view.showDownloadFirefoxQrCode(), true);
+    });
+
+    it('returns true if entry point is side-bar', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => 'tabs-sidebar');
+      assert.equal(view.showDownloadFirefoxQrCode(), true);
+    });
+
     it('returns false if entry point is not app menu', () => {
       sinon.stub(view, 'getSearchParam').callsFake(() => undefined);
       assert.equal(view.showDownloadFirefoxQrCode(), false);


### PR DESCRIPTION
## Because

- The pair screen with the QR code was not being shown when users were coming from about:preferences#sync

## This pull request

- Includes the 'preferences' entry point in the logic that conditionally shows the qr code.

## Issue that this pull request solves

Closes: #13488 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="883" alt="image" src="https://user-images.githubusercontent.com/94418270/181636909-5b07f744-691a-41f7-a2b4-140f58f6f050.png">
<img width="877" alt="image" src="https://user-images.githubusercontent.com/94418270/181637057-a7f7d63a-c211-4978-9355-a4b9790db138.png">

AND

![image](https://user-images.githubusercontent.com/94418270/181641246-93755024-c40f-4a55-b081-79ecec673d71.png)

AND

![image](https://user-images.githubusercontent.com/94418270/181641279-9605fb51-859e-43a7-8572-4e1f229d16b4.png)





## Other information (Optional)

This is a follow PR to https://github.com/mozilla/fxa/pull/13594 that is based on QA feedback.
