### PR TITLE
 fix(payments): add missing class for button styles to take effect

### DIFF
--- a/packages/fxa-payments-server/src/components/CouponForm/index.scss
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.scss
@@ -42,20 +42,20 @@
     padding: 0 16px 16px 0;
   }
 
-  button {
+  .button {
     max-height: 40px;
     width: 110px;
     margin: 0 16px 16px 0;
   }
 
   @media (min-width: 521px) {
-    button {
+    .button {
       max-height: 48px;
     }
   }
 
   @media (orientation: landscape) and (max-width: 640px) {
-    button {
+    .button {
       max-height: 40px;
     }
   }

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -195,7 +195,7 @@ export const CouponForm = ({
           </div>
           {readOnly ? null : (
             <button
-              className={`${readOnly ? 'hidden' : ''}`}
+              className={`button ${readOnly ? 'hidden' : ''}`}
               onClick={removeCoupon}
               disabled={subscriptionInProgress}
               data-testid="coupon-remove-button"
@@ -228,6 +228,7 @@ export const CouponForm = ({
 
           <button
             name="apply"
+            className="button"
             type="submit"
             data-testid="coupon-button"
             disabled={checkingCoupon || readOnly || subscriptionInProgress}

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -133,7 +133,9 @@ const Subject = ({
     <MockApp languages={[locale]}>
       <SignInLayout>
         <div className="product-payment">
-          <button onClick={refreshSubmitNonce}>Refresh submit nonce</button>
+          <button className="button" onClick={refreshSubmitNonce}>
+            Refresh submit nonce
+          </button>
           <p>Current nonce: {submitNonce}</p>
           <PaymentForm {...paymentFormProps} />
         </div>

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -242,7 +242,7 @@ export const PaymentForm = ({
       <Localized id="payment-cancel-btn">
         <button
           data-testid="cancel"
-          className="settings-button cancel secondary-button"
+          className="button settings-button cancel secondary-button"
           onClick={onCancel}
         >
           Cancel
@@ -254,7 +254,7 @@ export const PaymentForm = ({
       >
         <SubmitButton
           data-testid="submit"
-          className="settings-button primary-button"
+          className="button settings-button primary-button"
           name="submit"
           disabled={inProgress}
         >
@@ -275,6 +275,7 @@ export const PaymentForm = ({
       <Localized id="payment-submit-btn">
         <SubmitButton
           data-testid="submit"
+          className="button"
           name="submit"
           disabled={!allowSubmit}
         >

--- a/packages/fxa-payments-server/src/components/fields/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.test.tsx
@@ -611,7 +611,7 @@ describe('SubmitButton', () => {
     const Subject = () => {
       return (
         <TestForm>
-          <SubmitButton data-testid="submit" name="submit">
+          <SubmitButton data-testid="submit" className="button" name="submit">
             Submit
           </SubmitButton>
           <Input name="foo" required />

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -50,8 +50,8 @@ export const SubscriptionUpgrade = ({
   resetUpdateSubscriptionPlan,
   updateSubscriptionPlanStatus,
 }: SubscriptionUpgradeProps) => {
-  const ariaLabelledBy = "error-plan-change-failed-header";
-  const ariaDescribedBy = "error-plan-change-failed-description";
+  const ariaLabelledBy = 'error-plan-change-failed-header';
+  const ariaDescribedBy = 'error-plan-change-failed-description';
   const validator = useValidatorState();
 
   const inProgress = updateSubscriptionPlanStatus.loading;
@@ -107,11 +107,9 @@ export const SubscriptionUpgrade = ({
           descId={ariaDescribedBy}
         >
           <Localized id="sub-change-failed">
-            <h4
-            id={ariaLabelledBy}
-            data-testid="error-plan-update-failed"
-          >
-            Plan change failed</h4>
+            <h4 id={ariaLabelledBy} data-testid="error-plan-update-failed">
+              Plan change failed
+            </h4>
           </Localized>
           <p id={ariaDescribedBy}>
             {updateSubscriptionPlanStatus.error.message}
@@ -177,6 +175,7 @@ export const SubscriptionUpgrade = ({
             <div className="button-row">
               <SubmitButton
                 data-testid="submit"
+                className="button"
                 name="submit"
                 disabled={inProgress}
               >

--- a/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
@@ -35,7 +35,7 @@ export const ActionButton = ({
   const stripeActionButton = () => (
     <button
       data-testid="reveal-payment-update-button"
-      className="settings-button"
+      className="button settings-button"
       onClick={onRevealUpdateClick}
     >
       <Localized id="pay-update-change-btn">
@@ -50,7 +50,7 @@ export const ActionButton = ({
     <Localized id="pay-update-change-btn">
       <LinkExternal
         data-testid="change-payment-update-button"
-        className="settings-button"
+        className="button settings-button"
         href={`${apiUrl}/myaccount/autopay/connect/${billing_agreement_id}`}
       >
         <span className="change-button" data-testid="change-button">
@@ -63,7 +63,7 @@ export const ActionButton = ({
   const paypalFundingSourceActionButton = () => (
     <LinkExternal
       data-testid="manage-payment-update-button"
-      className="settings-button error-button"
+      className="button settings-button error-button"
       href={`${apiUrl}/myaccount/autopay/connect/${billing_agreement_id}`}
     >
       <Localized id="pay-update-manage-btn">
@@ -77,7 +77,7 @@ export const ActionButton = ({
   const paypalMissingAgreementActionButton = () => (
     <button
       data-testid="reveal-payment-modal-button"
-      className="settings-button error-button"
+      className="button settings-button error-button"
       onClick={revealFixPaymentModal}
     >
       <Localized id="pay-update-manage-btn">

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -156,7 +156,7 @@ const CancelSubscriptionPanel = ({
               </div>
               <div className="action">
                 <button
-                  className="settings-button"
+                  className="button settings-button"
                   onClick={revealCancel}
                   data-testid="reveal-cancel-subscription-button"
                 >
@@ -218,7 +218,7 @@ const CancelSubscriptionPanel = ({
             <div className="button-row">
               <Localized id="sub-item-stay-sub">
                 <button
-                  className="settings-button primary-button"
+                  className="button settings-button primary-button"
                   data-testid="stay-subscribed-button"
                   onClick={engagedOnHideCancel}
                 >
@@ -227,7 +227,7 @@ const CancelSubscriptionPanel = ({
               </Localized>
               <button
                 data-testid="cancel-subscription-button"
-                className="settings-button secondary-button"
+                className="button settings-button secondary-button"
                 onClick={confirmCancellation}
                 disabled={
                   cancelSubscriptionStatus.loading || !confirmationChecked

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -17,7 +17,7 @@ import AppContext from '../../../lib/AppContext';
 
 const ConfirmationDialogErrorContent = ({
   headerId,
-  descId
+  descId,
 }: {
   headerId: string;
   descId: string;
@@ -116,7 +116,7 @@ const ConfirmationDialogContent = ({
       )}
       <div className="action">
         <button
-          className="settings-button"
+          className="button settings-button"
           onClick={onConfirm}
           data-testid="reactivate-subscription-confirm-button"
         >
@@ -157,14 +157,16 @@ const ConfirmationDialog = ({
     plan
   );
 
-  const ariaLabelledByError = "error-content-header";
-  const ariaDescribedByError = "error-content-description";
+  const ariaLabelledByError = 'error-content-header';
+  const ariaDescribedByError = 'error-content-description';
 
-  const ariaLabelledByConfirmation = "confirmation-content-header";
-  const ariaDescribedByConfirmation = "confirmation-content-description";
+  const ariaLabelledByConfirmation = 'confirmation-content-header';
+  const ariaDescribedByConfirmation = 'confirmation-content-description';
 
-  const ariaLabelledBy = !loading && error ? ariaLabelledByError : ariaLabelledByConfirmation;
-  const ariaDescribedBy = !loading && !error ? ariaDescribedByError : ariaDescribedByConfirmation;
+  const ariaLabelledBy =
+    !loading && error ? ariaLabelledByError : ariaLabelledByConfirmation;
+  const ariaDescribedBy =
+    !loading && !error ? ariaDescribedByError : ariaDescribedByConfirmation;
 
   return (
     <DialogMessage

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -77,7 +77,7 @@ const ReactivateSubscriptionPanel = ({
           </div>
           <div className="action">
             <button
-              className="settings-button"
+              className="button settings-button"
               onClick={revealReactivateConfirmation}
               data-testid="reactivate-subscription-button"
             >

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
@@ -21,8 +21,8 @@ const SuccessDialog = ({
     config.featureFlags.useFirestoreProductConfigs
   );
 
-  const ariaLabelledBy = "reactivate-subscription-success-header";
-  const ariaDescribedBy = "reactivate-subscription-success-description";
+  const ariaLabelledBy = 'reactivate-subscription-success-header';
+  const ariaDescribedBy = 'reactivate-subscription-success-description';
 
   const setWebIconBackground = webIconBackground
     ? { background: webIconBackground }
@@ -35,7 +35,11 @@ const SuccessDialog = ({
       headerId={ariaLabelledBy}
       descId={ariaDescribedBy}
     >
-      <div id={ariaLabelledBy} className="dialog-icon" style={{ ...setWebIconBackground }}>
+      <div
+        id={ariaLabelledBy}
+        className="dialog-icon"
+        style={{ ...setWebIconBackground }}
+      >
         <img
           alt={productName}
           src={webIcon || fpnImage}
@@ -53,7 +57,7 @@ const SuccessDialog = ({
         </Localized>
       </p>
       <button
-        className="settings-button"
+        className="button settings-button"
         onClick={onDismiss}
         data-testid="reactivate-subscription-success-button"
       >

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/SubscriptionIapItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/SubscriptionIapItem.tsx
@@ -83,7 +83,7 @@ const GooglePlaySubscriptionIapItem = (
           <div className="action">
             <LinkExternal
               data-testid="manage-iap-subscription-button"
-              className="settings-button"
+              className="button settings-button"
               href={appStoreLink}
             >
               <Localized id="sub-iap-item-manage-button">
@@ -144,7 +144,7 @@ const AppleSubscriptionIapItem = (
           <div className="action">
             <LinkExternal
               data-testid="manage-iap-subscription-button"
-              className="settings-button"
+              className="button settings-button"
               href={appStoreLink}
             >
               <Localized id="sub-iap-item-manage-button">

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -232,11 +232,14 @@ export const Subscriptions = ({
   const planId =
     activeWebSubscription && (activeWebSubscription as WebSubscription).plan_id;
 
-  const ariaLabelledByReactivateSubscription = "error-subscription-reactivation-failed-header";
-  const ariaDescribedByReactivateSubscription = "error-subscription-reactivation-failed-description";
+  const ariaLabelledByReactivateSubscription =
+    'error-subscription-reactivation-failed-header';
+  const ariaDescribedByReactivateSubscription =
+    'error-subscription-reactivation-failed-description';
 
-  const ariaLabelledByCancellationStatus = "error-cancellation-failed-header";
-  const ariaDescribedByCancellationStatus = "error-cancellation-failed-description";
+  const ariaLabelledByCancellationStatus = 'error-cancellation-failed-header';
+  const ariaDescribedByCancellationStatus =
+    'error-cancellation-failed-description';
 
   return (
     <div className="subscription-management" onClick={onAnyClick}>
@@ -273,7 +276,10 @@ export const Subscriptions = ({
           descId={ariaDescribedByReactivateSubscription}
         >
           <Localized id="sub-route-idx-reactivating">
-            <h4 id={ariaLabelledByReactivateSubscription} data-testid="error-reactivation">
+            <h4
+              id={ariaLabelledByReactivateSubscription}
+              data-testid="error-reactivation"
+            >
               Reactivating subscription failed
             </h4>
           </Localized>
@@ -298,7 +304,10 @@ export const Subscriptions = ({
           descId={ariaDescribedByCancellationStatus}
         >
           <Localized id="sub-route-idx-cancel-failed">
-            <h4 id={ariaLabelledByCancellationStatus} data-testid="error-cancellation">
+            <h4
+              id={ariaLabelledByCancellationStatus}
+              data-testid="error-cancellation"
+            >
               Cancelling subscription failed
             </h4>
           </Localized>
@@ -327,7 +336,7 @@ export const Subscriptions = ({
               </header>
               <button
                 data-testid="contact-support-button"
-                className="settings-button primary-button settings-unit-toggle"
+                className="button settings-button primary-button settings-unit-toggle"
                 onClick={onSupportClick}
               >
                 <Localized id="sub-route-idx-contact">
@@ -479,8 +488,8 @@ const CancellationDialogMessage = ({
     subscriptionId,
     customerSubscriptions
   );
-  const ariaLabelledBy = "subscription-cancellation-header";
-  const ariaDescribedBy = "subscription-cancellation-description";
+  const ariaLabelledBy = 'subscription-cancellation-header';
+  const ariaDescribedBy = 'subscription-cancellation-description';
   const plan = planForId(customerSubscription!.plan_id, plans) as Plan;
 
   return (


### PR DESCRIPTION
## Because

- Changes in button styling that are shared across FxA were not made in payments
- `button` element selector was removed from stylesheets in a separate commit, making all buttons and button-styled CTAs require `.button` class for styles to take effect

## This pull request

- Adds `.button` class to all button and button-styled CTAs
- Updates `index.scss` to target `.button` class and not `button` element
- Updates test to include `.button` class in submit button

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Follow up to #13739 where `button` element was removed from shared stylesheets.
