### PR TITLE
refactor(css): Tailwindify 'supp_allow' page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/supp_allow.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/supp_allow.mustache
@@ -1,7 +1,7 @@
-<div id="main-content" class="card pair-auth">
+<div class="card">
   <header>
-    <h1 id="fxa-pair-supp-allow-header">
-      {{#unsafeTranslate}}Confirm pairing <small>for %(email)s</small>{{/unsafeTranslate}}
+    <h1 id="fxa-pair-supp-allow-header" class="card-header">
+      {{#unsafeTranslate}}Confirm pairing <span class="card-subheader">for <span class="break-all">%(email)s</span></span>{{/unsafeTranslate}}
     </h1>
   </header>
 
@@ -12,8 +12,8 @@
     <form novalidate>
         {{{ unsafeDeviceBeingPairedHTML }}}
 
-      <div class="button-row">
-        <button type="submit" id="supp-approve-btn">{{#t}}Confirm pairing{{/t}}</button>
+      <div class="flex my-5">
+        <button type="submit" class="cta-primary cta-xl" id="supp-approve-btn">{{#t}}Confirm pairing{{/t}}</button>
       </div>
 
       <div class="links">

--- a/packages/fxa-content-server/app/scripts/templates/pair/supp_wait_for_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/supp_wait_for_auth.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card pair-auth">
+<div id="main-content" class="card">
   <header>
     <h1 id="fxa-pair-supp-wait-for-auth-header">
       {{#unsafeTranslate}}Approval now required <small>from your other device</small>{{/unsafeTranslate}}

--- a/packages/fxa-content-server/app/scripts/templates/partial/device-being-paired.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/device-being-paired.mustache
@@ -1,8 +1,8 @@
-<div class="client {{ deviceType }}">
-    {{#deviceName}}<h2 class="device-name">{{deviceName}}</h2>{{/deviceName}}
-    <div class="family-os">{{#t}}%(family)s on %(OS)s{{/t}}</div>
+<div class="mt-9">
+    {{#deviceName}}<h2 class="mb-5 text-base">{{deviceName}}</h2>{{/deviceName}}
 
-    <div class="location">
+    <p class="text-xs" id="family-os">{{#t}}%(family)s on %(OS)s{{/t}}</p>
+    <p class="text-xs" id="location">
         {{#country}}
             {{#city}}
                 {{#region}}{{#t}}%(city)s, %(region)s, %(country)s (estimated){{/t}}{{/region}}
@@ -14,6 +14,6 @@
             {{/city}}
         {{/country}}
         {{^country}}{{#t}}Location unknown{{/t}}{{/country}}
-    </div>
-    <div class="ip-address">{{#t}}IP address: %(ipAddress)s{{/t}}</div>
+    </p>
+    <p class="text-xs" id="ip-address">{{#t}}IP address: %(ipAddress)s{{/t}}</p>
 </div>

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -165,38 +165,6 @@
       display: block;
     }
   }
-
-  h2 {
-    color: $grey-80;
-    font-size: 16px;
-    font-weight: 500;
-    margin-bottom: 25px;
-  }
-
-  .client {
-    background-position: center top !important;
-    background-size: 65px;
-    color: $grey-70;
-    font-size: 13px;
-    margin: 0;
-    padding: 0 !important;
-    text-align: center;
-
-    .ip-address {
-      margin-bottom: 20px;
-    }
-  }
-
-  &.pair-auth-complete {
-    .client {
-      background-image: none;
-      padding: 0 !important;
-    }
-
-    .device-name {
-      display: none;
-    }
-  }
 }
 
 .qr-code-container {

--- a/packages/fxa-content-server/app/tests/spec/views/pair/auth_allow.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/auth_allow.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import $ from 'jquery';
 import Backbone from 'backbone';
 import { assert } from 'chai';
-import AuthorityBroker from 'models/auth_brokers/pairing/authority';
+import $ from 'jquery';
 import Notifier from 'lib/channels/notifier';
-import Relier from 'models/reliers/relier';
 import Session from 'lib/session';
-import sinon from 'sinon';
+import AuthorityBroker from 'models/auth_brokers/pairing/authority';
+import Relier from 'models/reliers/relier';
 import User from 'models/user';
+import sinon from 'sinon';
 import View from 'views/pair/auth_allow';
 
 const REMOTE_METADATA = {
@@ -30,7 +30,7 @@ const MOCK_ACCOUNT_PROFILE = {
   email: MOCK_EMAIL,
 };
 
-describe ('views/pair/auth_allow', () => {
+describe('views/pair/auth_allow', () => {
   let account;
   let broker;
   let config;
@@ -105,13 +105,13 @@ describe ('views/pair/auth_allow', () => {
             .includes(HEADER_TEXT)
         );
         assert.isTrue(view.$el.find('header p').text().includes(MOCK_EMAIL));
-        assert.equal(view.$el.find('.family-os').text(), 'Firefox on Windows');
+        assert.equal(view.$el.find('#family-os').text(), 'Firefox on Windows');
         assert.equal(
-          view.$el.find('.location').text().trim(),
+          view.$el.find('#location').text().trim(),
           'Toronto, Ontario, Canada (estimated)'
         );
         assert.equal(
-          view.$el.find('.ip-address').text(),
+          view.$el.find('#ip-address').text(),
           'IP address: 1.1.1.1'
         );
         view.submit();
@@ -127,14 +127,16 @@ describe ('views/pair/auth_allow', () => {
 
     it('can change password', async () => {
       sinon.spy(view, 'navigateAway');
-      
+
       await view.render();
-      
+
       view.$('#change-password').click();
-      
-      assert.isTrue(view.navigateAway.calledOnceWith('/settings/change_password'));
+
+      assert.isTrue(
+        view.navigateAway.calledOnceWith('/settings/change_password')
+      );
     });
-    
+
     it('handles errors', (done) => {
       sinon.spy(view, 'displayError');
       view.initialize();
@@ -185,13 +187,13 @@ describe ('views/pair/auth_allow', () => {
             .text()
             .includes(HEADER_TEXT)
         );
-        assert.equal(view.$el.find('.family-os').text(), 'Firefox on Windows');
+        assert.equal(view.$el.find('#family-os').text(), 'Firefox on Windows');
         assert.equal(
-          view.$el.find('.location').text().trim(),
+          view.$el.find('#location').text().trim(),
           'Toronto, Ontario, Canada (estimated)'
         );
         assert.equal(
-          view.$el.find('.ip-address').text(),
+          view.$el.find('#ip-address').text(),
           'IP address: 1.1.1.1'
         );
       });

--- a/packages/fxa-content-server/app/tests/spec/views/pair/auth_wait_for_supp.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/auth_wait_for_supp.js
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { assert } from 'chai';
-import AuthorityBroker from 'models/auth_brokers/pairing/authority';
-import Session from 'lib/session';
 import Notifier from 'lib/channels/notifier';
+import Session from 'lib/session';
+import AuthorityBroker from 'models/auth_brokers/pairing/authority';
 import Relier from 'models/reliers/relier';
-import sinon from 'sinon';
 import User from 'models/user';
+import sinon from 'sinon';
 import View from 'views/pair/auth_wait_for_supp';
 
 const REMOTE_METADATA = {
@@ -92,13 +92,13 @@ describe('views/pair/auth_wait_for_supp', () => {
   describe('render', () => {
     it('renders', () => {
       return view.render().then(() => {
-        assert.equal(view.$el.find('.family-os').text(), 'Firefox on Windows');
+        assert.equal(view.$el.find('#family-os').text(), 'Firefox on Windows');
         assert.equal(
-          view.$el.find('.location').text().trim(),
+          view.$el.find('#location').text().trim(),
           'Toronto, Ontario, Canada (estimated)'
         );
         assert.equal(
-          view.$el.find('.ip-address').text(),
+          view.$el.find('#ip-address').text(),
           'IP address: 1.1.1.1'
         );
       });

--- a/packages/fxa-content-server/app/tests/spec/views/pair/supp_allow.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/supp_allow.js
@@ -5,10 +5,10 @@
 import { assert } from 'chai';
 import $ from 'jquery';
 import Notifier from 'lib/channels/notifier';
+import SupplicantBroker from 'models/auth_brokers/pairing/supplicant';
 import Relier from 'models/reliers/relier';
 import sinon from 'sinon';
 import { mockPairingChannel } from 'tests/mocks/pair';
-import SupplicantBroker from 'models/auth_brokers/pairing/supplicant';
 import View from 'views/pair/supp_allow';
 
 const REMOTE_METADATA = {
@@ -74,13 +74,13 @@ describe('views/pair/supp_allow', () => {
       return view.render().then(() => {
         $('#container').html(view.el);
         assert.ok(view.$el.find('#supp-approve-btn').length);
-        assert.equal(view.$el.find('.family-os').text(), 'Firefox on Windows');
+        assert.equal(view.$el.find('#family-os').text(), 'Firefox on Windows');
         assert.equal(
-          view.$el.find('.location').text().trim(),
+          view.$el.find('#location').text().trim(),
           'Toronto, Ontario, Canada (estimated)'
         );
         assert.equal(
-          view.$el.find('.ip-address').text(),
+          view.$el.find('#ip-address').text(),
           'IP address: 1.1.1.1'
         );
         view.submit();

--- a/packages/fxa-content-server/app/tests/spec/views/pair/supp_wait_for_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/supp_wait_for_auth.js
@@ -4,12 +4,12 @@
 
 import { assert } from 'chai';
 import Notifier from 'lib/channels/notifier';
-import Relier from 'models/reliers/relier';
 import Session from 'lib/session';
-import { mockPairingChannel } from 'tests/mocks/pair';
-import sinon from 'sinon';
 import SupplicantBroker from 'models/auth_brokers/pairing/supplicant';
+import Relier from 'models/reliers/relier';
 import User from 'models/user';
+import sinon from 'sinon';
+import { mockPairingChannel } from 'tests/mocks/pair';
 import View from 'views/pair/supp_wait_for_auth';
 
 const REMOTE_METADATA = {
@@ -98,13 +98,13 @@ describe('views/pair/supp_wait_for_auth', () => {
   describe('render', () => {
     it('renders', () => {
       return view.render().then(() => {
-        assert.equal(view.$el.find('.family-os').text(), 'Firefox on Windows');
+        assert.equal(view.$el.find('#family-os').text(), 'Firefox on Windows');
         assert.equal(
-          view.$el.find('.location').text().trim(),
+          view.$el.find('#location').text().trim(),
           'Toronto, Ontario, Canada (estimated)'
         );
         assert.equal(
-          view.$el.find('.ip-address').text(),
+          view.$el.find('#ip-address').text(),
           'IP address: 1.1.1.1'
         );
       });


### PR DESCRIPTION
Because:
* We want to use Tailwind throughout the codebase for styling

This commit:
* Uses Tailwind styles for 'supp_allow.mustache' and 'device-being-paired.mustache'

Closes [FXA-5747](https://mozilla-hub.atlassian.net/browse/FXA-5747)

---

You can't test this locally unfortunately. I ended up hard-coding values into `pair/unsupported` to view the page that way.

<details>
<summary>click for code if you want to copy and paste this into pair/unsupported</summary>

```
<div class="card">
  <header>
    <h1 id="fxa-pair-supp-allow-header" class="card-header">
      {{#unsafeTranslate}}Confirm pairing <span class="card-subheader">for <span class="break-all">hackystuff@mozilla.com</span></span>{{/unsafeTranslate}}
    </h1>
  </header>

  <section>
    <div class="error"></div>
    <div class="success"></div>

    <form novalidate>

<div class="mt-9">
    <h2 class="mb-5 text-base">whomever's Nightly on Macbook-Pro</h2>

<p class="text-sm">
Firefox on MacOS
</p>
<p class="text-sm">
      Austin, Texas, United States (estimated)
</p>
    <p class="text-sm">{{#t}}IP address: 123.45.678.90{{/t}}</p>
    </div>


      <div class="flex my-5">
        <button type="submit" class="cta-primary cta-xl" id="supp-approve-btn">{{#t}}Confirm pairing{{/t}}</button>
      </div>

      <div>
        <a href="#" id="cancel" class="link-blue">{{#t}}Cancel{{/t}}</a>
      </div>
    </form>
  </section>
</div>
```
</details>

[Check Figma](https://www.figma.com/file/SE4xHgOW84yLiv7vFugm9R/Firefox-View-Stepping-Stone?node-id=12287%3A150711) for designs

Before (check ticket):
![image](https://user-images.githubusercontent.com/13018240/185684265-7bca4a1c-4b00-46d5-81a2-05dfba199da0.png)


After:
<img width="449" alt="E7F75C05-96E6-42FD-B717-A628323EDEEA" src="https://user-images.githubusercontent.com/13018240/185684316-048fd5f1-9331-4e1e-b424-189071584771.png">

