### PR TITLE
fix(settings): test relies on system timezone

### DIFF
--- a/packages/fxa-settings/src/components/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Security/index.test.tsx
@@ -68,6 +68,7 @@ describe('Security', () => {
         passwordCreated: 1234567890,
         hasPassword: true,
       } as unknown as Account;
+      const createDate = new Date(1234567890).getDate();
       renderWithRouter(
         <AppContext.Provider value={mockAppContext({ account })}>
           <Security />
@@ -76,7 +77,7 @@ describe('Security', () => {
       const passwordRouteLink = screen.getByTestId('password-unit-row-route');
 
       await screen.findByText('••••••••••••••••••');
-      await screen.findByText('Created 1/15/1970');
+      await screen.findByText(`Created 1/${createDate}/1970`);
 
       expect(passwordRouteLink).toHaveTextContent('Change');
       expect(passwordRouteLink).toHaveAttribute(


### PR DESCRIPTION
Because:

* Translating a numerical value into a system local time is inconsistent depending on timezone.

This commit:

* Gets the local systems day of the month for the password render test so that it passes regardless of the systems timezone.

Closes #FXA-6080.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
