### PR TITLE
fix(content): Undo modifications to navigation timings.

### DIFF
--- a/packages/fxa-shared/metrics/navigation-timing.ts
+++ b/packages/fxa-shared/metrics/navigation-timing.ts
@@ -16,32 +16,11 @@ const NAV_ENTRY_TYPE = 'navigation';
 // export for testing
 export const sendFn = () => {
   if (!!navigator.sendBeacon) {
-    return (url: string, navTiming: PerformanceNavigationTiming) => {
-      // Clamp timings to 0. Sometimes negative values are getting reported
-      // causing validation errors. The w3c spec indicates all timing values
-      // should be unsigned longs, so we will enforce this here.
-      navTiming = Object.assign({}, navTiming, {
-        domComplete: Math.max(0, navTiming.domComplete),
-        domContentLoadedEventEnd: Math.max(
-          0,
-          navTiming.domContentLoadedEventEnd
-        ),
-        domContentLoadedEventStart: Math.max(
-          0,
-          navTiming.domContentLoadedEventStart
-        ),
-        domInteractive: Math.max(0, navTiming.domInteractive),
-        loadEventEnd: Math.max(0, navTiming.loadEventEnd),
-        loadEventStart: Math.max(0, navTiming.loadEventStart),
-        unloadEventEnd: Math.max(0, navTiming.unloadEventEnd),
-        unloadEventStart: Math.max(0, navTiming.unloadEventStart),
-      });
-
-      return navigator.sendBeacon(
+    return (url: string, navTiming: PerformanceNavigationTiming) =>
+      navigator.sendBeacon(
         url,
         new Blob([JSON.stringify(navTiming)], { type: 'application/json' })
       );
-    };
   }
 
   // noop if no avaiable API to send


### PR DESCRIPTION
## Because:
- After more discussion, we will not attempt to modify any navigation timing data.

## This pull request
- Undoes the part of the change made in #13493, so navigation timings aren't coerced into valid values.


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

