### PR TITLE
chore(l10n): reduce redundant gettext review requests

### DIFF
--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -62,9 +62,25 @@ jobs:
           then
             echo "No changes found."
           else
-            # Add mozilla/fxa-l10n as reviewer for pull request if .pot file changes
-            echo "New changes found, adding reviewer."
-            gh pr edit $PR_NUMBER --add-reviewer mozilla/fxa-l10n
+            gh pr view $PR_NUMBER --json reviewRequests | jq -r ".reviewRequests[].name" | grep -q "fxa-l10n"
+            if [ $? -ne 0 ]; then
+                # Check if someone from the Localization Team already reviewed the PR.
+                # Get the list of fxa-l10n reviewers, excluding non-l10n members
+                L10N_REVIEWERS=$(gh api -H "Accept: application/vnd.github+json" /orgs/mozilla/teams/fxa-l10n/members | jq -r '(.[].login | select(. != "clouserw"))' | sort)
+                # Get the list of reviewers who already approved the pull request
+                PR_REVIEWERS=$(gh pr view $PR_NUMBER --json reviews | jq -r '.reviews[] | select(.state=="APPROVED") | .author.login' | sort)
+                # Check intersection of the two lists
+                L10N_APPROVERS=$(comm -12 <(echo "$L10N_REVIEWERS") <(echo "$PR_REVIEWERS"))
+                if [ -z "$L10N_APPROVERS" ]; then
+                    # Add mozilla/fxa-l10n as reviewer
+                    echo "New changes found, adding reviewer."
+                    gh pr edit $PR_NUMBER --add-reviewer mozilla/fxa-l10n
+                else
+                    echo "PR already reviewed by the localization team, skip adding reviewer."
+                fi
+            else
+                echo "fxa-l10n already added, skip adding reviewer."
+            fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.L10N_BUILDCHECK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Because

- Reviewer requests will be issued to fxa-l10n team every time a pull request is updated (for PRs where new gettext strings are found).

## This pull request

- Adds some additional checks (Is fxa-l10n already assigned as reviewer?, Has someone from l10n team already approved this PR?). This reduces the amount of times fxa-l10n is issued a request for review.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
