### PR TITLE
feat(pair): Add new entrypoint `fx-view` for showing QR code

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -171,6 +171,7 @@ module.exports = {
   FIREFOX_PREFERENCES_ENTRYPOINT: 'preferences',
   FIREFOX_SYNCED_TABS_ENTRYPOINT: 'synced-tabs',
   FIREFOX_TABS_SIDEBAR_ENTRYPOINT: 'tabs-sidebar',
+  FIREFOX_FX_VIEW: 'fx-view',
 
   // This is compared against all secondary email
   // records, both verified and unverified

--- a/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
@@ -33,7 +33,7 @@ export default {
   },
 
   /**
-   * Returns true if the we believe the current entry points merits that we show the user
+   * Returns true if we believe the current entry points merits that we show the user
    * a QR code that can be used download firefox on a mobile device.
    */
   showDownloadFirefoxQrCode() {
@@ -42,7 +42,8 @@ export default {
       entryPoint === Constants.FIREFOX_MENU_ENTRYPOINT ||
       entryPoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT ||
       entryPoint === Constants.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT
+      entryPoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT ||
+      entryPoint === Constants.FIREFOX_FX_VIEW
     );
   },
 };

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
@@ -60,6 +60,11 @@ describe('views/mixins/pairing-graphics-mixin', function () {
       assert.equal(view.showDownloadFirefoxQrCode(), true);
     });
 
+    it('returns true if entry point is fx-view', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => 'fx-view');
+      assert.equal(view.showDownloadFirefoxQrCode(), true);
+    });
+
     it('returns false if entry point is not app menu', () => {
       sinon.stub(view, 'getSearchParam').callsFake(() => undefined);
       assert.equal(view.showDownloadFirefoxQrCode(), false);


### PR DESCRIPTION
## Because

- Fx Desktop requested to show QR code when coming from `fx-view` entrypoint

## This pull request

- Adds the entrypoint

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5729

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="790" alt="Screen Shot 2022-08-29 at 1 56 40 PM" src="https://user-images.githubusercontent.com/1295288/187268278-ec6bc815-cebc-427f-9d61-12955b8a9217.png">

