### PR TITLE
fix(fxa-settings): add missing error to auth-errors obj

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -246,6 +246,10 @@ const ERRORS = {
     message:
       'This request requires two step authentication enabled on your account.',
   },
+  RECOVERY_KEY_ALREADY_EXISTS: {
+    errno: 161,
+    message: 'Account recovery key already exists.',
+  },
   REDIS_CONFLICT: {
     errno: 165,
     message: 'Failed due to a conflicting request, please try again.',


### PR DESCRIPTION
## Because:

* Our new strategy for allowing localization of error messages relies on the (existing) assumption that all auth UI errors are present in the auth-errors object. Since this error was not included in the object, it threw an error when trying to generate a localization ID. We don't want that error to be thrown, and we do want the error to localized if it's visible to users. (See Sentry error [FXA-CONTENT-60F](https://sentry.io/organizations/mozilla/issues/3610017696/?referrer=jira_integration))

## This commit:

* Adds the new error into the dictionary of localized errors.

Closes:  # https://mozilla-hub.atlassian.net/browse/FXA-6054

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
