### PR TITLE
fix(admin): Add error alert in admin panel

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
@@ -374,7 +374,6 @@ it('displays the error state if there is an error', async () => {
     target: { value: testEmail },
   });
   fireEvent.click(screen.getByTestId('search-button'));
-
   await waitFor(() => screen.getByTestId('error-alert'));
   expect(calledAccountSearch).toBeTruthy();
 });

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
@@ -375,7 +375,7 @@ it('displays the error state if there is an error', async () => {
   });
   fireEvent.click(screen.getByTestId('search-button'));
 
-  await waitFor(() => screen.getByTestId('error-message'));
+  await waitFor(() => screen.getByTestId('error-alert'));
   expect(calledAccountSearch).toBeTruthy();
 });
 

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -3,10 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useLazyQuery, gql } from '@apollo/client';
+import { useLazyQuery, gql, ApolloError } from '@apollo/client';
 import Account from './Account';
 import { Account as AccountType } from 'fxa-admin-server/src/graphql';
 import iconSearch from '../../images/icon-search.svg';
+import ErrorAlert from '../ErrorAlert';
 
 const ACCOUNT_SCHEMA = `
   uid
@@ -297,7 +298,7 @@ const AccountSearchResult = ({
 }: {
   onCleared: () => void;
   loading: boolean;
-  error?: {};
+  error?: ApolloError;
   data?: {
     accountByEmail: AccountType;
     accountByUid: AccountType;
@@ -311,11 +312,7 @@ const AccountSearchResult = ({
       </p>
     );
   if (error) {
-    return (
-      <p data-testid="error-message" className="mt-2">
-        An error occurred. Error: {error.toString()}
-      </p>
-    );
+    return <ErrorAlert {...{ error }}></ErrorAlert>;
   }
 
   if (data?.accountByEmail) {

--- a/packages/fxa-admin-panel/src/components/ErrorAlert/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/ErrorAlert/index.test.tsx
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ServerError, ServerParseError } from '@apollo/client';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ErrorAlert from '.';
+import {
+  GQL_ERROR,
+  NETWORK_ERROR,
+  NETWORK_SERVER_ERROR,
+  NETWORK_SERVER_PARSE_ERROR,
+} from './mocks';
+
+describe('ApolloErrorAlert', () => {
+  it('handles a standard error', () => {
+    render(<ErrorAlert error={new Error('boop')} />);
+    screen.getByText('General GQL Error');
+    screen.getByText('boop');
+  });
+
+  it('handles a network server error', () => {
+    render(<ErrorAlert error={NETWORK_SERVER_ERROR} />);
+    screen.getByText('Network Error');
+    screen.getByText(NETWORK_SERVER_ERROR.message);
+    screen.getByText(
+      (NETWORK_SERVER_ERROR.networkError! as ServerError).result!.errors[0]
+        .message
+    );
+  });
+
+  it('handles a network server parse error', () => {
+    render(<ErrorAlert error={NETWORK_SERVER_PARSE_ERROR} />);
+    screen.getByText('Network Error');
+    screen.getByText(NETWORK_SERVER_PARSE_ERROR.message);
+    screen.getByText(
+      (NETWORK_SERVER_PARSE_ERROR.networkError! as ServerParseError).statusCode
+    );
+    // an actual bodyText response is difficult to test for; just check for error details
+    screen.getByText('Request URL:', { exact: false });
+  });
+
+  it('handles a network error', () => {
+    render(<ErrorAlert error={NETWORK_ERROR} />);
+    screen.getByText('Network Error');
+    screen.getByText(NETWORK_ERROR.message);
+    screen.getByText(
+      (NETWORK_ERROR.networkError! as ServerError).result.errors[0].message
+    );
+  });
+
+  it('handles a graphQL error', () => {
+    render(<ErrorAlert error={GQL_ERROR} />);
+    screen.getByText('GraphQL Apollo Error');
+    // in this case, `GQL_ERROR.message` matches `GQL_ERROR.graphQLErrors[0].message`
+    expect(screen.getAllByText(GQL_ERROR.message)).toHaveLength(2);
+  });
+});

--- a/packages/fxa-admin-panel/src/components/ErrorAlert/index.tsx
+++ b/packages/fxa-admin-panel/src/components/ErrorAlert/index.tsx
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ApolloError, ServerError, ServerParseError } from '@apollo/client';
+import { GraphQLError } from 'graphql';
+import React from 'react';
+
+export type NetworkError = ApolloError['networkError'];
+
+// Type guards - If the `networkError` is a `ServerError`, we want to display its `result.errors`
+// array containing extra info
+function isNetworkServerError(
+  networkError: NetworkError
+): networkError is ServerError {
+  return (networkError as ServerError)?.result !== undefined;
+}
+
+// If the `networkError` is a `ServerParseError`, we want to display `bodyText` and `statusCode`
+function isNetworkServerParseError(
+  networkError: NetworkError
+): networkError is ServerParseError {
+  return (
+    (networkError as ServerParseError)?.bodyText !== undefined &&
+    (networkError as ServerParseError)?.statusCode !== undefined
+  );
+}
+
+// This alert dialog is based on the experimenter alert dialog
+// Ref: https://github.com/mozilla/experimenter/blob/main/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert/index.tsx
+export const ErrorAlert = ({ error }: { error: any }) => {
+  const { graphQLErrors = [], networkError } = error as ApolloError;
+  const networkServerErrors =
+    networkError && isNetworkServerError(networkError)
+      ? networkError.result.errors
+      : [];
+
+  let heading = 'General GQL Error';
+  if (graphQLErrors.length) {
+    heading = 'GraphQL Apollo Error';
+  } else if (networkError) {
+    heading = 'Network Error';
+  }
+
+  return (
+    <div
+      className="border border-red-400 text-red-700 px-4 py-3 my-4 rounded relative"
+      role="alert"
+      data-testid="error-alert"
+    >
+      <div className="font-bold py-2">{heading}</div>
+      <p className="mb-6 pt-2">Something went wrong. Please try again later.</p>
+      <hr />
+      {error.message && (
+        <p>
+          <b>Message:</b> {error.message}
+        </p>
+      )}
+      {graphQLErrors.length > 0 &&
+        graphQLErrors.map((gqlError: GraphQLError) => (
+          <p key={gqlError.message}>
+            <b>graphQL error:</b> {gqlError.message}
+          </p>
+        ))}
+      {networkServerErrors.length > 0 &&
+        networkServerErrors.map((serverError: ServerError) => (
+          <p key={serverError.message}>
+            <b>Network error:</b> {serverError.message}
+          </p>
+        ))}
+      {networkError && isNetworkServerParseError(networkError) && (
+        <>
+          <p>
+            <b>Status code:</b> {networkError.statusCode}
+          </p>
+          <p>
+            <b>Body text:</b> {networkError.bodyText}
+          </p>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ErrorAlert;

--- a/packages/fxa-admin-panel/src/components/ErrorAlert/mocks.tsx
+++ b/packages/fxa-admin-panel/src/components/ErrorAlert/mocks.tsx
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ApolloError } from '@apollo/client';
+import { GraphQLError } from 'graphql';
+
+export const NETWORK_SERVER_ERROR = new ApolloError({
+  graphQLErrors: [],
+  networkError: {
+    name: 'ServerError',
+    message: 'Response not successful: Received status code 400',
+    response: new Response(),
+    statusCode: 400,
+    result: {
+      errors: [
+        {
+          message: 'Cannot query field "MOOO" on type "CowExperimentType".',
+          locations: [
+            {
+              line: 3,
+              column: 5,
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+export const NETWORK_SERVER_PARSE_ERROR = new ApolloError({
+  graphQLErrors: [],
+  networkError: {
+    name: 'ServerParseError',
+    message:
+      'JSON.parse: unexpected character at line 1 column 1 of the JSON data',
+    response: new Response(),
+    statusCode: 404,
+    bodyText:
+      '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta http-equiv="content-type" content="text/html; charset=utf-8">\n  <title>Page not found at /graphql</title>\n  <meta name="robots" content="NONE,NOARCHIVE">\n  <style type="text/css">\n    html * { padding:0; margin:0; }\n    body * { padding:10px 20px; }\n    body * * { padding:0; }\n    body { font:small sans-serif; background:#eee; color:#000; }\n    body>div { border-bottom:1px solid #ddd; }\n    h1 { font-weight:normal; margin-bottom:.4em; }\n    h1 span { font-size:60%; color:#666; font-weight:normal; }\n    table { border:none; border-collapse: collapse; width:100%; }\n    td, th { vertical-align:top; padding:2px 3px; }\n    th { width:12em; text-align:right; color:#666; padding-right:.5em; }\n    #info { background:#f6f6f6; }\n    #info ol { margin: 0.5em 4em; }\n    #info ol li { font-family: monospace; }\n    #summary { background: #ffc; }\n    #explanation { background:#eee; border-bottom: 0px none; }\n    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5em; margin: 10px 0 10px 0; }\n  </style>\n</head>\n<body>\n  <div id="summary">\n    <h1>Page not found <span>(404)</span></h1>\n    \n    <table class="meta">\n      <tr>\n        <th>Request Method:</th>\n        <td>POST</td>\n      </tr>\n      <tr>\n        <th>Request URL:</th>\n        <td>https://localhost/graphql</td>\n      </tr>\n      \n    </table>\n  </div>\n  <div id="info">\n    \n      <p>\n      Using the URLconf defined in <code>experimenter.urls</code>,\n      Django tried these URL patterns, in this order:\n      </p>\n      <ol>\n        \n          <li>\n            \n                ^media/(?P&lt;path&gt;.*)$\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v1/experiments/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v2/experiments/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v3/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v5/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^api/v6/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^admin/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^experiments/\n                \n            \n          </li>\n        \n          <li>\n            \n                ^nimbus/\n                [name=\'nimbus-list\']\n            \n          </li>\n        \n          <li>\n            \n                ^nimbus/(?P&lt;slug&gt;[\\w-]+)/\n                [name=\'nimbus-detail\']\n            \n          </li>\n        \n          <li>\n            \n                ^$\n                [name=\'home\']\n            \n          </li>\n        \n          <li>\n            \n                ^404/\n                \n            \n          </li>\n        \n      </ol>\n      <p>\n        \n          The current path, <code>graphql</code>,\n        \n        didn’t match any of these.\n      </p>\n    \n  </div>\n\n  <div id="explanation">\n    <p>\n      You’re seeing this error because you have <code>DEBUG = True</code> in\n      your Django settings file. Change that to <code>False</code>, and Django\n      will display a standard 404 page.\n    </p>\n  </div>\n</body>\n</html>\n',
+  },
+});
+
+export const NETWORK_ERROR = new ApolloError({
+  graphQLErrors: [],
+  networkError: {
+    name: 'Error',
+    message: 'Response not successful: Received status code 400',
+    response: new Response(),
+    statusCode: 400,
+    result: {
+      errors: [
+        {
+          message: 'Cannot query field "WOOT" on type "NimbusExperimentType".',
+          locations: [
+            {
+              line: 3,
+              column: 5,
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+export const GQL_ERROR = new ApolloError({
+  graphQLErrors: [new GraphQLError('Received incompatible instance "MOO".')],
+  networkError: null,
+});
+
+export const GQL_ERROR_MULTIPLE = new ApolloError({
+  graphQLErrors: [
+    new GraphQLError('Received incompatible instance "b".'),
+    new GraphQLError('Received incompatible instance "a".'),
+    new GraphQLError('Received incompatible instance "d".'),
+  ],
+  networkError: null,
+});

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -8,6 +8,7 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import { RelyingParty } from 'fxa-admin-server/src/graphql';
 import { DATE_FORMAT } from '../AccountSearch/Account';
 import dateFormat from 'dateformat';
+import ErrorAlert from '../ErrorAlert';
 
 const RELYING_PARTIES_SCHEMA = `
   relyingParties {
@@ -46,7 +47,7 @@ const Result = ({
     return <p className="mt-2">Loading...</p>;
   }
   if (error) {
-    return <p className="mt-2">An error occurred.</p>;
+    return <ErrorAlert {...{ error }}></ErrorAlert>;
   }
   if (data && data.relyingParties.length > 0) {
     return (


### PR DESCRIPTION
## Because

- The admin panel doesn't give devs much details on any error

## This pull request

- Reuses the alert in https://github.com/mozilla/experimenter/tree/c9f568e53af26f7a548b2542d7259345a3c4b26e/app/experimenter/nimbus-ui/src/components/ApolloErrorAlert
- Doesn't use `react-bootstrap` since it seemed overkill, opted to style with tailwind

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5249

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screen Shot 2022-09-12 at 11 52 17 AM](https://user-images.githubusercontent.com/1295288/189713430-cf8f5eea-c410-465f-84d7-2981637ee834.png)

