### PR TITLE
fix(metrics): Add many 'amplitude' event mappings for Settings events

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -78,14 +78,6 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'cwts_view',
   },
-  'settings.change-password.success': {
-    group: GROUPS.settings,
-    event: 'password',
-  },
-  'settings.signout.success': {
-    group: GROUPS.settings,
-    event: 'logout',
-  },
   'cached.signin.success': {
     group: GROUPS.login,
     event: 'complete',
@@ -109,81 +101,81 @@ const EVENTS = {
     event: 'signup_code_submit',
   },
 
-  // Add recovery key metrics
+  // Add recovery key metrics, on `post_verify/account_recovery/*`
   'screen.add-recovery-key': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'add_recovery_key_view',
   },
   'flow.add-recovery-key.submit': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'add_recovery_key_submit',
   },
 
   // Recovery key confirm password
   'screen.confirm-password': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'recovery_key_confirm_password_view',
   },
   'flow.confirm-password.engage': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'recovery_key_confirm_password_engage',
   },
   'flow.confirm-password.submit': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'recovery_key_confirm_password_submit',
   },
   'flow.confirm-password.success': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'recovery_key_confirm_password_success',
   },
 
   // Save recovery key
   'screen.save-recovery-key': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'save_recovery_key_view',
   },
   'flow.save-recovery-key.submit': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'save_recovery_key_submit',
   },
   'flow.save-recovery-key.copy': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'save_recovery_key_copy',
   },
   'flow.save-recovery-key.download': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'save_recovery_key_download',
   },
   'flow.save-recovery-key.print': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'save_recovery_key_print',
   },
 
   // Confirm recovery key
   'screen.confirm-recovery-key': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'confirm_recovery_key_view',
   },
   'flow.confirm-recovery-key.engage': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'confirm_recovery_key_engage',
   },
   'flow.confirm-recovery-key.submit': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'confirm_recovery_key_submit',
   },
   'flow.confirm-recovery-key.success': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'confirm_recovery_key_success',
   },
 
   // Verified recovery key
   'screen.post-verify.account-recovery.verified-recovery-key': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'verified_recovery_key_view',
   },
   'flow.post-verify.account-recovery.verified-recovery-key.submit': {
-    group: GROUPS.settings,
+    group: GROUPS.activity,
     event: 'verified_recovery_key_submit',
   },
 
@@ -259,6 +251,170 @@ const EVENTS = {
   'enter-email.thirdPartyAuth': {
     group: GROUPS.thirdPartyAuth,
     event: 'view',
+  },
+
+  /* Everything under this point should be Settings events, aka 'fxa_pref' group */
+  // temp fallback tests
+  'settings.test.fallback.start': {
+    group: GROUPS.settings,
+    event: 'test_fallback_start',
+    minimal: true,
+  },
+  'settings.test.fallback.text-needed': {
+    group: GROUPS.settings,
+    event: 'test_fallback_text_needed',
+    minimal: true,
+  },
+  'settings.test.fallback.text-not-needed': {
+    group: GROUPS.settings,
+    event: 'test_fallback_text_not_needed',
+    minimal: true,
+  },
+  // Recovery key
+  'screen.settings.account-recovery': {
+    group: GROUPS.settings,
+    event: 'account_recovery_view',
+  },
+  // Revoke
+  'flow.settings.account-recovery.confirm-revoke.submit': {
+    group: GROUPS.settings,
+    event: 'account_recovery_confirm_revoke_submit',
+  },
+  'flow.settings.account-recovery.confirm-revoke.success': {
+    group: GROUPS.settings,
+    event: 'account_recovery_confirm_revoke_success',
+  },
+  'flow.settings.account-recovery.confirm-revoke.fail': {
+    group: GROUPS.settings,
+    event: 'account_recovery_confirm_revoke_fail',
+  },
+  // Add
+  'flow.settings.account-recovery.confirm-password.submit': {
+    group: GROUPS.settings,
+    event: 'account_recovery_confirm_password_submit',
+  },
+  'flow.settings.account-recovery.confirm-password.success': {
+    group: GROUPS.settings,
+    event: 'account_recovery_confirm_password_success',
+  },
+  'flow.settings.account-recovery.confirm-password.fail': {
+    group: GROUPS.settings,
+    event: 'account_recovery_confirm_password_fail',
+  },
+  'flow.settings.account-recovery.recovery-key.download-option': {
+    group: GROUPS.settings,
+    event: 'account_recovery_option_download',
+  },
+  'flow.settings.account-recovery.recovery-key.copy-option': {
+    group: GROUPS.settings,
+    event: 'account_recovery_option_copy',
+  },
+  'flow.settings.account-recovery.recovery-key.print-option': {
+    group: GROUPS.settings,
+    event: 'account_recovery_option_print',
+  },
+  // Avatar
+  'screen.settings.avatar.change': {
+    group: GROUPS.settings,
+    event: 'avatar_change_view',
+  },
+  'avatar.crop.submit.change': {
+    group: GROUPS.settings,
+    event: 'avatar_crop_submit_change',
+  },
+  // Change password
+  'screen.settings.change-password': {
+    group: GROUPS.settings,
+    event: 'change_password_view',
+  },
+  'settings.change-password.success': {
+    group: GROUPS.settings,
+    event: 'password',
+  },
+  // Create password
+  'screen.settings.create-password': {
+    group: GROUPS.settings,
+    event: 'create_password_view',
+  },
+  'settings.create-password.engage': {
+    group: GROUPS.settings,
+    event: 'create_password_engage',
+  },
+  'settings.create-password.submit': {
+    group: GROUPS.settings,
+    event: 'create_password_submit',
+  },
+  'settings.create-password.success': {
+    group: GROUPS.settings,
+    event: 'create_password_success',
+  },
+  'settings.create-password.fail': {
+    group: GROUPS.settings,
+    event: 'create_password_fail',
+  },
+  // Delete account
+  'screen.settings.delete-account': {
+    group: GROUPS.settings,
+    event: 'delete_account_view',
+  },
+  'flow.settings.account-delete.terms-checked.success': {
+    group: GROUPS.settings,
+    event: 'delete_account_terms_checked_success',
+  },
+  'flow.settings.account-delete.confirm-password.success': {
+    group: GROUPS.settings,
+    event: 'delete_account_confirm_password_success',
+  },
+  'flow.settings.account-delete.confirm-password.fail': {
+    group: GROUPS.settings,
+    event: 'delete_account_confirm_password_fail',
+  },
+  // Secondary email
+  'screen.settings.emails': {
+    group: GROUPS.settings,
+    event: 'add_secondary_email_view',
+  },
+  'settings.emails.submit': {
+    group: GROUPS.settings,
+    event: 'add_secondary_email_submit',
+  },
+  'verify-secondary-email.verification.clicked': {
+    group: GROUPS.settings,
+    event: 'verify_secondary_email_clicked',
+  },
+  'verify-secondary-email.verification.success': {
+    group: GROUPS.settings,
+    event: 'verify_secondary_email_success',
+  },
+  'verify-secondary-email.verification.fail': {
+    group: GROUPS.settings,
+    event: 'verify_secondary_email_fail',
+  },
+  // Two factor auth
+  'screen.settings.two-step-authentication.recovery-codes': {
+    group: GROUPS.settings,
+    event: 'two_step_authentication_recovery_codes_view',
+  },
+  'flow.settings.two-step-authentication.submit': {
+    group: GROUPS.settings,
+    event: 'two_step_authentication_submit',
+  },
+  'flow.settings.two-step-authentication.download-option': {
+    group: GROUPS.settings,
+    event: 'two_step_authentication_recovery_codes_download',
+  },
+  'flow.settings.two-step-authentication.copy-option': {
+    group: GROUPS.settings,
+    event: 'two_step_authentication_recovery_codes_copy',
+  },
+  'flow.settings.two-step-authentication.print-option': {
+    group: GROUPS.settings,
+    event: 'two_step_authentication_recovery_codes_print',
+  },
+  // Misc
+  'settings.signout.success': {
+    group: GROUPS.settings,
+    event: 'logout',
   },
 };
 

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -41,6 +41,32 @@ const amplitude = proxyquire(path.resolve('server/lib/amplitude'), {
 const APP_VERSION_RE = /([0-9]+)\.([0-9]{1,2})$/;
 const APP_VERSION = APP_VERSION_RE.exec(pkg.version)[0];
 
+const getBasicEvent = (type) => ({
+  time: '1585321743',
+  type,
+});
+
+const BASIC_REQUEST = {
+  connection: {},
+  headers: {
+    'x-forwarded-for': '63.245.221.32',
+  },
+};
+
+const BASIC_DATA = {
+  flowBeginTime: '1585261624219',
+  flowId: '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+  uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+};
+
+function createAmplitudeEvent(
+  type = '',
+  request = BASIC_REQUEST,
+  data = BASIC_DATA
+) {
+  return amplitude({ ...getBasicEvent(type) }, { ...request }, { ...data });
+}
+
 registerSuite('amplitude', {
   beforeEach: function () {
     amplitudeConfig.disabled = false;
@@ -294,6 +320,16 @@ registerSuite('amplitude', {
       });
     },
 
+    'screen.settings.change-password': () => {
+      createAmplitudeEvent('screen.settings.change-password');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - change_password_view'
+      );
+    },
+
     'settings.change-password.success': () => {
       amplitude(
         {
@@ -365,6 +401,56 @@ registerSuite('amplitude', {
           utm_term: 'm',
         },
       });
+    },
+
+    'screen.settings.create-password': () => {
+      createAmplitudeEvent('screen.settings.create-password');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - create_password_view'
+      );
+    },
+
+    'settings.create-password.engage': () => {
+      createAmplitudeEvent('settings.create-password.engage');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - create_password_engage'
+      );
+    },
+
+    'settings.create-password.submit': () => {
+      createAmplitudeEvent('settings.create-password.submit');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - create_password_submit'
+      );
+    },
+
+    'settings.create-password.success': () => {
+      createAmplitudeEvent('settings.create-password.success');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - create_password_success'
+      );
+    },
+
+    'settings.create-password.fail': () => {
+      createAmplitudeEvent('settings.create-password.fail');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - create_password_fail'
+      );
     },
 
     'settings.clients.disconnect.submit': () => {
@@ -469,6 +555,248 @@ registerSuite('amplitude', {
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(logger.info.args[0][1].event_type, 'fxa_pref - logout');
+    },
+
+    'settings.test.fallback.start': () => {
+      createAmplitudeEvent('settings.test.fallback.start');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - test_fallback_start'
+      );
+    },
+
+    'settings.test.fallback.text-needed': () => {
+      createAmplitudeEvent('settings.test.fallback.text-needed');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - test_fallback_text_needed'
+      );
+    },
+
+    'settings.test.fallback.text-not-needed': () => {
+      createAmplitudeEvent('settings.test.fallback.text-not-needed');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - test_fallback_text_not_needed'
+      );
+    },
+
+    'flow.settings.account-recovery.confirm-revoke.submit': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.confirm-revoke.submit'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_confirm_revoke_submit'
+      );
+    },
+
+    'flow.settings.account-recovery.confirm-revoke.success': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.confirm-revoke.success'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_confirm_revoke_success'
+      );
+    },
+
+    'flow.settings.account-recovery.confirm-revoke.fail': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.confirm-revoke.fail'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_confirm_revoke_fail'
+      );
+    },
+
+    'flow.settings.account-recovery.confirm-password.submit': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.confirm-password.submit'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_confirm_password_submit'
+      );
+    },
+
+    'flow.settings.account-recovery.confirm-password.success': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.confirm-password.success'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_confirm_password_success'
+      );
+    },
+
+    'flow.settings.account-recovery.confirm-password.fail': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.confirm-password.fail'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_confirm_password_fail'
+      );
+    },
+
+    'flow.settings.account-recovery.recovery-key.download-option': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.recovery-key.download-option'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_option_download'
+      );
+    },
+
+    'flow.settings.account-recovery.recovery-key.print-option': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.recovery-key.print-option'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_option_print'
+      );
+    },
+
+    'screen.settings.avatar.change': () => {
+      createAmplitudeEvent('screen.settings.avatar.change');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - avatar_change_view'
+      );
+    },
+
+    'avatar.crop.submit.change': () => {
+      createAmplitudeEvent('avatar.crop.submit.change');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - avatar_crop_submit_change'
+      );
+    },
+
+    'screen.settings.delete-account': () => {
+      createAmplitudeEvent('screen.settings.delete-account');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - delete_account_view'
+      );
+    },
+
+    'flow.settings.account-delete.terms-checked.success': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-delete.terms-checked.success'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - delete_account_terms_checked_success'
+      );
+    },
+
+    'flow.settings.account-delete.confirm-password.success': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-delete.confirm-password.success'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - delete_account_confirm_password_success'
+      );
+    },
+
+    'flow.settings.account-delete.confirm-password.fail': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-delete.confirm-password.fail'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - delete_account_confirm_password_fail'
+      );
+    },
+
+    'screen.settings.emails': () => {
+      createAmplitudeEvent('screen.settings.emails');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - add_secondary_email_view'
+      );
+    },
+
+    'settings.emails.submit': () => {
+      createAmplitudeEvent('settings.emails.submit');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - add_secondary_email_submit'
+      );
+    },
+
+    'verify-secondary-email.verification.clicked': () => {
+      createAmplitudeEvent('verify-secondary-email.verification.clicked');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - verify_secondary_email_clicked'
+      );
+    },
+
+    'verify-secondary-email.verification.success': () => {
+      createAmplitudeEvent('verify-secondary-email.verification.success');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - verify_secondary_email_success'
+      );
+    },
+
+    'verify-secondary-email.verification.fail': () => {
+      createAmplitudeEvent('verify-secondary-email.verification.fail');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - verify_secondary_email_fail'
+      );
     },
 
     'flow.update-firefox.view': () => {
@@ -876,6 +1204,16 @@ registerSuite('amplitude', {
       assert.equal(arg.event_type, 'fxa_connect_device - view');
       assert.equal(arg.event_properties.connect_device_flow, 'signin');
       assert.equal(arg.event_properties.connect_device_os, undefined);
+    },
+
+    'screen.add-recovery-key': () => {
+      createAmplitudeEvent('screen.add-recovery-key');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - add_recovery_key_view'
+      );
     },
 
     'flow.connect-another-device.link.app-store.foo': () => {
@@ -1477,28 +1815,56 @@ registerSuite('amplitude', {
     },
 
     'screen.settings.two-step-authentication': () => {
-      amplitude(
-        {
-          time: '1585321743',
-          type: 'screen.settings.two-step-authentication',
-        },
-        {
-          connection: {},
-          headers: {
-            'x-forwarded-for': '63.245.221.32',
-          },
-        },
-        {
-          flowBeginTime: '1585261624219',
-          flowId:
-            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
-          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
-        }
-      );
+      createAmplitudeEvent('screen.settings.two-step-authentication');
+
       assert.equal(logger.info.callCount, 1);
       assert.equal(
         logger.info.args[0][1].event_type,
         'fxa_pref - two_step_authentication_view'
+      );
+    },
+
+    'flow.settings.two-step-authentication.submit': () => {
+      createAmplitudeEvent('flow.settings.two-step-authentication.submit');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - two_step_authentication_submit'
+      );
+    },
+
+    'flow.settings.two-step-authentication.download-option': () => {
+      createAmplitudeEvent(
+        'flow.settings.two-step-authentication.download-option'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - two_step_authentication_recovery_codes_download'
+      );
+    },
+
+    'flow.settings.two-step-authentication.copy-option': () => {
+      createAmplitudeEvent('flow.settings.two-step-authentication.copy-option');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - two_step_authentication_recovery_codes_copy'
+      );
+    },
+
+    'flow.settings.two-step-authentication.print-option': () => {
+      createAmplitudeEvent(
+        'flow.settings.two-step-authentication.print-option'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - two_step_authentication_recovery_codes_print'
       );
     },
 

--- a/packages/fxa-settings/src/components/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.test.tsx
@@ -337,7 +337,7 @@ describe('Connected Services', () => {
     await clickConfirmDisconnectButton();
     expect(logViewEvent).toHaveBeenCalledWith(
       'settings.clients.disconnect',
-      'submit.'
+      'submit.no-reason'
     );
     expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
 
@@ -368,7 +368,7 @@ describe('Connected Services', () => {
     await clickFirstSignOutButton();
     expect(logViewEvent).toHaveBeenCalledWith(
       'settings.clients.disconnect',
-      'submit.'
+      'submit.no-reason'
     );
     expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
 
@@ -423,7 +423,7 @@ describe('Connected Services', () => {
       await clickFirstSignOutButton();
       expect(logViewEvent).toHaveBeenCalledWith(
         'settings.clients.disconnect',
-        'submit.'
+        'submit.no-reason'
       );
 
       expect(mockWindowAssign).toHaveBeenCalledWith('foo-bar/signin');

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -95,7 +95,10 @@ export const ConnectedServices = () => {
   const disconnectClient = useCallback(
     async (client: AttachedClient) => {
       try {
-        logViewEvent('settings.clients.disconnect', `submit.${reason}`);
+        logViewEvent(
+          'settings.clients.disconnect',
+          `submit.${reason ? reason : 'no-reason'}`
+        );
 
         // disconnect all clients/sessions with this name since only unique names
         // are displayed to the user. This is batched into one network request request


### PR DESCRIPTION
Because:
* Many settings events weren't being properly stored because they weren't mapped to an 'amplitude' event group/name which we currently require for validation and property capturing (uid, flowId etc.)

This commit:
* Combs through our Settings pages for event names and adds ones that were missing, and tweaks a connected-devices event to match regex
* Updates current recovery key events to be in the 'activity' group, since they were not for settings pages
* Adds tests

Fixes [FXA-5762](https://mozilla-hub.atlassian.net/browse/FXA-5762)

---

Reviewer: you might be interested in the comments in that issue and sheets link Wil provided.

Essentially what I did here was search in `fxa-settings` for when we're calling `usePageViewEvent` and `logViewEvent` and checked `amplitude.js` in content-server + tests (**please expand that file in the diff**) to see what we weren't mapping, and also looked at events in [Wil's spreadsheet](https://docs.google.com/spreadsheets/d/17p_8ptV5pX87PSUgtBfqWxrcjRPQQPcdtXSaBWG_ZJc/edit#gid=1557746571) (check the tabs at the bottom). The raw events are only from a day, you'll have to run the query in BigQuery to get latest, if you want to look.

I also went through a few flows in content-server and most of the ones Settings with the Network panel up, checking the `request` POSTing to `/metrics`, just to double check the names were right. In going through content-server, I discovered the `/post_verify/account_recovery/add_recovery_key` URL which you can see after creating an account, which looks like this (without a recovery key - there's a different view with a recovery key)...

<img src="https://user-images.githubusercontent.com/13018240/186979803-b0706ec5-8509-4d98-861d-dcfa3bb90422.png" width=300px>

~I didn't dig a whole lot here but I saw the events for this page showing up in that spreadsheet under Amplitude events, so users must be seeing it. This was in a "settings" group, which I changed to "registration" since it's under `post_verify`, but I'm not sure if another group is more appropriate, and then added the settings recovery key events.~ See [this comment](https://github.com/mozilla/fxa/pull/14016#issuecomment-1228881506), I used `activity` instead.

**Also**, I realize I probably could have added a couple of these groups to `FUZZY_EVENTS`. However, I found it much easier and more clear _not_ to do this. See [my rant here](https://mozilla.slack.com/archives/CLV3KMZ8B/p1661451602158679?thread_ts=1661451369.450659&cid=CLV3KMZ8B). I'd like us to review how we're doing all this stuff at some point.

And then, I did add a test for all of the new events, but I just went with the most basic tests to verify the mapping. I didn't do data capture validation, which we do sporadically in tests it seems? We're thorough in some event tests, and not in others. I feel like we have _a lot_ of tests in this file already, so 🤷‍♀️ lemme know if you want to see anything in particular.