### PR TITLE
feat(l10n): Add temporary fallback text test in Settings

### DIFF
--- a/packages/fxa-settings/src/components/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import Nav from '../Nav';
 import Security from '../Security';
@@ -13,17 +13,37 @@ import LinkedAccounts from '../LinkedAccounts';
 import * as Metrics from '../../lib/metrics';
 import { useAccount } from '../../models';
 import { DeleteAccountPath } from 'fxa-settings/src/constants';
-import { Localized } from '@fluent/react';
+import { Localized, useLocalization } from '@fluent/react';
 import DataCollection from '../DataCollection';
 
 export const PageSettings = (_: RouteComponentProps) => {
   const { uid } = useAccount();
+  const { l10n } = useLocalization();
 
   Metrics.setProperties({
     lang: document.querySelector('html')?.getAttribute('lang'),
     uid,
   });
   Metrics.usePageViewEvent(Metrics.settingsViewName);
+
+  // Temp test to see how often we actually display fallback text
+  useEffect(() => {
+    Metrics.logViewEvent(Metrics.settingsViewName, 'test.fallback.start');
+    const ftlId = 'app-footer-mozilla-logo-label';
+    const text = l10n.getString(ftlId);
+
+    if (text && text !== ftlId) {
+      Metrics.logViewEvent(
+        Metrics.settingsViewName,
+        'test.fallback.text-not-needed'
+      );
+    } else {
+      Metrics.logViewEvent(
+        Metrics.settingsViewName,
+        'test.fallback.text-needed'
+      );
+    }
+  }, [l10n]);
 
   return (
     <div id="fxa-settings" className="flex">


### PR DESCRIPTION
Because:
* We want to make an informed decision when it comes to keeping or removing fallback text

This commit:
* Adds a temporary 'test' in PageSettings around l10n.getString() by sending different metrics events (test.fallback.start plus test.fallback.text-not-needed vs test.fallback.text-needed) for when a translation pulls from an ftl bundle successfully vs when it relies on fallback text

Closes #13213

---

To get translated strings, we either use a `Localized` wrapper or we use `useLocalization` and get them with `l10n.getString`. I hoped I could test for both of these, however, any variation of the following that I tried...

```
  const FallbackTextTest = () => {
    Metrics.logViewEvent(
      Metrics.settingsViewName,
      'fallback.test.Localized.start'
    );

    return (
      <Localized id="quoth-the-raven-nevermore">
        <span className="hidden">
          {Metrics.logViewEvent(
            Metrics.settingsViewName,
            'fallback.test.Localized.fallback-text-needed'
          )}{' '}
        </span>
      </Localized>
    );
  };
```

... would make that metrics call no matter what. I thought I could find a way to "trick" Fluent into not executing some JS if the string was found by replacing its children but I'm not actually seeing how to do that, which is probably a good thing so that our JS inside `Localized` executes no matter what. `Localized` seems to function the same under the hood anyway as `l10.getString()`, so I'm fine with going with whatever comes out of this.

Something to note though - I was checking some Fluent docs while working on this and found [this section](https://github.com/projectfluent/fluent.js/wiki/Localized#fallback-string), where fallback text is recommended to use, and there's some interesting notes on "future plans". I know we were told some other React-fluent combinations at Moz weren't using fallback text, but we should chat with the l10n team about that if we do ultimately decide removing fallback text is the way to go.