### PR TITLE
feat(pair): Updates for 123Done to support Heroku

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,6 @@
+*.pdf
+*.png
+*.svg
+*.md
+assets
+docs

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "config-fxios": "node _scripts/config-fxios.js",
     "format": "yarn workspaces foreach run format",
     "ports": "pm2 jlist | json -a -c 'this.pm2_env.env.PORT' pm2_env.env.PORT name",
-    "heroku-postbuild": "yarn workspace 123done install",
+    "heroku-postbuild": "yarn workspaces foreach --verbose --include 123done install",
     "mysql": "docker exec -it $(docker container ls | grep mysql | cut -d' ' -f1) mysql"
   },
   "homepage": "https://github.com/mozilla/fxa",

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -34,7 +34,6 @@
     "audit-filter": "0.5.0",
     "eslint": "^7.32.0",
     "eslint-plugin-fxa": "^2.0.2",
-    "fxa-shared": "workspace:*",
     "pm2": "^5.1.2",
     "prettier": "^2.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,6 @@ __metadata:
     eslint-plugin-fxa: ^2.0.2
     express: ^4.17.2
     fxa-jwtool: ^0.7.2
-    fxa-shared: "workspace:*"
     ioredis: ^5.0.6
     morgan: ^1.10.0
     node-rsa: 1.1.1


### PR DESCRIPTION
## Because

- 123Done needed to be updated so that it could be deployed to heroku

## This pull request

- Removes fxa-shared as a dependency
- Adds a slug ignore file so that heroku slug stays below max [500mb](https://devcenter.heroku.com/articles/slug-compiler)

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5692

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Main branch has been deployed to https://stage-123done.herokuapp.com/

Something we can consider in the future is to have this automatically deploy when 123Done changes are merged to main.
