### PR TITLE
fix(CAD): Update entrypoint checks causing unwanted redirects/wrong graphic

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -87,10 +87,8 @@ export default {
       this.isDefault() &&
       context === Constants.FX_DESKTOP_V3_CONTEXT &&
       (entrypoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT ||
-        entrypoint === Constants.FIREFOX_MENU_ENTRYPOINT ||
-        entrypoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT ||
-        entrypoint === Constants.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
-        entrypoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT)
+        (entrypoint === Constants.FIREFOX_MENU_ENTRYPOINT &&
+          this.relier.get('action') !== 'email'))
     ) {
       return true;
     }

--- a/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
@@ -43,7 +43,8 @@ export default {
       entryPoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT ||
       entryPoint === Constants.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
       entryPoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_FX_VIEW
+      entryPoint === Constants.FIREFOX_FX_VIEW ||
+      entryPoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT
     );
   },
 };

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -93,13 +93,7 @@ describe('views/connect_another_device', () => {
       });
     });
 
-    [
-      'fxa_discoverability_native',
-      'fxa_app_menu',
-      'preferences',
-      'synced-tabs',
-      'tabs-sidebar',
-    ].forEach((entrypoint) => {
+    ['fxa_discoverability_native', 'fxa_app_menu'].forEach((entrypoint) => {
       describe(`with a Fx desktop user that can pair from ${entrypoint}`, () => {
         beforeEach(() => {
           sinon.stub(view, '_isSignedIn').callsFake(() => true);
@@ -121,6 +115,38 @@ describe('views/connect_another_device', () => {
         });
       });
     });
+
+    ['preferences', 'synced-tabs', 'tabs-sidebar', 'fxa_app_menu'].forEach(
+      (entrypoint) => {
+        const isAppMenu = entrypoint === 'fxa_app_menu';
+        describe(`with known entrypoint ${entrypoint}${
+          isAppMenu && ' and action=email'
+        }`, () => {
+          beforeEach(() => {
+            sinon.stub(view, '_isSignedIn').callsFake(() => true);
+            relier.set('entrypoint', entrypoint);
+            relier.set('context', 'fx_desktop_v3');
+            // `fxa_app_menu` without `action=email` redirects. If present, it does not redirect.
+            if (isAppMenu) {
+              relier.set('action', 'email');
+            }
+            sinon.spy(view, 'navigate');
+
+            windowMock.navigator.userAgent =
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+
+            return view.render().then(() => {
+              view.afterVisible();
+            });
+          });
+
+          it('shows the success message and does not redirect', () => {
+            assert.lengthOf(view.$(FXA_CONNECTED_SELECTOR), 1);
+            assert.isTrue(view.navigate.notCalled);
+          });
+        });
+      }
+    );
 
     describe('with a fennec user that is signed in', () => {
       beforeEach(() => {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
@@ -65,6 +65,11 @@ describe('views/mixins/pairing-graphics-mixin', function () {
       assert.equal(view.showDownloadFirefoxQrCode(), true);
     });
 
+    it('returns true if entry point is fxa_discoverability_native', () => {
+      sinon.stub(view, 'getSearchParam').callsFake(() => 'fx-view');
+      assert.equal(view.showDownloadFirefoxQrCode(), true);
+    });
+
     it('returns false if entry point is not app menu', () => {
       sinon.stub(view, 'getSearchParam').callsFake(() => undefined);
       assert.equal(view.showDownloadFirefoxQrCode(), false);


### PR DESCRIPTION
Because:
* We were redirecting users to /pair when they should be shown the connect another device screen and were showing users the wrong graphic at another entrypoint

This commit:
* Adds a check for 'action=email' and doesn't redirect if present with 'entrypoint=fxa_app_menu'
* Removes other, new entrypoint checks for the redirect
* Adds an entrypoint check to show the QR code graphic

Closes [FXA-5850](https://mozilla-hub.atlassian.net/browse/FXA-5850), closes [FXA-5947](https://mozilla-hub.atlassian.net/browse/FXA-5947)

---

See ticket and see [this comment](https://mozilla-hub.atlassian.net/browse/FXA-5452?focusedCommentId=573894). I tested most of the flows laid out, but there's a lot, so feel free to poke around.