### PR TITLE
fix(auth-server): Fix failing test due to updated email copy strings

### DIFF
--- a/packages/fxa-auth-server/test/local/senders/renderer.ts
+++ b/packages/fxa-auth-server/test/local/senders/renderer.ts
@@ -123,12 +123,12 @@ describe('Renderer', () => {
       const result = await renderer.localizeAndRender(
         undefined,
         {
-          id: 'verifyShortCode-title',
-          message: 'Is this you signing up?',
+          id: 'verifyShortCode-title-2',
+          message: 'Open the internet with Firefox',
         },
         rendererContext
       );
-      assert.equal(result, 'Hai effettuato tu questo accesso?');
+      assert.equal(result, 'Esplora Internet con Firefox');
     });
   });
 });


### PR DESCRIPTION
## Because

- verifyShortCode email copy was updated

## This pull request

- updates the test that causes failing CI test in auth-server

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
<img width="1398" alt="Screen Shot 2022-08-26 at 11 41 52 AM" src="https://user-images.githubusercontent.com/28129806/186942590-46ff2044-0cbb-4550-897b-7d063b9b56c5.png">

