### PR TITLE
chore(dependabot): ignore patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,14 @@ updates:
       - dependency-name: "@types/*"
       - dependency-name: "web-push"
       - dependency-name: "jest-watch-typeahead" # To be removed after react-scripts update
+      - update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule: 
+    schedule:
       interval: daily
     open-pull-requests-limit: 6
-    reviewers: 
+    reviewers:
      - "@mozilla/fxa-devs"
-    labels: 
+    labels:
      - "maintenance"
      - "dependencies"


### PR DESCRIPTION
Because:

* we have too much dependabot traffic

This commit:

* ignores patch releases

Closes FXA-5684

