### PR TITLE
chore(copy): update get Firefox message

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -1,6 +1,6 @@
 <div class="card">
   <header>
-    <h2 id="pair-header" class="card-header">{{#t}}Get Firefox on your phone or tablet{{/t}}</h2>
+    <h2 id="pair-header" class="card-header">{{#t}}Download Firefox on your phone or tablet{{/t}}</h2>
   </header>
 
   <section>
@@ -8,7 +8,7 @@
 
     {{#showQrCode}}
       <div class="bg-image-cad-qr-code" role="img" aria-label="{{#t}}QR code{{/t}}"></div>
-      <p class="my-5">{{#t}}Hold your phone’s camera over the code to scan.{{/t}}<br>{{#unsafeTranslate}}Or, send yourself a <a href="https://www.mozilla.org/firefox/mobile/get-app/" target="_blank" class="link-blue">download link.</a>{{/unsafeTranslate}}</p>
+      <p class="my-5">{{#t}}To download Firefox on your mobile device, hold the device’s camera over this code to scan.{{/t}}<br>{{#unsafeTranslate}}Or, send yourself a <a href="https://www.mozilla.org/firefox/mobile/get-app/" target="_blank" class="link-blue">download link.</a>{{/unsafeTranslate}}</p>
     {{/showQrCode}}
     {{^showQrCode}}
       <div class="{{graphicId}} mt-5" role="img" aria-label="{{#t}}Complete your set-up{{/t}}"></div>

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -128,7 +128,7 @@ describe('views/pair/index', () => {
         );
         assert.ok(
           view.$el.find('#pair-header').text(),
-          'Get Firefox on your phone or tablet'
+          'Download Firefox on your phone or tablet'
         );
         assert.ok(view.$el.find('#start-pairing').length);
         assert.ok(view.$el.find('.bg-image-cad-hearts').length);


### PR DESCRIPTION
Because:
 - language on downloading mobile Firefox on the pairing screen was
   confusing

This commit:
 - update copy for downloading mobile Firefox

