### PR TITLE
fix(dependabot): fix ignore patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,14 +14,15 @@ updates:
       - dependency-name: "@types/*"
       - dependency-name: "web-push"
       - dependency-name: "jest-watch-typeahead" # To be removed after react-scripts update
-      - update-types: ["version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 6
     reviewers:
-     - "@mozilla/fxa-devs"
+      - "@mozilla/fxa-devs"
     labels:
-     - "maintenance"
-     - "dependencies"
+      - "maintenance"
+      - "dependencies"


### PR DESCRIPTION
## Because

- CI test failed :(
<img width="891" alt="Screen Shot 2022-08-26 at 9 19 29 AM" src="https://user-images.githubusercontent.com/28129806/186912759-4f1a53d0-80d6-4d82-a1bc-9015edb32b2a.png">


## This pull request

- revises .yml file to include missing line

Screenshot:
<img width="757" alt="Screen Shot 2022-08-26 at 9 20 24 AM" src="https://user-images.githubusercontent.com/28129806/186912934-d4906ec9-7a4c-44e9-8452-811f407fd62f.png">

Source: [https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
