### PR TITLE
fix(emails): update subscriptionUpgrade email copy

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -2,7 +2,7 @@
   "subscriptionAccountFinishSetup": 2,
   "subscriptionReactivation": 2,
   "subscriptionRenewalReminder": 2,
-  "subscriptionUpgrade": 2,
+  "subscriptionUpgrade": 3,
   "subscriptionDowngrade": 2,
   "subscriptionPaymentExpired": 3,
   "subscriptionsPaymentExpired": 3,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -13,6 +13,7 @@ subscriptionUpgrade-upgrade-info = You have successfully upgraded from { $produc
 # $productPaymentCycleOld (String) - The interval of time from the end of one payment statement date to the next payment statement date of the old subscription, e.g. month
 # $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
 subscriptionUpgrade-content-charge-info = Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycleOld } to { $paymentAmountNew } per { $productPaymentCycleNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycleOld }.
+subscriptionUpgrade-content-charge-info-different-cycle = You will be charged a one-time fee of { $paymentProrated } to reflect your subscription’s higher price for the remainder of this { $productPaymentCycleOld }. Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycleOld } to { $paymentAmountNew } per { $productPaymentCycleNew }.
 # Variables:
 # $productName (String) - The name of the new subscribed product, e.g. Mozilla VPN
 subscriptionUpgrade-install = If there is new software for you to install in order to use { $productName }, you will receive a separate email with download instructions.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -19,9 +19,12 @@
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionUpgrade-content-charge-info" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>.</span>
+      <% if (locals.productPaymentCycleOld === locals.productPaymentCycleNew) { %>
+        <span data-l10n-id="subscriptionUpgrade-content-charge-info" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>.</span>
+      <% } else { %>
+        <span data-l10n-id="subscriptionUpgrade-content-charge-info-different-cycle" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>.</span>
+      <% } %>
     </mj-text>
-
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionUpgrade-install" data-l10n-args="<%= JSON.stringify({productName}) %>">If there is new software for you to install in order to use <%- productName %>, you will receive a separate email with download instructions.</span>
     </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
@@ -21,11 +21,24 @@ const createStory = subplatStoryWithProps(
       'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     productName: 'Product Name B',
     productNameOld: 'Product Name A',
-    productPaymentCycleNew: 'year',
+    productPaymentCycleNew: 'month',
     productPaymentCycleOld: 'month',
     paymentProrated: '$5,231.00',
     subscriptionSupportUrl: 'http://localhost:3030/support',
   }
 );
 
-export const SubscriptionUpgrade = createStory();
+export const SubscriptionUpgradeSameBillingCycle = createStory(
+  {},
+  'Subscription upgrade - same billing cycle'
+);
+
+export const SubscriptionUpgradeDifferentBillingCycle = createStory(
+  {
+    paymentAmountNew: '$69.89',
+    paymentAmountOld: '$9.89',
+    productPaymentCycleNew: 'year',
+    paymentProrated: '$60.00',
+  },
+  'Subscription upgrade - different billing cycle'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
@@ -4,7 +4,7 @@ subscriptionUpgrade-title = "Thank you for upgrading!"
 
 subscriptionUpgrade-upgrade-info = "You have successfully upgraded from <%- productNameOld %> to <%- productName %>."
 
-subscriptionUpgrade-content-charge-info = "Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>."
+<% if (locals.productPaymentCycleOld === locals.productPaymentCycleNew) { %>subscriptionUpgrade-content-charge-info = "Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>."<% } else { %>subscriptionUpgrade-content-charge-info-different-cycle = "You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>."<% } %>
 
 subscriptionUpgrade-install = "If there is new software for you to install in order to use <%- productName %>, you will receive a separate email with download instructions."
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -2066,6 +2066,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ]), {updateTemplateValues: x => (
     {...x, discountType: 'repeating', discountDuration: 3})}
   ],
+  // subscription upgrade email for different billing cycle
   ['subscriptionUpgradeEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
     ['headers', new Map([
@@ -2080,8 +2081,9 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-upgrade', 'subscription-terms')) },
       { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
       { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycleOld} to ${MESSAGE_FORMATTED.paymentAmountNew} per ${MESSAGE.productPaymentCycleNew}.` },
-      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect your subscription’s higher price for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
       { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
@@ -2089,12 +2091,47 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: 'Thank you for upgrading!' },
       { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
       { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycleOld} to ${MESSAGE_FORMATTED.paymentAmountNew} per ${MESSAGE.productPaymentCycleNew}.` },
-      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect your subscription’s higher price for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
       { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ]), {updateTemplateValues: x => (
-    {...x, productName: MESSAGE.productNameNew})}],
+    {...x, productName: MESSAGE.productNameNew })}
+  ],
+  // subscription upgrade email for same billing cycle
+  ['subscriptionUpgradeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionUpgrade') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionUpgrade' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionUpgrade }],
+    ])],
+    ['html', [
+      { test: 'include', expected: `You have upgraded to ${MESSAGE.productNameNew}` },
+      { test: 'include', expected: 'Thank you for upgrading!' },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-upgrade', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-upgrade', 'subscription-terms')) },
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycleOld} to ${MESSAGE_FORMATTED.paymentAmountNew} per ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect your subscription’s higher price for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `You have upgraded to ${MESSAGE.productNameNew}` },
+      { test: 'include', expected: 'Thank you for upgrading!' },
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycleOld} to ${MESSAGE_FORMATTED.paymentAmountNew} per ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect your subscription’s higher price for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]), {updateTemplateValues: x => (
+    {...x, productName: MESSAGE.productNameNew, productPaymentCycleNew: MESSAGE.productPaymentCycleOld })}
+  ],
 
   // Template partial specific tests (choose a template containing the partial)
   ['verifyLoginEmail', new Map<string, Test | any>([


### PR DESCRIPTION
## Because

- Our existing `subscriptionUpgrade` template was written to only handle upgrades in the same billing cycle
- We want to properly communicate what the user should expect when they upgrade to a different billing cycle

## This pull request

- Updates `subscriptionUpgrade` email template for different billing cycle
- Updates `subscriptionUpgrade` email template for stories and plaintext
- Updates and adds tests for same and different billing cycles

## Issue that this pull request solves

Closes: FXA-5734

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
