### PR TITLE
task(settings): Improve UX when saving account recovery keys and backup verification codes

### DIFF
--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -119,7 +119,9 @@ test.describe('severity-3 #smoke', () => {
     await recoveryKey.setPassword(credentials.password);
     await recoveryKey.submit();
     const dl = await recoveryKey.dataTrio.clickDownload();
-    expect(dl.suggestedFilename()).toBe(`${credentials.email} Firefox.txt`);
+    expect(dl.suggestedFilename()).toBe(
+      `${credentials.email} Firefox recovery key.txt`
+    );
     const clipboard = await recoveryKey.dataTrio.clickCopy();
     expect(clipboard).toEqual(await recoveryKey.getKey());
     const printed = await recoveryKey.dataTrio.clickPrint();

--- a/packages/fxa-settings/src/components/DataBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.test.tsx
@@ -77,3 +77,27 @@ it('displays a tooltip on action', async () => {
     await screen.findByTestId('datablock-copy-tooltip')
   ).toBeInTheDocument();
 });
+
+it('sets download file name', async () => {
+  render(
+    <AppContext.Provider value={{ account }}>
+      <DataBlock value={multiValue} contentType="Firefox recovery key" />
+    </AppContext.Provider>
+  );
+  let element = await screen.findByTestId('databutton-download');
+  expect(element).toBeInTheDocument();
+  expect(element.getAttribute('download')).toContain(
+    'Firefox recovery key.txt'
+  );
+});
+
+it('sets has fallback download file name', async () => {
+  render(
+    <AppContext.Provider value={{ account }}>
+      <DataBlock value={multiValue} />
+    </AppContext.Provider>
+  );
+  const element = await screen.findByTestId('databutton-download');
+  expect(element).toBeInTheDocument();
+  expect(element.getAttribute('download')).toContain('Firefox.txt');
+});

--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -4,7 +4,7 @@
 
 import { Localized } from '@fluent/react';
 import React, { useState } from 'react';
-import GetDataTrio from '../GetDataTrio';
+import GetDataTrio, { DownloadContentType } from '../GetDataTrio';
 import { Tooltip } from '../Tooltip';
 
 const actionTypeToNotification = {
@@ -18,6 +18,7 @@ type actionFn = (action: actions) => void;
 
 export type DataBlockProps = {
   value: string | string[];
+  contentType?: DownloadContentType;
   prefixDataTestId?: string;
   separator?: string;
   onCopy?: (event: React.ClipboardEvent<HTMLDivElement>) => void;
@@ -26,6 +27,7 @@ export type DataBlockProps = {
 
 export const DataBlock = ({
   value,
+  contentType,
   prefixDataTestId,
   separator,
   onCopy,
@@ -77,7 +79,7 @@ export const DataBlock = ({
           </Localized>
         )}
       </div>
-      <GetDataTrio {...{ value, onAction: actionCb }} />
+      <GetDataTrio {...{ value, contentType, onAction: actionCb }} />
     </>
   );
 };

--- a/packages/fxa-settings/src/components/GetDataTrio/en-US.ftl
+++ b/packages/fxa-settings/src/components/GetDataTrio/en-US.ftl
@@ -1,6 +1,9 @@
 # GetDataTrio component, part of Recovery Key flow
 
 get-data-trio-title = Recovery Codes
+get-data-trio-title-firefox = { -brand-firefox }
+get-data-trio-title-firefox-recovery-key = { -brand-firefox } recovery key
+get-data-trio-title-firefox-backup-verification-codes = { -brand-firefox } backup verification codes
 get-data-trio-download =
   .title = Download
 get-data-trio-copy =

--- a/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
@@ -7,23 +7,28 @@ import { render, screen } from '@testing-library/react';
 import { Account, AppContext } from '../../models';
 import GetDataTrio from './index';
 
+const contentType = 'Firefox recovery key';
 const value = 'Sun Tea';
 const url = 'https://mozilla.org';
 
-const account = ({
+const account = {
   primaryEmail: {
     email: 'pbooth@mozilla.com',
   },
-} as unknown) as Account;
+} as unknown as Account;
 
 it('renders as expected', () => {
   window.URL.createObjectURL = jest.fn();
   render(
     <AppContext.Provider value={{ account }}>
-      <GetDataTrio {...{ value, url }} />
+      <GetDataTrio {...{ value, contentType, url }} />
     </AppContext.Provider>
   );
   expect(screen.getByTestId('databutton-download')).toBeInTheDocument();
+  expect(screen.getByTestId('databutton-download')).toHaveAttribute(
+    'download',
+    expect.stringMatching(contentType)
+  );
   expect(screen.getByTestId('databutton-copy')).toBeInTheDocument();
   expect(screen.getByTestId('databutton-print')).toBeInTheDocument();
 });

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -10,8 +10,21 @@ import { ReactComponent as DownloadIcon } from './download.svg';
 import { ReactComponent as PrintIcon } from './print.svg';
 import { useAccount } from '../../models';
 
+export type DownloadContentType =
+  | 'Firefox recovery key'
+  | 'Firefox backup verification codes'
+  | 'Firefox';
+
+const DownloadContentTypeL10nMapping: Record<DownloadContentType, string> = {
+  Firefox: 'get-data-trio-title-firefox',
+  'Firefox backup verification codes':
+    'get-data-trio-title-firefox-backup-verification-codes',
+  'Firefox recovery key': 'get-data-trio-title-firefox-recovery-key',
+};
+
 export type GetDataTrioProps = {
   value: string | string[];
+  contentType?: DownloadContentType;
   onAction?: (type: 'download' | 'copy' | 'print') => void;
 };
 
@@ -30,12 +43,22 @@ const recoveryCodesPrintTemplate = (
   `;
 };
 
-export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
+export const GetDataTrio = ({
+  value,
+  contentType,
+  onAction,
+}: GetDataTrioProps) => {
   const { l10n } = useLocalization();
+
+  // Fall back to 'Firefox' just in case.
+  if (contentType == null) {
+    contentType = 'Firefox';
+  }
+
   const pageTitle = l10n.getString(
-    'get-data-trio-title',
+    DownloadContentTypeL10nMapping[contentType],
     null,
-    'Recovery Codes'
+    contentType
   );
   const print = useCallback(() => {
     const printWindow = window.open('', 'Print', 'height=600,width=800')!;
@@ -57,7 +80,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
               type: 'text/plain',
             })
           )}
-          download={`${primaryEmail.email} Firefox.txt`}
+          download={`${primaryEmail.email} ${contentType}.txt`}
           data-testid="databutton-download"
           className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-dotted active:outline-black focus:outline-dotted focus:outline-black hover:bg-grey-50"
           onClick={() => onAction?.('download')}

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.test.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.test.tsx
@@ -58,6 +58,11 @@ it('renders', async () => {
   );
 
   expect(screen.getByTestId('ack-recovery-code')).toBeInTheDocument();
+
+  expect(screen.getByTestId('databutton-download')).toHaveAttribute(
+    'download',
+    expect.stringContaining('Firefox backup verification codes')
+  );
 });
 
 it('displays an error when fails to fetch new recovery codes', async () => {

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -141,6 +141,7 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
                   value={recoveryCodes}
                   separator=" "
                   onCopy={copyRecoveryCodes}
+                  contentType="Firefox backup verification codes"
                 />
               ) : (
                 <LoadingSpinner />

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -136,6 +136,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
                     `recovery-key.${type}-option`
                   );
                 }}
+                contentType="Firefox recovery key"
               ></DataBlock>
               <Localized id="recovery-key-close-button">
                 <button

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -148,6 +148,10 @@ describe('step 2', () => {
     expect(screen.getByTestId('datablock').textContent?.trim()).toEqual(
       totp.recoveryCodes.join(' ')
     );
+    expect(screen.getByTestId('databutton-download')).toHaveAttribute(
+      'download',
+      expect.stringContaining('Firefox backup verification codes')
+    );
   });
 
   it('shows an error when an invalid auth code is entered', async () => {

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -15,7 +15,10 @@ import { checkCode, copyRecoveryCodes, getCode } from '../../lib/totp';
 import { HomePath } from '../../constants';
 import { logViewEvent, useMetrics } from '../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
-import { AuthUiErrors, composeAuthUiErrorTranslationId } from '../../lib/auth-errors/auth-errors';
+import {
+  AuthUiErrors,
+  composeAuthUiErrorTranslationId,
+} from '../../lib/auth-errors/auth-errors';
 import { useAsync } from 'react-async-hook';
 
 export const metricsPreInPostFix = 'settings.two-step-authentication';
@@ -316,6 +319,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 separator=" "
                 onAction={logDataTrioActionEvent}
                 onCopy={copyRecoveryCodes}
+                contentType="Firefox backup verification codes"
               ></DataBlock>
             </div>
           </div>


### PR DESCRIPTION
## Because

- We want to improve the UX for saving recovery keys and backup verification codes (2FA backup codes)

## This pull request

- Adds a parameter to GetDataTrio called contentType to indicate the content displayed.
- Applies the this contentType parameter to file download names.
- Applies the this contentType parameter to the page title of printed documents.
- Updates the DataBlock component with a contentType parameter than can be passed through to GetDataTrio.
- Uses the 'Firefox recovery key' contentType in PageRecoveryKeyAdd's DataBlock component.
- Uses the 'Firefox backup verification codes' contentType in PageTwoStepAuthentication and Page2faReplaceRecoveryCode components.

## Issue that this pull request solves

Closes: FXA-3817

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Download names:
![image](https://user-images.githubusercontent.com/94418270/187800696-60bfe1f0-6dd7-4445-b4c8-c7152b9d4f14.png)
![image](https://user-images.githubusercontent.com/94418270/187800808-20457671-f8d2-44a7-9f4a-69ac2e1a0358.png)

Print Titles
![image](https://user-images.githubusercontent.com/94418270/187800631-26e8839f-a7e9-40a9-87b8-eb6bd12ea866.png)
![image](https://user-images.githubusercontent.com/94418270/187800996-f14170ab-ec39-45d0-bfae-1501dbd3b88f.png)





