### PR TITLE
feat(payments): surface plan_metadata name when present

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -175,6 +175,50 @@ describe('PlanDetails', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders product_name when product:name is not present', () => {
+    render(
+      <PlanDetails
+        {...{
+          profile: userProfile,
+          showExpandButton: true,
+          isMobile: false,
+          selectedPlan,
+        }}
+      />
+    );
+
+    const detailsTitle = document.getElementById(
+      'plan-details-product'
+    )?.textContent;
+    expect(detailsTitle).toEqual(selectedPlan.product_name);
+  });
+
+  it('renders product:name if present instead of product_name', () => {
+    const name = 'Foxkeh Pro Level';
+    const selectedPlanWithPlanMetadataName = {
+      ...selectedPlan,
+      plan_metadata: {
+        'product:name': name,
+      },
+    };
+
+    render(
+      <PlanDetails
+        {...{
+          profile: userProfile,
+          showExpandButton: true,
+          isMobile: false,
+          selectedPlan: selectedPlanWithPlanMetadataName,
+        }}
+      />
+    );
+
+    const detailsTitle = document.getElementById(
+      'plan-details-product'
+    )?.textContent;
+    expect(detailsTitle).toEqual(name);
+  });
+
   it('hides expand button when showExpandButton is false', () => {
     const subject = () => {
       return render(

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -87,7 +87,7 @@ export const PlanDetails = ({
               >
                 <img
                   src={webIcon || ffLogo}
-                  alt={product_name}
+                  alt={productDetails.name || product_name}
                   data-testid="product-logo"
                   className="w-8 h-8"
                 />
@@ -95,7 +95,7 @@ export const PlanDetails = ({
 
               <div className="plan-details-heading-wrap">
                 <h3 id="plan-details-product" className="plan-details-product">
-                  {product_name}
+                  {productDetails.name || product_name}
                 </h3>
 
                 <p className="plan-details-description">

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -574,6 +574,23 @@ export const MOCK_PLANS: Plan[] = [
     },
     active: false,
   },
+  {
+    plan_id: 'plan_withname',
+    product_id: PRODUCT_ID,
+    product_name: PRODUCT_NAME,
+    interval: 'year' as const,
+    interval_count: 1,
+    amount: 999,
+    currency: 'usd',
+    plan_metadata: {
+      'product:name': 'Nyctereutes viverrinus',
+    },
+    product_metadata: {
+      webIconURL: 'http://example.com/product.jpg',
+      webIconBackground: 'purple',
+    },
+    active: true,
+  },
 ];
 
 export const MOCK_PROFILE: Profile = {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -116,7 +116,7 @@ export const PlanDetailsCard = ({
           >
             <img
               src={webIcon || ffLogo}
-              alt={product_name}
+              alt={productDetails.name || product_name}
               data-testid="product-logo"
               className="w-8 h-8"
             />
@@ -127,7 +127,7 @@ export const PlanDetailsCard = ({
               id="plan-details-product"
               className="product-name plan-details-product"
             >
-              {product_name}
+              {productDetails.name || product_name}
             </h3>
 
             {/* TODO: make this configurable, issue #4741 / FXA-1484 */}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -175,6 +175,38 @@ describe('PlanDetailsCard', () => {
       expect(planPriceComponent.props.children).toBe(expectedMsg);
     }
 
+    it('displays product:name when present instead of product_name', () => {
+      const plan_id = 'plan_withname';
+      const plan = findMockPlan(plan_id);
+
+      const props = { plan: plan };
+
+      const testRenderer = TestRenderer.create(<PlanDetailsCard {...props} />);
+      const testInstance = testRenderer.root;
+      const planPriceComponent = testInstance.findByProps({
+        id: 'plan-details-product',
+      });
+
+      expect(planPriceComponent.props.children).toEqual(
+        plan.plan_metadata?.['product:name']
+      );
+    });
+
+    it('displays product_name when plan_metadata name is not present', () => {
+      const plan_id = 'plan_daily';
+      const plan = findMockPlan(plan_id);
+
+      const props = { plan: plan };
+
+      const testRenderer = TestRenderer.create(<PlanDetailsCard {...props} />);
+      const testInstance = testRenderer.root;
+      const planPriceComponent = testInstance.findByProps({
+        id: 'plan-details-product',
+      });
+
+      expect(planPriceComponent.props.children).toEqual(plan.product_name);
+    });
+
     describe('When plan has day interval', () => {
       const expectedMsgId = dayBasedId;
 

--- a/packages/fxa-shared/subscriptions/configuration/base.ts
+++ b/packages/fxa-shared/subscriptions/configuration/base.ts
@@ -45,6 +45,7 @@ const urlsSchema = joi.object({
 });
 
 export const UiContentConfigKeys = {
+  name: 'name',
   subtitle: 'subtitle',
   details: 'details',
   successActionButtonLabel: 'successActionButtonLabel',
@@ -56,6 +57,7 @@ export type UiContentConfig = {
 } & { details?: string[] };
 
 const uiContentSchema = joi.object({
+  name: joi.string(),
   subtitle: joi.string(),
   details: joi.array().items(joi.string()),
   successActionButtonLabel: joi.string(),

--- a/packages/fxa-shared/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/subscriptions/configuration/utils.ts
@@ -215,6 +215,7 @@ export const uiContentFromProductConfig = (
     const detailsFromPlan = productDetailsFromPlan(plan, userLocales);
 
     return {
+      name: detailsFromPlan.name,
       subtitle: detailsFromPlan.subtitle,
       details: detailsFromPlan.details,
       successActionButtonLabel: detailsFromPlan.successActionButtonLabel,

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -62,6 +62,7 @@ export interface ProductMetadata {
 // The ProductDetails type is exploded out into enums describing keys to
 // make Stripe metadata parsing & validation easier.
 export enum ProductDetailsStringProperties {
+  'name',
   'subtitle',
   'successActionButtonLabel',
   'termsOfServiceURL',

--- a/packages/fxa-shared/test/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/utils.ts
@@ -44,6 +44,7 @@ const PLAN_WITH_METADATA: Plan = {
     'product:privacyNoticeDownloadURL':
       'https://example.org/en-US/privacy/download',
     'product:ignoreme': 'Unknown name here',
+    'product:name': 'Name override!',
     'product:subtitle': 'Great Full-device VPN',
     'product:details:3': 'Baz Connects 5 devices with one subscription',
     'product:details:1': 'Foo Device-level encryption',
@@ -410,6 +411,7 @@ describe('product configuration util functions', () => {
         false
       );
       expect(actual).to.deep.equal({
+        name: PLAN_WITH_METADATA.product_metadata!['product:name'],
         subtitle: PLAN_WITH_METADATA.product_metadata!['product:subtitle'],
         details: [
           PLAN_WITH_METADATA.product_metadata!['product:details:1'],


### PR DESCRIPTION
## Because

Other teams have requested the ability to add specific names to individual prices and have those appear in place of the product name.

## This pull request

Displays the 'name' field from the plan_metadata if it's present, otherwise falls back to the product name when not present.

## Issue that this pull request solves

Closes: FXA-5959

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
