### PR TITLE
fix(metrics): restore nav to /pair click event

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
@@ -46,7 +46,7 @@
               <p class="font-normal text-sm px-16">{{#t}}Want to get your tabs, bookmarks, and passwords on another device?{{/t}}</p>
             </div>
             <div class="flex">
-              <a id="sync-firefox-devices" href="{{{pairingUrl}}}" class="cta-primary cta-xl">{{#t}}Connect another device{{/t}}</a>
+              <a id="sync-firefox-devices" href="{{{pairingUrl}}}" class="cta-primary cta-xl" data-flow-event="link.pair">{{#t}}Connect another device{{/t}}</a>
             </div>
             <div class="mt-5">
               <a id="cad-not-now" class="link-blue" href="/settings">{{#t}}Not now{{/t}}</a>


### PR DESCRIPTION
Because:
 - the CAD page was changed a couple times recently and an event was dropped between those changes somehow

The change was previously approved in https://github.com/mozilla/fxa/pull/14078, specifically https://github.com/mozilla/fxa/pull/14078/files#diff-ffde16ed75a1413c6306b919b2e700495620eaa75a15fc9e17ae13a7e996a683R46 but when the CAD was updated again it was merged out of existence I think.