### PR TITLE
fix(fxa-auth-server): switch out partial to make mjml and txt consistent

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.txt
@@ -7,5 +7,6 @@ verifyLogin-description-2 = "Help us keep your account safe by confirming you si
 verifyLogin-action = "Confirm sign-in"
 <%- link %>
 
-<%- include('/partials/changePassword/index.txt') %>
+<%- include('/partials/automatedEmailNotAuthorized/index.txt') %>
+
 <%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -801,7 +801,6 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
     ['text', [
       { test: 'include', expected: 'Did you sign in to Mock Relier?' },
-      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'new-signin', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'new-signin', 'privacy')}` },
       { test: 'include', expected: `Confirm sign-in\n${configUrl('verifyLoginUrl', 'new-signin', 'confirm-signin', 'code', 'uid', 'service')}` },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },


### PR DESCRIPTION
## Because

- I forgot to add this fix in before merging the last PR

## This pull request

- Matches up the MJML and TXT footers

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
<img width="1021" alt="Screen Shot 2022-08-15 at 1 07 06 PM" src="https://user-images.githubusercontent.com/11150372/184709536-959a9ed1-0d55-4c82-912b-f38cfb7e3986.png">

