### PR TITLE
copy(fxa-auth-server): update copy for verifyShortCode email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -36,7 +36,7 @@
   "verifyPrimary": 8,
   "verifyLogin": 5,
   "verifyLoginCode": 7,
-  "verifyShortCode": 4,
+  "verifyShortCode": 5,
   "verifySecondaryCode": 3,
   "postAddTwoStepAuthentication": 8,
   "postRemoveTwoStepAuthentication": 8,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
@@ -1,6 +1,8 @@
 # Variables:
 #  $code (Number) - e.g. 123456
-verifyShortCode-subject-2 = Confirmation code: { $code }
-verifyShortCode-title = Is this you signing up?
-verifyShortCode-prompt-2 = If yes, use this confirmation code in your registration form:
+verifyShortCode-subject-3 = Confirm your account
+verifyShortCode-title-2 = Open the internet with { -brand-firefox }
+# Information on the browser and device triggering this confirmation email follows below this string.
+verifyShortCode-title-subtext = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in starting with:
+verifyShortCode-prompt-3 = Use this confirmation code:
 verifyShortCode-expiry-notice = It expires in 5 minutes.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/includes.json
@@ -1,6 +1,6 @@
 {
   "subject": {
-    "id": "verifyShortCode-subject-2",
-    "message": "Confirmation code: <%- code %>"
+    "id": "verifyShortCode-subject-3",
+    "message": "Confirm your account"
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
@@ -5,7 +5,10 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verifyShortCode-title">Is this you signing up?</span>
+      <span data-l10n-id="verifyShortCode-title-2">Open the internet with Firefox</span>
+    </mj-text>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifyShortCode-title-subtext">Confirm your account and get the most out of Firefox everywhere you sign in starting with:</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -15,7 +18,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="verifyShortCode-prompt-2">If yes, use this confirmation code in your registration form:</span>
+      <span data-l10n-id="verifyShortCode-prompt-3">Use this confirmation code:</span>
     </mj-text>
 
     <mj-text css-class="code-large"><%- code %></mj-text>
@@ -27,3 +30,4 @@
 </mj-section>
 
 <%- include('/partials/automatedEmailNoAction/index.mjml') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.txt
@@ -1,8 +1,10 @@
-verifyShortCode-title = "Is this you signing up?"
+verifyShortCode-title-2 = "Open the internet with Firefox"
+
+verifyShortCode-title-subtext = "Confirm your account and  get the most out of Firefox everywhere you sign in starting with:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
-verifyShortCode-prompt-2 = "If yes, use this confirmation code in your registration form:"
+verifyShortCode-prompt-3 = "Use this confirmation code:"
 <%- code %>
 
 verifyShortCode-expiry-notice = "It expires in 5 minutes."

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -496,7 +496,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['verifyShortCodeEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: `Confirmation code: ${MESSAGE.code}` }],
+    ['subject', { test: 'equal', expected: 'Confirm your account' }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verify') }],
       ['X-Template-Name', { test: 'equal', expected: 'verifyShortCode' }],
@@ -504,8 +504,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Verify-Short-Code', { test: 'equal', expected: MESSAGE.code }],
     ])],
     ['html', [
-      { test: 'include', expected: `Confirmation code: ${MESSAGE.code}` },
-      { test: 'include', expected: 'Is this you signing up?' },
+      { test: 'include', expected: 'Confirm your account' },
+      { test: 'include', expected: 'Open the internet with Firefox' },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome', 'privacy')) },
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'welcome', 'support')) },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
@@ -513,19 +513,19 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
       { test: 'exists', expected: `${MESSAGE.time}` },
-      { test: 'include', expected: 'If yes, use this confirmation code in your registration form:' },
+      { test: 'include', expected: 'Use this confirmation code:' },
       { test: 'include', expected: MESSAGE.code },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Is this you signing up?' },
+      { test: 'include', expected: 'Open the internet with Firefox' },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'welcome', 'privacy')}` },
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'welcome', 'support')}` },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.date}` },
       { test: 'exists', expected: `${MESSAGE.time}` },
-      { test: 'include', expected: `If yes, use this confirmation code in your registration form:\n${MESSAGE.code}` },
+      { test: 'include', expected: `Use this confirmation code:\n${MESSAGE.code}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],


### PR DESCRIPTION
## Because

- We want to update copy for verification/confirmation emails

## This pull request

- Updates strings and adds a new translation string to match the new given copy

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="992" alt="Screen Shot 2022-08-04 at 1 45 06 PM" src="https://user-images.githubusercontent.com/11150372/182949263-cd3f0aad-a2b8-4b53-92e9-00974908696f.png">


## Other information (Optional)

To see the changes, `cd` into the fxa-auth-server directory and run `yarn storybook`.

This PR actually only has one commit, but is on top of my prior copy PR (and will be rebased onto main once that's merged.)
