### PR TITLE
feat(payments): display Tax Amount If Applicable

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -22,17 +22,11 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
   };
 
   // Add tax if it exists
-  if (
-    invoice.total_tax_amounts.length > 0 &&
-    invoice.default_tax_rates.length > 0
-  ) {
-    const taxObject = invoice.default_tax_rates[0];
+  if (invoice.total_tax_amounts.length > 0) {
     const tax = invoice.total_tax_amounts[0];
     invoicePreview.tax = {
       amount: tax.amount,
       inclusive: tax.inclusive,
-      name: taxObject.display_name,
-      percentage: taxObject.percentage,
     };
   }
 

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -71,6 +71,7 @@ import { AppStoreSubscriptionPurchase } from './iap/apple-app-store/subscription
 import { PlayStoreSubscriptionPurchase } from './iap/google-play/subscription-purchase';
 import { getIapPurchaseType } from './iap/iap-config';
 import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
+import { stripeInvoiceToFirstInvoicePreviewDTO } from './stripe-formatter';
 import { generateIdempotencyKey } from './utils';
 
 // Maintains backwards compatibility. Some type defs hoisted to fxa-shared/payments/stripe
@@ -656,19 +657,19 @@ export class StripeHelper extends StripeHelperBase {
    * a promotion code.
    */
   async previewInvoice({
+    automaticTax,
     country,
+    ipAddress,
     priceId,
     promotionCode,
   }: {
+    automaticTax: boolean;
     country: string;
+    ipAddress: string;
     priceId: string;
     promotionCode?: string;
   }) {
     const params: Stripe.InvoiceRetrieveUpcomingParams = {};
-    const taxRate = await this.taxRateByCountryCode(country);
-    if (taxRate) {
-      params.subscription_default_tax_rates = [taxRate.id];
-    }
 
     if (promotionCode) {
       const stripePromotionCode = await this.findValidPromoCode(
@@ -679,19 +680,54 @@ export class StripeHelper extends StripeHelperBase {
         params['coupon'] = stripePromotionCode.coupon.id;
       }
     }
-    return this.stripe.invoices.retrieveUpcoming({
-      customer_details: {
-        address: {
-          country,
+
+    if (automaticTax) {
+      try {
+        return this.stripe.invoices.retrieveUpcoming({
+          automatic_tax: {
+            enabled: true,
+          },
+          customer_details: {
+            tax: {
+              ip_address: ipAddress,
+            },
+          },
+          subscription_items: [
+            {
+              price: priceId,
+            },
+          ],
+          ...params,
+        });
+      } catch (e: any) {
+        this.log.warn('stripe.previewInvoice.automatic_tax', {
+          ipAddress,
+          priceId,
+          promotionCode,
+        });
+
+        throw e;
+      }
+    } else {
+      const taxRate = await this.taxRateByCountryCode(country);
+      if (taxRate) {
+        params.subscription_default_tax_rates = [taxRate.id];
+      }
+
+      return this.stripe.invoices.retrieveUpcoming({
+        customer_details: {
+          address: {
+            country,
+          },
         },
-      },
-      subscription_items: [
-        {
-          price: priceId,
-        },
-      ],
-      ...params,
-    });
+        subscription_items: [
+          {
+            price: priceId,
+          },
+        ],
+        ...params,
+      });
+    }
   }
 
   /**
@@ -896,11 +932,15 @@ export class StripeHelper extends StripeHelperBase {
    * exist for the provided priceId.
    */
   async retrieveCouponDetails({
+    automaticTax,
     country,
+    ipAddress,
     priceId,
     promotionCode,
   }: {
+    automaticTax: boolean;
     country: string;
+    ipAddress: string;
     priceId: string;
     promotionCode: string;
   }): Promise<Coupon.couponDetailsSchema> {
@@ -930,10 +970,13 @@ export class StripeHelper extends StripeHelperBase {
         try {
           const { currency, discount, total, total_discount_amounts } =
             await this.previewInvoice({
+              automaticTax,
               country,
+              ipAddress,
               priceId,
               promotionCode,
             });
+
           const minAmount = getMinimumAmount(currency);
           if (total !== 0 && minAmount && total < minAmount) {
             throw error.invalidPromoCode(promotionCode);
@@ -2421,7 +2464,9 @@ export class StripeHelper extends StripeHelperBase {
       !!invoice.discounts?.length &&
       invoice.discounts.length === 1
     ) {
-      const invoiceWithDiscount = await this.getInvoiceWithDiscount(invoice.id!);
+      const invoiceWithDiscount = await this.getInvoiceWithDiscount(
+        invoice.id!
+      );
       const discount = invoiceWithDiscount.discounts?.pop() as Stripe.Discount;
       discountType = discount.coupon.duration;
       discountDuration = discount.coupon.duration_in_months;

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -421,12 +421,19 @@ export class StripeHandler {
       string,
       string
     >;
+
     const country = request.app.geo.location?.country || 'US';
+    const ipAddress = request.info.remoteAddress;
+    const automaticTax = this.automaticTax;
+
     const previewInvoice = await this.stripeHelper.previewInvoice({
+      automaticTax,
       country,
+      ipAddress,
       promotionCode,
       priceId,
     });
+
     return stripeInvoiceToFirstInvoicePreviewDTO(previewInvoice);
   }
 
@@ -478,8 +485,13 @@ export class StripeHandler {
       string
     >;
     const country = request.app.geo.location?.country || 'US';
+    const ipAddress = request.info.remoteAddress;
+    const automaticTax = this.automaticTax;
+
     const couponDetails = this.stripeHelper.retrieveCouponDetails({
+      automaticTax,
       country,
+      ipAddress,
       priceId,
       promotionCode,
     });

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -25,10 +25,6 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
       invoice.tax.amount,
       previewInvoiceWithTax.total_tax_amounts[0].amount
     );
-    assert.equal(
-      invoice.tax.percentage,
-      previewInvoiceWithTax.default_tax_rates[0].percentage
-    );
     assert.equal(invoice.tax.inclusive, true);
     assert.isUndefined(invoice.discount);
   });
@@ -42,10 +38,6 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     assert.equal(
       invoice.tax.amount,
       previewInvoiceWithDiscountAndTax.total_tax_amounts[0].amount
-    );
-    assert.equal(
-      invoice.tax.percentage,
-      previewInvoiceWithDiscountAndTax.default_tax_rates[0].percentage
     );
     assert.equal(invoice.tax.inclusive, true);
     assert.equal(

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -123,6 +123,7 @@ const mockConfig = {
     cacheTtlSeconds: 10,
     productConfigsFirestore: { enabled: true },
     stripeApiKey: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc',
+    stripeAutomaticTax: { enabled: false },
   },
   subhub: {
     enabled: true,
@@ -1763,13 +1764,17 @@ describe('StripeHelper', () => {
       });
 
       const actual = await stripeHelper.retrieveCouponDetails({
+        automaticTax: false,
         country: 'US',
+        ipAddress: '1.1.1.1',
         priceId: 'planId',
         promotionCode: 'promo',
       });
 
       sinon.assert.calledOnceWithExactly(stripeHelper.previewInvoice, {
+        automaticTax: false,
         country: 'US',
+        ipAddress: '1.1.1.1',
         priceId: 'planId',
         promotionCode: 'promo',
       });
@@ -1798,13 +1803,17 @@ describe('StripeHelper', () => {
       });
 
       const actual = await stripeHelper.retrieveCouponDetails({
+        automaticTax: false,
         country: 'US',
+        ipAddress: '1.1.1.1',
         priceId: 'planId',
         promotionCode: 'promo',
       });
 
       sinon.assert.calledOnceWithExactly(stripeHelper.previewInvoice, {
+        automaticTax: false,
         country: 'US',
+        ipAddress: '1.1.1.1',
         priceId: 'planId',
         promotionCode: 'promo',
       });
@@ -2041,6 +2050,82 @@ describe('StripeHelper', () => {
         });
       } catch (e) {
         assert.equal(e.errno, error.ERRNO.INVALID_PROMOTION_CODE);
+      }
+    });
+  });
+
+  describe('previewInvoice', () => {
+    it('uses country when automatic tax is not enabled', async () => {
+      const stripeStub = sandbox
+        .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
+        .resolves();
+      sandbox.stub(stripeHelper, 'taxRateByCountryCode').resolves();
+
+      await stripeHelper.previewInvoice({
+        automaticTax: false,
+        country: 'US',
+        ipAddress: '1.1.1.1',
+        priceId: 'priceId',
+      });
+
+      sinon.assert.calledOnceWithExactly(stripeStub, {
+        customer_details: {
+          address: {
+            country: 'US',
+          },
+        },
+        subscription_items: [
+          {
+            price: 'priceId',
+          },
+        ],
+      });
+    });
+
+    it('uses ipAddress when automatic tax is enabled', async () => {
+      const stripeStub = sandbox
+        .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
+        .resolves();
+
+      await stripeHelper.previewInvoice({
+        automaticTax: true,
+        country: 'US',
+        ipAddress: '1.1.1.1',
+        priceId: 'priceId',
+      });
+
+      sinon.assert.calledOnceWithExactly(stripeStub, {
+        automatic_tax: {
+          enabled: true,
+        },
+        customer_details: {
+          tax: {
+            ip_address: '1.1.1.1',
+          },
+        },
+        subscription_items: [
+          {
+            price: 'priceId',
+          },
+        ],
+      });
+    });
+
+    it('logs when there is an error when automatic tax is enabled', async () => {
+      // const logStub = sandbox.stub(stripeHelper.log, 'warn');
+      sandbox
+        .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
+        .throws(new Error());
+
+      try {
+        await stripeHelper.previewInvoice({
+          automaticTax: true,
+          country: 'US',
+          ipAddress: '1.1.1.1',
+          priceId: 'priceId',
+        });
+      } catch (e) {
+        sinon.assert.calledOnce(stripeHelper.log.warn);
       }
     });
   });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -661,6 +661,9 @@ describe('DirectStripeRoutes', () => {
         priceId: 'priceId',
       };
       VALID_REQUEST.app.geo = {};
+      VALID_REQUEST.info = {
+        remoteAddress: '1.1.1.1',
+      };
       const actual = await directStripeRoutesInstance.previewInvoice(
         VALID_REQUEST
       );
@@ -671,7 +674,13 @@ describe('DirectStripeRoutes', () => {
       );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.previewInvoice,
-        { country: 'US', promotionCode: 'promotionCode', priceId: 'priceId' }
+        {
+          automaticTax: false,
+          country: 'US',
+          ipAddress: '1.1.1.1',
+          promotionCode: 'promotionCode',
+          priceId: 'priceId',
+        }
       );
       assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
     });
@@ -809,6 +818,9 @@ describe('DirectStripeRoutes', () => {
         priceId: 'priceId',
       };
       VALID_REQUEST.app.geo = {};
+      VALID_REQUEST.info = {
+        remoteAddress: '1.1.1.1',
+      };
 
       const actual = await directStripeRoutesInstance.retrieveCouponDetails(
         VALID_REQUEST
@@ -816,7 +828,13 @@ describe('DirectStripeRoutes', () => {
 
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.retrieveCouponDetails,
-        { country: 'US', promotionCode: 'promotionCode', priceId: 'priceId' }
+        {
+          automaticTax: false,
+          country: 'US',
+          ipAddress: '1.1.1.1',
+          promotionCode: 'promotionCode',
+          priceId: 'priceId',
+        }
       );
 
       assert.deepEqual(actual, expected);

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -353,6 +353,7 @@ plan-details-show-button = Show details
 plan-details-hide-button = Hide details
 plan-details-total-label = Total
 plan-details-list-price = List Price
+plan-details-tax = Taxes and Fees
 
 ## Coupons
 

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -8,6 +8,7 @@ import PlanDetails, { PlanDetailsProps } from './index';
 import { Profile } from '../../store/types';
 import { COUPON_DETAILS_VALID } from '../../lib/mock-data';
 import { Meta } from '@storybook/react';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export default {
   title: 'components/PlanDetails',
@@ -53,9 +54,35 @@ const selectedPlan = {
   },
 };
 
+const invoicePreviewNoTax: FirstInvoicePreview = {
+  subtotal: 935,
+  total: 935,
+  line_items: [],
+};
+
+const invoicePreviewInclusiveTax: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 885,
+  total: 935,
+  tax: {
+    amount: 50,
+    inclusive: true,
+  },
+};
+const invoicePreviewExclusiveTax: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 935,
+  total: 985,
+  tax: {
+    amount: 50,
+    inclusive: false,
+  },
+};
+
 const storyWithProps = (
   plan: PlanDetailsProps,
-  languages?: readonly string[]
+  languages?: readonly string[],
+  invoicePreview?: FirstInvoicePreview
 ) => {
   const story = () => (
     <MockApp languages={languages}>
@@ -63,6 +90,7 @@ const storyWithProps = (
         {...{
           ...plan,
           profile: userProfile,
+          invoicePreview: invoicePreview || invoicePreviewNoTax,
         }}
       />
     </MockApp>
@@ -74,6 +102,20 @@ export const Default = storyWithProps({
   selectedPlan,
   isMobile: false,
   showExpandButton: false,
+});
+
+export const DefaulWithInclusiveTax = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: false,
+  invoicePreview: invoicePreviewInclusiveTax,
+});
+
+export const DefaulWithExclusiveTax = storyWithProps({
+  selectedPlan,
+  isMobile: false,
+  showExpandButton: false,
+  invoicePreview: invoicePreviewExclusiveTax,
 });
 
 export const LocalizedToPirate = storyWithProps(

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import TestRenderer from 'react-test-renderer';
 
@@ -356,12 +356,11 @@ describe('PlanDetails', () => {
         },
       };
 
-      const testRenderer = TestRenderer.create(<PlanDetails {...props} />);
-      const testInstance = testRenderer.root;
+      const subject = () => {
+        return render(<PlanDetails {...props} />);
+      };
 
-      const planPriceComponent = testInstance.findByProps({
-        'data-testid': `plan-price-total`,
-      });
+      const { queryByTestId } = subject();
 
       const expectedAmount = getLocalizedCurrency(
         selectedPlan.amount && coupon.discountAmount
@@ -370,12 +369,14 @@ describe('PlanDetails', () => {
         selectedPlan.currency
       );
 
-      expect(planPriceComponent.props.vars.amount).toStrictEqual(
-        expectedAmount
-      );
+      await waitFor(() => {
+        const totalPriceComponent = queryByTestId('total-price');
+        expect(totalPriceComponent).toBeInTheDocument();
+        expect(totalPriceComponent?.innerHTML).toContain(expectedAmount.value);
+      });
     });
 
-    it('for coupon info box without couponDurationDate, display coupon-success message', () => {
+    it('for coupon info box without couponDurationDate, display coupon-success message', async () => {
       const subject = () => {
         return render(
           <PlanDetails
@@ -391,11 +392,16 @@ describe('PlanDetails', () => {
       };
 
       const { queryByTestId } = subject();
-      expect(queryByTestId('coupon-success')).toBeInTheDocument();
-      expect(queryByTestId('coupon-success-with-date')).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(queryByTestId('coupon-success')).toBeInTheDocument();
+        expect(
+          queryByTestId('coupon-success-with-date')
+        ).not.toBeInTheDocument();
+      });
     });
 
-    it('for coupon info box with couponDurationDate, display coupon-success-with-date message', () => {
+    it('for coupon info box with couponDurationDate, display coupon-success-with-date message', async () => {
       const subject = () => {
         return render(
           <PlanDetails
@@ -415,8 +421,10 @@ describe('PlanDetails', () => {
       };
 
       const { queryByTestId } = subject();
-      expect(queryByTestId('coupon-success')).not.toBeInTheDocument();
-      expect(queryByTestId('coupon-success-with-date')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(queryByTestId('coupon-success')).not.toBeInTheDocument();
+        expect(queryByTestId('coupon-success-with-date')).toBeInTheDocument();
+      });
     });
 
     it('do not show either coupon-success message, if info box is empty', () => {

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import { Localized } from '@fluent/react';
 import {
   getLocalizedCurrency,
@@ -22,6 +22,9 @@ import './index.scss';
 import { Plan } from '../../store/types';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { useInfoBoxMessage } from '../../lib/hooks';
+import { apiInvoicePreview } from '../../lib/apiClient';
+import { LoadingSpinner } from '../LoadingSpinner';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type PlanDetailsProps = {
   selectedPlan: Plan;
@@ -30,6 +33,7 @@ export type PlanDetailsProps = {
   className?: string;
   coupon?: CouponDetails;
   children?: any;
+  invoicePreview?: FirstInvoicePreview;
 };
 
 export const PlanDetails = ({
@@ -38,11 +42,21 @@ export const PlanDetails = ({
   showExpandButton = false,
   coupon,
   children,
+  invoicePreview,
 }: PlanDetailsProps) => {
   const { navigatorLanguages, config } = useContext(AppContext);
   const [detailsHidden, setDetailsState] = useState(showExpandButton);
   const { product_name, amount, currency, interval, interval_count } =
     selectedPlan;
+
+  const [loading, setLoading] = useState(true);
+  const [taxAmount, setTaxAmount] = useState(0);
+  const [discountAmount, setDiscountAmount] = useState(0);
+  const [totalAmount, setTotalAmount] = useState(0);
+  const [subTotal, setSubTotal] = useState(0);
+  const [totalPrice, setTotalPrice] = useState('');
+  const invoice = useRef(invoicePreview);
+
   const { webIcon, webIconBackground } = webIconConfigFromProductConfig(
     selectedPlan,
     navigatorLanguages,
@@ -58,18 +72,85 @@ export const PlanDetails = ({
     ? { background: webIconBackground }
     : '';
 
-  const discountAmount =
-    coupon && amount && coupon.discountAmount
-      ? amount - coupon.discountAmount
-      : amount;
+  const infoBoxMessage = useInfoBoxMessage(coupon, selectedPlan);
+
   const planPrice = formatPlanPricing(
-    discountAmount,
+    amount,
     currency,
     interval,
     interval_count
   );
 
-  const infoBoxMessage = useInfoBoxMessage(coupon, selectedPlan);
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+
+      try {
+        if (!invoicePreview) {
+          invoice.current = await apiInvoicePreview({
+            priceId: selectedPlan.plan_id,
+            promotionCode: coupon?.promotionCode as string,
+          });
+        }
+
+        setSubTotal(invoice.current!.subtotal);
+        setTotalAmount(invoice.current!.total);
+
+        if (invoice.current!.tax && invoice.current?.tax.amount) {
+          setTaxAmount(invoice.current!.tax.amount);
+        } else {
+          setTaxAmount(0);
+        }
+
+        if (invoice.current!.discount) {
+          setDiscountAmount(invoice.current!.discount.amount);
+        } else {
+          setDiscountAmount(0);
+        }
+
+        const price = formatPlanPricing(
+          totalAmount as unknown as number,
+          currency,
+          interval,
+          interval_count
+        );
+
+        setTotalPrice(price);
+        setLoading(false);
+      } catch (e: any) {
+        // gracefully fail/set the state according to the data we have
+        // if previewInvoice errors or if stripe tax is not enabled
+        setSubTotal(amount!);
+        if (coupon && coupon.discountAmount && amount) {
+          setDiscountAmount(coupon.discountAmount);
+          setTotalAmount(amount - coupon.discountAmount);
+        } else {
+          setDiscountAmount(0);
+          setTotalAmount(amount!);
+        }
+
+        const price = formatPlanPricing(
+          totalAmount as unknown as number,
+          currency,
+          interval,
+          interval_count
+        );
+
+        setTotalPrice(price);
+        setLoading(false);
+      }
+    })();
+  }, [
+    amount,
+    config.featureFlags.useStripeAutomaticTax,
+    coupon,
+    currency,
+    interval,
+    interval_count,
+    selectedPlan.plan_id,
+    totalAmount,
+    invoicePreview,
+  ]);
 
   return (
     <div
@@ -134,119 +215,138 @@ export const PlanDetails = ({
                 ))}
               </ul>
 
-              <div className="plan-details-total">
-                {coupon && coupon.discountAmount && (
-                  <div className="row-divider-grey-200 mb-4 pb-6">
-                    <div className="plan-details-total-inner">
-                      <Localized id="plan-details-list-price">
-                        <div>List Price</div>
-                      </Localized>
-
-                      <Localized
-                        id={`list-price`}
-                        attrs={{ title: true }}
-                        vars={{
-                          amount: getLocalizedCurrency(amount, currency),
-                          intervalCount: interval_count,
-                        }}
-                      >
-                        <div>
-                          {getLocalizedCurrencyString(amount, currency)}
-                        </div>
-                      </Localized>
-                    </div>
-
-                    <div className="plan-details-total-inner">
-                      <Localized id="coupon-promo-code">
-                        <div>Promo Code</div>
-                      </Localized>
-
-                      <Localized
-                        id={`coupon-amount`}
-                        attrs={{ title: true }}
-                        vars={{
-                          amount: getLocalizedCurrency(
-                            coupon.discountAmount,
-                            currency
-                          ),
-                          intervalCount: interval_count,
-                        }}
-                      >
-                        <div>
-                          {`- ${getLocalizedCurrencyString(
-                            coupon.discountAmount,
-                            currency
-                          )}`}
-                        </div>
-                      </Localized>
-                    </div>
-                  </div>
-                )}
-
-                <div className="plan-details-total-inner">
-                  <Localized id="plan-details-total-label">
-                    <div className="total-label">Total</div>
-                  </Localized>
-
-                  <Localized
-                    id={`plan-price-${interval}`}
-                    data-testid="plan-price-total"
-                    attrs={{ title: true }}
-                    vars={{
-                      amount:
-                        coupon && coupon.discountAmount
-                          ? getLocalizedCurrency(
-                              amount ? amount - coupon.discountAmount : amount,
-                              currency
-                            )
-                          : getLocalizedCurrency(amount, currency),
-                      intervalCount: interval_count,
-                    }}
-                  >
-                    <div
-                      className="total-price"
-                      title={planPrice}
-                      data-testid="total-price"
-                      id="total-price"
-                    >
-                      {planPrice}
-                    </div>
-                  </Localized>
+              {loading ? (
+                <div className="pb-4">
+                  <LoadingSpinner />
                 </div>
+              ) : (
+                <div className="plan-details-total">
+                  <div className="row-divider-grey-200 mb-4 pb-6">
+                    {!!subTotal && (
+                      <div className="plan-details-total-inner">
+                        <Localized id="plan-details-list-price">
+                          <div>List Price</div>
+                        </Localized>
+                        <Localized
+                          id={`list-price`}
+                          attrs={{ title: true }}
+                          vars={{
+                            amount: getLocalizedCurrency(subTotal, currency),
+                            intervalCount: interval_count,
+                          }}
+                        >
+                          <div>
+                            {getLocalizedCurrencyString(subTotal, currency)}
+                          </div>
+                        </Localized>
+                      </div>
+                    )}
+                    {!!taxAmount && (
+                      <div className="plan-details-total-inner">
+                        <Localized id="plan-details-tax">
+                          <div>Taxes and Fees</div>
+                        </Localized>
+                        <Localized
+                          id={`tax`}
+                          attrs={{ title: true }}
+                          vars={{
+                            amount: getLocalizedCurrency(taxAmount, currency),
+                            intervalCount: interval_count,
+                          }}
+                        >
+                          <div>
+                            {getLocalizedCurrencyString(taxAmount, currency)}
+                          </div>
+                        </Localized>
+                      </div>
+                    )}
+                    {!!discountAmount && (
+                      <div className="plan-details-total-inner">
+                        <Localized id="coupon-promo-code">
+                          <div>Promo Code</div>
+                        </Localized>
 
-                {infoBoxMessage &&
-                  (infoBoxMessage.couponDurationDate ? (
-                    <div
-                      className="green-icon-text coupon-info"
-                      data-testid="coupon-success-with-date"
-                    >
-                      <img src={infoLogo} alt="" />
+                        <Localized
+                          id={`coupon-amount`}
+                          attrs={{ title: true }}
+                          vars={{
+                            amount: getLocalizedCurrency(
+                              discountAmount,
+                              currency
+                            ),
+                            intervalCount: interval_count,
+                          }}
+                        >
+                          <div>
+                            {`- ${getLocalizedCurrencyString(
+                              discountAmount,
+                              currency
+                            )}`}
+                          </div>
+                        </Localized>
+                      </div>
+                    )}
+                  </div>
+                  {!!totalAmount && (
+                    <div className="plan-details-total-inner">
+                      <Localized id="plan-details-total-label">
+                        <div className="total-label">Total</div>
+                      </Localized>
 
                       <Localized
-                        id={infoBoxMessage.message}
+                        id={`plan-price-${interval}`}
+                        data-testid="plan-price-total"
+                        attrs={{ title: true }}
                         vars={{
-                          couponDurationDate: getLocalizedDate(
-                            infoBoxMessage.couponDurationDate,
-                            true
-                          ),
+                          amount: getLocalizedCurrency(totalAmount, currency),
+                          intervalCount: interval_count,
                         }}
                       >
-                        {infoBoxMessage.message}
+                        <div
+                          className="total-price"
+                          title={totalPrice}
+                          data-testid="total-price"
+                          id="total-price"
+                        >
+                          {totalPrice}
+                        </div>
                       </Localized>
                     </div>
-                  ) : (
-                    <div
-                      className="green-icon-text coupon-info"
-                      data-testid="coupon-success"
-                    >
-                      <img src={infoLogo} alt="" />
+                  )}
+                  {infoBoxMessage &&
+                    (infoBoxMessage.couponDurationDate ? (
+                      <div
+                        className="green-icon-text coupon-info"
+                        data-testid="coupon-success-with-date"
+                      >
+                        <img src={infoLogo} alt="" />
 
-                      <Localized id={infoBoxMessage.message}>
-                        {infoBoxMessage.message}
-                      </Localized>
-                    </div>
-                  ))}
-              </div>
+                        <Localized
+                          id={infoBoxMessage.message}
+                          vars={{
+                            couponDurationDate: getLocalizedDate(
+                              infoBoxMessage.couponDurationDate,
+                              true
+                            ),
+                          }}
+                        >
+                          {infoBoxMessage.message}
+                        </Localized>
+                      </div>
+                    ) : (
+                      <div
+                        className="green-icon-text coupon-info"
+                        data-testid="coupon-success"
+                      >
+                        <img src={infoLogo} alt="" />
+
+                        <Localized id={infoBoxMessage.message}>
+                          {infoBoxMessage.message}
+                        </Localized>
+                      </div>
+                    ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -132,6 +132,7 @@ export const Checkout = ({
   useEffect(() => {
     fetchCheckoutRouteResources();
   }, [fetchCheckoutRouteResources]);
+
   usePaypalButtonSetup(config, setPaypalScriptLoaded, paypalButtonBase);
 
   const signInQueryParams = { ...queryParams, signin: 'yes' };

--- a/packages/fxa-payments-server/src/store/selectors.ts
+++ b/packages/fxa-payments-server/src/store/selectors.ts
@@ -8,7 +8,6 @@ export const selectors = {
   plans: (state: State) => state.plans,
   subsequentInvoices: (state: State) => state.subsequentInvoices,
   customer: (state: State) => state.customer,
-
   updateSubscriptionPlanStatus: (state: State) => state.updateSubscriptionPlan,
   cancelSubscriptionStatus: (state: State) => state.cancelSubscription,
   reactivateSubscriptionStatus: (state: State) => state.reactivateSubscription,

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -60,7 +60,12 @@ export const updateSubscriptionPlanAndRefresh =
   async (dispatch: Function) => {
     try {
       await dispatch(
-        updateSubscriptionPlan(subscriptionId, currentPlan, newPlan, paymentProvider)
+        updateSubscriptionPlan(
+          subscriptionId,
+          currentPlan,
+          newPlan,
+          paymentProvider
+        )
       );
       await dispatch(fetchCustomerAndSubscriptions());
     } catch (err) {

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -13,8 +13,6 @@ export interface InvoiceLineItem {
 export interface InvoiceTax {
   amount: number;
   inclusive: boolean;
-  name: string;
-  percentage: number;
 }
 
 export interface InvoiceDiscount {
@@ -54,8 +52,6 @@ export const firstInvoicePreviewSchema = joi.object({
   tax: joi.object({
     amount: joi.number().required(),
     inclusive: joi.boolean().required(),
-    name: joi.string().required(),
-    percentage: joi.number().required(),
   }),
   discount: joi.object({
     amount: joi.number().required(),
@@ -78,8 +74,6 @@ export type firstInvoicePreviewSchema = {
   tax?: {
     amount: number;
     inclusive: boolean;
-    name: string;
-    percentage: number;
   };
   discount?: {
     amount: number;


### PR DESCRIPTION
Because:

* we want to display the amount of tax charged or included if applicable

This commit:

* updates an api endpoint to fetch automatic tax amount and displays it on the plan details component

Closes #FXA-5539, #FXA-5651

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
