### PR TITLE
chore(pm2): watch styles in fxa-react

### DIFF
--- a/packages/fxa-content-server/pm2.config.js
+++ b/packages/fxa-content-server/pm2.config.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const path = require('path');
 const PATH = process.env.PATH.split(':')
   .filter((p) => !p.includes(process.env.TMPDIR))
   .join(':');
@@ -42,6 +43,11 @@ module.exports = {
         'app/styles/tailwind.css',
         'app/styles/tailwind/**/*.css',
         require.resolve('fxa-react/configs/tailwind.js'),
+        path.normalize(
+          `${path.dirname(
+            require.resolve('fxa-react/configs/tailwind.js')
+          )}/../styles`
+        ),
       ],
       time: true,
     },

--- a/packages/fxa-payments-server/pm2.config.js
+++ b/packages/fxa-payments-server/pm2.config.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const path = require('path');
 const PATH = process.env.PATH.split(':')
   .filter((p) => !p.includes(process.env.TMPDIR))
   .join(':');
@@ -61,6 +62,11 @@ module.exports = {
         'src/components/**/*.css',
         'src/**/*.tsx',
         require.resolve('fxa-react/configs/tailwind.js'),
+        path.normalize(
+          `${path.dirname(
+            require.resolve('fxa-react/configs/tailwind.js')
+          )}/../styles`
+        ),
       ],
       ignore_watch: ['src/styles/tailwind.out.*'],
       time: true,

--- a/packages/fxa-settings/pm2.config.js
+++ b/packages/fxa-settings/pm2.config.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const path = require('path');
 const PATH = process.env.PATH.split(':')
   .filter((p) => !p.includes(process.env.TMPDIR))
   .join(':');
@@ -41,6 +42,11 @@ module.exports = {
         'src/styles',
         'src/components/**/*.scss',
         'src/**/*.tsx',
+        path.normalize(
+          `${path.dirname(
+            require.resolve('fxa-react/configs/tailwind.js')
+          )}/../styles`
+        ),
         require.resolve('fxa-react/configs/tailwind.js'),
       ],
       ignore_watch: ['src/styles/tailwind.out.*'],


### PR DESCRIPTION
Because:
 - we should rebuild the styles in content, payments, and settings when
   the styles in fxa-react change

This commit:
 - watch the styles dir in fxa-react for the css "app" PM2 configs in
   content, payments, and settings
