### PR TITLE
bug(admin-panel): Fix broken requests to admin-server

### DIFF
--- a/packages/fxa-admin-panel/src/index.tsx
+++ b/packages/fxa-admin-panel/src/index.tsx
@@ -13,24 +13,25 @@ import { config, readConfigFromMeta, getExtraHeaders } from './lib/config';
 import App from './App';
 import './styles/tailwind.out.css';
 
-const httpLink = createHttpLink({
-  uri: `${config.servers.admin.url}/graphql`,
-});
-
-const authLink = setContext((_, { headers }) => ({
-  headers: {
-    ...headers,
-    ...getExtraHeaders(config),
-  },
-}));
-
-const client = new ApolloClient({
-  link: authLink.concat(httpLink),
-  cache: new InMemoryCache(),
-});
-
 try {
+  // Watch out! This mutates the config. Make sure it gets run first!
   readConfigFromMeta(headQuerySelector);
+
+  const httpLink = createHttpLink({
+    uri: `${config.servers.admin.url}/graphql`,
+  });
+
+  const authLink = setContext((_, { headers }) => ({
+    headers: {
+      ...headers,
+      ...getExtraHeaders(config),
+    },
+  }));
+
+  const client = new ApolloClient({
+    link: authLink.concat(httpLink),
+    cache: new InMemoryCache(),
+  });
 
   sentryMetrics.configure({
     release: config.version,


### PR DESCRIPTION
## Because

- All gql queries were being directed to 8091 instead of 8095 where the graphql api lives.
- A recent refactor changed when readConfigFromMeta was being called.

## This pull request

- Makes sure the config is parsed right away by calling readConfigFromMeta first.

## Issue that this pull request solves

Closes: FXA-5961

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

