### PR TITLE
fix(fxa-settings): make copy sizes in connected services uniform

### DIFF
--- a/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
@@ -115,7 +115,7 @@ export function Service({
                   {name}
                 </LinkExternal>
               ) : (
-                <p className="text-xs break-word" data-testid="service-name">
+                <p className="text-sm break-word" data-testid="service-name">
                   {name}
                 </p>
               )}


### PR DESCRIPTION
## Because

- @pdehaan noticed that in the list of connected services visible when signed in to fxa-settings, linked connected services (such as Firefox Monitors) are a different font-size from unlinked connected services (such as a browser version).  We want the text to appear uniform.

## This pull request

- Matches the font-sizes across linked and unlinked services. The two sizes were "text-sm" and "text-xs" -- I have opted to change "text-xs" to "text-sm". There are other instances of "text-xs" within the services (such as location, if the location is provided, and the text within the button), so there are grounds for going in the other direction if anyone feels strongly about it.

## Issue that this pull request solves

Closes: #13899

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before: 
<img width="798" alt="Screen Shot 2022-08-25 at 11 02 37 AM" src="https://user-images.githubusercontent.com/11150372/186737301-2b5d7775-a804-41df-8977-eace761e0631.png">
After:
<img width="796" alt="Screen Shot 2022-08-25 at 11 02 07 AM" src="https://user-images.githubusercontent.com/11150372/186737292-c3101d28-0100-420c-855d-acf820d00532.png">

