### PR TITLE
FXA-6026-trace-noise-in-circle-ci

### DIFF
--- a/packages/fxa-shared/test/tracing/node-tracing.ts
+++ b/packages/fxa-shared/test/tracing/node-tracing.ts
@@ -181,11 +181,27 @@ describe('node-tracing', () => {
   });
 
   describe('init', () => {
+    it('skips initialization if all modes are disabled', () => {
+      tracing.init(
+        {
+          serviceName: '',
+          sampleRate: 1,
+        },
+        spies.logger
+      );
+      sinon.assert.calledWith(spies.logger.debug, 'node-tracing', {
+        msg: 'Trace initialization skipped. No exporters configured. Enable, gcp, jeager, or console to activate tracing.',
+      });
+    });
+
     it('skips initialization if serviceName is missing', () => {
       tracing.init(
         {
           serviceName: '',
           sampleRate: 1,
+          console: {
+            enabled: true,
+          },
         },
         spies.logger
       );
@@ -200,6 +216,9 @@ describe('node-tracing', () => {
           {
             serviceName: 'test',
             sampleRate: sampleRate,
+            console: {
+              enabled: true,
+            },
           },
           spies.logger
         );
@@ -214,6 +233,9 @@ describe('node-tracing', () => {
         {
           serviceName: 'test',
           sampleRate: 1,
+          console: {
+            enabled: true,
+          },
         },
         spies.logger
       );
@@ -228,6 +250,9 @@ describe('node-tracing', () => {
         {
           serviceName: 'test',
           sampleRate: 1,
+          console: {
+            enabled: true,
+          },
         },
         spies.logger
       );

--- a/packages/fxa-shared/tracing/node-tracing.ts
+++ b/packages/fxa-shared/tracing/node-tracing.ts
@@ -167,6 +167,17 @@ export function init(opts: TracingOpts, logger?: ILogger) {
     return;
   }
 
+  if (
+    opts.console?.enabled !== true &&
+    opts.gcp?.enabled !== true &&
+    opts.jaeger?.enabled !== true
+  ) {
+    logger?.debug(log_type, {
+      msg: 'Trace initialization skipped. No exporters configured. Enable, gcp, jeager, or console to activate tracing.',
+    });
+    return;
+  }
+
   try {
     nodeTracing = new NodeTracingInitializer(opts, logger);
     logger?.info(log_type, { msg: 'Trace initialized succeeded!' });


### PR DESCRIPTION
## Because

- With default configs, we'd see lots of warning messages in Circle CI logs.

## This pull request

- Checks if any exporters are enabled before initializing the tracer.
- If no tracers are enabled, initialization is skipped, which prevents the error state from being triggered.

## Issue that this pull request solves

Closes: FXA-6062

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
