### PR TITLE
fix(l10n): fix inconsistencies and typography in reminder email strings

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en.ftl
@@ -1,7 +1,7 @@
 postVerify-sub-title-3 = We’re delighted to see you!
 postVerify-title-2 = Want to see the same tab on two devices?
 postVerify-description-2 = It’s easy! Just install { -brand-firefox } on another device and log in to sync. It’s like magic!
-postVerify-sub-description = (Psst…It also means you can get your bookmarks, passwords, and other { -brand-firefox } data everywhere you’re signed in.)
+postVerify-sub-description = (Psst… It also means you can get your bookmarks, passwords, and other { -brand-firefox } data everywhere you’re signed in.)
 postVerify-subject-3 = Welcome to { -brand-firefox }!
 postVerify-setup-2 = Connect another device:
 postVerify-action-2 = Connect another device

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.mjml
@@ -20,7 +20,7 @@
       <span data-l10n-id="postVerify-description-2">It’s easy! Just install Firefox on another device and log in to sync. It’s like magic!</span>
     </mj-text>
     <mj-text css-class="text-body">
-      <span data-l10n-id="postVerify-sub-description">(Psst…It also means you can get your bookmarks, passwords, and other Firefox data everywhere you’re signed in.)</span>
+      <span data-l10n-id="postVerify-sub-description">(Psst… It also means you can get your bookmarks, passwords, and other Firefox data everywhere you’re signed in.)</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.txt
@@ -4,7 +4,7 @@ postVerify-title-2 = "Want to see the same tab on two devices?"
 
 postVerify-description-2 = "It’s easy! Just install Firefox on another device and log in to sync. It’s like magic!"
 
-postVerify-sub-description = "(Psst…It also means you can get your bookmarks, passwords, and other Firefox data everywhere you’re signed in.)"
+postVerify-sub-description = "(Psst… It also means you can get your bookmarks, passwords, and other Firefox data everywhere you’re signed in.)"
 
 postVerify-setup-2 = "Connect another device:"
 <%- link %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
@@ -1,6 +1,6 @@
 verificationReminderFirst-subject-2 = Remember to confirm your account
 verificationReminderFirst-title-2 = Welcome to { -brand-firefox }!
-verificationReminderFirst-description-2 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account within the next 15 days or it will be automatically deleted.
+verificationReminderFirst-description-2 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.
 verificationReminderFirst-sub-description-2 = Don’t miss out on tech that puts you and your privacy first.
 confirm-email-2 = Confirm account
 confirm-email-plaintext-2 = { confirm-email-2 }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
@@ -13,7 +13,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-sub-body">
-      <span data-l10n-id="verificationReminderFirst-description-2">A few days ago you created a Firefox account, but never confirmed it. Please confirm your account within the next 15 days or it will be automatically deleted.</span>
+      <span data-l10n-id="verificationReminderFirst-description-2">A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.</span>
     </mj-text>
     <mj-text css-class="text-body">
       <span data-l10n-id="verificationReminderFirst-sub-description">Don’t miss out on tech that puts you and your privacy first.</span>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
@@ -1,6 +1,6 @@
 verificationReminderFirst-title-2 = "Welcome to Firefox"
 
-verificationReminderFirst-description-2 = "A few days ago you created a Firefox account, but never confirmed it. Please confirm your account within the next 15 days or it will be automatically deleted."
+verificationReminderFirst-description-2 = "A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted."
 
 verificationReminderFirst-sub-description = "Don’t miss out on tech that puts you and your privacy first."
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
@@ -1,5 +1,5 @@
 verificationReminderSecond-subject-2 = Remember to confirm your account
-verificationReminderSecond-title-2 = Don’t miss out on { -brand-firefox }
+verificationReminderSecond-title-2 = Don’t miss out on { -brand-firefox }!
 verificationReminderSecond-description-3 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.
 verificationReminderSecond-second-description = Your { -product-firefox-account } lets you sync your info across devices and unlocks access to more privacy-protecting products from { -brand-mozilla }.
 verificationReminderSecond-sub-description-2 = Be part of our mission to transform the internet into a place that’s open for everyone.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verificationReminderSecond-title-2">Don’t miss out on Firefox</span>
+      <span data-l10n-id="verificationReminderSecond-title-2">Don’t miss out on Firefox!</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.txt
@@ -1,4 +1,4 @@
-verificationReminderSecond-title-2 = "Don’t miss out on Firefox"
+verificationReminderSecond-title-2 = "Don’t miss out on Firefox!"
 
 verificationReminderSecond-description-3 = "A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted."
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -365,7 +365,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: 'We’re delighted to see you!' },
       { test: 'include', expected: 'Want to see the same tab on two devices?' },
       { test: 'include', expected: 'It’s easy! Just install Firefox on another device and log in to sync. It’s like magic!' },
-      { test: 'include', expected: '(Psst…It also means you can get your bookmarks, passwords, and other Firefox data everywhere you’re signed in.)' },
+      { test: 'include', expected: '(Psst… It also means you can get your bookmarks, passwords, and other Firefox data everywhere you’re signed in.)' },
       { test: 'include', expected: decodeUrl(configHref('syncUrl', 'account-verified', 'connect-device')) },
       { test: 'include', expected: decodeUrl(config.smtp.androidUrl) },
       { test: 'include', expected: decodeUrl(config.smtp.iosUrl) },


### PR DESCRIPTION
## Because

* A few inconsistencies were identified when reviewing strings before exposing them for localization in https://github.com/mozilla/fxa-content-server-l10n/pull/636

## This pull request

* Removes inconsistencies and fix typography (space after ellipsis)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Extracting new strings is currently blocked on this, since we want to avoid unnecessary churn for both localizers and devs.
