### PR TITLE
chore(auth): improve Apple IAP error and notification logging

### DIFF
--- a/packages/fxa-auth-server/lib/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/apple-app-store/purchase-manager.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { CollectionReference } from '@google-cloud/firestore';
 import {
-  decodeNotificationPayload,
   DecodedNotificationPayload,
+  decodeNotificationPayload,
   decodeTransaction,
   NotificationSubtype,
   NotificationType,
@@ -61,6 +61,13 @@ export class PurchaseManager extends PurchaseManagerBase {
         // Error when attempt to query purchase. Return not found error to caller.
         const libraryError = new Error(err.message);
         libraryError.name = PurchaseUpdateError.INVALID_ORIGINAL_TRANSACTION_ID;
+        this.log.error(
+          'registerToUserAccount.PurchaseUpdateError.InvalidOriginalTransactionId',
+          {
+            err: libraryError,
+            originalTransactionId,
+          }
+        );
         throw libraryError;
       }
     }
@@ -81,6 +88,10 @@ export class PurchaseManager extends PurchaseManagerBase {
         'Purchase has been registered to another user'
       );
       libraryError.name = PurchaseUpdateError.CONFLICT;
+      this.log.error('registerToUserAccount.PurchaseUpdateError.Conflict', {
+        err: libraryError,
+        originalTransactionId,
+      });
       throw libraryError;
     }
 
@@ -105,6 +116,13 @@ export class PurchaseManager extends PurchaseManagerBase {
     } catch (err) {
       const libraryError = new Error(err.message);
       libraryError.name = PurchaseUpdateError.OTHER_ERROR;
+      this.log.error(
+        'forceRegisterToUserAccount.PurchaseUpdateError.OtherError',
+        {
+          err: libraryError,
+          originalTransactionId,
+        }
+      );
       throw libraryError;
     }
   }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/apple.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/apple.ts
@@ -47,6 +47,14 @@ export class AppleIapHandler {
       }
       throw err;
     }
+    this.log.debug('appleIap.processNotification.decodedPayload', {
+      bundleId,
+      originalTransactionId,
+      notificationType: decodedPayload.notificationType,
+      ...(decodedPayload.subtype && {
+        notificationSubtype: decodedPayload.subtype,
+      }),
+    });
     const purchase =
       await this.appStore.purchaseManager.getSubscriptionPurchase(
         originalTransactionId

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
@@ -157,7 +157,10 @@ describe('AppleIapHandler', () => {
     let mockPurchase;
     let mockRequest;
     beforeEach(() => {
-      mockDecodedNotificationPayload = {};
+      mockDecodedNotificationPayload = {
+        notificationType: 'WOW',
+        subtype: 'IMPRESS',
+      };
       mockPurchase = {
         userId: 'test1234',
       };
@@ -187,6 +190,31 @@ describe('AppleIapHandler', () => {
       assert.calledOnce(appleIap.purchaseManager.getSubscriptionPurchase);
       assert.calledOnce(appleIap.purchaseManager.processNotification);
       assert.calledOnce(mockCapabilityService.iapUpdate);
+      assert.calledOnceWithExactly(
+        log.debug,
+        'appleIap.processNotification.decodedPayload',
+        {
+          bundleId: mockBundleId,
+          originalTransactionId: mockOriginalTransactionId,
+          notificationType: mockDecodedNotificationPayload.notificationType,
+          notificationSubtype: mockDecodedNotificationPayload.subtype,
+        }
+      );
+    });
+
+    it("doesn't log a notificationSubtype when omitted from the notification", async () => {
+      delete mockDecodedNotificationPayload.subtype;
+      const result = await appleIapHandler.processNotification(mockRequest);
+      assert.deepEqual(result, {});
+      assert.calledOnceWithExactly(
+        log.debug,
+        'appleIap.processNotification.decodedPayload',
+        {
+          bundleId: mockBundleId,
+          originalTransactionId: mockOriginalTransactionId,
+          notificationType: mockDecodedNotificationPayload.notificationType,
+        }
+      );
     });
 
     it('throws an unauthorized error on certificate validation failure', async () => {


### PR DESCRIPTION
Because:

* Apple doesn't keep logs of notifications it sends, and neither do we.
* When we get a Firestore error for our Apple IAP subscription purchase collection, we don't know which purchase the error is from.

This commit:

* Log App Store Server notifications at the debug level (enabled in Stage only for Apple's Sandbox environment only).
* Add the originalTransactionId to the Sentry scope for all Firetore PurchaseQueryErrors and PurchaseUpdateErrors.

Closes #FXA-5817

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Example Sentry error with additional App Store IDs context:
<img width="347" alt="Screen Shot 2022-08-30 at 12 09 20 PM" src="https://user-images.githubusercontent.com/17437436/187574353-6f3c6849-c65e-47bb-85cf-01198523045d.png">
