### PR TITLE
chore(db): development mysql version

### DIFF
--- a/_scripts/mysql.sh
+++ b/_scripts/mysql.sh
@@ -22,7 +22,7 @@ docker run --rm --name=mydb \
   -e MYSQL_ROOT_HOST=% \
   -e MYSQL_DATABASE=pushbox \
   -p 3306:3306 \
-  mysql/mysql-server:8.0.29 --default-authentication-plugin=mysql_native_password &
+  mysql/mysql-server:8.0.30 --default-authentication-plugin=mysql_native_password &
 
 cd "$DIR"
 ./check-mysql.sh


### PR DESCRIPTION
Because:
MySQL version 8.0.29 was pulled by MySQL due to a critical issue (see here: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html) and is no longer available for download. Attempting to run the _scripts/mysql.sh file will fail due to the lack of any 8.0.29 tag (https://hub.docker.com/r/mysql/mysql-server).

This commit:
Bumps MySQL to 8.0.30 as recommended by MySQL here https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html.

Closes: no corresponding issue

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).