### PR TITLE
fix(scripts): don't remove first line of 'yarn workspaces list' output

### DIFF
--- a/_scripts/compile-backend-ts-services.sh
+++ b/_scripts/compile-backend-ts-services.sh
@@ -5,8 +5,8 @@ fi
 
 # 1. Get the list of all modified and dependent services.
 echo "checking for modified services..."
-# Cleans up yarn's output by removing everything before the package name, the first and the last line.
-PACKAGES_MODIFIED=`yarn workspaces list --since=HEAD^ -R | cut -d/ -f2 | sed '1d' | sed '$d'`
+# Cleans up yarn's output by removing everything before the package name, and the last line.
+PACKAGES_MODIFIED=`yarn workspaces list --since=HEAD^ -R | cut -d/ -f2 | sed '$d'`
 
 # 2. If no services were modified, return early; otherwise we'd try to compile everything.
 if [[ $PACKAGES_MODIFIED == "" ]]; then


### PR DESCRIPTION
Because:
- Some affected packages were not being compiled

This pull request
- Includes the first line output by 'yarn workspaces list', so that the package is included in subsequent checks.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

For context, see https://app.circleci.com/pipelines/github/mozilla/fxa/33070/workflows/929a0641-6cff-48da-8b17-4c59fbb7de41/jobs/360331?invite=true#step-105-6 -- this patch modified the auth-server, yet the script erroneously said it was not modified.
