### PR TITLE
test(functional): rewrite recovery tests using playwright

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -53,6 +53,12 @@ export class LoginPage extends BaseLayout {
     return this.page.fill('input[type=text]', code);
   }
 
+  async loginHeader() {
+    const header = this.page.locator('[data-testid=logo]');
+    await header.waitFor();
+    return header.isVisible();
+  }
+
   async signInError() {
     const error = this.page.locator('.error');
     await error.waitFor();
@@ -93,6 +99,12 @@ export class LoginPage extends BaseLayout {
 
   async resetPasswordHeader() {
     const resetPass = this.page.locator('#fxa-reset-password-header');
+    await resetPass.waitFor();
+    return resetPass.isVisible();
+  }
+
+  async resetPasswordLinkExpriredHeader() {
+    const resetPass = this.page.locator('#fxa-reset-link-expired-header');
     await resetPass.waitFor();
     return resetPass.isVisible();
   }

--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -12,9 +12,22 @@ export class RecoveryKeyPage extends SettingsLayout {
     return this.page.innerText('[data-testid=datablock] span');
   }
 
+  async invalidRecoveryKeyError() {
+    return this.page.innerText('#error-tooltip-159');
+  }
+
   setPassword(password: string) {
     return this.page.fill('input[type=password]', password);
   }
+
+  async confirmRecoveryKey() {
+    return this.page.click('button[type=submit]');
+  }
+
+  async clickLostRecoveryKey() {
+    return this.page.click('.lost-recovery-key');
+  }
+
 
   submit() {
     return Promise.all([

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -1,42 +1,186 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
-test.describe('severity-1 #smoke', () => {
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293421
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293429
-  test('add and remove account recovery key #1293421 #1293429', async ({
-    credentials,
-    pages: { settings, recoveryKey },
+let status;
+let key;
+
+test.describe('recovery key test', () => {
+  test.beforeEach(
+    async ({ credentials, page, pages: { settings, recoveryKey } }) => {
+      await settings.goto();
+      let status = await settings.recoveryKey.statusText();
+      expect(status).toEqual('Not Set');
+      await settings.recoveryKey.clickCreate();
+      await recoveryKey.setPassword(credentials.password);
+      await recoveryKey.submit();
+
+      // Store key to be used later
+      key = await recoveryKey.getKey();
+      await recoveryKey.clickClose();
+
+      // Verify status as 'enabled'
+      status = await settings.recoveryKey.statusText();
+      expect(status).toEqual('Enabled');
+    }
+  );
+
+  test('revoke recovery key', async ({
+    pages: { settings },
   }) => {
-    await settings.goto();
-    let status = await settings.recoveryKey.statusText();
-    expect(status).toEqual('Not Set');
-    await settings.recoveryKey.clickCreate();
-    await recoveryKey.setPassword(credentials.password);
-    await recoveryKey.submit();
-    await recoveryKey.clickClose();
-    status = await settings.recoveryKey.statusText();
-    expect(status).toEqual('Enabled');
     await settings.recoveryKey.clickRemove();
     await settings.clickModalConfirm();
     await settings.waitForAlertBar();
     status = await settings.recoveryKey.statusText();
+
+    // Verify status as 'not set'
     expect(status).toEqual('Not Set');
   });
 
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293432
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293433
-  test('use account recovery key #1293432 #1293433', async ({
+  test('create new recovery key, use old key and verify cannot change password', async ({
+    credentials,
+    target,
+    page,
+    pages: { settings, recoveryKey, login },
+  }) => {
+    let secondKey;
+
+    // Create new recovery key
+    await settings.recoveryKey.clickRemove();
+    await settings.clickModalConfirm();
+    await settings.waitForAlertBar();
+    await settings.recoveryKey.clickCreate();
+    await recoveryKey.setPassword(credentials.password);
+    await recoveryKey.submit();
+
+    // Store new key to be used later
+    secondKey = await recoveryKey.getKey();
+    await recoveryKey.clickClose();
+    await settings.signOut();
+
+    // Use old key to reset password
+    await login.setEmail(credentials.email);
+    await login.submit();
+    await login.clickForgotPassword();
+    await login.setEmail(credentials.email);
+    await login.submit();
+    const link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    await page.goto(link, { waitUntil: 'networkidle' });
+    await login.setRecoveryKey(key);
+    await recoveryKey.confirmRecoveryKey();
+
+    // Verify the error
+    expect(await recoveryKey.invalidRecoveryKeyError()).toMatch(
+      'Invalid account recovery key'
+    );
+
+    // Enter new recovery key
+    await login.setRecoveryKey(secondKey);
+    await login.submit();
+
+    // Reset password
+    credentials.password = credentials.password + '_new';
+    await login.setNewPassword(credentials.password);
+    await settings.waitForAlertBar();
+    await settings.signOut();
+
+    // login
+    await login.login(credentials.email, credentials.password);
+
+    // Verify login successful
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+
+  test('can reset password when forgot recovery key', async ({
+    credentials,
+    target,
+    page,
+    pages: { settings, recoveryKey, login },
+  }) => {
+    await settings.signOut();
+
+    // Use old key to reset password
+    await login.setEmail(credentials.email);
+    await login.submit();
+    await login.clickForgotPassword();
+    await login.setEmail(credentials.email);
+    await login.submit();
+    const link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    await page.goto(link, { waitUntil: 'networkidle' });
+    await recoveryKey.clickLostRecoveryKey();
+
+    // Reset password
+    credentials.password = credentials.password + '_new';
+    await login.setNewPassword(credentials.password);
+    await settings.waitForAlertBar();
+    await settings.signOut();
+
+    // login
+    await login.login(credentials.email, credentials.password);
+
+    // Verify login successful
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('cannot reuse recovery key', async ({
+    credentials,
+    target,
+    page,
+    pages: { settings, recoveryKey, login },
+  }) => {
+    await settings.signOut();
+
+    // Use old key to reset password
+    await login.setEmail(credentials.email);
+    await login.submit();
+    await login.clickForgotPassword();
+    await login.setEmail(credentials.email);
+    await login.submit();
+    const link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    await page.goto(link, { waitUntil: 'networkidle' });
+    await login.setRecoveryKey(key);
+    await recoveryKey.confirmRecoveryKey();
+
+    // Reset password
+    credentials.password = credentials.password + '_new';
+    await login.setNewPassword(credentials.password);
+    await settings.waitForAlertBar();
+    await settings.signOut();
+
+    // login
+    await login.login(credentials.email, credentials.password);
+
+    // Attempt to reuse reset link,
+    const link2 = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    await page.goto(link2, { waitUntil: 'networkidle' });
+
+    // Verify reset link expired
+    expect(await login.resetPasswordLinkExpriredHeader()).toBe(true);
+
+  });
+
+  test('use account recovery key', async ({
     credentials,
     target,
     pages: { page, login, recoveryKey, settings },
   }, { project }) => {
     test.slow(project.name !== 'local', 'email delivery can be slow');
-    await settings.goto();
-    await settings.recoveryKey.clickCreate();
-    await recoveryKey.setPassword(credentials.password);
-    await recoveryKey.submit();
-    const key = await recoveryKey.getKey();
     await settings.signOut();
     await login.setEmail(credentials.email);
     await login.submit();


### PR DESCRIPTION
## Because

`-As part of the playwright test migration, the [recovery key tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/settings/recovery_key.js) have been rewritten in this PR. The only tests not covered here are the last 'unnormalized email' tests present in the file linked above. Those test will be covered as part of a different PR`

## This pull request

`-Contains tests for all the scenarios related to recovery key present in the [file](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/settings/recovery_key.js) except the last test related to unnormalized email. This test will be covered as part of a different PR`

## Issue that this pull request solves

Closes: [FXA-5893](https://mozilla-hub.atlassian.net/browse/FXA-5893)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@pdehaan @mozilla/fxa-devs please review! Thanks!
