### PR TITLE
copy(fxa-auth-server): update postRemoveTwoStepAuthentication email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -40,7 +40,7 @@
   "verifyShortCode": 5,
   "verifySecondaryCode": 3,
   "postAddTwoStepAuthentication": 8,
-  "postRemoveTwoStepAuthentication": 8,
+  "postRemoveTwoStepAuthentication": 9,
   "postConsumeRecoveryCode": 7,
   "postNewRecoveryCodes": 7,
   "passwordResetAccountRecovery": 8,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en.ftl
@@ -1,6 +1,6 @@
-postRemoveTwoStepAuthentication-subject-line = Two-step authentication is off
-postRemoveTwoStepAuthentication-title = Two-step authentication disabled
-postRemoveTwoStepAuthentication-description = You have successfully disabled two-step authentication on your { -product-firefox-account } from the following device:
-postRemoveTwoStepAuthentication-description-plaintext = You have successfully disabled two-step authentication on your { -product-firefox-account }. Security codes will no longer be required at each sign-in.
+postRemoveTwoStepAuthentication-subject-line-2 = Two-step authentication turned off
+postRemoveTwoStepAuthentication-title-2 = You turned off two-step authentication
+# After the colon is a description of the device the user used to disable two-step authentication
+postRemoveTwoStepAuthentication-from-device = You disabled it from:
 postRemoveTwoStepAuthentication-action = Manage account
-postRemoveTwoStepAuthentication-not-required = Security codes will no longer be required at each sign-in.
+postRemoveTwoStepAuthentication-not-required-2 = You no longer need security codes from your authentication app when you sign in.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "postRemoveTwoStepAuthentication-subject-line",
-    "message": "Two-step authentication is off"
+    "id": "postRemoveTwoStepAuthentication-subject-line-2",
+    "message": "Two-step authentication turned off"
   },
   "action": {
     "id": "postRemoveTwoStepAuthentication-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.mjml
@@ -5,24 +5,18 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postRemoveTwoStepAuthentication-title">Two-step authentication disabled</span>
+      <span data-l10n-id="postRemoveTwoStepAuthentication-title-2">You turned off two-step authentication</span>
     </mj-text>
-
     <mj-text css-class="text-body">
-      <span data-l10n-id="postRemoveTwoStepAuthentication-description">You have successfully disabled two-step authentication on your Firefox account from the following device:</span>
+      <span data-l10n-id="postRemoveTwoStepAuthentication-not-required-2">You no longer need security codes from your authentication app when you sign in.</span>
+    </mj-text>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postRemoveTwoStepAuthentication-from-device">You disabled it from:</span>
     </mj-text>
   </mj-column>
 </mj-section>
 
 <%- include('/partials/userInfo/index.mjml') %>
-
-<mj-section>
-  <mj-column>
-<mj-text css-class="text-body">
-  <span data-l10n-id="postRemoveTwoStepAuthentication-not-required">Security codes will no longer be required at each sign-in.</span>
-</mj-text>
-</mj-column>
-</mj-section>
 
 <%- include('/partials/button/index.mjml', {
   buttonL10nId: "postRemoveTwoStepAuthentication-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.txt
@@ -1,11 +1,11 @@
-postRemoveTwoStepAuthentication-title = "Two-step authentication disabled"
+postRemoveTwoStepAuthentication-title-2 = "You turned off two-step authentication"
 
-postRemoveTwoStepAuthentication-description-plaintext = "You have successfully disabled two-step authentication on your Firefox account. Security codes will no longer be required at each sign-in."
+postRemoveTwoStepAuthentication-not-required-2 = "You no longer need security codes from your authentication app when you sign in."
+
+postRemoveTwoStepAuthentication-from-device = "You disabled it from:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
 <%- include('/partials/manageAccount/index.txt') %>
 
-<%- include('/partials/changePassword/index.txt') %>
-
-<%- include('/partials/support/index.txt') %>
+<%- include('/partials/automatedEmailChangePassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1044,7 +1044,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postRemoveTwoStepAuthenticationEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Two-step authentication is off' }],
+    ['subject', { test: 'equal', expected: 'Two-step authentication turned off' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveTwoStepAuthentication') }],
@@ -1052,7 +1052,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postRemoveTwoStepAuthentication }],
     ])],
     ['html', [
-      { test: 'include', expected: 'Two-step authentication disabled' },
+      { test: 'include', expected: 'You turned off two-step authentication' },
       { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-two-step-disabled', 'change-password', 'email')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-two-step-disabled', 'privacy')) },
@@ -1065,11 +1065,11 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'Two-step authentication disabled' },
+      { test: 'include', expected: 'You turned off two-step authentication' },
       { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid')}` },
-      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-disabled', 'change-password', 'email')}` },
+      { test: 'include', expected: `change your password right away:\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-disabled', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-two-step-disabled', 'privacy')}` },
-      { test: 'include', expected: `For more info, visit Mozilla Support: ${configUrl('supportUrl', 'account-two-step-disabled', 'support')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support:\n${configUrl('supportUrl', 'account-two-step-disabled', 'support')}` },
       { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
       { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },


### PR DESCRIPTION
## Because:

* We're updating copy for emails

## This commit:

* Updates copy and tests for the postRemoveTwoStepAuthentication email

## Closes # https://mozilla-hub.atlassian.net/browse/FXA-5201

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshot
<img width="1082" alt="Screen Shot 2022-09-29 at 4 47 25 PM" src="https://user-images.githubusercontent.com/11150372/193161127-41d5df71-2b45-4b76-8165-9bb132595e06.png">
s of the changes made in case of change in user interface.
