### PR TITLE
chore(style): add more space between coppa & cwts

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/coppa-age-input.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/coppa-age-input.mustache
@@ -1,4 +1,4 @@
-<div id="coppa" class="input-row input-row-age">
+<div id="coppa" class="input-row input-row-age mb-8">
   <input type="number" pattern="\d*" id="age" placeholder="{{#t}}How old are you?{{/t}}" min="0" max="130" value="{{ age }}" {{#required}}required{{/required}} />
   <p>{{#t}}You must be at least 13 years old to create an account.{{/t}}</p>
 </div>


### PR DESCRIPTION
Because:
 - coppa input was too close to cwts

This commit:
 - add more whitespace
