### PR TITLE
feat(scripts): pull pdfs from legal-docs

### DIFF
--- a/.github/workflows/pull-legal-docs.yml
+++ b/.github/workflows/pull-legal-docs.yml
@@ -1,0 +1,50 @@
+name: Pull legal-docs
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * TUE'
+
+jobs:
+  pull-legal-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone FxA code repository
+        uses: actions/checkout@v3
+        with:
+          path: fxa
+          fetch-depth: 2
+
+      - name: Clone legal-docs repository
+        uses: actions/checkout@v3
+        with:
+          repository: mozilla/legal-docs
+          ref: prod
+          path: legal-docs
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull pdfs from legal-docs and push changes to FxA
+        run: |
+          cd fxa
+
+          # Setup git
+          git config --global user.email "pdfs@example.com"
+          git config --global user.name "Pdf Bot"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+
+          # Checkout branch
+          git checkout -b pull-legal-docs
+
+          # Run script to pull docs
+          node _scripts/pull-legal-docs.js ../legal-docs/ assets/legal
+
+          # Add changes and push to Github
+          git add -A
+          git commit -m "[skip ci] Latest legal PDFs"
+          git push origin pull-legal-docs -f
+
+      - name: create pull request
+        run: |
+          cd fxa
+          gh pr create -B main -H pull-legal-docs --title "[skip ci] Latest legal PDFs" --body "Adding latest legal PDFs from `mozilla/legal-docs` to FxA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ Thumbs.db
 .yarn/build-state.yml
 .yarn/install-state.gz
 
+# nektos/act - Github Actions
+bin/
+
 ## Package-specific ##
 
 # circleci

--- a/_scripts/.eslintrc
+++ b/_scripts/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": ["plugin:fxa/recommended"],
+  "plugins": ["fxa"],
+  "parserOptions": {
+    "ecmaVersion": "2020"
+  },
+}

--- a/_scripts/pull-legal-docs.js
+++ b/_scripts/pull-legal-docs.js
@@ -1,0 +1,86 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const PDF_FOLDER = 'pdf';
+const PDF_EXTENSIONS = '.pdf';
+const DEFAULT_SOURCE_DIRECTORY = './default/source/';
+const DEFAULT_TARGET_DIRECTORY = './default/target/';
+
+let targetDirectory = '';
+let sourceDirectory = '';
+let copyCount = 0;
+
+function buildLocalePdfName(filename, currentPath) {
+  const locale = path.basename(path.dirname(currentPath));
+  const fileOnly = path.basename(filename, PDF_EXTENSIONS);
+
+  return path.join(`${fileOnly}.${locale}${PDF_EXTENSIONS}`);
+}
+
+async function checkDir(currentPath) {
+  return (await fs.stat(currentPath)).isDirectory();
+}
+
+async function copyPdfToTarget(currentPath) {
+  const files = await fs.readdir(currentPath);
+
+  for (const file of files) {
+    if (path.extname(file) === PDF_EXTENSIONS) {
+      await fs.cp(
+        path.join(currentPath, file),
+        path.join(targetDirectory, buildLocalePdfName(file, currentPath))
+      );
+      copyCount++;
+    }
+  }
+}
+
+async function findAndCopyPdfs(currentPath) {
+  const validDir = await checkDir(currentPath);
+  if (validDir) {
+    if (path.basename(currentPath) === PDF_FOLDER) {
+      return copyPdfToTarget(currentPath);
+    }
+    const files = await fs.readdir(currentPath);
+    for (const file of files) {
+      await findAndCopyPdfs(path.join(currentPath, file));
+    }
+  }
+}
+
+async function init() {
+  const myArgs = process.argv.slice(2);
+
+  sourceDirectory = path.normalize(myArgs[0] || DEFAULT_SOURCE_DIRECTORY);
+  targetDirectory = path.normalize(myArgs[1] || DEFAULT_TARGET_DIRECTORY);
+
+  try {
+    await checkDir(targetDirectory);
+  } catch (err) {
+    throw new Error(
+      `The provided target directory does not exist. (${targetDirectory})`
+    );
+  }
+  try {
+    await checkDir(sourceDirectory);
+  } catch (err) {
+    throw new Error(
+      `The provided source directory does not exist. (${sourceDirectory})`
+    );
+  }
+
+  console.log(
+    `Start - Find and copy all pdfs in "${sourceDirectory}" to "${targetDirectory}"`
+  );
+  await findAndCopyPdfs(sourceDirectory);
+  console.log(`End - ${copyCount} PDFs were copied.`);
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}


### PR DESCRIPTION
## Because

- We need to pull the latest pdfs from legal-docs into the fxa assets folder.

## This pull request

- Create a script to copy the latest pdfs into assets/legal.
- Create a Github Action to automatically pull in the pdfs from legal-docs, and open a pull request to move pdfs into assets/legal.

## Issue that this pull request solves

Closes: #fxa-5100

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
