### PR TITLE
fix(metrics): update pair authority events

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -434,9 +434,15 @@ const EVENTS = {
     group: GROUPS.qrConnectDevice,
     event: 'view',
   },
+  // submit event from pairing authority
+  'flow.pair.auth.allow.submit': {
+    group: GROUPS.qrConnectDevice,
+    event: 'submit',
+  },
+  // the screen displayed if the pairing authority approved first
   'screen.pair.auth.wait-for-supp': {
     group: GROUPS.qrConnectDevice,
-    event: 'engage',
+    event: 'wait_for_supp',
   },
   'screen.pair.auth.complete': {
     group: GROUPS.qrConnectDevice,

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -2516,28 +2516,19 @@ registerSuite('amplitude', {
       );
     },
 
-    'screen.pair.auth.wait-for-supp': () => {
-      amplitude(
-        {
-          offset: 31721,
-          type: 'screen.pair.auth.wait-for-supp',
-        },
-        {
-          connection: {},
-          headers: {
-            'x-forwarded-for': '63.245.221.32',
-          },
-        },
-        {
-          flowBeginTime: '1582051366041',
-          flowId:
-            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0a',
-          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
-        }
-      );
+    'flow.pair.auth.allow.submit': () => {
+      createAmplitudeEvent('flow.pair.auth.allow.submit');
       assert.equal(
         logger.info.args[0][1].event_type,
-        'fxa_qr_connect_device - engage'
+        'fxa_qr_connect_device - submit'
+      );
+    },
+
+    'screen.pair.auth.wait-for-supp': () => {
+      createAmplitudeEvent('screen.pair.auth.wait-for-supp');
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_qr_connect_device - wait_for_supp'
       );
     },
 


### PR DESCRIPTION
Because:
 - the event for pairing authority "approval" was misleading
   - it was based on the post-approval view where it's waiting for the supplicant's confirmation, a view that is not displayed if the supplicant confirmed before the authority's approval

This commit:
 - rename the wait for supplicant view event
 - add an event for the authority approval submission

Fixes FXA-6024