### PR TITLE
fix(auth): use relative import on fxa-auth-server modules

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -42,7 +42,7 @@ import { COUNTRIES_LONG_NAME_TO_SHORT_NAME_MAP } from '../../payments/stripe';
 import { deleteAccountIfUnverified } from '../utils/account';
 import SUBSCRIPTIONS_DOCS from '../../../docs/swagger/subscriptions-api';
 import { ALL_RPS_CAPABILITIES_KEY } from 'fxa-shared/subscriptions/configuration/base';
-import { CapabilityService } from 'fxa-auth-server/lib/payments/capability';
+import { CapabilityService } from '../../payments/capability';
 import Container from 'typedi';
 
 // List of countries for which we need to look up the province/state of the


### PR DESCRIPTION
Because:

* There's some discrepancy in how imports work between local and stage (FXA-6051).

This commit:

* Fixes the immediate error (long term fix is in FXA-6051).

Closes #FXA-6070

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).