### PR TITLE
fix(settings): Fix secondary email 'Not Set' state

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.test.tsx
@@ -49,9 +49,15 @@ describe('UnitRowSecondaryEmail', () => {
       expect(
         screen.getByTestId('secondary-email-unit-row-route')
       ).toHaveAttribute('href', '/settings/emails');
-      expect(
-        screen.getByTestId('secondary-email-default-content')
-      ).toBeInTheDocument();
+
+      screen.getByText(
+        'Access your account if you can’t log in to your primary email',
+        { exact: false }
+      );
+      screen.getByText(
+        'Note: a secondary email won’t restore your information',
+        { exact: false }
+      );
       expect(
         screen.getByTestId('secondary-email-link-recovery-key')
       ).toHaveAttribute('href', '#recovery-key');

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -130,25 +130,18 @@ export const UnitRowSecondaryEmail = () => {
   const UnitRowSecondaryEmailNotSet = () => {
     // user doesn't have a secondary email (verified or unverified) set
     return (
-      <Localized id="se-heading" attrs={{ header: true }}>
-        <UnitRow
-          header="Secondary email"
-          headerId="secondary-email"
-          prefixDataTestId="secondary-email"
-          headerValue={null}
-          noHeaderValueText={l10n.getString(
-            'se-secondary-email-none',
-            null,
-            'None'
-          )}
-          route={`${HomePath}/emails`}
-          {...{
-            alertBarRevealed: alertBar.visible,
-          }}
-        >
-          <SecondaryEmailDefaultContent />
-        </UnitRow>
-      </Localized>
+      <UnitRow
+        header={l10n.getString('se-heading', null, 'Secondary email')}
+        headerId="secondary-email"
+        prefixDataTestId="secondary-email"
+        headerValue={null}
+        route={`${HomePath}/emails`}
+        {...{
+          alertBarRevealed: alertBar.visible,
+        }}
+      >
+        <SecondaryEmailDefaultContent />
+      </UnitRow>
     );
   };
 
@@ -338,7 +331,7 @@ const SecondaryEmailDefaultContent = () => (
   <div data-testid="secondary-email-default-content">
     <Localized id="se-default-content">
       <p className="text-sm mt-3">
-        Access your account if you can't log in to your primary email.
+        Access your account if you can’t log in to your primary email.
       </p>
     </Localized>
     <Localized
@@ -356,7 +349,7 @@ const SecondaryEmailDefaultContent = () => (
       }}
     >
       <p className="text-grey-400 text-xs mt-2">
-        Note: a secondary email won't restore your information — you'll need an{' '}
+        Note: a secondary email won’t restore your information — you’ll need an{' '}
         <a
           className="link-blue"
           href="#recovery-key"


### PR DESCRIPTION
Because:
* Users can't see our additional secondary email info because Fluent is replacing the entire section with header text

This commit:
* Sends localized text into the 'header' prop for UnitRow, rather than using a Localized wrapper that was replacing the entire DOM output

fixes [FXA-2984](https://mozilla-hub.atlassian.net/browse/FXA-2984)

---

Before:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/13018240/192008491-6d0e4632-0d94-4bea-bc52-6ed87adb3408.png">


After:

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/13018240/192008063-80a65d8d-2345-41ee-86f9-e04db8d92f36.png">

Testing in Italian for good measure:
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/13018240/192008235-130bfa77-b7fd-4d6f-b757-818c4ece915a.png">
