### PR TITLE
fix(sentry): Don't report to sentry when user disables metrics

### DIFF
--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { render } from 'react-dom';
 import AppErrorBoundary from 'fxa-react/components/AppErrorBoundary';
-import sentryMetrics from 'fxa-shared/lib/sentry';
 import {
   getTracingHeadersFromDocument,
   init as initTracing,
@@ -38,13 +37,6 @@ try {
   );
 
   const appContext = initializeAppContext();
-
-  sentryMetrics.configure({
-    release: config.version,
-    sentry: {
-      ...config.sentry,
-    },
-  });
 
   render(
     <React.StrictMode>

--- a/packages/fxa-shared/lib/sentry.ts
+++ b/packages/fxa-shared/lib/sentry.ts
@@ -11,6 +11,7 @@ import { options } from 'superagent';
 // https://stackoverflow.com/questions/35240469/how-to-mock-the-imports-of-an-es6-module
 export const _Sentry = {
   captureException: Sentry.captureException,
+  close: Sentry.close,
 };
 
 const ALLOWED_QUERY_PARAMETERS = [
@@ -108,6 +109,7 @@ interface SentryMetrics {
   _logger: Logger;
   configure: (config: SentryConfigOpts) => void;
   captureException: (arg0: Error) => void;
+  disable: () => void;
   __beforeSend: (arg0: Sentry.Event) => Sentry.Event;
   __cleanUpQueryParam: (arg0: string) => string;
 }
@@ -180,6 +182,14 @@ SentryMetrics.prototype = {
       });
       _Sentry.captureException(err);
     });
+  },
+
+  /**
+   * Disables the current Sentry client. A timeout of 0 is used otherwise Sentry
+   * would try to flush any pending metrics.
+   */
+  disable() {
+    return _Sentry.close(0);
   },
 
   // Private functions, exposed for testing

--- a/packages/fxa-shared/test/lib/sentry.ts
+++ b/packages/fxa-shared/test/lib/sentry.ts
@@ -205,4 +205,13 @@ describe('lib/sentry', () => {
       sentryCaptureException.restore();
     });
   });
+
+  describe('disable', () => {
+    it('calls Sentry.close', () => {
+      const close = sinon.stub(_Sentry, 'close');
+      sentryMetrics.disable();
+      sinon.assert.calledOnce(close);
+      close.restore();
+    });
+  });
 });


### PR DESCRIPTION
## Because

- When a user opts out of metrics they also want to opt out of telemetry

## This pull request

- Disables/Enables sentry based on the user's metrics preferences

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5475

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that Sentry is disabled in the settings app because in our login pages we don't know their metrics status until after they log in.
