### PR TITLE
fix(auth): duplicate sub on refresh

### DIFF
--- a/packages/fxa-auth-server/lib/payments/utils.ts
+++ b/packages/fxa-auth-server/lib/payments/utils.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { createHash } from 'crypto';
 
 // Parse a comma-separated list with allowance for varied whitespace
 export function commaSeparatedListToArray(s: string) {
@@ -9,4 +10,10 @@ export function commaSeparatedListToArray(s: string) {
     .split(',')
     .map((c) => c.trim())
     .filter((c) => !!c);
+}
+
+export function generateIdempotencyKey(params: string[]) {
+  let sha = createHash('sha256');
+  sha.update(params.join(''));
+  return sha.digest('base64url');
 }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -914,7 +914,6 @@ describe('DirectStripeRoutes', () => {
           promotionCode: {
             coupon: { id: 'couponId' },
           },
-          subIdempotencyKey: `${VALID_REQUEST.payload.idempotencyKey}-createSub`,
           taxRateId: undefined,
         }
       );
@@ -1164,7 +1163,6 @@ describe('DirectStripeRoutes', () => {
           priceId: 'quux',
           promotionCode: undefined,
           paymentMethodId: undefined,
-          subIdempotencyKey: `${idempotencyKey}-createSub`,
           taxRateId: undefined,
         }
       );

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -116,9 +116,7 @@ export const PaypalButton = ({
           ...apiClientOverrides,
         };
         if (needsCustomer(customer)) {
-          await apiCreateCustomer({
-            idempotencyKey,
-          });
+          await apiCreateCustomer({});
         }
         // This is the same token as obtained in createOrder
         const token = data.orderID;
@@ -153,14 +151,15 @@ export const PaypalButton = ({
     [
       apiClientOverrides,
       customer,
-      idempotencyKey,
+      priceId,
+      productId,
       newPaypalAgreement,
       refreshSubmitNonce,
       postSubscriptionAttemptPaypalCallback,
-      selectedPlan,
       setSubscriptionError,
       setTransactionInProgress,
       promotionCode,
+      idempotencyKey,
     ]
   );
 
@@ -214,9 +213,11 @@ export const PaypalButton = ({
   return (
     <>
       <div
-        className={disabled
-          ? "relative after:absolute after:bg-white after:content-[''] after:opacity-60 after:top-0 after:left-0 after:w-full after:h-full after:z-[1000]"
-          : undefined}
+        className={
+          disabled
+            ? "relative after:absolute after:bg-white after:content-[''] after:opacity-60 after:top-0 after:left-0 after:w-full after:h-full after:z-[1000]"
+            : undefined
+        }
         data-testid="paypal-button-container"
       >
         {ButtonBase && (

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -367,7 +367,6 @@ describe('API requests', () => {
       expect(
         await apiCreateCustomer({
           displayName: 'Bar Fooson',
-          idempotencyKey: 'idk-8675309',
         })
       ).toEqual(MOCK_CUSTOMER);
       requestMock.done();
@@ -380,7 +379,6 @@ describe('API requests', () => {
       priceId: 'price_12345',
       productId: 'prod_abdce',
       paymentMethodId: 'pm_test',
-      idempotencyKey: 'idk-8675309',
     };
     const metricsOptions: EventProperties = {
       planId: params.priceId,
@@ -409,9 +407,9 @@ describe('API requests', () => {
     });
 
     it('sends amplitude ping on error', async () => {
-      const { priceId, paymentMethodId, idempotencyKey } = params;
+      const { priceId, paymentMethodId } = params;
       const requestMock = nock(AUTH_BASE_URL)
-        .post(path, { priceId, paymentMethodId, idempotencyKey })
+        .post(path, { priceId, paymentMethodId })
         .reply(400, { message: 'oops' });
       let error = null;
       try {
@@ -660,7 +658,6 @@ describe('API requests', () => {
   describe('apiCapturePaypalPayment', () => {
     const path = '/v1/oauth/subscriptions/active/new-paypal';
     const params = {
-      idempotencyKey: 'idk-8675309',
       priceId: 'price_12345',
       productId: 'product_2a',
       ...MOCK_CHECKOUT_TOKEN,

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -242,7 +242,6 @@ export async function apiCreatePasswordlessAccount(params: {
 
 export async function apiCreateCustomer(params: {
   displayName?: string;
-  idempotencyKey: string;
 }): Promise<Customer> {
   return apiFetch(
     'POST',
@@ -310,7 +309,6 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
   priceId: string;
   productId: string;
   paymentMethodId?: string;
-  idempotencyKey: string;
   promotionCode?: string;
 }): Promise<{
   id: string;
@@ -326,7 +324,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
     };
   };
 }> {
-  const { priceId, paymentMethodId, idempotencyKey, promotionCode } = params;
+  const { priceId, paymentMethodId, promotionCode } = params;
   const metricsOptions: Amplitude.EventProperties = {
     planId: params.priceId,
     productId: params.productId,
@@ -342,7 +340,6 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
         body: JSON.stringify({
           priceId,
           paymentMethodId,
-          idempotencyKey,
           metricsContext: getFlowData(),
           promotionCode: promotionCode,
         }),

--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -112,7 +112,6 @@ export async function handleSubscriptionPayment({
       await apiCreateSubscriptionWithPaymentMethod({
         priceId: selectedPlan.plan_id,
         productId: selectedPlan.product_id,
-        idempotencyKey,
         promotionCode: promotionCode,
       });
     return handlePaymentIntent({
@@ -152,7 +151,6 @@ export async function handleSubscriptionPayment({
     // No need to retain the result of this call for later.
     await apiCreateCustomer({
       displayName: name,
-      idempotencyKey,
     });
   }
 
@@ -172,7 +170,6 @@ export async function handleSubscriptionPayment({
         priceId: selectedPlan.plan_id,
         productId: selectedPlan.product_id,
         paymentMethodId: paymentMethod.id,
-        idempotencyKey,
         promotionCode: promotionCode,
       });
     return handlePaymentIntent({

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -326,29 +326,26 @@ export const SubscriptionCreate = ({
           </div>
         </div>
 
-        { (transactionInProgress && isMobile)
-          ? null
-          : (
-            <PlanDetails
+        {transactionInProgress && isMobile ? null : (
+          <PlanDetails
+            {...{
+              selectedPlan,
+              isMobile,
+              showExpandButton: isMobile,
+              coupon: coupon,
+            }}
+          >
+            <CouponForm
               {...{
-                selectedPlan,
-                isMobile,
-                showExpandButton: isMobile,
-                coupon: coupon,
+                planId: selectedPlan.plan_id,
+                readOnly: false,
+                subscriptionInProgress: inProgress || transactionInProgress,
+                coupon,
+                setCoupon,
               }}
-            >
-              <CouponForm
-                {...{
-                  planId: selectedPlan.plan_id,
-                  readOnly: false,
-                  subscriptionInProgress: inProgress || transactionInProgress,
-                  coupon,
-                  setCoupon,
-                }}
-              />
-            </PlanDetails>
-          )
-        }
+            />
+          </PlanDetails>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Because

- Users are able to create duplicate subscriptions when losing network
connectivity shortly after hitting the Pay Now button, trying again
and selecting Pay Now again.

## This pull request

- Create a hash of the uid and optionally the priceId of the
  subscription, to use as the idempotency key when creating the Stripe
  customer and subscription.

## Issue that this pull request solves

Closes: #13755

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).