### PR TITLE
copy(fxa-auth-server): update postAddTwoStepAuthentication email copy

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -39,7 +39,7 @@
   "verifyLoginCode": 8,
   "verifyShortCode": 5,
   "verifySecondaryCode": 3,
-  "postAddTwoStepAuthentication": 8,
+  "postAddTwoStepAuthentication": 9,
   "postRemoveTwoStepAuthentication": 9,
   "postConsumeRecoveryCode": 7,
   "postNewRecoveryCodes": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en.ftl
@@ -1,6 +1,6 @@
-postAddTwoStepAuthentication-subject = Two-step authentication enabled
-postAddTwoStepAuthentication-title = Two-step authentication enabled
-postAddTwoStepAuthentication-description-plaintext = You have successfully enabled two-step authentication on your { -product-firefox-account }. Security codes from your authentication app will now be required at each sign-in.
-postAddTwoStepAuthentication-description = You have successfully enabled two-step authentication on your { -product-firefox-account } from the following device:
+postAddTwoStepAuthentication-subject-2 = Two-step authentication turned on
+postAddTwoStepAuthentication-title-2 = You turned on two-step authentication
+# After the colon, there is a description of the device that the user used to enable two-step authentication
+postAddTwoStepAuthentication-from-device = You enabled it from:
 postAddTwoStepAuthentication-action = Manage account
-postAddTwoStepAuthentication-code-required = Security codes from your authentication app will now be required at each sign-in.
+postAddTwoStepAuthentication-code-required-2 = Security codes from your authentication app are now required every time you sign in.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "postAddTwoStepAuthentication-subject",
-    "message": "Two-step authentication enabled"
+    "id": "postAddTwoStepAuthentication-subject-2",
+    "message": "Two-step authentication turned on"
   },
   "action": {
     "id": "postAddTwoStepAuthentication-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
@@ -5,24 +5,19 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postAddTwoStepAuthentication-title">Two-step authentication enabled</span>
+      <span data-l10n-id="postAddTwoStepAuthentication-title-2">You turned on two-step authentication</span>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postAddTwoStepAuthentication-description">You have successfully enabled two-step authentication on your Firefox account from the following device:</span>
+      <span data-l10n-id="postAddTwoStepAuthentication-code-required-2">Security codes from your authentication app are now required every time you sign in.</span>
+    </mj-text>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddTwoStepAuthentication-from-device">You enabled it from:</span>
     </mj-text>
   </mj-column>
 </mj-section>
 
 <%- include('/partials/userInfo/index.mjml') %>
-
-<mj-section>
-  <mj-column>
-    <mj-text css-class="text-body">
-      <span data-l10n-id="postAddTwoStepAuthentication-code-required">Security codes from your authentication app will now be required at each sign-in.</span>
-    </mj-text>
-  </mj-column>
-</mj-section>
 
 <%- include('/partials/button/index.mjml', {
   buttonL10nId: "postAddTwoStepAuthentication-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'postAddTwoStepAuthentication',
-  'Sent when a user has enabled 2FA on their account, informing them of the change and new requirement to use a security code',
+  'Sent to notify the account is linked to another account.',
   {
     ...MOCK_USER_INFO,
     link: 'http://localhost:3030/settings',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
@@ -1,11 +1,11 @@
-postAddTwoStepAuthentication-title = "Two-step authentication enabled"
+postAddTwoStepAuthentication-title-2 = "You turned on two-step authentication"
 
-postAddTwoStepAuthentication-description-plaintext = "You have successfully enabled two-step authentication on your Firefox account. Security codes from your authentication app will now be required at each sign-in."
+postAddTwoStepAuthentication-code-required-2 = "Security codes from your authentication app are now required every time you sign in."
+
+postAddTwoStepAuthentication-from-device = "You enabled it from:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
 <%- include('/partials/manageAccount/index.txt') %>
 
-<%- include('/partials/changePassword/index.txt') %>
-
-<%- include('/partials/support/index.txt') %>
+<%- include('/partials/automatedEmailChangePassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1107,7 +1107,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postAddTwoStepAuthenticationEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Two-step authentication enabled' }],
+    ['subject', { test: 'equal', expected: 'Two-step authentication turned on' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddTwoStepAuthentication') }],
@@ -1115,8 +1115,8 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postAddTwoStepAuthentication }],
     ])],
     ['html', [
-      { test: 'include', expected: 'You have successfully enabled two-step authentication on your Firefox account from the following device:' },
-      { test: 'include', expected: 'Security codes from your authentication app will now be required at each sign-in.' },
+      { test: 'include', expected: 'You turned on two-step authentication' },
+      { test: 'include', expected: 'Security codes from your authentication app are now required every time you sign in.' },
       { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-two-step-enabled', 'privacy')) },
@@ -1129,12 +1129,12 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'You have successfully enabled two-step authentication on your Firefox account.' },
-      { test: 'include', expected: 'Security codes from your authentication app will now be required at each sign-in.' },
+      { test: 'include', expected: 'You turned on two-step authentication' },
+      { test: 'include', expected: 'Security codes from your authentication app are now required every time you sign in.' },
       { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid')}` },
-      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')}` },
+      { test: 'include', expected: `change your password right away:\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-two-step-enabled', 'privacy')}` },
-      { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'account-two-step-enabled', 'support')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support:\n${configUrl('supportUrl', 'account-two-step-enabled', 'support')}` },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },


### PR DESCRIPTION
## Because:

* We're updating email copy

## This commit:

* Update copy, tests, and fluent files for postAddTwoStepAuthentication email

## Closes # https://mozilla-hub.atlassian.net/browse/FXA-5195

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1082" alt="Screen Shot 2022-10-04 at 12 14 38 PM" src="https://user-images.githubusercontent.com/11150372/193906134-507f6df3-6861-405b-a43a-a9f19620b1a0.png">



