### PR TITLE
feat(fxa-auth-server): add new verification reminder email

### DIFF
--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -57,6 +57,7 @@ export enum EmailType {
   verifyPrimary,
   verificationReminderFirst,
   verificationReminderSecond,
+  verificationReminderFinal,
   cadReminderFirst,
   cadReminderSecond,
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -418,7 +418,8 @@
   },
   "verificationReminders": {
     "firstInterval": "5s",
-    "secondInterval": "10s"
+    "secondInterval": "10s",
+    "finalInterval": "15s"
   },
   "cadReminders": {
     "firstInterval": "1s",

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1709,6 +1709,12 @@ const conf = convict({
       env: 'VERIFICATION_REMINDERS_SECOND_INTERVAL',
       format: 'duration',
     },
+    finalInterval: {
+      doc: 'Time since account creation after which the final reminder is sent',
+      default: '15 days',
+      env: 'VERIFICATION_REMINDERS_FINAL_INTERVAL',
+      format: 'duration',
+    },
     redis: {
       prefix: {
         default: 'verificationReminders:',

--- a/packages/fxa-auth-server/docs/metrics-events.md
+++ b/packages/fxa-auth-server/docs/metrics-events.md
@@ -253,9 +253,9 @@ Possible values for `${linkName}` are:
 
 Possible values for `${experiment}` are:
 
-| Experiment name        | Description                            |
-| ---------------------- | -------------------------------------- |
-| `connectAnotherDevice` | Connect another device, phase 1        |
+| Experiment name        | Description                     |
+| ---------------------- | ------------------------------- |
+| `connectAnotherDevice` | Connect another device, phase 1 |
 
 #### Connect method names
 
@@ -384,10 +384,10 @@ has the same schema as `daily_multi_device_users`.
 | `device.created`       | A device record has been created for a Sync account.         |
 | `device.updated`       | Device record is updated on a Sync account.                  |
 | `device.deleted`       | Device record has been deleted from a Sync account.          |
-| `oauth.token.created`  | An oauth access token has been issued for an account. **      |
+| `oauth.token.created`  | An oauth access token has been issued for an account. \*\*   |
 | `sync.sentTabToDevice` | Device sent a push message for send-tab-to-device feature.   |
 
-** We emit the ecosystem_anonymous_id along with this event into the AET pipeline, this is so that we can calulate Daily Active Users in a safe, non-identifiable way.
+\*\* We emit the ecosystem_anonymous_id along with this event into the AET pipeline, this is so that we can calulate Daily Active Users in a safe, non-identifiable way.
 
 ## Email events
 
@@ -424,18 +424,19 @@ NOTE: the following is outdated, we have many more templates than this. Check ou
 
 Possible values for `${template}` include
 
-| Name                       | Description                                                     |
-| -------------------------- | --------------------------------------------------------------- |
-| `newDeviceLoginEmail`      | Email sent when a login has occurred from a new device.         |
-| `passwordChangedEmail`     | Email sent when a user has successfully changed their password. |
-| `passwordResetEmail`       | Email sent when a user has reset their password.                |
-| `postAddLinkedAccountEmail`| Email sent when an account is linked to another account.        |
-| `postVerifyEmail`          | Email sent when a user has verified their account.              |
-| `recoveryEmail`            | Email sent when a user attempts to reset their password.        |
-| `unblockCodeEmail`         | Email sent containing the account unblock code.                 |
-| `verifyEmail`              | Email sent to verify a user's account.                          |
-| `verifyLoginEmail`         | Sign-in confirmation email was sent.                            |
-| `postVerifySecondaryEmail` | Email sent when a user has added a secondary email.             |
+| Name                             | Description                                                           |
+| -------------------------------- | --------------------------------------------------------------------- |
+| `newDeviceLoginEmail`            | Email sent when a login has occurred from a new device.               |
+| `passwordChangedEmail`           | Email sent when a user has successfully changed their password.       |
+| `passwordResetEmail`             | Email sent when a user has reset their password.                      |
+| `postAddLinkedAccountEmail`      | Email sent when an account is linked to another account.              |
+| `postVerifyEmail`                | Email sent when a user has verified their account.                    |
+| `recoveryEmail`                  | Email sent when a user attempts to reset their password.              |
+| `unblockCodeEmail`               | Email sent containing the account unblock code.                       |
+| `verifyEmail`                    | Email sent to verify a user's account.                                |
+| `verifyLoginEmail`               | Sign-in confirmation email was sent.                                  |
+| `postVerifySecondaryEmail`       | Email sent when a user has added a secondary email.                   |
+| `verificationReminderFinalEmail` | Final reminder sent to users with unverified accounts before deletion |
 
 #### Type names
 

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -72,6 +72,7 @@ const EMAIL_TYPES = {
   verifyPrimary: 'verify',
   verificationReminderFirst: 'registration',
   verificationReminderSecond: 'registration',
+  verificationReminderFinal: 'registration',
   cadReminderFirst: 'connect_another_device',
   cadReminderSecond: 'connect_another_device',
 };

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -34,6 +34,7 @@ module.exports = function (log, config, bounces) {
     log,
     config
   );
+
   const cadReminders = require('../cad-reminders')(config, log);
   const subscriptionAccountReminders =
     require('../subscription-account-reminders')(log, config);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -32,6 +32,7 @@
   "unblockCode": 6,
   "verificationReminderFirst": 10,
   "verificationReminderSecond": 11,
+  "verificationReminderFinal": 1,
   "verify": 7,
   "verifyPrimary": 8,
   "verifyLogin": 6,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/en.ftl
@@ -1,0 +1,4 @@
+verificationReminderFinal-subject = Final reminder to confirm your account
+verificationReminderFinal-description = A couple of weeks ago you created a { -product-firefox-account }, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours.
+confirm-account = Confirm account
+confirm-account-plaintext = { confirm-account }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/includes.json
@@ -1,0 +1,10 @@
+{
+  "subject": {
+    "id": "verificationReminderFinal-subject",
+    "message": "Final reminder to confirm your account"
+  },
+  "action": {
+    "id": "confirm-account",
+    "message": "Confirm account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/index.mjml
@@ -1,0 +1,17 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="verificationReminderFinal-description">A couple of weeks ago you created a Firefox account, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml', {
+  buttonL10nId: "confirm-account",
+  buttonText: "Confirm account"
+}) %>
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/index.stories.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'FxA Emails/Templates/verificationReminderFinal',
+} as Meta;
+
+const createStory = storyWithProps(
+  'verificationReminderFinal',
+  'Final reminder sent to users that have not verified their account, sent 15 days after initial attempt.',
+  {
+    link: 'http://localhost:3030/verify_email',
+  }
+);
+
+export const VerificationReminderFinal = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/index.txt
@@ -1,0 +1,7 @@
+verificationReminderFinal-description = "A couple of weeks ago you created a Firefox account, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours."
+
+confirm-account-plaintext = "Confirm account:"
+<%- link %>
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -462,6 +462,29 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
   ])],
 
+  ['verificationReminderFinalEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Final reminder to confirm your account' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'final-verification-reminder', 'confirm-email', 'code', 'reminder=final', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderFinal') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verificationReminderFinal' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verificationReminderFinal }],
+      ['X-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'final-verification-reminder', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'final-verification-reminder', 'support')) },
+      { test: 'include', expected: decodeUrl(configHref('verificationUrl', 'final-verification-reminder', 'confirm-email', 'code', 'reminder=final', 'uid')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'final-verification-reminder', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'final-verification-reminder', 'support')}` },
+      { test: 'include', expected: `Confirm account:\n${configUrl('verificationUrl', 'final-verification-reminder', 'confirm-email', 'code', 'reminder=final', 'uid')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
   ['verifyEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Finish creating your account' }],
     ['headers', new Map([

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -798,11 +798,15 @@ function mockRequest(data, errors) {
 
 function mockVerificationReminders(data = {}) {
   return {
-    keys: ['first', 'second', 'third'],
-    create: sinon.spy(() => data.create || { first: 1, second: 1, third: 1 }),
-    delete: sinon.spy(() => data.delete || { first: 1, second: 1, third: 1 }),
+    keys: ['first', 'second', 'third', 'final'],
+    create: sinon.spy(
+      () => data.create || { first: 1, second: 1, third: 1, final: 1 }
+    ),
+    delete: sinon.spy(
+      () => data.delete || { first: 1, second: 1, third: 1, final: 1 }
+    ),
     process: sinon.spy(
-      () => data.process || { first: [], second: [], third: [] }
+      () => data.process || { first: [], second: [], third: [], final: [] }
     ),
   };
 }


### PR DESCRIPTION
## Because

- We want to add a new email to alert users that their account will be deleted if they do not confirm it

## This pull request

- Adds on a new email template, and all associated tests and documentation
- Was originally [this PR](https://github.com/mozilla/fxa/pull/13938) but I messed up the PR and ended up just moving the changes onto a new branch

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1275" alt="Screen Shot 2022-08-16 at 1 38 18 PM" src="https://user-images.githubusercontent.com/11150372/184980584-76f1d041-410c-4e29-8cd3-ffd999cf2b5b.png">

