### PR TITLE
Rewrite change password using playwright

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -91,6 +91,12 @@ export class LoginPage extends BaseLayout {
     ]);
   }
 
+  async resetPasswordHeader() {
+    const resetPass = this.page.locator('#fxa-reset-password-header');
+    await resetPass.waitFor();
+    return resetPass.isVisible();
+  }
+
   async clickDontHaveRecoveryKey() {
     return Promise.all([
       this.page.click('a.lost-recovery-key'),

--- a/packages/functional-tests/pages/settings/changePassword.ts
+++ b/packages/functional-tests/pages/settings/changePassword.ts
@@ -25,7 +25,6 @@ export class ChangePasswordPage extends SettingsLayout {
     await this.setCurrentPassword(oldPassword);
     await this.setNewPassword(newPassword);
     await this.setConfirmPassword(newPassword);
-    await this.page.click('button[type=submit]');
   }
 
   async changePasswordTooltip() {

--- a/packages/functional-tests/pages/settings/changePassword.ts
+++ b/packages/functional-tests/pages/settings/changePassword.ts
@@ -32,6 +32,52 @@ export class ChangePasswordPage extends SettingsLayout {
     return this.page.innerText('[data-testid=tooltip]');
   }
 
+  async passwordLengthError() {
+    const error = this.page.locator('[data-testid=icon-invalid]');
+    error.locator(':scope', { hasText: 'At least 8 characters' });
+    await error.waitFor();
+    return error.isVisible();
+  }
+
+  async validPasswordLength() {
+    const error = this.page.locator('[data-testid=change-password-length]',
+      { has: this.page.locator('[data-testid=icon-unset]') });
+    error.locator(':scope', { hasText: 'At least 8 characters' });
+    await error.waitFor();
+    return error.isVisible();
+  }
+
+  async passwordSameAsEmailError() {
+    const error = this.page.locator('[data-testid=icon-invalid]');
+    error.locator(':scope', { hasText: 'Not your email address' });
+    await error.waitFor();
+    return error.isVisible();
+  }
+
+  async commonPasswordError() {
+    const error = this.page.locator('[data-testid=icon-invalid]');
+    error.locator(':scope', { hasText: 'Not a commonly used password' });
+    await error.waitFor();
+    return error.isVisible();
+  }
+
+  async confirmPasswordError() {
+    const error = this.page.locator('[data-testid=icon-invalid]');
+    error.locator(':scope', { hasText: 'New password matches confirmation' });
+    await error.waitFor();
+    return error.isVisible();
+  }
+
+  async submitButton() {
+    const submit = this.page.locator('button[type=submit]');
+    await submit.waitFor();
+    return submit.isEnabled();
+  }
+
+  async clickCancelChangePassword() {
+    return this.page.locator('[data-testid=cancel-password-button]').click();
+  }
+
   submit() {
     return Promise.all([
       this.page.click('button[type=submit]'),

--- a/packages/functional-tests/pages/settings/changePassword.ts
+++ b/packages/functional-tests/pages/settings/changePassword.ts
@@ -21,6 +21,17 @@ export class ChangePasswordPage extends SettingsLayout {
     );
   }
 
+  async fillOutChangePassword(oldPassword, newPasswod) {
+    await this.setCurrentPassword(oldPassword);
+    await this.setNewPassword(newPasswod);
+    await this.setConfirmPassword(newPasswod);
+    await this.page.click('button[type=submit]');
+  }
+
+  async changePasswordTooltip() {
+    return this.page.innerText('[data-testid=tooltip]');
+  }
+
   submit() {
     return Promise.all([
       this.page.click('button[type=submit]'),

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -54,6 +54,10 @@ export abstract class SettingsLayout extends BaseLayout {
     return this.page.click('[data-testid=avatar-menu-sign-out]');
   }
 
+  clickSignIn() {
+    return this.page.click('button[type=submit]');
+  }
+
   async signOut() {
     await this.clickAvatarIcon();
     await Promise.all([

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -104,7 +104,6 @@ test.describe('change primary email tests', () => {
     // Enter the correct password
     await deleteAccount.setPassword(credentials.password);
     await deleteAccount.submit();
-    await page.pause();
 
     // // Try creating a new account with the same secondary email as previous account and new password
     await login.fillOutFirstSignUp(newEmail, credentials.password);

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -19,6 +19,7 @@ test.describe('change password tests', () => {
 
     // Enter incorrect old password and verify the tooltip error
     await changePassword.fillOutChangePassword('Incorrect Password', newPassword);
+    await changePassword.clickSignIn();
     expect(await changePassword.changePasswordTooltip()).toMatch('Incorrect password');
   });
 
@@ -29,6 +30,7 @@ test.describe('change password tests', () => {
 
     // Enter the correct old password and verify that chnage password is succesful
     await changePassword.fillOutChangePassword(credentials.password, newPassword);
+    await changePassword.submit();
 
     // Sign out and login with new password
     await settings.signOut();

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -19,7 +19,7 @@ test.describe('change password tests', () => {
 
     // Enter incorrect old password and verify the tooltip error
     await changePassword.fillOutChangePassword('Incorrect Password', newPassword);
-    expect(await changePassword.changePasswordTooltip()).toMatch('abcd');
+    expect(await changePassword.changePasswordTooltip()).toMatch('Incorrect password');
   });
 
   test('change password with a correct password', async ({

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -1,37 +1,94 @@
 import { test, expect } from '../../lib/fixtures/standard';
-import { EmailHeader, EmailType } from '../../lib/email';
+let newPassword;
 
-test.describe('severity-1 #smoke', () => {
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293385
+test.describe('change password tests', () => {
+  test.beforeEach(
+    async ({
+      pages: { settings },
+      credentials,
+    }) => {
+      newPassword = credentials.password + '@@2';
+      await settings.goto();
+      await settings.password.clickChange();
+    }
+  );
+
   test('change password with an incorrect password', async ({
     pages: { settings, changePassword, login },
-    credentials, page,
+    credentials,
   }) => {
-    const newPassword = credentials.password + '@@2';
-    await settings.goto();
-    await settings.password.clickChange();
 
     // Enter incorrect old password and verify the tooltip error
     await changePassword.fillOutChangePassword('Incorrect Password', newPassword);
     expect(await changePassword.changePasswordTooltip()).toMatch('Incorrect password');
 
     // Enter the correct old password and verify that chnage password is succesful
-    //await changePassword.fillOutChangePassword(credentials.password, newPassword);
-    //await page.fill('[data-testid=current-password-input-field]', '');
-    //await changePassword.setCurrentPassword(credentials.password);
-    await page.fill('[data-testid=current-password-input-field]', credentials.password);
-    //await page.pause();
-    //await page.locator('button[type=submit]').click();
+    await changePassword.setCurrentPassword(credentials.password);
     await changePassword.submit();
 
     // Sign out and login with new password
     await settings.signOut();
     credentials.password = newPassword;
     await login.setEmail(credentials.email);
-    await page.locator('button[type=submit]').click();
+    await changePassword.clickSignIn();
     await login.setPassword(credentials.password);
     await login.submit();
     const primaryEmail = await settings.primaryEmail.statusText();
     expect(primaryEmail).toEqual(credentials.email);
+  });
+
+  test('new password validation', async ({
+    pages: { changePassword, },
+    credentials,
+  }) => {
+
+    // Short password
+    await changePassword.setNewPassword('short');
+    expect(await changePassword.passwordLengthError()).toBe(true);
+
+    // Password same as email
+    await changePassword.setNewPassword(credentials.email);
+    expect(await changePassword.passwordSameAsEmailError()).toBe(true);
+
+    // Set a common password
+    await changePassword.setNewPassword('passwords');
+    expect(await changePassword.commonPasswordError()).toBe(true);
+
+    // Confirm password doesn't match the new password
+    await changePassword.setNewPassword(credentials.password);
+    await changePassword.setConfirmPassword(credentials.password + '2');
+    expect(await changePassword.confirmPasswordError()).toBe(true);
+
+    // valid password
+    await changePassword.setCurrentPassword(credentials.password)
+    await changePassword.setNewPassword(newPassword);
+    await changePassword.setConfirmPassword(newPassword);
+    expect(await changePassword.submitButton()).toBe(true);
+  });
+
+
+  test('change password with short password tooltip shows, cancel and try to change password again, tooltip is not shown', async ({
+    pages: { settings, changePassword, },
+  }) => {
+
+    // Short password
+    await changePassword.setNewPassword('short');
+    expect(await changePassword.passwordLengthError()).toBe(true);
+
+    // Click cancel and navigate to change password again
+    await changePassword.clickCancelChangePassword();
+    await settings.password.clickChange();
+    expect(await changePassword.validPasswordLength()).toBe(true);
+  });
+
+  test('reset password via settings works', async ({
+    pages: { login },
+  }) => {
+
+    // Click forgot password link
+    await login.clickForgotPassword();
+
+    // Verify it navigates to reset password page
+    expect(await login.resetPasswordHeader()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -13,18 +13,22 @@ test.describe('change password tests', () => {
     }
   );
 
-  test('change password with an incorrect password', async ({
-    pages: { settings, changePassword, login },
-    credentials,
+  test('change password with an incorrect old password', async ({
+    pages: { changePassword },
   }) => {
 
     // Enter incorrect old password and verify the tooltip error
     await changePassword.fillOutChangePassword('Incorrect Password', newPassword);
-    expect(await changePassword.changePasswordTooltip()).toMatch('Incorrect password');
+    expect(await changePassword.changePasswordTooltip()).toMatch('abcd');
+  });
+
+  test('change password with a correct password', async ({
+    pages: { settings, changePassword, login },
+    credentials,
+  }) => {
 
     // Enter the correct old password and verify that chnage password is succesful
-    await changePassword.setCurrentPassword(credentials.password);
-    await changePassword.submit();
+    await changePassword.fillOutChangePassword(credentials.password, newPassword);
 
     // Sign out and login with new password
     await settings.signOut();

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -28,7 +28,7 @@ test.describe('change password tests', () => {
     credentials,
   }) => {
 
-    // Enter the correct old password and verify that chnage password is succesful
+    // Enter the correct old password and verify that change password is successful
     await changePassword.fillOutChangePassword(credentials.password, newPassword);
     await changePassword.submit();
 

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '../../lib/fixtures/standard';
+import { EmailHeader, EmailType } from '../../lib/email';
+
+test.describe('severity-1 #smoke', () => {
+  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293385
+  test('change password with an incorrect password', async ({
+    pages: { settings, changePassword, login },
+    credentials, page,
+  }) => {
+    const newPassword = credentials.password + '@@2';
+    await settings.goto();
+    await settings.password.clickChange();
+
+    // Enter incorrect old password and verify the tooltip error
+    await changePassword.fillOutChangePassword('Incorrect Password', newPassword);
+    expect(await changePassword.changePasswordTooltip()).toMatch('Incorrect password');
+
+    // Enter the correct old password and verify that chnage password is succesful
+    //await changePassword.fillOutChangePassword(credentials.password, newPassword);
+    //await page.fill('[data-testid=current-password-input-field]', '');
+    //await changePassword.setCurrentPassword(credentials.password);
+    await page.fill('[data-testid=current-password-input-field]', credentials.password);
+    //await page.pause();
+    //await page.locator('button[type=submit]').click();
+    await changePassword.submit();
+
+    // Sign out and login with new password
+    await settings.signOut();
+    credentials.password = newPassword;
+    await login.setEmail(credentials.email);
+    await page.locator('button[type=submit]').click();
+    await login.setPassword(credentials.password);
+    await login.submit();
+    const primaryEmail = await settings.primaryEmail.statusText();
+    expect(primaryEmail).toEqual(credentials.email);
+  });
+});

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -2,25 +2,6 @@ import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
 test.describe('severity-1 #smoke', () => {
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293385
-  test('change password #1293385', async ({
-    pages: { settings, changePassword, login },
-    credentials,
-  }) => {
-    const newPassword = credentials.password + '2';
-    await settings.goto();
-    await settings.password.clickChange();
-    await changePassword.setCurrentPassword(credentials.password);
-    await changePassword.setNewPassword(newPassword);
-    await changePassword.setConfirmPassword(newPassword);
-    await changePassword.submit();
-    await settings.signOut();
-    credentials.password = newPassword;
-    await login.login(credentials.email, credentials.password);
-    const primaryEmail = await settings.primaryEmail.statusText();
-    expect(primaryEmail).toEqual(credentials.email);
-  });
-
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293389
   test('forgot password #1293389', async ({
     target,


### PR DESCRIPTION
## Because

`- As part of the playwright test migration, the [change password tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/settings/change_password.js) have been rewritten in this PR. The only tests not covered here are the last 2 'unnormalized email' tests present in the file linked above. Those two tests will be covered as part of a different PR`

## This pull request

`- Contains tests for all the scenarios related to change password present in the [file](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/settings/change_password.js) except the last 2 tests related to unnormalized email. Those two tests will be covered as part of a different PR`

## Issue that this pull request solves

Closes: [FXA-5903](https://mozilla-hub.atlassian.net/browse/FXA-5903)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@mozilla/fxa-devs @pdehaan please review!
