### PR TITLE
fix(payments): Revise style in AcceptedCards component

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/AcceptedCards/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/AcceptedCards/index.tsx
@@ -7,11 +7,11 @@ import amexLogo from '../../../images/amex.svg';
 
 export const AcceptedCards = () => {
   return (
-    <div className="flex justify-center mb-10">
-      <img className="py-1 pl-0 pr-1" src={visaLogo} alt="visa" />
-      <img className="p-1" src={mastercardLogo} alt="mastercard" />
-      <img className="p-1" src={discoverLogo} alt="discover" />
-      <img className="p-1" src={amexLogo} alt="american express" />
+    <div className="flex justify-center mb-4 gap-2">
+      <img src={visaLogo} alt="visa" />
+      <img src={mastercardLogo} alt="mastercard" />
+      <img src={discoverLogo} alt="discover" />
+      <img src={amexLogo} alt="american express" />
     </div>
   );
 };


### PR DESCRIPTION
## Because

- margin-bottom (16px) was miscalculated when converting to Tailwind

## This pull request

- fixes margin-bottom to mb-4
- adds `gap-2` in place of individual padding

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Original
![](https://user-images.githubusercontent.com/28129806/182205079-0f1c4586-d3a9-439a-a28c-1afcfc8a84ae.png)

Before
![](https://user-images.githubusercontent.com/28129806/182205149-ec23f0a8-1ec2-428d-abb2-c8e3e70dd98b.png)

After
<img width="1283" alt="Screen Shot 2022-08-02 at 12 09 23 PM" src="https://user-images.githubusercontent.com/28129806/182423046-14afcd7b-222a-4710-85de-bffcbba84007.png">

