### PR TITLE
bug(auth): Fix double log scenario

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -10,7 +10,7 @@ const config = require('../config');
 const TracingProvider = require('fxa-shared/tracing/node-tracing');
 TracingProvider.init(
   config.get('tracing'),
-  require('../lib/log')({ ...config.log })
+  require('../lib/log')({ ...config.log, name: 'tracing' })
 );
 
 const error = require('../lib/error');

--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -20,6 +20,7 @@ const CLIENT_ID_TO_SERVICE_NAMES = config.get('oauth.clientIds') || {};
 function Lug(options) {
   EventEmitter.call(this);
   this.name = options.name || 'fxa-auth-server';
+
   this.logger = mozlog({
     app: this.name,
     level: options.level,


### PR DESCRIPTION
## Because

- Logs were being emitted twice

## This pull request

- Provides a name to the logger instance sent into node-tracing
- Adds a fail hard fail fast check to prevent this from happening in the future.

## Issue that this pull request solves

Closes: FXA-6000

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
