### PR TITLE
FXA-5861-add-trace-sample-rate

### DIFF
--- a/packages/fxa-shared/README.md
+++ b/packages/fxa-shared/README.md
@@ -100,8 +100,8 @@ require('fxa-shared/tracing/node-tracing').init(config.get('tracing'));
 ```
 
 To see traces on your local system, simply enable Jaeger exports on the service. This can be done by setting the environment
-variable TRACING_JAEGER_EXPORTER_ENABLED=true. The default config for tracing found at fxa-shared/tracing/config.ts will pick
-up this variable and start exporting trace data to the Jaeger container running at `localhost:16686`.
+variable TRACING_JAEGER_EXPORTER_ENABLED=true and TRACING_SAMPLE_RATE=1. The default config for tracing found at fxa-shared/tracing/config.ts
+will pick up this variable and start exporting trace data to the Jaeger container running at `localhost:16686`.
 
 It is also possible to publish directly to google cloud trace from your local environment; however, this is not recommended. If you
 are interested in doing this, more info can be found [here](https://cloud.google.com/trace/docs/setup/nodejs-ot#running_locally_and_elsewhere).

--- a/packages/fxa-shared/tracing/config.ts
+++ b/packages/fxa-shared/tracing/config.ts
@@ -7,6 +7,7 @@
  */
 export type TracingOpts = {
   serviceName: string;
+  sampleRate: number;
   console?: {
     enabled: boolean;
   };
@@ -25,6 +26,11 @@ export const tracingConfig = {
     doc: 'The name service being traced.',
     env: 'TRACING_SERVICE_NAME',
     format: String,
+  },
+  sampleRate: {
+    default: 0,
+    doc: 'A number between 0 and 1 that indicates the rate at which to sample. 1 will capture all traces. .5 would capture half the traces, and 0 would capture no traces.',
+    env: 'TRACING_SAMPLE_RATE',
   },
   console: {
     enabled: {


### PR DESCRIPTION
## Because

- We don't need to capture all open telemetry traces.
- We want to control the rate at which traces are captured.

## This pull request

- Introduces a tracer config setting 'sampleRate'
- Adds a ParentBasedSampler with TraceIdRatioSampling to our NodeTracerProvider

## Issue that this pull request solves

Closes: FXA-5861

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

To see this see the effect of this config setting, do the following:

- In the your .env file set `TRACING_JAEGER_EXPORTER_ENABLED=true` and set `TRACING_SAMPLE_RATE=0.05`
- Make sure pm2 is stopped and start it fresh with `dotenv -- yarn start` (note, dotenv-cli npm package must be installed)
- Conduct a typical sign up flow.
- Check Jaeger running on localhost:16686, select fxa-auth-server from the services drop down, click `find traces` and see that very few traces were captured.
- Now set `TRACING_SAMPLE_RATE=1` in the .env file
- Restart the auth server `dotenv -- pm2 reload auth --update-env`
- Conduct a typical sign up flow.
- Check Jaeger again, refresh the graph by selecting ‘find traces’ once more, and see that lots of traces were captured.

