### PR TITLE
chore(l10n): Revise workflow to fetch base commit

### DIFF
--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Clone FxA code repository
         uses: actions/checkout@v3
         with:
-          repository: "mozilla/fxa"
           fetch-depth: 2
           path: "fxa-code"
       - name: Install npm packages
@@ -47,6 +46,7 @@ jobs:
           NEW_HASHES=$(python ../fxa-l10n/scripts/pot_checksum.py ./packages/fxa-content-server/locale/templates/)
 
           # Checkout base commit
+          git fetch origin ${{ github.event.pull_request.base.sha }}
           git checkout ${{ github.event.pull_request.base.sha }}
 
           # Extract gettext


### PR DESCRIPTION
## Because:

* Action fails under certain conditions when it tries to checkout the base SHA but it cannot be found

## This pull request:

* Adds an explicit fetch for the base SHA to ensure it can be checked out
* Also removes the redundant repository call-out (which would cause issues for forks)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).