### PR TITLE
fix(docs): Updated links to API docs

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
@@ -291,7 +291,7 @@ export const AUTH_SERVER_API_DESCRIPTION = {
             "errno": 201,
             "error": "Service Unavailable",
             "message": "Service unavailable",
-            "info": "https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format",
+            "info": "https://mozilla.github.io/ecosystem-platform/api#section/Response-format",
             "retryAfter": 30,
             "retryAfterLocalized": "in a few seconds"
         }

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -130,7 +130,7 @@ const DEFAULTS = {
   error: 'Internal Server Error',
   errno: ERRNO.UNEXPECTED_ERROR,
   message: 'Unspecified error',
-  info: 'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
+  info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
 };
 
 const TOO_LARGE =
@@ -267,10 +267,7 @@ AppError.translate = function (request, response) {
       );
     }
   } else if (payload.validation) {
-    if (
-      payload.message &&
-      payload.message.includes('is required')
-    ) {
+    if (payload.message?.includes('is required')) {
       error = AppError.missingRequestParameter(payload.validation.keys[0]);
     } else {
       error = AppError.invalidRequestParameter(payload.validation);
@@ -371,14 +368,12 @@ AppError.incorrectPassword = function (dbEmail, requestEmail) {
 };
 
 AppError.cannotCreatePassword = function () {
-  return new AppError(
-    {
-      code: 400,
-      error: 'Bad Request',
-      errno: ERRNO.CANNOT_CREATE_PASSWORD,
-      message: 'Can not create password, password already set.',
-    }
-  );
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.CANNOT_CREATE_PASSWORD,
+    message: 'Can not create password, password already set.',
+  });
 };
 
 AppError.unverifiedAccount = function () {

--- a/packages/fxa-auth-server/lib/oauth/assertion.js
+++ b/packages/fxa-auth-server/lib/oauth/assertion.js
@@ -31,7 +31,7 @@ const { verifyJWT } = require('../../lib/serverJWT');
 const HEX_STRING = /^[0-9a-f]+$/;
 
 // FxA sends several custom claims, ref
-// https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#post-certificatesign
+// https://mozilla.github.io/ecosystem-platform/api#tag/Sign/operation/postCertificateSign
 const CLAIMS_SCHEMA = Joi.object({
   uid: Joi.string().length(32).regex(HEX_STRING).required(),
   'fxa-generation': Joi.number().integer().min(0).required(),

--- a/packages/fxa-auth-server/lib/oauth/error.js
+++ b/packages/fxa-auth-server/lib/oauth/error.js
@@ -9,8 +9,7 @@ const DEFAULTS = {
   code: 500,
   error: 'Internal Server Error',
   errno: 999,
-  info:
-    'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#errors',
+  info: 'https://mozilla.github.io/ecosystem-platform/api#section/Errors',
   message: 'Unspecified error',
 };
 

--- a/packages/fxa-auth-server/test/local/sentry.js
+++ b/packages/fxa-auth-server/test/local/sentry.js
@@ -111,7 +111,7 @@ describe('Sentry', () => {
       code: 500,
       errno: 998,
       error: 'Internal Server Error',
-      info: 'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
+      info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
       message: 'An internal validation check failed.',
       op: 'internalError',
     });

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -486,7 +486,7 @@ describe('lib/server', () => {
             code: 400,
             errno: 125,
             error: 'Request blocked',
-            info: 'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
+            info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
             message: 'The request was blocked for security reasons',
           };
           beforeEach(() => {

--- a/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
@@ -195,7 +195,7 @@ export default _.extend({}, Errors, {
    */
   toInterpolationContext(err) {
     // For data returned by backend, see
-    // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#errors
+    // https://mozilla.github.io/ecosystem-platform/api#section/Errors
     try {
       if (this.is(err, 'MISSING_PARAMETER')) {
         return {

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -174,7 +174,7 @@ const Account = Backbone.Model.extend(
       return this.createOAuthToken(this._oAuthClientId, {
         scope: CONTENT_SERVER_OAUTH_SCOPE,
         // set authorization TTL to 5 minutes.
-        // Docs: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#post-v1authorization
+        // Docs: https://mozilla.github.io/ecosystem-platform/api#tag/OAuth-Server-API-Overview/operation/postAuthorization
         // Issue: https://github.com/mozilla/fxa-content-server/issues/3982
         ttl: 300,
       }).then((accessToken) => {

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -199,7 +199,7 @@ var OAuthRelier = Relier.extend({
 
   _setupSignInSignUpFlow() {
     // params listed in:
-    // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md
+    // https://mozilla.github.io/ecosystem-platform/api#tag/OAuth-Server-API-Overview
     this.importSearchParamsUsingSchema(
       SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA,
       OAuthErrors

--- a/packages/fxa-content-server/docs/architecture.md
+++ b/packages/fxa-content-server/docs/architecture.md
@@ -249,9 +249,9 @@ UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on
 ## Additional Resources
 
 - [APIs attached to Firefox Accounts](https://developer.mozilla.org/docs/Mozilla/APIs_attached_to_Firefox_Accounts)
-- [Firefox Accounts Auth Server API](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md)
+- [Firefox Accounts Auth Server API](https://mozilla.github.io/ecosystem-platform/api)
 - [Firefox Acocunts Auth Server Codebase](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server/)
-- [Firefox Accounts OAuth Server API](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md)
+- [Firefox Accounts OAuth Server API](https://mozilla.github.io/ecosystem-platform/api#tag/OAuth-Server-API-Overview)
 - [Firefox Accounts OAuth Server Codebase](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server/lib/oauth)
 - [Firefox Accounts Profile Server API](https://github.com/mozilla/fxa/blob/main/packages/fxa-profile-server/docs/API.md)
 - [Firefox Accounts Profile Server Codebase](https://github.com/mozilla/fxa/tree/main/packages/fxa-profile-server)


### PR DESCRIPTION
## Because

- links no longer work as API docs are now in Ecosystem Platform

## This pull request

- updates links to API docs in Ecosystem Platform

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.