### PR TITLE
fix(auth-server): swap import style for mozilla.ts

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ServerRoute } from '@hapi/hapi';
-import { CapabilityService } from 'fxa-auth-server/lib/payments/capability';
+import { CapabilityService } from '../../../lib/payments/capability';
 import { MozillaSubscription } from 'fxa-shared/subscriptions/types';
 import { Container } from 'typedi';
 


### PR DESCRIPTION
## Because

It looks like importing from package names does not resolve correctly once we go to STG.

## This pull request

Swaps a package name based import to a relative one.

## Issue that this pull request solves

Closes: [FXA-6023](https://mozilla-hub.atlassian.net/browse/FXA-6023)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).