### PR TITLE
fix(settings): fix zh-cn locale store badges

### DIFF
--- a/packages/fxa-settings/src/components/ConnectAnotherDevicePromo/storeImageLoader.tsx
+++ b/packages/fxa-settings/src/components/ConnectAnotherDevicePromo/storeImageLoader.tsx
@@ -83,7 +83,7 @@ const storeImages = [
     sl: slApple,
     'sv-SE': svSEApple,
     tr: trApple,
-    'zh-CH': zhCNApple,
+    'zh-CN': zhCNApple,
     'zh-TW': zhTWApple,
   },
   {
@@ -112,7 +112,7 @@ const storeImages = [
     sv: svGoogle,
     tr: trGoogle,
     uk: ukGoogle,
-    'zh-CH': zhCNGoogle,
+    'zh-CN': zhCNGoogle,
     'zh-TW': zhTWGoogle,
   },
 ];


### PR DESCRIPTION
## Because

- Badges text not translated for zh-cn locale

## This pull request

- Fix spelling mistake in map to return translated badge for zh-cn

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
