### PR TITLE
[HOLD][DO NOT MERGE] feat(pushbox): shard writes and combine reads

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1601,11 +1601,11 @@ const conf = convict({
       env: 'PUSHBOX_MAX_TTL',
     },
     database: makeMySQLConfig('PUSHBOX', 'pushbox'),
-    directDbAccessPercentage: {
-      doc: 'The percentage of pushbox request to be handle through direct database access. 0 = off',
-      format: Number,
-      default: 0,
-      env: 'PUSHBOX_DIRECT_DB_PERCENT',
+    directDbAccessUidDigits: {
+      doc: 'List of hex digits [0-f] that is used to match the first digit of a uid; direct DB access is used on a match.',
+      format: Array,
+      env: 'PUSHBOX_DIRECT_DB_UID_DIGITS',
+      default: [],
     },
   },
   secondaryEmail: {


### PR DESCRIPTION
Because:
 - we are going to migrate to new Pushbox DB instance that is directly accessed from the auth-server

This commit:
 - shard writes based on account uids
 - read from both the service and the new DB instance

Fixes FXA-5955