### PR TITLE
test(functional): rewrite display name and delete account tests in playwright

### DIFF
--- a/packages/functional-tests/pages/settings/deleteAccount.ts
+++ b/packages/functional-tests/pages/settings/deleteAccount.ts
@@ -16,14 +16,19 @@ export class DeleteAccountPage extends SettingsLayout {
     return this.page.click('button[data-testid=continue-button]');
   }
 
+  clickCancel() {
+    return this.page.click('button[data-testid=cancel-button]');
+  }
+
   setPassword(password: string) {
     return this.page.fill('input[type=password]', password);
   }
 
+  toolTipText() {
+    return this.page.innerText('[data-testid="tooltip"]');
+  }
+
   submit() {
-    return Promise.all([
-      this.page.click('button[type=submit]'),
-      this.page.waitForNavigation(),
-    ]);
+    return this.page.click('button[type=submit]');
   }
 }

--- a/packages/functional-tests/pages/settings/displayName.ts
+++ b/packages/functional-tests/pages/settings/displayName.ts
@@ -11,6 +11,10 @@ export class DisplayNamePage extends SettingsLayout {
     return this.page.fill('input[type=text]', name);
   }
 
+  clickCancelDisplayName() {
+    return this.page.click('[data-testid="cancel-display-name"]');
+  }
+
   submit() {
     return Promise.all([
       this.page.click('button[type=submit]'),

--- a/packages/functional-tests/tests/settings/deleteAccount.spec.ts
+++ b/packages/functional-tests/tests/settings/deleteAccount.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, newPages } from '../../lib/fixtures/standard';
+
+test.describe('severity-1 #smoke', () => {
+  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293493
+  test('delete account and cancel delete #1293493', async ({
+    credentials,
+    pages: { settings, deleteAccount, page },
+  }) => {
+    test.slow();
+    await settings.goto();
+    await settings.clickDeleteAccount();
+    await deleteAccount.checkAllBoxes();
+
+    // Click cancel to cancel the deletion
+    await deleteAccount.clickCancel();
+
+    // Click Delete account again
+    await settings.clickDeleteAccount();
+    await deleteAccount.checkAllBoxes();
+    await deleteAccount.clickContinue();
+
+    // Enter incorrect password
+    await deleteAccount.setPassword('incorrect password');
+    await deleteAccount.submit();
+
+    // Verifying that the tooltip throws error
+    expect(await deleteAccount.toolTipText()).toMatch('Incorrect password');
+
+    // Enter correct password
+    await deleteAccount.setPassword(credentials.password);
+    await deleteAccount.submit();
+    const success = await page.waitForSelector('.success');
+    expect(await success.isVisible()).toBeTruthy();
+  });
+});

--- a/packages/functional-tests/tests/settings/displayName.spec.ts
+++ b/packages/functional-tests/tests/settings/displayName.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, newPages } from '../../lib/fixtures/standard';
+
+test.describe('severity-2 #smoke', () => {
+  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293371
+  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293373
+  test('add/change/cancel/remove the display name', async ({
+    pages: { settings, displayName },
+  }) => {
+    await settings.goto();
+    expect(await settings.displayName.statusText()).toEqual('None');
+    await settings.displayName.clickAdd();
+    await displayName.setDisplayName('TestUser1');
+
+    // Click cancel to cancel adding a display name
+    await displayName.clickCancelDisplayName();
+    await settings.displayName.clickAdd();
+    await displayName.setDisplayName('TestUser1');
+    await displayName.submit();
+
+    // Verify the added display name
+    expect(await settings.displayName.statusText()).toEqual('TestUser1');
+    await settings.displayName.clickAdd();
+    await displayName.setDisplayName('TestUser2');
+
+    // Click cancel to cancel changing the display name
+    await displayName.clickCancelDisplayName();
+    await settings.displayName.clickAdd();
+    await displayName.setDisplayName('TestUser2');
+    await displayName.submit();
+
+    //Verify the changed display name
+    expect(await settings.displayName.statusText()).toEqual('TestUser2');
+
+    // Remove display name
+    await settings.displayName.clickAdd();
+    await displayName.setDisplayName('');
+    await displayName.submit();
+    expect(await settings.displayName.statusText()).toEqual('None');
+  });
+});

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -21,41 +21,6 @@ test.describe('severity-1 #smoke', () => {
     expect(primary).toEqual(newEmail);
   });
 
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293493
-  test('delete account #1293493', async ({
-    credentials,
-    pages: { settings, deleteAccount, page },
-  }) => {
-    test.slow();
-    await settings.goto();
-    await settings.clickDeleteAccount();
-    await deleteAccount.checkAllBoxes();
-    await deleteAccount.clickContinue();
-    await deleteAccount.setPassword(credentials.password);
-    await deleteAccount.submit();
-    const success = await page.waitForSelector('.success');
-    expect(await success.isVisible()).toBeTruthy();
-  });
-});
-
-test.describe('severity-2 #smoke', () => {
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293371
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293373
-  test('set/unset the display name #1293371 #1293373', async ({
-    pages: { settings, displayName },
-  }) => {
-    await settings.goto();
-    expect(await settings.displayName.statusText()).toEqual('None');
-    await settings.displayName.clickAdd();
-    await displayName.setDisplayName('me');
-    await displayName.submit();
-    expect(await settings.displayName.statusText()).toEqual('me');
-    await settings.displayName.clickAdd();
-    await displayName.setDisplayName('');
-    await displayName.submit();
-    expect(await settings.displayName.statusText()).toEqual('None');
-  });
-
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293407
   test('removing secondary emails #1293407', async ({
     credentials,


### PR DESCRIPTION
## Because

As part of the Playwright Migration epic, rewrote the 'Settings - Display Name' and 'Delete account' tests (previously found in `tests/functional/settings/display_name.js` and `tests/functional/settings/delete_account.js` files) using playwright.

## This pull request
Contains tests for Settings - Display name and Delete account

## Issue that this pull request solves

Closes: #13855  

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@mozilla/fxa-devs @pdehaan please review!
