### PR TITLE
Verify/verification copy update patch

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -287,7 +287,7 @@ var ERRORS = {
   },
   INVALID_EXPIRED_SIGNUP_CODE: {
     errno: 183,
-    message: t('Invalid or expired verification code'),
+    message: t('Invalid or expired confirmation code'),
   },
   SERVER_BUSY: {
     errno: 201,
@@ -389,7 +389,7 @@ var ERRORS = {
   },
   SIGNUP_EMAIL_BOUNCE: {
     errno: 1018,
-    message: t('Your verification email was just returned. Mistyped email?'),
+    message: t('Your confirmation email was just returned. Mistyped email?'),
   },
   DIFFERENT_EMAIL_REQUIRED: {
     errno: 1019,

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
@@ -17,7 +17,7 @@ const t = (msg) => msg;
 const proto = BaseBroker.prototype;
 
 const redirectToSettingsBehavior = new NavigateOrRedirectBehavior('settings', {
-  success: t('Account verified successfully'),
+  success: t('Account confirmed successfully'),
 });
 
 const redirectToSettingsAfterResetBehavior = new NavigateBehavior('settings', {

--- a/packages/fxa-content-server/tests/functional/sign_up_with_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_up_with_code.js
@@ -96,7 +96,7 @@ registerSuite('signup with code', {
         .then(
           testElementTextInclude(
             selectors.SIGNIN_TOKEN_CODE.TOOLTIP,
-            'invalid or expired verification code'
+            'invalid or expired confirmation code'
           )
         );
     },


### PR DESCRIPTION
## Because

- A few instances of the old "verify/verification" language slipped through because of the duplicate auth-error files.

## This pull request

- Addresses all instances of the old language persisting 

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
I've only provided screenshots of two (out of the three) instances that are mentioned in the ticket, because one of them seems to not trigger in local (if I put an invalid/non-existent email into the email input in local, the code still goes through to the inbox and does not trigger that error.) but I have updated strings for all of them!

<img width="453" alt="Screen Shot 2022-08-25 at 2 31 52 PM" src="https://user-images.githubusercontent.com/11150372/186772789-6c6e1c14-2cab-4028-985b-6180408b9c8c.png">
<img width="753" alt="Screen Shot 2022-08-25 at 2 32 15 PM" src="https://user-images.githubusercontent.com/11150372/186772793-e1dd3425-4afc-4840-82ac-17ce9e54e428.png">

