### PR TITLE
copy(fxa-auth-server): update email copy verificationReminderFirst

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -30,7 +30,7 @@
   "postVerifySecondary": 6,
   "recovery": 5,
   "unblockCode": 6,
-  "verificationReminderFirst": 9,
+  "verificationReminderFirst": 10,
   "verificationReminderSecond": 10,
   "verify": 6,
   "verifyPrimary": 8,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
@@ -1,7 +1,7 @@
-verificationReminderFirst-subject = Reminder: Finish creating your account
-verificationReminderFirst-title = Welcome to the { -brand-firefox } family
-verificationReminderFirst-description = A few days ago you created a { -product-firefox-account }, but never confirmed it.
-verificationReminderFirst-sub-description = Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.
-confirm-email = Confirm email
-confirm-email-plaintext = { confirm-email }:
-verificationReminderFirst-action = Confirm email
+verificationReminderFirst-subject-2 = Remember to confirm your account
+verificationReminderFirst-title-2 = Welcome to { -brand-firefox }!
+verificationReminderFirst-description-2 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account within the next 15 days or it will be automatically deleted.
+verificationReminderFirst-sub-description-2 = Don’t miss out on tech that puts you and your privacy first.
+confirm-email-2 = Confirm account
+confirm-email-plaintext-2 = { confirm-email-2 }:
+verificationReminderFirst-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/includes.json
@@ -1,10 +1,10 @@
 {
   "subject": {
-    "id": "verificationReminderFirst-subject",
-    "message": "Reminder: Finish creating your account"
+    "id": "verificationReminderFirst-subject-2",
+    "message": "Remember to confirm your account"
   },
   "action": {
-    "id": "verificationReminderFirst-action",
-    "message": "Confirm email"
+    "id": "verificationReminderFirst-action-2",
+    "message": "Confirm account"
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verificationReminderFirst-title">Welcome to the Firefox family</span>
+      <span data-l10n-id="verificationReminderFirst-title-2">Welcome to Firefox!</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -13,16 +13,16 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-sub-body">
-      <span data-l10n-id="verificationReminderFirst-description">A few days ago you created a Firefox account, but never confirmed it.</span>
+      <span data-l10n-id="verificationReminderFirst-description-2">A few days ago you created a Firefox account, but never confirmed it. Please confirm your account within the next 15 days or it will be automatically deleted.</span>
     </mj-text>
     <mj-text css-class="text-body">
-      <span data-l10n-id="verificationReminderFirst-sub-description">Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.</span>
+      <span data-l10n-id="verificationReminderFirst-sub-description">Don’t miss out on tech that puts you and your privacy first.</span>
     </mj-text>
   </mj-column>
 </mj-section>
 
 <%- include('/partials/button/index.mjml', {
-  buttonL10nId: "verificationReminderFirst-action",
-  buttonText: "Confirm email"
+  buttonL10nId: "verificationReminderFirst-action-2",
+  buttonText: "Confirm account"
 }) %>
 <%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
@@ -1,10 +1,10 @@
-verificationReminderFirst-title = "Welcome to the Firefox family"
+verificationReminderFirst-title-2 = "Welcome to Firefox"
 
-verificationReminderFirst-description = "A few days ago you created a Firefox account, but never confirmed it."
+verificationReminderFirst-description-2 = "A few days ago you created a Firefox account, but never confirmed it. Please confirm your account within the next 15 days or it will be automatically deleted."
 
-verificationReminderFirst-sub-description = "Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve."
+verificationReminderFirst-sub-description = "Don’t miss out on tech that puts you and your privacy first."
 
-confirm-email-plaintext = "Confirm email:"
+confirm-email-plaintext-2 = "Confirm account:"
 <%- link %>
 
 <%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -414,7 +414,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['verificationReminderFirstEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Reminder: Finish creating your account' }],
+    ['subject', { test: 'equal', expected: 'Remember to confirm your account' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderFirst') }],
@@ -423,18 +423,18 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
     ])],
     ['html', [
-      { test: 'include', expected: 'Reminder: Finish creating your account' },
-      { test: 'include', expected: 'Welcome to the Firefox family' },
+      { test: 'include', expected: 'Remember to confirm your account' },
+      { test: 'include', expected: 'Welcome to Firefox' },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'first-verification-reminder', 'privacy')) },
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'first-verification-reminder', 'support')) },
       { test: 'include', expected: decodeUrl(configHref('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid')) },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Welcome to the Firefox family' },
+      { test: 'include', expected: 'Welcome to Firefox' },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'first-verification-reminder', 'privacy')}` },
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'first-verification-reminder', 'support')}` },
-      { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid')}` },
+      { test: 'include', expected: `Confirm account:\n${configUrl('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],


### PR DESCRIPTION
## Because

- We're updating language in emails

## This pull request

- Updates email copy strings and their corresponding localization IDs

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="957" alt="Screen Shot 2022-08-10 at 12 29 25 PM" src="https://user-images.githubusercontent.com/11150372/184003798-6c6eeedf-b01f-4f3a-8443-5582b9c6d788.png">

