### PR TITLE
chore(migrations): combine pushbox create table and indexes DDL

### DIFF
--- a/packages/db-migrations/databases/pushbox/patches/patch-001-002.sql
+++ b/packages/db-migrations/databases/pushbox/patches/patch-001-002.sql
@@ -6,10 +6,11 @@ CREATE TABLE IF NOT EXISTS pushboxv1 (
     data Blob,
     idx BigInt AUTO_INCREMENT,
     ttl BigInt,
-    PRIMARY KEY(idx)
+    PRIMARY KEY(idx),
+
+    INDEX user_id_idx (user_id),
+    INDEX full_idx (user_id, device_id)
 );
 
-CREATE INDEX user_id_idx ON pushbox.pushboxv1 (user_id);
-CREATE INDEX full_idx ON pushbox.pushboxv1 (user_id, device_id);
 
 UPDATE dbMetadata SET value = '2' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Because:
 - some self-hosters might already have the pushbox db up and running

This commit:
 - move the CREATE INDEXs into the CREATE TABLE to avoid conflicts
