### PR TITLE
fix(payments): remove duplicate css selectors

### DIFF
--- a/packages/fxa-payments-server/src/routes/Checkout/index.scss
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.scss
@@ -18,40 +18,28 @@
 }
 
 .subscription-title + .product-payment {
+  grid-row: 2/3;
   border-top: 0;
   border-radius: 0 0 8px 8px;
   box-shadow: 0 -1px white, 0 1px white, -2px 2px 2px -2px rgba(12, 12, 13, 0.1),
     2px 2px 2px -2px rgba(12, 12, 13, 0.1);
 
   @include max-width('tablet') {
+    grid-row: 4/5;
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
   }
 
   @media (orientation: landscape) and (max-width: 927px) and (max-height: 429px) {
+    grid-row: 4/5;
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
   }
 
   @media (orientation: portrait) and (max-width: 429px) and (max-height: 927px) {
+    grid-row: 4/5;
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
-  }
-}
-
-.subscription-title + .product-payment {
-  grid-row: 2/3;
-
-  @include max-width('tablet') {
-    grid-row: 4/5;
-  }
-
-  @media (orientation: landscape) and (max-width: 927px) and (max-height: 429px) {
-    grid-row: 4/5;
-  }
-
-  @media (orientation: portrait) and (max-width: 429px) and (max-height: 927px) {
-    grid-row: 4/5;
   }
 }
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
@@ -3,40 +3,28 @@
 @import '../../../styles/variables';
 
 .subscription-title + .product-payment {
+  grid-row: 2/3;
   border-top: 0;
   border-radius: 0 0 8px 8px;
   box-shadow: 0 -1px white, 0 1px white, -2px 2px 2px -2px rgba(12, 12, 13, 0.1),
     2px 2px 2px -2px rgba(12, 12, 13, 0.1);
 
   @include max-width('tablet') {
+    grid-row: 4/5;
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
   }
 
   @media (orientation: landscape) and (max-width: 927px) and (max-height: 429px) {
+    grid-row: 4/5;
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
   }
 
   @media (orientation: portrait) and (max-width: 429px) and (max-height: 927px) {
+    grid-row: 4/5;
     box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
     border-radius: 8px;
-  }
-}
-
-.subscription-title + .product-payment {
-  grid-row: 2/3;
-
-  @include max-width('tablet') {
-    grid-row: 4/5;
-  }
-
-  @media (orientation: landscape) and (max-width: 927px) and (max-height: 429px) {
-    grid-row: 4/5;
-  }
-
-  @media (orientation: portrait) and (max-width: 429px) and (max-height: 927px) {
-    grid-row: 4/5;
   }
 }
 


### PR DESCRIPTION
## Because

- Husky pre-commit hook returns an error on stylelint of scss files
  informing that no duplicate selectors are allowed.

## This pull request

- Removes duplicate selectors and moves all logic into one.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).