### PR TITLE
chore(settings): remove a confusing link

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/en-US.ftl
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/en-US.ftl
@@ -10,7 +10,6 @@ rk-key-removed-2 = Account recovery key removed
 rk-cannot-remove-key = Your account recovery key could not be removed.
 rk-refresh-key-1 = Refresh account recovery key
 rk-content-explain = Restore your information when you forget your password.
-rk-content-reset-data = Why does resetting my password reset my data?
 rk-cannot-verify-session-4 = Sorry, there was a problem confirming your session
 rk-remove-modal-heading-1 = Remove account recovery key?
 rk-remove-modal-content-1 = In the event you reset your password, you won’t be

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from 'react';
-import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { useAccount, useAlertBar } from '../../models';
 import { logViewEvent } from '../../lib/metrics';
@@ -95,14 +94,6 @@ export const UnitRowRecoveryKey = () => {
         <p className="text-sm mt-3">
           Restores your information when you forget your password.
         </p>
-      </Localized>
-      <Localized id="rk-content-reset-data">
-        <LinkExternal
-          className="link-blue text-xs mt-2"
-          href="https://support.mozilla.org/en-US/kb/reset-your-firefox-account-password-recovery-keys"
-        >
-          Why does resetting my password reset my data?
-        </LinkExternal>
       </Localized>
       {modalRevealed && (
         <VerifiedSessionGuard


### PR DESCRIPTION
Because:
 - it's confusing to mention data loss from password change on the account recovery key section of Settings

This commit:
 - remove the link
