### PR TITLE
feat(admin): Allow support agents to send password reset email

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -218,3 +218,12 @@ it('displays the locale', async () => {
   expect(getByTestId('account-locale')).toHaveTextContent('en-US');
   expect(getByTestId('edit-account-locale')).toBeInTheDocument();
 });
+
+it('displays send password reset', async () => {
+  const { getByTestId } = render(
+    <MockedProvider>
+      <Account {...accountResponse} />
+    </MockedProvider>
+  );
+  expect(getByTestId('password-reset-button')).toBeInTheDocument();
+});

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -65,6 +65,12 @@ export const ENABLE_ACCOUNT = gql`
   }
 `;
 
+export const SEND_PASSWORD_RESET_EMAIL = gql`
+  mutation sendPasswordResetEmail($email: String!) {
+    sendPasswordResetEmail(email: $email)
+  }
+`;
+
 export const UNLINK_ACCOUNT = gql`
   mutation unlinkAccount($uid: String!) {
     unlinkAccount(uid: $uid)
@@ -211,6 +217,16 @@ export const DangerZone = ({
     },
   });
 
+  const [sendPasswordResetEmail] = useMutation(SEND_PASSWORD_RESET_EMAIL, {
+    onCompleted: () => {
+      window.alert(`Password reset email sent to ${email.email}`);
+      onCleared();
+    },
+    onError: () => {
+      window.alert('Error sending password reset email.');
+    },
+  });
+
   const [recordAdminSecurityEvent] = useMutation(RECORD_ADMIN_SECURITY_EVENT);
 
   const handleDisable = () => {
@@ -227,6 +243,13 @@ export const DangerZone = ({
     }
     enableAccount({ variables: { uid } });
     recordAdminSecurityEvent({ variables: { uid, name: 'account.enable' } });
+  };
+
+  const handleSendPasswordReset = () => {
+    if (!window.confirm('Are you sure?')) {
+      return;
+    }
+    sendPasswordResetEmail({ variables: { email: email.email } });
   };
 
   // define loading messages
@@ -288,6 +311,24 @@ export const DangerZone = ({
               Disable
             </button>
           )}
+        </div>
+      </Guard>
+      <Guard features={[AdminPanelFeature.SendPasswordResetEmail]}>
+        <h2 className="text-lg account-header">Send Password Reset Email</h2>
+        <div className="border-l-2 border-red-600 mb-4 pl-4">
+          <p className="text-base leading-6 ">
+            Send the user a password reset email to all verified emails. For
+            Sync users this will also reset their encryption key so make sure
+            they have a backup of Sync data.
+          </p>
+          <button
+            className="bg-grey-10 border-2 border-grey-100 font-medium h-12 leading-6 mt-4 mr-4 rounded text-red-700 w-40 hover:border-2 hover:border-grey-10 hover:bg-grey-50 hover:text-red-700"
+            type="button"
+            onClick={handleSendPasswordReset}
+            data-testid="password-reset-button"
+          >
+            Password Reset
+          </button>
         </div>
       </Guard>
       {disabledAt && (

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -47,6 +47,7 @@
     "convict-format-with-moment": "^6.2.0",
     "convict-format-with-validator": "^6.2.0",
     "express": "^4.17.2",
+    "fxa-auth-client": "workspace:*",
     "fxa-shared": "workspace:*",
     "googleapis": "^102.0.0",
     "graphql": "^15.6.1",

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -23,6 +23,7 @@ import { DatabaseService } from './database/database.service';
 import { EventLoggingModule } from './event-logging/event-logging.module';
 import { GqlModule } from './gql/gql.module';
 import { SubscriptionModule } from './subscriptions/subscriptions.module';
+import { BackendModule } from './backend/backend.module';
 
 const version = getVersionInfo(__dirname);
 
@@ -32,6 +33,7 @@ const version = getVersionInfo(__dirname);
       load: [(): AppConfig => Config.getProperties()],
       isGlobal: true,
     }),
+    BackendModule,
     DatabaseModule,
     EventLoggingModule,
     SubscriptionModule,

--- a/packages/fxa-admin-server/src/backend/auth-client.service.ts
+++ b/packages/fxa-admin-server/src/backend/auth-client.service.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import AuthClient from 'fxa-auth-client';
+
+import { AppConfig } from '../config';
+
+export const AuthClientService = Symbol('AUTH_SERVER_CLIENT');
+
+export const AuthClientFactory: Provider = {
+  provide: AuthClientService,
+  useFactory: async (config: ConfigService<AppConfig>) => {
+    const authServerConfig = config.get(
+      'authServer'
+    ) as AppConfig['authServer'];
+    return new AuthClient(authServerConfig.url);
+  },
+  inject: [ConfigService],
+};

--- a/packages/fxa-admin-server/src/backend/backend.module.ts
+++ b/packages/fxa-admin-server/src/backend/backend.module.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Module } from '@nestjs/common';
+
+import { AuthClientFactory, AuthClientService } from './auth-client.service';
+
+@Module({
+  providers: [AuthClientFactory],
+  exports: [AuthClientService],
+})
+export class BackendModule {}

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -18,6 +18,13 @@ const conf = convict({
     env: 'AUTH_HEADER',
     format: String,
   },
+  authServer: {
+    url: {
+      doc: 'URL of fxa-auth-server',
+      env: 'AUTH_SERVER_URL',
+      default: 'http://localhost:9000/v1',
+    },
+  },
   user: {
     group: {
       default: '',

--- a/packages/fxa-admin-server/src/gql/gql.module.ts
+++ b/packages/fxa-admin-server/src/gql/gql.module.ts
@@ -9,9 +9,15 @@ import { SubscriptionModule } from '../subscriptions/subscriptions.module';
 import { AccountResolver } from './account/account.resolver';
 import { EmailBounceResolver } from './email-bounce/email-bounce.resolver';
 import { RelyingPartyResolver } from './relying-party/relying-party.resolver';
+import { BackendModule } from '../backend/backend.module';
 
 @Module({
-  imports: [DatabaseModule, SubscriptionModule, EventLoggingModule],
+  imports: [
+    DatabaseModule,
+    SubscriptionModule,
+    EventLoggingModule,
+    BackendModule,
+  ],
   providers: [AccountResolver, EmailBounceResolver, RelyingPartyResolver],
 })
 export class GqlModule {}

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -170,6 +170,7 @@ export interface IMutation {
     disableAccount(uid: string): boolean | Promise<boolean>;
     editLocale(locale: string, uid: string): boolean | Promise<boolean>;
     enableAccount(uid: string): boolean | Promise<boolean>;
+    sendPasswordResetEmail(email: string): boolean | Promise<boolean>;
     recordAdminSecurityEvent(name: string, uid: string): boolean | Promise<boolean>;
     unlinkAccount(uid: string): boolean | Promise<boolean>;
     clearEmailBounce(email: string): boolean | Promise<boolean>;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -165,6 +165,7 @@ type Mutation {
   disableAccount(uid: String!): Boolean!
   editLocale(locale: String!, uid: String!): Boolean!
   enableAccount(uid: String!): Boolean!
+  sendPasswordResetEmail(email: String!): Boolean!
   recordAdminSecurityEvent(name: String!, uid: String!): Boolean!
   unlinkAccount(uid: String!): Boolean!
   clearEmailBounce(email: String!): Boolean!

--- a/packages/fxa-shared/guards/AdminPanelGuard.ts
+++ b/packages/fxa-shared/guards/AdminPanelGuard.ts
@@ -30,6 +30,7 @@ export enum AdminPanelFeature {
   UnverifyEmail = 'UnverifyEmail',
   UnlinkAccount = 'UnlinkAccount',
   RelyingParties = 'RelyingParties',
+  SendPasswordResetEmail = 'SendPasswordResetEmail',
 }
 
 /** Enum of known user groups */
@@ -126,6 +127,10 @@ const defaultAdminPanelPermissions: Permissions = {
   },
   [AdminPanelFeature.RelyingParties]: {
     name: 'View Relying Parties',
+    level: PermissionLevel.Support,
+  },
+  [AdminPanelFeature.SendPasswordResetEmail]: {
+    name: 'Send Password Reset Email',
     level: PermissionLevel.Support,
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -23817,6 +23817,7 @@ fsevents@~2.1.1:
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
     express: ^4.17.2
+    fxa-auth-client: "workspace:*"
     fxa-shared: "workspace:*"
     googleapis: ^102.0.0
     graphql: ^15.6.1


### PR DESCRIPTION
## Because

- This feature was requested by our support team

## This pull request

- Allows a support agent to iniitate the password reset flow for a user
- Reuses the fxa-auth-client to call FxA api
- Adds nestjs backend module (looking to refactor this since it exisits in fxa-graphql-api project too)
- Adds guards for the feature

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5716

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

![Screen Shot 2022-09-13 at 1 36 08 PM](https://user-images.githubusercontent.com/1295288/189971943-7baaf41b-fcf1-41f8-9fa6-741f192ad1db.png)

