### PR TITLE
refactor(storybook): Reformat 'Profile' stories to new SB format, add/update mocks

### DIFF
--- a/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
@@ -17,7 +17,6 @@ import { AppContext } from 'fxa-settings/src/models';
 import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 import { Meta } from '@storybook/react';
 
-
 const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
 export default {
@@ -45,18 +44,15 @@ const partiallyFilledOutAccount = {
 const completelyFilledOutAccount = {
   ...MOCK_ACCOUNT,
   subscriptions: [{ created: 1, productName: 'x' }],
-  emails: [
-    mockEmail('johndope@example.com'),
-    mockEmail('johndope2@gmail.com', false),
-  ],
+  emails: [mockEmail(), mockEmail('johndope2@gmail.com', false)],
   attachedClients: SERVICES_NON_MOBILE,
   linkedAccounts: MOCK_LINKED_ACCOUNTS,
-}
+};
 
 const storyWithContext = (
   account: Partial<Account>,
   storyName?: string,
-  config?: Config,
+  config?: Config
 ) => {
   const context = config
     ? { account: account as Account, config: config }
@@ -66,7 +62,7 @@ const storyWithContext = (
     <LocationProvider>
       <AppContext.Provider value={mockAppContext(context)}>
         <AppLayout>
-          <PageSettings/>
+          <PageSettings />
         </AppLayout>
       </AppContext.Provider>
     </LocationProvider>
@@ -75,17 +71,14 @@ const storyWithContext = (
   return story;
 };
 
-export const ColdStart = storyWithContext(
-  coldStartAccount,
-  'cold start',
-);
+export const ColdStart = storyWithContext(coldStartAccount, 'cold start');
 
 export const PartiallyFilledOut = storyWithContext(
   partiallyFilledOutAccount,
-  'partially filled out',
+  'partially filled out'
 );
 
 export const CompletelyFilledOut = storyWithContext(
   completelyFilledOutAccount,
-  'completely filled out',
+  'completely filled out'
 );

--- a/packages/fxa-settings/src/components/Profile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.stories.tsx
@@ -3,10 +3,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { LocationProvider } from '@reach/router';
 import { Profile } from '.';
+import { Account, AppContext } from '../../models';
+import { mockAppContext } from '../../models/mocks';
+import {
+  MOCK_PROFILE_EMPTY,
+  MOCK_PROFILE_UNCONFIRMED_FEATURES,
+  MOCK_PROFILE_ALL,
+} from './mocks';
+import { Meta } from '@storybook/react';
+import { LocationProvider } from '@reach/router';
 
-storiesOf('Components/Profile', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => <Profile />);
+export default {
+  title: 'components/Profile',
+  component: Profile,
+} as Meta;
+
+const storyWithContext = (account: Account, storyName?: string) => {
+  const story = () => (
+    <LocationProvider>
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <Profile />
+      </AppContext.Provider>
+    </LocationProvider>
+  );
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const FreshAccount = storyWithContext(MOCK_PROFILE_EMPTY);
+export const UnconfirmedFeatures = storyWithContext(
+  MOCK_PROFILE_UNCONFIRMED_FEATURES
+);
+export const CompletelyFilledOut = storyWithContext(MOCK_PROFILE_ALL);

--- a/packages/fxa-settings/src/components/Profile/mocks.tsx
+++ b/packages/fxa-settings/src/components/Profile/mocks.tsx
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Account } from '../../models';
+import { mockEmail } from '../../models/mocks';
+
+export const MOCK_PROFILE_EMPTY = {
+  displayName: null,
+  avatar: { id: null, url: null },
+  primaryEmail: mockEmail(),
+  emails: [mockEmail()],
+} as unknown as Account;
+
+export const MOCK_PROFILE_UNCONFIRMED_FEATURES = {
+  ...MOCK_PROFILE_EMPTY,
+  emails: [mockEmail(), mockEmail('johndope2@example.com', false, false)],
+} as unknown as Account;
+
+export const MOCK_PROFILE_ALL = {
+  displayName: 'John Dope',
+  avatar: { id: 'abc123', url: 'http://placekitten.com/512/512' },
+  primaryEmail: mockEmail(),
+  emails: [mockEmail(), mockEmail('johndope2@example.com', false)],
+} as unknown as Account;

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
@@ -15,7 +15,7 @@ storiesOf('Components/UnitRowSecondaryEmail', module)
   .add('No secondary email set', () => <UnitRowSecondaryEmail />)
   .add('One secondary email set, unverified', () => {
     const emails = [
-      mockEmail('johndope@example.com'),
+      mockEmail(),
       mockEmail('johndope2@example.com', false, false),
     ];
     return (
@@ -27,10 +27,7 @@ storiesOf('Components/UnitRowSecondaryEmail', module)
     );
   })
   .add('One secondary email set, verified', () => {
-    const emails = [
-      mockEmail('johndope@example.com'),
-      mockEmail('johndope2@example.com', false),
-    ];
+    const emails = [mockEmail(), mockEmail('johndope2@example.com', false)];
     return (
       <AppContext.Provider
         value={mockAppContext({ account: { emails } as any })}
@@ -41,7 +38,7 @@ storiesOf('Components/UnitRowSecondaryEmail', module)
   })
   .add('Multiple secondary emails set, all verified', () => {
     const emails = [
-      mockEmail('johndope@example.com'),
+      mockEmail(),
       mockEmail('johndope2@example.com', false),
       mockEmail('johndope3@example.com', false),
       mockEmail('johndope4@example.com', false),
@@ -56,7 +53,7 @@ storiesOf('Components/UnitRowSecondaryEmail', module)
   })
   .add('Multiple secondary emails set, one unverified', () => {
     const emails = [
-      mockEmail('johndope@example.com'),
+      mockEmail(),
       mockEmail('johndope2@example.com', false),
       mockEmail('johndope3@example.com', false, false),
       mockEmail('johndope4@example.com', false),
@@ -71,7 +68,7 @@ storiesOf('Components/UnitRowSecondaryEmail', module)
   })
   .add('Multiple secondary emails set, multiple unverified', () => {
     const emails = [
-      mockEmail('johndope@example.com'),
+      mockEmail(),
       mockEmail('johndope2@example.com', false),
       mockEmail('johndope3@example.com', false, false),
       mockEmail('johndope4@example.com', false, false),

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.test.tsx
@@ -14,10 +14,7 @@ import { UnitRowSecondaryEmail } from '.';
 import { Account, AppContext } from '../../models';
 
 const account = {
-  emails: [
-    mockEmail('johndope@example.com'),
-    mockEmail('johndope2@example.com', false, false),
-  ],
+  emails: [mockEmail(), mockEmail('johndope2@example.com', false, false)],
   resendEmailCode: jest.fn().mockResolvedValue(true),
   makeEmailPrimary: jest.fn().mockResolvedValue(true),
   deleteSecondaryEmail: jest.fn().mockResolvedValue(true),
@@ -35,7 +32,7 @@ describe('UnitRowSecondaryEmail', () => {
   describe('no secondary email set', () => {
     it('renders as expected', () => {
       const account = {
-        emails: [mockEmail('johndope@example.com')],
+        emails: [mockEmail()],
       } as unknown as Account;
       renderWithRouter(
         <AppContext.Provider value={mockAppContext({ account })}>
@@ -86,10 +83,7 @@ describe('UnitRowSecondaryEmail', () => {
 
     it('renders as expected when verified', () => {
       const account = {
-        emails: [
-          mockEmail('johndope@example.com'),
-          mockEmail('johndope2@example.com', false),
-        ],
+        emails: [mockEmail(), mockEmail('johndope2@example.com', false)],
       } as unknown as Account;
       renderWithRouter(
         <AppContext.Provider value={mockAppContext({ account })}>
@@ -132,7 +126,7 @@ describe('UnitRowSecondaryEmail', () => {
   describe('multiple secondary emails set', () => {
     it('renders as expected and with verified email text only present on the last verified', () => {
       const emails = [
-        mockEmail('johndope@example.com'),
+        mockEmail(),
         mockEmail('johndope2@example.com', false),
         mockEmail('johndope3@example.com', false),
         mockEmail('johndope4@example.com', false),
@@ -170,7 +164,7 @@ describe('UnitRowSecondaryEmail', () => {
 
     it('renders multiple unverified as expected', () => {
       const emails = [
-        mockEmail('johndope@example.com'),
+        mockEmail(),
         mockEmail('johndope2@example.com', false, false),
         mockEmail('johndope3@example.com', false),
         mockEmail('johndope4@example.com', false, false),
@@ -230,7 +224,7 @@ describe('UnitRowSecondaryEmail', () => {
 
     it('displays an error message in the AlertBar', async () => {
       const emails = [
-        mockEmail('johndope@example.com'),
+        mockEmail(),
         mockEmail('johndope2@example.com', false, false),
       ];
       const account = {
@@ -281,7 +275,7 @@ describe('UnitRowSecondaryEmail', () => {
 
     it('displays an error message in the AlertBar', async () => {
       const emails = [
-        mockEmail('johndope@example.com'),
+        mockEmail(),
         mockEmail('johndope2@example.com', false, true),
       ];
       const account = {
@@ -331,7 +325,7 @@ describe('UnitRowSecondaryEmail', () => {
 
     it('displays an error message in the AlertBar', async () => {
       const emails = [
-        mockEmail('johndope@example.com'),
+        mockEmail(),
         mockEmail('johndope2@example.com', false, false),
       ];
       const account = {

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -66,7 +66,7 @@ export function mockSession(verified: boolean = true) {
 }
 
 export const mockEmail = (
-  email: string,
+  email = 'johndope@example.com',
   isPrimary = true,
   verified = true
 ) => ({


### PR DESCRIPTION
Because:
* We need to update our components to use the new Storybook format and want components to contain their own mocks

This commit:
* Refactors 'Profile' stories to new SB format
* Creates mocks.tsx for Profile and adds these mocks, used in SB, and to be used in tests in another PR
* Updates mockEmail to use a mocked email address without arguments

---

I'm working on FXA-5999 and I'm adding the wrapper to strings within the `Profile` component. Since that ticket warrants test creation, I wanted some states to test, which prompted me to create `mocks.tsx`, and I figured I'd go ahead and update the SB format to show these states, which also lead me to also update `mockEmail`, and I figured it made sense for this to go in a separate PR so when I do get the PR up for FXA-9999 the diff will be better set to the ask.