### PR TITLE
feat(metrics): add CAD/pairing events

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
@@ -43,7 +43,7 @@
         <p id="install-mobile-firefox-desktop">
           {{#isSignedIn}}
             <div class="flex">
-              <a id="sync-firefox-devices" href="{{{pairingUrl}}}" class="cta-primary cta-xl">{{#t}}Sync Firefox across devices{{/t}}</a>
+              <a id="sync-firefox-devices" href="{{{pairingUrl}}}" class="cta-primary cta-xl" data-flow-event="link.pair">{{#t}}Sync Firefox across devices{{/t}}</a>
             </div>
           {{/isSignedIn}}
         </p>

--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -8,7 +8,7 @@
 
     {{#showQrCode}}
       <div class="bg-image-cad-qr-code" role="img" aria-label="{{#t}}QR code{{/t}}"></div>
-      <p class="my-5">{{#t}}To download Firefox on your mobile device, hold the device’s camera over this code to scan.{{/t}}<br>{{#unsafeTranslate}}Or, send yourself a <a href="https://www.mozilla.org/firefox/mobile/get-app/" target="_blank" class="link-blue">download link.</a>{{/unsafeTranslate}}</p>
+      <p class="my-5">{{#t}}To download Firefox on your mobile device, hold the device’s camera over this code to scan.{{/t}}<br>{{#unsafeTranslate}}Or, send yourself a <a id="get-fx-mobile" href="https://www.mozilla.org/firefox/mobile/get-app/" target="_blank" class="link-blue">download link.</a>{{/unsafeTranslate}}</p>
     {{/showQrCode}}
     {{^showQrCode}}
       <div class="{{graphicId}} mt-5" role="img" aria-label="{{#t}}Complete your set-up{{/t}}"></div>

--- a/packages/fxa-content-server/app/scripts/views/pair/auth_allow.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/auth_allow.js
@@ -4,6 +4,7 @@
 
 import Cocktail from 'cocktail';
 import DeviceBeingPairedMixin from './device-being-paired-mixin';
+import FlowEventsMixin from '../mixins/flow-events-mixin';
 import PairingTotpMixin from './pairing-totp-mixin';
 import FormView from '../form';
 import Template from '../../templates/pair/auth_allow.mustache';
@@ -25,19 +26,23 @@ class PairAuthAllowView extends FormView {
 
   beforeRender() {
     this.listenTo(this.broker, 'error', this.displayError);
-
     return this.checkTotpStatus();
   }
 
   submit() {
     return this.invokeBrokerMethod('afterPairAuthAllow');
   }
-  
+
   changePassword() {
     this.navigateAway('/settings/change_password');
   }
 }
 
-Cocktail.mixin(PairAuthAllowView, PairingTotpMixin(), DeviceBeingPairedMixin());
+Cocktail.mixin(
+  PairAuthAllowView,
+  FlowEventsMixin,
+  PairingTotpMixin(),
+  DeviceBeingPairedMixin()
+);
 
 export default PairAuthAllowView;

--- a/packages/fxa-content-server/app/scripts/views/pair/auth_complete.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/auth_complete.js
@@ -50,6 +50,8 @@ class PairAuthCompleteView extends FormView {
   }
 
   openFirefoxView() {
+    this.metrics.logEvent('screen.pair.auth.fx-view');
+    this.metrics.flush();
     const channel = this._notificationChannel;
     return channel.send(channel.COMMANDS.FIREFOX_VIEW, {
       // TODO: What is the correct entrypoint value?

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -16,7 +16,13 @@ import MarketingMixin from '../mixins/marketing-mixin';
 class PairIndexView extends FormView {
   template = Template;
 
+  events = {
+    ...FormView.prototype.events,
+    'click #get-fx-mobile': 'downloadLinkEngagement',
+  };
+
   submit() {
+    this.metrics.flush();
     return this.broker.openPairPreferences();
   }
 
@@ -53,6 +59,10 @@ class PairIndexView extends FormView {
       graphicId,
       showQrCode,
     });
+  }
+
+  downloadLinkEngagement() {
+    this.metrics.logEvent('screen.pair.downloadlink.engage');
   }
 }
 

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -416,6 +416,47 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'logout',
   },
+
+  // pairing page during sign up
+  'screen.signup.pair': {
+    group: GROUPS.connectDevice,
+    event: 'pair_view',
+  },
+  'screen.pair': {
+    group: GROUPS.connectDevice,
+    event: 'pair_view',
+  },
+  'signup.pair.submit': {
+    group: GROUPS.connectDevice,
+    event: 'pair_submit',
+  },
+  'pair.submit': {
+    group: GROUPS.connectDevice,
+    event: 'pair_submit',
+  },
+  // link to download mobile Firefox
+  'screen.pair.downloadlink.engage': {
+    group: GROUPS.connectDevice,
+    event: 'download_engage',
+  },
+
+  // pairing process
+  'screen.pair.auth.allow': {
+    group: GROUPS.qrConnectDevice,
+    event: 'view',
+  },
+  'screen.pair.auth.wait-for-supp': {
+    group: GROUPS.qrConnectDevice,
+    event: 'engage',
+  },
+  'screen.pair.auth.complete': {
+    group: GROUPS.qrConnectDevice,
+    event: 'complete',
+  },
+  'screen.pair.auth.fx-view': {
+    group: GROUPS.qrConnectDevice,
+    event: 'fx_view_engage',
+  },
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
@@ -538,6 +579,13 @@ const FUZZY_EVENTS = new Map([
   ],
   [
     /^flow\.connect-another-device\.link\.(app-store)\.([\w-]+)$/,
+    {
+      group: GROUPS.connectDevice,
+      event: 'engage',
+    },
+  ],
+  [
+    /^flow\.(signup|signin)\.connect-another-device\.link\.([\w-]+)$/,
     {
       group: GROUPS.connectDevice,
       event: 'engage',

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -2391,8 +2391,7 @@ registerSuite('amplitude', {
 
       assert.equal(logger.info.callCount, 1);
       const arg = logger.info.args[0][1];
-      assert.equal(arg.event_type, 'fxa_connect_device - view');
-      assert.equal(arg.event_properties.connect_device_flow, 'pairing');
+      assert.equal(arg.event_type, 'fxa_connect_device - pair_view');
     },
 
     'flow.pair.submit': () => {
@@ -2419,6 +2418,206 @@ registerSuite('amplitude', {
       const arg = logger.info.args[0][1];
       assert.equal(arg.event_type, 'fxa_connect_device - submit');
       assert.equal(arg.event_properties.connect_device_flow, 'pairing');
+    },
+
+    'screen.signup.pair': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'screen.signup.pair',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_connect_device - pair_view'
+      );
+    },
+
+    'signup.pair.submit': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'signup.pair.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_connect_device - pair_submit'
+      );
+    },
+
+    'pair.submit': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'signup.pair.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_connect_device - pair_submit'
+      );
+    },
+
+    'screen.pair.downloadlink.engage': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'screen.pair.downloadlink.engage',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_connect_device - download_engage'
+      );
+    },
+
+    'screen.pair.auth.allow': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'screen.pair.auth.allow',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_qr_connect_device - view'
+      );
+    },
+
+    'screen.pair.auth.wait-for-supp': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'screen.pair.auth.wait-for-supp',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_qr_connect_device - engage'
+      );
+    },
+
+    'screen.pair.auth.complete': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'screen.pair.auth.complete',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_qr_connect_device - complete'
+      );
+    },
+
+    'screen.pair.auth.fx-view': () => {
+      amplitude(
+        {
+          offset: 31721,
+          type: 'screen.pair.auth.fx-view',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_qr_connect_device - fx_view_engage'
+      );
     },
   },
 });

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -42,7 +42,7 @@ const CONNECT_DEVICE_FLOWS = {
   'app-store': 'store_buttons',
   install_from: 'store_buttons',
   pair: 'pairing',
-  signin_from: 'signin'
+  signin_from: 'signin',
 };
 
 const EVENT_PROPERTIES = {


### PR DESCRIPTION
Because:
 - we want to know about user interactions during the Connect Another Device and pairing process

This commit:
 - capture new events on CAD/pairing pages

Fixes FXA-5751