### PR TITLE
refactor(payments): update PlanDetails component to utilize Tailwind

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.scss
@@ -36,10 +36,6 @@
 }
 
 .plan-details-component {
-  font-size: 15px;
-  margin: 32px 0;
-  padding: 0;
-
   @include min-width('tablet') {
     display: flex;
     flex-direction: column;
@@ -61,7 +57,7 @@
     margin: 0 16px 0 16px;
     grid-row: 2/3;
 
-    .container.plan-details-component-card {
+    .plan-details-component-card {
       border-radius: 0 0 8px 8px;
       box-shadow: 0 -1px white, 0 1px white,
         -2px 2px 2px -2px rgba(12, 12, 13, 0.1),
@@ -74,7 +70,7 @@
     margin: 0 16px 0 16px;
     grid-row: 2/3;
 
-    .container.plan-details-component-card {
+    .plan-details-component-card {
       border-radius: 0 0 8px 8px;
       box-shadow: 0 -1px white, 0 1px white,
         -2px 2px 2px -2px rgba(12, 12, 13, 0.1),
@@ -87,7 +83,7 @@
     margin: 0 16px 0 16px;
     grid-row: 2/3;
 
-    .container.plan-details-component-card {
+    .plan-details-component-card {
       border-radius: 0 0 8px 8px;
       box-shadow: 0 -1px white, 0 1px white,
         -2px 2px 2px -2px rgba(12, 12, 13, 0.1),
@@ -95,211 +91,8 @@
     }
   }
 
-  .plan-details-component-inner {
-    @include min-width('tablet') {
-      max-width: 327px;
-      // position: fixed;
-    }
-  }
-
-  .plan-details-component-card {
-    background: $color-white;
-    border-radius: 8px;
-    box-shadow: 0 1px 4px rgba(12, 12, 13, 0.1);
-  }
-
-  .plan-details-logo-wrap {
-    align-items: center;
-    background: #20123a;
-    border-radius: 8px;
-    display: flex;
-    flex-shrink: 0;
-    height: 64px;
-    justify-content: center;
-    width: 64px;
-  }
-
-  .plan-details-logo-wrap img {
-    height: 32px;
-    width: 32px;
-  }
-
-  .plan-details-header-wrap {
-    display: flex;
-  }
-
-  .plan-details-heading-wrap {
-    display: flex;
-    flex-direction: column;
-    padding-left: 16px;
-    text-align: left;
-
-    .plan-details-product {
-      color: $grey-80;
-      font-size: 15px;
-      font-weight: 600;
-      line-height: 19px;
-      margin: 0 4px 0 0;
-      word-wrap: break-word;
-    }
-
-    .plan-details-description {
-      color: $grey-50;
-      margin-top: 4px;
-    }
-  }
-
-  .plan-details-header {
-    border-bottom: 1px solid $grey-30;
-    display: flex;
-    justify-content: space-between;
-    margin: 0 16px;
-    padding: 16px 0;
-
-    p {
-      margin: 0;
-    }
-  }
-
-  .plan-details-list {
-    border-bottom: 1px solid $grey-30;
-    color: rgba(12, 12, 13, 0.8);
-    // list-style-position: inside;
-    margin-top: 10px;
-    // 1px bottom is a hack to get the padding from the last li
-    // to show up on tablet and higher that have position: fixed;
-    padding: 0 16px 1px;
-    text-align: left;
-
-    h4 {
-      margin: 16px 0;
-    }
-
-    ul {
-      color: $grey-50;
-      margin: 0;
-      padding-left: 12px;
-    }
-
-    li {
-      margin-bottom: 16px;
-      line-height: 22px;
-
-      span {
-        padding-left: 8px;
-      }
-
-      &::marker {
-        font-size: 12px;
-      }
-    }
-
-    @include min-width('tablet') {
-      border-bottom: 0;
-    }
-
-    .plan-details-coupon-details {
-      border-bottom: 1px solid #d7d7db;
-      margin-bottom: 16px;
-      padding-bottom: 24px;
-    }
-  }
-
-  .footer {
-    text-align: center;
-  }
-
-  .btn {
-    background: none;
-    border: 1px solid transparent;
-    color: $blue-60;
-    font-size: 15px;
-    font-weight: normal;
-    height: initial;
-    line-height: 22px;
-    margin: 9px 0;
-    outline: none;
-    padding: 7px 6px 7px 25px;
-    position: relative;
-    width: initial;
-
-    &:focus {
-      border: 1px solid #0a84ff;
-      box-shadow: unset;
-      padding: 7px 16px 7px 40px;
-    }
-  }
-
-  .arrow::before {
-    background: url('./images/chevron.svg');
-    content: '';
-    display: inline-block;
-    height: 16px;
-    left: 0;
-    position: absolute;
-    top: 10px;
-    width: 24px;
-  }
-
-  .arrow:focus::before {
-    left: 14px;
-  }
-
+  /* can be removed once '@tailwind base' is enabled */
   .up-arrow::before {
     transform: rotate(180deg);
-  }
-
-  .plan-details-total {
-    padding: 24px 0;
-    width: 100%;
-    border-top: 1px solid $grey-30;
-
-    .plan-details-total-inner {
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-    }
-
-    p {
-      margin: 0;
-      padding: unset;
-    }
-
-    .label {
-      color: #6d6d6e;
-      font-weight: 600;
-      margin-top: auto;
-    }
-
-    .total-price {
-      color: rgba(12, 12, 13, 0.8);
-      font-size: 18px;
-      font-weight: 600;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      margin-top: auto;
-    }
-
-    .coupon-info {
-      padding-top: 24px;
-      color: #1cc4a0;
-      display: flex;
-      font-size: 15px;
-      font-weight: normal;
-      justify-content: center;
-      align-items: center;
-    }
-
-    .coupon-info::before {
-      background-image: url('./images/Information.svg');
-      background-position: center;
-      background-repeat: no-repeat;
-      content: '';
-      display: inline-block;
-      height: 40px;
-      margin-right: 12px;
-      width: 40px;
-    }
   }
 }

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -3,11 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import MockApp from '../../../.storybook/components/MockApp';
-import PlanDetails from './index';
+import PlanDetails, { PlanDetailsProps} from './index';
 import { Profile } from '../../store/types';
 import { COUPON_DETAILS_VALID } from '../../lib/mock-data';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'components/PlanDetails',
+  component: PlanDetails,
+} as Meta;
 
 const userProfile: Profile = {
   avatar: 'http://placekitten.com/256/256',
@@ -47,99 +52,84 @@ const selectedPlan = {
   },
 };
 
-storiesOf('components/PlanDetail', module)
-  .add('default', () => (
-    <MockApp>
+const storyWithProps = (
+  plan: PlanDetailsProps,
+  languages?: readonly string[],
+) => {
+  const story = () => (
+    <MockApp languages={languages}>
       <PlanDetails
         {...{
+          ...plan,
           profile: userProfile,
-          showExpandButton: false,
-          selectedPlan,
-          isMobile: false,
         }}
       />
     </MockApp>
-  ))
-  .add('localized to xx-pirate', () => (
-    <MockApp languages={['xx-pirate']}>
-      <PlanDetails
-        {...{
-          profile: userProfile,
-          showExpandButton: false,
-          selectedPlan,
-          isMobile: false,
-        }}
-      />
-    </MockApp>
-  ))
-  .add('with expand button', () => (
-    <MockApp>
-      <PlanDetails
-        {...{
-          profile: userProfile,
-          showExpandButton: true,
-          selectedPlan,
-          isMobile: false,
-        }}
-      />
-    </MockApp>
-  ))
-  .add('with coupon - type "forever"', () => (
-    <MockApp>
-      <PlanDetails
-        {...{
-          profile: userProfile,
-          showExpandButton: false,
-          selectedPlan,
-          isMobile: false,
-          coupon: { ...COUPON_DETAILS_VALID, type: 'forever' },
-        }}
-      />
-    </MockApp>
-  ))
-  .add('with coupon - type "once"', () => (
-    <MockApp>
-      <PlanDetails
-        {...{
-          profile: userProfile,
-          showExpandButton: false,
-          selectedPlan,
-          isMobile: false,
-          coupon: { ...COUPON_DETAILS_VALID, type: 'once' },
-        }}
-      />
-    </MockApp>
-  ))
-  .add(
-    'with coupon - type "repeating" where plan interval is greater than coupon duration',
-    () => (
-      <MockApp>
-        <PlanDetails
-          {...{
-            profile: userProfile,
-            showExpandButton: false,
-            selectedPlan: { ...selectedPlan, interval_count: 6 },
-            isMobile: false,
-            coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
-          }}
-        />
-      </MockApp>
-    )
   )
-  .add('with coupon - type "repeating"', () => (
-    <MockApp>
-      <PlanDetails
-        {...{
-          profile: userProfile,
-          showExpandButton: false,
-          selectedPlan,
-          isMobile: false,
-          coupon: {
-            ...COUPON_DETAILS_VALID,
-            durationInMonths: 3,
-            type: 'repeating',
-          },
-        }}
-      />
-    </MockApp>
-  ));
+  return story;
+};
+
+export const Default = storyWithProps(
+  {
+    selectedPlan,
+    isMobile: false,
+    showExpandButton: false,
+  },
+);
+
+export const LocalizedToPirate = storyWithProps(
+  {
+    selectedPlan,
+    isMobile: false,
+    showExpandButton: false,
+  },
+  ['xx-pirate'],
+);
+
+export const WithExpandedButton = storyWithProps(
+  {
+    selectedPlan,
+    isMobile: false,
+    showExpandButton: true,
+  },
+);
+
+export const WithCouponTypeForever = storyWithProps(
+  {
+    selectedPlan,
+    isMobile: false,
+    showExpandButton: false,
+    coupon: {...COUPON_DETAILS_VALID, type: 'forever'}
+  },
+);
+
+export const WithCouponTypeOnce = storyWithProps(
+  {
+    selectedPlan,
+    isMobile: false,
+    showExpandButton: false,
+    coupon: {...COUPON_DETAILS_VALID, type: 'once'}
+  },
+);
+
+export const WithCouponTypeRepeatingPlanIntervalGreaterThanCouponDuration = storyWithProps(
+  {
+    selectedPlan: {...selectedPlan, interval_count: 6},
+    isMobile: false,
+    showExpandButton: false,
+    coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
+  },
+);
+
+export const WithCouponTypeRepeating = storyWithProps(
+  {
+    selectedPlan,
+    isMobile: false,
+    showExpandButton: false,
+    coupon: {
+      ...COUPON_DETAILS_VALID,
+      durationInMonths: 3,
+      type: 'repeating',
+    }
+  },
+);

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -16,13 +16,14 @@ import { AppContext } from '../../lib/AppContext';
 // this is a rare case, but it also keeps typescript
 // happy
 import ffLogo from '../../images/firefox-logo.svg';
+import infoLogo from './images/Information.svg';
 
 import './index.scss';
 import { Plan } from '../../store/types';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { useInfoBoxMessage } from '../../lib/hooks';
 
-type PlanDetailsProps = {
+export type PlanDetailsProps = {
   selectedPlan: Plan;
   isMobile: boolean;
   showExpandButton?: boolean;
@@ -35,7 +36,6 @@ export const PlanDetails = ({
   selectedPlan,
   isMobile,
   showExpandButton = false,
-  className = 'default',
   coupon,
   children,
 }: PlanDetailsProps) => {
@@ -73,16 +73,14 @@ export const PlanDetails = ({
 
   return (
     <div
-      className={`plan-details-component ${className}`}
+      className="plan-details-component my-8 mx-0 p-0"
       {...{ role }}
       data-testid="plan-details-component"
     >
       <div className="plan-details-component-inner">
-        <div
-          className={`container card plan-details-component-card ${className}`}
-        >
-          <div className="plan-details-header">
-            <div className="plan-details-header-wrap">
+        <div className="plan-details-component-card">
+          <div className="plan-details-header row-divider-grey-200">
+            <div className="flex">
               <div
                 className="plan-details-logo-wrap"
                 style={{ ...setWebIconBackground }}
@@ -91,12 +89,15 @@ export const PlanDetails = ({
                   src={webIcon || ffLogo}
                   alt={product_name}
                   data-testid="product-logo"
+                  className="w-8 h-8"
                 />
               </div>
+
               <div className="plan-details-heading-wrap">
                 <h3 id="plan-details-product" className="plan-details-product">
                   {product_name}
                 </h3>
+
                 <p className="plan-details-description">
                   <Localized
                     id={`plan-price-${interval}`}
@@ -108,73 +109,80 @@ export const PlanDetails = ({
                     {planPrice}
                   </Localized>
                   &nbsp;&bull;&nbsp;
-                  <span className="plan-details-subtitle">
-                    {productDetails.subtitle}
-                  </span>
+                  <span>{productDetails.subtitle}</span>
                 </p>
               </div>
             </div>
           </div>
-          {!detailsHidden && productDetails.details ? (
-            <div className="plan-details-list" data-testid="list">
+
+          {!detailsHidden && productDetails.details && (
+            <div className="mt-2 pt-0 px-4 pb-px tablet:border-b-0 text-left" data-testid="list">
               <Localized id="plan-details-header">
-                <h4>Product details</h4>
+                <h4 className="text-sm text-grey-600 my-4 mx-0">Product details</h4>
               </Localized>
-              <ul>
+
+              <ul className="row-divider-grey-200 text-grey-400 m-0 pl-3">
                 {productDetails.details.map((detail, idx) => (
-                  <li key={idx}>{detail}</li>
+                  <li className="mb-4 leading-5 marker:text-xs" key={idx}>
+                    {detail}
+                  </li>
                 ))}
               </ul>
-              <div
-                className="plan-details-total"
-                aria-labelledby="plan-details-product"
-              >
-                {coupon && coupon.discountAmount ? (
-                  <div className="plan-details-coupon-details">
+
+              <div className="plan-details-total">
+                {coupon && coupon.discountAmount && (
+                  <div className="row-divider-grey-200 mb-4 pb-6">
                     <div className="plan-details-total-inner">
                       <Localized id="plan-details-list-price">
                         <div>List Price</div>
                       </Localized>
+
+                      <Localized
+                        id={`list-price`}
+                        attrs={{ title: true }}
+                        vars={{
+                          amount: getLocalizedCurrency(amount, currency),
+                          intervalCount: interval_count,
+                        }}
+                      >
                       <div>
-                        <Localized
-                          id={`list-price`}
-                          attrs={{ title: true }}
-                          vars={{
-                            amount: getLocalizedCurrency(amount, currency),
-                            intervalCount: interval_count,
-                          }}
-                        >
-                          {getLocalizedCurrencyString(amount, currency)}
-                        </Localized>
+                        {getLocalizedCurrencyString(amount, currency)}
                       </div>
+                      </Localized>
                     </div>
+
                     <div className="plan-details-total-inner">
                       <Localized id="coupon-discount">
                         <div>Discount</div>
                       </Localized>
-                      <div>
-                        <Localized
-                          id={`coupon-amount`}
-                          attrs={{ title: true }}
-                          vars={{
-                            amount: getLocalizedCurrency(
-                              coupon.discountAmount,
-                              currency
-                            ),
-                            intervalCount: interval_count,
-                          }}
-                        >{`- ${getLocalizedCurrencyString(
-                          coupon.discountAmount,
-                          currency
-                        )}`}</Localized>
-                      </div>
+
+                      <Localized
+                        id={`coupon-amount`}
+                        attrs={{ title: true }}
+                        vars={{
+                          amount: getLocalizedCurrency(
+                            coupon.discountAmount,
+                            currency
+                          ),
+                          intervalCount: interval_count,
+                        }}
+                      >
+                        <div>
+                          {`- ${getLocalizedCurrencyString(
+                            coupon.discountAmount,
+                            currency
+                          )}`}
+                        </div>
+                      </Localized>
                     </div>
                   </div>
-                ) : null}
+                )}
+
                 <div className="plan-details-total-inner">
                   <Localized id="plan-details-total-label">
-                    <p className="label">Total</p>
+                    <div className="total-label">Total</div>
                   </Localized>
+
                   <Localized
                     id={`plan-price-${interval}`}
                     data-testid="plan-price-total"
@@ -190,52 +198,55 @@ export const PlanDetails = ({
                       intervalCount: interval_count,
                     }}
                   >
-                    <p
+                    <div
                       className="total-price"
                       title={planPrice}
                       data-testid="total-price"
                       id="total-price"
                     >
                       {planPrice}
-                    </p>
+                    </div>
                   </Localized>
                 </div>
-                {infoBoxMessage ? (
+
+                {infoBoxMessage && (
                   infoBoxMessage.couponDurationDate ? (
-                    <Localized
-                      id={infoBoxMessage.message}
-                      vars={{
-                        couponDurationDate: getLocalizedDate(
-                          infoBoxMessage.couponDurationDate,
-                          true
-                        ),
-                      }}
-                    >
-                      <div
-                        className="coupon-info"
-                        data-testid="coupon-success-with-date"
+                    <div className="coupon-info" data-testid="coupon-success-with-date">
+                      <img src={infoLogo} alt="" />
+
+                      <Localized
+                        id={infoBoxMessage.message}
+                        vars={{
+                          couponDurationDate: getLocalizedDate(
+                            infoBoxMessage.couponDurationDate,
+                            true
+                          ),
+                        }}
                       >
                         {infoBoxMessage.message}
-                      </div>
-                    </Localized>
+                      </Localized>
+                    </div>
                   ) : (
-                    <Localized id={infoBoxMessage.message}>
-                      <div className="coupon-info" data-testid="coupon-success">
+                    <div className="coupon-info" data-testid="coupon-success">
+                      <img src={infoLogo} alt="" />
+
+                      <Localized id={infoBoxMessage.message}>
                         {infoBoxMessage.message}
-                      </div>
-                    </Localized>
+                      </Localized>
+                    </div>
                   )
-                ) : null}
+                )}
               </div>
             </div>
-          ) : null}
-          {showExpandButton ? (
-            <div className="footer" data-testid="footer">
+          )}
+
+          { showExpandButton && (
+            <div className="footer text-center" data-testid="footer">
               {detailsHidden ? (
                 <Localized id="plan-details-show-button">
                   <button
                     data-testid="button"
-                    className="btn arrow"
+                    className="accordion-btn arrow"
                     aria-expanded={!detailsHidden}
                     onClick={() => setDetailsState(false)}
                   >
@@ -246,7 +257,7 @@ export const PlanDetails = ({
                 <Localized id="plan-details-hide-button">
                   <button
                     data-testid="button"
-                    className="btn arrow up-arrow"
+                    className="accordion-btn arrow before:rotate-180 up-arrow"
                     aria-expanded={!detailsHidden}
                     onClick={() => setDetailsState(true)}
                   >
@@ -255,7 +266,7 @@ export const PlanDetails = ({
                 </Localized>
               )}
             </div>
-          ) : null}
+          )}
         </div>
       </div>
       {children}

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -461,27 +461,29 @@ export const Checkout = ({
             </>
           </div>
         </div>
-        <PlanDetails
-          {...{
-            className: classNames('default', {
-              hidden: transactionInProgress && isMobile,
-            }),
-            selectedPlan,
-            isMobile,
-            showExpandButton: isMobile,
-            coupon,
-          }}
-        >
-          <CouponForm
+
+        { (transactionInProgress && isMobile)
+          ? null
+          : (
+          <PlanDetails
             {...{
-              planId: selectedPlan.plan_id,
-              readOnly: false,
-              subscriptionInProgress: inProgress || transactionInProgress,
+              selectedPlan,
+              isMobile,
+              showExpandButton: isMobile,
               coupon,
-              setCoupon,
             }}
-          />
-        </PlanDetails>
+          >
+            <CouponForm
+              {...{
+                planId: selectedPlan.plan_id,
+                readOnly: false,
+                subscriptionInProgress: inProgress || transactionInProgress,
+                coupon,
+                setCoupon,
+              }}
+            />
+          </PlanDetails>
+        )}
       </div>
     </>
   );

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -325,27 +325,30 @@ export const SubscriptionCreate = ({
             {selectedPlan && <TermsAndPrivacy plan={selectedPlan} />}
           </div>
         </div>
-        <PlanDetails
-          {...{
-            className: classNames('default', {
-              hidden: transactionInProgress && isMobile,
-            }),
-            selectedPlan,
-            isMobile,
-            showExpandButton: isMobile,
-            coupon: coupon,
-          }}
-        >
-          <CouponForm
-            {...{
-              planId: selectedPlan.plan_id,
-              readOnly: false,
-              subscriptionInProgress: inProgress || transactionInProgress,
-              coupon,
-              setCoupon,
-            }}
-          />
-        </PlanDetails>
+
+        { (transactionInProgress && isMobile)
+          ? null
+          : (
+            <PlanDetails
+              {...{
+                selectedPlan,
+                isMobile,
+                showExpandButton: isMobile,
+                coupon: coupon,
+              }}
+            >
+              <CouponForm
+                {...{
+                  planId: selectedPlan.plan_id,
+                  readOnly: false,
+                  subscriptionInProgress: inProgress || transactionInProgress,
+                  coupon,
+                  setCoupon,
+                }}
+              />
+            </PlanDetails>
+          )
+        }
       </div>
     </>
   );

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -34,7 +34,7 @@ export const PlanUpgradeDetails = ({
 
   return (
     <section
-      className={`plan-details-component plan-upgrade-details-component ${className}`}
+      className={`plan-details-component my-8 mx-0 p-0 plan-upgrade-details-component ${className}`}
       {...{ role }}
       data-testid="plan-upgrade-details-component"
     >
@@ -42,20 +42,21 @@ export const PlanUpgradeDetails = ({
         <p className="plan-label current-plan-label">
           <Localized id="sub-update-current-plan-label">Current plan</Localized>
         </p>
+
         <PlanDetailsCard className="from-plan" plan={upgradeFromPlan} />
+
         <p className="plan-label new-plan-label">
           <Localized id="sub-update-new-plan-label">New plan</Localized>
         </p>
+
         <PlanDetailsCard className="to-plan" plan={selectedPlan} />
 
-        <div
-          className="plan-details-total plan-upgrade-details-total"
-          aria-labelledby="plan-details-product"
-        >
+        <div className="plan-details-total plan-upgrade-details-total">
           <div className="plan-details-total-inner">
             <Localized id="sub-update-total-label">
-              <p className="label">New total</p>
+              <div className="total-label">New total</div>
             </Localized>
+
             <Localized
               id={`plan-price-${selectedPlan.interval}`}
               vars={{
@@ -66,7 +67,9 @@ export const PlanUpgradeDetails = ({
                 intervalCount: selectedPlan.interval_count,
               }}
             >
-              <p className="total-price">{totalPrice}</p>
+              <div className="total-price">
+                {totalPrice}
+              </div>
             </Localized>
           </div>
         </div>
@@ -107,10 +110,10 @@ export const PlanDetailsCard = ({
 
   return (
     <div
-      className={`container card plan-details-component-card plan-upgrade-details-component-card ${className}`}
+      className={`plan-details-component-card ${className}`}
     >
       <div className="plan-details-header">
-        <div className="plan-details-header-wrap">
+        <div className="flex">
           <div
             className="plan-details-logo-wrap"
             style={{ ...setWebIconBackground }}
@@ -119,8 +122,10 @@ export const PlanDetailsCard = ({
               src={webIcon || ffLogo}
               alt={product_name}
               data-testid="product-logo"
+              className="w-8 h-8"
             />
           </div>
+
           <div className="plan-details-heading-wrap">
             <h3
               id="plan-details-product"
@@ -128,8 +133,9 @@ export const PlanDetailsCard = ({
             >
               {product_name}
             </h3>
+
             {/* TODO: make this configurable, issue #4741 / FXA-1484 */}
-            <p className="product-description plan-details-description">
+            <p id="product-description" className="plan-details-description">
               <Localized
                 id={`plan-price-${interval}`}
                 vars={{

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -51,7 +51,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
     ) as Element;
     expect(fromName.textContent).toEqual(UPGRADE_FROM_PLAN.product_name);
     const fromDesc = container.querySelector(
-      '.from-plan .product-description'
+      '.from-plan #product-description'
     ) as Element;
     expect(fromDesc.textContent).toContain(
       UPGRADE_FROM_PLAN.product_metadata['product:subtitle']
@@ -59,7 +59,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
     const toName = container.querySelector('.to-plan .product-name') as Element;
     expect(toName.textContent).toEqual(SELECTED_PLAN.product_name);
     const toDesc = container.querySelector(
-      '.to-plan .product-description'
+      '.to-plan #product-description'
     ) as Element;
     expect(toDesc.textContent).toContain(
       SELECTED_PLAN.product_metadata['product:subtitle']

--- a/packages/fxa-payments-server/src/styles/tailwind.css
+++ b/packages/fxa-payments-server/src/styles/tailwind.css
@@ -37,3 +37,60 @@
 .payment-error .legal-heading {
   @apply mt-5;
 }
+
+/* shared styles used in PlanDetails and PlanUpgradeDetails */
+.accordion-btn {
+  @apply bg-transparent border-transparent cursor-pointer text-blue-500 leading-5 my-2 outline-none py-2 pr-2 pl-6 relative w-auto h-auto focus:border focus:border-solid focus:border-blue-400 focus:py-2 focus:pr-4 focus:pl-10 focus:shadow-none;
+}
+
+.arrow {
+  @apply before:bg-[url('../components/PlanDetails/images/chevron.svg')] before:content-[''] before:absolute before:h-4 before:w-6 before:top-2.5  before:left-0 focus:before:left-3.5;
+}
+
+.coupon-info {
+  @apply flex items-center justify-center gap-2 pt-6 text-sm text-green-700;
+}
+
+.plan-details-component-card {
+  @apply bg-white rounded-lg shadow-sm shadow-grey-300;
+}
+
+.plan-details-component-inner {
+  @apply tablet:max-w-xs;
+}
+
+.plan-details-description {
+  @apply text-grey-400 mt-1 mb-0;
+}
+
+.plan-details-header {
+  @apply flex justify-between my-0 mx-4 py-4 px-0;
+}
+
+.plan-details-heading-wrap {
+  @apply pl-4 text-left;
+}
+
+.plan-details-logo-wrap {
+  @apply flex h-16 items-center justify-center rounded-lg shrink-0 w-16;
+}
+
+.plan-details-product {
+  @apply text-grey-600 text-sm leading-5 my-0 mr-1 ml-0 break-words;
+}
+
+.plan-details-total {
+  @apply py-6 w-full;
+}
+
+.plan-details-total-inner {
+  @apply flex items-center justify-between gap-2 text-grey-600 text-sm;
+}
+
+.total-label {
+  @apply font-semibold text-base;
+}
+
+.total-price {
+  @apply font-semibold overflow-hidden text-ellipsis text-lg whitespace-nowrap;
+}

--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -75,6 +75,12 @@ module.exports = {
         ten: '10%',
         full: '100%',
       },
+      top: {
+        2.5: '0.6rem',
+      },
+      left: {
+        3.5: '.87rem',
+      },
       boxShadow: {
         // Specific-use focus shadows for input elements
         'input-blue-focus': '0 0 0 1px #0090ED, 0 0 0 3px #C2D8F7',


### PR DESCRIPTION
## Because

- we are converting to Tailwind

## This pull request

- [x] Replaces all CSS/SCSS with Tailwind utility classes - responsive design to be handle in #13589
- [x] Removes the style from .scss file with the exception of `.up-arrow` as it needs `@tailwind base` to be enabled
- [x] Reworks Storybook files

Note:
- Font sizes were revised to match `PaymentConfirmation`
- While shared styles were updated in `PlanUpgradeDetails`, this component still has a stylesheet. However, it will be handled in the `SubscriptionUpgrade` flow phase.

## Issue that this pull request solves

Closes: #13676

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots 
**PlanDetails**
Default
<img width="717" alt="Screen Shot 2022-08-12 at 10 25 24 AM" src="https://user-images.githubusercontent.com/28129806/184379888-da41f03f-ab3b-4592-8e49-7bfdf7cb9c53.png">

Localized to Pirate
<img width="699" alt="Screen Shot 2022-08-12 at 10 25 46 AM" src="https://user-images.githubusercontent.com/28129806/184379869-6cc27167-193d-42ef-a92a-d32bc284e618.png">

With Expanded Button
<img width="713" alt="Screen Shot 2022-08-12 at 10 26 17 AM" src="https://user-images.githubusercontent.com/28129806/184379859-756b0e3c-3078-4e5c-959c-4e05c1accfea.png">

<img width="719" alt="Screen Shot 2022-08-12 at 10 34 26 AM" src="https://user-images.githubusercontent.com/28129806/184379707-39b1c1fd-1d6a-4060-8650-88beedae8ac8.png">

With Coupon Type Forever
<img width="702" alt="Screen Shot 2022-08-12 at 10 28 36 AM" src="https://user-images.githubusercontent.com/28129806/184379833-a8999e4f-264e-4edd-a7df-3244d6ec41ba.png">

With Coupon Type Once
<img width="713" alt="Screen Shot 2022-08-12 at 10 29 06 AM" src="https://user-images.githubusercontent.com/28129806/184379806-956f72bc-8b10-4bcd-9f93-7e2f6fffb677.png">

With Coupon Type Repeating Plan Interval is Greater Than Coupon Duration
<img width="713" alt="Screen Shot 2022-08-12 at 10 29 32 AM" src="https://user-images.githubusercontent.com/28129806/184379787-6b29e949-d72a-4c1e-ae78-a92cf0b21d22.png">

With Coupon Type Repeating
<img width="717" alt="Screen Shot 2022-08-12 at 10 29 49 AM" src="https://user-images.githubusercontent.com/28129806/184379756-490d2691-45da-4ce2-b9ec-14488b3242cb.png">

**PlanUpgradeDetails**
<img width="2029" alt="Screen Shot 2022-08-12 at 10 32 33 AM" src="https://user-images.githubusercontent.com/28129806/184379733-25be2440-1fe3-43dc-83d5-f0a3cbcc8296.png">

