### PR TITLE
task(shared) - Add service to capture client side traces

### DIFF
--- a/_dev/pm2/infrastructure.config.js
+++ b/_dev/pm2/infrastructure.config.js
@@ -55,6 +55,14 @@ module.exports = {
       kill_timeout: 20000,
     },
 
+    {
+      name: 'otel-collector',
+      script: '_scripts/otel-collector.sh',
+      max_restarts: '1',
+      autorestart: false,
+      kill_timeout: 20000,
+    },
+
     // TODO FIXME?? this has been broken for-ev-er, do we even want it?
     // {
     //   name: 'pushbox',

--- a/_scripts/configs/otel-collector-config.yaml
+++ b/_scripts/configs/otel-collector-config.yaml
@@ -1,0 +1,36 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+
+exporters:
+  logging:
+    loglevel: debug
+  jaeger:
+    endpoint: "jaeger.otel:14250"
+    tls:
+      insecure: true
+  googlecloud:
+    project: '${TRACING_GCP_PROJECT}'
+    retry_on_failure:
+      enabled: false
+    log:
+      default_log_name: opentelemetry.io/collector-exported-log
+
+processors:
+  batch:
+  memory_limiter:
+    # 75% of maximum memory up to 4G
+    limit_mib: 1536
+    # 25% of limit up to 2G
+    spike_limit_mib: 512
+    check_interval: 5s
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      # Set env EXPORTERS to toggle exporters. ie to turn all exporters set as:
+      #    EXPORTERS=logging,jaeger,googlecloud
+      exporters: '${EXPORTERS}'

--- a/_scripts/jaeger.sh
+++ b/_scripts/jaeger.sh
@@ -1,11 +1,15 @@
 #!/bin/bash -ex
 
 
-if [ "$TRACING_JAEGER_EXPORTER_ENABLED" == "true" ]
+if [ "$TRACING_OTEL_EXPORTER_ENABLED" == "true" ]
 then
   echo -e "Jaeger enabled! Go to http://localhost:16686 to view traces. \n"
 
+  # Create an otel network. If it already exists and error will be shown that can be ignored
+  docker network create otel
+
   docker run --rm --name jaeger \
+    --net otel \
     -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
     -e COLLECTOR_OTLP_ENABLED=true \
     -p 6831:6831/udp \
@@ -15,9 +19,10 @@ then
     -p 16686:16686 \
     -p 14268:14268 \
     -p 9411:9411 \
-    -p 4317:4317 \
-    -p 4318:4318 \
+    -p 43170:4317 \
+    -p 43180:4318 \
+    -p 14250:14250 \
     jaegertracing/all-in-one:latest
 else
-  echo -e "Jaeger did not start, because it is not enabled. Set env TRACING_JAEGER_EXPORTER_ENABLED=true to enable. Running Jaeger is optional! \n"
+  echo -e "Jaeger did not start, because it is not enabled. Set env TRACING_OTEL_EXPORTER_ENABLED=true to enable. Running Jaeger is optional! \n"
 fi

--- a/_scripts/otel-collector.sh
+++ b/_scripts/otel-collector.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+
+if [ "$TRACING_OTEL_COLLECTOR_ENABLED" == "true" ]
+then
+
+  # Outputs traces to console/stdout
+  EXPORTERS="logging"
+
+  if [ "$TRACING_OTEL_COLLECTOR_GCP_ENABLED" == "true" ]
+  then
+    EXPORTERS="$EXPORTERS,googlecloud"
+  fi
+
+  if [ "$TRACING_OTEL_COLLECTOR_JAEGER_ENABLED" == "true" ]
+  then
+    EXPORTERS="$EXPORTERS,jaeger"
+  fi
+
+  echo -e "Starting otel collector to capture client traces.\n exporters=$EXPORTERS\n gcp-proj-id=$TRACING_GCP_PROJECT"
+
+  # Create an otel network. If it already exists and error will be shown that can be ignored
+  docker network create otel
+
+  docker run --rm --name otel-collector \
+    --net otel \
+    -v $(pwd)/_scripts/configs/otel-collector-config.yaml:/etc/otel/config.yaml \
+    -v $HOME/.config/gcloud/application_default_credentials.json:/etc/otel/key.json \
+    -e GOOGLE_APPLICATION_CREDENTIALS=/etc/otel/key.json \
+    -e EXPORTERS=$EXPORTERS \
+    -e TRACING_GCP_PROJECT=$TRACING_GCP_PROJECT \
+    -p 4317:4317 \
+    -p 4318:4318 \
+    -p 55681:55681 \
+    otel/opentelemetry-collector-contrib:0.61.0 --config=/etc/otel/config.yaml
+else
+  echo -e "The open telemtry connector did not start, because it is not enabled. Set env TRACING_OTEL_COLLECTOR_ENABLED=true to enable. Running an open telemetry collector is optional! \n"
+fi

--- a/packages/fxa-content-server/app/scripts/app.js
+++ b/packages/fxa-content-server/app/scripts/app.js
@@ -2,15 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import 'core-js';
-import * as tracing from 'fxa-shared/tracing/browser-tracing';
+import {
+  init as initTracing,
+  getTracingHeadersFromDocument,
+} from 'fxa-shared/tracing/browser-tracing';
 import ConfigLoader from './lib/config-loader';
 import AppStart from './lib/app-start';
 
 const configLoader = new ConfigLoader();
 configLoader.fetch().then((config) => {
   if (config.tracing) {
-    const flowId = $ && $(document.body).data('flowId'); // eslint-disable-line no-undef
-    tracing.init(config.tracing, flowId, console);
+    initTracing(
+      config.tracing,
+      getTracingHeadersFromDocument(document),
+      console
+    );
   }
 
   const appStart = new AppStart({

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -82,6 +82,15 @@ function swapBetaMeta(html, metaContent = {}) {
   return result;
 }
 
+// Try to pull the flow id from the request query to setup the trace state context
+function getTraceState(req) {
+  let state = '';
+  if (req && req.query && req.query.flowId) {
+    state = `flow.id=${req.query.flowId}`;
+  }
+  return state;
+}
+
 // Conditionally modify the response
 function modifyProxyRes(proxyRes, req, res) {
   const bodyChunks = [];
@@ -108,6 +117,7 @@ function modifyProxyRes(proxyRes, req, res) {
       html = swapBetaMeta(html, {
         __SERVER_CONFIG__: settingsConfig,
         __TRACE_PARENT__: getTraceParentId(),
+        __TRACE_STATE__: getTraceState(req),
       });
       res.send(new Buffer.from(html));
     } else {
@@ -131,6 +141,7 @@ const modifySettingsStatic = function (req, res) {
     swapBetaMeta(settingsIndexFile, {
       __SERVER_CONFIG__: settingsConfig,
       __TRACE_PARENT__: getTraceParentId(),
+      __TRACE_STATE__: getTraceState(req),
     })
   );
 };

--- a/packages/fxa-content-server/server/lib/csp/blocking.js
+++ b/packages/fxa-content-server/server/lib/csp/blocking.js
@@ -39,8 +39,8 @@ module.exports = function (config) {
 
   const tracingConfig = config.get('tracing');
   let TRACE_OTLP_URL = undefined;
-  if (tracingConfig.jaeger && tracingConfig.jaeger.otlpUrl) {
-    TRACE_OTLP_URL = url.parse(tracingConfig.jaeger.otlpUrl);
+  if (tracingConfig.otel && tracingConfig.otel.url) {
+    TRACE_OTLP_URL = url.parse(tracingConfig.otel.url);
     TRACE_OTLP_URL = TRACE_OTLP_URL.href.replace(TRACE_OTLP_URL.pathname, '');
   }
 

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -6,7 +6,10 @@ import React from 'react';
 import { render } from 'react-dom';
 import AppErrorBoundary from 'fxa-react/components/AppErrorBoundary';
 import sentryMetrics from 'fxa-shared/lib/sentry';
-import { init as initTracing } from 'fxa-shared/tracing/browser-tracing';
+import {
+  getTracingHeadersFromDocument,
+  init as initTracing,
+} from 'fxa-shared/tracing/browser-tracing';
 import App from './components/App';
 import config, { readConfigMeta } from './lib/config';
 import { searchParams } from './lib/utilities';
@@ -25,7 +28,14 @@ try {
   });
 
   // Add tracing support
-  initTracing(config.tracing, flowQueryParams.flowId || '', console);
+  initTracing(
+    config.tracing,
+    {
+      ...getTracingHeadersFromDocument(document),
+      flowid: flowQueryParams.flowId,
+    },
+    console
+  );
 
   const appContext = initializeAppContext();
 

--- a/packages/fxa-shared/test/tracing/exporters.ts
+++ b/packages/fxa-shared/test/tracing/exporters.ts
@@ -9,9 +9,9 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { expect } from 'chai';
-import { addConsoleExporter } from 'fxa-shared/tracing/exporters/fxa-console';
-import { addGcpTraceExporter } from 'fxa-shared/tracing/exporters/fxa-gcp';
-import { addOtlpTraceExporter } from 'fxa-shared/tracing/exporters/fxa-otlp';
+import { addConsoleExporter } from '../../tracing/exporters/fxa-console';
+import { addGcpTraceExporter } from '../../tracing/exporters/fxa-gcp';
+import { addOtlpTraceExporter } from '../../tracing/exporters/fxa-otlp';
 import sinon from 'sinon';
 import { TracingOpts } from '../../tracing/config';
 import { addExporter } from '../../tracing/exporters/exporters';
@@ -37,9 +37,9 @@ describe('tracing exports', () => {
       console: {
         enabled: true,
       },
-      jaeger: {
+      otel: {
         enabled: true,
-        otlpUrl: 'http://localhost:4138/v1/traces',
+        url: 'http://localhost:4138/v1/traces',
         concurrencyLimit: 10,
       },
       gcp: {

--- a/packages/fxa-shared/test/tracing/node-tracing.ts
+++ b/packages/fxa-shared/test/tracing/node-tracing.ts
@@ -162,7 +162,7 @@ describe('node-tracing', () => {
         spies.logger
       );
       sinon.assert.calledWithMatch(spies.logger.debug, log_type, {
-        msg: 'Trace initialization skipped. No exporters configured. Enable gcp, jeager or console to activate tracing.',
+        msg: 'Trace initialization skipped. No exporters configured. Enable gcp, otel or console to activate tracing.',
       });
     });
 

--- a/packages/fxa-shared/tracing/config.ts
+++ b/packages/fxa-shared/tracing/config.ts
@@ -19,9 +19,9 @@ export type TracingOpts = {
   gcp?: {
     enabled: boolean;
   };
-  jaeger?: {
+  otel?: {
     enabled: boolean;
-    otlpUrl: string;
+    url: string;
     concurrencyLimit: number;
   };
 };
@@ -80,23 +80,23 @@ export const tracingConfig = {
       format: Boolean,
     },
   },
-  jaeger: {
+  otel: {
     enabled: {
       default: false,
-      doc: 'Traces report to the jaeger. This is only applicable for local development.',
-      env: 'TRACING_JAEGER_EXPORTER_ENABLED',
+      doc: 'Traces report to the otel. This is only applicable for local development.',
+      env: 'TRACING_OTEL_EXPORTER_ENABLED',
       format: Boolean,
     },
-    otlpUrl: {
+    url: {
       default: 'http://localhost:4318/v1/traces',
       doc: 'Open telemetry collector url',
-      env: 'TRACING_JAEGER_OTLP_URL',
+      env: 'TRACING_OTEL_URL',
       format: String,
     },
     concurrencyLimit: {
       default: 10,
       doc: 'Max amount of concurrency',
-      env: 'TRACING_JAEGER_CONCURRENCY_LIMIT',
+      env: 'TRACING_OTEL_CONCURRENCY_LIMIT',
       format: Number,
     },
   },
@@ -128,7 +128,7 @@ export function checkClientName(opts: Pick<TracingOpts, 'clientName'>) {
 }
 
 export function someModesEnabled(
-  opts: Pick<TracingOpts, 'jaeger' | 'gcp' | 'console'>
+  opts: Pick<TracingOpts, 'otel' | 'gcp' | 'console'>
 ) {
-  return opts.jaeger?.enabled || opts.gcp?.enabled || opts.console?.enabled;
+  return opts.otel?.enabled || opts.gcp?.enabled || opts.console?.enabled;
 }

--- a/packages/fxa-shared/tracing/exporters/exporters.ts
+++ b/packages/fxa-shared/tracing/exporters/exporters.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import {
   BasicTracerProvider,
   BatchSpanProcessor,

--- a/packages/fxa-shared/tracing/exporters/fxa-otlp.ts
+++ b/packages/fxa-shared/tracing/exporters/fxa-otlp.ts
@@ -14,6 +14,12 @@ import { TracingPiiFilter } from '../pii-filters';
 import { addExporter } from './exporters';
 import { checkDuration } from './util';
 
+export type FxaOtlpTracingHeaders = {
+  flowid?: string;
+  traceparent?: string;
+  tracestate?: string;
+};
+
 /** OTLP exporter customized for FxA */
 export class FxaOtlpWebExporter extends OTLPTraceExporter {
   constructor(
@@ -31,21 +37,25 @@ export class FxaOtlpWebExporter extends OTLPTraceExporter {
       checkDuration(x);
       this.filter?.filter(x);
     });
-    return super.export(spans, resultCallback);
+    super.export(spans, (result) => {
+      resultCallback(result);
+    });
   }
 }
 
 export function addOtlpTraceExporter(
   opts: TracingOpts,
   provider: BasicTracerProvider,
+  headers?: FxaOtlpTracingHeaders,
   filter?: TracingPiiFilter
 ) {
-  if (!opts.jaeger?.enabled) {
+  if (!opts.otel?.enabled) {
     return;
   }
   const config = {
-    url: opts.jaeger?.otlpUrl,
-    concurrencyLimit: opts.jaeger?.concurrencyLimit,
+    url: opts.otel?.url,
+    headers,
+    concurrencyLimit: opts.otel?.concurrencyLimit,
   };
   const exporter = new FxaOtlpWebExporter(filter, config);
   addExporter(opts, provider, exporter);

--- a/packages/fxa-shared/tracing/node-tracing.ts
+++ b/packages/fxa-shared/tracing/node-tracing.ts
@@ -40,7 +40,7 @@ export class NodeTracingInitializer {
 
     const filter = createPiiFilter(!!this.opts?.filterPii, this.logger);
     addGcpTraceExporter(opts, provider, filter);
-    addOtlpTraceExporter(opts, provider, filter);
+    addOtlpTraceExporter(opts, provider, undefined, filter);
     addConsoleExporter(opts, provider, filter);
 
     this.register();
@@ -119,9 +119,9 @@ export function init(opts: TracingOpts, logger: ILogger) {
     return nodeTracing;
   }
 
-  if (!opts.jaeger?.enabled && !opts.gcp?.enabled && !opts.console?.enabled) {
+  if (!opts.otel?.enabled && !opts.gcp?.enabled && !opts.console?.enabled) {
     logger.debug(log_type, {
-      msg: 'Trace initialization skipped. No exporters configured. Enable gcp, jeager or console to activate tracing.',
+      msg: 'Trace initialization skipped. No exporters configured. Enable gcp, otel or console to activate tracing.',
     });
     return;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5942,7 +5942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.6.0, @opentelemetry/core@npm:^1.0.0":
+"@opentelemetry/core@npm:1.6.0":
   version: 1.6.0
   resolution: "@opentelemetry/core@npm:1.6.0"
   dependencies:
@@ -5953,7 +5953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.7.0":
+"@opentelemetry/core@npm:1.7.0, @opentelemetry/core@npm:^1.0.0":
   version: 1.7.0
   resolution: "@opentelemetry/core@npm:1.7.0"
   dependencies:
@@ -6568,7 +6568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:1.6.0, @opentelemetry/resources@npm:^1.0.0":
+"@opentelemetry/resources@npm:1.6.0":
   version: 1.6.0
   resolution: "@opentelemetry/resources@npm:1.6.0"
   dependencies:
@@ -6580,7 +6580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:1.7.0":
+"@opentelemetry/resources@npm:1.7.0, @opentelemetry/resources@npm:^1.0.0":
   version: 1.7.0
   resolution: "@opentelemetry/resources@npm:1.7.0"
   dependencies:
@@ -10382,9 +10382,9 @@ __metadata:
   linkType: hard
 
 "@types/bluebird@npm:*":
-  version: 3.5.36
-  resolution: "@types/bluebird@npm:3.5.36"
-  checksum: efe7484e1f6c3443c083f052efb7688b461a9f43899b1891c10b1faf92e4932d686265d10c3e02b8c8fe0c8c371774e6a55ff6eec5e79525390a1ddeee7eb41b
+  version: 3.5.37
+  resolution: "@types/bluebird@npm:3.5.37"
+  checksum: 851a2eca0ae2daa422d4bcea5f8f659a673fcff5f51d18997ffb19bb9e54b64800301b167613d9cbbebaa8fdfd2433f0f9f8bb39267efd7b6898011aedcc944d
   languageName: node
   linkType: hard
 
@@ -41252,9 +41252,9 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "safe-stable-stringify@npm:^2.1.0":
-  version: 2.3.1
-  resolution: "safe-stable-stringify@npm:2.3.1"
-  checksum: a0a0bad0294c3e2a9d1bf3cf2b1096dfb83c162d09a5e4891e488cce082120bd69161d2a92aae7fc48255290f17700decae9c89a07fe139794e61b5c8b411377
+  version: 2.4.0
+  resolution: "safe-stable-stringify@npm:2.4.0"
+  checksum: 5c9e4b2b2423470becafe232244948e7ce9545baaa65d67965e8c36536c93d2f7b4c1ddeb4bba8a912d0325e02c7691f24dd4de6935a9c1221402c17582ae1c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because
- We want to start trace capture at client side
- We can't report trace data directly to cloud trace

## This pull request

- Adds an open telemetry collector service (otel-collector)
- Configures service to export to jaeger and gcp
- Ability to uses otel-collector service for all trace capture
- Rename 'jaeger' in config to 'otel' since export is no longer jaeger specific.
- Adds flow id to trace id headers so traces can be validated

## Issue that this pull request solves

Closes: FXA-6021
Closes: FXA-6022

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="618" alt="image" src="https://user-images.githubusercontent.com/94418270/195180036-59faaa56-6fd7-4acc-9afe-70531eacadd6.png">
<img width="645" alt="image" src="https://user-images.githubusercontent.com/94418270/195180133-e6baae85-a18c-4724-bb21-7959acdc6f0b.png">

_GCP trace view captured from local host_

## Testing Instructions

Make sure the default application credentials are fresh
```
gcloud auth application-default login
```

Set the following envs in the .env file in fxa root.

```
# Capture all traces.
TRACING_SAMPLE_RATE=1

# Turn off batch processing for more responsive trace capture
TRACING_BATCH_PROCESSING=false

# This will transmit traces to the otel collector service
TRACING_OTEL_EXPORTER_ENABLED = true

# Turns on the OTEL_COLLECTOR SERVICE.
TRACING_OTEL_COLLECTOR_ENABLED=true

# Tells collector to send trace to google cloud trace.
TRACING_OTEL_COLLECTOR_GCP_ENABLED=true

# Tells collector to send traces to Jaeger. This is the preferred setting for local development.
TRACING_OTEL_COLLECTOR_JAEGER_ENABLED=true
```

Start up the stack with the .env file applied.

```
yarn stop
dotenv -- yarn start
```


