### PR TITLE
task(shared): Remove stack trace from init log in mysql.ts

### DIFF
--- a/packages/fxa-shared/db/mysql.ts
+++ b/packages/fxa-shared/db/mysql.ts
@@ -188,7 +188,6 @@ export class MysqlStoreShared {
     log?.info('MysqlStoreShared', {
       msg: 'MysqlStoreShared: Creating new MysqlStoreShared.',
       poolStats: getPoolStats(),
-      stack: Error().stack,
     });
   }
 


### PR DESCRIPTION
## Because

- Adding the stack made the log message confusing and look like an error.

## This pull request

- Removes the 'stack' field from the log message.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
