### PR TITLE
chore(signup): add FTC COPPA link

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/coppa-age-input.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/coppa-age-input.mustache
@@ -1,7 +1,5 @@
 <div id="coppa" class="mb-8 tooltip-container">
-  <label for="age" id="age-label" class="sr-only">{{#t}}How old are you? You must be at least 13 years old to create an account.{{/t}}</label>
+  <label for="age" id="age-label" class="sr-only">{{#t}}How old are you? To learn why we ask for your age, follow the “why do we ask” link below.{{/t}}</label>
   <input type="number" pattern="\d*" id="age" class="input-text no-step" placeholder="{{#t}}How old are you?{{/t}}" aria-labelledby="age-label" min="0" max="130" value="{{ age }}" {{#required}}required{{/required}} />
-  <!-- If you update this string you must update it in the label as well.
-  This is hidden from screenreaders in favor of reading it before users enter their age. -->
-  <p aria-hidden="true" id="age-explainer" class="text-grey-500 text-start text-xs mt-3">{{#t}}You must be at least 13 years old to create an account.{{/t}}</p>
+  <p id="coppa-link" class="text-start mt-3 link-blue"><a href="https://www.ftc.gov/business-guidance/resources/childrens-online-privacy-protection-rule-not-just-kids-sites" target="_blank">{{#t}}Why do we ask?{{/t}}</a></p>
 </div>

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
@@ -105,7 +105,7 @@ describe('views/sign_up_password', () => {
       assert.lengthOf(view.$(Selectors.PASSWORD), 1);
       assert.lengthOf(view.$(Selectors.VPASSWORD), 1);
       assert.lengthOf(view.$(Selectors.AGE), 1);
-      assert.lengthOf(view.$(Selectors.AGE_EXPLAINER), 1);
+      assert.lengthOf(view.$(Selectors.COPPA_LINK), 1);
       assert.lengthOf(view.$(Selectors.TOS), 1);
       assert.lengthOf(view.$(Selectors.PRIVACY_POLICY), 1);
       assert.lengthOf(view.$(Selectors.LINK_USE_DIFFERENT), 1);

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -764,8 +764,8 @@ module.exports = {
   },
   SIGNUP_PASSWORD: {
     AGE: '#age',
-    AGE_EXPLAINER: '#age-explainer',
     CHOOSE_WHAT_TO_SYNC_HEADER: '#fxa-choose-what-to-sync-header',
+    COPPA_LINK: '#coppa-link',
     EMAIL: 'input[type=email]',
     ERROR: '.error',
     ERROR_PASSWORDS_DO_NOT_MATCH: '.error',


### PR DESCRIPTION
Because:
 - feedback from legal

This commit:
 - link to an explanation on FTC's web site for COPPA
 - update the input's label to refer to the new link

Fixes FXA-6011