### PR TITLE
chore: upgrade typescript to 4.8.2

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -86,6 +86,6 @@
     "tailwindcss": "^3.0.24",
     "tailwindcss-textshadow": "^2.1.3",
     "ts-jest": "^28.0.7",
-    "typescript": "^4.5.2"
+    "typescript": "^4.8.2"
   }
 }

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -78,7 +78,7 @@
     "pm2": "^5.1.2",
     "supertest": "^6.2.4",
     "ts-jest": "^28.0.7",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "yargs": "^17.0.1"
   },
   "jest": {

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -32,7 +32,7 @@
     "esbuild-register": "^3.2.0",
     "fast-text-encoding": "^1.0.4",
     "mocha": "^10.0.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "webcrypto-liner": "https://github.com/mozilla-fxa/webcrypto-liner.git#6b3ad971b3b1f0d4da3855c6ceee9b3afa9f0eeb"
   }
 }

--- a/packages/fxa-auth-client/server.ts
+++ b/packages/fxa-auth-client/server.ts
@@ -17,6 +17,7 @@ https.globalAgent = new https.Agent({
 global.crypto = new Crypto();
 // @ts-ignore
 global.fetch = fetch;
+// @ts-ignore
 global.AbortController = AbortController;
 // @ts-ignore
 global.Headers = Headers;

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -210,7 +210,7 @@
     "through": "2.3.8",
     "type-fest": "^2.12.2",
     "typesafe-node-firestore": "^1.4.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "webpack": "^4.43.0",
     "webpack-watch-files-plugin": "^1.2.1",
     "ws": "^8.0.0"

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -46,7 +46,7 @@ export async function init() {
     .option(
       '-d, --lock-duration [milliseconds]',
       `The max duration in milliseconds to hold the lock.  The lock will be extended as needed.  Defaults to ${DEFAULT_LOCK_DURATION_MS}.`,
-      DEFAULT_LOCK_DURATION_MS
+      DEFAULT_LOCK_DURATION_MS.toString()
     )
     .parse(process.argv);
 

--- a/packages/fxa-auth-server/scripts/prune-oauth-authorization-codes.ts
+++ b/packages/fxa-auth-server/scripts/prune-oauth-authorization-codes.ts
@@ -25,7 +25,7 @@ export async function init() {
     .option(
       '--ttl <number>',
       'The TTL of OAuth authorization codes in milliseconds.  Defaults to 15 minutes.',
-      DEFAULT_TTL_MS
+      DEFAULT_TTL_MS.toString()
     )
     .on('--help', () =>
       console.log('\n\nPrunes up to 10000 expired OAuth authorization codes.')

--- a/packages/fxa-auth-server/scripts/prune-tokens.ts
+++ b/packages/fxa-auth-server/scripts/prune-tokens.ts
@@ -42,17 +42,17 @@ export async function init() {
     .option(
       '--maxTokenAge <duration>',
       'Max age of token. Any tokens older than this value will be pruned. A value of 0 results in a no-op.',
-      0
+      '0'
     )
     .option(
       '--maxCodeAge <duration>',
       'Max age of code. Any codes older than this value will be pruned. A value of 0 results in a no-op.',
-      0
+      '0'
     )
     .option(
       '--maxSessions <number>',
       'Max number of sessions that any account is allowed to hold. A value of 0 results in a no-op.',
-      0
+      '0'
     )
     .on('--help', function () {
       console.log(`

--- a/packages/fxa-auth-server/scripts/subscription-reminders.ts
+++ b/packages/fxa-auth-server/scripts/subscription-reminders.ts
@@ -21,12 +21,12 @@ async function init() {
     .option(
       '-p, --plan-length [days]',
       'Plan length in days beyond which a reminder email before the next recurring charge should be sent. Defaults to 180.',
-      DEFAULT_PLAN_LENGTH
+      DEFAULT_PLAN_LENGTH.toString()
     )
     .option(
       '-r, --reminder-length [days]',
       'Reminder length in days before the renewal date to send the reminder email. Defaults to 14.',
-      DEFAULT_REMINDER_LENGTH
+      DEFAULT_REMINDER_LENGTH.toString()
     )
     .parse(process.argv);
 

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -132,7 +132,7 @@
     "speed-trap": "0.0.10",
     "thread-loader": "^3.0.4",
     "time-grunt": "2.0.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "ua-parser-js": "1.0.2",
     "underscore": "^1.13.1",
     "verror": "1.10.1",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -105,7 +105,7 @@
     "ts-loader": "^8.4.0",
     "tsconfig-paths": "^4.0.0",
     "typesafe-node-firestore": "^1.4.0",
-    "typescript": "^4.5.2"
+    "typescript": "^4.8.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -101,7 +101,7 @@
     "prettier": "^2.3.1",
     "supertest": "^6.2.4",
     "ts-jest": "^28.0.7",
-    "typescript": "^4.5.2"
+    "typescript": "^4.8.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -100,7 +100,7 @@
     "supertest": "^6.2.4",
     "tailwindcss": "^3.0.24",
     "ts-jest": "^28.0.7",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "wait-for-expect": "^3.0.2",
     "webpack": "^4.43.0"
   },

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -79,7 +79,7 @@
     "sass-loader": "^10.0.3",
     "tailwindcss": "^3.0.24",
     "ts-jest": "^28.0.7",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "webpack": "^4.43.0"
   },
   "repository": {

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -76,7 +76,7 @@
     "react-scripts": "^4.0.3",
     "react-webcam": "^7.0.0",
     "subscriptions-transport-ws": "^0.11.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -77,7 +77,7 @@
     "ts-jest": "^28.0.7",
     "ts-loader": "^8.4.0",
     "tsconfig-paths": "^4.0.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "underscore": "^1.13.1",
     "uuid": "^8.3.2"
   },

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -76,7 +76,7 @@
     "prettier": "^2.3.1",
     "supertest": "^6.2.4",
     "ts-jest": "^28.0.7",
-    "typescript": "^4.5.2"
+    "typescript": "^4.8.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -22904,7 +22904,7 @@ fsevents@~2.1.1:
     tailwindcss: ^3.0.24
     tailwindcss-textshadow: ^2.1.3
     ts-jest: ^28.0.7
-    typescript: ^4.5.2
+    typescript: ^4.8.2
   languageName: unknown
   linkType: soft
 
@@ -22954,7 +22954,7 @@ fsevents@~2.1.1:
     ts-jest: ^28.0.7
     ts-morph: ^15.1.0
     tslib: ^2.3.1
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     yargs: ^17.0.1
   languageName: unknown
   linkType: soft
@@ -22977,7 +22977,7 @@ fsevents@~2.1.1:
     fast-text-encoding: ^1.0.4
     mocha: ^10.0.0
     node-fetch: ^2.6.1
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     webcrypto-liner: "https://github.com/mozilla-fxa/webcrypto-liner.git#6b3ad971b3b1f0d4da3855c6ceee9b3afa9f0eeb"
   languageName: unknown
   linkType: soft
@@ -23136,7 +23136,7 @@ fsevents@~2.1.1:
     type-fest: ^2.12.2
     typedi: ^0.8.0
     typesafe-node-firestore: ^1.4.0
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     uuid: ^8.3.2
     verror: ^1.10.1
     web-push: 3.4.4
@@ -23302,7 +23302,7 @@ fsevents@~2.1.1:
     thread-loader: ^3.0.4
     time-grunt: 2.0.0
     ts-loader: ^8.4.0
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     ua-parser-js: 1.0.2
     underscore: ^1.13.1
     upng-js: 2.1.0
@@ -23457,7 +23457,7 @@ fsevents@~2.1.1:
     ts-loader: ^8.4.0
     tsconfig-paths: ^4.0.0
     typesafe-node-firestore: ^1.4.0
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -23555,7 +23555,7 @@ fsevents@~2.1.1:
     supertest: ^6.2.4
     ts-jest: ^28.0.7
     tslib: ^2.3.1
-    typescript: ^4.5.2
+    typescript: ^4.8.2
   languageName: unknown
   linkType: soft
 
@@ -23692,7 +23692,7 @@ fsevents@~2.1.1:
     tailwindcss: ^3.0.24
     ts-jest: ^28.0.7
     typedi: ^0.8.0
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     uuid: ^8.3.2
     wait-for-expect: ^3.0.2
     webpack: ^4.43.0
@@ -23802,7 +23802,7 @@ fsevents@~2.1.1:
     tailwindcss: ^3.0.24
     tailwindcss-dir: ^4.0.0
     ts-jest: ^28.0.7
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     webpack: ^4.43.0
   languageName: unknown
   linkType: soft
@@ -23881,7 +23881,7 @@ fsevents@~2.1.1:
     style-loader: ^1.3.0
     subscriptions-transport-ws: ^0.11.0
     tailwindcss: ^3.0.24
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     uuid: ^8.3.2
     webpack: ^4.43.0
     webpack-merge-and-include-globally: ^2.3.4
@@ -23976,7 +23976,7 @@ fsevents@~2.1.1:
     ts-loader: ^8.4.0
     tsconfig-paths: ^4.0.0
     typesafe-node-firestore: ^1.4.0
-    typescript: ^4.5.2
+    typescript: ^4.8.2
     underscore: ^1.13.1
     uuid: ^8.3.2
   languageName: unknown
@@ -24027,7 +24027,7 @@ fsevents@~2.1.1:
     supertest: ^6.2.4
     ts-jest: ^28.0.7
     tslib: ^2.3.1
-    typescript: ^4.5.2
+    typescript: ^4.8.2
   languageName: unknown
   linkType: soft
 
@@ -43947,7 +43947,27 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.5.2#~builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.5.2#~builtin<compat/typescript>":
+"typescript@npm:^4.8.2":
+  version: 4.8.2
+  resolution: "typescript@npm:4.8.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7f5b81d0d558c9067f952c7af52ab7f19c2e70a916817929e4a5b256c93990bf3178eccb1ac8a850bc75df35f6781b6f4cb3370ce20d8b1ded92ed462348f628
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.8.2#~builtin<compat/typescript>":
+  version: 4.8.2
+  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=493e53"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 6f49363af8af2fe480da1d5fa68712644438785208b06690a3cbe5e7365fd652c3a0f1e587bc8684d78fb69de3dde4de185c0bad7bb4f3664ddfc813ce8caad6
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^4.5.2#~builtin<compat/typescript>":
   version: 4.5.2
   resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=493e53"
   bin:


### PR DESCRIPTION
Because:

* We want faster compilation and inferencing of TS 4.8.2.

This commit:

* Updates TS to 4.8.2. across the fxa workspace.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
