### PR TITLE
feat(sentry): Add AppErrorBoundary to admin-panel and enable Sentry

### DIFF
--- a/packages/fxa-admin-panel/interfaces/index.ts
+++ b/packages/fxa-admin-panel/interfaces/index.ts
@@ -22,6 +22,14 @@ export interface IClientConfig {
   servers: {
     admin: IServerInfo;
   };
+  sentry: {
+    dsn: string;
+    env: string;
+    serverName: string;
+    clientName: string;
+    sampleRate: number;
+  };
+  version?: string;
 }
 
 export interface IncomingAdminPanelHttpHeaders extends IncomingHttpHeaders {

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -78,9 +78,15 @@ const conf = convict({
     },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
-      default: 'fxa-admin-panel',
+      default: 'fxa-admin-panel-server',
       format: 'String',
       env: 'SENTRY_SERVER_NAME',
+    },
+    clientName: {
+      doc: 'Name used by sentry to identify the client.',
+      default: 'fxa-admin-panel-client',
+      format: 'String',
+      env: 'SENTRY_CLIENT_NAME',
     },
   },
   listen: {

--- a/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
@@ -15,8 +15,9 @@ import {
 import { IUserInfo } from '../../../interfaces';
 
 describe('ClientConfig', () => {
+  const html = `<head><meta name="fxa-config" content="${SERVER_CONFIG_PLACEHOLDER}"/></meta></head>`;
+
   function configCheck(remoteHeader: string, user: IUserInfo) {
-    const html = `<head><meta name="fxa-config" content="${SERVER_CONFIG_PLACEHOLDER}"/></meta></head>`;
     const expectedConfig = Object.assign({}, ClientConfig.defaultConfig, {
       user,
     });
@@ -74,6 +75,19 @@ describe('ClientConfig', () => {
         level: PermissionLevel.None,
       },
     });
+  });
+
+  it('injects sentry config into html', () => {
+    const injectedHtml = ClientConfig.injectIntoHtml(html, {});
+    const injectedVal = JSDOM.fragment(injectedHtml)
+      .querySelector('meta[name="fxa-config"]')
+      ?.getAttribute('content');
+
+    expect(injectedVal).toBeDefined();
+    expect(injectedHtml).not.toEqual(html);
+
+    const decodedConfig = JSON.parse(decodeURIComponent(injectedVal!));
+    expect(decodedConfig.sentry).toEqual(ClientConfig.defaultConfig.sentry);
   });
 
   it('handles noisy remote groups header', () => {

--- a/packages/fxa-admin-panel/server/lib/client-config/index.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.ts
@@ -14,12 +14,14 @@ import {
 } from '../../../constants';
 import { AdminPanelEnv, AdminPanelGuard } from 'fxa-shared/guards';
 import log from '../logging';
+import version from '../version';
 
 const guard = new AdminPanelGuard(config.get('guard.env') as AdminPanelEnv);
 
 /** Client Config Defaults provided by env */
 const defaultConfig: IClientConfig = {
   env: config.get('env'),
+  version: version?.version,
   guard,
   user: {
     group: guard.getBestGroup(config.get('user.group')),
@@ -29,6 +31,13 @@ const defaultConfig: IClientConfig = {
     admin: {
       url: config.get('servers.admin.url'),
     },
+  },
+  sentry: {
+    dsn: config.get('sentry.dsn'),
+    env: config.get('sentry.env'),
+    sampleRate: config.get('sentry.sampleRate'),
+    serverName: config.get('sentry.serverName'),
+    clientName: config.get('sentry.clientName'),
   },
 };
 

--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -33,15 +33,6 @@ const cspRulesReportOnly = cspReportOnly(config);
 
 logger.info('version', { version: version });
 
-const CLIENT_CONFIG = {
-  env: config.get('env'),
-  servers: {
-    admin: {
-      url: config.get('servers.admin.url'),
-    },
-  },
-};
-
 // Initialize Sentry
 const sentryConfig = config.get('sentry');
 if (sentryConfig.dsn) {

--- a/packages/fxa-admin-panel/src/index.test.tsx
+++ b/packages/fxa-admin-panel/src/index.test.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { ReactNode } from 'react';
+
+describe('index', () => {
+  const origError = global.console.error;
+  let mockError: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    const div = document.createElement('div');
+    div.id = 'root';
+    document.body.appendChild(div);
+    mockError = jest.fn();
+    global.console.error = mockError;
+  });
+
+  afterEach(() => {
+    global.console.error = origError;
+  });
+
+  it('should render as expected', () => {
+    jest.mock('./lib/config', () => ({
+      __esModule: true,
+      ...jest.requireActual('./lib/config'),
+      readConfigFromMeta: jest.fn(),
+    }));
+    require('./index');
+
+    const root = document.getElementById('root')!;
+    // Assert that these mock components are nested as expected
+    let currRoot: any = root;
+    ['StrictMode', 'AppErrorBoundary', 'ApolloProvider', 'App'].forEach(
+      (name) => {
+        currRoot = currRoot?.querySelector(`*[data-testid="${name}"]`);
+        expect(currRoot).toBeDefined();
+      }
+    );
+  });
+
+  it('should log initialization errors', () => {
+    jest.mock('./lib/config', () => ({
+      __esModule: true,
+      ...jest.requireActual('./lib/config'),
+      readConfigFromMeta: jest.fn(() => {
+        throw new Error('uh oh');
+      }),
+    }));
+    require('./index');
+
+    expect(mockError).toHaveBeenCalled();
+  });
+});
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  StrictMode: mockComponent('StrictMode'),
+}));
+
+jest.mock('fxa-react/components/AppErrorBoundary', () => ({
+  __esModule: true,
+  default: mockComponent('AppErrorBoundary'),
+}));
+
+jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
+  ApolloProvider: mockComponent('ApolloProvider'),
+}));
+
+jest.mock('./App', () => ({
+  __esModule: true,
+  default: mockComponent('App'),
+}));
+
+function mockComponent(testid: string) {
+  return (props: { children: ReactNode }) => (
+    <div data-testid={testid}>{props.children}</div>
+  );
+}

--- a/packages/fxa-admin-panel/src/lib/config.ts
+++ b/packages/fxa-admin-panel/src/lib/config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // This configuration is a subset of the configuration declared in server/config/index.ts
 
 import {
@@ -32,6 +36,14 @@ export function defaultConfig(): IClientConfig {
         url: '',
       },
     },
+    sentry: {
+      dsn: '',
+      env: 'local',
+      serverName: 'fxa-admin-panel-server',
+      clientName: 'fxa-admin-panel-client',
+      sampleRate: 1.0,
+    },
+    version: undefined,
   };
 }
 

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -60,7 +60,7 @@ export function defaultConfig(): Config {
     productRedirectURLs: {},
     sentry: {
       dsn: '',
-      env: 'test',
+      env: 'local',
       sampleRate: 1.0,
       serverName: 'fxa-payments-server',
       clientName: 'fxa-payments-client',


### PR DESCRIPTION
Because:
* Admin-panel was missing AppErrorBoundary and Sentry hook up

This commit:
* Adds AppErrorBoundary from fxa-react, adds Sentry config options, and updates tests

Closes [FXA-5256](https://mozilla-hub.atlassian.net/browse/FXA-5256) (sorry for branch number confusion, I must've been looking at the wrong number)