### PR TITLE
feat(fxa-profile-server): add OpenTelemetry library to profile server

### DIFF
--- a/packages/fxa-profile-server/bin/server.js
+++ b/packages/fxa-profile-server/bin/server.js
@@ -14,6 +14,13 @@ const Server = require('../lib/server');
 // The stringify/parse is to force the output back to unindented json.
 logger.info('config', JSON.stringify(JSON.parse(configuration.toString())));
 
+// Must be required and initialized right away
+require('fxa-shared/tracing/node-tracing').init(
+  configuration.get('tracing'),
+  require('../lib/logging')({ ...configuration.log })
+);
+
+
 async function start() {
   const server = await Server.create();
   const events = require('../lib/events')(server);

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -5,11 +5,14 @@
 const fs = require('fs');
 const path = require('path');
 
+const tracing = require('fxa-shared/tracing/config');
 const convict = require('convict');
 const convict_format_with_validator = require('convict-format-with-validator');
 const convict_format_with_moment = require('convict-format-with-moment');
 convict.addFormats(convict_format_with_validator);
 convict.addFormats(convict_format_with_moment);
+
+const tracingConfig = tracing.tracingConfig;
 
 const conf = convict({
   api: {
@@ -317,12 +320,6 @@ const conf = convict({
       format: ['local', 'ci', 'dev', 'stage', 'prod'],
       env: 'SENTRY_ENV',
     },
-    sampleRate: {
-      doc: 'Rate at which sentry traces are captured.',
-      default: 1.0,
-      format: 'Number',
-      env: 'SENTRY_SAMPLE_RATE',
-    },
     serverName: {
       doc: 'Name used by sentry to identify the server.',
       default: 'fxa-profile-server',
@@ -336,6 +333,7 @@ const conf = convict({
     env: 'AUTH_SECRET_BEARER_TOKEN',
     format: 'String',
   },
+  tracing: tracingConfig,
 });
 
 var envConfig = path.join(__dirname, '..', 'config', conf.get('env') + '.json');

--- a/packages/fxa-profile-server/lib/server/_static.js
+++ b/packages/fxa-profile-server/lib/server/_static.js
@@ -31,7 +31,6 @@ exports.create = async function () {
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        additionalHeaders: ['sentry-trace'],
         // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
         // which is more forgiving of missing Origin header.
         origin: config.corsOrigin[0] === '*' ? 'ignore' : config.corsOrigin[0],

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -63,7 +63,6 @@ exports.create = async function createServer() {
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        additionalHeaders: ['sentry-trace'],
         // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
         // which is more forgiving of missing Origin header.
         origin: ['*'],

--- a/packages/fxa-profile-server/lib/server/worker.js
+++ b/packages/fxa-profile-server/lib/server/worker.js
@@ -22,7 +22,6 @@ exports.create = async function () {
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        additionalHeaders: ['sentry-trace'],
         // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
         // which is more forgiving of missing Origin header.
         origin: ['*'],

--- a/packages/fxa-profile-server/pm2.config.js
+++ b/packages/fxa-profile-server/pm2.config.js
@@ -21,6 +21,7 @@ module.exports = {
         PATH,
         SENTRY_ENV: 'local',
         SENTRY_DSN: process.env.SENTRY_DSN_PROFILE,
+        TRACING_SERVICE_NAME: 'fxa-profile-server'
       },
       filter_env: ['npm_'],
       min_uptime: '2m',


### PR DESCRIPTION
## Because:

* We're replacing the sentry tracing library/configuration with OpenTelemetry (per the auth server)

## This commit:

* Removes sentry tracing and replaces it with OpenTelemetry, modelled on the work already done in the auth server

Closes # https://mozilla-hub.atlassian.net/browse/FXA-5720


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
<img width="1727" alt="profile-server-jaeger" src="https://user-images.githubusercontent.com/11150372/191862019-a357753a-b6d6-48d0-b279-4d131a9834d3.png">
<img width="1710" alt="profile-server-tracing" src="https://user-images.githubusercontent.com/11150372/191862033-44580bfd-7cdd-4ae1-b507-db9091b95c3e.png">


