### PR TITLE
feat(auth): allow including tax amounts for PayPal DoReferenceTransaction

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/client.ts
@@ -181,6 +181,7 @@ export type DoReferenceTransactionOptions = {
   invoiceNumber: string;
   idempotencyKey: string;
   currencyCode: string;
+  taxAmount?: string;
   ipaddress?: string;
 };
 
@@ -448,6 +449,7 @@ export class PayPalClient {
       PAYMENTACTION: 'Sale',
       PAYMENTTYPE: 'instant',
       REFERENCEID: options.billingAgreementId,
+      ...(options.taxAmount && { TAXAMT: options.taxAmount }),
     };
     return this.doRequest<NVPDoReferenceTransactionResponse>(
       'DoReferenceTransaction',

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -53,6 +53,7 @@ export type ChargeCustomerOptions = {
   idempotencyKey: string;
   invoiceNumber: string;
   ipaddress?: string;
+  taxAmount?: string;
 };
 
 export type ChargeResponse = {
@@ -267,6 +268,7 @@ export class PayPalHelper {
       idempotencyKey: options.idempotencyKey,
       invoiceNumber: options.invoiceNumber,
       ...(options.ipaddress && { ipaddress: options.ipaddress }),
+      ...(options.taxAmount && { taxAmount: options.taxAmount }),
     };
     const response = await this.client.doReferenceTransaction(
       doReferenceTransactionOptions

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const { assert } = require('chai');
+const { deepCopy } = require('./util');
 const nock = require('nock');
 const sinon = require('sinon');
 
@@ -376,72 +377,25 @@ describe('PayPalClient', () => {
       );
     });
 
-    it('calls api with requested amount', async () => {
+    it('calls api with requested optional tax amount', async () => {
+      const data = deepCopy(defaultData);
+      data.TAXAMT = '500';
       client.doRequest = sandbox.fake.resolves(
         successfulDoReferenceTransactionResponse
       );
-      const amt = '44.55';
       await client.doReferenceTransaction({
-        amount: amt,
-        billingAgreementId: defaultData.REFERENCEID,
-        currencyCode: defaultData.CURRENCYCODE,
-        idempotencyKey: defaultData.MSGSUBID,
-        invoiceNumber: defaultData.INVNUM,
-        ipaddress: defaultData.IPADDRESS,
+        amount: data.AMT,
+        billingAgreementId: data.REFERENCEID,
+        currencyCode: data.CURRENCYCODE,
+        idempotencyKey: data.MSGSUBID,
+        invoiceNumber: data.INVNUM,
+        ipaddress: data.IPADDRESS,
+        taxAmount: data.TAXAMT,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
         'DoReferenceTransaction',
-        {
-          ...defaultData,
-          AMT: amt,
-        }
-      );
-    });
-
-    it('calls api with requested referenceID', async () => {
-      client.doRequest = sandbox.fake.resolves(
-        successfulDoReferenceTransactionResponse
-      );
-      const ref = 'B-123588';
-      await client.doReferenceTransaction({
-        amount: defaultData.AMT,
-        billingAgreementId: ref,
-        currencyCode: defaultData.CURRENCYCODE,
-        idempotencyKey: defaultData.MSGSUBID,
-        invoiceNumber: defaultData.INVNUM,
-        ipaddress: defaultData.IPADDRESS,
-      });
-      sinon.assert.calledOnceWithExactly(
-        client.doRequest,
-        'DoReferenceTransaction',
-        {
-          ...defaultData,
-          REFERENCEID: ref,
-        }
-      );
-    });
-
-    it('calls api with requested currency', async () => {
-      client.doRequest = sandbox.fake.resolves(
-        successfulDoReferenceTransactionResponse
-      );
-      const currency = 'EUR';
-      await client.doReferenceTransaction({
-        amount: defaultData.AMT,
-        billingAgreementId: defaultData.REFERENCEID,
-        currencyCode: currency,
-        idempotencyKey: defaultData.MSGSUBID,
-        invoiceNumber: defaultData.INVNUM,
-        ipaddress: defaultData.IPADDRESS,
-      });
-      sinon.assert.calledOnceWithExactly(
-        client.doRequest,
-        'DoReferenceTransaction',
-        {
-          ...defaultData,
-          CURRENCYCODE: currency,
-        }
+        data
       );
     });
 

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -266,6 +266,31 @@ describe('PayPalHelper', () => {
       assert.deepEqual(response, expectedResponse);
     });
 
+    it('calls doReferenceTransaction with taxAmount option', async () => {
+      const options = deepCopy(validOptions);
+      options.taxAmount = '500';
+      paypalHelper.client.doReferenceTransaction = sinon.fake.resolves(
+        successfulDoReferenceTransactionResponse
+      );
+      await paypalHelper.chargeCustomer(options);
+      const expectedOptions = {
+        amount:
+          paypalHelper.currencyHelper.getPayPalAmountStringFromAmountInCents(
+            options.amountInCents
+          ),
+        billingAgreementId: options.billingAgreementId,
+        invoiceNumber: options.invoiceNumber,
+        idempotencyKey: options.idempotencyKey,
+        currencyCode: options.currencyCode,
+        taxAmount: options.taxAmount,
+      };
+      assert.ok(
+        paypalHelper.client.doReferenceTransaction.calledOnceWith(
+          expectedOptions
+        )
+      );
+    });
+
     it('if doRequest unsuccessful, throws an error', async () => {
       paypalHelper.client.doRequest = sinon.fake.throws(
         new PayPalClientError('Fake', {})


### PR DESCRIPTION
Because:

* We want to charge users sales tax and ensure it shows up on PayPal invoices.

This commit:

* Includes the tax amount as an optional argument into DoReferenceTransaction. *

Closes #FXA-5764

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).