### PR TITLE
chore(settings): Remove temp fallback text test

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -254,22 +254,6 @@ const EVENTS = {
   },
 
   /* Everything under this point should be Settings events, aka 'fxa_pref' group */
-  // temp fallback tests
-  'settings.test.fallback.start': {
-    group: GROUPS.settings,
-    event: 'test_fallback_start',
-    minimal: true,
-  },
-  'settings.test.fallback.text-needed': {
-    group: GROUPS.settings,
-    event: 'test_fallback_text_needed',
-    minimal: true,
-  },
-  'settings.test.fallback.text-not-needed': {
-    group: GROUPS.settings,
-    event: 'test_fallback_text_not_needed',
-    minimal: true,
-  },
   // Account recovery key
   'screen.settings.account-recovery': {
     group: GROUPS.settings,

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -557,36 +557,6 @@ registerSuite('amplitude', {
       assert.equal(logger.info.args[0][1].event_type, 'fxa_pref - logout');
     },
 
-    'settings.test.fallback.start': () => {
-      createAmplitudeEvent('settings.test.fallback.start');
-
-      assert.equal(logger.info.callCount, 1);
-      assert.equal(
-        logger.info.args[0][1].event_type,
-        'fxa_pref - test_fallback_start'
-      );
-    },
-
-    'settings.test.fallback.text-needed': () => {
-      createAmplitudeEvent('settings.test.fallback.text-needed');
-
-      assert.equal(logger.info.callCount, 1);
-      assert.equal(
-        logger.info.args[0][1].event_type,
-        'fxa_pref - test_fallback_text_needed'
-      );
-    },
-
-    'settings.test.fallback.text-not-needed': () => {
-      createAmplitudeEvent('settings.test.fallback.text-not-needed');
-
-      assert.equal(logger.info.callCount, 1);
-      assert.equal(
-        logger.info.args[0][1].event_type,
-        'fxa_pref - test_fallback_text_not_needed'
-      );
-    },
-
     'flow.settings.account-recovery.confirm-revoke.submit': () => {
       createAmplitudeEvent(
         'flow.settings.account-recovery.confirm-revoke.submit'

--- a/packages/fxa-settings/src/components/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.test.tsx
@@ -8,11 +8,6 @@ import PageSettings from '.';
 import { renderWithRouter } from '../../models/mocks';
 import * as Metrics from '../../lib/metrics';
 
-import fetchMock from 'fetch-mock';
-import waitUntil from 'async-wait-until';
-import sinon from 'sinon';
-import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
-
 jest.spyOn(Metrics, 'setProperties');
 jest.spyOn(Metrics, 'usePageViewEvent');
 
@@ -27,73 +22,4 @@ it('renders without imploding', async () => {
     uid: 'abc123',
   });
   expect(Metrics.usePageViewEvent).toHaveBeenCalledWith('settings');
-});
-
-describe('Fluent fallback text test', () => {
-  function waitUntilTranslated() {
-    return waitUntil(() => {
-      // @ts-ignore
-      return AppLocalizationProvider.prototype.render.callCount === 2;
-    });
-  }
-
-  beforeEach(() => {
-    jest.spyOn(Metrics, 'logViewEvent');
-    sinon.spy(AppLocalizationProvider.prototype, 'render');
-  });
-  afterEach(() => {
-    jest.spyOn(Metrics, 'logViewEvent').mockClear();
-    // @ts-ignore
-    AppLocalizationProvider.prototype.render.restore();
-  });
-
-  it('makes expected metrics calls when ID is found', async () => {
-    fetchMock.get(
-      '/locales/en/hasTranslation.ftl',
-      'app-footer-mozilla-logo-label = Hello'
-    );
-    renderWithRouter(
-      <AppLocalizationProvider
-        bundles={['hasTranslation']}
-        userLocales={['en']}
-      >
-        <PageSettings />
-      </AppLocalizationProvider>
-    );
-    await waitUntilTranslated();
-
-    expect(Metrics.logViewEvent).toHaveBeenCalledWith(
-      Metrics.settingsViewName,
-      'test.fallback.start'
-    );
-    expect(Metrics.logViewEvent).toHaveBeenCalledWith(
-      Metrics.settingsViewName,
-      'test.fallback.text-not-needed'
-    );
-  });
-
-  it('makes expected metrics calls when ID is not found', async () => {
-    fetchMock.get(
-      '/locales/en/missingTranslation.ftl',
-      'something-else = Hello'
-    );
-
-    renderWithRouter(
-      <AppLocalizationProvider
-        bundles={['missingTranslation']}
-        userLocales={['en']}
-      >
-        <PageSettings />
-      </AppLocalizationProvider>
-    );
-    await waitUntilTranslated();
-    expect(Metrics.logViewEvent).toHaveBeenCalledWith(
-      Metrics.settingsViewName,
-      'test.fallback.start'
-    );
-    expect(Metrics.logViewEvent).toHaveBeenCalledWith(
-      Metrics.settingsViewName,
-      'test.fallback.text-needed'
-    );
-  });
 });

--- a/packages/fxa-settings/src/components/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import Nav from '../Nav';
 import Security from '../Security';
@@ -13,37 +13,17 @@ import LinkedAccounts from '../LinkedAccounts';
 import * as Metrics from '../../lib/metrics';
 import { useAccount } from '../../models';
 import { DeleteAccountPath } from 'fxa-settings/src/constants';
-import { Localized, useLocalization } from '@fluent/react';
+import { Localized } from '@fluent/react';
 import DataCollection from '../DataCollection';
 
 export const PageSettings = (_: RouteComponentProps) => {
   const { uid } = useAccount();
-  const { l10n } = useLocalization();
 
   Metrics.setProperties({
     lang: document.querySelector('html')?.getAttribute('lang'),
     uid,
   });
   Metrics.usePageViewEvent(Metrics.settingsViewName);
-
-  // Temp test to see how often we actually display fallback text
-  useEffect(() => {
-    Metrics.logViewEvent(Metrics.settingsViewName, 'test.fallback.start');
-    const ftlId = 'app-footer-mozilla-logo-label';
-    const text = l10n.getString(ftlId);
-
-    if (text && text !== ftlId) {
-      Metrics.logViewEvent(
-        Metrics.settingsViewName,
-        'test.fallback.text-not-needed'
-      );
-    } else {
-      Metrics.logViewEvent(
-        Metrics.settingsViewName,
-        'test.fallback.text-needed'
-      );
-    }
-  }, [l10n]);
 
   return (
     <div id="fxa-settings" className="flex">


### PR DESCRIPTION
Because:
* We've gotten some preliminary data from this test and no longer need it around

This commit:
* Removes all references to fallback text needed/not needed metrics events in PageSettings and Amplitude mapping

closes [FXA-5932](https://mozilla-hub.atlassian.net/browse/FXA-5932)