### PR TITLE
copy(fxa-auth-server) copy updates for postNewRecoveryCodes

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -42,7 +42,7 @@
   "postAddTwoStepAuthentication": 8,
   "postRemoveTwoStepAuthentication": 8,
   "postConsumeRecoveryCode": 6,
-  "postNewRecoveryCodes": 6,
+  "postNewRecoveryCodes": 7,
   "passwordResetAccountRecovery": 8,
   "postAddAccountRecovery": 8,
   "postRemoveAccountRecovery": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/en.ftl
@@ -1,4 +1,5 @@
-postNewRecoveryCodes-subject-1 = New backup authentication codes generated
-postNewRecoveryCodes-title-1 = New backup authentication codes generated
-postNewRecoveryCodes-description-1 = You have successfully generated new backup authentication codes from the following device:
+postNewRecoveryCodes-subject-2 = New backup authentication codes created
+postNewRecoveryCodes-title-2 = You created new backup authentication codes
+# After the colon, there is information about the device that the authentication codes were created on
+postNewRecoveryCodes-description-2 = They were created on:
 postNewRecoveryCodes-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "postNewRecoveryCodes-subject-1",
-    "message": "New backup authentication codes generated"
+    "id": "postNewRecoveryCodes-subject-2",
+    "message": "New backup authentication codes created"
   },
   "action": {
     "id": "postNewRecoveryCodes-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.mjml
@@ -5,11 +5,11 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postNewRecoveryCodes-title-1">New backup authentication codes generated</span>
+      <span data-l10n-id="postNewRecoveryCodes-title-2">You created new backup authentication codes</span>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postNewRecoveryCodes-description-1">You have successfully generated new backup authentication codes from the following device:</span>
+      <span data-l10n-id="postNewRecoveryCodes-description-2">They were created on:</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.txt
@@ -1,11 +1,9 @@
-postNewRecoveryCodes-title-1 = "New backup authentication codes generated"
+postNewRecoveryCodes-title-2 = "You created new backup authentication codes"
 
-postNewRecoveryCodes-description-1 = "You have successfully generated new backup authentication codes from the following device:"
+postNewRecoveryCodes-description-2 = "They were created on:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
 <%- include('/partials/manageAccount/index.txt') %>
 
-<%- include('/partials/changePassword/index.txt') %>
-
-<%- include('/partials/support/index.txt') %>
+<%- include('/partials/automatedEmailChangePassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1213,7 +1213,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postNewRecoveryCodesEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'New backup authentication codes generated' }],
+    ['subject', { test: 'equal', expected: 'New backup authentication codes created' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postNewRecoveryCodes') }],
@@ -1221,8 +1221,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postNewRecoveryCodes }],
     ])],
     ['html', [
-      { test: 'include', expected: 'New backup authentication codes generated' },
-      { test: 'include', expected: 'You have successfully generated new backup authentication codes' },
+      { test: 'include', expected: 'You created new backup authentication codes' },
+      { test: 'include', expected: 'They were created on:' },
       { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-replace-recovery-codes', 'change-password', 'email')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-replace-recovery-codes', 'privacy')) },
@@ -1235,12 +1235,12 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'New backup authentication codes generated' },
-      { test: 'include', expected: 'You have successfully generated new backup authentication codes' },
+      { test: 'include', expected: 'You created new backup authentication codes' },
+      { test: 'include', expected: 'They were created on:' },
       { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid')}` },
-      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-replace-recovery-codes', 'change-password', 'email')}` },
+      { test: 'include', expected: `change your password right away: \n${configUrl('initiatePasswordChangeUrl', 'account-replace-recovery-codes', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-replace-recovery-codes', 'privacy')}` },
-      { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'account-replace-recovery-codes', 'support')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support: \n${configUrl('supportUrl', 'account-replace-recovery-codes', 'support')}` },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },


### PR DESCRIPTION
Because:

* We have updated copy and storybook text the for postNewRecoveryCodes email

This commit:

* Updates the copy, and updates the storybook condition

## Issue that this pull request solves

Closes: # https://mozilla-hub.atlassian.net/browse/FXA-5198

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1132" alt="Screen Shot 2022-09-09 at 12 29 52 PM" src="https://user-images.githubusercontent.com/11150372/189429159-dc678606-7564-4e89-b865-1eec8269bd5e.png">
