### PR TITLE
fix(fxa-content-server): remove optional chaining from content server

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -644,7 +644,7 @@ function receiveEvent(event, request, data) {
         eventSource: 'content',
         version: VERSION,
         emailTypes: EMAIL_TYPES,
-        userAgent: request.headers?.['user-agent'],
+        userAgent: request.headers && request.headers['user-agent'],
         ..._.pick(data, [
           'deviceId',
           'devices',
@@ -677,7 +677,7 @@ function receiveEvent(event, request, data) {
     statsd.increment('amplitude.event.raw');
   }
 
-  const userAgent = ua.parse(request.headers?.['user-agent']);
+  const userAgent = ua.parse(request.headers && request.headers['user-agent']);
 
   const amplitudeEvent = transform(
     event,


### PR DESCRIPTION
## Because

- l10n is breaking due to the optional chaining changes 

## This pull request

- Removes optional chaining from the content server

## Issue that this pull request solves

Closes: # https://mozilla-hub.atlassian.net/browse/FXA-5865

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
