### PR TITLE
chore(fxa-auth-server) update copy for verify email, add date/time

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -504,6 +504,11 @@ module.exports = function (log, config, bounces) {
       code: message.code,
     };
 
+    const [time, date] = this._constructLocalTimeString(
+      message.timeZone,
+      message.acceptLanguage
+    );
+
     if (message.service) {
       query.service = message.service;
     }
@@ -538,6 +543,7 @@ module.exports = function (log, config, bounces) {
       template: templateName,
       templateValues: {
         device: this._formatUserAgentInfo(message),
+        date: date,
         email: message.email,
         ip: message.ip,
         link: links.link,
@@ -549,6 +555,7 @@ module.exports = function (log, config, bounces) {
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         sync: message.service === 'sync',
+        time: time,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -32,7 +32,7 @@
   "unblockCode": 6,
   "verificationReminderFirst": 10,
   "verificationReminderSecond": 11,
-  "verify": 6,
+  "verify": 7,
   "verifyPrimary": 8,
   "verifyLogin": 6,
   "verifyLoginCode": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/en.ftl
@@ -1,5 +1,4 @@
-verify-title = Activate the { -brand-firefox } family of products
-verify-description-plaintext = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in.
+verify-title-2 = Open the internet with { -brand-firefox }
 verify-description = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in starting with:
 verify-subject = Finish creating your account
-verify-action = Confirm email
+verify-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/includes.json
@@ -4,7 +4,7 @@
     "message": "Finish creating your account"
   },
   "action": {
-    "id": "verify-action",
-    "message": "Confirm email"
+    "id": "verify-action-2",
+    "message": "Confirm account"
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.mjml
@@ -4,7 +4,7 @@
 
 <mj-section>
   <mj-column>
-    <mj-text css-class="text-header"><span data-l10n-id="verify-title">Activate the Firefox family of products</span></mj-text>
+    <mj-text css-class="text-header"><span data-l10n-id="verify-title-2">Open the internet with Firefox</span></mj-text>
   </mj-column>
 </mj-section>
 
@@ -16,7 +16,8 @@
 
 <%- include('/partials/userInfo/index.mjml') %>
 <%- include('/partials/button/index.mjml', {
-  buttonL10nId: "verify-action",
-  buttonText: "Confirm email"
+  buttonL10nId: "verify-action-2",
+  buttonText: "Confirm account"
 }) %>
 <%- include('/partials/automatedEmailNoAction/index.mjml') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { MOCK_USER_INFO_TRUNCATED } from '../../partials/userInfo/mocks';
+import { MOCK_USER_INFO } from '../../partials/userInfo/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
@@ -14,7 +14,7 @@ const createStory = storyWithProps(
   'verify',
   "Sent to users that create an account through Firefox, don't verify their email, and go into Sync preferences to resend the verification email as a link.",
   {
-    ...MOCK_USER_INFO_TRUNCATED,
+    ...MOCK_USER_INFO,
     link: 'http://localhost:3030/verify_email',
     sync: true,
   }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.txt
@@ -1,8 +1,8 @@
-verify-title = "Activate the Firefox family of products"
+verify-title-2 = "Open the internet with Firefox"
 
-verify-description-plaintext = "Confirm your account and get the most out of Firefox everywhere you sign in."
+verify-description = "Confirm your account and get the most out of Firefox everywhere you sign in starting with:"
 
-confirm-email-plaintext = "Confirm email:"
+confirm-email-plaintext-2 = "Confirm account:"
 <%- link %>
 
 <%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -473,7 +473,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: 'Finish creating your account' },
-      { test: 'include', expected: 'Activate the Firefox family of products' },
+      { test: 'include', expected: 'Open the internet with Firefox' },
       { test: 'include', expected: 'Confirm your account and get the most out of Firefox everywhere you sign in starting with:' },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome', 'privacy')) },
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'welcome', 'support')) },
@@ -486,11 +486,11 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Activate the Firefox family of products' },
-      { test: 'include', expected: 'Confirm your account and get the most out of Firefox everywhere you sign in.' },
+      { test: 'include', expected: 'Open the internet with Firefox' },
+      { test: 'include', expected: 'Confirm your account and get the most out of Firefox everywhere you sign in starting with:' },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'welcome', 'privacy')}` },
       { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'welcome', 'support')}` },
-      { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'welcome', 'activate', 'uid', 'code', 'service')}` },
+      { test: 'include', expected: `Confirm account:\n${configUrl('verificationUrl', 'welcome', 'activate', 'uid', 'code', 'service')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -152,7 +152,7 @@ describe('remote account create', function () {
         return server.mailbox.waitForEmail(email);
       })
       .then((emailData) => {
-        assert.include(emailData.text, 'Confirm email', 'en-US');
+        assert.include(emailData.text, 'Confirm account', 'en-US');
         // TODO: reinstate after translations catch up
         //assert.notInclude(emailData.text, 'Ativar agora', 'not pt-BR');
         return client.destroyAccount();

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.js
@@ -174,7 +174,7 @@ describe('scripts/bulk-mailer', function () {
     this.timeout(10000);
     return cp
       .execAsync(
-        `node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendVerifyEmail --write ${OUTPUT_DIRECTORY}`,
+        `node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendPasswordChangedEmail --write ${OUTPUT_DIRECTORY}`,
         execOptions
       )
       .then(() => {
@@ -192,11 +192,11 @@ describe('scripts/bulk-mailer', function () {
         const test1Html = fs
           .readFileSync(path.join(OUTPUT_DIRECTORY, 'user1@test.com.html'))
           .toString();
-        assert.include(test1Html, 'This is an automated email');
+        assert.include(test1Html, 'Password changed successfully');
         const test1Text = fs
           .readFileSync(path.join(OUTPUT_DIRECTORY, 'user1@test.com.txt'))
           .toString();
-        assert.include(test1Text, 'This is an automated email');
+        assert.include(test1Text, 'Password changed successfully');
 
         assert.isTrue(
           fs.existsSync(path.join(OUTPUT_DIRECTORY, 'user1@test.com.headers'))
@@ -212,28 +212,29 @@ describe('scripts/bulk-mailer', function () {
         const test2Html = fs
           .readFileSync(path.join(OUTPUT_DIRECTORY, 'user2@test.com.html'))
           .toString();
-        assert.include(test2Html, 'Confirma tu cuenta');
+        assert.include(test2Html, 'Has cambiado la contraseña correctamente');
         const test2Text = fs
           .readFileSync(path.join(OUTPUT_DIRECTORY, 'user2@test.com.txt'))
           .toString();
-        assert.include(test2Text, 'Confirma tu cuenta');
+        assert.include(test2Text, 'Has cambiado la contraseña correctamente');
       });
   });
+
 
   it('succeeds with valid input file and method, writing emails to stdout', () => {
     return cp
       .execAsync(
-        `node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendVerifyEmail`,
+        `node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendPasswordChangedEmail`,
         execOptions
       )
       .then(({ stdout: result }) => {
         assert.include(result, account1Mock.uid);
         assert.include(result, account1Mock.email);
-        assert.include(result, 'This is an automated email');
+        assert.include(result, 'Password changed successfully');
 
         assert.include(result, account2Mock.uid);
         assert.include(result, account2Mock.email);
-        assert.include(result, 'Confirma tu cuenta');
+        assert.include(result, 'Has cambiado la contraseña correctamente');
       });
   });
 


### PR DESCRIPTION
## Because

- We're updating copy for emails!

## This pull request

- Updates copy, localization IDs, and tests for the `verify` email, and also adds the `date` and `time` variables so as to display the date and time within the `userInfo` partial

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="416" alt="Screen Shot 2022-08-10 at 3 13 47 PM" src="https://user-images.githubusercontent.com/11150372/184029899-74050d8c-2940-46ca-ab6a-af50cd1b958d.png">


## Other information (Optional)

Any other information that is important to this pull request.
