### PR TITLE
fix(subscription): duplicate sub on refresh

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -492,7 +492,9 @@ export class StripeHandler {
     try {
       await this.customs.check(request, email, 'createSubscriptionWithPMI');
 
-      const customer = await this.stripeHelper.fetchCustomer(uid);
+      const customer = await this.stripeHelper.fetchCustomer(uid, [
+        'subscriptions',
+      ]);
       if (!customer) {
         throw error.unknownCustomer(uid);
       }
@@ -544,7 +546,7 @@ export class StripeHandler {
       const subIdempotencyKey = `${idempotencyKey}-createSub`;
       const subscription: any =
         await this.stripeHelper.createSubscriptionWithPMI({
-          customerId: customer.id,
+          customer,
           priceId,
           paymentMethodId,
           promotionCode: promotionCode,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -831,7 +831,7 @@ describe('StripeHelper', () => {
         .resolves({});
       stripeFirestore.insertPaymentMethodRecord = sandbox.stub().resolves({});
       const actual = await stripeHelper.createSubscriptionWithPMI({
-        customerId: 'customerId',
+        customer: customer1,
         priceId: 'priceId',
         paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
         subIdempotencyKey,
@@ -842,7 +842,7 @@ describe('StripeHelper', () => {
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.subscriptions.create,
         {
-          customer: 'customerId',
+          customer: customer1.id,
           items: [{ price: 'priceId' }],
           expand: ['latest_invoice.payment_intent'],
           default_tax_rates: ['tr_asdf'],
@@ -887,7 +887,7 @@ describe('StripeHelper', () => {
         .resolves({});
       stripeFirestore.insertPaymentMethodRecord = sandbox.stub().resolves({});
       const actual = await stripeHelper.createSubscriptionWithPMI({
-        customerId: 'customerId',
+        customer: customer1,
         priceId: 'priceId',
         paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
         subIdempotencyKey,
@@ -906,7 +906,7 @@ describe('StripeHelper', () => {
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.subscriptions.create,
         {
-          customer: 'customerId',
+          customer: customer1.id,
           items: [{ price: 'priceId' }],
           expand: ['latest_invoice.payment_intent'],
           default_tax_rates: ['tr_asdf'],
@@ -959,7 +959,7 @@ describe('StripeHelper', () => {
 
       try {
         await stripeHelper.createSubscriptionWithPMI({
-          customerId: 'customerId',
+          customer: customer1,
           priceId: 'priceId',
           paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
           subIdempotencyKey,
@@ -975,7 +975,7 @@ describe('StripeHelper', () => {
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.subscriptions.create,
         {
-          customer: 'customerId',
+          customer: customer1.id,
           items: [{ price: 'priceId' }],
           expand: ['latest_invoice.payment_intent'],
           default_tax_rates: ['tr_asdf'],
@@ -1001,7 +1001,7 @@ describe('StripeHelper', () => {
 
       return stripeHelper
         .createSubscriptionWithPMI({
-          customerId: 'customerId',
+          customer: customer1,
           priceId: 'priceId',
           paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
           subIdempotencyKey: uuidv4(),
@@ -1025,7 +1025,7 @@ describe('StripeHelper', () => {
 
       return stripeHelper
         .createSubscriptionWithPMI({
-          customerId: 'customerId',
+          customer: customer1,
           priceId: 'invoiceId',
           paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
           subIdempotencyKey: uuidv4(),

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -783,6 +783,8 @@ describe('DirectStripeRoutes', () => {
   describe('createSubscriptionWithPMI', () => {
     let plan, paymentMethod;
 
+    const customer = deepCopy(emptyCustomer);
+
     beforeEach(() => {
       plan = deepCopy(PLANS[2]);
       plan.currency = 'USD';
@@ -792,7 +794,6 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
         paymentMethod
       );
-      const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(customer);
       directStripeRoutesInstance.stripeHelper.setCustomerLocation.resolves();
     });
@@ -908,7 +909,7 @@ describe('DirectStripeRoutes', () => {
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {
-          customerId: 'cus_new',
+          customer,
           priceId: 'Jane Doe',
           paymentMethodId: 'pm_asdf',
           promotionCode: {
@@ -1160,7 +1161,7 @@ describe('DirectStripeRoutes', () => {
       sinon.assert.calledWith(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {
-          customerId: customer.id,
+          customer,
           priceId: 'quux',
           promotionCode: undefined,
           paymentMethodId: undefined,

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -173,28 +173,6 @@ it('calls onSubmit when all fields valid and submitted', async () => {
   expect(onSubmit).toHaveBeenCalled();
 });
 
-it('renders a progress spinner when submitted, disables further submission (issue #4386 / FXA-1275)', async () => {
-  const onSubmit = jest.fn();
-
-  const { queryByTestId, getByTestId } = renderWithValidFields({
-    onSubmit,
-    submitNonce: 'unique-nonce-1',
-  });
-
-  const submitButton = getByTestId('submit');
-  fireEvent.click(submitButton);
-
-  await waitForExpect(() => expect(onSubmit).toHaveBeenCalled());
-
-  expect(queryByTestId('spinner-submit')).toBeInTheDocument();
-  expect(getByTestId('submit')).toHaveAttribute('disabled');
-
-  fireEvent.submit(getByTestId('paymentForm'));
-  fireEvent.click(submitButton);
-
-  expect(onSubmit).toHaveBeenCalledTimes(1);
-});
-
 it('renders a progress spinner when inProgress = true', () => {
   const { queryByTestId } = render(<Subject {...{ inProgress: true }} />);
   expect(queryByTestId('spinner-submit')).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import {
   Localized,
   withLocalization,
@@ -130,11 +130,8 @@ export const PaymentForm = ({
     onChangeProp();
   }, [engageOnce, onChangeProp]);
 
-  const [lastSubmitNonce, setLastSubmitNonce] = useState('');
-  const nonceMatch = submitNonce === lastSubmitNonce;
-  const allowSubmit =
-    !nonceMatch && !inProgress && validator.allValid() && shouldAllowSubmit;
-  const showProgressSpinner = nonceMatch || inProgress;
+  const allowSubmit = !inProgress && validator.allValid() && shouldAllowSubmit;
+  const showProgressSpinner = inProgress;
 
   const payButtonL10nId = (c?: Customer | null) =>
     hasPaymentProvider(c) && isPaypal(c!.payment_provider)
@@ -144,7 +141,6 @@ export const PaymentForm = ({
   const onPaypalFormSubmit = useCallback(
     async (ev: React.FormEvent<HTMLFormElement>) => {
       ev.preventDefault();
-      setLastSubmitNonce(submitNonce);
       (onSubmitForParent as PaypalSubmitHandler)({
         priceId: plan!.plan_id,
         idempotencyKey: submitNonce,
@@ -160,7 +156,6 @@ export const PaymentForm = ({
       if (!stripe || !elements || !allowSubmit) {
         return;
       }
-      setLastSubmitNonce(submitNonce);
       const { name } = validator.getValues();
       const card = elements.getElement(CardElement);
       /* istanbul ignore next - card should exist unless there was an external stripe loading error, handled above */

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -156,12 +156,12 @@ export const SubscriptionCreate = ({
               });
             },
           });
+          refreshSubmitNonce();
         } catch (error) {
           console.error('handleSubscriptionPayment failed', error);
           setSubscriptionError(error);
         }
         setInProgress(false);
-        refreshSubmitNonce();
       },
       [
         selectedPlan,
@@ -187,12 +187,12 @@ export const SubscriptionCreate = ({
             priceId,
             productId: selectedPlan.product_id,
           });
+          refreshSubmitNonce();
           refreshSubscriptions();
         } catch (error) {
           setSubscriptionError(error);
         }
         setInProgress(false);
-        refreshSubmitNonce();
       },
       [setInProgress, refreshSubmitNonce, refreshSubscriptions, selectedPlan]
     );


### PR DESCRIPTION
## Because

- Users are able to create duplicate subscriptions when losing network
  connectivity shortly after hitting the Pay Now button, trying again
  and selecting Pay Now again.

## This pull request

- When paying by credit card, before creating the subscription, check 
  if the customer already has an existing subscription for this plan.
- When the payment action fails on the frontend, do not refresh the
  nonce, so that the same idempotency key is used, which should ensure
  that Stripe does not create a duplicate subscription.

## Issue that this pull request solves

Closes: #13755

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
