### PR TITLE
fix(content): Be more lenient with blocked uri values

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/post-csp.js
+++ b/packages/fxa-content-server/server/lib/routes/post-csp.js
@@ -15,7 +15,7 @@ const validation = require('../validation');
 
 const INTEGER_TYPE = validation.TYPES.INTEGER;
 const STRING_TYPE = validation.TYPES.LONG_STRING;
-const URL_TYPE = validation.TYPES.LONG_URL;
+const LONG_URI_TYPE = validation.TYPES.LONG_URI;
 
 const BODY_SCHEMA = {
   'csp-report': joi
@@ -23,7 +23,7 @@ const BODY_SCHEMA = {
     .keys({
       // CSP 2, 3 required
       // `eval` and `inline` are specified in CSP 3 and sent by Chrome
-      'blocked-uri': URL_TYPE.allow('')
+      'blocked-uri': LONG_URI_TYPE.allow('')
         .allow('asset')
         .allow('blob')
         .allow('data')
@@ -37,7 +37,7 @@ const BODY_SCHEMA = {
       disposition: STRING_TYPE.optional(),
       // CSP 2, 3 required
       // Allow 'about:srcdoc', see https://bugzilla.mozilla.org/show_bug.cgi?id=1073952#c22
-      'document-uri': URL_TYPE.required().allow('about:srcdoc'),
+      'document-uri': LONG_URI_TYPE.required().allow('about:srcdoc'),
       // CSP 2 required, but not always sent
       'effective-directive': STRING_TYPE.optional(),
       // CSP 2 optional

--- a/packages/fxa-content-server/server/lib/validation.js
+++ b/packages/fxa-content-server/server/lib/validation.js
@@ -59,10 +59,11 @@ const TYPES = {
     .string()
     .max(2048)
     .uri({ scheme: ['http', 'https'] }), // 2048 is also arbitrary, the same limit we use on the front end.
-  LONG_URL: joi
+  LONG_URI: joi
     .string()
     .max(64 * 1024) // 64k is the upper bounds of what is supported for URLs by browsers
-    .uri({ scheme: ['http', 'https'] }), // 2048 is also arbitrary, the same limit we use on the front end.
+    .uri()
+    .regex(/^telnet/i, { invert: true }),
   USER_PREFERENCES: joi.object().keys({
     'account-recovery': joi.boolean(),
     emails: joi.boolean(),


### PR DESCRIPTION
## Because:
- Many csp reports are being rejected due to value sent in for blocked-uri
- The spec doesn't limit URLs to http(s)

## This pull request
- Moves from LONG_URL validator to LONG_URI validator that doesn't have scheme restrictions
- Denies telnet scheme because there's a test explicitly checking this. Perhaps there are historical reasons to block this case

## Issue that this pull request solves

Closes: FXA-5756

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
