### PR TITLE
feat(admin): Ignore traces from users that have opted out of metrics

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1018,40 +1018,40 @@ export class AccountHandler {
         if (sessionToken.tokenVerified || !sessionToken.mustVerify) {
           const geoData = request.app.geo;
           const service =
-           (request.payload as any).service || request.query.service;
+            (request.payload as any).service || request.query.service;
           const ip = request.app.clientAddress;
           const { deviceId, flowId, flowBeginTime } = await request.app
-           .metricsContext;
+            .metricsContext;
 
           try {
             await this.mailer.sendNewDeviceLoginEmail(
-             accountRecord.emails,
-             accountRecord,
-             {
-               acceptLanguage: request.app.acceptLanguage,
-               deviceId,
-               flowId,
-               flowBeginTime,
-               ip,
-               location: geoData.location,
-               service,
-               timeZone: geoData.timeZone,
-               uaBrowser: request.app.ua.browser,
-               uaBrowserVersion: request.app.ua.browserVersion,
-               uaOS: request.app.ua.os,
-               uaOSVersion: request.app.ua.osVersion,
-               uaDeviceType: request.app.ua.deviceType,
-               uid: sessionToken.uid,
-             },
+              accountRecord.emails,
+              accountRecord,
+              {
+                acceptLanguage: request.app.acceptLanguage,
+                deviceId,
+                flowId,
+                flowBeginTime,
+                ip,
+                location: geoData.location,
+                service,
+                timeZone: geoData.timeZone,
+                uaBrowser: request.app.ua.browser,
+                uaBrowserVersion: request.app.ua.browserVersion,
+                uaOS: request.app.ua.os,
+                uaOSVersion: request.app.ua.osVersion,
+                uaDeviceType: request.app.ua.deviceType,
+                uid: sessionToken.uid,
+              }
             );
           } catch (err) {
             // If we couldn't email them, no big deal. Log
             // and pretend everything worked.
             this.log.trace(
-             'Account.login.sendNewDeviceLoginNotification.error',
-             {
-               error: err,
-             },
+              'Account.login.sendNewDeviceLoginNotification.error',
+              {
+                error: err,
+              }
             );
           }
         }

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -43,6 +43,7 @@ export interface AuthApp extends RequestApplicationState {
     formFactor: string;
   };
   isSuspiciousRequest: boolean;
+  isMetricsEnabled: Promise<boolean>;
   geo: {
     location?: {
       city: string;

--- a/packages/fxa-shared/tracing/node-tracing.ts
+++ b/packages/fxa-shared/tracing/node-tracing.ts
@@ -11,6 +11,7 @@ import { ExportResult } from '@opentelemetry/core';
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
+
 import {
   BatchSpanProcessor,
   ConsoleSpanExporter,
@@ -38,7 +39,7 @@ export class FxaGcpTraceExporter extends GcpTraceExporter {
     resultCallback: (result: ExportResult) => void
   ) {
     for (const span of spans) {
-      // Don't record raw db statemets. They often leak PII.
+      // Don't record raw db statements. They often leak PII.
       if (span.attributes['db.statement']) {
         span.attributes['db.statement'] = '[FILTERED]';
       }
@@ -146,7 +147,7 @@ export class NodeTracingInitializer {
   }
 }
 
-let nodeTracing: NodeTracingInitializer;
+export let nodeTracing: NodeTracingInitializer;
 export function init(opts: TracingOpts, logger?: ILogger) {
   logger?.info(log_type, { msg: 'Initializing node tracing.' });
 


### PR DESCRIPTION
## Because

- Users that opted out of metrics don't want their traces sampled

## This pull request

- I looked at several different ways to accomplish this and landed on adding a parent context that suppresses telemetry
- Options considered
  - Add attributes to span to specfic excluding it from tracing, Add a custom sampler to filter out these spans
    - This approach was not the intended use of span attributes and could have costly lookups
  - Update node auto instrumentation to exclude urls
    - If we did this we would have to manually add urls to exclude from tracing
  - Wrap trace supported routes with a new parent context that suppresses tracing
  - Read a custom request header and filter out request if it is set
    - This approach would be great and very straightforward however, it requires knowing the metrics status of a user. Routes like `/account/login` wouldn't be able to set this flag because the client wouldnt have that data yet.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5942

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Notes

I'm not really sure the best way to test this besides running it locally and verifying...

## Screenshots (Optional)

Logging in after and before opting out of metrics.
![Screen Shot 2022-09-21 at 3 09 03 PM](https://user-images.githubusercontent.com/1295288/191810140-cffbdb29-db87-4278-b1e1-2f97f43c380d.png)
