### PR TITLE
chore(fxa-auth-server): add link to PayPal dashboard in fxa-auth-server-readme

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -73,7 +73,7 @@ Use the following as a template, and fill in your own values:
 - `pwd` should be a sandbox PayPal business account password
 - `signature` should be a sandbox PayPal business account signature
 
-The sandbox PayPal business account API credentials above can be found in the PayPal developer dashboard under "Sandbox" > "Accounts". You may need to create a business account if one doesn't exist.
+The sandbox PayPal business account API credentials above can be found in the PayPal developer dashboard under ["Sandbox" > "Accounts"](https://developer.paypal.com/developer/accounts/). You may need to create a business account if one doesn't exist.
 
 ## Testing
 


### PR DESCRIPTION
## Because
It's somewhat unclear how to get to the PayPal dashboard if you're unfamiliar.

## This pull request
Adds a link directly to the relevant dashboard section.

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).