### PR TITLE
task(content-server): Add tracing to content server

### DIFF
--- a/packages/fxa-content-server/pm2.config.js
+++ b/packages/fxa-content-server/pm2.config.js
@@ -20,6 +20,7 @@ module.exports = {
         PATH,
         SENTRY_ENV: 'local',
         SENTRY_DSN: process.env.SENTRY_DSN_CONTENT,
+        TRACING_SERVICE_NAME: 'fxa-content-server',
       },
       filter_env: ['npm_'],
       watch: ['server'],

--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -16,6 +16,11 @@ logger.info(`version set to: ${version.version}`);
 logger.info(`commit hash set to: ${version.commit}`);
 logger.info(`fxa-content-server-l10n commit hash set to: ${version.l10n}`);
 logger.info(`tos-pp (legal-docs) commit hash set to: ${version.tosPp}`);
+const config = require('../lib/configuration');
+
+// Tracing must be initialized asap
+const tracing = require('fxa-shared/tracing/node-tracing');
+tracing.init(config.getProperties().tracing, logger);
 
 const bodyParser = require('body-parser');
 const consolidate = require('consolidate');
@@ -27,7 +32,6 @@ const https = require('https');
 const path = require('path');
 const serveStatic = require('serve-static');
 
-const config = require('../lib/configuration');
 const sentry = require('../lib/sentry');
 const statsd = require('../lib/statsd');
 const { cors, routing } = require('fxa-shared/express')();

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -11,6 +11,7 @@ const path = require('path');
 const versionInfo = require('./version');
 
 const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
+const { tracingConfig } = require('fxa-shared/tracing/config');
 const DEFAULT_SUPPORTED_LANGUAGES =
   require('fxa-shared').l10n.supportedLanguages;
 
@@ -767,6 +768,7 @@ const conf = (module.exports = convict({
       threshold: 50,
     },
   },
+  tracing: tracingConfig,
   use_https: false,
   var_path: {
     default: path.resolve(__dirname, '..', 'var'),


### PR DESCRIPTION
## Because

- We want to see traces

## This pull request

- Adds tracing to the content server. Note this is limited to tracing on server side, and does not include the client side.

## Issue that this pull request solves

Closes: FXA-5970

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/190527489-5ec7b8be-1f78-42aa-b9ba-86df0f0c43a7.png)

## Other information (Optional)

Compared to other services, I don't see this trace info being terribly useful. It might not even be worth capturing these traces in production; however, we may as well have the instrumentation ready to go in the event we need it to troubleshoot something.
