### PR TITLE
fix(admin): Don't show unknown values in devices and apps table

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -87,9 +87,9 @@ let accountResponse: AccountProps = {
       lastAccessTime: new Date(Date.now() - 5 * 1e3).getTime(),
       lastAccessTimeFormatted: '5 seconds ago',
       location: {
-        city: null,
-        country: null,
-        state: null,
+        city: 'Orlando',
+        country: 'USA',
+        state: 'FL',
         stateCode: null,
       },
       name: "UserX's Nightly on machine-xyz",
@@ -307,13 +307,23 @@ it('displays the attached clients', async () => {
     sessionTokenIdFields: await findAllByTestId(
       'attached-clients-session-token-id'
     ),
-    freshreshTokenIdFields: await findAllByTestId(
+    refreshTokenIdFields: await findAllByTestId(
       'attached-clients-refresh-token-id'
     ),
   };
 
-  // Make sure all data is rendered
-  Object.values(fields).forEach((x) => expect(x).toHaveLength(5));
+  // Ensure that only known data is rendered
+  expect(fields['clientFields']).toHaveLength(5);
+  expect(fields['deviceTypeFields']).toHaveLength(1);
+  expect(fields['userAgentFields']).toHaveLength(3);
+  expect(fields['osFields']).toHaveLength(3);
+  expect(fields['createdAtFields']).toHaveLength(5);
+  expect(fields['lastAccessFields']).toHaveLength(5);
+  expect(fields['locationFields']).toHaveLength(1);
+  expect(fields['clientIdFields']).toHaveLength(2);
+  expect(fields['deviceIdFields']).toHaveLength(1);
+  expect(fields['sessionTokenIdFields']).toHaveLength(3);
+  expect(fields['refreshTokenIdFields']).toHaveLength(1);
 
   // Make sure fields have some sort of content
   Object.values(fields)

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -535,7 +535,7 @@ export const Account = ({
                     attachedClient.sessionTokenId ||
                     attachedClient.refreshTokenId ||
                     attachedClient.clientId ||
-                    'unknown'
+                    'Unknown'
                   }-${attachedClient.createdTime}`}
                   {...attachedClient}
                 />
@@ -869,7 +869,7 @@ const AttachedClients = ({
           />
           <ResultTableRow
             label="Device Type"
-            value={format.deviceType(deviceType, sessionTokenId, deviceId)}
+            value={deviceType}
             testId={testId('device-type')}
           />
           <ResultTableRow
@@ -934,12 +934,16 @@ const ResultTableRow = ({
   testId: string;
   className?: string;
 }) => {
+  if (!value || value === 'Unknown' || value === 'N/A') {
+    return null;
+  }
+
   return (
     <tr className={className || ''}>
       <td className="account-label">
         <span>{label}</span>
       </td>
-      <td data-testid={testId}>{value ? value : <i>Unknown</i>}</td>
+      <td data-testid={testId}>{value}</td>
     </tr>
   );
 };
@@ -985,18 +989,6 @@ const format = {
         {name} {clientId && <i>[{clientId}]</i>}
       </>
     );
-  },
-  deviceType(
-    deviceType?: Nullable<string>,
-    sessionId?: Nullable<string>,
-    deviceId?: Nullable<string>
-  ) {
-    // This logic might be better at the api level, but it's probably better not to introduce a breaking change.
-    return deviceType
-      ? deviceType
-      : sessionId || deviceId
-      ? 'desktop'
-      : 'unknown';
   },
 };
 

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -312,7 +312,7 @@ const AccountSearchResult = ({
   if (error) {
     return (
       <p data-testid="error-message" className="mt-2">
-        An error occurred.
+        An error occurred. Error: {error.toString()}
       </p>
     );
   }


### PR DESCRIPTION
## Because

- We show `Unknown` value in devices and apps tables, which isn't help because not all have those values set

## This pull request

- Does not show unknown or null values in the admin panel devices table

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-4594

## Checklist

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screen Shot 2022-09-09 at 12 15 54 PM](https://user-images.githubusercontent.com/1295288/189401489-8fd1c737-0a7b-450d-ae38-d81676417253.png)

## Other

Created this PR for consideration. It doesn't really fix https://mozilla-hub.atlassian.net/browse/FXA-4594 since user agent information is not avaible on oauth tokens, however I think it does provide some small improvement to the UX. Ideally I think we should close that bug and open a new bug to show the estimated location of the oauth token. This would provide the user with some additional security context around the oauth token in leiu of storing user agent information.