### PR TITLE
fix(subscriptions): wrong upgrade emails

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2898,7 +2898,7 @@ export class StripeHelper extends StripeHelperBase {
     } = this.mergeMetadata(planOld, abbrevProductOld);
 
     const updateType =
-      productOrderNew > productOrderOld
+      parseInt(productOrderNew) > parseInt(productOrderOld)
         ? SUBSCRIPTION_UPDATE_TYPES.UPGRADE
         : SUBSCRIPTION_UPDATE_TYPES.DOWNGRADE;
 

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_customer_subscription_updated.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_customer_subscription_updated.json
@@ -51,7 +51,7 @@
               "interval_count": 1,
               "livemode": false,
               "metadata": {
-                "productOrder": 0,
+                "productOrder": "0",
                 "emailIconURL": "http://example.com/icon-new",
                 "successActionButtonURL": "http://example.com/download-new"
               },
@@ -93,7 +93,7 @@
         "interval_count": 1,
         "livemode": false,
         "metadata": {
-          "productOrder": 0,
+          "productOrder": "0",
           "emailIconURL": "http://example.com/icon-new",
           "successActionButtonURL": "http://example.com/download-new"
         },
@@ -121,7 +121,7 @@
         "interval": "month",
         "interval_count": 1,
         "metadata": {
-          "productOrder": 1,
+          "productOrder": "1",
           "emailIconURL": "http://example.com/icon-old",
           "successActionButtonURL": "http://example.com/download-old"
         },

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5163,7 +5163,7 @@ describe('StripeHelper', () => {
             .successActionButtonURL,
         'product:termsOfServiceURL': termsOfServiceURL,
         'product:privacyNoticeURL': privacyNoticeURL,
-        productOrder: 0,
+        productOrder: '0',
       },
     };
 


### PR DESCRIPTION
## Because

- In certain scenarios when a customer upgrades their subscription, the
  subscriptionDowngrade email template is sent instead of
  subscriptionUpgrade

## This pull request

- Parse the productOrder from string to int before doing the comparison
  to determine if the downgrade or upgrade email should be sent.


## Issue that this pull request solves

Closes: #13851

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).