### PR TITLE
feat(auth): add /account/set_password route

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -238,15 +238,56 @@ const ACCOUNT_DESTROY_POST = {
   },
 };
 
+const ACCOUNT_FINISH_SETUP_POST = {
+  ...TAGS_ACCOUNT,
+  description: '/account/finish_setup',
+};
+
+const ACCOUNT_SET_PASSWORD_POST = {
+  ...TAGS_ACCOUNT,
+  description: '/account/set_password',
+  notes: [
+    dedent`
+      🔒🔓 Authenticated with oauth access token.
+
+      Sets the password on an unverified stub account.
+
+      By default, a verification email will be sent.
+
+      If the user is subscribed to a product, and we find a valid, matching Stripe productId, they will be added to a list to receive verification reminder emails.
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 110\` - Invalid token (token already used)
+          `,
+        },
+      },
+    },
+  },
+};
+
+const ACCOUNT_STUB_POST = {
+  ...TAGS_ACCOUNT,
+  description: '/account/stub',
+};
+
 const API_DOCS = {
   ACCOUNT_CREATE_POST,
   ACCOUNT_DESTROY_POST,
+  ACCOUNT_FINISH_SETUP_POST,
   ACCOUNT_KEYS_GET,
   ACCOUNT_LOGIN_POST,
   ACCOUNT_PROFILE_GET,
   ACCOUNT_RESET_POST,
+  ACCOUNT_SET_PASSWORD_POST,
   ACCOUNT_STATUS_GET,
   ACCOUNT_STATUS_POST,
+  ACCOUNT_STUB_POST,
   ACCOUNT_UNLOCK_RESEND_CODE_POST,
   ACCOUNT_UNLOCK_VERIFY_CODE_POST,
 };

--- a/packages/fxa-auth-server/docs/swagger/misc-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/misc-api.ts
@@ -8,16 +8,6 @@ const TAGS_MISC = {
   tags: TAGS.MISCELLANEOUS,
 };
 
-const ACCOUNT_STUB_POST = {
-  ...TAGS_MISC,
-  description: '/account/stub',
-};
-
-const ACCOUNT_FINISH_SETUP_POST = {
-  ...TAGS_MISC,
-  description: '/account/finish_setup',
-};
-
 const ACCOUNT_GET = {
   ...TAGS_MISC,
   description: '/account',
@@ -68,10 +58,8 @@ const OAUTH_ID_TOKEN_VERIFY_POST = {
 
 const API_DOCS = {
   ACCOUNT_GET,
-  ACCOUNT_FINISH_SETUP_POST,
   ACCOUNT_LOCK_POST,
   ACCOUNT_SESSIONS_LOCATIONS_GET,
-  ACCOUNT_STUB_POST,
   NEWSLETTERS_POST,
   OAUTH_ID_TOKEN_VERIFY_POST,
   SUPPORT_TICKET_POST,

--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -152,6 +152,8 @@ const DESCRIPTIONS = {
     'Opaque URL-encoded string to be included in the verification link as a query parameter.',
   scope:
     'A space-separated list of scope values that the user has authorized, or is held by the granted access token that the connecting client will be granted. The requested scope will be provided by the connecting client as part of its authorization request, but may be pruned by the user in a confirmation dialog before being sent to this endpoint.',
+  sendVerifyEmail:
+    'Boolean indicating whether a verification email should be sent.',
   service: 'Opaque alphanumeric token to be included in verification links.',
   serviceRP:
     'Identifies the relying service the user was interacting with that triggered the password reset.',

--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -210,7 +210,7 @@ export class CapabilityService {
   /**
    * Return a list of all price ids with an active subscription.
    */
-  private async subscribedPriceIds(uid: string) {
+  async subscribedPriceIds(uid: string) {
     const [
       subscribedStripePrices,
       subscribedPlayPrices,


### PR DESCRIPTION
Because:

* To reduce app switching in the mobile subscription process, we want new users to set their account password and verify their email after subscribing -- in that order.

This commit:

* Creates a new account/set_password route that requires an access token and sets a password for an unverified, stub account, optionally sending a verification email.

Closes #13646

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
