### PR TITLE
fix(auth): Capture error if billing agreement is cancelled

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -176,7 +176,15 @@ export class PayPalNotificationHandler extends PayPalHandler {
       });
       return;
     }
-    if (billingAgreement.status === 'Cancelled') {
+    if (
+      billingAgreement.status === 'Canceled' ||
+      billingAgreement.status === 'Cancelled'
+    ) {
+      this.log.error('handleMpCancel', {
+        message: 'Billing agreement was cancelled',
+        ipnMessage: message,
+        customerUid: billingAgreement.uid,
+      });
       return;
     }
     const account = await Account.findByUid(billingAgreement.uid, {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -646,6 +646,7 @@ describe('PayPalNotificationHandler', () => {
         dbStub.getPayPalBAByBAId,
         billingAgreementCancelNotification.mp_id
       );
+      sinon.assert.calledOnce(log.error);
     });
 
     it('receives IPN message for billing agreement with no FXA account', async () => {


### PR DESCRIPTION
## Because

- PayPal NVP returned a non-success ACK - billing agreement was cancelled, as we are not capturing the error

## This pull request

- logs error when the billing agreement's status is `Canceled`

## Issue that this pull request solves

Closes: [FXA-5936](https://mozilla-hub.atlassian.net/browse/FXA-5936)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information

<img width="630" alt="Screen Shot 2022-09-13 at 10 51 05 AM" src="https://user-images.githubusercontent.com/28129806/189933831-5e485a15-dc73-4d43-a972-08ad8edd5180.png">

Source: [PayPal](https://developer.paypal.com/api/nvp-soap/ba-update-soap/#link-baupdaterequestmessage)
