### PR TITLE
copy(fxa-auth-server): update copy for postRemoveAccountRecovery

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en.ftl
@@ -1,5 +1,6 @@
-postRemoveAccountRecovery-subject = Account recovery key removed
-postRemoveAccountRecovery-title = Account recovery key removed
-postRemoveAccountRecovery-description = You have successfully removed an account recovery key for your { -product-firefox-account } using the following device:
+postRemoveAccountRecovery-subject-2 = Account recovery key deleted
+postRemoveAccountRecovery-title-2 = You deleted your account recovery key.
+# After the colon, there is information about the device that the account recovery key was deleted from
+postRemoveAccountRecovery-description-2 = It was deleted from:
 postRemoveAccountRecovery-action = Manage account
-postRemoveAccountRecovery-invalid-1 = This account recovery key can no longer be used to recover your account.
+postRemoveAccountRecovery-invalid-2 = You need an account recovery key to recover your Firefox data if you forget your password.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "postRemoveAccountRecovery-subject",
-    "message": "Account recovery key removed"
+    "id": "postRemoveAccountRecovery-subject-2",
+    "message": "Account recovery key deleted"
   },
   "action": {
     "id": "postRemoveAccountRecovery-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.mjml
@@ -5,11 +5,11 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postRemoveAccountRecovery-title">Account recovery key removed</span>
+      <span data-l10n-id="postRemoveAccountRecovery-title-2">You deleted your account recovery key.</span>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postRemoveAccountRecovery-description">You have successfully removed an account recovery key for your Firefox account using the following device:</span>
+      <span data-l10n-id="postRemoveAccountRecovery-description-2"It was deleted from:</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -19,7 +19,7 @@
 <mj-section>
   <mj-column>
 <mj-text css-class="text-body">
-  <span data-l10n-id="postRemoveAccountRecovery-invalid-1">This account recovery key can no longer be used to recover your account.</span>
+  <span data-l10n-id="postRemoveAccountRecovery-invalid-2">You need an account recovery key to recover your Firefox data if you forget your password.</span>
 </mj-text>
 </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.txt
@@ -1,13 +1,11 @@
-postRemoveAccountRecovery-title = "Account recovery key removed"
+postRemoveAccountRecovery-title-2 = "You deleted your account recovery key."
 
-postRemoveAccountRecovery-description = "You have successfully removed an account recovery key for your Firefox account using the following device:"
+postRemoveAccountRecovery-description-2 = "It was deleted from:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
-postRemoveAccountRecovery-invalid-1 = "This account recovery key can no longer be used to recover your account."
+postRemoveAccountRecovery-invalid-2 = "You need an account recovery key to recover your Firefox data if you forget your password. "
 
 <%- include('/partials/manageAccount/index.txt') %>
 
-<%- include('/partials/changePassword/index.txt') %>
-
-<%- include('/partials/support/index.txt') %>
+<%- include('/partials/automatedEmailChangePassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1010,7 +1010,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postRemoveAccountRecoveryEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Account recovery key removed' }],
+    ['subject', { test: 'equal', expected: 'Account recovery key deleted' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveAccountRecovery') }],
@@ -1018,7 +1018,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postRemoveAccountRecovery }],
     ])],
     ['html', [
-      { test: 'include', expected: 'Account recovery key removed' },
+      { test: 'include', expected: 'You deleted your account recovery key.' },
       { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-recovery-removed', 'change-password', 'email')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-recovery-removed', 'privacy')) },
@@ -1031,11 +1031,11 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Account recovery key removed' },
+      { test: 'include', expected: 'You deleted your account recovery key.' },
       { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid')}` },
-      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-recovery-removed', 'change-password', 'email')}` },
+      { test: 'include', expected: `change your password right away: \n${configUrl('initiatePasswordChangeUrl', 'account-recovery-removed', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-recovery-removed', 'privacy')}` },
-      { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'account-recovery-removed', 'support')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support: \n${configUrl('supportUrl', 'account-recovery-removed', 'support')}` },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },


### PR DESCRIPTION
Because:

* We're updating copy and Storybook for emails

This commit:

* updates tests, copy, and storybook for postRemoveAccountRecovery

Closes # https://mozilla-hub.atlassian.net/browse/FXA-5199

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Uploading Screen Shot 2022-09-09 at 4.29.10 PM.png…]()

