### PR TITLE
task(shared): Scrub PII from tracing data

### DIFF
--- a/packages/fxa-shared/test/tracing/node-tracing.ts
+++ b/packages/fxa-shared/test/tracing/node-tracing.ts
@@ -32,6 +32,7 @@ import {
   SpanStatus,
 } from '@opentelemetry/api';
 import { FxaGcpTraceExporter } from '../../tracing/node-tracing';
+import { TracingPiiFilter } from '../../tracing/pii-filters';
 
 describe('node-tracing', () => {
   const sandbox = sinon.createSandbox();
@@ -267,13 +268,46 @@ describe('node-tracing', () => {
       }
     }
 
-    it('removes db.statements', () => {
-      const exporter = new FxaGcpTraceExporter();
-      const spans: ReadableSpan[] = [
-        new FakeSpan({ 'db.statement': 'select * from test' }),
-      ];
-      exporter.export(spans, () => {});
-      expect(spans[0].attributes['db.statement']).equals('[FILTERED]');
+    describe('pii filters', () => {
+      function check(key: string, val: string, mutation: string) {
+        const filter = new TracingPiiFilter();
+        const exporter = new FxaGcpTraceExporter(filter);
+        const spans: ReadableSpan[] = [new FakeSpan({ [key]: val })];
+        exporter.export(spans, () => {});
+        expect(spans[0].attributes[key]).equals(mutation);
+      }
+
+      it('filters pii from typical db.query', () => {
+        check(
+          'db.query',
+          `select * from test where email = 'test@mozilla.com' or ip = '1.1.1.1' or uid = x'abcd1234abcd1234abcd1234abcd1234';`,
+          `select * from test where email = '[Filtered]' or ip = '[Filtered]' or uid = x'[Filtered]';`
+        );
+      });
+
+      it('filters pii from typical db.statement call', () => {
+        check(
+          'db.statement',
+          `Call deleteSessionToken_4(X'28d678b8d828ad79d6666877ae6c2919556a1bdaa1598efc264633203abbc279');`,
+          `Call deleteSessionToken_4(X'[Filtered]');`
+        );
+      });
+
+      it('filters pii from typical http url call', () => {
+        check(
+          'http.route',
+          `/v1/session/28d678b8d828ad79d6666877ae6c2919556a1bdaa1598efc264633203abbc279`,
+          `/v1/session/[Filtered]`
+        );
+      });
+
+      it('filters pii from typical http url call', () => {
+        check(
+          'http.route',
+          `/v1/find?email=test@mozilla.com`,
+          `/v1/find?email=[Filtered]`
+        );
+      });
     });
   });
 });

--- a/packages/fxa-shared/tracing/config.ts
+++ b/packages/fxa-shared/tracing/config.ts
@@ -13,9 +13,11 @@ export type TracingOpts = {
   };
   gcp?: {
     enabled: boolean;
+    filterPii: boolean;
   };
   jaeger?: {
     enabled: boolean;
+    filterPii: boolean;
   };
 };
 
@@ -45,12 +47,22 @@ export const tracingConfig = {
       doc: 'Traces report to the jaeger. This is only applicable for local development.',
       env: 'TRACING_JAEGER_EXPORTER_ENABLED',
     },
+    filterPii: {
+      default: true,
+      doc: 'Enables filtering PII in Jaeger traces.',
+      env: 'TRACING_JAEGER_FILTER_PII',
+    },
   },
   gcp: {
     enabled: {
       default: false,
       doc: 'Traces report to google cloud tracing. This should be turned on in the wild, but is discouraged for local development.',
       env: 'TRACING_GCP_EXPORTER_ENABLED',
+    },
+    filterPii: {
+      default: true,
+      doc: 'Enables filtering PII in GCP traces',
+      env: 'TRACING_GCP_FILTER_PII',
     },
   },
 };

--- a/packages/fxa-shared/tracing/pii-filters.ts
+++ b/packages/fxa-shared/tracing/pii-filters.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { FilterBase } from '../sentry/pii-filters';
+import { CommonPiiActions } from '../sentry/pii-filter-actions';
+import { PiiData } from '../sentry/models/pii';
+import { ILogger } from '../log';
+
+/** Matches attribute names that need to be filtered. */
+const reTargetPiiAttributes = /^(db|http)\./;
+
+/**
+ * PiiFilter specifically for scrubbing open telemetry traces.
+ */
+export class TracingPiiFilter extends FilterBase {
+  /**
+   * Creates new PII Filter for tracing
+   * @param logger - optional logger
+   */
+  constructor(logger?: ILogger) {
+    super(
+      [
+        CommonPiiActions.breadthFilter,
+        CommonPiiActions.depthFilter,
+        CommonPiiActions.piiKeys,
+        CommonPiiActions.emailValues,
+        CommonPiiActions.tokenValues,
+        CommonPiiActions.ipV4Values,
+        CommonPiiActions.ipV6Values,
+        CommonPiiActions.urlUsernamePassword,
+      ],
+      logger
+    );
+  }
+
+  /**
+   * Filter traces.
+   * @param data - Data to filter.
+   */
+  filter(data: PiiData): PiiData {
+    try {
+      if (typeof data === 'object' && data?.attributes) {
+        for (const key of Object.keys(data.attributes)) {
+          if (reTargetPiiAttributes.test(key)) {
+            data.attributes[key] = this.applyFilters(data.attributes[key]);
+          }
+        }
+      }
+    } catch (err) {
+      // Note, we have to throw the error, since the trace could contain PII if
+      // the routine doesn't exist cleanly. We will log this, so there's some way
+      // to track the problem down if we notice missing spans.
+      this.logger?.error('pii-trace-filter', err);
+      throw err;
+    }
+
+    return data;
+  }
+}


### PR DESCRIPTION
## Because

- We want to scrub PII from span attributes in trace data.

## This pull request

- Piggy backs for sentry PII scrubbing to scrub traces before they exported to jaeger/gcp.
- Makes minor improvements to email and token scrubbing actions.

## Issue that this pull request solves

Closes: FXA-5883

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/192032678-8ff6bf29-033c-46cb-b563-109c91cc80a2.png)

