### PR TITLE
bug(auth): Fix typo in function name

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -218,7 +218,7 @@ module.exports = function (
           // Hapi's auto instrumentation inherits from the parent context and therefore
           // will get this.
 
-          return tracing.suppressTracing(() => {
+          return tracing.suppressTrace(() => {
             return fn(request);
           });
         }

--- a/packages/fxa-shared/tracing/node-tracing.ts
+++ b/packages/fxa-shared/tracing/node-tracing.ts
@@ -147,6 +147,7 @@ export function isInitialized() {
   return !!nodeTracing;
 }
 
+/** Suppresses trace capture on the current context */
 export function suppressTrace(action: () => any) {
   const currentCtx = api.context.active();
   return api.context.with(suppressTracing(currentCtx), action);


### PR DESCRIPTION
## Because

- We broke the 'suppressTracing' tracing call during a refactor

## This pull request

- Renames the call in fxa-auth from suppressTracing to suppressTrace.

## Issue that this pull request solves

Closes: FXA-6065

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

