### PR TITLE
fix(payments): add padding to coupon error

### DIFF
--- a/packages/fxa-payments-server/src/components/CouponForm/index.scss
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.scss
@@ -8,6 +8,7 @@
   background: $color-white;
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(12, 12, 13, 0.1);
+  overflow: hidden;
 
   @include min-width('tablet') {
     max-width: 327px;
@@ -62,17 +63,8 @@
 
   .coupon-error {
     margin: 0px 16px 16px 16px;
-    padding-bottom: 0px;
     width: 57%;
     color: red;
-
-    @include max-width('tablet') {
-      padding-bottom: 16px;
-    }
-
-    @media (orientation: landscape) and (max-width: 927px) and (max-height: 429px) {
-      padding-bottom: 16px;
-    }
   }
 
   .coupon-header {


### PR DESCRIPTION
## Because

- Coupon error message has no bottom padding for certain screen sizes

## This pull request

- Removes padding, and changes parents overflow to hidden, so that
  child margins are not collapsed.
- This is a temporary fix and will be reworked by Tailwind changes

## Issue that this pull request solves

Closes: #FXA-6027

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

Before change
![image](https://user-images.githubusercontent.com/10620585/194348140-2ef0bee8-17b0-4db3-9c8d-6b76a5229dd9.png)


After change
![image](https://user-images.githubusercontent.com/10620585/194348236-ae64a12e-89f4-4bfe-9f41-00131fe87920.png)
