### PR TITLE
feat(admin): Add `traceId` to log statements

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -7,7 +7,8 @@
 const config = require('../config');
 
 // Must be required and initialized right away
-require('fxa-shared/tracing/node-tracing').init(
+const TracingProvider = require('fxa-shared/tracing/node-tracing');
+TracingProvider.init(
   config.get('tracing'),
   require('../lib/log')({ ...config.log })
 );
@@ -46,7 +47,11 @@ async function run(config) {
       };
   Container.set(StatsD, statsd);
 
-  const log = require('../lib/log')({ ...config.log, statsd });
+  const log = require('../lib/log')({
+    ...config.log,
+    statsd,
+    nodeTracer: TracingProvider.nodeTracing,
+  });
   Container.set(AuthLogger, log);
 
   if (!Container.has(AuthFirestore)) {

--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -29,11 +29,22 @@ function Lug(options) {
 
   this.stdout = options.stdout || process.stdout;
 
+  this.nodeTracer = options.nodeTracer;
+
   this.notifier = require('./notifier')(this, statsd);
 }
 util.inherits(Lug, EventEmitter);
 
 Lug.prototype.close = function () {};
+
+Lug.prototype.setTraceId = function (data) {
+  if (this.nodeTracer) {
+    const traceId = this.nodeTracer.getTraceId();
+    if (traceId) {
+      data.traceId = traceId;
+    }
+  }
+};
 
 // Expose the standard error/warn/info/debug/etc log methods.
 
@@ -42,10 +53,12 @@ Lug.prototype.trace = function (op, data) {
 };
 
 Lug.prototype.debug = function (op, data) {
+  this.setTraceId(data);
   this.logger.debug(op, data);
 };
 
 Lug.prototype.error = function (op, data) {
+  this.setTraceId(data);
   // If the error object contains an email address,
   // lift it into top-level fields so that our
   // PII-scrubbing tool is able to find it.
@@ -67,6 +80,7 @@ Lug.prototype.warn = function (op, data) {
 };
 
 Lug.prototype.info = function (op, data) {
+  this.setTraceId(data);
   this.logger.info(op, data);
 };
 

--- a/packages/fxa-content-server/server/lib/logging/route_logging.js
+++ b/packages/fxa-content-server/server/lib/logging/route_logging.js
@@ -13,7 +13,6 @@ const config = require('../configuration').getProperties();
 const remoteAddress = require('fxa-shared/express/remote-address')(
   config.clientAddressDepth
 );
-// const tracing = require('fxa-shared/tracing/node-tracing');
 
 /**
  * Enhances connect logger middleware - custom formats.
@@ -27,8 +26,7 @@ const disabled = function (req, res, next) {
 
 function defaultFxaFormat(tokens, req, res) {
   const { clientAddress, addresses } = remoteAddress(req);
-
-  const data = {
+  return JSON.stringify({
     clientAddress,
     contentLength: tokens.res(req, res, 'content-length'),
     method: tokens.method(req, res),
@@ -38,13 +36,7 @@ function defaultFxaFormat(tokens, req, res) {
     status: tokens.status(req, res),
     t: tokens['response-time'](req, res),
     userAgent: req.headers['user-agent'],
-  };
-
-  // if (tracing.nodeTracing) {
-  //   data.traceId = tracing.nodeTracing.getTraceId();
-  // }
-  //
-  return data;
+  });
 }
 
 const formats = {

--- a/packages/fxa-content-server/server/lib/logging/route_logging.js
+++ b/packages/fxa-content-server/server/lib/logging/route_logging.js
@@ -13,6 +13,7 @@ const config = require('../configuration').getProperties();
 const remoteAddress = require('fxa-shared/express/remote-address')(
   config.clientAddressDepth
 );
+// const tracing = require('fxa-shared/tracing/node-tracing');
 
 /**
  * Enhances connect logger middleware - custom formats.
@@ -26,7 +27,8 @@ const disabled = function (req, res, next) {
 
 function defaultFxaFormat(tokens, req, res) {
   const { clientAddress, addresses } = remoteAddress(req);
-  return JSON.stringify({
+
+  const data = {
     clientAddress,
     contentLength: tokens.res(req, res, 'content-length'),
     method: tokens.method(req, res),
@@ -36,7 +38,13 @@ function defaultFxaFormat(tokens, req, res) {
     status: tokens.status(req, res),
     t: tokens['response-time'](req, res),
     userAgent: req.headers['user-agent'],
-  });
+  };
+
+  // if (tracing.nodeTracing) {
+  //   data.traceId = tracing.nodeTracing.getTraceId();
+  // }
+  //
+  return data;
 }
 
 const formats = {

--- a/packages/fxa-shared/tracing/node-tracing.ts
+++ b/packages/fxa-shared/tracing/node-tracing.ts
@@ -22,6 +22,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import api from '@opentelemetry/api';
 
 import { ILogger } from '../log';
 import { TracingOpts } from './config';
@@ -144,6 +145,14 @@ export class NodeTracingInitializer {
     this.provider.addSpanProcessor(processor);
     this.provider.register();
     this.logger?.info(log_type, { msg: 'gcp enabled' });
+  }
+
+  protected getTraceId() {
+    const currentSpan = api.trace.getSpan(api.context.active());
+    if (currentSpan) {
+      return currentSpan.spanContext().traceId;
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
## Because

- We want to capture `traceId` in our log statements

## This pull request

- Adds `traceId` to auth server info, debug, error logs

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5086

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

I'm not sure how we intend to use the traceId in logs, but I added it to the auth-server since that seems most valuable?
