### PR TITLE
feat(shared): make productSet Comma Separated Field

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -7,7 +7,7 @@ import { ClientIdCapabilityMap } from 'fxa-shared/subscriptions/types';
 import Stripe from 'stripe';
 import Container from 'typedi';
 
-import { commaSeparatedListToArray } from './utils';
+import { commaSeparatedListToArray } from 'fxa-shared/lib/utils';
 import error from '../error';
 import { AppleIAP } from './iap/apple-app-store/apple-iap';
 import { authEvents } from '../events';

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1829,7 +1829,7 @@ export class StripeHelper extends StripeHelperBase {
     ) {
       currentPlan.plan_metadata ??= {};
       currentPlan.plan_metadata['productSet'] =
-        currentPlan.configuration.productSet;
+        currentPlan.configuration.productSet.join(',');
       currentPlan.plan_metadata[
         'productOrder'
       ] = `${currentPlan.configuration.productOrder}`;
@@ -1839,7 +1839,8 @@ export class StripeHelper extends StripeHelperBase {
       newPlan.configuration?.productOrder
     ) {
       newPlan.plan_metadata ??= {};
-      newPlan.plan_metadata['productSet'] = newPlan.configuration.productSet;
+      newPlan.plan_metadata['productSet'] =
+        newPlan.configuration.productSet.join(',');
       newPlan.plan_metadata[
         'productOrder'
       ] = `${newPlan.configuration.productOrder}`;

--- a/packages/fxa-auth-server/lib/payments/utils.ts
+++ b/packages/fxa-auth-server/lib/payments/utils.ts
@@ -3,15 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { createHash } from 'crypto';
 
-// Parse a comma-separated list with allowance for varied whitespace
-export function commaSeparatedListToArray(s: string) {
-  return (s || '')
-    .trim()
-    .split(',')
-    .map((c) => c.trim())
-    .filter((c) => !!c);
-}
-
 export function generateIdempotencyKey(params: string[]) {
   let sha = createHash('sha256');
   sha.update(params.join(''));

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -24,7 +24,7 @@ import { Stripe } from 'stripe';
 
 import { ConfigType } from '../../../config';
 import error from '../../error';
-import { commaSeparatedListToArray } from '../../payments/utils';
+import { commaSeparatedListToArray } from 'fxa-shared/lib/utils';
 import { StripeHelper } from '../../payments/stripe';
 import {
   stripeInvoiceToFirstInvoicePreviewDTO,

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
@@ -21,7 +21,7 @@ import { Container } from 'typedi';
 
 import { PaymentConfigManager } from '../../lib/payments/configuration/manager';
 import { StripeHelper } from '../../lib/payments/stripe';
-import { commaSeparatedListToArray } from '../../lib/payments/utils';
+import { commaSeparatedListToArray } from 'fxa-shared/lib/utils';
 import {
   PLAN_EN_LANG_ERROR,
   getLanguageTagFromPlanMetadata,
@@ -270,7 +270,7 @@ export class StripeProductsAndPlansConverter {
     productConfig.stripeProductId = product.id;
     const { productSet, promotionCodes } = product.metadata;
     if (productSet) {
-      productConfig.productSet = productSet;
+      productConfig.productSet = commaSeparatedListToArray(productSet);
     }
     if (promotionCodes) {
       productConfig.promotionCodes = commaSeparatedListToArray(promotionCodes);

--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
@@ -255,7 +255,7 @@ describe('StripeProductsAndPlansConverter', () => {
           dcdb5ae7add825d2: ['123donePro', 'gogogo'],
         },
         locales: {},
-        productSet: '123done',
+        productSet: ['123done'],
         styles: {
           webIconBackground: 'lime',
         },
@@ -566,7 +566,7 @@ describe('StripeProductsAndPlansConverter', () => {
         dcdb5ae7add825d2: ['123donePro', 'gogogo'],
       },
       locales: {},
-      productSet: '123done',
+      productSet: ['123done'],
       styles: {
         webIconBackground: 'lime',
       },

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -362,7 +362,7 @@ export const MOCK_PLANS: Plan[] = [
       productOrder: 3,
     },
     product_metadata: {
-      productSet: 'example_upgrade',
+      productSet: ['example_upgrade'],
       webIconURL: 'http://example.com/product.jpg',
       webIconBackground: 'purple',
     },
@@ -377,7 +377,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: '123done',
+      productSet: ['123done'],
       webIconURL: 'http://example.com/123donepro.jpg',
       webIconBackground: 'orange',
       'product:subtitle': '123DonePro subtitle',
@@ -395,7 +395,7 @@ export const MOCK_PLANS: Plan[] = [
       productOrder: 5,
     },
     product_metadata: {
-      productSet: 'example_upgrade',
+      productSet: ['example_upgrade'],
     },
   },
   {
@@ -408,7 +408,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: {},
     product_metadata: {
-      productSet: 'example_upgrade',
+      productSet: ['example_upgrade'],
     },
   },
   {
@@ -423,7 +423,7 @@ export const MOCK_PLANS: Plan[] = [
       productOrder: 1,
     },
     product_metadata: {
-      productSet: 'example_upgrade',
+      productSet: ['example_upgrade'],
     },
   },
   {
@@ -436,7 +436,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -449,7 +449,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -462,7 +462,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -475,7 +475,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -488,7 +488,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -501,7 +501,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -514,7 +514,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {
@@ -527,7 +527,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     plan_metadata: null,
     product_metadata: {
-      productSet: 'fpn',
+      productSet: ['fpn'],
     },
   },
   {

--- a/packages/fxa-shared/lib/utils.ts
+++ b/packages/fxa-shared/lib/utils.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Parse a comma-separated list with allowance for varied whitespace
+export function commaSeparatedListToArray(s: string) {
+  return (s || '')
+    .trim()
+    .split(',')
+    .map((c) => c.trim())
+    .filter((c) => !!c);
+}

--- a/packages/fxa-shared/subscriptions/configuration/base.ts
+++ b/packages/fxa-shared/subscriptions/configuration/base.ts
@@ -116,7 +116,7 @@ export interface ProductConfigSchemaValidation {
 
 export const minimalConfigSchema = joi.object({
   id: joi.string().optional().allow(null).allow(''),
-  productSet: joi.string().optional().allow(null).allow(''),
+  productSet: joi.array().items(joi.string()).optional().allow(null),
   urls: urlsSchema,
   uiContent: uiContentSchema,
   styles: stylesSchema,

--- a/packages/fxa-shared/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/subscriptions/configuration/plan.ts
@@ -57,7 +57,7 @@ export class PlanConfig implements BaseConfig {
 
   // Extended by PlanConfig
   stripePriceId?: string;
-  productSet?: string;
+  productSet?: string[];
   productOrder?: number;
   [STRIPE_PRICE_METADATA.PLAY_SKU_IDS]?: string[];
   [STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS]?: string[];

--- a/packages/fxa-shared/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/subscriptions/configuration/product.ts
@@ -17,7 +17,7 @@ import {
 
 export const productConfigJoiKeys = {
   stripeProductId: joi.string().optional(),
-  productSet: joi.string().optional(),
+  productSet: joi.array().items(joi.string()).optional(),
   promotionCodes: joi.array().items(joi.string()).optional(),
 };
 
@@ -77,7 +77,7 @@ export class ProductConfig implements BaseConfig {
 
   // Extended by ProductConfig
   stripeProductId?: string;
-  productSet?: string;
+  productSet?: string[];
 
   static async validate(
     productConfig: ProductConfig,

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -10,6 +10,7 @@ import {
   ProductMetadata,
   RawMetadata,
 } from './types';
+import { commaSeparatedListToArray } from '../lib/utils';
 
 const DEFAULT_LOCALE = 'en-US';
 
@@ -35,20 +36,30 @@ export const DEFAULT_PRODUCT_DETAILS: ProductDetails = {
 
 // Support some default null values for product / plan metadata and
 // allow plan metadata to override product metadata
-export const metadataFromPlan = (plan: Plan): ProductMetadata => ({
-  productSet: null,
-  productOrder: null,
-  emailIconURL: null,
-  webIconURL: null,
-  webIconBackground: null,
-  upgradeCTA: null,
-  successActionButtonURL: null,
-  'product:termsOfServiceDownloadURL': '',
-  'product:termsOfServiceURL': '',
-  'product:privacyNoticeURL': '',
-  ...plan.product_metadata,
-  ...plan.plan_metadata,
-});
+export const metadataFromPlan = (plan: Plan): ProductMetadata => {
+  const metadata = {
+    productSet: null,
+    productOrder: null,
+    emailIconURL: null,
+    webIconURL: null,
+    webIconBackground: null,
+    upgradeCTA: null,
+    successActionButtonURL: null,
+    'product:termsOfServiceDownloadURL': '',
+    'product:termsOfServiceURL': '',
+    'product:privacyNoticeURL': '',
+    ...plan.product_metadata,
+    ...plan.plan_metadata,
+  };
+
+  if (typeof metadata.productSet === 'string') {
+    //@ts-ignore
+    // prettier-ignore
+    metadata.productSet = commaSeparatedListToArray(metadata.productSet);
+  }
+
+  return metadata;
+};
 
 /**
  * Parses through Stripe metadata for product detail strings and localized overrides

--- a/packages/fxa-shared/subscriptions/stripe.ts
+++ b/packages/fxa-shared/subscriptions/stripe.ts
@@ -252,14 +252,33 @@ export const getSubscriptionUpdateEligibility: (
   const newOrder =
     !!newPlanConfig.productOrder && parseInt(newPlanConfig.productOrder);
 
+  // if any of the following conditions is true, then the proposed
+  // subscription update from currentPlan to newPlan is invalid
   if (
+    // plans have the same planId
     currentPlan.plan_id === newPlan.plan_id ||
+    // metadata is missing for the currentPlan's product set
     !currentPlanConfig.productSet ||
-    currentPlanConfig.productSet !== newPlanConfig.productSet ||
+    // metadata is missing for the newPlan's product set
+    !newPlanConfig.productSet ||
+    // currentPlan productSet is empty
+    !currentPlanConfig.productSet.length ||
+    // newPlan productSet is empty
+    !newPlanConfig.productSet.length ||
+    // there is not at least 1 element in common between
+    // currentPlan and newPlan product sets
+    !newPlanConfig.productSet.filter((elem) =>
+      currentPlanConfig.productSet!.includes(elem)
+    ).length ||
+    // currentPlan productOrder is missing
     !currentOrder ||
+    // currenPlan productOrder can't be cast to a number
     Number.isNaN(currentOrder) ||
+    // newPlan productOrder is missing
     !newOrder ||
+    // newPlan productOrder can't be cast to a number
     Number.isNaN(newOrder) ||
+    // currentPlan and newPlan have the same productOrder
     newOrder === currentOrder
   ) {
     return SubscriptionUpdateEligibility.INVALID;

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -46,7 +46,7 @@ export interface ProductMetadata {
   emailIconURL?: string | null;
   playStoreLink?: string;
   productOrder?: string | null;
-  productSet?: string | null;
+  productSet?: string[] | null;
   upgradeCTA?: string | null;
   webIconBackground?: string | null;
   webIconURL: string | null;

--- a/packages/fxa-shared/test/subscriptions/configuration/helpers.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/helpers.ts
@@ -135,7 +135,7 @@ const CONFIGURATION: PlanConfigurationDtoT = {
   styles: {
     webIconBackground: 'webbackgroundfr',
   },
-  productSet: 'Set 1',
+  productSet: ['Set 1'],
   productOrder: 1,
 };
 
@@ -359,7 +359,7 @@ describe('subscriptions/configuration/helpers', () => {
       const actual = productUpgradeFromProductConfig(PLAN_WITH_METADATA, false);
       expect(actual).to.deep.equal({
         productOrder: PLAN_WITH_METADATA.product_metadata!.productOrder,
-        productSet: PLAN_WITH_METADATA.product_metadata!.productSet,
+        productSet: PLAN_WITH_METADATA.product_metadata!.productSet.split(','),
       });
     });
 

--- a/packages/fxa-shared/test/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/utils.ts
@@ -138,7 +138,7 @@ const CONFIGURATION: PlanConfigurationDtoT = {
   styles: {
     webIconBackground: 'webbackgroundfr',
   },
-  productSet: 'Set 1',
+  productSet: ['Set 1'],
   productOrder: 1,
 };
 
@@ -207,7 +207,7 @@ describe('product configuration util functions', () => {
   const productConfig = {
     id: '001',
     active: true,
-    productSet: 'testo',
+    productSet: ['testo'],
     capabilities: productCapabilities,
     urls: productUrls,
     uiContent: productUiContent,
@@ -262,7 +262,7 @@ describe('product configuration util functions', () => {
     },
     support: planSupport,
     promotionCodes: ['generous', 'very', 'insane'],
-    productSet: 'testo',
+    productSet: ['testo'],
     productOrder: 3,
   };
 
@@ -484,7 +484,7 @@ describe('product configuration util functions', () => {
       const actual = productUpgradeFromProductConfig(PLAN_WITH_METADATA, false);
       expect(actual).to.deep.equal({
         productOrder: PLAN_WITH_METADATA.product_metadata!.productOrder,
-        productSet: PLAN_WITH_METADATA.product_metadata!.productSet,
+        productSet: PLAN_WITH_METADATA.product_metadata!.productSet.split(','),
       });
     });
 

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -102,7 +102,7 @@ describe('subscriptions/metadata', () => {
       const product_metadata: ProductMetadata = Object.assign(
         requiredProductMetadata,
         {
-          productSet: 'foo',
+          productSet: ['foo'],
           productOrder: '1',
         }
       );
@@ -116,7 +116,7 @@ describe('subscriptions/metadata', () => {
       const plan_metadata: ProductMetadata = Object.assign(
         requiredProductMetadata,
         {
-          productSet: 'foo',
+          productSet: ['foo'],
           productOrder: '1',
         }
       );
@@ -130,14 +130,14 @@ describe('subscriptions/metadata', () => {
       const product_metadata: ProductMetadata = Object.assign(
         requiredProductMetadata,
         {
-          productSet: 'foo',
+          productSet: ['foo'],
           productOrder: '1',
         }
       );
       const plan_metadata: ProductMetadata = Object.assign(
         requiredProductMetadata,
         {
-          productSet: 'bar',
+          productSet: ['bar'],
         }
       );
       expect(
@@ -145,7 +145,7 @@ describe('subscriptions/metadata', () => {
       ).to.deep.equal({
         ...NULL_METADATA,
         productOrder: '1',
-        productSet: 'bar',
+        productSet: ['bar'],
       });
     });
   });
@@ -302,7 +302,7 @@ describe('subscriptions/metadata', () => {
         styles: {},
         locales: {},
         support: {},
-        productSet: 'foxkeh',
+        productSet: ['foxkeh'],
       },
     ];
 

--- a/packages/fxa-shared/test/subscriptions/stripe.ts
+++ b/packages/fxa-shared/test/subscriptions/stripe.ts
@@ -258,6 +258,105 @@ describe('stripe', () => {
         SubscriptionUpdateEligibility.INVALID
       );
     });
+
+    it('returns invalid if the current plan does not have any productSet', () => {
+      const x = {
+        ...currentPlan,
+        plan_metadata: { ...currentPlan.plan_metadata, productSet: null },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(x, newPlan),
+        SubscriptionUpdateEligibility.INVALID
+      );
+    });
+
+    it('returns invalid if the new plan does not have any productSet', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: null },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(currentPlan, x),
+        SubscriptionUpdateEligibility.INVALID
+      );
+    });
+
+    it('returns invalid if the new plan product set is an empty array', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: [] },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(currentPlan, x),
+        SubscriptionUpdateEligibility.INVALID
+      );
+    });
+
+    it('returns invalid if the current plan productSet is an empty array', () => {
+      const x = {
+        ...currentPlan,
+        plan_metadata: { ...currentPlan.plan_metadata, productSet: [] },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(x, newPlan),
+        SubscriptionUpdateEligibility.INVALID
+      );
+    });
+
+    it('returns invalid if there is not at least one element of overlap in the productSet arrays', () => {
+      const newPlanCopy = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: ['1'] },
+      };
+
+      const currentPlanCopy = {
+        ...currentPlan,
+        plan_metadata: { ...currentPlan.plan_metadata, productSet: ['2'] },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(currentPlanCopy, newPlanCopy),
+        SubscriptionUpdateEligibility.INVALID
+      );
+    });
+
+    it('returns upgrade if there is 1 element of overlap in the productSet arrays', () => {
+      const newPlanCopy = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: ['1'] },
+      };
+
+      const currentPlanCopy = {
+        ...currentPlan,
+        plan_metadata: { ...currentPlan.plan_metadata, productSet: ['1', '2'] },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(currentPlanCopy, newPlanCopy),
+        SubscriptionUpdateEligibility.UPGRADE
+      );
+    });
+
+    it('returns upgrade if there is more than 1 element of overlap in the productSet arrays', () => {
+      const newPlanCopy = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: ['1', '2'] },
+      };
+
+      const currentPlanCopy = {
+        ...currentPlan,
+        plan_metadata: { ...currentPlan.plan_metadata, productSet: ['1', '2'] },
+      };
+
+      assert.equal(
+        getSubscriptionUpdateEligibility(currentPlanCopy, newPlanCopy),
+        SubscriptionUpdateEligibility.UPGRADE
+      );
+    });
   });
 
   describe('getMinimumAmount', () => {


### PR DESCRIPTION
Because:

* We want to support multiple values on productSet to determine which plans can be upgraded to different plans or different bundles

This commit:

* Changes the productSet property to by an array of strings that is comma delimited. RP can then specify in stripe metadata the possible productSets a product or price
can be belong to along with an order field. Upgrade eligibility is determined by having at least 1 overlapping productSet element and the correct order.

Closes #[FXA-5739](https://mozilla-hub.atlassian.net/browse/FXA-5739)

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
