### PR TITLE
feat(tests): Migrate oauth handshake and force auth tests to playwright

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -5,9 +5,33 @@ import { getCode } from 'fxa-settings/src/lib/totp';
 export class LoginPage extends BaseLayout {
   readonly path = '';
 
+  readonly selectors = {
+    AGE: '#age',
+    DATA_TESTID: '[data-testid=logo]',
+    EMAIL: 'input[type=email]',
+    EMAIL_PREFILLED: '#prefillEmail',
+    ERROR: '.error',
+    LINK_LOST_RECOVERY_KEY: 'a.lost-recovery-key',
+    LINK_RESET_PASSWORD: 'a[href^="/reset_password"]',
+    LINK_USE_DIFFERENT: '#use-different',
+    LINK_USE_RECOVERY_CODE: '#use-recovery-code-link',
+    NUMBER_INPUT: 'input[type=number]',
+    PASSWORD: '#password',
+    PASSWORD_INPUT: 'input[type=password]',
+    PERMISSIONS_HEADER: '#fxa-permissions-header',
+    RESET_PASSWORD_EXPIRED_HEADER: '#fxa-reset-link-expired-header',
+    RESET_PASSWORD_HEADER: '#fxa-reset-password-header',
+    SIGNIN_HEADER: '#fxa-signin-header',
+    SUBMIT: 'button[type=submit]',
+    SUBMIT_USER_SIGNED_IN: '#use-logged-in',
+    TEXT_INPUT: 'input[type=text]',
+    TOOLTIP: '.tooltip',
+    VPASSWORD: '#vpassword',
+  };
+
   async login(email: string, password: string, recoveryCode?: string) {
     await this.setEmail(email);
-    await this.page.click('button[type=submit]');
+    await this.page.click(this.selectors.SUBMIT);
     await this.setPassword(password);
     await this.submit();
     if (recoveryCode) {
@@ -19,11 +43,11 @@ export class LoginPage extends BaseLayout {
 
   async fillOutFirstSignUp(email: string, password: string) {
     await this.setEmail(email);
-    await this.page.click('button[type=submit]');
-    await this.page.fill('#password', password);
-    await this.page.fill('#vpassword', password);
-    await this.page.fill('#age', '24');
-    await this.page.click('#submit-btn');
+    await this.page.click(this.selectors.SUBMIT);
+    await this.page.fill(this.selectors.PASSWORD, password);
+    await this.page.fill(this.selectors.VPASSWORD, password);
+    await this.page.fill(this.selectors.AGE, '24');
+    await this.page.click(this.selectors.SUBMIT);
     await this.fillOutSignUpCode(email);
   }
 
@@ -38,39 +62,39 @@ export class LoginPage extends BaseLayout {
   }
 
   setEmail(email: string) {
-    return this.page.fill('input[type=email]', email);
+    return this.page.fill(this.selectors.EMAIL, email);
   }
 
   setPassword(password: string) {
-    return this.page.fill('input[type=password]', password);
+    return this.page.fill(this.selectors.PASSWORD, password);
   }
 
   async clickUseRecoveryCode() {
-    return this.page.click('#use-recovery-code-link');
+    return this.page.click(this.selectors.LINK_USE_RECOVERY_CODE);
   }
 
   async setCode(code: string) {
-    return this.page.fill('input[type=text]', code);
+    return this.page.fill(this.selectors.TEXT_INPUT, code);
   }
 
   async loginHeader() {
-    const header = this.page.locator('[data-testid=logo]');
+    const header = this.page.locator(this.selectors.DATA_TESTID);
     await header.waitFor();
     return header.isVisible();
   }
 
   async signInError() {
-    const error = this.page.locator('.error');
+    const error = this.page.locator(this.selectors.ERROR);
     await error.waitFor();
     return error.textContent();
   }
 
   async useDifferentAccountLink() {
-    return this.page.click('#use-different');
+    return this.page.click(this.selectors.LINK_USE_DIFFERENT);
   }
 
-  async signInPasswordTooltip() {
-    return this.page.innerText('#error-tooltip-103');
+  async getTooltipError() {
+    return this.page.innerText(this.selectors.TOOLTIP);
   }
 
   async unblock(email: string) {
@@ -85,51 +109,73 @@ export class LoginPage extends BaseLayout {
 
   async submit() {
     return Promise.all([
-      this.page.click('button[type=submit]'),
-      this.page.waitForNavigation({ waitUntil: 'networkidle' }),
+      this.page.click(this.selectors.SUBMIT),
+      this.page.waitForNavigation({ waitUntil: 'load' }),
     ]);
   }
 
   async clickForgotPassword() {
     return Promise.all([
-      this.page.click('a[href="/reset_password"]'),
+      this.page.click(this.selectors.LINK_RESET_PASSWORD),
       this.page.waitForNavigation({ waitUntil: 'networkidle' }),
     ]);
   }
 
   async resetPasswordHeader() {
-    const resetPass = this.page.locator('#fxa-reset-password-header');
+    const resetPass = this.page.locator(this.selectors.RESET_PASSWORD_HEADER);
     await resetPass.waitFor();
     return resetPass.isVisible();
   }
 
   async resetPasswordLinkExpriredHeader() {
-    const resetPass = this.page.locator('#fxa-reset-link-expired-header');
+    const resetPass = this.page.locator(
+      this.selectors.RESET_PASSWORD_EXPIRED_HEADER
+    );
+    await resetPass.waitFor();
+    return resetPass.isVisible();
+  }
+
+  async permissionsHeader() {
+    const resetPass = this.page.locator(this.selectors.PERMISSIONS_HEADER);
     await resetPass.waitFor();
     return resetPass.isVisible();
   }
 
   async clickDontHaveRecoveryKey() {
     return Promise.all([
-      this.page.click('a.lost-recovery-key'),
+      this.page.click(this.selectors.LINK_LOST_RECOVERY_KEY),
       this.page.waitForNavigation(),
     ]);
   }
 
   setRecoveryKey(key: string) {
-    return this.page.fill('input[type=text]', key);
+    return this.page.fill(this.selectors.TEXT_INPUT, key);
+  }
+
+  setAge(age: string) {
+    return this.page.fill(this.selectors.AGE, age);
   }
 
   async setNewPassword(password: string) {
-    await this.page.fill('#password', password);
-    await this.page.fill('#vpassword', password);
+    await this.page.fill(this.selectors.PASSWORD, password);
+    await this.page.fill(this.selectors.VPASSWORD, password);
     await this.submit();
   }
 
   async setTotp(secret: string) {
     const code = await getCode(secret);
-    await this.page.fill('input[type=number]', code);
+    await this.page.fill(this.selectors.NUMBER_INPUT, code);
     await this.submit();
+  }
+
+  async getPrefilledEmail() {
+    return this.page.innerText(this.selectors.EMAIL_PREFILLED);
+  }
+
+  async isCachedLogin() {
+    return this.page.isVisible(this.selectors.SUBMIT_USER_SIGNED_IN, {
+      timeout: 100,
+    });
   }
 
   async useCredentials(credentials: any) {

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -32,6 +32,13 @@ export class RelierPage extends BaseLayout {
     ]);
   }
 
+  clickForceAuth() {
+    return Promise.all([
+      this.page.click('button.force-auth'),
+      this.page.waitForNavigation({ waitUntil: 'load' }),
+    ]);
+  }
+
   async clickSubscribe() {
     await Promise.all([
       this.page.click('a[data-currency=usd]'),

--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -20,15 +20,10 @@ test.describe('severity-1', () => {
     pages: { page, relier, login },
   }, { project }) => {
     test.skip(project.name === 'production', 'no 123done relier in prod');
-    await relier.goto();
-    await relier.clickEmailFirst();
-    await login.login(credentials.email, credentials.password);
-    expect(await relier.isLoggedIn()).toBe(true);
-    await relier.signOut();
     await relier.goto('prompt=consent');
     await relier.clickEmailFirst();
-    await login.submit();
-    expect(page.url()).toMatch(/signin_permissions/);
+    await login.login(credentials.email, credentials.password);
+    expect(await login.permissionsHeader()).toBe(true);
     await login.submit();
     expect(await relier.isLoggedIn()).toBe(true);
   });

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../lib/fixtures/standard';
+
+test.describe('OAuth force auth', () => {
+  test('with a registered email', async ({
+    credentials,
+    pages: { login, relier },
+  }) => {
+    await relier.goto(`email=${credentials.email}`);
+    await relier.clickForceAuth();
+
+    // Email is prefilled
+    await expect(await login.page.innerText('#prefillEmail')).toMatch(
+      credentials.email
+    );
+    await login.setPassword(credentials.password);
+    await login.submit();
+    await relier.isLoggedIn();
+  });
+
+  test('with a unregistered email', async ({
+    credentials,
+    pages: { login, relier },
+  }, { project }) => {
+    test.slow(project.name !== 'local', 'email delivery can be slow');
+    const newEmail = `${Date.now()}@restmail.net`;
+    await relier.goto(`email=${newEmail}`);
+    await relier.clickForceAuth();
+
+    // Signup form is shown and email is prefilled
+    await expect(await login.getPrefilledEmail()).toMatch(newEmail);
+    await login.setAge('21');
+    await login.setNewPassword(credentials.password);
+    await login.fillOutSignUpCode(newEmail);
+
+    await relier.isLoggedIn();
+  });
+
+  test('with blocked email', async ({ credentials, pages: { login, relier } }, {
+    project,
+  }) => {
+    test.slow(project.name !== 'local', 'email delivery can be slow');
+    const blockedEmail = `blocked${Date.now()}@restmail.net`;
+    await relier.goto(`email=${blockedEmail}`);
+    await relier.clickForceAuth();
+
+    await expect(await login.getPrefilledEmail()).toMatch(blockedEmail);
+    await login.setAge('21');
+    await login.setNewPassword(credentials.password);
+    await login.fillOutSignUpCode(blockedEmail);
+
+    await relier.isLoggedIn();
+
+    await relier.signOut();
+
+    // Attempt to log in again which will show the blocked page
+    await relier.goto(`email=${blockedEmail}`);
+    await relier.clickForceAuth();
+    await login.setPassword(credentials.password);
+    await login.submit();
+
+    await login.unblock(blockedEmail);
+    await relier.isLoggedIn();
+  });
+});

--- a/packages/functional-tests/tests/oauth/handshake.spec.ts
+++ b/packages/functional-tests/tests/oauth/handshake.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../../lib/fixtures/standard';
+
+test.describe('OAuth and Fx Desktop handshake', () => {
+  test('user signed into browser and OAuth login', async ({
+    target,
+    page,
+    credentials,
+    pages: { login, relier },
+  }) => {
+    await page.goto(
+      target.contentServerUrl +
+        '?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email'
+    );
+    await login.login(credentials.email, credentials.password);
+
+    await relier.goto();
+    await relier.clickEmailFirst();
+
+    // User can sign in with cached credentials, no password needed.
+    await expect(await login.getPrefilledEmail()).toMatch(credentials.email);
+    await expect(await login.isCachedLogin()).toBe(true);
+    await login.submit();
+    await relier.isLoggedIn();
+
+    await relier.signOut();
+
+    // Attempt to sign back in
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await expect(await login.getPrefilledEmail()).toMatch(credentials.email);
+    await expect(await login.isCachedLogin()).toBe(true);
+    await login.submit();
+    await relier.isLoggedIn();
+  });
+});

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -55,7 +55,7 @@ test.describe('change primary email tests', () => {
     await page.locator('button[type=submit]').click();
     await login.setPassword(credentials.password);
     await page.locator('button[type=submit]').click();
-    expect(await login.signInPasswordTooltip()).toMatch('Incorrect password');
+    expect(await login.getTooltipError()).toMatch('Incorrect password');
 
     // Sign in with new password
     credentials.password = newPassword;

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -26,8 +26,6 @@ module.exports = testsSettings.concat([
   'tests/functional/fx_ios_v1_sign_in.js',
   'tests/functional/fx_ios_v1_sign_up.js',
   'tests/functional/legal.js',
-  'tests/functional/oauth_force_auth.js',
-  'tests/functional/oauth_handshake.js',
   'tests/functional/oauth_permissions.js',
   'tests/functional/oauth_prompt_none.js',
   'tests/functional/oauth_query_param_validation.js',
@@ -68,6 +66,11 @@ module.exports = testsSettings.concat([
 
   // Disabled because of https://github.com/mozilla/fxa/issues/9863
   // 'tests/functional/verification_reminders.js',
+
+  // Disabled because this test migrated to Playwright
+  // See `/functional-test`
+  // 'tests/functional/oauth_handshake.js',
+  // 'tests/functional/oauth_force_auth.js',
 ]);
 
 // Mocha tests are only exposed during local dev, not on prod-like


### PR DESCRIPTION
## Because

- We are migrating functional tests overs to playwright

## This pull request

-Migrates `oauth_handshake` and `oauth_force_auth` tests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5896
Closes: https://mozilla-hub.atlassian.net/browse/FXA-5908

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test, from `functional-tests` directory run `yarn test-local --grep="OAuth"`
