### PR TITLE
feat(scripts): add script to prune oauth codes

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -220,6 +220,12 @@ class OauthDB extends ConnectedServicesDb {
   getPocketIds() {
     return POCKET_IDS;
   }
+
+  async pruneAuthorizationCodes(ttlInMs) {
+    return await this.mysql._pruneAuthorizationCodes(
+      ttlInMs || config.get('oauthServer.expiration.code')
+    );
+  }
 }
 
 // Helper functions

--- a/packages/fxa-auth-server/scripts/prune-oauth-authorization-codes.ts
+++ b/packages/fxa-auth-server/scripts/prune-oauth-authorization-codes.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import program from 'commander';
+import { StatsD } from 'hot-shots';
+import { promisify } from 'util';
+const pckg = require('../package.json');
+const DEFAULT_TTL_MS = 900000;
+
+export async function init() {
+  // Setup utilities
+  const config = require('../config').getProperties();
+  const statsd = new StatsD({ ...config.statsd, maxBufferSize: 0 });
+  const log = require('../lib/log')(
+    config.log.level,
+    'prune-oauth-codes',
+    statsd
+  );
+  const oauthDb = require('../lib/oauth/db');
+
+  // Parse args
+  program
+    .version(pckg.version)
+    .option(
+      '--ttl <number>',
+      'The TTL of OAuth authorization codes in milliseconds.  Defaults to 15 minutes.',
+      DEFAULT_TTL_MS
+    )
+    .on('--help', () =>
+      console.log('\n\nPrunes up to 10000 expired OAuth authorization codes.')
+    )
+    .parse(process.argv);
+
+  const ttlInMs = parseInt(program.ttl) || DEFAULT_TTL_MS;
+
+  log.info('OAuth codes pruning', { ttl: ttlInMs });
+
+  try {
+    log.info('OAuth codes pruning start', { ttl: ttlInMs });
+    const result = await oauthDb.pruneAuthorizationCodes(ttlInMs);
+    statsd.increment('oauth-codes.pruned', result.pruned);
+    log.info('token pruning complete', result);
+  } catch (err) {
+    log.error('error during prune', err);
+    return 1;
+  }
+
+  await promisify(statsd.close).bind(statsd)();
+  return 0;
+}
+
+if (require.main === module) {
+  let exitStatus = 1;
+  init()
+    .then((result) => {
+      exitStatus = result;
+    })
+    .catch((err) => {
+      console.error(err);
+    })
+    .finally(() => {
+      process.exit(exitStatus);
+    });
+}

--- a/packages/fxa-auth-server/test/scripts/prune-oauth-authorization-codes.js
+++ b/packages/fxa-auth-server/test/scripts/prune-oauth-authorization-codes.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const cp = require('child_process');
+const util = require('util');
+const path = require('path');
+
+const execAsync = util.promisify(cp.exec);
+
+const cwd = path.resolve(__dirname, ROOT_DIR);
+const execOptions = {
+  cwd,
+};
+
+describe('scripts/prune-oauth-authorization-codes:', () => {
+  it('does not fail with no argument', () => {
+    return execAsync(
+      'node -r esbuild-register scripts/prune-oauth-authorization-codes',
+      execOptions
+    );
+  });
+
+  it('does not fail with an argument', () => {
+    return execAsync(
+      'node -r esbuild-register scripts/prune-oauth-authorization-codes --ttl 600000',
+      execOptions
+    );
+  });
+});


### PR DESCRIPTION
Because:
 - we should prune the expired OAuth authorization codes from the OAuth
   database

This commit:
 - add a script that calls a pruning function that deletes up to 10,000
   expired OAuth authorization code
