### PR TITLE
task(ci): Activate tracing in CI to uncover potential issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ executors:
           FXA_EMAIL_LOG_LEVEL: debug
           RUST_BACKTRACE: 1
           AUTH_FIRESTORE_EMULATOR_HOST: localhost:9090
+          TRACING_SERVICE_NAME: ci-content-server-executor
+          TRACING_CONSOLE_EXPORTER_ENABLED: true
     environment:
       FXA_MX_RECORD_EXCLUSIONS: restmail.dev.lcip.org
 
@@ -103,6 +105,8 @@ jobs:
     environment:
       NODE_ENV: dev
       FIRESTORE_EMULATOR_HOST: localhost:9090
+      TRACING_SERVICE_NAME: ci-test-package
+      TRACING_CONSOLE_EXPORTER_ENABLED: true
     parameters:
       package:
         type: string
@@ -126,6 +130,9 @@ jobs:
       - image: jdlk7/firestore-emulator
       - image: memcached
       - image: redis
+    environment:
+      TRACING_SERVICE_NAME: ci-test-many
+      TRACING_CONSOLE_EXPORTER_ENABLED: true
     steps:
       - base-install
       - run:
@@ -268,6 +275,8 @@ jobs:
       - image: jdlk7/firestore-emulator
     environment:
       NODE_ENV: dev
+      TRACING_SERVICE_NAME: ci-playwright-functional-tests
+      TRACING_CONSOLE_EXPORTER_ENABLED: true
     steps:
       # needed by check-mysql.sh
       - run: apt-get update && apt-get install -y netcat

--- a/.circleci/test-package.sh
+++ b/.circleci/test-package.sh
@@ -8,6 +8,10 @@ if grep -e "$MODULE" -e 'all' "$DIR/../packages/test.list" > /dev/null; then
   echo -e "\n###################################"
   echo "# testing $MODULE"
   echo -e "###################################\n"
+
+  echo -e "TRACING_SERVICE_NAME=$TRACING_SERVICE_NAME"
+  echo -e "TRACING_CONSOLE_EXPORTER_ENABLED=$TRACING_CONSOLE_EXPORTER_ENABLED"
+
   if [[ -x scripts/test-ci.sh ]]; then
     time ./scripts/test-ci.sh
   else

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -203,7 +203,7 @@ module.exports = function (
   );
 
   function optionallyIgnoreTrace(fn) {
-    return async function (request) {
+    return async function (request, ...args) {
       // Only authenticated routes or routes that specify an uid/email
       // can be traced because those routes can look a user up
       const canOptOut =
@@ -219,11 +219,11 @@ module.exports = function (
           // will get this.
 
           return tracing.suppressTrace(() => {
-            return fn(request);
+            return fn(request, ...args);
           });
         }
       }
-      return fn(request);
+      return fn(request, ...args);
     };
   }
 


### PR DESCRIPTION
## Because

- We want to exercise tracing code paths in CI to spot potential errors

## This pull request

- Configures CI to turn basic tracing
- Configures a sample rate of 0, so as not execute code paths but not output traces
- Fixes a bug found in the suppress tracing code in fxa shared. Not all arguments were getting propagated.

## Issue that this pull request solves

Closes: FXA-6069

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

Enabling these tests uncovered at least one defect. See changes in [packages/fxa-auth-server/lib/routes/index.js](https://github.com/mozilla/fxa/pull/14262/files#diff-a4c2724b23c40ac94cedc61b73c4cbdc9ee44bda6b5b873d7bab85badd4d49eb)
