### PR TITLE
chore(deps): bump @google-cloud/firestore from 5.0.2 to 6.3.0

### DIFF
--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -35,7 +35,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "@golevelup/ts-jest": "^0.3.2",
-    "@google-cloud/firestore": "^5.0.2",
+    "@google-cloud/firestore": "^6.3.0",
     "@nestjs/common": "^9.1.2",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.1.1",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -58,7 +58,7 @@
     "@fluent/dom": "^0.8.1",
     "@fluent/langneg": "^0.6.2",
     "@google-cloud/bigquery": "^6.0.2",
-    "@google-cloud/firestore": "^5.0.2",
+    "@google-cloud/firestore": "^6.3.0",
     "@google-cloud/translate": "^6.3.1",
     "@googlemaps/google-maps-services-js": "^3.3.16",
     "@hapi/hapi": "^20.2.1",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/mozilla/fxa#readme",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@google-cloud/firestore": "^5.0.2",
+    "@google-cloud/firestore": "^6.3.0",
     "@google-cloud/pubsub": "^2.19.4",
     "@grpc/grpc-js": "^1.1.3",
     "@hapi/hoek": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,15 +3872,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/firestore@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@google-cloud/firestore@npm:5.0.2"
+"@google-cloud/firestore@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "@google-cloud/firestore@npm:6.3.0"
   dependencies:
     fast-deep-equal: ^3.1.1
     functional-red-black-tree: ^1.0.1
-    google-gax: ^2.24.1
-    protobufjs: ^6.8.6
-  checksum: 4b669f54a7da2287d0559435586bcf9792a3e240d1b75868a6557c4c1a7265aae335ab24d0d1458ed32320ee258c107802f9650ed24f86b0d03ff49f202ee530
+    google-gax: ^3.5.1
+    protobufjs: ^7.0.0
+  checksum: 50f52dc06746fe3af1e9abb1063244015f968b71387104f65bd752ce6522406fe987291791c40fd40e84a11033c993e7847e5b8619173b7202c70382e55e853b
   languageName: node
   linkType: hard
 
@@ -23826,7 +23826,7 @@ fsevents@~2.1.1:
   resolution: "fxa-admin-server@workspace:packages/fxa-admin-server"
   dependencies:
     "@golevelup/ts-jest": ^0.3.2
-    "@google-cloud/firestore": ^5.0.2
+    "@google-cloud/firestore": ^6.3.0
     "@nestjs/cli": ^9.1.3
     "@nestjs/common": ^9.1.2
     "@nestjs/config": ^2.2.0
@@ -23905,7 +23905,7 @@ fsevents@~2.1.1:
     "@fluent/dom": ^0.8.1
     "@fluent/langneg": ^0.6.2
     "@google-cloud/bigquery": ^6.0.2
-    "@google-cloud/firestore": ^5.0.2
+    "@google-cloud/firestore": ^6.3.0
     "@google-cloud/translate": ^6.3.1
     "@googlemaps/google-maps-services-js": ^3.3.16
     "@hapi/hapi": ^20.2.1
@@ -24300,7 +24300,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa-event-broker@workspace:packages/fxa-event-broker"
   dependencies:
-    "@google-cloud/firestore": ^5.0.2
+    "@google-cloud/firestore": ^6.3.0
     "@google-cloud/pubsub": ^2.19.4
     "@grpc/grpc-js": ^1.1.3
     "@hapi/hoek": ^10.0.0
@@ -32089,6 +32089,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"long@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "long@npm:5.2.0"
+  checksum: 37aa4e67b9c3eebc6d9d675adcc9d06f06059ca268922a71273de389746bf07f0ff282f9e604d17fdf84c4149099b44e936ea2b621a6c4759a216621afa97efd
+  languageName: node
+  linkType: hard
+
 "longest-streak@npm:^2.0.0":
   version: 2.0.4
   resolution: "longest-streak@npm:2.0.4"
@@ -38304,7 +38311,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^6.10.0, protobufjs@npm:^6.11.2, protobufjs@npm:^6.8.6, protobufjs@npm:^6.8.8":
+"protobufjs@npm:^6.10.0, protobufjs@npm:^6.11.2, protobufjs@npm:^6.8.8":
   version: 6.11.2
   resolution: "protobufjs@npm:6.11.2"
   dependencies:
@@ -38325,6 +38332,26 @@ fsevents@~2.1.1:
     pbjs: bin/pbjs
     pbts: bin/pbts
   checksum: 80e9d9610c3eb66f9eae4e44a1ae30381cedb721b7d5f635d781fe4c507e2c77bb7c879addcd1dda79733d3ae589d9e66fd18d42baf99b35df7382a0f9920795
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.0.0":
+  version: 7.1.2
+  resolution: "protobufjs@npm:7.1.2"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: ae41669b1b0372fb1d49f506f2d1f2b0fb3dc3cece85987b17bcb544e4cef7c8d27f480486cdec324146ad0a5d22a327166a7ea864a9b3e49cc3c92a5d3f6500
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* We want to use the latest version of firestore.

This commit:

* Updates firestore to 6.3.0.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
