### PR TITLE
feat(auth): get plan eligibility

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
@@ -158,6 +158,19 @@ const OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_BILLING_AND_SUBSCRIPTIONS_GET = {
   notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
+const OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_PLAN_ELIGIBILITY = {
+  ...TAGS_SUBSCRIPTIONS,
+  description:
+    '/oauth/mozilla-subscriptions/customer/plan-eligibility/{planid}',
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Get eligibility for a given plan. Returns eligibility as 'create'|'upgrade'|'downgrade'|'blocked_iap'|'invalid'.
+    `,
+  ],
+};
+
 const OAUTH_SUBSCRIPTIONS_IAP_RTDN_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/iap/rtdn',
@@ -243,6 +256,7 @@ const API_DOCS = {
   OAUTH_SUBSCRIPTIONS_PLANS_GET,
   OAUTH_SUBSCRIPTIONS_SETUPINTENT_CREATE_POST,
   OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_BILLING_AND_SUBSCRIPTIONS_GET,
+  OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_PLAN_ELIGIBILITY,
   OAUTH_SUBSCRIPTIONS_ACTIVE_NEW_PAYPAL_POST,
   OAUTH_SUBSCRIPTIONS_ACTIVE_SUBSCRIPTIONID_PUT,
   OAUTH_SUBSCRIPTIONS_CLIENTS_GET,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
@@ -144,6 +144,7 @@ const db = mocks.mockDB({
 });
 const customs = mocks.mockCustoms();
 let stripeHelper;
+let capabilityService;
 
 async function runTest(routePath, routeDependencies = {}) {
   const playSubscriptions = {
@@ -161,6 +162,7 @@ async function runTest(routePath, routeDependencies = {}) {
     db,
     customs,
     stripeHelper,
+    capabilityService,
     playSubscriptions,
     appStoreSubscriptions,
     ...routeDependencies,
@@ -172,6 +174,7 @@ async function runTest(routePath, routeDependencies = {}) {
 
 describe('mozilla-subscriptions', () => {
   beforeEach(() => {
+    capabilityService = {};
     stripeHelper = {
       getBillingDetailsAndSubscriptions: sandbox
         .stub()
@@ -309,6 +312,29 @@ describe('mozilla-subscriptions', () => {
       } catch (e) {
         assert.strictEqual(e.errno, ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
       }
+    });
+  });
+});
+
+describe('plan-eligibility', () => {
+  beforeEach(() => {
+    capabilityService = {
+      getPlanEligibility: sandbox.stub().resolves('eligibility'),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('GET /customer/plan-eligibility/example-planid', () => {
+    it('gets plan eligibility', async () => {
+      const resp = await runTest(
+        '/oauth/mozilla-subscriptions/customer/plan-eligibility/{planId}'
+      );
+      assert.deepEqual(resp, {
+        eligibility: 'eligibility',
+      });
     });
   });
 });

--- a/packages/fxa-shared/subscriptions/stripe.ts
+++ b/packages/fxa-shared/subscriptions/stripe.ts
@@ -229,15 +229,11 @@ export function singlePlan(
  * Given two plans, A and B, determine whether B is eligible for a subscription
  * update (upgrade/downgrade) from A.
  */
-export const getSubscriptionUpdateEligibility: (
-  x: Plan,
-  y: Plan,
-  useFirestoreProductConfigs?: boolean
-) => SubscriptionUpdateEligibility = (
+export const getSubscriptionUpdateEligibility = (
   currentPlan: Plan,
   newPlan: Plan,
   useFirestoreProductConfigs: boolean = false
-) => {
+): SubscriptionUpdateEligibility => {
   const currentPlanConfig = productUpgradeFromProductConfig(
     currentPlan,
     useFirestoreProductConfigs


### PR DESCRIPTION
## Because

There isn't a great way to currently get your eligibility for a given plan outside of a 1-to-1 upgrade from plan A to B.

## This pull request

This endpoint provides a way to check your eligibility path for a given plan, and will return an eligibility status of:
- create (user can create a brand new subscription to this plan)
- upgrade (user is subscribed to a plan that can be upgraded to this plan)
- downgrade (user is subscribed to a plan that can be downgraded to this plan
- blocked_iap (user is subscribed to a plan via IAP that includes a productSet that conflicts with this plan and therefore cannot subscribe to this plan)
- invalid (configuration issue)

## Issue that this pull request solves

Closes: FXA-5479

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
