### PR TITLE
fix(fxa-auth-server): correct local var names and add missing word

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1654,11 +1654,11 @@ module.exports = function (log, config, bounces) {
       headers,
       template: templateName,
       templateValues: {
-        androidLink: links.androidLink,
+        androidUrl: links.androidLink,
         date,
         device: this._formatUserAgentInfo(message),
         email: message.email,
-        iosLink: links.iosLink,
+        iosUrl: links.iosLink,
         ip: message.ip,
         link: links.link,
         location: message.location,

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.mjml
@@ -47,7 +47,7 @@
         </mj-text>
       <% } else { %>
         <mj-text css-class="text-footer-appBadges"><span data-l10n-id="another-device-2" data-l10n-args="<%= JSON.stringify({ productName }) %>"> Install <%- locals.productName %>
-          <a href="<%- link %>" class="link-blue" data-l10n-name="anotherDeviceLink">another device</a></span>
+           on <a href="<%- link %>" class="link-blue" data-l10n-name="anotherDeviceLink">another device</a></span>
         </mj-text>
       <% } %>
     </mj-column>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -957,7 +957,6 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
       { test: 'exists', expected: `${MESSAGE.time}` },
-      { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
       { test: 'include', expected: 'Password reset successfully' },
@@ -973,7 +972,6 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Download ${MESSAGE.productName} on the App Store:` },
       { test: 'include', expected: `Install ${MESSAGE.productName} on another device:` },
       { test: 'include', expected: `Get ${MESSAGE.productName} on Google Play:` },
-      { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
 


### PR DESCRIPTION
Because:

* A word was missing from the template, and the template was receiving incorrectly named variables for some reason. I searched in the template for the (original) variable names but did not find them, so it must have just been an error?

This commit:

* Fixes the var names to match the appBadges partial, and adds the missing word

Closes # https://mozilla-hub.atlassian.net/browse/FXA-5193

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Since the errors were not showing up in Storybook (so I can't show meaningful changes), I've included screenshots of the amended plaintext and .html files as output by `yarn write-emails`. 
Here you can see the populated links as required:
<img width="456" alt="Screen Shot 2022-09-15 at 9 23 27 AM" src="https://user-images.githubusercontent.com/11150372/190457003-3113fa9d-4020-4232-ac9a-e5d8d9f132a6.png">
Here you can see the added preposition ("Install `on` another device"):
<img width="496" alt="Screen Shot 2022-09-15 at 9 23 45 AM" src="https://user-images.githubusercontent.com/11150372/190457008-5cf9b775-0fbb-47f2-96f6-c2b90f9acf6d.png">