### PR TITLE
refactor(fxa-settings): update avatar story to new SB format

### DIFF
--- a/packages/fxa-settings/src/components/Avatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.stories.tsx
@@ -3,20 +3,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import Avatar from '.';
-import { AppContext } from 'fxa-settings/src/models';
+import { Account, AppContext } from '../../models';
+import { mockAppContext } from '../../models/mocks';
+import { MOCK_AVATAR_DEFAULT, MOCK_AVATAR_NON_DEFAULT } from './mocks';
+import { Meta } from '@storybook/react';
 
-const account = {
-  avatar: {
-    url: null,
-    id: null,
-  },
-} as any;
-storiesOf('Components/Avatar', module)
-  .add('default avatar', () => (
-    <AppContext.Provider value={{ account }}>
+export default {
+  title: 'Components/Avatar',
+  component: Avatar,
+} as Meta;
+
+const storyWithContext = (account: Account, storyName?: string) => {
+  const story = () => (
+    <AppContext.Provider value={mockAppContext({ account })}>
       <Avatar className="w-32 h-32" />
     </AppContext.Provider>
-  ))
-  .add('non-default avatar', () => <Avatar className="w-32 h-32" />);
+  );
+  if (storyName) story.storyName = storyName;
+  return story;
+};
+
+export const DefaultAvatar = storyWithContext(MOCK_AVATAR_DEFAULT);
+
+export const NonDefaultAvatar = storyWithContext(MOCK_AVATAR_NON_DEFAULT);

--- a/packages/fxa-settings/src/components/Avatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.test.tsx
@@ -4,17 +4,14 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Account, AppContext } from '../../models';
+import { AppContext } from '../../models';
+import { MOCK_AVATAR_DEFAULT, MOCK_AVATAR_NON_DEFAULT } from './mocks';
 import Avatar from '.';
-
-const account = ({
-  avatar: { url: null, id: null },
-} as unknown) as Account;
 
 describe('Avatar', () => {
   it('renders default avatar with expected attributes', () => {
     render(
-      <AppContext.Provider value={{ account }}>
+      <AppContext.Provider value={{ account: MOCK_AVATAR_DEFAULT }}>
         <Avatar />
       </AppContext.Provider>
     );
@@ -28,7 +25,7 @@ describe('Avatar', () => {
 
   it('renders default avatar with a custom className', () => {
     render(
-      <AppContext.Provider value={{ account }}>
+      <AppContext.Provider value={{ account: MOCK_AVATAR_DEFAULT }}>
         <Avatar className="my-class" />
       </AppContext.Provider>
     );
@@ -37,11 +34,8 @@ describe('Avatar', () => {
   });
 
   it('renders the avatar with expected attributes', () => {
-    const account = ({
-      avatar: { id: 'abc1234', url: 'http://placekitten.com/512/512' },
-    } as unknown) as Account;
     render(
-      <AppContext.Provider value={{ account }}>
+      <AppContext.Provider value={{ account: MOCK_AVATAR_NON_DEFAULT }}>
         <Avatar />
       </AppContext.Provider>
     );
@@ -58,11 +52,8 @@ describe('Avatar', () => {
   });
 
   it('renders the avatar with a custom className', () => {
-    const account = ({
-      avatar: { id: 'abc1234', url: 'http://placekitten.com/512/512' },
-    } as unknown) as Account;
     render(
-      <AppContext.Provider value={{ account }}>
+      <AppContext.Provider value={{ account: MOCK_AVATAR_NON_DEFAULT }}>
         <Avatar className="my-class" />
       </AppContext.Provider>
     );

--- a/packages/fxa-settings/src/components/Avatar/mocks.tsx
+++ b/packages/fxa-settings/src/components/Avatar/mocks.tsx
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Account } from '../../models';
+
+export const MOCK_AVATAR_DEFAULT = {
+  avatar: { id: null, url: null },
+} as unknown as Account;
+
+export const MOCK_AVATAR_NON_DEFAULT = {
+  avatar: { id: 'abc123', url: 'http://placekitten.com/512/512' },
+} as unknown as Account;


### PR DESCRIPTION
## Because

- We want to standardize all component stories to the new Storybook format

## This pull request

- Refactor the 'Avatar' component story to the new SB format

## Issue that this pull request solves

Closes: # [14248](https://github.com/mozilla/fxa/issues/14248)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
