### PR TITLE
fix(styles): update :focus color of link dressed as a button

### DIFF
--- a/packages/fxa-content-server/app/styles/tailwind/ctas.css
+++ b/packages/fxa-content-server/app/styles/tailwind/ctas.css
@@ -13,3 +13,7 @@
   background-image: inline('../images/spinnerwhite.svg');
   @apply -mt-[6px] mx-auto;
 }
+
+a.cta-primary:focus {
+  color: #fff;
+}


### PR DESCRIPTION
Because:
 - a link that's styled like a button with cta-primary has the same font and background color when it's focused

This commit:
 - update the :focus color of the link

Fixes FXA-5972