### PR TITLE
feat(scopes): Allow trusted reliers to increase scope of token when using refresh token

### DIFF
--- a/packages/fxa-auth-server/test/lib/oauth-test.json
+++ b/packages/fxa-auth-server/test/lib/oauth-test.json
@@ -61,7 +61,7 @@
       {
         "name": "Untrusted",
         "id": "ea3ca969f8c6bb0e",
-        "hashedSecret": "ec62e3281e3b56e702fe7e82ca7b1fa59d6c2a6766d6d28cccbf8bfa8d5fc8a8",
+        "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
         "imageUri": "",
         "redirectUri": "https://example.domain/return?foo=bar",
         "trusted": false,


### PR DESCRIPTION
## Because

- To provide a better user experience we want trusted RPs to be able to increase the scope of access token

## This pull request

- Allows trusted RPs to request additional scopes during the refresh token grant
  - Only scopes in the client's `allowedScopes` property can be requested.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5880

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
