### PR TITLE
fix(css): Fix a couple of regressions from TW Sync flow changes

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card">
+<div class="card">
   <header>
     <h1 id="fxa-signin-code-header" class="card-header">{{#unsafeTranslate}}Enter confirmation code<span class="card-subheader">for your Firefox account</span>{{/unsafeTranslate}}</h1>
   </header>

--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -58,6 +58,15 @@
       @include title30();
       color: $header-color;
       line-height: 26px;
+
+      .service,
+      .email,
+      .description {
+        display: block;
+        font-size: 15px;
+        line-height: 22px;
+        margin-top: 4px;
+      }
     }
 
     h2 {

--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -44,6 +44,29 @@
     background-image: image-url('default-profile.svg');
     background-size: cover;
   }
+
+  // remove when Payments isn't using `avatar-settings-view`
+  &.avatar-settings-view {
+    border: 2px solid transparent;
+    display: block;
+    flex-shrink: 0;
+    margin: 0;
+
+    &.spinner-completed {
+      border: 2px solid $avatar-border-color;
+      box-shadow: $card-box-low;
+    }
+
+    @include respond-to('big') {
+      height: 64px;
+      width: 64px;
+    }
+
+    @include respond-to('small') {
+      height: 50px;
+      width: 50px;
+    }
+  }
 }
 
 #done {

--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -1,5 +1,6 @@
 // After all .button-rows are converted to TW, we can remove this entire file
-.button {
+.button,
+#main-content button {
   @include font();
   align-items: center;
   background: $button-background-color-default;

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -239,11 +239,11 @@ body.settings #stage .settings {
   max-width: 100vw;
 
   @include respond-to('big') {
-    padding: 0 32px;
+    padding: 0 32px 15px;
   }
 
   @include respond-to('small') {
-    padding: 0 16px;
+    padding: 0 16px 15px;
   }
 }
 

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -292,7 +292,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="submit"
                 data-testid="submit-totp"
-                className="cta-primary mx-2 flex-1"
+                className="cta-primary cta-base-p mx-2 flex-1"
                 disabled={
                   !totpForm.formState.isDirty || !totpForm.formState.isValid
                 }
@@ -333,7 +333,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 data-testid="ack-recovery-code"
                 type="submit"
-                className="cta-primary mx-2 flex-1"
+                className="cta-primary cta-base-p mx-2 flex-1"
                 onClick={onRecoveryCodesAcknowledged}
               >
                 Continue
@@ -383,7 +383,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="submit"
                 data-testid="submit-recovery-code"
-                className="cta-primary mx-2 flex-1"
+                className="cta-primary cta-base-p mx-2 flex-1"
                 disabled={
                   !recoveryCodeForm.formState.isDirty ||
                   !recoveryCodeForm.formState.isValid


### PR DESCRIPTION
Because:
* Aint nobody got time for UI regressions

This commit:
* Removes the ID main-content from an already TW-ified file which allowed TW styles to take precedence
* Adds back a couple of styles that were removed but, only applicable to elements falling under #main-content to not affect TW styles

--

Decided to poke through some content-server pages I didn't test as thoroughly and found a couple regressions. Good thing I looked 😅 

Before:
![94E7B83F-666E-4C60-A2B2-7ABDB7A435B7](https://user-images.githubusercontent.com/13018240/182494835-bdc59aa6-1fb2-47df-a104-719d44136037.png)
![F6A29347-0379-4E9E-B88F-9BE3055A2D47](https://user-images.githubusercontent.com/13018240/182494848-8992149d-9421-473b-98af-b3d7dc2c4dee.png)

After:
![16077265-FCA0-4D23-886A-713D2BA0008B](https://user-images.githubusercontent.com/13018240/182494882-b60488e9-7400-46be-ace9-f19ba4f558c9.png)

![03DEB7C0-5063-4157-B9A8-990A420F69E5](https://user-images.githubusercontent.com/13018240/182494968-2b868425-419e-420e-a17a-e0d2d7f31b5d.png)


TW-ified UI remain unaffected because these styles only affect `#main-content` styles, an ID that was removed on TW-ified files.
