### PR TITLE
feat(emails): update post add recovery key email

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1974,10 +1974,7 @@ conf.set(
   `${baseUri}/post_verify/finish_account_setup/set_password`
 );
 conf.set('smtp.reportSignInUrl', `${baseUri}/report_signin`);
-conf.set(
-  'smtp.revokeAccountRecoveryUrl',
-  `${baseUri}/settings/account_recovery`
-);
+conf.set('smtp.revokeAccountRecoveryUrl', `${baseUri}/settings#recovery-key`);
 conf.set(
   'smtp.createAccountRecoveryUrl',
   `${baseUri}/settings/account_recovery`

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -43,7 +43,7 @@
   "postConsumeRecoveryCode": 5,
   "postNewRecoveryCodes": 5,
   "passwordResetAccountRecovery": 6,
-  "postAddAccountRecovery": 6,
+  "postAddAccountRecovery": 7,
   "postRemoveAccountRecovery": 6,
   "cadReminderFirst": 3,
   "cadReminderSecond": 3,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en.ftl
@@ -1,6 +1,10 @@
-postAddAccountRecovery-subject = Account recovery key generated
-postAddAccountRecovery-title = Account recovery key generated
-postAddAccountRecovery-description = You have successfully generated an account recovery key for your { -product-firefox-account } using the following device:
+postAddAccountRecovery-subject-2 = Account recovery key created
+postAddAccountRecovery-title2 = You created a new account recovery key
+# Information on the browser and device triggering this string follows.
+postAddAccountRecovery-description-2 = A new key was created from:
+# This is asking whether the person who took the action is the recipient of the email.
+postAddAccountRecovery-not-you = Not you?
+postAddAccountRecovery-change = <a data-l10n-name="revokeAccountRecoveryLink">Delete the new key</a> and <a data-l10n-name="passwordChangeLink">change your password</a>
 postAddAccountRecovery-action = Manage account
-postAddAccountRecovery-recovery = If this was not you, <a data-l10n-name="revokeAccountRecoveryLink">click here</a>.
-postAddAccountRecovery-revoke = If this was not you, revoke key.
+postAddAccountRecovery-delete-key = Delete the new key:
+postAddAccountRecovery-changd-password = Change your password:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "postAddAccountRecovery-subject",
-    "message": "Account recovery key generated"
+    "id": "postAddAccountRecovery-subject-2",
+    "message": "Account recovery key created"
   },
   "action": {
     "id": "postAddAccountRecovery-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.mjml
@@ -5,11 +5,11 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postAddAccountRecovery-title">Account recovery key generated</span>
+      <span data-l10n-id="postAddAccountRecovery-title-2">You created a new account recovery key</span>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postAddAccountRecovery-description">You have successfully generated an account recovery key for your Firefox account using the following device:</span>
+      <span data-l10n-id="postAddAccountRecovery-description-2">A new key was created from:</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -19,9 +19,14 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="postAddAccountRecovery-recovery">
-        If this was not you,
-        <a class="link-blue" href="<%- revokeAccountRecoveryLink %>" data-l10n-name="revokeAccountRecoveryLink">click here</a>.
+      <span data-l10n-id="postAddAccountRecovery-not-you">
+        Not you?
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddAccountRecovery-change">
+        <a class="link-blue" href="<%- revokeAccountRecoveryLink %>" data-l10n-name="revokeAccountRecoveryLink">Delete the new key</a> and <a class="link-blue" href="<%- passwordChangeLink %>" data-l10n-name="passwordChangeLink">change your password</a>
       </span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.stories.ts
@@ -17,8 +17,7 @@ const createStory = storyWithProps(
     ...MOCK_USER_INFO,
     link: 'http://localhost:3030/settings',
     passwordChangeLink: 'http://localhost:3030/settings/change_password',
-    revokeAccountRecoveryLink:
-      'http://localhost:3030/settings/account_recovery',
+    revokeAccountRecoveryLink: 'http://localhost:3030/settings/#recovery-key',
   }
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.txt
@@ -1,15 +1,18 @@
-postAddAccountRecovery-title = "Account recovery key generated"
+postAddAccountRecovery-title-2 = "You created a new account recovery key"
 
-postAddAccountRecovery-description = "You have successfully generated an account recovery key for your Firefox account from the following device:"
+postAddAccountRecovery-description-2 = "A new key was created from:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
-postAddAccountRecovery-revoke = "If this was not you, revoke key."
+postAddAccountRecovery-not-you = "Not you?"
 
+postAddAccountRecovery-delete-key = "Delete the new key:"
 <%- revokeAccountRecoveryLink %>
 
-<%- include('/partials/manageAccount/index.txt') %>
+postAddAccountRecovery-changd-password = "Change your password:"
+<%- passwordChangeLink %>
 
-<%- include('/partials/changePassword/index.txt') %>
+<%- include('/partials/manageAccount/index.txt') %>
+<%- include('/partials/automatedEmailNotAuthorized/index.txt') %>
 
 <%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -913,7 +913,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postAddAccountRecoveryEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Account recovery key generated' }],
+    ['subject', { test: 'equal', expected: 'Account recovery key created' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddAccountRecovery') }],
@@ -921,7 +921,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postAddAccountRecovery }],
     ])],
     ['html', [
-      { test: 'include', expected: 'Account recovery key generated' },
+      { test: 'include', expected: 'You created a new account recovery key' },
+      { test: 'include', expected: decodeUrl(configHref('revokeAccountRecoveryUrl', 'account-recovery-generated', 'report')) },
       { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-recovery-generated', 'change-password', 'email')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-recovery-generated', 'privacy')) },
@@ -931,9 +932,10 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Account recovery key generated' },
+      { test: 'include', expected: 'You created a new account recovery key' },
       { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid')}` },
-      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-recovery-generated', 'change-password', 'email')}` },
+      { test: 'include', expected: `Delete the new key:\n${configUrl('revokeAccountRecoveryUrl', 'account-recovery-generated', 'report')}` },
+      { test: 'include', expected: `Change your password:\n${configUrl('initiatePasswordChangeUrl', 'account-recovery-generated', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-recovery-generated', 'privacy')}` },
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-recovery-generated', 'support')}` },
       { test: 'include', expected: `${MESSAGE.date}` },


### PR DESCRIPTION
Because:
 - new copy for the post add recovery key email

This commit:
 - update email templates for post add recovery key email
