### PR TITLE
fix(infrastructure): Improve jaeger startup behavior

### DIFF
--- a/_dev/pm2/infrastructure.config.js
+++ b/_dev/pm2/infrastructure.config.js
@@ -51,8 +51,6 @@ module.exports = {
     {
       name: 'jaeger',
       script: '_scripts/jaeger.sh',
-      max_restarts: '1',
-      min_uptime: '2m',
       autorestart: false,
       kill_timeout: 20000,
     },

--- a/_scripts/jaeger.sh
+++ b/_scripts/jaeger.sh
@@ -16,5 +16,5 @@ then
     -p 9411:9411 \
     jaegertracing/all-in-one:latest
 else
-  echo -e "Jaeger not enabled. Set env TRACING_JAEGER_EXPORTER_ENABLED=true to enable. \n"
+  echo -e "Jaeger did not start, because it is not enabled. Set env TRACING_JAEGER_EXPORTER_ENABLED=true to enable. Running Jaeger is optional! \n"
 fi


### PR DESCRIPTION
## Because

- When not enabled, Jaeger was exiting with an 'error' status which was confusing.

## This pull request
- Adjust infrastructure.config.js so that Jaeger exists cleanly with a 'stopped' status.
- Reports a better log message so that it's clear Jaeger is not required to run FxA.

## Issue that this pull request solves

Closes: FXA-5886

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/189000280-6d25907a-69ab-48c7-9766-05fe776d60fb.png)

![image](https://user-images.githubusercontent.com/94418270/189000301-12c7ba96-eb4c-4aa9-a5e8-00e92822c560.png)

