### PR TITLE
fix(customs,auth,profile): Remove references sentry.transaction

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -241,16 +241,6 @@ async function configureSentry(server, config, processName = 'key_server') {
       },
     });
 
-    server.events.on('response', (request) => {
-      request.app.sentry.transaction.name = `${request.method.toUpperCase()} ${
-        request.route.path
-      }`;
-      request.app.sentry.transaction.setHttpStatus(request.response.statusCode);
-      request.app.sentry.transaction.setData('url', request.path);
-      request.app.sentry.transaction.setData('query', request.query);
-      request.app.sentry.transaction.finish();
-    });
-
     server.events.on('request', (request, event, tags) => {
       if (event?.error && tags?.handler && tags?.error) {
         reportSentryError(event.error, request);

--- a/packages/fxa-customs-server/lib/sentry.js
+++ b/packages/fxa-customs-server/lib/sentry.js
@@ -25,9 +25,7 @@ async function configureSentry(server, config, log) {
   );
   Sentry.init({
     ...opts,
-    integrations: [
-      new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' }),
-    ],
+    integrations: [new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' })],
     beforeSend(event, _hint) {
       event = tagCriticalEvent(event);
       event = tagFxaName(event, opts.serverName);
@@ -73,17 +71,6 @@ async function configureSentry(server, config, log) {
 
       return h.continue;
     },
-  });
-
-  // Finalize Transaction
-  server.events.on('response', (request) => {
-    request.app.sentry.transaction.name = `${request.method.toUpperCase()} ${
-      request.route.path
-    }`;
-    request.app.sentry.transaction.setHttpStatus(request.response.statusCode);
-    request.app.sentry.transaction.setData('url', request.path);
-    request.app.sentry.transaction.setData('query', request.query);
-    request.app.sentry.transaction.finish();
   });
 
   // Sentry handler for hapi errors

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -149,17 +149,6 @@ exports.create = async function createServer() {
       },
     });
 
-    // Finalize sentry transaction
-    server.events.on('response', (request) => {
-      request.app.sentry.transaction.name = `${request.method.toUpperCase()} ${
-        request.route.path
-      }`;
-      request.app.sentry.transaction.setHttpStatus(request.response.statusCode);
-      request.app.sentry.transaction.setData('url', request.path);
-      request.app.sentry.transaction.setData('query', request.query);
-      request.app.sentry.transaction.finish();
-    });
-
     // Handle sentry errors
     server.events.on(
       { name: 'request', channels: 'error' },


### PR DESCRIPTION
## Because

- We removed the @sentry/tracing module so sentry.transactions is now undefined.

## This pull request

- Removes references to sentry.transaction. They are no longer useful or supported.

## Issue that this pull request solves

Closes: FXA-5852

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
