### PR TITLE
chore(auth): allow profile scope on App Store registration route

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
@@ -84,6 +84,15 @@ describe('AppleIapHandler', () => {
       assert.deepEqual(result, { transactionIdValid: true });
     });
 
+    it('accepts a "profile" scope for auth', async () => {
+      request.auth.credentials.scope = ['profile'];
+      appleIap.purchaseManager = {
+        registerToUserAccount: sinon.fake.resolves({}),
+      };
+      iapConfig.getBundleId = sinon.fake.resolves('testPackage');
+      await appleIapHandler.registerOriginalTransactionId(request);
+    });
+
     it('throws on invalid package', async () => {
       appleIap.purchaseManager = {
         registerToUserAccount: sinon.fake.resolves({}),


### PR DESCRIPTION
Because:

* The VPN team needs to migrate existing Apple IAP users to SubPlat.
* They only have the 'profile' scope in this context.

This commit:

* Allows the 'profile:subscriptions' scope, which is a subset of the 'profile' scope, in the App Store registration route.

Notes:
* This is a temporary change that should be reverted once the migrations are completed successfully (see FXA-5848).

Closes #FXA-5833

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).