### PR TITLE
feat(auth): update firestore saving structure

### DIFF
--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
@@ -404,10 +404,14 @@ describe('StripeProductsAndPlansConverter', () => {
       const productConfig = deepCopy(product);
       const productConfigId = 'docid_prod_123';
       const testPath = 'home/dir/prod_123';
-      const expectedJSON = JSON.stringify({
-        ...productConfig,
-        id: productConfigId,
-      });
+      const expectedJSON = JSON.stringify(
+        {
+          ...productConfig,
+          id: productConfigId,
+        },
+        null,
+        2
+      );
 
       paymentConfigManager.validateProductConfig = sandbox.stub().resolves();
       const spyWriteFile = sandbox.stub(fs.promises, 'writeFile').resolves();
@@ -481,10 +485,14 @@ describe('StripeProductsAndPlansConverter', () => {
       const planConfig = deepCopy(plan);
       const existingPlanConfigId = 'docid_plan_123';
       const testPath = 'home/dir/plan_123';
-      const expectedJSON = JSON.stringify({
-        ...planConfig,
-        id: existingPlanConfigId,
-      });
+      const expectedJSON = JSON.stringify(
+        {
+          ...planConfig,
+          id: existingPlanConfigId,
+        },
+        null,
+        2
+      );
 
       paymentConfigManager.validatePlanConfig = sandbox.stub().resolves();
       const spyWriteFile = sandbox.stub(fs.promises, 'writeFile').resolves();


### PR DESCRIPTION
Because:

* We want easier to locate metadata in github for loading to firestore.

This commit:

* Updates the name saving convention to be more descriptive.

Closes FXA-5577

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
