### PR TITLE
fix(dnt): apply dnt filtering to more metrics

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -238,12 +238,6 @@ const conf = convict({
       env: 'AMPLITUDE_SCHEMA_VALIDATION',
       format: Boolean,
     },
-    rawEvents: {
-      default: false,
-      doc: 'Log raw Amplitude events',
-      env: 'AMPLITUDE_RAW_EVENTS',
-      format: Boolean,
-    },
   },
   memcached: {
     address: {

--- a/packages/fxa-auth-server/lib/metrics/context.js
+++ b/packages/fxa-auth-server/lib/metrics/context.js
@@ -6,6 +6,7 @@
 
 const bufferEqualConstantTime = require('buffer-equal-constant-time');
 const crypto = require('crypto');
+const { filterDntValues } = require('fxa-shared/metrics/dnt');
 const HEX_STRING = require('../routes/validators').HEX_STRING;
 const isA = require('joi');
 
@@ -162,24 +163,25 @@ module.exports = function (log, config) {
       data.flowBeginTime = metadata.flowBeginTime;
       data.flowCompleteSignal = metadata.flowCompleteSignal;
       data.flowType = metadata.flowType;
+      data.entrypoint = metadata.entrypoint;
+      data.entrypoint_experiment = metadata.entrypointExperiment;
+      data.entrypoint_variation = metadata.entrypointVariation;
+      data.utm_campaign = metadata.utmCampaign;
+      data.utm_content = metadata.utmContent;
+      data.utm_medium = metadata.utmMedium;
+      data.utm_source = metadata.utmSource;
+      data.utm_term = metadata.utmTerm;
+      data.product_id = metadata.productId;
+      data.plan_id = metadata.planId;
 
       if (metadata.service) {
         data.service = metadata.service;
       }
+    }
 
-      const doNotTrack = this.headers && this.headers.dnt === '1';
-      if (!doNotTrack) {
-        data.entrypoint = metadata.entrypoint;
-        data.entrypoint_experiment = metadata.entrypointExperiment;
-        data.entrypoint_variation = metadata.entrypointVariation;
-        data.utm_campaign = metadata.utmCampaign;
-        data.utm_content = metadata.utmContent;
-        data.utm_medium = metadata.utmMedium;
-        data.utm_source = metadata.utmSource;
-        data.utm_term = metadata.utmTerm;
-        data.product_id = metadata.productId;
-        data.plan_id = metadata.planId;
-      }
+    const doNotTrack = this.headers && this.headers.dnt === '1';
+    if (doNotTrack) {
+      data = filterDntValues(data);
     }
 
     return data;

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -25,7 +25,6 @@ const amplitudeModule = proxyquire('../../../lib/metrics/amplitude', {
 const events = proxyquire('../../../lib/metrics/events', {
   './amplitude': amplitudeModule,
 })(log, {
-  amplitude: { rawEvents: false },
   oauth: {
     clientIds: {},
   },

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -715,7 +715,6 @@ function mockRequest(data, errors) {
   const events = proxyquire('../lib/metrics/events', {
     './amplitude': amplitudeModule,
   })(data.log || module.exports.mockLog(), {
-    amplitude: { rawEvents: false },
     oauth: {
       clientIds: data.clientIds || {},
     },

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -14,7 +14,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const {
   GROUPS,
   initialize,
@@ -24,6 +23,7 @@ const {
   mapOs,
   validate,
 } = require('fxa-shared/metrics/amplitude');
+const { filterDntValues } = require('fxa-shared/metrics/dnt');
 const logger = require('./logging/log')();
 const ua = require('fxa-shared/metrics/user-agent');
 const config = require('./configuration');
@@ -685,46 +685,6 @@ function receiveEvent(event, request, data) {
     return;
   }
 
-  if (amplitude.rawEvents) {
-    const rawEvent = {
-      event,
-      context: {
-        eventSource: 'content',
-        version: VERSION,
-        emailTypes: EMAIL_TYPES,
-        userAgent: request.headers && request.headers['user-agent'],
-        ..._.pick(data, [
-          'deviceId',
-          'devices',
-          'emailDomain',
-          'entrypoint_experiment',
-          'entrypoint_variation',
-          'entrypoint',
-          'experiments',
-          'flowBeginTime',
-          'flowId',
-          'lang',
-          'location',
-          'newsletters',
-          'planId',
-          'productId',
-          'service',
-          'syncEngines',
-          'templateVersion',
-          'uid',
-          'userPreferences',
-          'utm_campaign',
-          'utm_content',
-          'utm_medium',
-          'utm_source',
-          'utm_term',
-        ]),
-      },
-    };
-    logger.info('rawAmplitudeData', rawEvent);
-    statsd.increment('amplitude.event.raw');
-  }
-
   const userAgent = ua.parse(request.headers && request.headers['user-agent']);
 
   const amplitudeEvent = transform(
@@ -764,6 +724,17 @@ function receiveEvent(event, request, data) {
           );
         });
       }
+    }
+
+    const dnt = request && request.headers && request.headers.dnt === '1';
+
+    if (dnt) {
+      amplitudeEvent.event_properties = filterDntValues(
+        amplitudeEvent.event_properties
+      );
+      amplitudeEvent.user_properties = filterDntValues(
+        amplitudeEvent.user_properties
+      );
     }
 
     logger.info('amplitudeEvent', amplitudeEvent);

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -52,12 +52,6 @@ const conf = (module.exports = convict({
       env: 'AMPLITUDE_SCHEMA_VALIDATION',
       format: Boolean,
     },
-    rawEvents: {
-      default: false,
-      doc: 'Log raw Amplitude events',
-      env: 'AMPLITUDE_RAW_EVENTS',
-      format: Boolean,
-    },
   },
   are_dist_resources: {
     default: false,

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -16,9 +16,9 @@ const statsd = {
 };
 const amplitudeConfig = {
   disabled: false,
-  rawEvents: false,
   schemaValidation: false,
 };
+const dntStub = sinon.stub();
 
 const amplitude = proxyquire(path.resolve('server/lib/amplitude'), {
   './configuration': {
@@ -36,6 +36,7 @@ const amplitude = proxyquire(path.resolve('server/lib/amplitude'), {
   },
   './logging/log': () => logger,
   './statsd': statsd,
+  'fxa-shared/metrics/dnt': { filterDntValues: dntStub },
 });
 
 const APP_VERSION_RE = /([0-9]+)\.([0-9]{1,2})$/;
@@ -70,7 +71,6 @@ function createAmplitudeEvent(
 registerSuite('amplitude', {
   beforeEach: function () {
     amplitudeConfig.disabled = false;
-    amplitudeConfig.rawEvents = false;
     sinon.stub(process.stderr, 'write').callsFake(() => {});
   },
 
@@ -94,7 +94,6 @@ registerSuite('amplitude', {
     'disable writing amplitude events': {
       'logger.info was not called': () => {
         amplitudeConfig.disabled = true;
-        amplitudeConfig.rawEvents = true;
         amplitude(
           {
             time: 'a',
@@ -121,110 +120,6 @@ registerSuite('amplitude', {
       assert.doesNotThrow(amplitude);
       assert.doesNotThrow(() => amplitude('foo'));
       assert.doesNotThrow(() => amplitude(null, {}));
-    },
-
-    'logs raw event with context': () => {
-      amplitudeConfig.rawEvents = true;
-      const event = {
-        type: 'oauth.signup.success',
-        offset: 3846,
-        time: 1585695795375,
-        flowTime: 3847,
-      };
-
-      const context = {
-        eventSource: 'content',
-        version: pkg.version,
-        emailTypes: {
-          'complete-reset-password': 'reset_password',
-          'complete-signin': 'login',
-          'verify-email': 'registration',
-        },
-        userAgent:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0 FxATester/1.0',
-        deviceId: '6519d5fce18a427e87745ef6c25143ba',
-        devices: [{ name: 'cray-1', lastAccessTime: 1585695795375 }],
-        emailDomain: 'other',
-        entrypoint_experiment: 'herf',
-        entrypoint_variation: 'menk',
-        entrypoint: 'zoo',
-        experiments: ['abc', 'ASAP'],
-        flowBeginTime: 1585695791528,
-        flowId:
-          '804e3ce43ed994db863afcb93640809c239f6db0378a6f2b01659f7e26e25a66',
-        lang: 'en',
-        location: {
-          country: 'United States',
-          state: 'California',
-        },
-        newsletters: 'none',
-        planId: 'abc',
-        productId: 'gamma',
-        service: 'dcdb5ae7add825d2',
-        syncEngines: ['bookmarks', 'history'],
-        templateVersion: '3.1',
-        uid: '66853f3ab5404b5f30674d532a2dd54e',
-        userPreferences: { yes: 'no' },
-        utm_campaign: 'none',
-        utm_content: 'none',
-        utm_medium: 'none',
-        utm_source: 'none',
-        utm_term: 'none',
-      };
-      amplitude(
-        event,
-        {
-          headers: {
-            'user-agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0 FxATester/1.0',
-          },
-        },
-        {
-          junk: 'dontpickthis',
-          deviceId: '6519d5fce18a427e87745ef6c25143ba',
-          devices: [{ name: 'cray-1', lastAccessTime: 1585695795375 }],
-          emailDomain: 'other',
-          entrypoint_experiment: 'herf',
-          entrypoint_variation: 'menk',
-          entrypoint: 'zoo',
-          experiments: ['abc', 'ASAP'],
-          flowBeginTime: 1585695791528,
-          flowId:
-            '804e3ce43ed994db863afcb93640809c239f6db0378a6f2b01659f7e26e25a66',
-          lang: 'en',
-          location: {
-            country: 'United States',
-            state: 'California',
-          },
-          newsletters: 'none',
-          planId: 'abc',
-          productId: 'gamma',
-          service: 'dcdb5ae7add825d2',
-          syncEngines: ['bookmarks', 'history'],
-          templateVersion: '3.1',
-          uid: '66853f3ab5404b5f30674d532a2dd54e',
-          userPreferences: { yes: 'no' },
-          utm_campaign: 'none',
-          utm_content: 'none',
-          utm_medium: 'none',
-          utm_source: 'none',
-          utm_term: 'none',
-        }
-      );
-
-      assert.isTrue(
-        logger.info.calledOnceWith('rawAmplitudeData', { event, context })
-      );
-      sinon.assert.calledThrice(statsd.increment);
-      sinon.assert.calledWith(
-        statsd.increment.firstCall,
-        'amplitude.event.raw'
-      );
-      sinon.assert.calledWith(statsd.increment.secondCall, 'amplitude.event');
-      sinon.assert.calledWith(
-        statsd.increment.thirdCall,
-        'amplitude.event.dropped'
-      );
     },
 
     'flow.reset-password.submit': () => {
@@ -2596,6 +2491,14 @@ registerSuite('amplitude', {
         logger.info.args[0][1].event_type,
         'fxa_connect_device - pair_notnow_engage'
       );
+    },
+
+    'respects do not track': () => {
+      createAmplitudeEvent('screen.pair.notnow.engage', {
+        ...BASIC_REQUEST,
+        headers: { ...BASIC_REQUEST.headers, dnt: '1' },
+      });
+      sinon.assert.calledTwice(dntStub);
     },
   },
 });

--- a/packages/fxa-content-server/tests/server/flow-event.js
+++ b/packages/fxa-content-server/tests/server/flow-event.js
@@ -936,6 +936,7 @@ registerSuite('flow-event', {
         'process.stderr.write was called correctly': () => {
           assert.equal(process.stderr.write.callCount, 1);
           const arg = JSON.parse(process.stderr.write.args[0][0]);
+          assert.isUndefined(arg.entrypoint);
           assert.isUndefined(arg.utm_campaign);
           assert.isUndefined(arg.utm_content);
           assert.isUndefined(arg.utm_medium);

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -38,12 +38,6 @@ const conf = convict({
       env: 'AMPLITUDE_SCHEMA_VALIDATION',
       format: Boolean,
     },
-    rawEvents: {
-      default: false,
-      doc: 'Log raw Amplitude events',
-      env: 'AMPLITUDE_RAW_EVENTS',
-      format: Boolean,
-    },
   },
   clientAddressDepth: {
     default: 3,

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -2,16 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const pkg = require('../../package.json');
 const mockSchemaValidatorFn = jest.fn();
 const mockAmplitudeConfig = {
   enabled: true,
   schemaValidation: true,
-  rawEvents: false,
 };
 jest.mock('fxa-shared/metrics/amplitude.js', () => ({
   ...jest.requireActual('fxa-shared/metrics/amplitude.js'),
   validate: mockSchemaValidatorFn,
+}));
+const mockDntFn = jest.fn();
+jest.mock('fxa-shared/metrics/dnt', () => ({
+  filterDntValues: mockDntFn,
 }));
 let scope;
 const mockSentry = {
@@ -90,7 +92,6 @@ describe('lib/amplitude', () => {
     log.error.mockClear();
     mockSchemaValidatorFn.mockReset();
     mockAmplitudeConfig.schemaValidation = true;
-    mockAmplitudeConfig.rawEvents = false;
     Container.set(StatsD, { increment: jest.fn() });
   });
   it('logs a correctly formatted message', () => {
@@ -100,35 +101,6 @@ describe('lib/amplitude', () => {
     expect(log.info.mock.calls[0][0]).toMatch('amplitudeEvent');
     expect(log.info.mock.calls[0][1]).toMatchObject(expectedOutput);
     expect(statsd.increment).toHaveBeenCalledTimes(1);
-  });
-  it('logs raw events', () => {
-    const statsd = Container.get(StatsD);
-    const expectedContext = {
-      eventSource: 'payments',
-      version: pkg.version,
-      userAgent:
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
-      deviceId: '0123456789abcdef0123456789abcdef',
-      flowBeginTime: 1570000000000,
-      flowId:
-        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-      lang: 'gd',
-    };
-    mockAmplitudeConfig.rawEvents = true;
-    amplitude(mocks.event, mocks.request, {
-      ...mocks.data,
-      useless: 'junk',
-      lang: 'gd',
-    });
-    expect(log.info).toHaveBeenCalledTimes(2);
-    expect(log.info.mock.calls[0][0]).toMatch('rawAmplitudeData');
-    expect(log.info.mock.calls[0][1]).toEqual({
-      event: mocks.event,
-      context: expectedContext,
-    });
-    expect(statsd.increment).toHaveBeenCalledTimes(2);
-    expect(statsd.increment.mock.calls[0][0]).toBe('amplitude.event.raw');
-    expect(statsd.increment.mock.calls[1][0]).toBe('amplitude.event');
   });
   describe('validates inputs', () => {
     it('returns if `event` is missing', () => {
@@ -208,6 +180,25 @@ describe('lib/amplitude', () => {
         Sentry.Severity.Error
       );
       expect(log.info).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('respects do not track', () => {
+    describe('when dnt is not set', () => {
+      it('does not call the filtering function', () => {
+        amplitude(mocks.event, mocks.request, mocks.data);
+        expect(mockDntFn).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('when dnt is set', () => {
+      it('calls the filtering function', () => {
+        amplitude(
+          mocks.event,
+          { ...mocks.request, headers: { ...mocks.request.headers, dnt: '1' } },
+          mocks.data
+        );
+        expect(mockDntFn).toHaveBeenCalledTimes(2);
+      });
     });
   });
   describe('responds to configuration', () => {

--- a/packages/fxa-shared/index.ts
+++ b/packages/fxa-shared/index.ts
@@ -10,6 +10,7 @@ import featureFlags from './feature-flags';
 import { localizeTimestamp } from './l10n/localizeTimestamp';
 import supportedLanguages from './l10n/supportedLanguages.json';
 import amplitude from './metrics/amplitude';
+import { filterDntValues } from './metrics/dnt';
 import flowPerformance from './metrics/flow-performance';
 import navigationTimingSchema from './metrics/navigation-timing-validation';
 import userAgent from './metrics/user-agent';
@@ -36,6 +37,7 @@ module.exports = {
   },
   metrics: {
     amplitude,
+    filterDntValues,
     flowPerformance,
     navigationTimingSchema,
     userAgent,

--- a/packages/fxa-shared/metrics/dnt.ts
+++ b/packages/fxa-shared/metrics/dnt.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const denyPrefixes = ['entrypoint', 'utm'];
+const denyNames = ['product_id', 'plan_id', 'productId', 'planId'];
+
+const startsWithPrefix = (key: string) =>
+  denyPrefixes.some((prefix) => key.startsWith(prefix));
+
+export const filterDntValues = (metricsData: { [keys: string]: unknown }) =>
+  Object.entries(metricsData).reduce((acc, [k, v]) => {
+    if (startsWithPrefix(k) || denyNames.includes(k)) {
+      return acc;
+    }
+
+    acc[k] = v;
+    return acc;
+  }, {} as { [keys: string]: unknown });

--- a/packages/fxa-shared/test/metrics/dnt.ts
+++ b/packages/fxa-shared/test/metrics/dnt.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import { filterDntValues } from '../../metrics/dnt';
+
+describe('Do Not Track data filter', () => {
+  const properties = {
+    entrypoint: 'sync',
+    entrypoint_experiment: 'testo',
+    entrypoint_testo: 'another',
+    flowId: 'ddff00aa',
+    product_id: 'abcxyz',
+    productId: 'abcxyz',
+    plan_id: 'quux',
+    planId: 'quux',
+    service: 'sync',
+    utm_campaign: 'mr2022',
+    utm_content: 'none',
+    utm_gobbledygook: 'donottrack',
+  };
+
+  it('filters out DNT properties', () => {
+    const filtered = filterDntValues(properties);
+    assert.deepEqual(filtered, {
+      flowId: 'ddff00aa',
+      service: 'sync',
+    });
+  });
+});


### PR DESCRIPTION
Because:
 - Do Not Track was inconsistently applied to flow metrics
 - dnt handling was missing in "Amplitude" metrics

This commit:
 - apply the same dnt filter to flow and "Amplitude" metrics in multiple
   packages
 - delete old code for logging "raw" (untransformed) "Amplitude" events,
   which we never used in production

Fixes FXA-3647