### PR TITLE
feat(auth): add tax via ip for new stripe subscriptions

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -371,7 +371,8 @@ export class StripeHelper extends StripeHelperBase {
     uid: string,
     email: string,
     displayName: string,
-    idempotencyKey: string
+    idempotencyKey: string,
+    ipAddress?: string
   ): Promise<Stripe.Customer> {
     const stripeCustomer = await this.stripe.customers.create(
       {
@@ -379,6 +380,7 @@ export class StripeHelper extends StripeHelperBase {
         name: displayName,
         description: uid,
         metadata: { userid: uid },
+        ...{ tax: { ip_address: ipAddress } },
       },
       {
         idempotency_key: idempotencyKey,
@@ -1614,7 +1616,11 @@ export class StripeHelper extends StripeHelperBase {
    */
   async fetchCustomer(
     uid: string,
-    expand?: ('subscriptions' | 'invoice_settings.default_payment_method')[]
+    expand?: (
+      | 'subscriptions'
+      | 'invoice_settings.default_payment_method'
+      | 'tax'
+    )[]
   ): Promise<Stripe.Customer | void> {
     try {
       return await super.fetchCustomer(uid, expand);

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -48,7 +48,10 @@ describe('PaypalProcessor', () => {
   beforeEach(() => {
     mockConfig = {
       currenciesToCountries: { ZAR: ['AS', 'CA'] },
-      subscriptions: { paypalNvpSigCredentials: { enabled: false } },
+      subscriptions: {
+        paypalNvpSigCredentials: { enabled: false },
+        stripeAutomaticTax: { enabled: false },
+      },
     };
     mockStripeHelper = {};
     mockPaypalHelper = {};

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -347,6 +347,38 @@ describe('StripeHelper', () => {
       );
     });
 
+    it('creates a customer using the stripe api with an ipaddress', async () => {
+      const expected = deepCopy(newCustomerPM);
+      sandbox.stub(stripeHelper.stripe.customers, 'create').resolves(expected);
+      stripeFirestore.insertCustomerRecord = sandbox.stub().resolves({});
+      const uid = chance.guid({ version: 4 }).replace(/-/g, '');
+      const idempotencyKey = uuidv4();
+      const actual = await stripeHelper.createPlainCustomer(
+        uid,
+        'joe@example.com',
+        'Joe Cool',
+        idempotencyKey,
+        '127.0.0.1'
+      );
+      assert.deepEqual(actual, expected);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.customers.create,
+        {
+          email: 'joe@example.com',
+          name: 'Joe Cool',
+          description: uid,
+          metadata: { userid: uid },
+          tax: { ip_address: '127.0.0.1' },
+        },
+        { idempotency_key: idempotencyKey }
+      );
+      sinon.assert.calledWithExactly(
+        stripeHelper.stripeFirestore.insertCustomerRecord,
+        uid,
+        expected
+      );
+    });
+
     it('surfaces stripe errors', async () => {
       const apiError = new stripeError.StripeAPIError();
       sandbox.stub(stripeHelper.stripe.customers, 'create').rejects(apiError);
@@ -3882,6 +3914,28 @@ describe('StripeHelper', () => {
 
       // reset for tests:
       existingCustomer = await createAccountCustomer(existingUid, customer1.id);
+    });
+
+    it('expands the tax information if present', async () => {
+      const customer = deepCopy(customer1);
+      const customerSecond = deepCopy(customer1);
+      customerSecond.tax = {
+        location: { country: 'US', state: 'CA', source: 'billing_address' },
+        ip_address: null,
+        automatic_tax: 'supported',
+      };
+      sandbox.stub(stripeHelper, 'expandResource').returns(customer);
+      sandbox
+        .stub(stripeHelper.stripe.customers, 'retrieve')
+        .resolves(customerSecond);
+      const result = await stripeHelper.fetchCustomer(existingCustomer.uid, [
+        'tax',
+      ]);
+      const customerResult = {
+        ...customer,
+        tax: customerSecond.tax,
+      };
+      assert.deepEqual(result, customerResult);
     });
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -60,6 +60,7 @@ describe('PayPalNotificationHandler', () => {
       subscriptions: {
         enabled: true,
         stripeApiKey: 'sk_test_1234',
+        stripeAutomaticTax: { enabled: false },
         paypalNvpSigCredentials: {
           enabled: false,
         },

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -110,6 +110,7 @@ describe('subscriptions payPalRoutes', () => {
         paypalNvpSigCredentials: {
           enabled: true,
         },
+        stripeAutomaticTax: { enabled: false },
       },
       currenciesToCountries: {
         USD: ['US', 'CA', 'GB'],

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -89,6 +89,7 @@ describe('StripeWebhookHandler', () => {
         managementClientId: MOCK_CLIENT_ID,
         managementTokenTTL: MOCK_TTL,
         stripeApiKey: 'sk_test_1234',
+        stripeAutomaticTax: { enabled: false },
         paypalNvpSigCredentials: {
           enabled: true,
         },

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -199,6 +199,7 @@ describe('subscriptions stripeRoutes', () => {
         managementClientId: MOCK_CLIENT_ID,
         managementTokenTTL: MOCK_TTL,
         stripeApiKey: 'sk_test_1234',
+        stripeAutomaticTax: { enabled: false },
         paypalNvpSigCredentials: {
           enabled: false,
         },
@@ -415,6 +416,7 @@ describe('DirectStripeRoutes', () => {
     },
     app: {
       devices: ['deviceId1', 'deviceId2'],
+      clientAddress: '127.0.0.1',
     },
   };
 
@@ -427,6 +429,7 @@ describe('DirectStripeRoutes', () => {
         managementClientId: MOCK_CLIENT_ID,
         managementTokenTTL: MOCK_TTL,
         stripeApiKey: 'sk_test_1234',
+        stripeAutomaticTax: { enabled: false },
         productConfigsFirestore: { enabled: false },
       },
     };
@@ -617,7 +620,34 @@ describe('DirectStripeRoutes', () => {
       const actual = await directStripeRoutesInstance.createCustomer(
         VALID_REQUEST
       );
+      const callArgs =
+        directStripeRoutesInstance.stripeHelper.createPlainCustomer.getCall(
+          0
+        ).args;
+      assert.equal(callArgs[4], undefined);
 
+      assert.deepEqual(filterCustomer(expected), actual);
+    });
+
+    it('creates a stripe customer with the ip address on automatic tax', async () => {
+      const expected = deepCopy(emptyCustomer);
+      directStripeRoutesInstance.stripeHelper.createPlainCustomer.resolves(
+        expected
+      );
+      directStripeRoutesInstance.automaticTax = true;
+      VALID_REQUEST.payload = {
+        displayName: 'Jane Doe',
+        idempotencyKey: uuidv4(),
+      };
+
+      const actual = await directStripeRoutesInstance.createCustomer(
+        VALID_REQUEST
+      );
+      const callArgs =
+        directStripeRoutesInstance.stripeHelper.createPlainCustomer.getCall(
+          0
+        ).args;
+      assert.equal(callArgs[4], '127.0.0.1');
       assert.deepEqual(filterCustomer(expected), actual);
     });
   });
@@ -794,7 +824,7 @@ describe('DirectStripeRoutes', () => {
   });
 
   describe('createSubscriptionWithPMI', () => {
-    let plan, paymentMethod;
+    let plan, paymentMethod, customer;
 
     beforeEach(() => {
       plan = deepCopy(PLANS[2]);
@@ -805,7 +835,7 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
         paymentMethod
       );
-      const customer = deepCopy(emptyCustomer);
+      customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(customer);
       directStripeRoutesInstance.stripeHelper.findCustomerSubscriptionByPlanId.returns(
         undefined
@@ -813,7 +843,7 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.setCustomerLocation.resolves();
     });
 
-    it('creates a subscription with a payment method', async () => {
+    function setupCreateSuccessWithTaxIds() {
       const sourceCountry = 'US';
       directStripeRoutesInstance.stripeHelper.extractSourceCountryFromSubscription.returns(
         sourceCountry
@@ -829,11 +859,10 @@ describe('DirectStripeRoutes', () => {
         paymentMethodId: 'pm_asdf',
         idempotencyKey: uuidv4(),
       };
+      return { sourceCountry, expected };
+    }
 
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
-
+    function assertSuccessWithTaxIds(sourceCountry, actual, expected) {
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.getPaymentMethod,
         VALID_REQUEST.payload.paymentMethodId
@@ -870,48 +899,30 @@ describe('DirectStripeRoutes', () => {
         },
         actual
       );
-    });
+    }
 
-    it('creates a subscription with a payment method and promotion code', async () => {
-      const sourceCountry = 'us';
-      directStripeRoutesInstance.stripeHelper.extractSourceCountryFromSubscription.returns(
-        sourceCountry
+    function assertSuccessWithAutomaticTax(sourceCountry, actual, expected) {
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.stripeHelper.getPaymentMethod,
+        VALID_REQUEST.payload.paymentMethodId
       );
-      const expected = deepCopy(subscription2);
-      directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI.resolves(
-        expected
-      );
-      directStripeRoutesInstance.stripeHelper.customerTaxId.returns(false);
-      directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer.resolves({});
-      directStripeRoutesInstance.extractPromotionCode = sinon.stub().resolves({
-        coupon: { id: 'couponId' },
-      });
-      VALID_REQUEST.payload = {
-        priceId: 'Jane Doe',
-        paymentMethodId: 'pm_asdf',
-        promotionCode: 'promotionCode',
-        idempotencyKey: uuidv4(),
-      };
-
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
-
       sinon.assert.calledWith(
         directStripeRoutesInstance.customerChanged,
         VALID_REQUEST,
         UID,
         TEST_EMAIL
       );
-      sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.stripeHelper.taxRateByCountryCode,
-        'US'
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.taxRateByCountryCode
       );
-      sinon.assert.calledOnce(
+      sinon.assert.notCalled(
         directStripeRoutesInstance.stripeHelper.customerTaxId
       );
-      sinon.assert.calledOnce(
+      sinon.assert.notCalled(
         directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer
+      );
+      sinon.assert.notCalled(
+        directStripeRoutesInstance.stripeHelper.setCustomerLocation
       );
 
       assert.deepEqual(
@@ -921,6 +932,25 @@ describe('DirectStripeRoutes', () => {
         },
         actual
       );
+    }
+
+    it('creates a subscription with a payment method', async () => {
+      const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
+      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
+        VALID_REQUEST
+      );
+      assertSuccessWithTaxIds(sourceCountry, actual, expected);
+    });
+
+    it('creates a subscription with a payment method and promotion code', async () => {
+      const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
+      directStripeRoutesInstance.extractPromotionCode = sinon.stub().resolves({
+        coupon: { id: 'couponId' },
+      });
+      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
+        VALID_REQUEST
+      );
+      assertSuccessWithTaxIds(sourceCountry, actual, expected);
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {
@@ -931,6 +961,50 @@ describe('DirectStripeRoutes', () => {
             coupon: { id: 'couponId' },
           },
           taxRateId: undefined,
+        }
+      );
+    });
+
+    it('creates a subscription with a payment method using automatic tax', async () => {
+      const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
+      customer.tax = {
+        automatic_tax: 'supported',
+      };
+      directStripeRoutesInstance.automaticTax = true;
+      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
+        VALID_REQUEST
+      );
+      assertSuccessWithAutomaticTax(sourceCountry, actual, expected);
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
+        {
+          customerId: 'cus_new',
+          priceId: 'Jane Doe',
+          paymentMethodId: 'pm_asdf',
+          promotionCode: undefined,
+          automatic_tax: true,
+        }
+      );
+    });
+
+    it('creates a subscription with a payment method using automatic tax but in an unsupported region', async () => {
+      const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
+      customer.tax = {
+        automatic_tax: 'unrecognized_location',
+      };
+      directStripeRoutesInstance.automaticTax = true;
+      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
+        VALID_REQUEST
+      );
+      assertSuccessWithAutomaticTax(sourceCountry, actual, expected);
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
+        {
+          customerId: 'cus_new',
+          priceId: 'Jane Doe',
+          paymentMethodId: 'pm_asdf',
+          promotionCode: undefined,
+          automatic_tax: false,
         }
       );
     });
@@ -1113,6 +1187,7 @@ describe('DirectStripeRoutes', () => {
           managementClientId: MOCK_CLIENT_ID,
           managementTokenTTL: MOCK_TTL,
           stripeApiKey: 'sk_test_1234',
+          stripeAutomaticTax: { enabled: false },
         },
       };
 

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -25,6 +25,7 @@ describe('remote account create', function () {
     config.subscriptions = {
       enabled: true,
       stripeApiKey: 'fake_key',
+      stripeAutomaticTax: { enabled: false },
       paypalNvpSigCredentials: {
         enabled: false,
       },

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -40,6 +40,7 @@ describe('remote subscriptions:', function () {
     config.subscriptions = {
       sharedSecret: 'wibble',
       paymentsServer: config.subscriptions.paymentsServer,
+      stripeAutomaticTax: { enabled: false },
     };
   });
 


### PR DESCRIPTION
Because:

* We want to switch to Stripe Tax calculations for taxing new
  Stripe subscriptions.

This commit:

* Adds the IP for Stripe Tax to calculate appropriate tax for further
  subscriptions and enables it for a new Stripe subscription if the
  user is in a taxable location.

Closes: FXA-5649

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
