### PR TITLE
fix(coupons): pass promotion code on second sub

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -179,12 +179,11 @@ export const SubscriptionCreate = ({
 
   const onPaypalFormSubmit: (x: PaypalPaymentSubmitResult) => void =
     useCallback(
-      async ({ priceId, idempotencyKey }: PaypalPaymentSubmitResult) => {
+      async (params: PaypalPaymentSubmitResult) => {
         setInProgress(true);
         try {
           await apiCapturePaypalPayment({
-            idempotencyKey,
-            priceId,
+            ...params,
             productId: selectedPlan.product_id,
           });
           refreshSubscriptions();


### PR DESCRIPTION
## Because

- When a customer, using PayPal, has an existing subscription, the promotion code is not included in the request to the backend.

## This pull request

- Rework the onPaypalFormSubmit to match onStripeFormSubmit, so that all arguments are passed to the api call.

## Issue that this pull request solves

Closes: #FXA-5878

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).