### PR TITLE
fix(fxa-admin-server): throw error when iap sub has no matching stripe plan

### DIFF
--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
@@ -94,7 +94,7 @@ describe('Subscription Service', () => {
     product_metadata: {},
     product_name: productName,
   };
-  const subscription = {
+  const mockStripeCustomer = {
     subscriptions: {
       data: [],
     },
@@ -138,7 +138,7 @@ describe('Subscription Service', () => {
   });
 
   it('should resolve no subscriptions', async () => {
-    mockFetchCustomers.mockImplementation(async () => subscription);
+    mockFetchCustomers.mockImplementation(async () => mockStripeCustomer);
     mockAppStoreGetSubscriptions.mockImplementation(async () => []);
     mockPlayStoreGetSubscriptions.mockImplementation(async () => []);
 
@@ -245,7 +245,7 @@ describe('Subscription Service', () => {
       },
     };
 
-    mockFetchCustomers.mockImplementation(async () => subscription);
+    mockFetchCustomers.mockImplementation(async () => mockStripeCustomer);
     mockAppStoreGetSubscriptions.mockImplementation(async (_uid: string) => [
       appStoreSubscriptionPurchase,
     ]);
@@ -277,6 +277,50 @@ describe('Subscription Service', () => {
     expect(mockFetchCustomers).toBeCalledWith(uid, ['subscriptions']);
     expect(mockAppStoreGetSubscriptions).toBeCalledWith(uid);
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
+  });
+
+  it('should throw an error when apple IAP subscription has no stripe plan', async () => {
+    // Arrange
+    const appStoreSubscriptionPurchase: Partial<AppStoreSubscriptionPurchase> =
+      {
+        autoRenewStatus: 1,
+        bundleId,
+        expiresDate: currentPeriodEnd,
+        isEntitlementActive: () => true,
+        isExpired: () => false,
+        isFreeTrial: () => false,
+        isInBillingRetryPeriod: () => false,
+        isInGracePeriod: () => false,
+        originalPurchaseDate: created,
+        originalTransactionId: subscriptionId,
+        productId: 'some-unmatched-product-id',
+        verifiedAt: currentPeriodStart,
+        willRenew: () => true,
+      };
+    const abbrevPlan = {
+      ...plan,
+      plan_metadata: {
+        [STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS]:
+          'product-123,product-234',
+      },
+    };
+
+    mockFetchCustomers.mockImplementation(async () => mockStripeCustomer);
+    mockAppStoreGetSubscriptions.mockImplementation(async (_uid: string) => [
+      appStoreSubscriptionPurchase,
+    ]);
+    mockPlayStoreGetSubscriptions.mockImplementation(
+      async (_uid: string) => []
+    );
+    mockAllAbbrevPlans.mockImplementation(async () => [abbrevPlan]);
+
+    // Act
+    const result = service.getSubscriptions(uid);
+
+    // Assert
+    await expect(result).rejects.toThrow(
+      `No matching plan for IAP apple subscription productId: ${appStoreSubscriptionPurchase.productId}`
+    );
   });
 
   it('should provide play store subscriptions', async () => {
@@ -338,6 +382,47 @@ describe('Subscription Service', () => {
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
   });
 
+  it('should throw an error when play store IAP subscription has no stripe plan', async () => {
+    // Arrange
+    const playStorePurchase: Partial<PlayStoreSubscriptionPurchase> = {
+      autoRenewing: true,
+      countryCode: 'US',
+      expiryTimeMillis: currentPeriodEnd,
+      isEntitlementActive: () => true,
+      orderId: orderId,
+      paymentState: 1,
+      packageName: productName,
+      priceCurrencyCode: plan.currency,
+      priceAmountMicros: plan.amount * 10e6,
+      purchaseToken: subscriptionId,
+      sku: 'some-unmatched-sku',
+      startTimeMillis: currentPeriodStart,
+      verifiedAt: created,
+    };
+
+    mockFetchCustomers.mockImplementation(async () => mockStripeCustomer);
+    mockAppStoreGetSubscriptions.mockImplementation(async (_uid: string) => []);
+    mockPlayStoreGetSubscriptions.mockImplementation(async (_uid: string) => [
+      playStorePurchase,
+    ]);
+    mockAllAbbrevPlans.mockImplementation(async () => [
+      {
+        ...plan,
+        plan_metadata: {
+          [STRIPE_PRICE_METADATA.PLAY_SKU_IDS]: 'product-123,product-234',
+        },
+      },
+    ]);
+
+    // Act
+    const result = service.getSubscriptions(uid);
+
+    // Assert
+    expect(result).rejects.toThrow(
+      `No matching plan for IAP play subscription sku: ${playStorePurchase.sku}`
+    );
+  });
+
   describe('feature flags', () => {
     beforeEach(() => {
       mockConfigOverrides['featureFlags.subscriptions.appStore'] = false;
@@ -346,7 +431,7 @@ describe('Subscription Service', () => {
     });
 
     it('should respect feature flags', async () => {
-      mockFetchCustomers.mockImplementation(async () => subscription);
+      mockFetchCustomers.mockImplementation(async () => mockStripeCustomer);
       mockAppStoreGetSubscriptions.mockImplementation(async () => []);
       mockPlayStoreGetSubscriptions.mockImplementation(async () => []);
 

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
@@ -130,6 +130,10 @@ export class SubscriptionsService {
         'iap_apple',
         plans
       );
+      if (!plan)
+        throw new Error(
+          `No matching plan for IAP apple subscription productId: ${subscription.productId}`
+        );
       yield AppStoreFormatter.toMozSubscription(subscription, plan);
     }
   }
@@ -142,6 +146,10 @@ export class SubscriptionsService {
     const subscriptions = await this.playStoreService.getSubscriptions(uid);
     for (const subscription of subscriptions || []) {
       const plan = iapPurchaseToPlan(subscription.sku, 'iap_google', plans);
+      if (!plan)
+        throw new Error(
+          `No matching plan for IAP play subscription sku: ${subscription.sku}`
+        );
       yield PlayStoreFormatter.toMozSubscription(subscription, plan);
     }
   }


### PR DESCRIPTION
## Because

Due to some typecasting and improper typing, the admin server would try to return null for some properties which were declared as non-null in the schema if there existed an IAP subscription with no matching stripe plan. This would cause GraphQL to throw a "cannot return null for non-nullable field" error.

## This pull request

Throws an error when the user has an IAP subscription with no matching stripe plan.
There is further work to do in this area of the codebase, however. The underlying issue at play here is the improper typing and typecasting of many of the fields assembled to serve these requests. A followup ticket will be made to solve these issues.

## Issue that this pull request solves

Closes FXA-5820

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
