### PR TITLE
feat(auth): use ipAddress for customer updates

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2477,7 +2477,7 @@ describe('StripeHelper', () => {
     it('updates Customer with empty PayPal billing address', async () => {
       sandbox
         .stub(stripeHelper.stripe.customers, 'update')
-        .resolves({ metadata: {} });
+        .resolves({ metadata: {}, tax: {} });
       stripeFirestore.insertCustomerRecordWithBackfill = sandbox
         .stub()
         .resolves({});
@@ -2492,7 +2492,7 @@ describe('StripeHelper', () => {
           state: 'CA',
         },
       });
-      assert.deepEqual(result, { metadata: {} });
+      assert.deepEqual(result, { metadata: {}, tax: {} });
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.customers.update,
         customer1.id,
@@ -2505,6 +2505,34 @@ describe('StripeHelper', () => {
             postal_code: '12345',
             state: 'CA',
           },
+          expand: ['tax'],
+        }
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeFirestore.insertCustomerRecordWithBackfill,
+        undefined,
+        { metadata: {} }
+      );
+    });
+
+    it('updates Customer with the ip address', async () => {
+      sandbox
+        .stub(stripeHelper.stripe.customers, 'update')
+        .resolves({ metadata: {}, tax: {} });
+      stripeFirestore.insertCustomerRecordWithBackfill = sandbox
+        .stub()
+        .resolves({});
+      const result = await stripeHelper.updateCustomerBillingAddress({
+        customerId: customer1.id,
+        ipAddress: '1.1.1.1',
+      });
+      assert.deepEqual(result, { metadata: {}, tax: {} });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.customers.update,
+        customer1.id,
+        {
+          tax: { ip_address: '1.1.1.1' },
+          expand: ['tax'],
         }
       );
       sinon.assert.calledOnceWithExactly(


### PR DESCRIPTION
Because:

* We want to optionally update a users Stripe location based on ip
  address.

This commit:

* Adds an ipAddress option to uppdateCustomerBillingAddress to update
  their address based on the IP address for tax handling.

Closes FXA-5670

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
