### PR TITLE
chore(content): update sync option to just "Passwords"

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/sync-engines.js
+++ b/packages/fxa-content-server/app/scripts/models/sync-engines.js
@@ -37,7 +37,7 @@ const AVAILABLE_ENGINES = [
   {
     checked: true,
     id: 'passwords',
-    text: t('Logins and Passwords'),
+    text: t('Passwords'),
   },
   {
     checked: true,


### PR DESCRIPTION
Because:
 - too many words in "Logins and Passwords"

This commit:
 - change to just "Passwords"
