### PR TITLE
Fxa 5455 address content server validation errors having high error rates p2

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -185,6 +185,7 @@ Start.prototype = {
       entrypointVariation: relier.get('entrypointVariation'),
       isSampledUser: isSampledUser,
       lang: this._config.lang,
+      maxEventOffset: this._config.maxEventOffset,
       notifier: this._notifier,
       screenHeight: screenInfo.screenHeight,
       screenWidth: screenInfo.screenWidth,

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -29,6 +29,7 @@ module.exports = function (config) {
     'marketing_email.preferences_url'
   );
   const MX_RECORD_VALIDATION = config.get('mxRecordValidation');
+  const MAX_EVENT_OFFSET = config.get('client_metrics.max_event_offset');
   const REDIRECT_CHECK_ALLOW_LIST = config.get('redirect_check.allow_list');
   const SENTRY_CLIENT_DSN = config.get('sentry.dsn');
   const SENTRY_CLIENT_ENV = config.get('sentry.env');
@@ -60,6 +61,7 @@ module.exports = function (config) {
 
   const configForFrontEnd = {
     authServerUrl: AUTH_SERVER_URL,
+    maxEventOffset: MAX_EVENT_OFFSET,
     env: ENV,
     isCoppaEnabled: COPPA_ENABLED,
     isPromptNoneEnabled: PROMPT_NONE_ENABLED,

--- a/packages/fxa-content-server/server/lib/routes/post-csp.js
+++ b/packages/fxa-content-server/server/lib/routes/post-csp.js
@@ -22,21 +22,14 @@ const BODY_SCHEMA = {
     .object()
     .keys({
       // CSP 2, 3 required
-      // `eval` and `inline` are specified in CSP 3 and sent by Chrome
-      'blocked-uri': URL_TYPE.allow('')
-        .allow('asset')
-        .allow('blob')
-        .allow('data')
-        .allow('eval')
-        .allow('inline')
-        .allow('self')
+      'blocked-uri': STRING_TYPE.allow('')
+        .not(/^telnet:/i)
         .optional(),
       // CSP 2, 3 optional
       'column-number': INTEGER_TYPE.min(0).optional(),
       // CSP 3 required, but not always sent
       disposition: STRING_TYPE.optional(),
       // CSP 2, 3 required
-      // Allow 'about:srcdoc', see https://bugzilla.mozilla.org/show_bug.cgi?id=1073952#c22
       'document-uri': URL_TYPE.required().allow('about:srcdoc'),
       // CSP 2 required, but not always sent
       'effective-directive': STRING_TYPE.optional(),

--- a/packages/fxa-content-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-content-server/server/lib/routes/post-metrics.js
@@ -112,7 +112,7 @@ const BODY_SCHEMA = {
       loadEventStart: NAVIGATION_TIMING_TYPE.required(),
       navigationStart: NAVIGATION_TIMING_TYPE.required(),
       redirectEnd: NAVIGATION_TIMING_TYPE.required(),
-      redirectStart: NAVIGATION_TIMING_TYPE.required(),
+      redirectStart: NAVIGATION_TIMING_TYPE.optional(),
       requestStart: NAVIGATION_TIMING_TYPE.required(),
       responseEnd: NAVIGATION_TIMING_TYPE.required(),
       responseStart: NAVIGATION_TIMING_TYPE.required(),
@@ -215,7 +215,7 @@ function findInvalidEventOffsets(events, maxOffset) {
 function MaxOffsetError(offset, maxOffset) {
   return {
     error: 'Bad Request',
-    message: `offset ${offset} > maxiumum possible of ${maxOffset}`,
+    message: `offset exceeds maximum of ${maxOffset}`,
     statusCode: 400,
     validation: {
       keys: ['offset'],

--- a/packages/fxa-shared/metrics/metric-errors.ts
+++ b/packages/fxa-shared/metrics/metric-errors.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export class InvalidMetricError extends Error {
+  constructor(
+    public readonly name: string,
+    public readonly violation: string,
+    public readonly critical: boolean,
+    public readonly val: string | number | null | undefined,
+    public readonly limitOrDefault?: string | number
+  ) {
+    super(`Bad metric encountered: ${name} - ${violation}`);
+  }
+}
+
+export class InvalidNavigationTimingError extends Error {
+  constructor(
+    public readonly name: string,
+    public readonly violation: string,
+    public readonly critical: boolean,
+    public readonly val: string | number | null | undefined,
+    public readonly limitOrDefault?: string | number
+  ) {
+    super(`Bad timing metric encountered: ${name} - ${violation}`);
+  }
+}

--- a/packages/fxa-shared/metrics/validate.ts
+++ b/packages/fxa-shared/metrics/validate.ts
@@ -1,0 +1,375 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  InvalidMetricError,
+  InvalidNavigationTimingError,
+} from './metric-errors';
+import { BrowserClient } from '@sentry/browser';
+import { retry } from 'rxjs';
+
+export const UTM_REGEX = /^[\w\/.%-]{1,128}$/;
+export const DEVICE_ID_REGEX = /^[0-9a-f]{32}$|^none$/;
+export const INVALID_UTM = 'invalid';
+export const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+export const NOT_REPORTED_VALUE = 'none';
+
+/**
+ * These are a subset of all known metrics. Validation on the post-metrics endpoint for the full set.
+ * A the moment these are the metrics that are commonly incorrect.
+ */
+export type CheckMetricsNavigationTiming = {
+  connectStart: number | string | undefined | null;
+  connectEnd: number | string | undefined | null;
+  domainLookupEnd: number | string | undefined | null;
+  redirectStart: number | string | undefined | null;
+};
+export type CheckMetricsEvent = { type: string; offset: number };
+export type CheckedMetrics = {
+  deviceId: string | undefined | null;
+  duration: number | string | undefined | null;
+  navigationTiming: CheckMetricsNavigationTiming;
+  events: Array<CheckMetricsEvent>;
+  utm_campaign: string;
+  utm_content: string;
+  utm_medium: string;
+  utm_source: string;
+  utm_term: string;
+};
+
+/** A subtype of UtmMetrics */
+export type CheckedUtmMetrics = Pick<
+  CheckedMetrics,
+  'utm_campaign' | 'utm_content' | 'utm_medium' | 'utm_source' | 'utm_term'
+>;
+
+/**
+ * Handles tracking and report errors on raw metric data.
+ */
+export class MetricErrorReporter {
+  private _critical = 0;
+  private _captured = 0;
+
+  /**
+   * Returns a running total of errors counted and errors captured.
+   * Note, that not all errors need to be captured, and that not all
+   * errors need to be counted.
+   */
+  public get counts() {
+    return {
+      critical: this._critical,
+      captured: this._captured,
+    };
+  }
+
+  constructor(protected readonly sentry: BrowserClient) {}
+
+  /**
+   * Reports an error to sentry.
+   * @param error - Error to report
+   * @param capture - Flag indication whether or not to count the error.
+   *
+   * Note: The error.critical and capture flags operate independently. There might be situations where
+   * you want to report the error, but it is not critical... or vice versa.
+   */
+  public report(
+    error: InvalidMetricError | InvalidNavigationTimingError,
+    capture: boolean = true
+  ) {
+    if (error.critical) {
+      this._critical++;
+    }
+
+    if (capture) {
+      this._captured++;
+
+      console.log('metric error');
+      console.error(error);
+
+      if (this.sentry) {
+        this.sentry.captureException(error);
+      }
+    }
+  }
+}
+
+/** Optional configuration for Metric Validator */
+export type MetricValidatorOpts = {
+  /** Maximum allowed time for an event offset in milliseconds. Generally defaults to 2 days. */
+  maxEventOffset: number;
+  /** Validates a utm_* query param */
+  isUtmValid?: (val: string) => boolean;
+  /** Validates a device id. */
+  isDeviceIdValid?: (val: string) => boolean;
+};
+
+/** Checks and cleans metrics data. */
+export class MetricValidator {
+  protected readonly maxEventOffset: number;
+  protected readonly isUtmValid = (x: string) => UTM_REGEX.test(x);
+  protected readonly isDeviceIdValid = (x: string) => DEVICE_ID_REGEX.test(x);
+
+  /**
+   * Creates a new instance
+   * @param errorReporter reports issues to sentry and tracks error counts
+   * @param opts optional configuration
+   */
+  constructor(
+    public readonly errorReporter: MetricErrorReporter,
+    opts: MetricValidatorOpts
+  ) {
+    if (opts.maxEventOffset != null) {
+      this.maxEventOffset = opts.maxEventOffset;
+    } else {
+      console.trace('wut');
+      throw new Error('config.maxEventOffset missing');
+    }
+    if (opts.isDeviceIdValid != null) {
+      this.isUtmValid = opts.isDeviceIdValid;
+    }
+    if (opts.isUtmValid != null) {
+      this.isUtmValid = opts.isUtmValid;
+    }
+  }
+
+  /**
+   * Ensures the device adheres to a hex string of length 32 or 'none'.
+   *
+   * Coercion of data will be reported but NOT counted as a critical error.
+   */
+  public sanitizeDeviceId(data: Pick<CheckedMetrics, 'deviceId'>) {
+    if (this.isDeviceIdValid(data.deviceId || '')) {
+      return data;
+    }
+
+    data.deviceId = NOT_REPORTED_VALUE;
+
+    // The device is not valid, let's try to figure out where this is coming from, by
+    // capturing a sentry error which could uncover the call stack that resulted in
+    // this state. We won't count this as critical, however, because the NOT_REPORTED_VALUE
+    // won't be rejected by the API.
+    this.errorReporter.report(
+      new InvalidMetricError(
+        'deviceId',
+        'invalid value',
+        false,
+        data.deviceId,
+        NOT_REPORTED_VALUE
+      )
+    );
+
+    return data;
+  }
+
+  /**
+   * This will make sure duration is a sane value.
+   *
+   * Coercion of data will be reported and counted as a critical error.
+   */
+  public sanitizeDuration(data: Pick<CheckedMetrics, 'duration'>) {
+    data.duration = this.clamp(
+      'duration',
+      data.duration,
+      0,
+      MAX_SAFE_INTEGER,
+      0
+    );
+
+    return data;
+  }
+
+  /**
+   * Make sure navigation timings are sane values.
+   *
+   * Coercion of data will be reported and counted as a critical error.
+   */
+  public sanitizeNavigationTiming(
+    data: Pick<CheckedMetrics, 'navigationTiming'>
+  ) {
+    // Navigation timing
+    if (data.navigationTiming == null) {
+      return;
+    }
+
+    const { navigationTiming } = data;
+
+    const clamp = (name: keyof CheckMetricsNavigationTiming) => {
+      // Navigation timings can be null. All this and coerce other null like things
+      // into a null value.
+      if (
+        typeof navigationTiming[name] !== 'number' &&
+        !navigationTiming[name]
+      ) {
+        navigationTiming[name] = null;
+        return;
+      }
+
+      navigationTiming[name] = this.clamp(
+        `navigationTiming.${name}`,
+        navigationTiming[name],
+        0,
+        MAX_SAFE_INTEGER,
+        0
+      );
+    };
+
+    clamp('connectStart');
+    clamp('connectEnd');
+    clamp('domainLookupEnd');
+    clamp('redirectStart');
+
+    return data;
+  }
+
+  /**
+   * There are appear to be some issues with event data. This routine ensures
+   * the event offset is a sane number [0, maxEventOffset], and that the event
+   * types are valid string values.
+   *
+   * Coercion of data will be reported and counted as a critical error.
+   */
+  public sanitizeEvents(data: Pick<CheckedMetrics, 'events'>) {
+    if (!Array.isArray(data.events)) {
+      data.events = [];
+    }
+
+    for (const event of data.events) {
+      // Make sure offset is a valid value
+      event.offset = this.clamp(
+        'event.offset',
+        event.offset,
+        0,
+        this.maxEventOffset,
+        0
+      );
+
+      // Truncate as soon as an invalid character is hit. There is a limited set of valid characters for event type;
+      // however, the invoking code is sometimes a bit fast and loose with what gets provided here. e.g. Sometimes a
+      // noisy error messages is provided. Looking at existing data, this approach should allow most scenarios to
+      // result in a distinct event.type value, which is the desired end result.
+      if (typeof event.type === 'string') {
+        event.type = event.type.replace(/([\w\s.:-]*)(.*)/, '$1');
+      }
+    }
+
+    return data;
+  }
+
+  /**
+   * Since RPs and client do not have full control over the UTM
+   * params that could be passed to them, we need to sanitize those values
+   * the best we can. This replaces and reports any invalid utm params which
+   * allows us to still submit the metrics.
+   *
+   * Coercion of data will be reported but NOT counted as a critical error.
+   */
+  public sanitizeUtmParams(data: CheckedUtmMetrics) {
+    const sanitize = (utmKey: keyof CheckedUtmMetrics) => {
+      const val = data[utmKey];
+      if (!this.isUtmValid(val)) {
+        // Report the error so we can see the issue, but do not consider it critical.
+        this.errorReporter.report(
+          new InvalidMetricError(
+            utmKey,
+            'invalid utm value',
+            false,
+            val,
+            INVALID_UTM
+          )
+        );
+
+        // Override original UTM param with `invalid` value. This will allow us
+        // to submit the metrics
+        data[utmKey] = INVALID_UTM;
+      }
+    };
+
+    sanitize('utm_campaign');
+    sanitize('utm_content');
+    sanitize('utm_medium');
+    sanitize('utm_term');
+    sanitize('utm_source');
+
+    return data;
+  }
+
+  /**
+   * Attempts to enforce a numeric range on a number
+   * @param {string} metricName - name of value being checked, if blank no error will be reported to sentry
+   * @param {any} val - value to clamp
+   * @param {number} min - minimum allowed value
+   * @param {number} max - maximum allowed value
+   * @param {any} def - default value in the event value is not a number
+   * @param {boolean} critical - whether or not the value is considered critical.
+   * @returns A number between min and max. If the initial value is not a number, and no
+   * default value was provided, then the initial value is returned.
+   */
+  public clamp(
+    metricName: string,
+    val: any,
+    min: number,
+    max: number,
+    def?: any,
+    critical: boolean = true
+  ) {
+    // Check inputs
+    if (min > max) {
+      throw new Error('min must be less than max');
+    }
+    if (def && (def < min || def > max)) {
+      throw new Error('def must be between min and max');
+    }
+
+    // Make sure value is an integer. Note this code can be called for a javascript context, so
+    // we have limited assurance on type safety.
+    let parsedVal = parseInt(val);
+
+    // Try to set a default value if one was provided and val isn't already a valid number
+    if (Number.isNaN(parsedVal)) {
+      parsedVal = parseInt(def);
+      this.errorReporter.report(
+        new InvalidMetricError(
+          metricName,
+          'not a number',
+          critical,
+          parsedVal,
+          min
+        )
+      );
+
+      // Short circuit, this means a valid default value not provided, so return
+      // the original value.
+      if (Number.isNaN(parsedVal)) {
+        return val;
+      }
+    }
+
+    // Clamp to ranges
+    if (parsedVal < min) {
+      this.errorReporter.report(
+        new InvalidMetricError(
+          metricName,
+          'below limit',
+          critical,
+          parsedVal,
+          min
+        )
+      );
+      parsedVal = min;
+    } else if (parsedVal > max) {
+      this.errorReporter.report(
+        new InvalidMetricError(
+          metricName,
+          'above limit',
+          critical,
+          parsedVal,
+          max
+        )
+      );
+      parsedVal = max;
+    }
+
+    return parsedVal;
+  }
+}

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -117,7 +117,7 @@
     "knex": "^2.2.0",
     "lodash.omitby": "^4.6.0",
     "lodash.pick": "^4.4.0",
-    "moment": "^2.29.2",
+    "moment": "^2.29.4",
     "mozlog": "^3.0.2",
     "mysql": "^2.18.1",
     "node-uap": "https://github.com/mozilla-fxa/node-uap.git#96dc1f9f224422ec184395b6408cd1fc40ee452a",

--- a/packages/fxa-shared/test/metrics/validate.ts
+++ b/packages/fxa-shared/test/metrics/validate.ts
@@ -1,0 +1,362 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import { BrowserClient } from '@sentry/browser';
+import moment from 'moment';
+import sinon from 'sinon';
+
+import {
+  INVALID_UTM,
+  MetricErrorReporter,
+  MetricValidator,
+} from '../../metrics/validate';
+
+const MAX_INTEGER = Number.MAX_SAFE_INTEGER;
+const INTEGER_OVERFLOW = Number.MAX_SAFE_INTEGER + 1;
+
+describe.only('sanitize', function () {
+  let client: BrowserClient;
+  let reporter: MetricErrorReporter;
+  let metrics: MetricValidator;
+  let fakeSentryCapture: any;
+
+  beforeEach(() => {
+    client = new BrowserClient();
+    fakeSentryCapture = sinon.replace(
+      client,
+      'captureException',
+      sinon.fake.returns('')
+    );
+    reporter = new MetricErrorReporter(client);
+    metrics = new MetricValidator(reporter, {
+      maxEventOffset: moment.duration(2, 'days').asMilliseconds(),
+    });
+  });
+
+  describe('clamp', function () {
+    it('returns original value when no default is defined', () => {
+      assert.equal(metrics.clamp('test', 'a', 0, 100), 'a');
+    });
+
+    it('returns a default value when value is invalid', () => {
+      assert.equal(metrics.clamp('test', 'a', 0, 100, 2), 2);
+    });
+
+    it('handles undefined values a default value', () => {
+      assert.equal(metrics.clamp('test', null, 0, 100, 2), 2);
+      assert.equal(metrics.clamp('test', undefined, 0, 100, 2), 2);
+    });
+
+    it('clamps to max', () => {
+      assert.equal(metrics.clamp('test', '101', 0, 100, 2), 100);
+      assert.equal(metrics.clamp('test', 101, 0, 100, 2), 100);
+    });
+
+    it('clamps to min', () => {
+      assert.equal(metrics.clamp('test', '-1', 0, 100, 2), 0);
+      assert.equal(metrics.clamp('test', -1, 0, 100, 2), 0);
+    });
+
+    it('fails on invalid min/max request', () => {
+      assert.throws(() => metrics.clamp('test', 2, 100, 0, 2));
+    });
+
+    it('clamps max integer overflow', () => {
+      assert.equal(
+        metrics.clamp('test', INTEGER_OVERFLOW, 0, MAX_INTEGER),
+        MAX_INTEGER
+      );
+    });
+
+    it('tracks critical error and reports it', () => {
+      metrics.clamp('test', 0, 1, 2, 2, true);
+      assert.equal(metrics.errorReporter.counts.critical, 1);
+      assert.equal(metrics.errorReporter.counts.captured, 1);
+      assert.equal(fakeSentryCapture.callCount, 1);
+    });
+
+    it('does not track critical error but does report it', () => {
+      metrics.clamp('test', 0, 1, 2, 2, false);
+
+      assert.equal(metrics.errorReporter.counts.critical, 0);
+      assert.equal(metrics.errorReporter.counts.captured, 1);
+      assert.equal(fakeSentryCapture.callCount, 1);
+    });
+  });
+
+  describe('sanitize', () => {
+    it('fixes bad utm param', () => {
+      const badUtm = '[bad]';
+      assert.include(
+        metrics.sanitizeUtmParams({
+          utm_campaign: badUtm,
+          utm_content: badUtm,
+          utm_medium: badUtm,
+          utm_source: badUtm,
+          utm_term: badUtm,
+        }),
+        {
+          utm_campaign: INVALID_UTM,
+          utm_content: INVALID_UTM,
+          utm_medium: INVALID_UTM,
+          utm_source: INVALID_UTM,
+          utm_term: INVALID_UTM,
+        }
+      );
+
+      assert.equal(metrics.errorReporter.counts.critical, 0);
+      assert.equal(metrics.errorReporter.counts.captured, 5);
+    });
+
+    it('fixes duration', () => {
+      assert.include(
+        metrics.sanitizeDuration({
+          duration: '',
+        }),
+        {
+          duration: 0,
+        }
+      );
+      assert.include(
+        metrics.sanitizeDuration({
+          duration: null,
+        }),
+        {
+          duration: 0,
+        }
+      );
+      assert.include(
+        metrics.sanitizeDuration({
+          duration: undefined,
+        }),
+        {
+          duration: 0,
+        }
+      );
+      assert.include(
+        metrics.sanitizeDuration({
+          duration: -1,
+        }),
+        {
+          duration: 0,
+        }
+      );
+      assert.include(
+        metrics.sanitizeDuration({
+          duration: INTEGER_OVERFLOW,
+        }),
+        {
+          duration: MAX_INTEGER,
+        }
+      );
+
+      // Make sure counts are correct.
+      assert.equal(metrics.errorReporter.counts.captured, 5);
+      assert.equal(metrics.errorReporter.counts.critical, 5);
+    });
+
+    it('fixes nav timings', () => {
+      assert.deepInclude(
+        metrics.sanitizeNavigationTiming({
+          navigationTiming: {
+            connectStart: undefined,
+            connectEnd: undefined,
+            domainLookupEnd: undefined,
+            redirectStart: undefined,
+          },
+        }),
+        {
+          navigationTiming: {
+            connectStart: null,
+            connectEnd: null,
+            domainLookupEnd: null,
+            redirectStart: null,
+          },
+        }
+      );
+
+      assert.deepInclude(
+        metrics.sanitizeNavigationTiming({
+          navigationTiming: {
+            connectStart: null,
+            connectEnd: null,
+            domainLookupEnd: null,
+            redirectStart: null,
+          },
+        }),
+        {
+          navigationTiming: {
+            connectStart: null,
+            connectEnd: null,
+            domainLookupEnd: null,
+            redirectStart: null,
+          },
+        }
+      );
+
+      assert.deepInclude(
+        metrics.sanitizeNavigationTiming({
+          navigationTiming: {
+            connectStart: '',
+            connectEnd: '',
+            domainLookupEnd: '',
+            redirectStart: '',
+          },
+        }),
+        {
+          navigationTiming: {
+            connectStart: null,
+            connectEnd: null,
+            domainLookupEnd: null,
+            redirectStart: null,
+          },
+        }
+      );
+
+      assert.deepInclude(
+        metrics.sanitizeNavigationTiming({
+          navigationTiming: {
+            connectStart: INTEGER_OVERFLOW,
+            connectEnd: INTEGER_OVERFLOW,
+            domainLookupEnd: INTEGER_OVERFLOW,
+            redirectStart: INTEGER_OVERFLOW,
+          },
+        }),
+        {
+          navigationTiming: {
+            connectStart: MAX_INTEGER,
+            connectEnd: MAX_INTEGER,
+            domainLookupEnd: MAX_INTEGER,
+            redirectStart: MAX_INTEGER,
+          },
+        }
+      );
+
+      assert.deepInclude(
+        metrics.sanitizeNavigationTiming({
+          navigationTiming: {
+            connectStart: -1,
+            connectEnd: -1,
+            domainLookupEnd: -1,
+            redirectStart: -1,
+          },
+        }),
+        {
+          navigationTiming: {
+            connectStart: 0,
+            connectEnd: 0,
+            domainLookupEnd: 0,
+            redirectStart: 0,
+          },
+        }
+      );
+
+      // Make sure counts are correct.
+      // Note that per test there are 2 tests with invalid values with 4 issues each.
+      assert.equal(metrics.errorReporter.counts.captured, 2 * 4);
+      assert.equal(metrics.errorReporter.counts.critical, 2 * 4);
+    });
+
+    it('fixes events.type', () => {
+      assert.deepInclude(
+        metrics.sanitizeEvents({
+          events: [
+            {
+              offset: 0,
+              type: 'some.error[weirdness]',
+            },
+          ],
+        }),
+        {
+          events: [
+            {
+              offset: 0,
+              type: 'some.error',
+            },
+          ],
+        }
+      );
+
+      // Make sure counts are correct. Note that type is not considered critical or captured
+      assert.equal(metrics.errorReporter.counts.captured, 0);
+      assert.equal(metrics.errorReporter.counts.critical, 0);
+    });
+
+    it('fixes events.offset', () => {
+      assert.deepInclude(
+        metrics.sanitizeEvents({
+          events: [
+            {
+              offset: -1,
+              type: 'some.type',
+            },
+          ],
+        }),
+        {
+          events: [
+            {
+              offset: 0,
+              type: 'some.type',
+            },
+          ],
+        }
+      );
+      assert.deepInclude(
+        metrics.sanitizeEvents({
+          events: [
+            {
+              offset: INTEGER_OVERFLOW,
+              type: 'some.type',
+            },
+          ],
+        }),
+        {
+          events: [
+            {
+              offset: moment.duration(2, 'days').asMilliseconds(),
+              type: 'some.type',
+            },
+          ],
+        }
+      );
+
+      // Make sure counts are correct.
+      assert.equal(metrics.errorReporter.counts.captured, 2);
+      assert.equal(metrics.errorReporter.counts.critical, 2);
+    });
+
+    it('fixes bad device id', () => {
+      assert.include(
+        metrics.sanitizeDeviceId({
+          deviceId: null,
+        }),
+        {
+          deviceId: 'none',
+        }
+      );
+      assert.include(
+        metrics.sanitizeDeviceId({
+          deviceId: undefined,
+        }),
+        {
+          deviceId: 'none',
+        }
+      );
+      assert.include(
+        metrics.sanitizeDeviceId({
+          deviceId: '',
+        }),
+        {
+          deviceId: 'none',
+        }
+      );
+
+      // Make sure counts are correct. Note that device id isn't considered critical, but
+      // it's not idea that it's undefined, so for the time being we still capture it.
+      assert.equal(metrics.errorReporter.counts.captured, 3);
+      assert.equal(metrics.errorReporter.counts.critical, 0);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -24275,7 +24275,7 @@ fsevents@~2.1.1:
     lodash.omitby: ^4.6.0
     lodash.pick: ^4.4.0
     mocha: ^10.0.0
-    moment: ^2.29.2
+    moment: ^2.29.4
     mozlog: ^3.0.2
     mysql: ^2.18.1
     node-uap: "https://github.com/mozilla-fxa/node-uap.git#96dc1f9f224422ec184395b6408cd1fc40ee452a"
@@ -33163,6 +33163,13 @@ fsevents@~2.1.1:
   version: 2.29.2
   resolution: "moment@npm:2.29.2"
   checksum: ee850b5776485e2af0775ceb3cfebaa7d7638f0a750fe0678fcae24c310749f96c1938808384bd422a55e5703834a71fcb09c8a1d36d9cf847f6ed0205d7a3e5
+  languageName: node
+  linkType: hard
+
+"moment@npm:^2.29.4":
+  version: 2.29.4
+  resolution: "moment@npm:2.29.4"
+  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- In the previous sprint changes were made to expose reasons for validation failure to Sentry
- We want to address as many of these validation errors as possible.

## This pull request

- Adds more sanitization to metrics data gathered on the client side.
- Reports issues encountered during sanitization directly, instead of waiting for 400 on server side and losing track of call stack that result in issue.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
