### PR TITLE
fix(scope): Add support for 123done to request a scope key

### DIFF
--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -71,6 +71,7 @@ app.get('/api/auth_status', function (req, res) {
       subscriptions: req.session.subscriptions || [],
       amr: req.session.amr || null,
       acr: req.session.acr || '0',
+      keys_jwe: req.session.keys_jwe || null,
     })
   );
 });

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -54,6 +54,12 @@
       >
         Sign In (prompt=none)
       </button>
+        <button
+          class="btn btn-large btn-info btn-persona scope-keys"
+          type="submit"
+        >
+          Sign In (scopeKeys)
+        </button>
       <button
         class="btn btn-large btn-info btn-persona force-auth"
         type="submit"
@@ -204,6 +210,10 @@
         </div>
       </section>
     </div>
+
+    <section class="keys-data">
+      <div id="keys"></div>
+    </section>
 
     <footer id="footer-main">
       <div class="container">

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -167,6 +167,10 @@ $(document).ready(function () {
       } else {
         $('body').removeClass('is-subscribed');
       }
+
+      if (loggedInState.keys_jwe) {
+        $('#keys').text(`Scoped key: ${loggedInState.keys_jwe}`);
+      }
     }
 
     function updateListArea(email) {
@@ -256,6 +260,16 @@ $(document).ready(function () {
         forceExperiment: 'thirdPartyAuth',
         forceExperimentGroup: 'google',
         deeplink: 'googleLogin',
+      });
+    });
+
+    $('button.scope-keys').click(function (ev) {
+      authenticate('best_choice', {
+        keys_jwk:
+          'eyJrdHkiOiJFQyIsImtpZCI6Im9DNGFudFBBSFZRX1pmQ09RRUYycTRaQlZYblVNZ2xISGpVRzdtSjZHOEEiLCJjcnYiOi' +
+          'JQLTI1NiIsIngiOiJDeUpUSjVwbUNZb2lQQnVWOTk1UjNvNTFLZVBMaEg1Y3JaQlkwbXNxTDk0IiwieSI6IkJCWDhfcFVZeHpTaldsdX' +
+          'U5MFdPTVZwamIzTlpVRDAyN0xwcC04RW9vckEifQ',
+        scope: 'profile openid https://identity.mozilla.com/apps/123done',
       });
     });
 

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -205,7 +205,8 @@
         "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
         "redirectUri": "http://localhost:8080/api/oauth",
         "trusted": true,
-        "canGrant": false
+        "canGrant": false,
+        "allowedScopes": "https://identity.mozilla.com/apps/123done"
       },
       {
         "id": "38a6b9b3a65a1871",
@@ -400,6 +401,10 @@
     "scopes": [
       {
         "scope": "https://identity.mozilla.com/apps/notes",
+        "hasScopedKeys": true
+      },
+      {
+        "scope": "https://identity.mozilla.com/apps/123done",
         "hasScopedKeys": true
       },
       {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -609,6 +609,12 @@ const conf = (module.exports = convict({
             'https://send2.dev.lcip.org/oauth',
           ],
         },
+        'https://identity.mozilla.com/apps/123done': {
+          redirectUris: [
+            'http://localhost:8080/api/oauth',
+            'https://stage-123done.herokuapp.com/api/oauth',
+          ],
+        },
       },
       doc: 'Validates redirect uris for requested scopes',
       env: 'SCOPED_KEYS_VALIDATION',


### PR DESCRIPTION
## Because

- We currently don't have any accesible view/flows to test scope keys

## This pull request

- Adds support to 123done to request scope key
- Adds new scope `https://identity.mozilla.com/apps/123done`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6038

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="686" alt="Screen Shot 2022-10-05 at 4 14 20 PM" src="https://user-images.githubusercontent.com/1295288/194154528-08b715a7-afb7-4c87-8c43-426110deb8b6.png">


## Other information (Optional)

To test, goto `http://localhost:8080` and click on the `Sign in (scopeKeys)` button. Once this PR lands, I'll have to do a manual push to our 123done environment so that it picks up the changes.
