### PR TITLE
fix(tests): Throws a stripe rate limited error on tests

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -62,8 +62,12 @@ export class SubscribePage extends BaseLayout {
     this.page.click('[data-testid="retry-link"]');
   }
 
-  couponErrorMessageText() {
-    return this.page.innerText('[data-testid="coupon-error"]');
+  async couponErrorMessageText() {
+    const msg = await this.page.innerText('[data-testid="coupon-error"]');
+    if (msg === 'An error occurred processing the code. Please try again.') {
+      throw new Error('Stripe generic error, most likely rate limited');
+    }
+    return msg;
   }
 
   discountAppliedSucess() {

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -2,34 +2,37 @@ import { test, expect } from '../../lib/fixtures/standard';
 let newPassword;
 
 test.describe('change password tests', () => {
-  test.beforeEach(
-    async ({
-      pages: { settings },
-      credentials,
-    }) => {
-      newPassword = credentials.password + '@@2';
-      await settings.goto();
-      await settings.password.clickChange();
-    }
-  );
+  test.beforeEach(async ({ pages: { settings }, credentials }) => {
+    newPassword = credentials.password + '@@2';
+    await settings.goto();
+    await settings.password.clickChange();
+  });
 
   test('change password with an incorrect old password', async ({
     pages: { changePassword },
   }) => {
-
+    test.slow();
     // Enter incorrect old password and verify the tooltip error
-    await changePassword.fillOutChangePassword('Incorrect Password', newPassword);
+    await changePassword.fillOutChangePassword(
+      'Incorrect Password',
+      newPassword
+    );
     await changePassword.clickSignIn();
-    expect(await changePassword.changePasswordTooltip()).toMatch('Incorrect password');
+    expect(await changePassword.changePasswordTooltip()).toMatch(
+      'Incorrect password'
+    );
   });
 
   test('change password with a correct password', async ({
     pages: { settings, changePassword, login },
     credentials,
   }) => {
-
+    test.slow();
     // Enter the correct old password and verify that change password is successful
-    await changePassword.fillOutChangePassword(credentials.password, newPassword);
+    await changePassword.fillOutChangePassword(
+      credentials.password,
+      newPassword
+    );
     await changePassword.submit();
 
     // Sign out and login with new password
@@ -44,10 +47,9 @@ test.describe('change password tests', () => {
   });
 
   test('new password validation', async ({
-    pages: { changePassword, },
+    pages: { changePassword },
     credentials,
   }) => {
-
     // Short password
     await changePassword.setNewPassword('short');
     expect(await changePassword.passwordLengthError()).toBe(true);
@@ -66,17 +68,15 @@ test.describe('change password tests', () => {
     expect(await changePassword.confirmPasswordError()).toBe(true);
 
     // valid password
-    await changePassword.setCurrentPassword(credentials.password)
+    await changePassword.setCurrentPassword(credentials.password);
     await changePassword.setNewPassword(newPassword);
     await changePassword.setConfirmPassword(newPassword);
     expect(await changePassword.submitButton()).toBe(true);
   });
 
-
   test('change password with short password tooltip shows, cancel and try to change password again, tooltip is not shown', async ({
-    pages: { settings, changePassword, },
+    pages: { settings, changePassword },
   }) => {
-
     // Short password
     await changePassword.setNewPassword('short');
     expect(await changePassword.passwordLengthError()).toBe(true);
@@ -87,9 +87,10 @@ test.describe('change password tests', () => {
     expect(await changePassword.validPasswordLength()).toBe(true);
   });
 
-  test('reset password via settings works', async ({
-    pages: { login },
+  test('reset password via settings works', async ({ pages: { login } }, {
+    project,
   }) => {
+    test.slow();
 
     // Click forgot password link
     await login.clickForgotPassword();


### PR DESCRIPTION
## Because

- It would be helpful to know why stage subscription tests might fail

## This pull request

- Adds a throw when getting the coupon error

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5944

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).