### PR TITLE
fix(auth-server): check for duplicate subs when creating subscription

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -9,6 +9,7 @@ import {
 import {
   AbbrevPlan,
   ClientIdCapabilityMap,
+  SubscriptionEligibilityResult,
   SubscriptionUpdateEligibility,
 } from 'fxa-shared/subscriptions/types';
 import Stripe from 'stripe';
@@ -27,14 +28,6 @@ import { StripeHelper } from './stripe';
 import { PaymentConfigManager } from './configuration/manager';
 import { ALL_RPS_CAPABILITIES_KEY } from 'fxa-shared/subscriptions/configuration/base';
 import { productUpgradeFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
-
-enum SubscriptionEligibilityResult {
-  CREATE = 'create',
-  UPGRADE = 'upgrade',
-  DOWNGRADE = 'downgrade',
-  BLOCKED_IAP = 'blocked_iap',
-  INVALID = 'invalid',
-}
 
 function hex(blob: Buffer | string): string {
   if (Buffer.isBuffer(blob)) {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -61,7 +61,6 @@ const IGNORABLE_STRIPE_WEBHOOK_ERRNOS = [
 ];
 
 export class StripeWebhookHandler extends StripeHandler {
-  protected capabilityService: CapabilityService;
   protected paypalHelper?: PayPalHelper;
 
   constructor(
@@ -78,7 +77,6 @@ export class StripeWebhookHandler extends StripeHandler {
     if (config.subscriptions.paypalNvpSigCredentials.enabled) {
       this.paypalHelper = Container.get(PayPalHelper);
     }
-    this.capabilityService = Container.get(CapabilityService);
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -455,6 +455,7 @@ describe('DirectStripeRoutes', () => {
     mockCapabilityService.getPlanEligibility.resolves(
       SubscriptionEligibilityResult.CREATE
     );
+    Container.set(CapabilityService, mockCapabilityService);
 
     directStripeRoutesInstance = new DirectStripeRoutes(
       log,
@@ -464,8 +465,7 @@ describe('DirectStripeRoutes', () => {
       push,
       mailer,
       profile,
-      stripeHelperMock,
-      mockCapabilityService
+      stripeHelperMock
     );
   });
 

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -151,11 +151,23 @@ export type SentEmailParams = {
   subscriptionId: string;
 };
 
+// Used to represent upgrade eligibility only
+// Invalid is used in cases where plan is not an upgrade/downgrade
+// including new subscriptions
 export const SubscriptionUpdateEligibility = {
   UPGRADE: 'upgrade',
   DOWNGRADE: 'downgrade',
   INVALID: 'invalid',
 } as const;
+
+// Used to represent plan eligibility in general
+export enum SubscriptionEligibilityResult {
+  CREATE = 'create',
+  UPGRADE = 'upgrade',
+  DOWNGRADE = 'downgrade',
+  BLOCKED_IAP = 'blocked_iap',
+  INVALID = 'invalid',
+}
 
 export type SubscriptionUpdateEligibility =
   typeof SubscriptionUpdateEligibility[keyof typeof SubscriptionUpdateEligibility];


### PR DESCRIPTION
## Because

* Only the frontend enforces that you should not be able to create duplicate subscriptions.

## This pull request

* Checks to see if the subscription you're creating is a duplicate.

## Issue that this pull request solves

Closes FXA-6035

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
