### PR TITLE
task(admin-panel): Locate account by sign-up email

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -99,8 +99,9 @@ it('displays the account', async () => {
   );
 
   expect(getByTestId('account-section')).toBeInTheDocument();
-  expect(getByTestId('account-verified-status')).toHaveTextContent('confirmed');
-  expect(getByTestId('email-label')).toHaveTextContent(
+  expect(getByTestId('sign-up-email')).toHaveTextContent(accountResponse.email);
+  expect(getByTestId('primary-verified')).toHaveTextContent('confirmed');
+  expect(getByTestId('primary-email')).toHaveTextContent(
     accountResponse.emails![0].email
   );
   expect(getByTestId('account-uid')).toHaveTextContent(accountResponse.uid);
@@ -152,9 +153,7 @@ it('displays the unverified account', async () => {
       <Account {...accountResponse} />
     </MockedProvider>
   );
-  expect(getByTestId('account-verified-status')).toHaveTextContent(
-    'not confirmed'
-  );
+  expect(getByTestId('primary-verified')).toHaveTextContent('not confirmed');
 });
 
 it('displays the bounce type description', async () => {

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -354,6 +354,7 @@ export const DangerZone = ({
 
 export const Account = ({
   uid,
+  email,
   emails,
   createdAt,
   disabledAt,
@@ -400,20 +401,13 @@ export const Account = ({
     }
   };
 
+  function highlight(val: string) {
+    return query === val ? 'bg-yellow-100' : undefined;
+  }
+
   return (
     <section className="mt-8" data-testid="account-section">
       <ul>
-        <li className="account-li flex justify-between">
-          <h3 data-testid="email-label" className="account-header">
-            <span
-              className={
-                query === primaryEmail.email ? 'bg-yellow-100' : undefined
-              }
-            >
-              {primaryEmail.email}
-            </span>
-          </h3>
-        </li>
         <li className="account-li">
           <h3 className="account-header">Account Details</h3>
         </li>
@@ -421,21 +415,15 @@ export const Account = ({
           <ul>
             <table className="pt-1" aria-label="account details">
               <tbody>
-                <ResultTableRow label="uid" value={uid} testId="account-uid" />
                 <ResultTableRow
-                  label="Status"
-                  testId="account-verified-status"
-                  value={
-                    <span
-                      className={
-                        primaryEmail.isVerified
-                          ? 'account-enabled-verified'
-                          : 'account-disabled-unverified'
-                      }
-                    >
-                      {primaryEmail.isVerified ? 'confirmed' : 'not confirmed'}
-                    </span>
-                  }
+                  label="Sign-up Email"
+                  value={<span className={highlight(email)}>{email}</span>}
+                  testId="sign-up-email"
+                />
+                <ResultTableRow
+                  label="uid"
+                  value={<span className={highlight(uid)}>{uid}</span>}
+                  testId="account-uid"
                 />
                 <ResultTableRow
                   label="Created At"
@@ -496,6 +484,33 @@ export const Account = ({
         </li>
 
         <li className="account-li">
+          <h3 className="account-header">Primary Email</h3>
+        </li>
+        <li
+          className="account-li account-border-info"
+          data-testid="primary-section"
+        >
+          <ul>
+            <span
+              data-testid="primary-email"
+              className={highlight(primaryEmail.email)}
+            >
+              {primaryEmail.email}
+            </span>
+            <span
+              data-testid="primary-verified"
+              className={`ml-3 text-base ${
+                primaryEmail.isVerified
+                  ? 'account-enabled-verified'
+                  : 'account-disabled-unverified'
+              }`}
+            >
+              {primaryEmail.isVerified ? 'confirmed' : 'not confirmed'}
+            </span>
+          </ul>
+        </li>
+
+        <li className="account-li">
           <h3 className="account-header">Secondary Emails</h3>
         </li>
         {secondaryEmails.length > 0 ? (
@@ -508,11 +523,7 @@ export const Account = ({
                 <li key={secondaryEmail.createdAt} className="account-li">
                   <span
                     data-testid="secondary-email"
-                    className={
-                      query === secondaryEmail.email
-                        ? 'bg-yellow-100'
-                        : undefined
-                    }
+                    className={highlight(secondaryEmail.email)}
                   >
                     {secondaryEmail.email}
                   </span>

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
@@ -93,6 +93,7 @@ class GetAccountsByEmail {
             disabledAt: null,
             locale: testLocale,
             lockedAt: null,
+            email: email,
             emails: [
               {
                 email,
@@ -127,6 +128,7 @@ class GetAccountsByEmail {
       data: {
         accountByEmail: {
           uid: 'a1b2c3',
+          email: email,
           emails: [
             {
               email,

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -15,6 +15,7 @@ const ACCOUNT_SCHEMA = `
   disabledAt
   lockedAt
   locale
+  email
   emails {
     email
     isVerified

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -55,6 +55,11 @@ const DEVICE_TOKEN_1 = randomDeviceToken(SESSION_TOKEN_1.tokenId);
 const OAUTH_CLIENT_1 = randomOauthClient(Date.now() - 60 * 1e3);
 
 const USER_2 = randomAccount();
+// Fake a different sing up email
+const EMAIL_2 = randomEmail({
+  ...USER_2,
+  email: USER_2.email.replace('@', '+01@'),
+});
 
 describe('AccountResolver', () => {
   let resolver: AccountResolver;
@@ -219,7 +224,23 @@ describe('AccountResolver', () => {
   });
 
   it('does not locate non-existent users by email', async () => {
+    const result = await resolver.accountByEmail(
+      'non-existent@test.com',
+      true,
+      'joe'
+    );
+    expect(result).toBeUndefined();
+    expect(logger.info).toBeCalledTimes(2);
+  });
+
+  it('locate users by sign-up email', async () => {
     const result = await resolver.accountByEmail(USER_2.email, true, 'joe');
+    expect(result).toBeUndefined();
+    expect(logger.info).toBeCalledTimes(2);
+  });
+
+  it('locates users by secondary email', async () => {
+    const result = await resolver.accountByEmail(EMAIL_2.email, true, 'joe');
     expect(result).toBeUndefined();
     expect(logger.info).toBeCalledTimes(2);
   });


### PR DESCRIPTION
## Because
- We want to be able to locate a user by the email they signed up with.
- A user that swapped primary / secondary email, and then deleted the secondary email, could not be found by the admin panel.

## This pull request

- Adds the user's 'sign-up' email to the account section
- Falls back to the accounts.normalized email, if an email cannot be found in the emails table.

## Issue that this pull request solves

Closes: FXA-5866

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="508" alt="image" src="https://user-images.githubusercontent.com/94418270/196301882-b8f0bc9a-58f4-4aa2-92e6-946cc9420a5f.png">


