### PR TITLE
fix(payments-server): return inactive plans

### DIFF
--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.spec.ts
@@ -189,6 +189,7 @@ describe('Stripe Service', () => {
 
   describe('iap mappings', () => {
     const plan: AbbrevPlan = {
+      active: true,
       amount: 1.0,
       configuration: null,
       currency: 'USD',

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -547,6 +547,7 @@ module.exports.subscriptionsPlanWithMetaDataValidator = isA.object({
   interval_count: isA.number().required(),
   amount: isA.number().required(),
   currency: isA.string().required(),
+  active: isA.boolean().required(),
   configuration: minimalConfigSchema
     .keys(productConfigJoiKeys)
     .keys(planConfigJoiKeys)
@@ -565,6 +566,7 @@ module.exports.subscriptionsPlanWithProductConfigValidator = isA.object({
   interval_count: isA.number().required(),
   amount: isA.number().required(),
   currency: isA.string().required(),
+  active: isA.boolean().required(),
   configuration: minimalConfigSchema
     .keys(productConfigJoiKeys)
     .keys(planConfigJoiKeys)

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3098,6 +3098,7 @@ describe('StripeHelper', () => {
             product_id: p.product.id,
             product_metadata: p.product.metadata,
             product_name: p.product.name,
+            active: true,
             configuration: {
               locales: {},
               productSet: undefined,
@@ -3120,6 +3121,7 @@ describe('StripeHelper', () => {
               product_id: p.product.id,
               product_metadata: p.product.metadata,
               product_name: p.product.name,
+              active: true,
               configuration: null,
             }))
           )
@@ -3164,6 +3166,7 @@ describe('StripeHelper', () => {
             product_id: p.product.id,
             product_metadata: p.product.metadata,
             product_name: p.product.name,
+            active: true,
             configuration: {
               locales: {},
               productSet: undefined,
@@ -3186,6 +3189,7 @@ describe('StripeHelper', () => {
               product_id: p.product.id,
               product_metadata: p.product.metadata,
               product_name: p.product.name,
+              active: true,
               configuration: null,
             }))
           )

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -507,6 +507,7 @@ describe('lib/routes/validators:', () => {
       interval_count: 1,
       amount: '867',
       currency: 'usd',
+      active: true,
     };
 
     it('accepts missing plan and product metadata', () => {
@@ -549,6 +550,7 @@ describe('lib/routes/validators:', () => {
       interval_count: 1,
       amount: '867',
       currency: 'usd',
+      active: true,
       configuration: {
         urls: {
           emailIcon: 'http://firestore.example.gg/email.ico',

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -36,6 +36,7 @@ const selectedPlan: Plan = {
   amount: 935,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: null,
 };

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -46,6 +46,7 @@ const PLAN = {
   amount: 1099,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: {
     'product:termsOfServiceURL':

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.stories.tsx
@@ -12,6 +12,7 @@ const selectedPlan: Plan = {
   amount: 935,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: null,
 };

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import MockApp from '../../../.storybook/components/MockApp';
-import PlanDetails, { PlanDetailsProps} from './index';
+import PlanDetails, { PlanDetailsProps } from './index';
 import { Profile } from '../../store/types';
 import { COUPON_DETAILS_VALID } from '../../lib/mock-data';
 import { Meta } from '@storybook/react';
@@ -35,6 +35,7 @@ const selectedPlan = {
   amount: 935,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   product_metadata: null,
   plan_metadata: {
     'product:subtitle': 'Really keen product',
@@ -54,7 +55,7 @@ const selectedPlan = {
 
 const storyWithProps = (
   plan: PlanDetailsProps,
-  languages?: readonly string[],
+  languages?: readonly string[]
 ) => {
   const story = () => (
     <MockApp languages={languages}>
@@ -65,17 +66,15 @@ const storyWithProps = (
         }}
       />
     </MockApp>
-  )
+  );
   return story;
 };
 
-export const Default = storyWithProps(
-  {
-    selectedPlan,
-    isMobile: false,
-    showExpandButton: false,
-  },
-);
+export const Default = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: false,
+});
 
 export const LocalizedToPirate = storyWithProps(
   {
@@ -83,53 +82,44 @@ export const LocalizedToPirate = storyWithProps(
     isMobile: false,
     showExpandButton: false,
   },
-  ['xx-pirate'],
+  ['xx-pirate']
 );
 
-export const WithExpandedButton = storyWithProps(
-  {
-    selectedPlan,
-    isMobile: false,
-    showExpandButton: true,
-  },
-);
+export const WithExpandedButton = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: true,
+});
 
-export const WithCouponTypeForever = storyWithProps(
-  {
-    selectedPlan,
-    isMobile: false,
-    showExpandButton: false,
-    coupon: {...COUPON_DETAILS_VALID, type: 'forever'}
-  },
-);
+export const WithCouponTypeForever = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: false,
+  coupon: { ...COUPON_DETAILS_VALID, type: 'forever' },
+});
 
-export const WithCouponTypeOnce = storyWithProps(
-  {
-    selectedPlan,
-    isMobile: false,
-    showExpandButton: false,
-    coupon: {...COUPON_DETAILS_VALID, type: 'once'}
-  },
-);
+export const WithCouponTypeOnce = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: false,
+  coupon: { ...COUPON_DETAILS_VALID, type: 'once' },
+});
 
-export const WithCouponTypeRepeatingPlanIntervalGreaterThanCouponDuration = storyWithProps(
-  {
-    selectedPlan: {...selectedPlan, interval_count: 6},
+export const WithCouponTypeRepeatingPlanIntervalGreaterThanCouponDuration =
+  storyWithProps({
+    selectedPlan: { ...selectedPlan, interval_count: 6 },
     isMobile: false,
     showExpandButton: false,
     coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
-  },
-);
+  });
 
-export const WithCouponTypeRepeating = storyWithProps(
-  {
-    selectedPlan,
-    isMobile: false,
-    showExpandButton: false,
-    coupon: {
-      ...COUPON_DETAILS_VALID,
-      durationInMonths: 3,
-      type: 'repeating',
-    }
+export const WithCouponTypeRepeating = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: false,
+  coupon: {
+    ...COUPON_DETAILS_VALID,
+    durationInMonths: 3,
+    type: 'repeating',
   },
-);
+});

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -63,6 +63,7 @@ export const SELECTED_PLAN: Plan = {
   amount: 2999,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: {
     webIconURL: 'http://placekitten.com/49/49?image=2',
@@ -98,6 +99,7 @@ export const UPGRADE_FROM_PLAN: Plan = {
   amount: 999,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: {
     webIconURL: 'http://placekitten.com/49/49?image=9',
@@ -152,6 +154,7 @@ export const PLAN = {
   amount: 1050,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: {
     webIconURL: 'http://placekitten.com/512/512',

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -340,6 +340,7 @@ export const STRIPE_FIELDS = [
 ];
 
 export const PLAN_ID = 'plan_12345';
+export const INACTIVE_PLAN_ID = 'inactive';
 
 export const PRODUCT_ID = 'product_8675309';
 
@@ -366,6 +367,7 @@ export const MOCK_PLANS: Plan[] = [
       webIconURL: 'http://example.com/product.jpg',
       webIconBackground: 'purple',
     },
+    active: true,
   },
   {
     plan_id: '123doneProMonthly',
@@ -382,6 +384,7 @@ export const MOCK_PLANS: Plan[] = [
       webIconBackground: 'orange',
       'product:subtitle': '123DonePro subtitle',
     },
+    active: true,
   },
   {
     plan_id: 'plan_upgrade',
@@ -397,6 +400,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'example_upgrade',
     },
+    active: true,
   },
   {
     plan_id: 'plan_no_upgrade',
@@ -410,6 +414,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'example_upgrade',
     },
+    active: true,
   },
   {
     plan_id: 'plan_no_downgrade',
@@ -425,6 +430,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'example_upgrade',
     },
+    active: true,
   },
   {
     plan_id: 'plan_daily',
@@ -438,6 +444,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_6days',
@@ -451,6 +458,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_weekly',
@@ -464,6 +472,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_6weeks',
@@ -477,6 +486,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_monthly',
@@ -490,6 +500,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_6months',
@@ -503,6 +514,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_yearly',
@@ -516,6 +528,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'plan_6years',
@@ -529,6 +542,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: 'fpn',
     },
+    active: true,
   },
   {
     plan_id: 'nextlevel',
@@ -543,6 +557,22 @@ export const MOCK_PLANS: Plan[] = [
       webIconURL: 'http://example.com/product.jpg',
       webIconBackground: 'purple',
     },
+    active: true,
+  },
+  {
+    plan_id: INACTIVE_PLAN_ID,
+    product_id: PRODUCT_ID,
+    product_name: PRODUCT_NAME,
+    interval: 'year' as const,
+    interval_count: 1,
+    amount: 999,
+    currency: 'usd',
+    plan_metadata: null,
+    product_metadata: {
+      webIconURL: 'http://example.com/product.jpg',
+      webIconBackground: 'purple',
+    },
+    active: false,
   },
 ];
 

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -201,6 +201,7 @@ const PLANS: Plan[] = [
     amount: 1050,
     interval: 'month' as const,
     interval_count: 1,
+    active: true,
     plan_metadata: null,
     product_metadata: {
       webIconURL: 'http://placekitten.com/512/512',

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -22,6 +22,7 @@ import {
   mockConfig,
   mockServerUrl,
   mockOptionsResponses,
+  INACTIVE_PLAN_ID,
 } from '../../lib/test-utils';
 
 import { SignInLayout } from '../../components/AppLayout';
@@ -196,6 +197,24 @@ describe('routes/Product', () => {
     ];
     const { findByTestId } = render(<Subject />);
     const errorEl = await findByTestId('error-loading-plans');
+    expect(errorEl).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error when attempting to load inactive plan', async () => {
+    const apiMocks = [
+      nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get(
+          '/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions'
+        )
+        .reply(200, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject planId={INACTIVE_PLAN_ID} />);
+    const errorEl = await findByTestId('no-such-plan-error');
     expect(errorEl).toBeInTheDocument();
     expectNockScopesDone(apiMocks);
   });

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -221,7 +221,12 @@ export const Product = ({
     );
   }
 
-  if (!plans.result || plans.error !== null || !selectedPlan) {
+  if (
+    !plans.result ||
+    plans.error !== null ||
+    !selectedPlan ||
+    !selectedPlan.active
+  ) {
     return <PlanErrorDialog {...{ locationReload, plans }} />;
   }
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -274,6 +274,7 @@ const PLANS = [
     amount: 1099,
     interval: 'month' as const,
     interval_count: 1,
+    active: true,
     plan_metadata: null,
     product_metadata: {
       webIconURL: 'http://placekitten.com/512/512',

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -323,7 +323,6 @@ export abstract class StripeHelper {
     const plans = [];
 
     for await (const item of this.stripe.plans.list({
-      active: true,
       expand: ['data.product'],
     })) {
       if (!item.product) {
@@ -435,6 +434,7 @@ export abstract class StripeHelper {
       product_id: (p.product as Stripe.Product).id,
       product_metadata: (p.product as Stripe.Product).metadata,
       product_name: (p.product as Stripe.Product).name,
+      active: p.active,
       // TODO simply copy p.configuration below when remove the SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED feature flag
       // @ts-ignore: depending the SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED feature flag, p can be a Stripe.Plan, which does not have a `configuration`
       configuration: p.configuration ?? null,

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -26,6 +26,7 @@ export interface Plan {
   product_id: string;
   product_metadata: RawMetadata | null;
   product_name: string;
+  active: boolean;
   // TODO remove the '?' here when removing the SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED feature flag
   configuration?: PlanConfigurationDtoT | null;
 }
@@ -98,6 +99,7 @@ export type AbbrevPlan = {
   product_id: string;
   product_metadata: Stripe.Product['metadata'];
   product_name: string;
+  active: boolean;
   // TODO remove the '?' here when removing the SUBSCRIPTIONS_FIRESTORE_CONFIGS_ENABLED feature flag
   configuration?: PlanConfigurationDtoT | null;
 };

--- a/packages/fxa-shared/test/subscriptions/configuration/helpers.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/helpers.ts
@@ -20,6 +20,7 @@ const PLAN: Plan = {
   amount: 599,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: null,
 };

--- a/packages/fxa-shared/test/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/utils.ts
@@ -23,6 +23,7 @@ const PLAN: Plan = {
   amount: 599,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: null,
 };

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -37,6 +37,7 @@ const PLAN: Plan = {
   amount: 599,
   interval: 'month' as const,
   interval_count: 1,
+  active: true,
   plan_metadata: null,
   product_metadata: null,
 };
@@ -277,6 +278,7 @@ describe('subscriptions/metadata', () => {
         product_id: 'prod_HzXGNuO76B5o6g',
         product_metadata: { 'support:app:1': 'Pop!_OS' },
         product_name: 'myproduct',
+        active: true,
         configuration: null,
       },
     ];


### PR DESCRIPTION
## Because
The plans endpoint previously did not return inactive plans. This caused
issues with users who are subscribed to a plan which was then
subsequently marked inactive.

## This pull request
Returns inactive plans from the plans endpoint, along with the active
flag. The payments frontend now checks to see if a plan is inactive
before allowing the user to proceed through the payment flow.

## Issue that this pull request solves

Closes: FXA-5599

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).