### PR TITLE
chore(payments): remove plan info and update PaymentConsentCheckbox copy

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -142,30 +142,7 @@ payment-cvc =
 payment-zip =
   .label = ZIP code
 
-##  $amount (Number) - The amount billed. It will be formatted as currency.
-
-# $intervalCount (Number) - The interval between payments, in days.
-payment-confirm-with-legal-links-day = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-}
-# $intervalCount (Number) - The interval between payments, in weeks.
-payment-confirm-with-legal-links-week = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-}
-# $intervalCount (Number) - The interval between payments, in months.
-payment-confirm-with-legal-links-month = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-}
-# $intervalCount (Number) - The interval between payments, in years.
-payment-confirm-with-legal-links-year = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
-}
-
-##
+payment-confirm-with-legal-links-static = I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method for the amount shown, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 
 payment-cancel-btn = Cancel
 payment-update-btn = Update

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
@@ -1,19 +1,13 @@
-import React from 'react';
-import TestRenderer from 'react-test-renderer';
-import { render, cleanup, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { Plan } from '../../store/types';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
 
-import {
-  MOCK_PLANS,
-  setupFluentLocalizationTest,
-  getLocalizedMessage,
-} from '../../lib/test-utils';
-
-import { getLocalizedCurrency } from '../../lib/formats';
-import { PaymentConsentCheckbox } from './index';
+import { PaymentConsentCheckbox } from '.';
+import { MOCK_PLANS } from '../../lib/test-utils';
 import useValidatorState from '../../lib/validator';
+import { Plan } from '../../store/types';
 import { Form } from '../fields';
 
 jest.mock('../../lib/sentry');
@@ -77,217 +71,36 @@ describe('components/PaymentConsentCheckbox', () => {
         const testRenderer = TestRenderer.create(<WrapCheckbox {...props} />);
         const testInstance = testRenderer.root;
         const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
-        const expectedAmount = getLocalizedCurrency(plan.amount, plan.currency);
-
-        expect(legalCheckbox.props.vars.amount).toStrictEqual(expectedAmount);
-        expect(legalCheckbox.props.vars.intervalCount).toBe(
-          plan.interval_count
-        );
 
         expect(legalCheckbox.props.children.props.children[0]).toBe(
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method '
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to'
         );
-        expect(
-          legalCheckbox.props.children.props.children[1].props.children
-        ).toMatch(
-          /\$\d+[.]\d{2}[ ][daily|every 6 days|weekly|every 6 weeks|monthly|every 6 months|yearly|every 6 years]/
-        );
-        expect(legalCheckbox.props.children.props.children[2]).toBe(
-          ', according to'
-        );
-        expect(legalCheckbox.props.children.props.children[3]).toBe(' ');
-        expect(legalCheckbox.props.children.props.children[4].props.href).toBe(
+        expect(legalCheckbox.props.children.props.children[1]).toBe(' ');
+        expect(legalCheckbox.props.children.props.children[2].props.href).toBe(
           'https://www.mozilla.org/about/legal/terms/firefox-private-network'
         );
         expect(
-          legalCheckbox.props.children.props.children[4].props.children
+          legalCheckbox.props.children.props.children[2].props.children
         ).toBe('Terms of Service');
-        expect(legalCheckbox.props.children.props.children[5]).toBe(' and');
-        expect(legalCheckbox.props.children.props.children[6]).toBe(' ');
-        expect(legalCheckbox.props.children.props.children[7].props.href).toBe(
+        expect(legalCheckbox.props.children.props.children[3]).toBe(' and');
+        expect(legalCheckbox.props.children.props.children[4]).toBe(' ');
+        expect(legalCheckbox.props.children.props.children[5].props.href).toBe(
           'https://www.mozilla.org/privacy/firefox-private-network'
         );
         expect(
-          legalCheckbox.props.children.props.children[7].props.children
+          legalCheckbox.props.children.props.children[5].props.children
         ).toBe('Privacy Notice');
-        expect(legalCheckbox.props.children.props.children[8]).toBe(
+        expect(legalCheckbox.props.children.props.children[6]).toBe(
           ', until I cancel my subscription.'
         );
       }
 
-      it('renders Localized for daily plan with correct props and displays correct default string', async () => {
+      it('renders Localized for a plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_daily';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-day';
+        const expectedMsgId = 'payment-confirm-with-legal-links-static';
 
         runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for 6 days plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_6days';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-day';
-
-        runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for weekly plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_weekly';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-week';
-
-        runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for 6 weeks plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_6weeks';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-week';
-
-        runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for monthly plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_monthly';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-month';
-
-        runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for 6 months plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_6months';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-month';
-
-        runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for yearly plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_yearly';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-year';
-
-        runTests(plan, expectedMsgId);
-      });
-
-      it('renders Localized for years plan with correct props and displays correct default string', async () => {
-        const plan_id = 'plan_6years';
-        const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-year';
-
-        runTests(plan, expectedMsgId);
-      });
-    });
-
-    describe('Fluent Localized Text', () => {
-      const bundle = setupFluentLocalizationTest('en-US');
-      const amount = getLocalizedCurrency(500, 'USD');
-      const args = {
-        amount,
-      };
-
-      describe('when the localized id is payment-confirm-with-legal-links-day', () => {
-        const msgId = 'payment-confirm-with-legal-links-day';
-
-        it('returns the correct string for an interval count of 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 1,
-          });
-          expect(actual).toEqual(expected);
-        });
-
-        it('returns the correct string for an interval count greater than 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 6,
-          });
-          expect(actual).toEqual(expected);
-        });
-      });
-
-      describe('when the localized id is payment-confirm-with-legal-links-week', () => {
-        const msgId = 'payment-confirm-with-legal-links-week';
-
-        it('returns the correct string for an interval count of 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 1,
-          });
-          expect(actual).toEqual(expected);
-        });
-
-        it('returns the correct string for an interval count greater than 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 6,
-          });
-          expect(actual).toEqual(expected);
-        });
-      });
-
-      describe('when the localized id is payment-confirm-with-legal-links-month', () => {
-        const msgId = 'payment-confirm-with-legal-links-month';
-
-        it('returns the correct string for an interval count of 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 1,
-          });
-          expect(actual).toEqual(expected);
-        });
-
-        it('returns the correct string for an interval count greater than 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 6,
-          });
-          expect(actual).toEqual(expected);
-        });
-      });
-
-      describe('when the localized id is payment-confirm-with-legal-links-year', () => {
-        const msgId = 'payment-confirm-with-legal-links-year';
-
-        it('returns the correct string for an interval count of 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 1,
-          });
-          expect(actual).toEqual(expected);
-        });
-
-        it('returns the correct string for an interval count greater than 1', () => {
-          const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
-
-          const actual = getLocalizedMessage(bundle, msgId, {
-            ...args,
-            intervalCount: 6,
-          });
-          expect(actual).toEqual(expected);
-        });
       });
     });
   });

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
-import { Checkbox } from '../fields';
-import { Plan } from '../../store/types';
-import { formatPlanPricing, getLocalizedCurrency } from '../../lib/formats';
-import { urlsFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
-import AppContext from '../../lib/AppContext';
 import { Localized } from '@fluent/react';
+import { urlsFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
+import React, { useContext } from 'react';
+
+import AppContext from '../../lib/AppContext';
+import { Plan } from '../../store/types';
+import { Checkbox } from '../fields';
 
 export type PaymentConsentCheckboxProps = {
   plan: Plan;
@@ -23,29 +23,17 @@ export const PaymentConsentCheckbox = ({
     config.featureFlags.useFirestoreProductConfigs
   );
 
-  const planPricing = formatPlanPricing(
-    plan.amount,
-    plan.currency,
-    plan.interval,
-    plan.interval_count
-  );
-
   return (
     <Localized
-      id={`payment-confirm-with-legal-links-${plan.interval}`}
-      vars={{
-        intervalCount: plan.interval_count,
-        amount: getLocalizedCurrency(plan.amount, plan.currency),
-      }}
+      id="payment-confirm-with-legal-links-static"
       elems={{
-        strong: <strong></strong>,
         termsOfServiceLink: <a href={termsOfService}>Terms of Service</a>,
         privacyNoticeLink: <a href={privacyNotice}>Privacy Notice</a>,
       }}
     >
       <Checkbox name="confirm" data-testid="confirm" onClick={onClick} required>
         I authorize Mozilla, maker of Firefox products, to charge my payment
-        method <strong>{planPricing}</strong>, according to{' '}
+        method for the amount shown, according to{' '}
         <a href={termsOfService}>Terms of Service</a> and{' '}
         <a href={privacyNotice}>Privacy Notice</a>, until I cancel my
         subscription.

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { cleanup, fireEvent, render, act } from '@testing-library/react';
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
 import { PaymentMethodHeader, PaymentMethodHeaderType } from '.';
 import {
   getLocalizedMessage,
@@ -94,7 +96,7 @@ describe('components/PaymentMethodHeader', () => {
         MOCK_PLANS.find((p) => p.plan_id === 'plan_daily') || MOCK_PLANS[0];
       const props = { plan, onClick: () => {} };
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method $5.00 daily, according to Terms of Service and Privacy Notice, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to Terms of Service and Privacy Notice, until I cancel my subscription.';
 
       const { findByTestId } = render(<PaymentMethodHeader {...props} />);
 


### PR DESCRIPTION
Because:

* Displaying the correct, localized amount and interval in more than one place is a source of discrepancies.
* This information is already shown in the PlanDetails component.

This commit:

* Removes localized amount and interval from the PaymentConsentCheckbox copy and updates the copy to reference the information in the PlanDetails component.

Closes #FXA-6049

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).