### PR TITLE
fix(safari): Tweak content-server input and PW eye styles for Safari rendering bug

### DIFF
--- a/packages/fxa-content-server/app/styles/tailwind/inputs.css
+++ b/packages/fxa-content-server/app/styles/tailwind/inputs.css
@@ -15,6 +15,14 @@
 
 .input-text {
   @apply w-full p-4 text-grey-500 text-base rounded-md border border-grey-300 focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus;
+
+  /* SAFARI HACK: move the native PW helper further inside the input to avoid overlap with PW eye.
+   * REACT TODO: In Settings, our HTML structured differently for PW inputs and we use `flex` to
+   * keep the native PW helper to the side of the PW eye. When we refactor to React, we should use
+   * use that PW input or refactor to a similar structure using `flex`. */
+  &::-webkit-credentials-auto-fill-button {
+    @apply relative ltr:right-11 rtl:left-11;
+  }
 }
 
 /* REACT TODO: Probably move this into JSX, currently lives in `form.js`
@@ -46,7 +54,9 @@
   &-label {
     &-show,
     &-hide {
-      @apply bg-cover bg-no-repeat bg-center absolute cursor-pointer ltr:right-px rtl:left-px h-full w-14;
+      @apply bg-cover bg-no-repeat bg-center absolute cursor-pointer ltr:right-px rtl:left-px h-full w-14
+      /* SAFARI HACK: The PW eye appears below the input without `top` */
+      top-0;
     }
 
     &-show {


### PR DESCRIPTION
Because:
* The PW eye was rendering underneath the edge of the PW input in Safari, including FF on iOS

This commit:
* Adds 'top-0' to the PW eye to address the bug, then targets Safari's native PW helper to scoot it over to prevent overlap with the PW eye

Fixes [FXA-5871](https://mozilla-hub.atlassian.net/browse/FXA-5871)

--

I took a few different approaches to fixing this before landing here. The fix for the bug is easy (adding `top-0`, which fixes the problem in Safari and has no visual change in other browsers) but we needed to account for Safari's native PW helper because the eye would overlap it.

At first I used a [pretty hacky media query](https://github.com/mozilla/fxa/compare/FXA-5871?expand=1#diff-0223815a40e5acf034c88d92557eaf7515f57583e57ecdb3694a993cc388e5a5R51), TLDR is it would've caused a bug where if you took Safari desktop and resized it to a smaller screen, the PW eye and PW manager would still overlap. I considered checking the user agent and conditionally rendering a class if it matches, but it just felt like overkill.

Then, I realized I could actually target the key itself with CSS, which is what's done here. I ended up checking Settings and the HTML is structured differently and it's not a quick fix to refactor _all_ of our password inputs in content-server considering the logic we have around the structure in the JS, plus we've got the looming React refactor.

This is going to be difficult to test because we can't develop locally in Safari now without setting up HTTPS up locally. Instead, here's `top: 0px` showing the fix in Safari in prod:

Before:
![image](https://user-images.githubusercontent.com/13018240/191374524-a95c4aae-3255-4288-883c-03b65b1b74e4.png)

After:
![image](https://user-images.githubusercontent.com/13018240/191374677-697dde57-98d6-4888-b442-c99b4aa16ff1.png)


And then, check out what's outputted in the `tailwind.out.css` file:

```
.input-text::-webkit-credentials-auto-fill-button {
  position: relative;
}

[dir="ltr"] .input-text::-webkit-credentials-auto-fill-button {
  right: 2.75rem;
}

[dir="rtl"] .input-text::-webkit-credentials-auto-fill-button {
  left: 2.75rem;
}
```

I put this^ [in a codepen](https://codepen.io/LZoog/pen/PoejLGP). You can check this in FF, mobile FF, desktop Safari, etc. and see the key scooted over when it appears. Safari won't seem to let me edit the shadow DOM directly to show you what it should look like in prod but there's about `16px` of padding to the right, and `16px` + `44px` (2.75rem) = `60px` and the width of the eye is `56px` so this number seems fine.
