### PR TITLE
fix(auth): provide default string if undefined

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -497,7 +497,7 @@ export class StripeHelper extends StripeHelperBase {
     const subIdempotencyKey = generateIdempotencyKey([
       customerId,
       priceId,
-      paymentMethod?.card?.fingerprint,
+      paymentMethod?.card?.fingerprint || '',
     ]);
 
     const createParams: Stripe.SubscriptionCreateParams = {


### PR DESCRIPTION
## Because

- Function does not allow undefined or null types.

## This pull request

- Add default string value in case of undefined.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).