### PR TITLE
Fxa 5188 low recovery codes copy

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -18,7 +18,7 @@
   "subscriptionFirstInvoiceDiscount": 2,
   "downloadSubscription": 2,
   "fraudulentAccountDeletion": 1,
-  "lowRecoveryCodes": 6,
+  "lowRecoveryCodes": 7,
   "newDeviceLogin": 7,
   "passwordChanged": 5,
   "passwordChangeRequired": 2,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/en.ftl
@@ -1,11 +1,18 @@
 # The user has a low number of valid recovery codes remaining for use
-codes-reminder-title = Low recovery codes remaining
-codes-reminder-description = We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.
-codes-generate = Generate codes
-codes-generate-plaintext = { codes-generate }:
-lowRecoveryCodes-action = Generate codes
-lowRecoveryCodes-subject =
+codes-reminder-title-zero = You’re out of backup authentication codes!
+codes-reminder-title-one = You’re on your last backup authentication code
+codes-reminder-title-two = Time to create more backup authentication codes
+
+codes-reminder-description-part-one = Backup authentication codes help you restore your info when you forget your password.
+codes-reminder-description-part-two = Create new codes now so you don’t lose your data later.
+codes-reminder-description-two-left = You only have two codes left.
+codes-reminder-description-create-codes = Create new backup authentication codes to help you get back into your account if you’re locked out.
+
+lowRecoveryCodes-action-2 = Create codes
+codes-create-plaintext = { lowRecoveryCodes-action-2 }:
+lowRecoveryCodes-subject-2 =
     { $numberRemaining ->
-        [one] 1 recovery code remaining
-       *[other] { $numberRemaining } recovery codes remaining
+        [0] No backup authentication codes left
+        [one] Only 1 backup authentication code left
+       *[other] Only { $numberRemaining } backup authentication codes left!
    }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/includes.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/includes.ts
@@ -4,19 +4,19 @@
 
 import { GlobalTemplateValues } from '../../../renderer';
 
+const SUBJECTS = [ 'No backup authentication codes left', 'Only 1 backup authentication code left' ];
+
 const getSubject = (numberRemaining: number) =>
-  numberRemaining === 1
-    ? '1 recovery code remaining'
-    : '<%= numberRemaining %> recovery codes remaining';
+  SUBJECTS[numberRemaining] || 'Only <%= numberRemaining %> backup authentication codes left!';
 
 export const getIncludes = (numberRemaining: number): GlobalTemplateValues => ({
   subject: {
-    id: 'lowRecoveryCodes-subject',
+    id: 'lowRecoveryCodes-subject-2',
     message: getSubject(numberRemaining),
   },
   action: {
-    id: 'lowRecoveryCodes-action',
-    message: 'Confirm email',
+    id: 'lowRecoveryCodes-action-2',
+    message: 'Create codes',
   },
 });
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.mjml
@@ -5,21 +5,39 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="codes-reminder-title">Low recovery codes remaining</span>
+      <% if (numberRemaining === 0 ) { %>
+        <span data-l10n-id="codes-reminder-title-zero">You’re out of backup authentication codes!</span>
+      <% } else if (numberRemaining === 1) { %>
+        <span data-l10n-id="codes-reminder-title-one">You’re on your last backup authentication code</span>
+      <% } else { %>
+        <span data-l10n-id="codes-reminder-title-two">Time to create more backup authentication codes</span>
+      <%} %>
     </mj-text>
   </mj-column>
 </mj-section>
 
 <mj-section>
   <mj-column>
-    <mj-text css-class="text-body">
-      <span data-l10n-id="codes-reminder-description">We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.</span>
-    </mj-text>
+      <% if (numberRemaining < 2) { %>
+        <mj-text css-class="text-body">
+          <span data-l10n-id="codes-reminder-description-part-one">Backup authentication codes help you restore your info when you forget your password.</span>
+        </mj-text>
+        <mj-text css-class="text-body">
+          <span data-l10n-id="codes-reminder-description-part-two">Create new codes now so you don’t lose your data later.</span>
+        </mj-text>
+      <% } else { %>
+        <mj-text css-class="text-body">
+          <span data-l10n-id="codes-reminder-description-two-left">You only have two codes left.</span>
+        </mj-text>
+        <mj-text css-class="text-body">
+          <span data-l10n-id="codes-reminder-description-create-codes">Create new backup authentication codes to help you get back into your account if you’re locked out.</span>
+        </mj-text>
+      <%} %>
   </mj-column>
 </mj-section>
 
 <%- include('/partials/button/index.mjml', {
-  buttonL10nId: "lowRecoveryCodes-action",
-  buttonText: "Generate codes"
+  buttonL10nId: "lowRecoveryCodes-action-2",
+  buttonText: "Create codes"
 }) %>
 <%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
@@ -18,6 +18,13 @@ const createStory = storyWithProps(
   }
 );
 
+export const LowRecoveryCodesZero = createStory(
+  {
+    numberRemaining: 0,
+  },
+  'User has 0 recovery codes remaining'
+);
+
 export const LowRecoveryCodesOne = createStory(
   {
     numberRemaining: 1,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.txt
@@ -1,8 +1,29 @@
-codes-reminder-title = "Low recovery codes remaining"
+<%- body %>
 
-codes-reminder-description = "We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account."
+<% if (locals.numberRemaining === 0) { %>
+codes-reminder-title-zero = "You’re out of backup authentication codes!"
 
-codes-generate-plaintext = "Generate codes:"
+codes-reminder-description-part-one = "Backup authentication codes help you restore your info when you forget your password."
+
+codes-reminder-description-part-two = "Create new codes now so you don’t lose your data later."
+
+<% } else if (locals.numberRemaining === 1) { %>
+codes-reminder-title-one = "You’re on your last backup authentication code"
+
+codes-reminder-description-part-one = "Backup authentication codes help you restore your info when you forget your password."
+
+codes-reminder-description-part-two = "Create new codes now so you don’t lose your data later."
+
+<% } else { %>
+codes-reminder-title-two = "Time to create more backup authentication codes"
+
+codes-reminder-description-two-left = "You only have two codes left."
+
+codes-reminder-description-create-codes = "Create new backup authentication codes to help you get back into your account if you’re locked out."
+
+<% } %>
+
+codes-create-plaintext = "Create codes:"
 <%- link %>
 
 <%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -323,7 +323,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
 
   ['lowRecoveryCodesEmail', new Map<string, Test | any>([
     ['subject', [
-      { test: 'include', expected: '2 recovery codes remaining' }
+      { test: 'include', expected: 'Only 2 backup authentication codes left!' }
     ]],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid') }],
@@ -332,7 +332,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.lowRecoveryCodes }],
     ])],
     ['html', [
-      { test: 'include', expected: '2 recovery codes remaining' },
+      { test: 'include', expected: 'Time to create more backup authentication codes' },
       { test: 'include', expected: decodeUrl(configHref('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'low-recovery-codes', 'privacy')) },
       { test: 'include', expected: decodeUrl(configHref('supportUrl', 'low-recovery-codes', 'support')) },
@@ -340,8 +340,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Low recovery codes remaining' },
-      { test: 'include', expected: `Generate codes:\n${configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')}` },
+      { test: 'include', expected: 'You only have two codes left' },
+      { test: 'include', expected: `Create codes:\n${configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'low-recovery-codes', 'privacy')}` },
       { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'low-recovery-codes', 'support')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -349,9 +349,46 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
   ['lowRecoveryCodesEmail', new Map<string, Test | any>([
     ['subject', [
-      { test: 'include', expected: '1 recovery code remaining' }
-    ]]]),
+      { test: 'include', expected: 'Only 1 backup authentication code left' }
+    ]],
+    ['html', [
+      { test: 'include', expected: 'You’re on your last backup authentication code' },
+      { test: 'include', expected: decodeUrl(configHref('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'low-recovery-codes', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'low-recovery-codes', 'support')) },
+      { test: 'include', expected: 'alt="Firefox logo"' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'Backup authentication codes help you restore your info when you forget your password.' },
+      { test: 'include', expected: `Create codes:\n${configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'low-recovery-codes', 'privacy')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'low-recovery-codes', 'support')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ]),
       {updateTemplateValues: values => ({...values, numberRemaining: 1 })}],
+  ['lowRecoveryCodesEmail', new Map<string, Test | any>([
+    ['subject', [
+      { test: 'include', expected: 'No backup authentication codes left' }
+    ]],
+    ['html', [
+      { test: 'include', expected: 'You’re out of backup authentication codes!' },
+      { test: 'include', expected: decodeUrl(configHref('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'low-recovery-codes', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'low-recovery-codes', 'support')) },
+      { test: 'include', expected: 'alt="Firefox logo"' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'You’re out of backup authentication codes!' },
+      { test: 'include', expected: `Create codes:\n${configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'low-recovery-codes', 'privacy')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'low-recovery-codes', 'support')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ]),
+      {updateTemplateValues: values => ({...values, numberRemaining: 0 })}],
 
   ['postVerifyEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Welcome to Firefox!' }],


### PR DESCRIPTION
## Because

- We're updating copy for the lowRecoveryCode emails. 

## This pull request

- Updates the copy for the lowRecoveryCode emails, and makes the copy for the emails branch more based on the number of remaining recovery codes (as represented by `numberRemaining`.)
- Adds the `zero recovery codes` email to storybook

## Issue that this pull request solves

Closes: # https://mozilla-hub.atlassian.net/browse/FXA-5188

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="724" alt="Screen Shot 2022-09-02 at 1 49 55 PM" src="https://user-images.githubusercontent.com/11150372/188233453-2bae48da-b925-423b-86b6-1df14e4bc0cb.png">
<img width="735" alt="Screen Shot 2022-09-02 at 1 49 59 PM" src="https://user-images.githubusercontent.com/11150372/188233458-74ee4acb-bc32-4a2e-b66b-793321003c87.png">
<img width="734" alt="Screen Shot 2022-09-02 at 1 50 05 PM" src="https://user-images.githubusercontent.com/11150372/188233460-9fc4157a-082b-42e3-a311-51ac65e5b4fe.png">


## Other information (Optional)

The fact that the `txt` file references `locals.numberRemaining` and the mjml file references `numberRemaining` directly seems odd to me, but...it looks like it's working properly in storybook? 
