### PR TITLE
fix(metrics): Remove duplicate `fxa_login - complete` events

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -107,7 +107,10 @@ export default BaseAuthenticationBroker.extend({
         this.relier.set('service', this.relier.get('clientId'));
         this._metrics.setService(this.relier.get('clientId'));
       }
-      this._metrics.logEvent('pairing.signin.success');
+
+      if (result.action === 'pairing') {
+        this._metrics.logEvent('pairing.signin.success');
+      }
     }
 
     return this._metrics.flush().then(() => {

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -109,7 +109,10 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
         this.relier.set('service', this.relier.get('clientId'));
         this._metrics.setService(this.relier.get('clientId'));
       }
-      this._metrics.logEvent('pairing.signin.success');
+
+      if (result.action === 'pairing') {
+        this._metrics.logEvent('pairing.signin.success');
+      }
     }
 
     result.redirect = Constants.OAUTH_WEBCHANNEL_REDIRECT;

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -203,6 +203,7 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
     await broker.sendOAuthResultToRelier(
       {
         redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+        action: 'pairing',
       },
       account
     );

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -84,7 +84,7 @@ const EVENTS = {
   },
   'pairing.signin.success': {
     group: GROUPS.login,
-    event: 'complete',
+    event: 'complete_pairing',
   },
 
   // Signup code based metrics

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -2179,7 +2179,7 @@ registerSuite('amplitude', {
           oauth_client_id: '1',
           service: 'pocket',
         },
-        event_type: 'fxa_login - complete',
+        event_type: 'fxa_login - complete_pairing',
         language: 'gd',
         op: 'amplitudeEvent',
         os_name: 'Mac OS X',


### PR DESCRIPTION
## Because

- We were double counting our complete events for login
- This bug was introduced by adding pairing metrics

## This pull request

- Gives pairing complete a new metric `fxa_login - complete_pairing` to signify that a user has finished the pairing flow and connected a device

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6015

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before PR metrics
```
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_email_first - view","time":1666203872167,"device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_email_first - engage","time":1666203873357,"device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_email_first - submit","time":1666203875562,"device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - view","time":1666203875584,"device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - success","time":1666203888174,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1666203888174,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_email - sent","time":1666203888292,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2","email_type":"login","email_provider":"other","email_template":"newDeviceLogin","email_version":7},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","$append":{"fxa_services_used":"undefined_oauth"},"sync_device_count":0,"sync_active_devices_day":0,"sync_active_devices_week":0,"sync_active_devices_month":0}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_created","time":1666203888389,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","app_version":"243.2","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1666203888397,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","app_version":"243.2","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - engage","time":1666203885569,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1666203888042,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1666203888453,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1666203888461,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - engage","time":1666203885688,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1666203888161,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_rp_button - view","time":1666203892835,"device_id":"9d9073bc282f462180515db44245d5dd","app_version":"243.2","os_name":"Mac OS X","os_version":"10.15","event_properties":{},"user_properties":{"flow_id":"f176ccce41462030aa2a1944ba1aadc74742283f3760e891a9a5c88f86ac2466","ua_browser":"Firefox","ua_version":"104.0","utm_campaign":"123done"}}
```

After PR metrics
```
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - view","time":1666204321051,"device_id":"7aa0bb8a069a4fb7a745a344c5df8c20","session_id":1666204208813,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"3e93e2721c4aa397bcb7e4c77391fd344fda39717eaa33219155dbff4e0c9301","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_created","time":1666204321090,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","app_version":"243.2","event_properties":{"service":"undefined_oauth","oauth_client_id":"98e6508e88680e1a"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - oauth_access_token_created","time":1666204321090,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"c9cbd29630424f3c85fe81b35f236cc0","session_id":1666203868717,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"98e6508e88680e1a"},"user_properties":{"flow_id":"849cbcb042499599e8a7fe41cb96405ebad85560f596221b5c59826d6bcd9cfe","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"undefined_oauth"},"sync_device_count":3,"sync_active_devices_day":3,"sync_active_devices_week":3,"sync_active_devices_month":3}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1666204321102,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","app_version":"243.2","event_properties":{"service":"undefined_oauth","oauth_client_id":"98e6508e88680e1a"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1666204322213,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"7aa0bb8a069a4fb7a745a344c5df8c20","session_id":1666204208813,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"3e93e2721c4aa397bcb7e4c77391fd344fda39717eaa33219155dbff4e0c9301","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1666204322249,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","device_id":"7aa0bb8a069a4fb7a745a344c5df8c20","session_id":1666204208813,"app_version":"243.2","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"3e93e2721c4aa397bcb7e4c77391fd344fda39717eaa33219155dbff4e0c9301","ua_browser":"Firefox","ua_version":"104.0","$append":{"fxa_services_used":"123done"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_created","time":1666204322314,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","app_version":"243.2","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1666204322322,"user_id":"9695989e6c8644c8b5bb91d6f9b50c11","app_version":"243.2","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_rp_button - view","time":1666204322402,"device_id":"95af3eeb9196471a9a2903b72427ff24","app_version":"243.2","os_name":"Mac OS X","os_version":"10.15","event_properties":{},"user_properties":{"flow_id":"89ba883d1c6e4c9a2143e432d230692ece6b6b3dfef18c1d9f9c204ffd648ae8","ua_browser":"Firefox","ua_version":"104.0","utm_campaign":"123done"}}
```
