### PR TITLE
fix(content): Fixes double capture of validation errors.

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -217,7 +217,17 @@ function makeApp() {
   });
 
   // The sentry error handler must be before any other error middleware
-  app.use(sentry.sentryModule.Handlers.errorHandler());
+  app.use(
+    sentry.sentryModule.Handlers.errorHandler({
+      shouldHandleError(error) {
+        const success = tryCaptureValidationError(error);
+
+        // If the validation was explicitly captured, we return false. Otherwise the
+        // error is reported twice.
+        return !success;
+      },
+    })
+  );
 
   // log and capture any errors
   app.use((err, req, res, next) => {
@@ -229,7 +239,6 @@ function makeApp() {
         req.query,
         req.originalUrl
       );
-    tryCaptureValidationError(err);
     routeHelpers.validationErrorHandler(err, req, res, next);
   });
 

--- a/packages/fxa-content-server/server/lib/sentry.js
+++ b/packages/fxa-content-server/server/lib/sentry.js
@@ -115,13 +115,11 @@ function tryCaptureValidationError(err) {
       }, {});
 
       Sentry.withScope((scope) => {
+        scope.setTag('error_type', 'validation_error');
         scope.setContext('validationError', { validationError });
         Sentry.captureMessage(message, Sentry.Severity.Error);
       });
 
-      return true;
-    } else {
-      Sentry.captureException(err);
       return true;
     }
   } catch (err) {

--- a/packages/fxa-content-server/tests/server/sentry.js
+++ b/packages/fxa-content-server/tests/server/sentry.js
@@ -63,14 +63,10 @@ suite.tests['captures validation errors'] = function () {
   assert.ok(sentry.tryCaptureValidationError(err));
 };
 
-suite.tests['captures general error'] = function () {
-  var err = new Error('BOOM');
-  assert.ok(sentry.tryCaptureValidationError(err));
-};
-
-suite.tests['handles malformed error'] = function () {
-  var err = {};
-  assert.ok(sentry.tryCaptureValidationError(err));
+suite.tests['it ignores errors that are not validation based'] = function () {
+  assert.isFalse(sentry.tryCaptureValidationError(new Error('BOOM')));
+  assert.isFalse(sentry.tryCaptureValidationError({}));
+  assert.isFalse(sentry.tryCaptureValidationError('BOOM'));
 };
 
 registerSuite('sentry', suite);


### PR DESCRIPTION
## Because:
- The content server appeared to be capturing errors more than once.

## This pull request
- Ensures if the validation error is modified and captured, then the initial error is not reported.
- Adds a tag so that validation errors can be easily filtered for.

## Issue that this pull request solves

Closes: FXA-5792

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
