### PR TITLE
task(settings): Update card drop shadow, button focus outlines, and b…

### DIFF
--- a/packages/fxa-content-server/app/styles/tailwind/ctas.css
+++ b/packages/fxa-content-server/app/styles/tailwind/ctas.css
@@ -5,7 +5,7 @@
 /* Max-height is a likely temp "hack" for .spinner until it's converted to TW */
 /* font-color is also a hack until all buttons are TWified */
 .cta-xl {
-  @apply flex-1 font-bold text-base p-4 border-0 max-h-14;
+  @apply flex-1 font-bold text-base p-4 border-0 max-h-14 rounded-md;
 }
 
 /* Temp hack until .spinner is fully converted to TW */

--- a/packages/fxa-content-server/app/styles/tailwind/flows.css
+++ b/packages/fxa-content-server/app/styles/tailwind/flows.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .card {
-  @apply relative text-center w-full mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 pb-10 pt-33 mobileLandscape:pt-20;
+  @apply relative text-center w-full mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 pb-10 pt-33 mobileLandscape:pt-20 mobileLandscape:shadow-card-grey-drop;
 
   &::before {
     @apply h-16 mobileLandscape:h-20 left-0 block absolute bg-center bg-no-repeat w-full bg-contain top-8 mobileLandscape:-top-10;
@@ -17,13 +17,5 @@
 
   &-subheader {
     @apply font-body font-normal text-sm block mt-1;
-  }
-}
-
-@screen mobileLandscape {
-  /* Design specifically requested a custom box-shadow. */
-  .card {
-    box-shadow: 0 16px 24px rgba(34, 0, 51, 0.04),
-      0 6px 32px rgba(7, 48, 114, 0.12), 0 8px 12px rgba(14, 13, 26, 0.12);
   }
 }

--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -80,6 +80,7 @@ module.exports = {
         'input-blue-focus': '0 0 0 1px #0090ED, 0 0 0 3px #C2D8F7',
         'input-grey-focus': '0 0 0 1px #6D6D6E, 0 0 0 3px #E7E7E7',
         'tooltip-grey-drop': '0 0 4px rgba(32, 18, 58, 0.24)',
+        'card-grey-drop': '0px 2px 14px rgba(58, 57, 68, 0.2)',
       },
       scale: {
         80: '.8',

--- a/packages/fxa-react/styles/ctas.css
+++ b/packages/fxa-react/styles/ctas.css
@@ -20,8 +20,9 @@
       @apply border-grey-400 bg-grey-100 text-grey-400;
     }
 
-    &:focus {
-      @apply bg-white;
+    &:focus,
+    &:focus-visible {
+      @apply bg-white outline outline-2 outline-offset-2 outline-blue-500;
     }
 
     &:disabled {
@@ -36,8 +37,9 @@
       @apply bg-blue-800 border-blue-800;
     }
 
-    &:focus {
-      @apply border-0;
+    &:focus,
+    &:focus-visible {
+      @apply outline outline-2 outline-offset-2 outline-blue-500;
     }
 
     &:disabled {
@@ -52,7 +54,8 @@
       @apply bg-red-800 border-red-800;
     }
 
-    &:focus {
+    &:focus,
+    &:focus-visible {
       @apply border-transparent outline-dotted outline-black;
     }
 


### PR DESCRIPTION
## Because

- We want to bring button border radius inline with figma
- We want to bring card drop shadows in line with figma
- We want to bring focus states on buttons inline with figma

## This pull request

- Adds a new boxShadow extension 'card-grey-drop' to tailwind config and applies it to .cards
- Updates border radius on .cta-xl to be rounded-md. Previously this was defaulting to rounded.
- Updates :focus and :focus-visible outlines on .cta-primary and .cta-neutral and .cta-caution

## Issue that this pull request solves

Closes: #13866

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Note differences in card's drop shadow, main button's border radius and main button's outline (button is focused here).

Before:
![image](https://user-images.githubusercontent.com/94418270/183747699-8c7db000-cacb-437f-a029-f449a2bc891b.png)

After:
![image](https://user-images.githubusercontent.com/94418270/183747309-9462990f-53dc-4b4d-b5fe-9d7149a50f22.png)

A bit unsure about these neutral buttons:

Before:
![image](https://user-images.githubusercontent.com/94418270/183748139-e51246d6-4042-4dda-9d3d-4e5f3ae98189.png)

After:
![image](https://user-images.githubusercontent.com/94418270/183748193-c49b582f-7b78-4b44-9344-611c95296eac.png)


## Other information (Optional)

I was unsure about the :focus / :focus-visible state on .cta-neutral, as I was unable to locate this state in Figma. See screenshot above and comment in code. I ended up making it be inline with the 'focus' ring style observed on the 'primary buttons' figma spec.
