### PR TITLE
fix(content): Fix erroneous signin_bounced redirect

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/session-verification-poll-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/session-verification-poll-mixin.js
@@ -78,12 +78,26 @@ export default {
    * @private
    */
   _handleSessionVerificationPollErrors(account, err) {
-    // The user's email may have bounced because it was invalid.
-    // Redirect them to the sign up page with an error notice.
-    if (
-      AuthErrors.is(err, 'SIGNUP_EMAIL_BOUNCE') ||
-      AuthErrors.is(err, 'INVALID_TOKEN')
-    ) {
+    if (AuthErrors.is(err, 'INVALID_TOKEN')) {
+      // Something has tripped an invalid token error. Note, there are quite a
+      // few ways this can happen. One of which is cross contamination due
+      // to interactions on other tabs. This error state is a bit nebulous,
+      // so let's redirect the user to the main sign in, as it indicates that
+      // something invalidated local storage or perhaps their session token has
+      // expired and a polling operation picked up on this. Either way, the user
+      // is likely in the middle of login flow on another tab, or the tab has been
+      // idle for quite some time. See #13806
+      if (this.isSignUp()) {
+        this.replaceCurrentPage('/', {
+          account,
+        });
+      } else {
+        this.replaceCurrentPage('/signin');
+      }
+    } else if (AuthErrors.is(err, 'SIGNUP_EMAIL_BOUNCE')) {
+      // The user's email may have bounced because it was invalid.
+      // Redirect them to the sign up page with an error notice.
+
       account.set('hasBounced', true);
       if (this.isSignUp()) {
         this.replaceCurrentPage('/', {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/session-verification-poll-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/session-verification-poll-mixin.js
@@ -117,7 +117,7 @@ describe('views/mixins/session-verification-poll-mixin', () => {
       assert.isTrue(view.replaceCurrentPage.calledWith('/', { account }));
     });
 
-    it('navigates to /signin_bounced if INVALID_TOKEN occurs on signin', () => {
+    it('navigates to /signin if INVALID_TOKEN occurs on signin', () => {
       sinon.stub(view, 'isSignUp').callsFake(() => false);
       sinon.spy(view, 'replaceCurrentPage');
       view._handleSessionVerificationPollErrors(
@@ -125,11 +125,7 @@ describe('views/mixins/session-verification-poll-mixin', () => {
         AuthErrors.toError('INVALID_TOKEN')
       );
 
-      assert.isTrue(
-        view.replaceCurrentPage.calledWith('signin_bounced', {
-          email: 'a@a.com',
-        })
-      );
+      assert.isTrue(view.replaceCurrentPage.calledWith('/signin'));
     });
 
     it('displays an error when an unknown error occurs', function () {

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
@@ -58,19 +58,20 @@ registerSuite('OAuth signin token code', {
   },
 
   tests: {
-    'verified - bounce': function () {
+    'verified - invalid token': function () {
       experimentParams.query.forceExperiment = 'tokenCode';
       experimentParams.query.forceExperimentGroup = 'treatment-code';
 
-      return this.remote
-        .then(openFxaFromRp('enter-email', experimentParams))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
-        .then(destroySessionForEmail(email))
-        .then(testElementExists(selectors.SIGNIN_BOUNCED.HEADER))
-        .then(testElementExists(selectors.SIGNIN_BOUNCED.CREATE_ACCOUNT))
-        .then(testElementExists(selectors.SIGNIN_BOUNCED.BACK))
-        .then(testElementExists(selectors.SIGNIN_BOUNCED.SUPPORT));
+      return (
+        this.remote
+          .then(openFxaFromRp('enter-email', experimentParams))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
+          .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
+          // This will cause the token become 'invalid' and ultimately cause an
+          // INVALID_TOKEN error to be thrown.
+          .then(destroySessionForEmail(email))
+          .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+      );
     },
 
     'verified - valid code': function () {


### PR DESCRIPTION
## Because
- It was possible to ended up on the signin_bounced page, even though no email bounce actually happened.

## This pull request

- Handles the invalid token state separately for the sign in bounced email state.

## Issue that this pull request solves

Closes: #13806

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

It turns out that with two tabs open at the same time this is fairly easy to reproduce. This all ultimately has to do with the fact that the https://accounts.firefox.com/signin page is always polling sessionTokenStatus, which immediately [checks local storage for the sessionToken](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/models/account.js#L321). Because local storage is shared between tabs, a call to [discardSessionToken()](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/models/account.js#L162) in one tab, can send another polling tab into an unanticipated state. Here’s a run down on the chain of events:


- If tab A starts a sign in flow, the [session token is ‘touched’](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/models/user.js#L423) during sign in. 
- If there is another tab B, that is also on the signin page two things happen that trip the error. 

- First it will pick up the [change:sessionToken event](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/models/account.js#L120), which will lead to a [discardSessionToken()](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/models/account.js#L162) call. 

- Next, since the session has now been discarded and because tab B is polling, it will [throw an INVALID_TOKEN](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/models/account.js#L323) error in the polling code. 
- This error ultimately gets [caught by the error handler](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/views/mixins/session-verification-poll-mixin.js#L80), and we end up getting redirected to the signin_bounced page. The [‘hasBounced’ flag also gets fallaciously set](https://github.com/mozilla/fxa/blob/7f3b9994a93e1c0486f0819e031e5b8462771e5b/packages/fxa-content-server/app/scripts/views/mixins/session-verification-poll-mixin.js#L87). This is clearly incorrect, and the assumption that this is somehow related to an delivered email is simply not the case.
