### PR TITLE
chore(auth): improve error message for Apple IAP purchase conflict

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -121,6 +121,8 @@ const ERRNO = {
   CANNOT_CREATE_PASSWORD: 206,
   ACCOUNT_CREATION_REJECTED: 207,
 
+  IAP_PURCHASE_ALREADY_REGISTERED: 208,
+
   INTERNAL_VALIDATION_ERROR: 998,
   UNEXPECTED_ERROR: 999,
 };
@@ -1417,6 +1419,19 @@ AppError.iapInvalidToken = (error) => {
       error: 'Bad Request',
       errno: ERRNO.IAP_INVALID_TOKEN,
       message: 'Invalid token',
+    },
+    ...extra
+  );
+};
+
+AppError.iapPurchaseConflict = (error) => {
+  const extra = error ? [{}, undefined, error] : [];
+  return new AppError(
+    {
+      code: 403,
+      error: 'Forbidden',
+      errno: ERRNO.IAP_PURCHASE_ALREADY_REGISTERED,
+      message: 'Purchase has been registered to another user.',
     },
     ...extra
   );

--- a/packages/fxa-auth-server/lib/routes/subscriptions/apple.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/apple.ts
@@ -126,6 +126,7 @@ export class AppleIapHandler {
         case PurchaseUpdateError.INVALID_ORIGINAL_TRANSACTION_ID:
           throw error.iapInvalidToken(err);
         case PurchaseUpdateError.CONFLICT:
+          throw error.iapPurchaseConflict(err);
         case PurchaseUpdateError.OTHER_ERROR:
           throw error.iapInternalError(err);
         default:

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
@@ -137,7 +137,10 @@ describe('AppleIapHandler', () => {
         await appleIapHandler.registerOriginalTransactionId(request);
         assert.fail('Expected failure');
       } catch (err) {
-        assert.strictEqual(err.errno, error.ERRNO.IAP_INTERNAL_OTHER);
+        assert.strictEqual(
+          err.errno,
+          error.ERRNO.IAP_PURCHASE_ALREADY_REGISTERED
+        );
         assert.calledOnce(appleIap.purchaseManager.registerToUserAccount);
         assert.calledOnce(iapConfig.getBundleId);
       }


### PR DESCRIPTION
Because:

* Our default error message, "IAP Internal Error" is not very helpful to RPs in the case that a subscription purchase is already registered to another user.

This commit:

* Updates the error code and message to be more descriptive.

Closes #FXA-5876

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).