### PR TITLE
feat(metrics): Expand the metrics that are stored during upgrades

### DIFF
--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -68,6 +68,7 @@ module.exports = (event, request, data) => {
       'utm_campaign',
       'utm_content',
       'utm_medium',
+      'utm_referrer',
       'utm_source',
       'utm_term',
     ];

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -26,6 +26,7 @@ const BODY_SCHEMA = joi.object({
       utm_campaign: UTM_CAMPAIGN.optional(),
       utm_content: UTM.optional(),
       utm_medium: UTM.optional(),
+      utm_referrer: UTM.optional(),
       utm_source: UTM.optional(),
       utm_term: UTM.optional(),
     })

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -45,12 +45,17 @@ export type EventProperties = GlobalEventProperties & {
   productId?: string;
   product_id?: string;
   paymentProvider?: PaymentProvider;
+  previousPlanId?: string;
+  previous_plan_id?: string;
+  previousProductId?: string;
+  previous_product_id?: string;
   promotionCode?: string;
   error?: Error;
   checkoutType?: string;
   utm_campaign?: string;
   utm_content?: string;
   utm_medium?: string;
+  utm_referrer?: string;
   utm_source?: string;
   utm_term?: string;
   other?: string;
@@ -114,9 +119,14 @@ const normalizeEventProperties = (eventProperties: EventProperties) => {
     productId = undefined,
     product_id = undefined,
     paymentProvider = undefined,
+    previousPlanId = undefined,
+    previous_plan_id = undefined,
+    previousProductId = undefined,
+    previous_product_id = undefined,
     utm_campaign = undefined,
     utm_content = undefined,
     utm_medium = undefined,
+    utm_referrer = undefined,
     utm_source = undefined,
     utm_term = undefined,
     ...otherEventProperties
@@ -126,10 +136,13 @@ const normalizeEventProperties = (eventProperties: EventProperties) => {
     planId: planId || plan_id,
     productId: productId || product_id,
     paymentProvider,
+    previousPlanId: previousPlanId || previous_plan_id,
+    previousProductId: previousProductId || previous_product_id,
     reason: error && error.message ? error.message : undefined,
     utm_campaign,
     utm_content,
     utm_medium,
+    utm_referrer,
     utm_source,
     utm_term,
     ...otherEventProperties,

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -240,11 +240,15 @@ describe('API requests', () => {
       planId: 'plan_2345',
       productId: 'prod_4567',
       paymentProvider: 'paypal' as PaymentProvider,
+      previousPlanId: 'plan_1234',
+      previousProductId: 'prod_3456',
     };
     const metricsOptions = {
       planId: params.planId,
       productId: params.productId,
       paymentProvider: params.paymentProvider,
+      previousPlanId: params.previousPlanId,
+      previousProductId: params.previousProductId,
     };
 
     it('PUT {auth-server}/v1/oauth/subscriptions/active', async () => {

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -22,6 +22,7 @@ export interface MetricsContext {
   utmCampaign?: string;
   utmContext?: string;
   utmMedium?: string;
+  utmReferrer?: string;
   utmSource?: string;
   utmTerm?: string;
 }
@@ -153,12 +154,23 @@ export async function apiUpdateSubscriptionPlan(params: {
   planId: string;
   productId: string;
   paymentProvider: PaymentProvider | undefined;
+  previousPlanId: string;
+  previousProductId: string;
 }) {
-  const { subscriptionId, planId, productId, paymentProvider } = params;
+  const {
+    subscriptionId,
+    planId,
+    productId,
+    paymentProvider,
+    previousPlanId,
+    previousProductId,
+  } = params;
   const metricsOptions: Amplitude.EventProperties = {
     planId,
     productId,
     paymentProvider,
+    previousPlanId,
+    previousProductId,
   };
   try {
     Amplitude.updateSubscriptionPlan_PENDING(metricsOptions);

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -7,6 +7,7 @@ export interface QueryParams {
   utm_campaign?: string;
   utm_context?: string;
   utm_medium?: string;
+  utm_referrer?: string;
   utm_source?: string;
   utm_term?: string;
 }

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -87,6 +87,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
     fireEvent.click(getByTestId('submit'));
     expect(updateSubscriptionPlanAndRefresh).toBeCalledWith(
       CUSTOMER.subscriptions[0].subscription_id,
+      UPGRADE_FROM_PLAN,
       SELECTED_PLAN,
       CUSTOMER.payment_provider
     );

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -73,6 +73,7 @@ export const SubscriptionUpgrade = ({
       if (validator.allValid()) {
         updateSubscriptionPlanAndRefresh(
           upgradeFromSubscription.subscription_id,
+          upgradeFromPlan,
           selectedPlan,
           paymentProvider
         );
@@ -82,6 +83,7 @@ export const SubscriptionUpgrade = ({
       validator,
       updateSubscriptionPlanAndRefresh,
       upgradeFromSubscription,
+      upgradeFromPlan,
       selectedPlan,
       paymentProvider,
     ]

--- a/packages/fxa-payments-server/src/store/actions/api.ts
+++ b/packages/fxa-payments-server/src/store/actions/api.ts
@@ -33,17 +33,20 @@ export default {
     ({ type: 'fetchCustomer', payload: apiFetchCustomer() } as const),
   updateSubscriptionPlan: (
     subscriptionId: string,
-    plan: Plan,
+    currentPlan: Plan,
+    newPlan: Plan,
     paymentProvider: PaymentProvider | undefined
   ) =>
     ({
       type: 'updateSubscriptionPlan',
-      meta: { subscriptionId, plan },
+      meta: { subscriptionId, newPlan },
       payload: apiUpdateSubscriptionPlan({
         subscriptionId,
-        planId: plan.plan_id,
-        productId: plan.product_id,
+        planId: newPlan.plan_id,
+        productId: newPlan.product_id,
         paymentProvider,
+        previousPlanId: currentPlan.plan_id,
+        previousProductId: currentPlan.product_id,
       }),
     } as const),
   cancelSubscription: (

--- a/packages/fxa-payments-server/src/store/sequences.test.ts
+++ b/packages/fxa-payments-server/src/store/sequences.test.ts
@@ -34,7 +34,8 @@ const dispatchError = jest.fn().mockImplementation(() => {
 });
 
 describe('updateSubscriptionPlanAndRefresh', () => {
-  const plan = MOCK_PLANS[0];
+  const currentPlan = MOCK_PLANS[0];
+  const newPlan = MOCK_PLANS[1];
   const subscriptionId = 'sub-8675309';
   const paymentProvider = 'paypal';
 
@@ -45,14 +46,16 @@ describe('updateSubscriptionPlanAndRefresh', () => {
   it('handles action exceptions as expected', async () => {
     await sequences.updateSubscriptionPlanAndRefresh(
       subscriptionId,
-      plan,
+      currentPlan,
+      newPlan,
       paymentProvider
     )(dispatchError);
 
     expect(dispatchError).toHaveBeenCalledTimes(1);
     expect(actions.updateSubscriptionPlan).toBeCalledWith(
       subscriptionId,
-      plan,
+      currentPlan,
+      newPlan,
       paymentProvider
     );
     expect(actions.fetchCustomer).not.toBeCalled();
@@ -62,14 +65,16 @@ describe('updateSubscriptionPlanAndRefresh', () => {
   it('calls actions as expected', async () => {
     await sequences.updateSubscriptionPlanAndRefresh(
       subscriptionId,
-      plan,
+      currentPlan,
+      newPlan,
       paymentProvider
     )(dispatch);
 
     expect(dispatch).toHaveBeenCalledTimes(3);
     expect(actions.updateSubscriptionPlan).toBeCalledWith(
       subscriptionId,
-      plan,
+      currentPlan,
+      newPlan,
       paymentProvider
     );
     expect(actions.fetchCustomer).toBeCalled();

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -53,13 +53,14 @@ export const fetchCustomerAndSubscriptions =
 export const updateSubscriptionPlanAndRefresh =
   (
     subscriptionId: string,
-    plan: Plan,
+    currentPlan: Plan,
+    newPlan: Plan,
     paymentProvider: PaymentProvider | undefined
   ) =>
   async (dispatch: Function) => {
     try {
       await dispatch(
-        updateSubscriptionPlan(subscriptionId, plan, paymentProvider)
+        updateSubscriptionPlan(subscriptionId, currentPlan, newPlan, paymentProvider)
       );
       await dispatch(fetchCustomerAndSubscriptions());
     } catch (err) {

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -63,7 +63,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.subPayManage]: NOP,
   [GROUPS.subPaySetup]: mapSubscriptionPaymentEventProperties,
   [GROUPS.subPayAccountSetup]: mapSubscriptionPaymentEventProperties,
-  [GROUPS.subPayUpgrade]: NOP,
+  [GROUPS.subPayUpgrade]: mapSubscriptionUpgradeEventProperties,
   [GROUPS.subSupport]: NOP,
   [GROUPS.subCoupon]: NOP,
   [GROUPS.qrConnectDevice]: NOP,
@@ -127,6 +127,27 @@ function mapDomainValidationResult(
   // properties for the results pertaining to domain_validation_result.
   if (eventType === 'domain_validation_result' && eventCategory) {
     return { validation_result: eventCategory };
+  }
+}
+
+function mapSubscriptionUpgradeEventProperties(
+  eventType,
+  eventCategory,
+  eventTarget,
+  data
+) {
+  if (data) {
+    const properties = {};
+
+    if (data.previousPlanId) {
+      properties['previous_plan_id'] = data.previousPlanId;
+    }
+
+    if (data.previousProductId) {
+      properties['previous_product_id'] = data.previousProductId;
+    }
+
+    return properties;
   }
 }
 
@@ -363,6 +384,7 @@ module.exports = {
           utm_campaign: data.utm_campaign,
           utm_content: data.utm_content,
           utm_medium: data.utm_medium,
+          utm_referrer: data.utm_referrer,
           utm_source: data.utm_source,
           utm_term: data.utm_term,
         }),

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -187,6 +187,7 @@ describe('metrics/amplitude:', () => {
             utm_campaign: 'u',
             utm_content: 'v',
             utm_medium: 'w',
+            utm_referrer: 'z',
             utm_source: 'x',
             utm_term: 'y',
           }
@@ -240,6 +241,7 @@ describe('metrics/amplitude:', () => {
             utm_campaign: 'u',
             utm_content: 'v',
             utm_medium: 'w',
+            utm_referrer: 'z',
             utm_source: 'x',
             utm_term: 'y',
           },


### PR DESCRIPTION
## Because

- the product and price change when upgrading products, we need to add `previous_plan_id`, `previous_product_id`, and `utm_referrer` to metrics

## This pull request

- revises `updateSubscriptionPlanAndRefresh` to also pass through the current plan (which will become the previous plan), so that `updateSubscriptionPlan` can extract its `plan_id` and `product_id` into `apiUpdateSubscriptionPlan`, as it was initially only extracting the `plan_id` and `product_id` from the new plan
- adds `utm_referrer` within other utm parameters

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
