### PR TITLE
fix(fxa-content-server): fix selectors for password

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/elements/password-input.js
+++ b/packages/fxa-content-server/app/scripts/views/elements/password-input.js
@@ -8,7 +8,7 @@ import Vat from '../../lib/vat';
 export default {
   match($el) {
     const type = $el.attr('type');
-    return type === 'password' || (type === 'text' && $el.hasClass('password'));
+    return type === 'password' || (type === 'text' && $el.is('[id*="password"]:not([id^="show-"])'));
   },
 
   validate() {

--- a/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
@@ -13,8 +13,8 @@ export const PASSWORD_TOGGLE_LABEL = 'label[for^="show-"]';
 
 export default {
   events: {
-    'change input[id*="password"]': 'onPasswordChanged',
-    'keyup input[id*="password"]': 'onPasswordChanged',
+    'change input[id*="password"]:not([id^="show-"])': 'onPasswordChanged',
+    'keyup input[id*="password"]:not([id^="show-"])': 'onPasswordChanged',
     'blur #vpassword': 'hidePasswordHelper',
     'keyup #vpassword': 'onVPasswordChanged',
     'mousedown label[for^="show-"]': 'onShowPasswordMouseDown',
@@ -106,7 +106,7 @@ export default {
 
   onShowPasswordMouseUp(event) {
     // return focus to input
-    this.$(event.target).siblings('[id*="password"]').focus();
+    this.$(event.target).siblings('[id*="password"]:not([id^="show-"])').focus();
   },
 
   togglePasswordVisibility($el) {
@@ -118,9 +118,9 @@ export default {
   },
 
   getAffectedPasswordInputs(button) {
-    let $passwordEl = this.$(button).siblings('[id*="password"]');
+    let $passwordEl = this.$(button).siblings('[id*="password"]:not([id^="show-"])');
     if (this.$(button).data('synchronizeShow')) {
-      $passwordEl = this.$('[id*="password"][data-synchronize-show]');
+      $passwordEl = this.$('[id*="password"]:not([id^="show-"])[data-synchronize-show]');
     }
     return $passwordEl;
   },
@@ -207,7 +207,7 @@ export default {
    */
   hideVisiblePasswords() {
     const active = document.activeElement;
-    this.$el.find('[id*="password"][type=text]').each((index, el) => {
+    this.$el.find('[id*="password"][type=text]:not([id^="show-"])').each((index, el) => {
       this.hidePassword(el);
     });
     active.focus();

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -391,7 +391,7 @@ describe('/views/force_auth', function () {
       });
 
       it('isValid is successful when the password is filled out', function () {
-        view.$('input[id*="password"]').val('password');
+        view.$('input[id*="password"]:not([id^="show-"])').val('password');
         assert.isTrue(view.isValid());
       });
     });
@@ -537,7 +537,7 @@ describe('/views/force_auth', function () {
       isEmailRegistered = true;
 
       return view.render().then(function () {
-        view.$('input[id*="password"]').val('password');
+        view.$('input[id*="password"]:not([id^="show-"])').val('password');
         view.beforeDestroy();
       });
     });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/password-mixin.js
@@ -187,13 +187,11 @@ describe('views/mixins/password-mixin', function () {
       it('getAffectedPasswordInputs - gets all affected inputs', function () {
         $('#container').html(view.$el);
         let targets = view.getAffectedPasswordInputs('#show-password');
-        // Note that this affects 5 in the test template, but with the real template,
-        // only 2 are affected. We just care about the next assertion being 1 value higher.
-        assert.lengthOf(targets, 5);
+        assert.lengthOf(targets, 1);
 
         view.$('#vpassword').attr('data-synchronize-show', 'true');
         targets = view.getAffectedPasswordInputs('#show-password');
-        assert.lengthOf(targets, 6);
+        assert.lengthOf(targets, 2);
       });
     });
   });


### PR DESCRIPTION
because:
* "valid password required" message shown after selecting "show password"

this commit:
* adjust password selector bc the password eye (hide/show password) was included unintentionally

Co-authored-by: Lauren Zugai <lauren@zugai.com>

## Issue that this pull request solves

Closes: # https://mozilla-hub.atlassian.net/browse/FXA-5857

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
