### PR TITLE
feat(auth-server): env var to override client ip address chain

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1458,6 +1458,12 @@ const conf = convict({
     env: 'CLIENT_ADDRESS_DEPTH',
     default: 3,
   },
+  remoteAddressChainOverride: {
+    doc: 'Override address chain with this chain. Should be comma separated list of IPs',
+    format: String,
+    env: 'REMOTE_ADDRESS_CHAIN_OVERRIDE',
+    default: '',
+  },
   signinConfirmation: {
     forcedEmailAddresses: {
       doc: 'Force sign-in confirmation for email addresses matching this regex.',

--- a/packages/fxa-auth-server/lib/getRemoteAddressChain.ts
+++ b/packages/fxa-auth-server/lib/getRemoteAddressChain.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Hapi from '@hapi/hapi';
+import { IP_ADDRESS } from './routes/validators';
+
+export function getRemoteAddressChain(
+  request: Hapi.Request,
+  remoteAddressChainOverride?: string
+) {
+  if (remoteAddressChainOverride) {
+    return remoteAddressChainOverride.split(',');
+  }
+
+  const xff = (request.headers['x-forwarded-for'] || '').split(/\s*,\s*/);
+
+  xff.push(request.info.remoteAddress);
+
+  return xff
+    .filter(Boolean)
+    .map((address) => address.trim())
+    .filter((address) => !IP_ADDRESS.required().validate(address).error);
+}

--- a/packages/fxa-auth-server/test/local/getRemoteAddressChain.js
+++ b/packages/fxa-auth-server/test/local/getRemoteAddressChain.js
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const { getRemoteAddressChain } = require('../../lib/getRemoteAddressChain');
+
+describe('getRemoteAddressChain', () => {
+  describe('when remoteAddressChainOverride is disabled', () => {
+    const remoteAddressChainOverride = '';
+
+    it('builds remote address chain from x-forwarded-for', () => {
+      const xForwardedFor = '10.0.0.1,10.0.1.1';
+      const remoteAddress = '10.5.0.1';
+      const mockRequest = {
+        headers: {
+          'x-forwarded-for': xForwardedFor,
+        },
+        info: {
+          remoteAddress,
+        },
+      };
+
+      const result = getRemoteAddressChain(
+        mockRequest,
+        remoteAddressChainOverride
+      );
+
+      assert.equal(result.join(','), `${xForwardedFor},${remoteAddress}`);
+    });
+
+    it('filters invalid IP addresses', () => {
+      const xForwardedFor = 'asdf,asdf';
+      const remoteAddress = '10.5.0.1';
+      const mockRequest = {
+        headers: {
+          'x-forwarded-for': xForwardedFor,
+        },
+        info: {
+          remoteAddress,
+        },
+      };
+
+      const result = getRemoteAddressChain(
+        mockRequest,
+        remoteAddressChainOverride
+      );
+
+      assert.equal(result.join(','), remoteAddress);
+    });
+  });
+
+  describe('when remoteAddressChainOverride is enabled', () => {
+    const remoteAddressChainOverride = '192.168.1.1,192.168.2.1';
+
+    it('returns remoteAddressChainOverride', () => {
+      const xForwardedFor = '10.0.0.1,10.0.1.1';
+      const remoteAddress = '10.5.0.1';
+      const mockRequest = {
+        headers: {
+          'x-forwarded-for': xForwardedFor,
+        },
+        info: {
+          remoteAddress,
+        },
+      };
+
+      const result = getRemoteAddressChain(
+        mockRequest,
+        remoteAddressChainOverride
+      );
+
+      assert.equal(result.join(','), remoteAddressChainOverride);
+    });
+  });
+});


### PR DESCRIPTION
## Because

- We need an easy way to change users IP address in localdev for testing tax and other things.

## This pull request

- Adds an environment variable that overrides the remote address chain.

## Issue that this pull request solves

Closes FXA-6072

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
