### PR TITLE
fix(emails): update SubscriptionUpgrade proration amount in emails

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2935,16 +2935,12 @@ export class StripeHelper extends StripeHelperBase {
     productOrderNew: string,
     planOld: Stripe.Plan
   ) {
-    const upcomingInvoice = await this.stripe.invoices.retrieveUpcoming({
-      subscription: subscription.id,
-    });
-
-    const { id: invoiceId, number: invoiceNumber } = invoice;
-
     const {
+      id: invoiceId,
+      number: invoiceNumber,
       currency: paymentProratedCurrency,
       amount_due: paymentProratedInCents,
-    } = upcomingInvoice;
+    } = invoice;
 
     // https://github.com/mozilla/subhub/blob/e224feddcdcbafaf0f3cd7d52691d29d94157de5/src/hub/vendor/customer.py#L643
     const abbrevProductOld = await this.expandAbbrevProductForPlan(planOld);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5541,15 +5541,6 @@ describe('StripeHelper', () => {
             event.data.previous_attributes.plan
           );
 
-        // issue #5546: ensure we're looking for the upcoming invoice for this specific subscription
-        assert.deepEqual(mockStripe.invoices.retrieveUpcoming.args, [
-          [
-            {
-              subscription: event.data.object.id,
-            },
-          ],
-        ]);
-
         assert.deepEqual(result, {
           ...baseDetails,
           productIdNew,
@@ -5562,8 +5553,8 @@ describe('StripeHelper', () => {
           paymentAmountOldCurrency:
             event.data.previous_attributes.plan.currency,
           paymentAmountOldInCents: event.data.previous_attributes.plan.amount,
-          paymentProratedCurrency: mockInvoiceUpcoming.currency,
-          paymentProratedInCents: mockInvoiceUpcoming.amount_due,
+          paymentProratedCurrency: mockInvoice.currency,
+          paymentProratedInCents: mockInvoice.amount_due,
           invoiceNumber: mockInvoice.number,
           invoiceId: mockInvoice.id,
         });


### PR DESCRIPTION
## Because

- The wrong proration amount was being displayed in subscription upgrade emails for both same and different billings cycles

## This pull request

- Updates the proration amount so the proper one-time fee is being displayed in both same and different billing cycles
- Updates tests to compare against current invoice amount as opposed to upcoming invoice amount (i.e., next cycle)

## Issue that this pull request solves

Closes: FXA-5734

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
