### PR TITLE
fix(punctuation): add period and space

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -1,6 +1,6 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-signin-code-header" class="card-header">{{#unsafeTranslate}}Enter confirmation code<span class="card-subheader">for your Firefox account</span>{{/unsafeTranslate}}</h1>
+    <h1 id="fxa-signin-code-header" class="card-header">{{#unsafeTranslate}}Enter confirmation code <span class="card-subheader">for your Firefox account</span>{{/unsafeTranslate}}</h1>
   </header>
 
   <section>
@@ -10,7 +10,7 @@
     <div class="bg-image-email"></div>
 
     <p id="verification-email-message" class="mb-5">
-    {{#t}}Enter the code that was sent to %(email)s within 5 minutes{{/t}}
+    {{#t}}Enter the code that was sent to %(email)s within 5 minutes.{{/t}}
     </p>
 
     <form novalidate>


### PR DESCRIPTION
Because:
 - sentences are generally ended with a period (dot symbol)
 - a single space should be between words

This commit:
 - add a period and a space

