### PR TITLE
fix(l10n): Update Fluent negotiateLanguages strategy to default (filtering)

### DIFF
--- a/packages/fxa-auth-server/test/local/l10n/index.ts
+++ b/packages/fxa-auth-server/test/local/l10n/index.ts
@@ -28,14 +28,6 @@ describe('Localizer', () => {
       }, 'Invalid ftl translations basePath');
     });
 
-    it('produces the current locales', async () => {
-      const { currentLocales } = await localizer.getLocalizerDeps(
-        'de-CH,it;q=0.8,en-US;q=0.5,en;q=0.3'
-      );
-
-      assert.deepEqual(currentLocales, ['de', 'it', 'en-US', 'en']);
-    });
-
     it('selects the proper locale', async () => {
       const { selectedLocale } = await localizer.setupLocalizer(
         'de-DE,en-US;q=0.7,en;q=0.3'
@@ -82,75 +74,6 @@ describe('Localizer', () => {
           'If yes, here is the authorisation code you need:'
         );
       });
-    });
-  });
-
-  describe('language negotiation', () => {
-    it('handles empty case', () => {
-      const result = parseAcceptLanguage('');
-
-      assert.deepEqual(result, ['en']);
-    });
-
-    it('ignores unknown language', () => {
-      const result = parseAcceptLanguage('zy');
-      assert.deepEqual(result, ['en']);
-    });
-
-    it('handles en case', () => {
-      const result = parseAcceptLanguage('en');
-
-      // Note: We are using the 'filtering' mode for negotiate languages so all are going to be provided
-      assert.deepEqual(result, ['en']);
-    });
-
-    it('handles en-* case', () => {
-      const result = parseAcceptLanguage('en-US');
-
-      // Note: We are using the 'filtering' mode for negotiate languages so all are english dialects are going to be provided
-      assert.deepEqual(result, ['en-US', 'en']);
-    });
-
-    it('handles alias to en-GB', () => {
-      const result = parseAcceptLanguage('en-NZ');
-
-      assert.deepEqual(result, ['en-GB', 'en']);
-    });
-
-    it('always has default language, en, present', () => {
-      const result = parseAcceptLanguage('de');
-
-      assert.deepEqual(result, ['de', 'en']);
-    });
-
-    it('is falls back to root language if dialect is missing', () => {
-      const result = parseAcceptLanguage('fr-FR');
-
-      assert.deepEqual(result, ['fr', 'en']);
-    });
-
-    it('resolves dialects', () => {
-      const result = parseAcceptLanguage('es-MX');
-
-      assert.deepEqual(result, ['es-MX', 'en']);
-    });
-
-    it('handles multiple languages', () => {
-      const result = parseAcceptLanguage('ja, de-CH, en-US, en');
-
-      assert.deepEqual(result, ['ja', 'de', 'en-US', 'en']);
-    });
-
-    it('handles multiple languages with en-GB alias', () => {
-      const result = parseAcceptLanguage('en-NZ, en-GB, en-MY');
-
-      assert.deepEqual(result, ['en-GB', 'en']);
-    });
-
-    it('handles Chinese dialects properly', () => {
-      const result = parseAcceptLanguage('zh-CN, zh-TW, zh-HK, zh');
-
-      assert.deepEqual(result, ['zh-CN', 'zh-TW', 'en']);
     });
   });
 

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -234,7 +234,7 @@ describe('lib/server', () => {
             assert.equal(args[0], 'server.onRequest');
             assert.ok(args[1]);
             assert.equal(args[1].path, '/account/create');
-            assert.equal(args[1].app.locale, 'en-GB');
+            assert.equal(args[1].app.locale, 'fr');
           });
 
           it('called log.summary correctly', () => {
@@ -283,8 +283,8 @@ describe('lib/server', () => {
 
           it('parsed locale correctly', () => {
             // Note that fr-CH would be the correct language, but it is not in the list of supported
-            // languages. This means that en-GB has the highest q-value and should be selected.
-            assert.equal(request.app.locale, 'en-GB');
+            // languages so it defaults to fr.
+            assert.equal(request.app.locale, 'fr');
           });
 
           it('parsed user agent correctly', () => {
@@ -336,7 +336,7 @@ describe('lib/server', () => {
               return instance
                 .inject({
                   headers: {
-                    'accept-language': 'fr-CH, fr;q=0.9, en-GB, en;q=0.5',
+                    'accept-language': 'fr-CH, en-GB, en;q=0.5',
                     'user-agent': 'Firefox-Android-FxAccounts/34.0a1 (Nightly)',
                     'x-forwarded-for': ' 194.12.187.0 , 194.12.187.1 ',
                   },
@@ -379,14 +379,14 @@ describe('lib/server', () => {
             it('second request has its own accept-language', () => {
               assert.equal(
                 secondRequest.app.acceptLanguage,
-                'fr-CH, fr;q=0.9, en-GB, en;q=0.5'
+                'fr-CH, en-GB, en;q=0.5'
               );
             });
 
             it('second request has its own locale', () => {
               // Note that fr-CH would be the correct language, but it is not in the list of supported
-              // languages. This means that en-GB has the highest q-value and should be selected.
-              assert.equal(secondRequest.app.locale, 'en-GB');
+              // languages so it defaults to fr.
+              assert.equal(secondRequest.app.locale, 'fr');
             });
 
             it('second request has its own user agent info', () => {

--- a/packages/fxa-shared/l10n/parseAcceptLanguage.ts
+++ b/packages/fxa-shared/l10n/parseAcceptLanguage.ts
@@ -51,23 +51,16 @@ export function parseAcceptLanguage(
     }
   }
 
-  /*
-   * We use the 'matching' strategy because the default strategy, 'filtering', will load all
-   * English locales with dialects included, e.g. `en-CA`, even when the user prefers 'en' or
-   * 'en-US', which would then be shown instead of the English (US) fallback text.
-   */
+  // Order of locales represents priority and should correspond to q-values.
+  const sortedQValues = Object.entries(qValues).sort((a, b) => b[1] - a[1]);
+  const parsedLocalesByQValue = sortedQValues.map((qValue) => qValue[0]);
+
   const currentLocales = negotiateLanguages(
-    [...Object.keys(qValues)],
+    parsedLocalesByQValue,
     [...supportedLanguages],
     {
       defaultLocale: 'en',
-      strategy: 'matching',
     }
-  );
-
-  // Order of locales represents priority and should correspond to q-values.
-  currentLocales.sort(
-    (a, b) => qValues[b.toLocaleLowerCase()] - qValues[a.toLocaleLowerCase()]
   );
 
   return currentLocales;

--- a/packages/fxa-shared/test/l10n/determineLocale.ts
+++ b/packages/fxa-shared/test/l10n/determineLocale.ts
@@ -47,11 +47,11 @@ describe('l10n/determineLocale:', () => {
     expect(determineLocale('en-US;q=.1, es-MX; q=.8')).to.eq('es-MX');
   });
 
-  it('falls back to supported locale', () => {
-    // This is an intersting case. en-GB has an implicit q=1, fr has q=0.9, and fr-CH is thrown
-    // out because it is not supported. Therefore, en-GB ends up having the highest q value and
+  it('falls back to supported locale with unsupported locale', () => {
+    // en-GB has an implicit q=1, fr has q=0.9, and xyz is thrown out because it is
+    // not supported. Therefore, en-GB ends up having the highest q value and
     // should be the expected result.
-    expect(determineLocale('fr-CH, fr;q=0.9, en-GB, en;q=0.5')).to.eq('en-GB');
+    expect(determineLocale('xyz, fr;q=0.9, en-GB, en;q=0.5')).to.eq('en-GB');
   });
 
   it('handles q-values out of range', () => {

--- a/packages/fxa-shared/test/l10n/parseAcceptLanguage.ts
+++ b/packages/fxa-shared/test/l10n/parseAcceptLanguage.ts
@@ -7,48 +7,147 @@ import { parseAcceptLanguage } from '../../l10n/parseAcceptLanguage';
 
 describe('l10n/parseAcceptLanguage:', () => {
   it('returns default', () => {
-    expect(parseAcceptLanguage('en')).to.deep.equal(['en']);
+    expect(parseAcceptLanguage('en')).to.deep.equal([
+      'en',
+      'en-US',
+      'en-GB',
+      'en-CA',
+    ]);
+  });
+
+  it('handles empty case', () => {
+    expect(parseAcceptLanguage('')).to.deep.equal(['en']);
   });
 
   it('handles unknown', () => {
     expect(parseAcceptLanguage('xyz')).to.deep.equal(['en']);
   });
 
-  it('parses single', () => {
-    expect(parseAcceptLanguage('en')).to.deep.equal(['en']);
+  it('parses single and always contains default language (en)', () => {
+    expect(parseAcceptLanguage('it')).to.deep.equal(['it', 'en']);
   });
 
-  it('always contains default language (en)', () => {
-    expect(parseAcceptLanguage('es')).to.deep.equal(['es', 'en']);
-  });
-
-  it('handles region', () => {
-    expect(parseAcceptLanguage('es-MX')).to.deep.equal(['es-MX', 'en']);
-  });
-
-  it('handles region with incorrect case', () => {
-    expect(parseAcceptLanguage('es-mx, ru')).to.deep.equal([
-      'es-MX',
-      'ru',
-      'en',
-    ]);
-  });
-
-  it('parses several', () => {
+  it('parses several with expected output', () => {
     expect(parseAcceptLanguage('en, de, es, ru')).to.deep.equal([
       'en',
+      'en-US',
+      'en-GB',
+      'en-CA',
       'de',
       'es',
+      'es-ES',
+      'es-AR',
+      'es-CL',
+      'es-MX',
       'ru',
     ]);
   });
 
-  it('it applies qvalue', () => {
-    expect(parseAcceptLanguage('en, de;q=0.1, es, ru;q=0.3')).to.deep.equal([
-      'en',
-      'es',
-      'ru',
-      'de',
-    ]);
+  describe('qvalue', () => {
+    it('applies correctly with an implicit and explicit value', () => {
+      expect(parseAcceptLanguage('ru;q=0.3, it')).to.deep.equal([
+        'it',
+        'ru',
+        'en',
+      ]);
+    });
+
+    it('applies correctly with multiple explicit and implicit values', () => {
+      expect(
+        parseAcceptLanguage('de, it;q=0.8, en;q=0.5, es;q=1.0')
+      ).to.deep.equal([
+        'de',
+        'es',
+        'es-ES',
+        'es-AR',
+        'es-CL',
+        'es-MX',
+        'it',
+        'en',
+        'en-US',
+        'en-GB',
+        'en-CA',
+      ]);
+    });
+
+    it('applies correctly with dialects', () => {
+      expect(parseAcceptLanguage('de-DE, en-US;q=0.7, en;q=0.3')).to.deep.equal(
+        ['de', 'en-US', 'en', 'en-GB', 'en-CA']
+      );
+    });
+  });
+
+  describe('dialect (region) options', () => {
+    it('handles en-*', () => {
+      expect(parseAcceptLanguage('en-CA')).to.deep.equal([
+        'en-CA',
+        'en',
+        'en-US',
+        'en-GB',
+      ]);
+    });
+
+    it('includes all options and always contains default language (en)', () => {
+      expect(parseAcceptLanguage('es')).to.deep.equal([
+        'es',
+        'es-ES',
+        'es-AR',
+        'es-CL',
+        'es-MX',
+        'en',
+      ]);
+    });
+
+    it('handles region with incorrect case', () => {
+      expect(parseAcceptLanguage('es-mx, ru')).to.deep.equal([
+        'es-MX',
+        'es',
+        'es-ES',
+        'es-AR',
+        'es-CL',
+        'ru',
+        'en',
+      ]);
+    });
+
+    it('gives "en" higher priority than second locale when first locale is en-*', () => {
+      expect(parseAcceptLanguage('en-US, de')).to.deep.equal([
+        'en-US',
+        'en',
+        'en-GB',
+        'en-CA',
+        'de',
+      ]);
+    });
+
+    it('handles alias to en-GB', () => {
+      expect(parseAcceptLanguage('en-NZ')).to.deep.equal([
+        'en-GB',
+        'en',
+        'en-US',
+        'en-CA',
+      ]);
+    });
+
+    it('handles multiple languages with en-GB alias', () => {
+      expect(parseAcceptLanguage('en-NZ, en-GB, en-MY')).to.deep.equal([
+        'en-GB',
+        'en',
+        'en-US',
+        'en-CA',
+      ]);
+    });
+
+    it('falls back to root language if dialect is missing', () => {
+      expect(parseAcceptLanguage('fr-FR')).to.deep.equal(['fr', 'en']);
+    });
+
+    it('handles Chinese dialects properly', () => {
+      expect(parseAcceptLanguage('zh-CN, zh-TW, zh-HK, zh')).to.deep.equal([
+        'zh-CN',
+        'zh-TW',
+        'en',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Because:
* We previously set our negotiateLanguages strategy to 'matching' to address a bug where users with 'en' locales were showing 'en-GB' bundles since we didn't copy 'en' bundles into the l10n repo, as it was our intent that English users could see fallback text instead. We now deploy 'en' bundles for various reasons. Since we can't guarantee a bundle with all dialects will exist, like 'en-US' and others, we want to rely on Fluent's default 'filtering' strategy to provide us with similar locales as options, e.g. so 'en-US' will give us all dialects as options to load first, rather than a more strict check, which is what the 'matching' strategy gave us. TLDR, this ensures an 'en-US' locale will load the 'en' bundle we deploy.

This commit:
* Updates our negotiateLanguages call to go with the default 'strategy' argument
* Tweaks our locale sort functionality - we now sort by qvalue before sending an array of languages into negotiateLanguages instead of sorting after. NegotateLanguages returns a lot more locales than what a user has in their header, so sorting after is problematic since we don't have qvalues for those extra locales
* Modifies tests for parseAcceptLanguage and determineLocale, adds a few new ones, and moves tests from our auth-server Localizer into parseAcceptLanguage since it calls the same function

Fixes [FXA-6092](https://mozilla-hub.atlassian.net/browse/FXA-6092)