### PR TITLE
fix(auth-server): support billing period interval_counts in upgrade emails

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5418,13 +5418,17 @@ describe('StripeHelper', () => {
             event
           );
         assert.equal(result, mockUpgradeDowngradeDetails);
+        const oldPlan = {
+          ...event.data.object.plan,
+          ...event.data.previous_attributes.plan,
+        };
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
           event.data.object,
           expectedBaseUpdateDetails,
           mockInvoice,
           event.data.object.plan.metadata.productOrder,
-          event.data.previous_attributes.plan
+          oldPlan
         );
       });
 
@@ -5437,13 +5441,17 @@ describe('StripeHelper', () => {
             event
           );
         assert.equal(result, mockUpgradeDowngradeDetails);
+        const oldPlan = {
+          ...event.data.object.plan,
+          ...event.data.previous_attributes.plan,
+        };
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
           event.data.object,
           expectedBaseUpdateDetails,
           mockInvoice,
           event.data.object.plan.metadata.productOrder,
-          event.data.previous_attributes.plan
+          oldPlan
         );
       });
 


### PR DESCRIPTION
## Because

- We only use the interval (day/week/month/year), which does not indicate the period (ex 2 weeks) in which the user is billed.

## This pull request

- Adds the interval_count when the interval_count is not 1.

## Issue that this pull request solves

Closes FXA-5975

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Notes & Acknowledgements

There are two important notes with regard to the functionality in this PR:
1. The interval_count+interval combined string is not pluralized.
2. The interval is not localized (it was also not localized before).

Both of the above expand the scope of this bugfix and would require changing non-insignificant number of different files to introduce that support. We have a ticket (https://mozilla-hub.atlassian.net/browse/FXA-3645) that covers doing that work, but this bugfix is considered high enough priority to be merged prior to that support.

With the above acknowledged, the fix introduced in this PR is fairly trivial and simply adds the interval_count to the billing cycle if the interval_count is not 1.