### PR TITLE
fix(fxa-auth-server): update string id

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
@@ -1,7 +1,7 @@
 verificationReminderFirst-subject-2 = Remember to confirm your account
 verificationReminderFirst-title-2 = Welcome to { -brand-firefox }!
 verificationReminderFirst-description-2 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.
-verificationReminderFirst-sub-description-2 = Don’t miss out on tech that puts you and your privacy first.
+verificationReminderFirst-sub-description-3 = Don’t miss out on the browser that puts you and your privacy first.
 confirm-email-2 = Confirm account
 confirm-email-plaintext-2 = { confirm-email-2 }:
 verificationReminderFirst-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
@@ -16,7 +16,7 @@
       <span data-l10n-id="verificationReminderFirst-description-2">A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.</span>
     </mj-text>
     <mj-text css-class="text-body">
-      <span data-l10n-id="verificationReminderFirst-sub-description">Don’t miss out on tech that puts you and your privacy first.</span>
+      <span data-l10n-id="verificationReminderFirst-sub-description-3">Don’t miss out on the browser that puts you and your privacy first.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
@@ -2,7 +2,7 @@ verificationReminderFirst-title-2 = "Welcome to Firefox"
 
 verificationReminderFirst-description-2 = "A few days ago you created a Firefox account, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted."
 
-verificationReminderFirst-sub-description = "Don’t miss out on tech that puts you and your privacy first."
+verificationReminderFirst-sub-description-3 = "Don’t miss out on the browser that puts you and your privacy first."
 
 confirm-email-plaintext-2 = "Confirm account:"
 <%- link %>


### PR DESCRIPTION
## Because

- QA caught that copy wasn't updating in the verificationReminderFirst email -- closer examination showed that I had not updated the string ID in all places in the email. (per comments on [this ticket](https://mozilla-hub.atlassian.net/browse/FXA-5206))

## This pull request

- Updates the string id consistently.

## Issue that this pull request solves

Closes: # https://mozilla-hub.atlassian.net/browse/FXA-5859

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Updated copy: 
<img width="436" alt="Screen Shot 2022-09-01 at 10 50 44 AM" src="https://user-images.githubusercontent.com/11150372/187980068-7c79d0d1-21b5-41d4-be33-aaa2655cc1b6.png">

