### PR TITLE
fix(subscriptions): stop upgrade of IAP subscriptions on same product set

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -60,6 +60,14 @@ fxa-account-signup-error-2 = A system error caused your { $productName } sign-up
 newsletter-signup-error = You’re not signed up for product update emails. You can try again in your account settings.
 fxa-post-passwordless-sub-error = Subscription confirmed, but the confirmation page failed to load. Please check your email to set up your account.
 
+## IAP upgrade errors
+
+# $productName (String) - The name of the subscribed product.
+iap-upgrade-already-subscribed = You already have a { $productName } subscription via the { -brand-name-google } or { -brand-name-apple } app stores.
+iap-upgrade-no-bundle-support = We don’t support upgrades for these subscriptions, but we will soon.
+iap-upgrade-contact-support = You can still get this product — please contact support so we can help you.
+iap-upgrade-get-help-button = Get help
+
 ## Settings
 
 settings-home = Account Home
@@ -79,6 +87,7 @@ subscription-processing-title = Confirming subscription…
 subscription-error-title = Error confirming subscription…
 subscription-noplanchange-title = This subscription plan change is not supported
 subscription-iapsubscribed-title = Already subscribed
+subscription-iaperrorupgrade-title = We can’t upgrade you quite yet
 
 ## $productName (String) - The name of the subscribed product.
 ## $amount (Number) - The amount billed. It will be formatted as currency.

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.scss
@@ -8,4 +8,9 @@
 
 .payment-error {
   @include checkout-view();
+
+  // temporary fix and will be removed after FXA-5620
+  p {
+    margin-bottom: 1rem;
+  }
 }

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: PaymentErrorView,
 } as Meta;
 
-const storyWithContext = (storyName?: string) => {
+const storyWithProps = () => {
   const story = () => (
     <BrowserRouter>
       <Routes>
@@ -27,8 +27,7 @@ const storyWithContext = (storyName?: string) => {
     </BrowserRouter>
   );
 
-  if (storyName) story.storyName = storyName;
   return story;
 };
 
-export const Default = storyWithContext('default');
+export const Default = storyWithProps();

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.stories.tsx
@@ -39,4 +39,10 @@ export const NoPlanChange = storyWithProps({
 
 export const IapSubscribed = storyWithProps({
   screenType: 'iapsubscribed',
+  subtitle: <p />,
+});
+
+export const IapUpgradeError = storyWithProps({
+  screenType: 'iaperrorupgrade',
+  subtitle: <p />,
 });

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
@@ -9,6 +9,7 @@ export const titles = {
   error: 'Error confirming subscription…',
   noplanchange: 'This subscription plan change is not supported',
   iapsubscribed: 'Already subscribed',
+  iaperrorupgrade: 'We can’t upgrade you quite yet',
 } as const;
 
 export type SubscriptionTitleProps = {

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -27,6 +27,7 @@ import {
   MOCK_TOKEN,
   MOCK_PAYPAL_SUBSCRIPTION_RESULT,
   MOCK_PLANS,
+  PLAN_ID,
 } from './test-utils';
 
 import {
@@ -38,6 +39,7 @@ import {
   apiFetchSubscriptions,
   apiFetchToken,
   apiFetchCustomer,
+  apiFetchPlanUpgradeEligibility,
   apiUpdateSubscriptionPlan,
   apiCancelSubscription,
   apiReactivateSubscription,
@@ -228,6 +230,23 @@ describe('API requests', () => {
         )
         .reply(200, MOCK_CUSTOMER);
       expect(await apiFetchCustomer()).toEqual(MOCK_CUSTOMER);
+      requestMock.done();
+    });
+  });
+
+  describe('apiFetchPlanUpgradeEligibility', () => {
+    const path = (planId: string) =>
+      `/v1/oauth/mozilla-subscriptions/customer/plan-eligibility/${planId}`;
+    it(`GET {auth-server}${path}`, async () => {
+      const planId = 'plan_12345';
+      const requestMock = nock(AUTH_BASE_URL)
+        .get(
+          `/v1/oauth/mozilla-subscriptions/customer/plan-eligibility/${planId}`
+        )
+        .reply(200, MOCK_PLANS[0]);
+      expect(await apiFetchPlanUpgradeEligibility(PLAN_ID)).toEqual(
+        MOCK_PLANS[0]
+      );
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -149,6 +149,13 @@ export async function apiFetchCustomer(): Promise<Customer> {
   );
 }
 
+export async function apiFetchPlanUpgradeEligibility(planId: string) {
+  return apiFetch(
+    'GET',
+    `${config.servers.auth.url}/v1/oauth/mozilla-subscriptions/customer/plan-eligibility/${planId}`
+  );
+}
+
 export async function apiUpdateSubscriptionPlan(params: {
   subscriptionId: string;
   planId: string;

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -54,6 +54,7 @@ const errorToErrorMessageMap: { [key: string]: string } = {
   'Changing currencies is not permitted.': 'currency-currency-mismatch',
   no_subscription_change: 'no-subscription-change',
   iap_already_subscribed: 'iap-already-subscribed',
+  iap_upgrade_contact_support: 'iap-upgrade-contact-support',
 };
 
 const cardErrors = ['card_declined', 'incorrect_cvc'];

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import MockApp from '../../../../.storybook/components/MockApp';
 import { defaultAppContext, AppContextType } from '../../../lib/AppContext';
-
 import { SignInLayout } from '../../../components/AppLayout';
 
 import {
@@ -21,6 +20,7 @@ const MOCK_PROPS: IapRoadblockProps = {
   profile: PROFILE,
   selectedPlan: SELECTED_PLAN,
   subscription: IAP_GOOGLE_SUBSCRIPTION,
+  code: 'iap_already_subscribed',
 };
 
 const IapRoadblockView = ({
@@ -51,6 +51,14 @@ function init() {
         props={{
           ...MOCK_PROPS,
           subscription: IAP_APPLE_SUBSCRIPTION,
+        }}
+      />
+    ))
+    .add('Mozilla support needed for upgrade', () => (
+      <IapRoadblockView
+        props={{
+          ...MOCK_PROPS,
+          code: 'iap_upgrade_contact_support',
         }}
       />
     ));

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.test.tsx
@@ -25,26 +25,51 @@ const MOCK_PROPS: IapRoadblockProps = {
   isMobile: false,
   subscription,
   customer: MOCK_CUSTOMER as Customer,
-};
-
-const Subject = () => {
-  return (
-    <MockApp>
-      <SignInLayout>
-        <IapRoadblock {...MOCK_PROPS} />
-      </SignInLayout>
-    </MockApp>
-  );
+  code: 'iap_already_subscribed',
 };
 
 describe('routes/Product/IapRoadblock', () => {
   it('renders as expected', async () => {
-    const { findByTestId } = render(<Subject />);
+    const subject = () => {
+      return render(
+        <MockApp>
+          <SignInLayout>
+            <IapRoadblock {...MOCK_PROPS} />
+          </SignInLayout>
+        </MockApp>
+      );
+    };
+
+    const { findByTestId } = subject();
     const titleEl = await findByTestId('subscription-iapsubscribed-title');
     expect(titleEl).toBeInTheDocument();
     const errorEl = await findByTestId('payment-error');
     expect(errorEl).toBeInTheDocument();
     const actionButton = await findByTestId('manage-subscription-link');
+    expect(actionButton).toBeInTheDocument();
+    const detailsEl = await findByTestId('plan-details-component');
+    expect(detailsEl).toBeInTheDocument();
+  });
+
+  it('displays messaging to contact support for help in upgrading', async () => {
+    const subject = () => {
+      return render(
+        <MockApp>
+          <SignInLayout>
+            <IapRoadblock
+              {...{ ...MOCK_PROPS, code: 'iap_upgrade_contact_support' }}
+            />
+          </SignInLayout>
+        </MockApp>
+      );
+    };
+
+    const { findByTestId } = subject();
+    const titleEl = await findByTestId('subscription-iaperrorupgrade-title');
+    expect(titleEl).toBeInTheDocument();
+    const errorEl = await findByTestId('payment-error');
+    expect(errorEl).toBeInTheDocument();
+    const actionButton = await findByTestId('iap-upgrade-get-help-button');
     expect(actionButton).toBeInTheDocument();
     const detailsEl = await findByTestId('plan-details-component');
     expect(detailsEl).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
@@ -20,17 +20,19 @@ export type IapRoadblockProps = {
   profile: Profile;
   customer: Customer;
   selectedPlan: Plan;
-  subscription: IapSubscription;
+  subscription?: IapSubscription;
+  code: string;
 };
 
 const getIapSubscriptionAppStoreL10Id = (
   s: IapRoadblockProps['subscription']
 ) => {
-  switch (s._subscription_type) {
-    case MozillaSubscriptionTypes.IAP_GOOGLE:
-      return 'brand-name-google-play';
-    case MozillaSubscriptionTypes.IAP_APPLE:
-      return 'brand-name-apple-app-store';
+  if (s && s._subscription_type === MozillaSubscriptionTypes.IAP_GOOGLE) {
+    return 'brand-name-google-play';
+  } else if (s && s._subscription_type === MozillaSubscriptionTypes.IAP_APPLE) {
+    return 'brand-name-apple-app-store';
+  } else {
+    return ''; // if s is undefined return empty string
   }
 };
 
@@ -39,19 +41,29 @@ export const IapRoadblock = ({
   isMobile,
   selectedPlan,
   subscription,
+  code,
 }: IapRoadblockProps) => {
   const { l10n } = useLocalization();
-  const mobileAppStore = l10n.getString(
-    getIapSubscriptionAppStoreL10Id(subscription)
-  );
-  const appStoreLink = getIapSubscriptionManagementUrl(subscription);
+  let mobileAppStore = '';
+  let manageSubscription: VoidFunction = () => {};
+
+  if (subscription !== undefined) {
+    mobileAppStore = l10n.getString(
+      getIapSubscriptionAppStoreL10Id(subscription)
+    );
+
+    const appStoreLink = getIapSubscriptionManagementUrl(subscription);
+    manageSubscription = () => (window.location.href = appStoreLink);
+  }
+
+  const screenType =
+    code === 'iap_upgrade_contact_support'
+      ? 'iaperrorupgrade'
+      : 'iapsubscribed';
   const subtitle = <p />;
   const title = (
-    <SubscriptionTitle screenType="iapsubscribed" subtitle={subtitle} />
+    <SubscriptionTitle screenType={screenType} subtitle={subtitle} />
   );
-
-  const manageSubscription: VoidFunction = () =>
-    (window.location.href = appStoreLink);
 
   return (
     <>
@@ -60,7 +72,7 @@ export const IapRoadblock = ({
         <PaymentErrorView
           {...{
             subscriptionTitle: title,
-            error: { code: 'iap_already_subscribed' },
+            error: { code },
             actionFn: manageSubscription,
             plan: selectedPlan,
             contentProps: { mobileAppStore },

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -15,6 +15,7 @@ import { selectors, SelectorReturns } from '../../store/selectors';
 import { Plan, ProductMetadata } from '../../store/types';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import { getSubscriptionUpdateEligibility } from 'fxa-shared/subscriptions/stripe';
+import { apiFetchPlanUpgradeEligibility } from '../../lib/apiClient';
 
 import '../Product/index.scss';
 
@@ -171,6 +172,36 @@ export const Product = ({
 
   const [coupon, setCoupon] = useState<CouponDetails>();
 
+  const [planUpgradeEligibility, setPlanUpgradeEligibility] =
+    useState('invalid');
+
+  const checkPlanUpgradeEligibility = async (planId: string) => {
+    try {
+      const planUpgradeDetails = await apiFetchPlanUpgradeEligibility(planId);
+      const eligibility = await planUpgradeDetails.eligibility;
+
+      return eligibility;
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  // Fetch plan update eligibility
+  useEffect(() => {
+    (async () => {
+      if (selectedPlan) {
+        try {
+          const eligibilityResult = await checkPlanUpgradeEligibility(
+            selectedPlan.plan_id
+          );
+          setPlanUpgradeEligibility(eligibilityResult);
+        } catch (err) {
+          setPlanUpgradeEligibility('invalid');
+        }
+      }
+    })();
+  }, [selectedPlan]);
+
   // Please read the comment in `fetchProfileAndCustomer` in Checkout/index.tsx
   // regarding a possible race condition first.  The workaround here is to
   // simply delay the request on the front end so that the subscription is more
@@ -237,7 +268,26 @@ export const Product = ({
       productId
     );
 
-    if (iapSubscription) {
+    // Note regarding IAP roadblock:
+    //
+    // Currently, customers cannot upgrade IAP subscriptions directly.
+    // Products that are eligible for upgrade can only be done through support.
+    //
+    // iapSubscription checks if user is subscribed to product (not product set)
+    // planUpgradeEligibility returns 'blocked_iap' for all products on same product set.
+    // Therefore, a combination of both is required to show IAP roadblock (planUpgradeEligibility)
+    // and appropriate error messaging (iapSubscription).
+    //
+    // if desired product is already subscribed to, show iap already subscribed error
+    // else, product is not subscribed to, but on same product set/might be eligible for upgrade
+    // show iap upgrade contact support error messaging
+    const iapErrorMessageCode = () => {
+      return iapSubscription
+        ? 'iap_already_subscribed' // already subscribed to this product
+        : 'iap_upgrade_contact_support'; // different product, but same product set/eligible for upgrade
+    };
+
+    if (planUpgradeEligibility === 'blocked_iap') {
       return (
         <IapRoadblock
           {...{
@@ -245,7 +295,8 @@ export const Product = ({
             customer: customer.result,
             profile: profile.result,
             isMobile,
-            subscription: iapSubscription,
+            subscription: iapSubscription ? iapSubscription : undefined,
+            code: iapErrorMessageCode(),
           }}
         />
       );


### PR DESCRIPTION
## Because

- With the current setup, users either create a second subscription or don't know why their upgrade didn't go through
- We need clearer error messaging for all of our iap subscription upgrade roadblock scenarios

## This pull request

- Stops the upgrade and sends user to error page
- Provides appropriate error message detailing the specific issue
- Provides a link to our support team for users who want help or more information

## Issue that this pull request solves

Closes: FXA-5480

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
