### PR TITLE
feat(auth-server): mock iap subscriptions util

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "yarn emails-scss && tsc --build && cp -R config public lib scripts dist/fxa-auth-server",
     "compile": "tsc --noEmit",
+    "create-mock-iap": "NODE_ENV=dev FIRESTORE_EMULATOR_HOST=localhost:9090 node -r esbuild-register ./scripts/create-mock-iap-subscriptions.ts",
     "bump-template-versions": "node scripts/template-version-bump",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint . .storybook --ignore-pattern 'dist'",

--- a/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions.ts
+++ b/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+
+import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+
+const pckg = require('../package.json');
+import * as mockIapSubscriptions from './create-mock-iap-subscriptions/mock-iap-subscriptions.json';
+import { MockIapSubscriptionManager } from './create-mock-iap-subscriptions/mock-iap-subscription-manager';
+
+export async function init() {
+  program
+    .version(pckg.version)
+    .option('-u, --uid [uid]', 'User ID to create subscription for')
+    .option(
+      '--appStoreProductId [appStoreProductId]',
+      'Any string. Should be present in a plan\'s "appStoreProductIds" metadata field'
+    )
+    .option(
+      '--playSkuId [playSkuId]',
+      'Any string. Should be present in a plan\'s "playSkuIds" metadata field'
+    )
+    .parse(process.argv);
+
+  const options = program.opts();
+
+  if (!options.uid) throw new Error('UID must be specified via --uid [uid]');
+
+  await setupProcessingTaskObjects('create-mock-iap-subscriptions');
+
+  const expiry = new Date();
+  // Add 5 years for local testing (should be long enough!)
+  const EXPIRES_IN_YEARS = 5;
+  expiry.setFullYear(expiry.getFullYear() + EXPIRES_IN_YEARS);
+
+  const appStoreSubs = mockIapSubscriptions.appStore.map((mockEntry) => ({
+    ...mockEntry,
+    userId: options.uid,
+    expiresDate: expiry.getTime().toString(),
+    productId: options.appStoreProductId || mockEntry.productId,
+  }));
+
+  const playStoreSubs = mockIapSubscriptions.playStore.map((mockEntry) => ({
+    ...mockEntry,
+    userId: options.uid,
+    expiryTimeMillis: expiry.getTime(),
+    sku: options.playSkuId || mockEntry.sku,
+  }));
+
+  const mockIapSubscriptionManager = new MockIapSubscriptionManager();
+
+  await mockIapSubscriptionManager.createAppStore(appStoreSubs);
+
+  await mockIapSubscriptionManager.createPlayStore(playStoreSubs);
+
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscription-manager.ts
+++ b/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscription-manager.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { CollectionReference, Firestore } from '@google-cloud/firestore';
+import { AppConfig, AuthFirestore } from 'fxa-auth-server/lib/types';
+import Container from 'typedi';
+
+export class MockIapSubscriptionManager {
+  firestore: Firestore;
+  collectionPrefix: string;
+
+  constructor() {
+    this.firestore = Container.get(AuthFirestore);
+    const { authFirestore } = Container.get(AppConfig);
+    this.collectionPrefix = `${authFirestore.prefix}iap-`;
+  }
+
+  private async insert(purchasesDbRef: CollectionReference, records: any[]) {
+    for (const record of records) {
+      await purchasesDbRef.add(record);
+    }
+  }
+
+  private getDbRef(collectionName: string) {
+    return this.firestore.collection(this.collectionPrefix + collectionName);
+  }
+
+  public createAppStore(records: any[]) {
+    return this.insert(this.getDbRef('app-store-purchases'), records);
+  }
+
+  public createPlayStore(records: any[]) {
+    return this.insert(this.getDbRef('play-purchases'), records);
+  }
+}

--- a/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscriptions.json
+++ b/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscriptions.json
@@ -1,0 +1,40 @@
+{
+  "appStore": [{
+    "bundleId": "skydiving.with.foxkeh",
+    "environment": "Sandbox",
+    "expiresDate": "1707012573000",
+    "formOfPayment": "APPLE_APP_STORE",
+    "isInBillingRetry": false,
+    "originalPurchaseDate": 1602501465000,
+    "originalTransactionId": "1000000728852404",
+    "productId": "examplesku",
+    "status": 1,
+    "type": "Auto-Renewable Subscription",
+    "userId": "REPLACED_BY_SCRIPT",
+    "verifiedAt": 1661990504172
+  }],
+  "playStore": [{
+    "acknowledgementState": 1,
+    "autoRenewing": false,
+    "cancelReason": 1,
+    "countryCode": "US",
+    "developerPayload": null,
+    "expiryTimeMillis": 1659609760161,
+    "formOfPayment": "GOOGLE_PLAY",
+    "isMutable": true,
+    "kind": "androidpublisher#subscriptionPurchase",
+    "orderId": "GPA.3349-0308-2630-54525..5",
+    "packageName": "org.mozilla.firefox.vpn",
+    "paymentState": 1,
+    "priceAmountMicros": 9990000,
+    "priceCurrencyCode": "USD",
+    "purchaseToken": "some_purchase_token",
+    "purchaseType": 0,
+    "replacedByAnotherPurchase": false,
+    "sku": "examplesku",
+    "skuType": "subs",
+    "startTimeMillis": 1659607657566,
+    "userId": "REPLACED_BY_SCRIPT",
+    "verifiedAt": 1662249663096
+  }]
+}


### PR DESCRIPTION
## Because

* It's hard to test IAP locally since the emulator resets every time you restart local services

## This pull request

* Adds a util for easily creating IAP subscriptions locally

## Issue that this pull request solves

Closes FXA-5381

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
