### PR TITLE
fix(payments): Intermittent coupon test failure

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -209,8 +209,8 @@ describe('useInfoBoxMessage', () => {
     const couponDurationDate = getByTestId('couponDurationDate').textContent;
     expect(messageText).toBe(CouponInfoBoxMessageType.Repeating);
     expect(couponDurationDate).not.toBeNull();
-    expect(couponDurationDate?.slice(0, 8)).toBe(
-      expectedCouponDurationDate.slice(0, 8)
+    expect(couponDurationDate?.slice(0, 7)).toBe(
+      expectedCouponDurationDate.slice(0, 7)
     );
   });
 });


### PR DESCRIPTION
## Because

- intermittent coupon test failure

## This pull request

- slices on 7 digits instead of 8

## Issue that this pull request solves
- [FXA-5858](https://mozilla-hub.atlassian.net/browse/FXA-5858)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
