### PR TITLE
Fxa 5207 verification reminder second copy

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -31,7 +31,7 @@
   "recovery": 5,
   "unblockCode": 6,
   "verificationReminderFirst": 10,
-  "verificationReminderSecond": 10,
+  "verificationReminderSecond": 11,
   "verify": 6,
   "verifyPrimary": 8,
   "verifyLogin": 5,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
@@ -1,5 +1,6 @@
-verificationReminderSecond-subject = Final reminder: Activate your account
-verificationReminderSecond-title = Still there?
-verificationReminderSecond-description-2 = Almost a week ago you created a { -product-firefox-account } but never confirmed it. We’re worried about you.
-verificationReminderSecond-sub-description = Confirm this email address to activate your account and let us know you’re okay.
-verificationReminderSecond-action = Confirm email
+verificationReminderSecond-subject-2 = Remember to confirm your account
+verificationReminderSecond-title-2 = Don’t miss out on { -brand-firefox }
+verificationReminderSecond-description-3 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.
+verificationReminderSecond-second-description = Your { -product-firefox-account } lets you sync your info across devices and unlocks access to more privacy-protecting products from { -brand-mozilla }.
+verificationReminderSecond-sub-description-2 = Be part of our mission to transform the internet into a place that’s open for everyone.
+verificationReminderSecond-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/includes.json
@@ -1,10 +1,10 @@
 {
   "subject": {
-    "id": "verificationReminderSecond-subject",
-    "message": "Final reminder: Activate your account"
+    "id": "verificationReminderSecond-subject-2",
+    "message": "Remember to confirm your account"
   },
   "action": {
-    "id": "verificationReminderSecond-action",
-    "message": "Confirm email"
+    "id": "verificationReminderSecond-action-2",
+    "message": "Confirm account"
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verificationReminderSecond-title">Still there?</span>
+      <span data-l10n-id="verificationReminderSecond-title-2">Don’t miss out on Firefox</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -13,16 +13,19 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-sub-body">
-      <span data-l10n-id="verificationReminderSecond-description-2">Almost a week ago you created a Firefox account but never confirmed it. We’re worried about you.</span>
+      <span data-l10n-id="verificationReminderSecond-description-3">A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.</span>
+    </mj-text>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="verificationReminderSecond-second-description">Your Firefox account lets you sync your info across devices and unlocks access to more privacy-protecting products from Mozilla.</span>
     </mj-text>
     <mj-text css-class="text-body">
-      <span data-l10n-id="verificationReminderSecond-sub-description">Confirm this email address to activate your account and let us know you’re okay.</span>
+      <span data-l10n-id="verificationReminderSecond-sub-description-2">Be part of our mission to transform the internet into a place that’s open for everyone.</span>
     </mj-text>
   </mj-column>
 </mj-section>
 
 <%- include('/partials/button/index.mjml', {
-  buttonL10nId: "verificationReminderSecond-action",
-  buttonText: "Confirm email"
+  buttonL10nId: "verificationReminderSecond-action-2",
+  buttonText: "Confirm account"
 }) %>
 <%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.txt
@@ -1,10 +1,12 @@
-verificationReminderSecond-title = "Still there?"
+verificationReminderSecond-title-2 = "Don’t miss out on Firefox"
 
-verificationReminderSecond-description-2 = "Almost a week ago you created a Firefox account but never confirmed it. We’re worried about you."
+verificationReminderSecond-description-3 = "A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted."
 
-verificationReminderSecond-sub-description = "Confirm this email address to activate your account and let us know you’re okay."
+verificationReminderSecond-second-description = "Your Firefox account lets you sync your info across devices and unlocks access to more privacy-protecting products from Mozilla."
 
-confirm-email-plaintext = "Confirm email:"
+verificationReminderSecond-sub-description-2 = "Be part of our mission to transform the internet into a place that’s open for everyone."
+
+confirm-email-plaintext-2 = "Confirm account:"
 <%- link %>
 
 <%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -440,7 +440,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['verificationReminderSecondEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Final reminder: Activate your account' }],
+    ['subject', { test: 'equal', expected: 'Remember to confirm your account' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderSecond') }],
@@ -457,7 +457,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ['text', [
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'second-verification-reminder', 'privacy')}` },
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'second-verification-reminder', 'support')}` },
-      { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid')}` },
+      { test: 'include', expected: `Confirm account:\n${configUrl('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],


### PR DESCRIPTION
## Because

- We're updating copy for emails

## This pull request

- Updates copy, localization ids, and tests for the verificationReminderSecond email

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="482" alt="Screen Shot 2022-08-10 at 2 15 40 PM" src="https://user-images.githubusercontent.com/11150372/184023091-bb0075cd-627f-4d1b-8bc3-6c05d8924b15.png">
