### PR TITLE
fix(auth): test for proper mysql response

### DIFF
--- a/_scripts/mysql.sh
+++ b/_scripts/mysql.sh
@@ -22,7 +22,7 @@ docker run --rm --name=mydb \
   -e MYSQL_ROOT_HOST=% \
   -e MYSQL_DATABASE=pushbox \
   -p 3306:3306 \
-  mysql/mysql-server:8.0.30 --default-authentication-plugin=mysql_native_password &
+  mysql/mysql-server:8.0.28 --default-authentication-plugin=mysql_native_password &
 
 cd "$DIR"
 ./check-mysql.sh


### PR DESCRIPTION
Because:

* We updated the local mysql to a version that doesn't pass auth-server tests.

This commit:

* Bumps the mysql version and updates the test to pass.

Closes #FXA-6068.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
