### PR TITLE
bug(auth-server): Fix potential for high memory usage in auth server.

### DIFF
--- a/packages/fxa-auth-server/test/scripts/prune-tokens.js
+++ b/packages/fxa-auth-server/test/scripts/prune-tokens.js
@@ -244,7 +244,7 @@ describe('scripts/prune-tokens', () => {
       assert.isTrue(/"@sessionTokensDeleted":1/.test(stderr));
       assert.isTrue(/"@unblockCodesDeleted":1/.test(stderr));
       assert.isTrue(/"@signInCodesDeleted":1/.test(stderr));
-      assert.isTrue(/pruning orphaned tokens/.test(stderr));
+      assert.isTrue(/pruning orphaned sessions in redis/.test(stderr));
 
       const redisTokens = await redis.getSessionTokens(uid.toString('hex'));
       assert.equal(Object.keys(redisTokens).length, 0);
@@ -369,14 +369,14 @@ describe('scripts/prune-tokens', () => {
       }
     }
 
-    it('limits with large delete batch size', async () => {
+    it('limits with --maxSessionsBatchSize=1000', async () => {
       testScript(`--maxSessions=10 --maxSessionsBatchSize=1000 `, {
         remaining: size - 10,
         totalDeletions: 10 * 2,
       });
     });
 
-    it('limits with small delete batch size', async () => {
+    it('limits with --maxSessionsBatchSize=2', async () => {
       testScript(`--maxSessions=10 --maxSessionsBatchSize=2 `, {
         remaining: size - 10,
         totalDeletions: 10 * 2,
@@ -397,7 +397,7 @@ describe('scripts/prune-tokens', () => {
       });
     });
 
-    it('limits with maxSessionsMaxAccounts arg', async () => {
+    it('limits with --maxSessionsMaxAccounts=0', async () => {
       testScript(`--maxSessions=10 --maxSessionsMaxAccounts=0`, {
         remaining: size,
         totalDeletions: 0,


### PR DESCRIPTION
## Because

- We observed the token pruner exiting with a non-success error code.
- It was initially thought this was possible this is due to an OOM error.

## This pull request

- Stop querying all session ids for an account, as this could return a large number of sessions.
- Query Redis first, and use that as the basis for cleaning up orphaned tokens. Because there are a limited number of sessions in Redis, this should result in lighter weight operation.
- Improve logging of errors encountered during pruning.
- Removes recursive call that deletes sessions and uses a simple for loop instead. This could prevent a stack overflow in extreme cases.
- Makes tests names more consistent.

## Issue that this pull request solves

Closes: FXA-5945

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

We don't have any hard evidence that there is an OOM error at the moment; however, during investigation of the current behavior these potential problems were noticed. 
