### PR TITLE
fix(auth): Throw a 404 instead of a 500 for unknown app name

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1309,7 +1309,7 @@ AppError.unknownAppName = (appName) => {
       code: 404,
       error: 'Not Found',
       errno: ERRNO.IAP_UNKNOWN_APPNAME,
-      message: 'Unknown subscription',
+      message: 'Unknown app name',
     },
     {
       appName,

--- a/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
@@ -9,6 +9,7 @@ import {
 import { Container } from 'typedi';
 import { TypedCollectionReference } from 'typesafe-node-firestore';
 
+import error from '../../error';
 import { AppConfig, AuthFirestore, AuthLogger } from '../../types';
 import { AppStoreSubscriptionPurchase } from './apple-app-store/subscription-purchase';
 import { PlayStoreSubscriptionPurchase } from './google-play/subscription-purchase';
@@ -53,7 +54,7 @@ export class IAPConfig {
     if (doc.exists) {
       return doc.data()?.plans;
     } else {
-      throw Error(`IAP Plans document does not exist for ${appName}`);
+      throw error.unknownAppName(appName);
     }
   }
 
@@ -66,7 +67,7 @@ export class IAPConfig {
     if (doc.exists) {
       return doc.data()?.packageName;
     } else {
-      throw Error(`IAP Plans document does not exist for ${appName}`);
+      throw error.unknownAppName(appName);
     }
   }
 
@@ -79,7 +80,7 @@ export class IAPConfig {
     if (doc.exists) {
       return doc.data()?.bundleId;
     } else {
-      throw Error(`IAP Plans document does not exist for ${appName}`);
+      throw error.unknownAppName(appName);
     }
   }
 }

--- a/packages/fxa-auth-server/test/local/payments/iap/iap-config.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/iap-config.js
@@ -128,10 +128,7 @@ describe('IAPConfig', () => {
         await iapConfig.plans('testApp');
         assert.fail('Expected exception thrown.');
       } catch (err) {
-        assert.strictEqual(
-          err.message,
-          'IAP Plans document does not exist for testApp'
-        );
+        assert.strictEqual(err.message, 'Unknown app name');
       }
     });
   });
@@ -167,10 +164,7 @@ describe('IAPConfig', () => {
         await iapConfig.packageName('testApp');
         assert.fail('Expected exception thrown.');
       } catch (err) {
-        assert.strictEqual(
-          err.message,
-          'IAP Plans document does not exist for testApp'
-        );
+        assert.strictEqual(err.message, 'Unknown app name');
       }
     });
   });
@@ -206,10 +200,7 @@ describe('IAPConfig', () => {
         await iapConfig.getBundleId('testApp');
         assert.fail('Expected exception thrown.');
       } catch (err) {
-        assert.strictEqual(
-          err.message,
-          'IAP Plans document does not exist for testApp'
-        );
+        assert.strictEqual(err.message, 'Unknown app name');
       }
     });
   });


### PR DESCRIPTION
## Because

- we should throw a 404 error instead of a 500 for unknown app name

## This pull request

- updates to use error `unknownAppName` in all three methods (plans, packageName and getBundleId) in the IAPConfig class

## Issue that this pull request solves

Closes: [FXA-5244](https://mozilla-hub.atlassian.net/browse/FXA-5244)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
