### PR TITLE
fix(fxa-content-server): prevent error if headers absent

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -302,7 +302,7 @@ module.exports = (log, config) => {
           productId,
           service,
           uid,
-          userAgent: request.headers['user-agent'],
+          userAgent: request.headers?.['user-agent'],
         },
       };
       log.info('rawAmplitudeData', rawEvent);

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -488,7 +488,7 @@ function receiveEvent(event, request, data) {
         eventSource: 'content',
         version: VERSION,
         emailTypes: EMAIL_TYPES,
-        userAgent: request.headers['user-agent'],
+        userAgent: request.headers?.['user-agent'],
         ..._.pick(data, [
           'deviceId',
           'devices',
@@ -521,7 +521,7 @@ function receiveEvent(event, request, data) {
     statsd.increment('amplitude.event.raw');
   }
 
-  const userAgent = ua.parse(request.headers['user-agent']);
+  const userAgent = ua.parse(request.headers?.['user-agent']);
 
   const amplitudeEvent = transform(
     event,

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -82,7 +82,7 @@ module.exports = (event, request, data) => {
       context: {
         eventSource: 'payments',
         version: VERSION,
-        userAgent: request.headers['user-agent'],
+        userAgent: request.headers?.['user-agent'],
         ...picked,
       },
     };
@@ -90,7 +90,7 @@ module.exports = (event, request, data) => {
     statsd.increment('amplitude.event.raw');
   }
 
-  const userAgent = ua.parse(request.headers['user-agent']);
+  const userAgent = ua.parse(request.headers?.['user-agent']);
 
   statsd.increment('amplitude.event');
 


### PR DESCRIPTION
## Because

- We've been getting this issue in Sentry about [this spot in code](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/server/lib/amplitude.js#L491)
```TypeError: Cannot read properties of undefined (reading 'user-agent')
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/metrics/amplitude.js", line 305, in receiveEvent
    userAgent: request.headers['user-agent']
```
We want this to fail gracefully.

## This pull request

- My interpretation of the above is that the headers sometimes come back as undefined, and when they do, we error out when we try to read `user-agent` off of undefined. So instead of just reading it directly, I use optional chaining to check the truthiness of `headers` before trying to access `user-agent` and return undefined if `headers` is a falsy value. I think that this should be safe because at the end of this function, the information is just logged out (as opposed to being passed elsewhere, where there might be an error from `userAgent` being unexpectedly undefined.)
- I do the same below, on line 524 (`const userAgent = ua.parse(request.headers?.['user-agent']);`). The `ua.parse` function does seem to be designed to accept undefined values ([see here](https://github.com/mozilla/fxa/blob/93834649392025fb17667f629eaae504ac399641/packages/fxa-shared/metrics/user-agent.d.ts#L23)).

## Issue that this pull request solves

Closes: # n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).