### PR TITLE
fix(fxa-auth-server): close broken span tag in email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en.ftl
@@ -3,4 +3,4 @@ postRemoveAccountRecovery-title-2 = You deleted your account recovery key.
 # After the colon, there is information about the device that the account recovery key was deleted from
 postRemoveAccountRecovery-description-2 = It was deleted from:
 postRemoveAccountRecovery-action = Manage account
-postRemoveAccountRecovery-invalid-2 = You need an account recovery key to recover your Firefox data if you forget your password.
+postRemoveAccountRecovery-invalid-2 = You need an account recovery key to recover your { -brand-firefox } data if you forget your password.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.mjml
@@ -9,7 +9,7 @@
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postRemoveAccountRecovery-description-2"It was deleted from:</span>
+      <span data-l10n-id="postRemoveAccountRecovery-description-2">It was deleted from:</span>
     </mj-text>
   </mj-column>
 </mj-section>


### PR DESCRIPTION
Because:

* A string was missing from storybook and an mjml email due to a missing ">" in a span tag. Credit to @xlisachan for finding it!

This commit:

* Correctly closes the span tag.

Closes # https://mozilla-hub.atlassian.net/browse/FXA-5199

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="444" alt="Screen Shot 2022-09-15 at 10 41 03 AM" src="https://user-images.githubusercontent.com/11150372/190473481-699cd9fd-bc5d-4f9b-94f7-52f9f28e10c6.png">

