### PR TITLE
task(customs): Add tracing to customs server

### DIFF
--- a/packages/fxa-customs-server/bin/customs_server.js
+++ b/packages/fxa-customs-server/bin/customs_server.js
@@ -4,9 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const server = require('../lib/server');
 const config = require('../lib/config').getProperties();
 const log = require('../lib/log')(config.log.level, 'customs-server');
+
+// Tracing must be initialized asap
+require('fxa-shared/tracing/node-tracing').init(config.tracing, log);
+
+const server = require('../lib/server');
 
 log.info({ op: 'config', config: config });
 

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const { tracingConfig } = require('fxa-shared/tracing/config');
+
 module.exports = function (fs, path, url, convict) {
   var conf = convict({
     env: {
@@ -325,6 +327,7 @@ module.exports = function (fs, path, url, convict) {
         env: 'SENTRY_SERVER_NAME',
       },
     },
+    tracing: tracingConfig,
     userDefinedRateLimitRules: {
       totpCodeRules: {
         actions: {

--- a/packages/fxa-customs-server/pm2.config.js
+++ b/packages/fxa-customs-server/pm2.config.js
@@ -19,6 +19,7 @@ module.exports = {
         PATH,
         SENTRY_ENV: 'local',
         SENTRY_DSN: process.env.SENTRY_DSN_CUSTOMS,
+        TRACING_SERVICE_NAME: 'fxa-customs-server',
       },
       filter_env: ['npm_'],
       watch: ['bin', 'lib'],


### PR DESCRIPTION
## Because

- We want to see traces

## This pull request

- Adds tracing to the customs server

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

![image](https://user-images.githubusercontent.com/94418270/190525248-35eeceeb-a711-4f65-871e-f176e1c085a9.png)

Note that we can auth-server calls going to customs server with this addition. 

# Other information (Optional)

In order to see customs server traces locally, you will need to make sure the customs server is enabled. This can be done by setting `customsUrl` in fxa-auth-server/config/dev.json to http://localhost:7000.
