### PR TITLE
task(admin-panel): Allow editing user's locale

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -39,6 +39,7 @@ let accountResponse: AccountProps = {
   uid: 'ca1c61239f2448b2af618f0b50226cde',
   email: 'hey@happy.com',
   emailVerified: true,
+  locale: 'en-US',
   emails: [
     {
       email: 'hey@happy.com',
@@ -208,6 +209,10 @@ it('displays the account', async () => {
   expect(getByTestId('account-created-at')).toHaveTextContent(
     accountResponse.createdAt.toString()
   );
+
+  expect(getByTestId('account-locale')).toHaveTextContent(
+    accountResponse.locale!
+  );
 });
 
 it('displays when account is disabled', async () => {
@@ -355,4 +360,14 @@ it('displays secondary emails', async () => {
     'ohdeceiver@gmail.com'
   );
   expect(getByTestId('secondary-verified')).toHaveTextContent('not confirmed');
+});
+
+it('displays the locale', async () => {
+  const { getByTestId } = render(
+    <MockedProvider>
+      <Account {...accountResponse} />
+    </MockedProvider>
+  );
+  expect(getByTestId('account-locale')).toHaveTextContent('en-US');
+  expect(getByTestId('edit-account-locale')).toBeInTheDocument();
 });

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -54,6 +54,12 @@ export const DISABLE_ACCOUNT = gql`
   }
 `;
 
+export const EDIT_LOCALE = gql`
+  mutation editLocale($uid: String!, $locale: String!) {
+    editLocale(uid: $uid, locale: $locale)
+  }
+`;
+
 export const ENABLE_ACCOUNT = gql`
   mutation enableAccount($uid: String!) {
     enableAccount(uid: $uid)
@@ -311,6 +317,7 @@ export const Account = ({
   emails,
   createdAt,
   disabledAt,
+  locale,
   lockedAt,
   emailBounces,
   totp,
@@ -327,6 +334,32 @@ export const Account = ({
   const lockedAtDate = dateFormat(new Date(lockedAt || 0), DATE_FORMAT);
   const primaryEmail = emails!.find((email) => email.isPrimary)!;
   const secondaryEmails = emails!.filter((email) => !email.isPrimary);
+
+  const [editLocale] = useMutation(EDIT_LOCALE, {});
+  const handleEditLocale = async () => {
+    try {
+      const newLocale = window.prompt('Enter a new local.');
+      if (!newLocale) {
+        return;
+      }
+
+      const res = await editLocale({
+        variables: {
+          uid,
+          locale: newLocale,
+        },
+      });
+
+      if (res.data?.editLocale) {
+        onCleared();
+      } else {
+        window.alert(`Edit unsuccessful.`);
+      }
+    } catch (err) {
+      window.alert(`An unexpected error was encountered. Edit unsuccessful.`);
+    }
+  };
+
   return (
     <section className="mt-8" data-testid="account-section">
       <ul>
@@ -372,6 +405,26 @@ export const Account = ({
                     </>
                   }
                   testId="account-created-at"
+                />
+                <ResultTableRow
+                  label="Locale"
+                  value={
+                    <>
+                      {locale}
+
+                      <Guard features={[AdminPanelFeature.EditLocale]}>
+                        <button
+                          className="bg-grey-10 border-2 border-grey-100 font-small leading-6 ml-2 rounded text-red-700 w-10 hover:border-2 hover:border-grey-10 hover:bg-grey-50 hover:text-red-700"
+                          type="button"
+                          onClick={handleEditLocale}
+                          data-testid="edit-account-locale"
+                        >
+                          Edit
+                        </button>
+                      </Guard>
+                    </>
+                  }
+                  testId="account-locale"
                 />
                 {lockedAt != null && (
                   <ResultTableRow

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -13,6 +13,7 @@ const ACCOUNT_SCHEMA = `
   createdAt
   disabledAt
   lockedAt
+  locale
   emails {
     email
     isVerified

--- a/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
+++ b/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
@@ -11,6 +11,7 @@ export enum EventNames {
   UnverifyEmail = 'unverify-email',
   DisableLogin = 'disable-login',
   AccountSearch = 'account-search',
+  EditLocale = 'edit-locale',
 }
 
 /**

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -308,4 +308,11 @@ describe('AccountResolver', () => {
     expect(result).toBeDefined();
     expect(result.length).toBe(1);
   });
+
+  it('edits locale', async () => {
+    const result1 = await resolver.editLocale(USER_1.uid, 'en-CA');
+    const result2 = await resolver.accountByEmail(USER_1.email, true, 'joe');
+    expect(result1).toBe(true);
+    expect(result2.locale).toBe('en-CA');
+  });
 });

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -44,6 +44,7 @@ const ACCOUNT_COLUMNS = [
   'createdAt',
   'disabledAt',
   'lockedAt',
+  'locale',
 ];
 const EMAIL_COLUMNS = [
   'createdAt',
@@ -159,6 +160,22 @@ export class AccountResolver {
       .query()
       .update({ disabledAt: Date.now() })
       .where('uid', uidBuffer);
+    return !!result;
+  }
+
+  @Features(AdminPanelFeature.EditLocale)
+  @Mutation((returns) => Boolean)
+  public async editLocale(
+    @Args('uid') uid: string,
+    @Args('locale') locale: string
+  ) {
+    this.eventLogging.onEvent(EventNames.EditLocale);
+    const uidBuffer = uuidTransformer.to(uid);
+    const result = await this.db.account
+      .query()
+      .update({ locale: locale })
+      .where('uid', uidBuffer);
+
     return !!result;
   }
 

--- a/packages/fxa-admin-server/src/gql/model/account.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/account.model.ts
@@ -30,6 +30,9 @@ export class Account {
   public disabledAt?: number;
 
   @Field({ nullable: true })
+  public locale?: string;
+
+  @Field({ nullable: true })
   public lockedAt?: number;
 
   @Field((type) => [Email], { nullable: true })

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -134,6 +134,7 @@ export interface Account {
     emailVerified: boolean;
     createdAt: number;
     disabledAt?: Nullable<number>;
+    locale?: Nullable<string>;
     lockedAt?: Nullable<number>;
     emails?: Nullable<Email[]>;
     emailBounces?: Nullable<EmailBounce[]>;
@@ -167,6 +168,7 @@ export interface IQuery {
 export interface IMutation {
     unverifyEmail(email: string): boolean | Promise<boolean>;
     disableAccount(uid: string): boolean | Promise<boolean>;
+    editLocale(locale: string, uid: string): boolean | Promise<boolean>;
     enableAccount(uid: string): boolean | Promise<boolean>;
     recordAdminSecurityEvent(name: string, uid: string): boolean | Promise<boolean>;
     unlinkAccount(uid: string): boolean | Promise<boolean>;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -129,6 +129,7 @@ type Account {
   emailVerified: Boolean!
   createdAt: Float!
   disabledAt: Float
+  locale: String
   lockedAt: Float
   emails: [Email!]
   emailBounces: [EmailBounce!]
@@ -162,6 +163,7 @@ type Query {
 type Mutation {
   unverifyEmail(email: String!): Boolean!
   disableAccount(uid: String!): Boolean!
+  editLocale(locale: String!, uid: String!): Boolean!
   enableAccount(uid: String!): Boolean!
   recordAdminSecurityEvent(name: String!, uid: String!): Boolean!
   unlinkAccount(uid: String!): Boolean!

--- a/packages/fxa-shared/guards/AdminPanelGuard.ts
+++ b/packages/fxa-shared/guards/AdminPanelGuard.ts
@@ -25,6 +25,7 @@ export enum AdminPanelFeature {
   LinkedAccounts = 'LinkedAccounts',
   ClearEmailBounces = 'ClearEmailBounces',
   DisableAccount = 'DisableAccount',
+  EditLocale = 'EditLocale',
   EnableAccount = 'EnableAccount',
   UnverifyEmail = 'UnverifyEmail',
   UnlinkAccount = 'UnlinkAccount',
@@ -106,6 +107,10 @@ const defaultAdminPanelPermissions: Permissions = {
   [AdminPanelFeature.DisableAccount]: {
     name: 'Disable Account',
     level: PermissionLevel.Admin,
+  },
+  [AdminPanelFeature.EditLocale]: {
+    name: 'Edit Locale',
+    level: PermissionLevel.Support,
   },
   [AdminPanelFeature.EnableAccount]: {
     name: 'Enable Account',


### PR DESCRIPTION
## Because

- Support needed ability to change user's current locale


## This pull request

- Allows viewing of user locale
- Allows editing of user locale
- Adds guard requiring 'support' level to edit user locale

## Issue that this pull request solves

Closes: FXA-5736

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/189420686-312c779e-4148-424e-ad33-eda68f4a98cc.png)
![image](https://user-images.githubusercontent.com/94418270/189420827-f7093833-7f6d-43d9-bdb0-d9c7e4971a1a.png)
![image](https://user-images.githubusercontent.com/94418270/189420856-34db5791-c978-4903-85bb-39d98a51ff3e.png)

