### PR TITLE
fix(fxa-auth-server) match email colors to fxa-react colors

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -6,7 +6,7 @@
 $font-sans: sans-serif;
 
 // Colors
-$blue-400: #0090ed;
+$blue-500: #0060df;
 $white: #fff;
 $black: #000;
 $grey-400: #6d6d6e;
@@ -60,8 +60,8 @@ $s-10: 40px;
   font-family: $font-sans !important;
 }
 
-.text-blue-400 {
-  color: $blue-400;
+.text-blue-500 {
+  color: $blue-500;
 }
 
 .mt {
@@ -117,7 +117,7 @@ tr > td:first-child {
 }
 
 .link-blue {
-  @extend .text-blue-400;
+  @extend .text-blue-500;
   text-decoration: none;
   font-family: $font-sans;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/button/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/button/index.scss
@@ -11,7 +11,7 @@
   a {
     @extend .font-sans;
     @extend .text-lg;
-    background: global.$blue-400 !important;
+    background: global.$blue-500 !important;
     width: 310px !important;
     color: global.$white;
     padding: global.$s-4 global.$s-0 !important;


### PR DESCRIPTION
## Because:

* We want our color values to match across emails + services

## This commit:

* Updates the color variable from equalling TW blue-400 to blue-500.

Closes #https://mozilla-hub.atlassian.net/browse/FXA-5851

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
<img width="422" alt="Screen Shot 2022-09-29 at 2 30 24 PM" src="https://user-images.githubusercontent.com/11150372/193145995-a3ac54af-17b6-4e1f-aa86-94b7b2fe6bde.png">

After:
<img width="371" alt="Screen Shot 2022-10-04 at 10 53 09 AM" src="https://user-images.githubusercontent.com/11150372/193891027-de5b45d8-e043-4885-b3af-e9d0a8e77683.png">



## Other information (Optional)

Any other information that is important to this pull request.
