### PR TITLE
chore(styles): move Firefox logo down a bit

### DIFF
--- a/packages/fxa-content-server/app/styles/tailwind/flows.css
+++ b/packages/fxa-content-server/app/styles/tailwind/flows.css
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .card {
-  @apply relative text-center w-full mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 pb-10 pt-28 mobileLandscape:pt-20;
+  @apply relative text-center w-full mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 pb-10 pt-33 mobileLandscape:pt-20;
 
   &::before {
-    @apply h-16 mobileLandscape:h-20 left-0 block absolute bg-center bg-no-repeat w-full bg-contain top-5 mobileLandscape:-top-10;
+    @apply h-16 mobileLandscape:h-20 left-0 block absolute bg-center bg-no-repeat w-full bg-contain top-8 mobileLandscape:-top-10;
     content: '';
     background-image: inline('../images/firefox-logo.svg');
   }

--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -14,6 +14,7 @@ module.exports = {
         7: '1.75rem',
         11: '2.75rem',
         18: '4.5rem',
+        33: '8.5rem',
       },
       margin: {
         7: '1.75rem',


### PR DESCRIPTION
Because:
 - we want more space between top of viewport and the Firefox logo image

This commit:
 - add 12px worth of space
