### PR TITLE
bug(content): Address validation issues showing up in sentry with high rates

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -62,6 +62,7 @@ const fourOhFour = require('../lib/404');
 const serverErrorHandler = require('../lib/500');
 const localizedRender = require('../lib/localized-render');
 const csp = require('../lib/csp');
+const { tryCaptureValidationError } = require('../lib/sentry');
 const cspRulesBlocking = require('../lib/csp/blocking')(config);
 const cspRulesReportOnly = require('../lib/csp/report-only')(config);
 
@@ -228,7 +229,7 @@ function makeApp() {
         req.query,
         req.originalUrl
       );
-    sentry.sentryModule.captureException(err);
+    tryCaptureValidationError(err);
     routeHelpers.validationErrorHandler(err, req, res, next);
   });
 

--- a/packages/fxa-content-server/server/lib/routes/post-csp.js
+++ b/packages/fxa-content-server/server/lib/routes/post-csp.js
@@ -14,8 +14,8 @@ const url = require('url');
 const validation = require('../validation');
 
 const INTEGER_TYPE = validation.TYPES.INTEGER;
-const STRING_TYPE = validation.TYPES.STRING;
-const URL_TYPE = validation.TYPES.URL;
+const STRING_TYPE = validation.TYPES.LONG_STRING;
+const URL_TYPE = validation.TYPES.LONG_URL;
 
 const BODY_SCHEMA = {
   'csp-report': joi

--- a/packages/fxa-content-server/server/lib/validation.js
+++ b/packages/fxa-content-server/server/lib/validation.js
@@ -51,12 +51,17 @@ const TYPES = {
     .allow('none'),
   RESUME: joi.string().regex(PATTERNS.BASE64),
   SIGNIN_CODE: joi.string().regex(PATTERNS.BASE64_URL_SAFE).length(8),
-  STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
+  STRING: joi.string().max(1024), // 10k is arbitrary, seems like it should give CSP reports plenty of space.
+  LONG_STRING: joi.string().max(10 * 1024),
   SYNC_ENGINES: joi.array().items(joi.string().regex(PATTERNS.SYNC_ENGINE)),
   TIME: joi.number().integer().min(0),
   URL: joi
     .string()
     .max(2048)
+    .uri({ scheme: ['http', 'https'] }), // 2048 is also arbitrary, the same limit we use on the front end.
+  LONG_URL: joi
+    .string()
+    .max(64 * 1024) // 64k is the upper bounds of what is supported for URLs by browsers
     .uri({ scheme: ['http', 'https'] }), // 2048 is also arbitrary, the same limit we use on the front end.
   USER_PREFERENCES: joi.object().keys({
     'account-recovery': joi.boolean(),

--- a/packages/fxa-content-server/tests/server/sentry.js
+++ b/packages/fxa-content-server/tests/server/sentry.js
@@ -43,4 +43,34 @@ suite.tests['eventFilter'] = function () {
   assert.equal(response.exception[0].stacktrace.frames.length, 10);
 };
 
+suite.tests['captures validation errors'] = function () {
+  var err = {
+    details: new Map([
+      [
+        'body',
+        {
+          details: [
+            {
+              message: 'test1',
+              type: 'test2',
+              path: ['test3'],
+            },
+          ],
+        },
+      ],
+    ]),
+  };
+  assert.ok(sentry.tryCaptureValidationError(err));
+};
+
+suite.tests['captures general error'] = function () {
+  var err = new Error('BOOM');
+  assert.ok(sentry.tryCaptureValidationError(err));
+};
+
+suite.tests['handles malformed error'] = function () {
+  var err = {};
+  assert.ok(sentry.tryCaptureValidationError(err));
+};
+
 registerSuite('sentry', suite);

--- a/packages/fxa-shared/metrics/navigation-timing.ts
+++ b/packages/fxa-shared/metrics/navigation-timing.ts
@@ -16,11 +16,32 @@ const NAV_ENTRY_TYPE = 'navigation';
 // export for testing
 export const sendFn = () => {
   if (!!navigator.sendBeacon) {
-    return (url: string, navTiming: PerformanceNavigationTiming) =>
-      navigator.sendBeacon(
+    return (url: string, navTiming: PerformanceNavigationTiming) => {
+      // Clamp timings to 0. Sometimes negative values are getting reported
+      // causing validation errors. The w3c spec indicates all timing values
+      // should be unsigned longs, so we will enforce this here.
+      navTiming = Object.assign({}, navTiming, {
+        domComplete: Math.max(0, navTiming.domComplete),
+        domContentLoadedEventEnd: Math.max(
+          0,
+          navTiming.domContentLoadedEventEnd
+        ),
+        domContentLoadedEventStart: Math.max(
+          0,
+          navTiming.domContentLoadedEventStart
+        ),
+        domInteractive: Math.max(0, navTiming.domInteractive),
+        loadEventEnd: Math.max(0, navTiming.loadEventEnd),
+        loadEventStart: Math.max(0, navTiming.loadEventStart),
+        unloadEventEnd: Math.max(0, navTiming.unloadEventEnd),
+        unloadEventStart: Math.max(0, navTiming.unloadEventStart),
+      });
+
+      return navigator.sendBeacon(
         url,
         new Blob([JSON.stringify(navTiming)], { type: 'application/json' })
       );
+    };
   }
 
   // noop if no avaiable API to send


### PR DESCRIPTION

## Because

- Sentry is seeing lots of validation issues.
- We would like to correct some of these.
- We would like to get a better understanding of why some of these are happening.

## This pull request

- Makes a best effort to correct issues on the /navigation-timing endpoint
- Makes a best effort to correct issues on the /metrics endpoint
- Improves the error message reported sentry when a validation error occurs, which hopefully gives us more insight in the future.

## Issue that this pull request solves

Closes: #13493 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Example validation error in sentry:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/94418270/182494118-19d8ea98-1e9d-467a-b3c1-485ddb7a5eab.png">


## Additional Info

For /metrics and /csp-report the request body is not reported. As a result, knowing exactly what caused the issue is difficult. It is likely that it's due to long URLs so the URL length limit has been increased in some cases. The improved errors in sentry should also allow us to see if this guess is wrong, and another type of validation check is failing.

