### PR TITLE
fix(support): support frm required field check fix

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -219,11 +219,11 @@ const SupportView = BaseView.extend({
   },
 
   formatProductName: function (name) {
-    return `${productPrefix}${name}`;
+    return name ? `${productPrefix}${name}` : '';
   },
 
   unformatProductName: function (name) {
-    return name.slice(productPrefix.length);
+    return name ? name.slice(productPrefix.length) : '';
   },
 
   submitButtonUIToggle: function () {


### PR DESCRIPTION
## Because

- Support form can be sent even if not all mandatory fields are filled

## This pull request

- Removes productPrefix if productName is empty

## Issue that this pull request solves

Closes: #FXA-3640

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before
![image](https://user-images.githubusercontent.com/10620585/194370962-0110f100-a264-45d4-85ad-0cfbf3f21875.png)


After
![image](https://user-images.githubusercontent.com/10620585/194370811-60fc0594-a55d-4c01-ad59-d4b16e857067.png)
![image](https://user-images.githubusercontent.com/10620585/194371066-8c432142-4f77-4b31-93f5-3b604cad9b04.png)
