### PR TITLE
Fxa 5726 remove sentry tracing references

### DIFF
--- a/packages/browserid-verifier/lib/config.js
+++ b/packages/browserid-verifier/lib/config.js
@@ -102,12 +102,6 @@ function loadConf() {
         format: 'Number',
         env: 'SENTRY_SAMPLE_RATE',
       },
-      tracesSampleRate: {
-        doc: 'Rate at which sentry traces are captured.',
-        default: 0.0,
-        format: 'Number',
-        env: 'SENTRY_TRACES_SAMPLE_RATE',
-      },
       serverName: {
         doc: 'Name used by sentry to identify the server.',
         default: 'browserid-verifier',

--- a/packages/browserid-verifier/lib/server.js
+++ b/packages/browserid-verifier/lib/server.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Sentry = require('@sentry/node');
-const Tracing = require('@sentry/tracing');
 
 const express = require('express'),
   bodyParser = require('body-parser'),
@@ -47,13 +46,8 @@ if (sentryConfig.dsn) {
       event = tagFxaName(event, opts.serverName);
       return event;
     },
-    integrations: [
-      new Sentry.Integrations.Http({ tracing: true }),
-      new Tracing.Integrations.Express({ app }),
-    ],
   });
   app.use(Sentry.Handlers.requestHandler());
-  app.use(Sentry.Handlers.tracingHandler());
 }
 
 var verifier = new CCVerifier({

--- a/packages/browserid-verifier/package.json
+++ b/packages/browserid-verifier/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@sentry/integrations": "6.19.7",
     "@sentry/node": "6.19.7",
-    "@sentry/tracing": "6.19.7",
     "async": "3.2.4",
     "body-parser": "^1.19.1",
     "browserid-local-verify": "0.5.2",

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@apollo/client": "^3.4.5",
     "@sentry/node": "^7.3.1",
-    "@sentry/tracing": "^7.3.1",
     "body-parser": "^1.19.1",
     "convict": "^6.2.3",
     "convict-format-with-moment": "^6.2.0",

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -76,12 +76,6 @@ const conf = convict({
       format: 'Number',
       env: 'SENTRY_SAMPLE_RATE',
     },
-    tracesSampleRate: {
-      doc: 'Rate at which sentry traces are captured.',
-      default: 0.0,
-      format: 'Number',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-admin-panel',

--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -4,7 +4,6 @@
 
 // TO DO: CORS, other security-related tasks (#4312)
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 
 import express, { Request, Response } from 'express';
 import bodyParser from 'body-parser';
@@ -61,13 +60,8 @@ if (sentryConfig.dsn) {
       event = tagFxaName(event, opts.serverName);
       return event;
     },
-    integrations: [
-      new Sentry.Integrations.Http({ tracing: true }),
-      new Tracing.Integrations.Express({ app }),
-    ],
   });
   app.use(Sentry.Handlers.requestHandler());
-  app.use(Sentry.Handlers.tracingHandler());
 }
 
 app.use(

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -80,12 +80,6 @@ const conf = convict({
       format: 'Number',
       env: 'SENTRY_SAMPLE_RATE',
     },
-    tracesSampleRate: {
-      doc: 'Rate at which sentry traces are captured.',
-      default: 0.0,
-      format: 'Number',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-admin-server',

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1646,12 +1646,6 @@ const conf = convict({
       format: 'Number',
       env: 'SENTRY_SAMPLE_RATE',
     },
-    tracesSampleRate: {
-      doc: 'Rate at which sentry traces are captured.',
-      default: 0.0,
-      format: 'Number',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-auth-server',

--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -7,7 +7,6 @@
 const config = require('../config').getProperties();
 const Hoek = require('@hapi/hoek');
 const Sentry = require('@sentry/node');
-require('@sentry/tracing');
 const { ExtraErrorData } = require('@sentry/integrations');
 const verror = require('verror');
 const { ERRNO } = require('./error');
@@ -194,7 +193,6 @@ async function configureSentry(server, config, processName = 'key_server') {
       integrations: [
         new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' }),
         new ExtraErrorData({ depth: 5 }),
-        new Sentry.Integrations.Http({ tracing: true }),
       ],
       // https://docs.sentry.io/platforms/node/configuration/options/#max-value-length
       maxValueLength: 500,

--- a/packages/fxa-content-server/app/scripts/lib/sentry.js
+++ b/packages/fxa-content-server/app/scripts/lib/sentry.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as Sentry from '@sentry/browser';
-import { BrowserTracing } from '@sentry/tracing';
 
 import {
   buildSentryConfig,
@@ -140,11 +139,6 @@ function SentryMetrics(config) {
         event = beforeSend(event);
         return event;
       },
-      integrations: [
-        new BrowserTracing({
-          tracingOrigins: opts.tracingOrigins,
-        }),
-      ],
     });
   } catch (e) {
     this._logger.error(e);

--- a/packages/fxa-content-server/app/tests/spec/lib/sentry.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/sentry.js
@@ -26,7 +26,6 @@ describe('lib/sentry', function () {
             dsn,
             env: 'test',
             sampleRate: 1.0,
-            tracesSampleRate: 1.0,
             clientName: 'fxa-content-server-test',
           },
         });

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -43,7 +43,6 @@
     "@sentry/browser": "^6.19.7",
     "@sentry/integrations": "^6.19.1",
     "@sentry/node": "^6.19.1",
-    "@sentry/tracing": "^6.19.1",
     "asmcrypto.js": "^0.22.0",
     "autoprefixer": "^10.4.7",
     "babel-loader": "^8.2.2",

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -38,7 +38,6 @@ const settingsConfig = {
     dsn: config.get('sentry.dsn'),
     env: config.get('sentry.env'),
     sampleRate: config.get('sentry.sampleRate'),
-    tracesSampleRate: config.get('sentry.tracesSampleRate'),
     clientName: config.get('sentry.clientName'),
     serverName: config.get('sentry.serverName'),
   },

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -639,12 +639,6 @@ const conf = (module.exports = convict({
       env: 'SENTRY_SAMPLE_RATE',
       format: Number,
     },
-    tracesSampleRate: {
-      default: 0.0,
-      doc: 'Sentry config for client side errors. If not set, then no errors reported.',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-      format: Number,
-    },
   },
   sourceMapType: {
     default: 'source-map',

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -33,7 +33,6 @@ module.exports = function (config) {
   const SENTRY_CLIENT_DSN = config.get('sentry.dsn');
   const SENTRY_CLIENT_ENV = config.get('sentry.env');
   const SENTRY_SAMPLE_RATE = config.get('sentry.sampleRate');
-  const SENTRY_TRACES_SAMPLE_RATE = config.get('sentry.tracesSampleRate');
   const SENTRY_CLIENT_NAME = config.get('sentry.clientName');
   const OAUTH_SERVER_URL = config.get('oauth_url');
   const PAIRING_CHANNEL_URI = config.get('pairing.server_base_uri');
@@ -81,7 +80,6 @@ module.exports = function (config) {
       dsn: SENTRY_CLIENT_DSN,
       env: SENTRY_CLIENT_ENV,
       sampleRate: SENTRY_SAMPLE_RATE,
-      tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
       clientName: SENTRY_CLIENT_NAME,
     },
     staticResourceUrl: STATIC_RESOURCE_URL,

--- a/packages/fxa-content-server/server/lib/sentry.js
+++ b/packages/fxa-content-server/server/lib/sentry.js
@@ -15,7 +15,6 @@ const {
 const logger = require('./logging/log')('sentry');
 
 const Sentry = require('@sentry/node');
-require('@sentry/tracing');
 
 function removeQuery(url) {
   if (!url) {
@@ -60,7 +59,6 @@ if (config.get('sentry.dsn')) {
         dsn: config.get('sentry.dsn'),
         env: config.get('sentry.env'),
         sampleRate: config.get('sentry.sampleRate'),
-        tracesSampleRate: config.get('sentry.tracesSampleRate'),
         serverName: config.get('sentry.serverName'),
       },
     },
@@ -76,7 +74,6 @@ if (config.get('sentry.dsn')) {
     },
     integrations: [
       new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' }),
-      new Sentry.Integrations.Http({ tracing: true }),
     ],
   });
 }

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -318,12 +318,6 @@ module.exports = function (fs, path, url, convict) {
         format: 'Number',
         env: 'SENTRY_SAMPLE_RATE',
       },
-      tracesSampleRate: {
-        doc: 'Rate at which sentry traces are captured.',
-        default: 0.0,
-        format: 'Number',
-        env: 'SENTRY_TRACES_SAMPLE_RATE',
-      },
       serverName: {
         doc: 'Name used by sentry to identify the server.',
         default: 'fxa-customs-server',

--- a/packages/fxa-customs-server/lib/sentry.js
+++ b/packages/fxa-customs-server/lib/sentry.js
@@ -6,7 +6,6 @@
 
 const Hoek = require('@hapi/hoek');
 const Sentry = require('@sentry/node');
-require('@sentry/tracing');
 const {
   buildSentryConfig,
   tagCriticalEvent,
@@ -28,7 +27,6 @@ async function configureSentry(server, config, log) {
     ...opts,
     integrations: [
       new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' }),
-      new Sentry.Integrations.Http({ tracing: true }),
     ],
     beforeSend(event, _hint) {
       event = tagCriticalEvent(event);

--- a/packages/fxa-event-broker/src/config.ts
+++ b/packages/fxa-event-broker/src/config.ts
@@ -209,12 +209,6 @@ const conf = convict({
       env: 'SENTRY_SAMPLE_RATE',
       format: 'Number',
     },
-    tracesSampleRate: {
-      default: 0.0,
-      doc: 'Rate at which traces are sampled.',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-      format: 'Number',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-event-broker',

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -206,12 +206,6 @@ const conf = convict({
       env: 'SENTRY_SAMPLE_RATE',
       format: 'Number',
     },
-    tracesSampleRate: {
-      default: 0.0,
-      doc: 'Rate at which traces are sampled.',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-      format: 'Number',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-graphql-api',

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -107,7 +107,6 @@
   "dependencies": {
     "@sentry/browser": "^6.19.7",
     "@sentry/node": "^6.19.1",
-    "@sentry/tracing": "^6.19.1",
     "@stripe/react-stripe-js": "^1.10.0",
     "@stripe/stripe-js": "^1.31.0",
     "accept-language-parser": "^1.5.0",

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -236,12 +236,6 @@ const conf = convict({
       env: 'SENTRY_SAMPLE_RATE',
       format: 'Number',
     },
-    tracesSampleRate: {
-      default: 0.0,
-      doc: 'Rate at which traces are sampled.',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-      format: 'Number',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-payments-broker',

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -21,7 +21,6 @@ module.exports = () => {
   const helmet = require('helmet');
   const noCache = require('nocache');
   const Sentry = require('@sentry/node');
-  const Tracing = require('@sentry/tracing');
   const serveStatic = require('serve-static');
 
   const bodyParser = require('body-parser');
@@ -75,7 +74,6 @@ module.exports = () => {
       dsn: config.get('sentry.dsn'),
       env: config.get('sentry.env'),
       sampleRate: config.get('sentry.sampleRate'),
-      tracesSampleRate: config.get('sentry.tracesSampleRate'),
       serverName: config.get('sentry.serverName'),
       clientName: config.get('sentry.clientName'),
     },
@@ -131,13 +129,8 @@ module.exports = () => {
         event = tagFxaName(event, opts.serverName);
         return event;
       },
-      integrations: [
-        new Sentry.Integrations.Http({ tracing: true }),
-        new Tracing.Integrations.Express({ app }),
-      ],
     });
     app.use(Sentry.Handlers.requestHandler());
-    app.use(Sentry.Handlers.tracingHandler());
   }
 
   const hstsEnabled = config.get('hstsEnabled');

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -104,7 +104,6 @@ const mockConfig = {
     env: 'test',
     sampleRate: 1.0,
     serverName: 'fxa-payments-server',
-    tracesSampleRate: 0.0,
   },
   version: '1.0.0',
 };
@@ -138,7 +137,6 @@ const expectedMergedConfig = {
     env: 'test',
     sampleRate: 1.0,
     serverName: 'fxa-payments-server',
-    tracesSampleRate: 0.0,
   },
   servers: {
     auth: {

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -16,7 +16,6 @@ export interface Config {
     dsn: string;
     env: string;
     sampleRate: number;
-    tracesSampleRate: number;
     clientName?: string;
     serverName?: string;
   };
@@ -63,7 +62,6 @@ export function defaultConfig(): Config {
       dsn: '',
       env: 'test',
       sampleRate: 1.0,
-      tracesSampleRate: 0.0,
       serverName: 'fxa-payments-server',
       clientName: 'fxa-payments-client',
     },

--- a/packages/fxa-payments-server/src/lib/sentry.js
+++ b/packages/fxa-payments-server/src/lib/sentry.js
@@ -4,7 +4,6 @@
 
 import Logger from './logger';
 import * as Sentry from '@sentry/browser';
-import { BrowserTracing } from '@sentry/tracing';
 
 import {
   tagFxaName,
@@ -145,11 +144,6 @@ SentryMetrics.prototype = {
           event = tagFxaName(event, opts.clientName);
           return event;
         },
-        integrations: [
-          new BrowserTracing({
-            tracingOrigins: opts.tracingOrigins,
-          }),
-        ],
       });
     } catch (e) {
       this._logger.error(e);

--- a/packages/fxa-payments-server/src/lib/sentry.test.js
+++ b/packages/fxa-payments-server/src/lib/sentry.test.js
@@ -31,7 +31,6 @@ describe('lib/sentry', function () {
             env,
             serverName,
             sampleRate: 1.0,
-            tracesSampleRate: 0.0,
           },
         });
       } catch (e) {
@@ -51,7 +50,6 @@ describe('lib/sentry', function () {
         env,
         serverName,
         sampleRate: 1.0,
-        tracesSampleRate: 0.0,
       },
     });
 

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -323,12 +323,6 @@ const conf = convict({
       format: 'Number',
       env: 'SENTRY_SAMPLE_RATE',
     },
-    tracesSampleRate: {
-      doc: 'Rate at which sentry traces are captured.',
-      default: 0.0,
-      format: 'Number',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-profile-server',

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -4,7 +4,6 @@
 
 const Hapi = require('@hapi/hapi');
 const Sentry = require('@sentry/node');
-require('@sentry/tracing');
 const cloneDeep = require('lodash').cloneDeep;
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
@@ -112,7 +111,6 @@ exports.create = async function createServer() {
         event = tagFxaName(event, opts.serverName);
         return event;
       },
-      integrations: [new Sentry.Integrations.Http({ tracing: true })],
     });
 
     // Attach a new Sentry scope to the request for breadcrumbs/tags/extras

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -84,7 +84,6 @@
     "@rescripts/cli": "0.0.16",
     "@sentry/browser": "^6.19.7",
     "@sentry/integrations": "^6.19.1",
-    "@sentry/tracing": "^6.19.1",
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-links": "^6.5.9",
     "@storybook/addon-postcss": "^2.0.0",

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -19,7 +19,6 @@ export interface Config {
     dsn: string;
     env: string;
     sampleRate: number;
-    tracesSampleRate: number;
     serverName: string;
     clientName: string;
     version: string;
@@ -58,7 +57,6 @@ export function getDefault() {
       serverName: 'fxa-settings-server',
       clientName: 'fxa-settings-client',
       sampleRate: 1.0,
-      tracesSampleRate: 0.0,
     },
     servers: {
       gql: {

--- a/packages/fxa-shared/lib/sentry.ts
+++ b/packages/fxa-shared/lib/sentry.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as Sentry from '@sentry/browser';
-import { BrowserTracing } from '@sentry/tracing';
 import Logger from './logger';
 import { buildSentryConfig, SentryConfigOpts, tagFxaName } from '../sentry';
 import { options } from 'superagent';
@@ -154,12 +153,6 @@ SentryMetrics.prototype = {
           }
           return event;
         },
-        integrations: [
-          // @ts-ignore
-          new BrowserTracing({
-            tracingOrigins: opts.tracingOrigins,
-          }),
-        ],
       });
     } catch (e) {
       this._logger.error(e);

--- a/packages/fxa-shared/nestjs/README.md
+++ b/packages/fxa-shared/nestjs/README.md
@@ -97,7 +97,6 @@ const version = getVersionInfo(__dirname);
           serverName: sentry.serverName,
           release: version.version,
           sampleRate: sentry.sampleRate,
-          tracesSampleRate: sentry.tracesSampleRate,
         };
       },
     }),

--- a/packages/fxa-shared/nestjs/sentry/sentry.interceptor.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.interceptor.ts
@@ -9,7 +9,6 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
-import '@sentry/tracing';
 import { Span, Transaction } from '@sentry/types';
 import { ApolloError } from 'apollo-server';
 import { Observable } from 'rxjs';

--- a/packages/fxa-shared/nestjs/sentry/sentry.service.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.service.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Inject, Injectable } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
-require('@sentry/tracing');
 import { ExtraErrorData } from '@sentry/integrations';
 
 import { buildSentryConfig, tagCriticalEvent, tagFxaName } from '../../sentry';
@@ -28,7 +27,6 @@ export class SentryService {
       normalizeDepth: 6,
       integrations: [
         new ExtraErrorData({ depth: 5 }),
-        new Sentry.Integrations.Http({ tracing: true }),
       ],
 
       beforeSend(event, hint) {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -91,7 +91,6 @@
     "@sentry/browser": "^6.19.7",
     "@sentry/integrations": "^6.19.1",
     "@sentry/node": "^6.19.1",
-    "@sentry/tracing": "^6.19.1",
     "@types/js-md5": "^0.4.2",
     "@types/uuid": "^8.3.1",
     "accept-language-parser": "^1.5.0",

--- a/packages/fxa-shared/sentry/config-builder.ts
+++ b/packages/fxa-shared/sentry/config-builder.ts
@@ -32,12 +32,9 @@ export function buildSentryConfig(config: SentryConfigOpts, log: ILogger) {
     release: config.release || config.version,
     environment: toEnv(config.sentry?.env),
     sampleRate: config.sentry?.sampleRate,
-    tracesSampleRate: config.sentry?.tracesSampleRate,
     clientName: config.sentry?.clientName,
     serverName: config.sentry?.serverName,
     fxaName: config.sentry?.clientName || config.sentry?.serverName,
-    // Experimental
-    tracingOrigins: ['localhost', '*.mozaws.net'],
   };
 
   return opts;
@@ -73,9 +70,6 @@ function checkSentryConfig(config: SentryConfigOpts, log: ILogger) {
 
   if (config.sentry?.sampleRate == null) {
     raiseError('config missing sentry.sampleRate');
-  }
-  if (config.sentry?.tracesSampleRate == null) {
-    raiseError('config missing sentry.tracesSampleRate');
   }
   if (!config.sentry.clientName && !config.sentry.serverName) {
     raiseError('config missing either sentry.clientName or sentry.serverName');

--- a/packages/fxa-shared/sentry/models/SentryConfigOpts.ts
+++ b/packages/fxa-shared/sentry/models/SentryConfigOpts.ts
@@ -13,8 +13,6 @@ export type SentryConfigOpts = {
     env?: string;
     /** The rate (as percent between 0 and 1) at which errors are sampled. Can be reduced to decrease data volume. */
     sampleRate?: number;
-    /** The rate (as percent between 0 and 1) at which traces are sampled. Can be reduced to decrease data volume. */
-    tracesSampleRate?: number;
     /** The name of the active client. */
     clientName?: string;
     /** The name of the active server. */

--- a/packages/fxa-shared/test/lib/sentry.ts
+++ b/packages/fxa-shared/test/lib/sentry.ts
@@ -15,7 +15,6 @@ const config: SentryConfigOpts = {
     env: 'test',
     clientName: 'fxa-shared-testing',
     sampleRate: 0,
-    tracesSampleRate: 0,
   },
 };
 

--- a/packages/fxa-shared/test/sentry/config-builder.ts
+++ b/packages/fxa-shared/test/sentry/config-builder.ts
@@ -35,7 +35,6 @@ describe('config-builder', () => {
       dsn: 'https://foo.sentry.io',
       env: 'test',
       sampleRate: 1,
-      tracesSampleRate: 0,
       serverName: 'fxa-shared-test',
       clientName: 'fxa-shared-client-test',
     },

--- a/packages/fxa-support-panel/src/config.ts
+++ b/packages/fxa-support-panel/src/config.ts
@@ -129,12 +129,6 @@ const conf = convict({
       env: 'SENTRY_SAMPLE_RATE',
       format: 'Number',
     },
-    tracesSampleRate: {
-      default: 0.0,
-      doc: 'Rate at which traces are sampled.',
-      env: 'SENTRY_TRACES_SAMPLE_RATE',
-      format: 'Number',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-support-panel',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6365,44 +6365,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/tracing@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/tracing@npm:6.19.7"
-  dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/minimal": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: 26e7bf435f0478356d95fab50fe4acd2cf449bfdfd457996111aeedd082f6c76f0592abd0c5f5dcfe2b582d3fd7988ffef07787e7ecc7f5d228278731ce6264e
-  languageName: node
-  linkType: hard
-
-"@sentry/tracing@npm:^6.19.1":
-  version: 6.19.2
-  resolution: "@sentry/tracing@npm:6.19.2"
-  dependencies:
-    "@sentry/hub": 6.19.2
-    "@sentry/minimal": 6.19.2
-    "@sentry/types": 6.19.2
-    "@sentry/utils": 6.19.2
-    tslib: ^1.9.3
-  checksum: 07bdc2658118d5ad8b0c921d6b15362731cac6383f82396784ba8fdecfabc9a9712456d5c5c90a24dc57fa6ecb8cb366cc5dc426482f2a2a243ee04c1c61c2ba
-  languageName: node
-  linkType: hard
-
-"@sentry/tracing@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "@sentry/tracing@npm:7.3.1"
-  dependencies:
-    "@sentry/hub": 7.3.1
-    "@sentry/types": 7.3.1
-    "@sentry/utils": 7.3.1
-    tslib: ^1.9.3
-  checksum: 5d01f502a59340e5e35c2aca5ff18d6bec4cc5c774c6b6915733f3d2899d6b868be9a8fc24baff5f708b3eac68c5e2ddf9109d592389c52b429155d0ca394a81
-  languageName: node
-  linkType: hard
-
 "@sentry/types@npm:6.19.2":
   version: 6.19.2
   resolution: "@sentry/types@npm:6.19.2"
@@ -15211,7 +15173,6 @@ __metadata:
   dependencies:
     "@sentry/integrations": 6.19.7
     "@sentry/node": 6.19.7
-    "@sentry/tracing": 6.19.7
     async: 3.2.4
     audit-filter: 0.5.0
     body-parser: ^1.19.1
@@ -22855,7 +22816,6 @@ fsevents@~2.1.1:
     "@babel/core": ^7.15.0
     "@rescripts/cli": 0.0.16
     "@sentry/node": ^7.3.1
-    "@sentry/tracing": ^7.3.1
     "@testing-library/jest-dom": ^5.16.5
     "@testing-library/react": ^12.1.5
     "@types/chance": ^1.1.2
@@ -23171,7 +23131,6 @@ fsevents@~2.1.1:
     "@sentry/browser": ^6.19.7
     "@sentry/integrations": ^6.19.1
     "@sentry/node": ^6.19.1
-    "@sentry/tracing": ^6.19.1
     "@testing-library/react": ^12.1.5
     "@types/backbone": ^1.4.10
     "@types/postcss-import": ^14
@@ -23601,7 +23560,6 @@ fsevents@~2.1.1:
     "@rescripts/cli": ~0.0.16
     "@sentry/browser": ^6.19.7
     "@sentry/node": ^6.19.1
-    "@sentry/tracing": ^6.19.1
     "@storybook/addon-actions": ^6.5.9
     "@storybook/addon-links": ^6.5.9
     "@storybook/addon-postcss": ^2.0.0
@@ -23821,7 +23779,6 @@ fsevents@~2.1.1:
     "@rescripts/cli": 0.0.16
     "@sentry/browser": ^6.19.7
     "@sentry/integrations": ^6.19.1
-    "@sentry/tracing": ^6.19.1
     "@storybook/addon-actions": ^6.5.9
     "@storybook/addon-links": ^6.5.9
     "@storybook/addon-postcss": ^2.0.0
@@ -23903,7 +23860,6 @@ fsevents@~2.1.1:
     "@sentry/browser": ^6.19.7
     "@sentry/integrations": ^6.19.1
     "@sentry/node": ^6.19.1
-    "@sentry/tracing": ^6.19.1
     "@type-cacheable/core": ^10.1.2
     "@type-cacheable/ioredis-adapter": ^10.0.4
     "@types/accept-language-parser": ^1.5.3


### PR DESCRIPTION
## Because

- (From Jira ticket): As we go through and switch services to use open telemetry and google cloud tracing, we will be phasing out the current sentry tracing integrations. This is just a follow up task to ensure that this has really been cleaned up.

## This pull request

- Removes `@sentry/tracing` dependency, and turns off tracing in sentry, and removes references to tracing in configs.

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

