### PR TITLE
feat(fxa-content-server): add experiment to wrap new React app

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -24,6 +24,7 @@ const MANUAL_EXPERIMENTS = {
   qrCodeCad: BaseExperiment,
   pushLogin: BaseExperiment,
   pocketMigration: BaseExperiment,
+  generalizeReactApp: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/generalized-react-app.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/generalized-react-app.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Template file for new grouping rules. To use:
+ *
+ * 1. Copy TEMPLATE.js to a new grouping rule file.
+ * 2. Change `ChangeMeGroupingRule` class name to another name.
+ * 3. Change `this.name` from `CHANGE_ME` in the constructor.
+ * 4. Fill in the `choose` function.
+ * 5. Include the new rule file in index.js.
+ * 6. Access in views via `this.experiments.choose('name from 3')`
+ *    or `this.isInExperimentGroup('name from 3', 'group name')`.
+ */
+'use strict';
+
+const BaseGroupingRule = require('./base');
+
+const GROUPS = [
+  'control',
+
+  // Treatment branches. This one is for users who will see the new, generalized React app which houses more urls than just `/settings`
+  'generalized',
+];
+
+// This experiment is disabled by default. If you would like to go through
+// open the settings page with the following query params:
+// `?forceExperiment=generalizedReactApp&forceExperimentGroup=generalized`
+const ROLLOUT_RATE = 0.0;
+
+// This splits users into users who see the original Settings React app,
+// and users who see a generalized version of that app which can also display
+// routes that were previously content-server routes. This is not intended to wrap
+// the entirety of the Content Server React project -- it is a temporary experiment
+// which only wraps the generalization of the React app, and will be removed after
+// successful roll out of those changes.
+module.exports = class GeneralizedReactApp extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'generalizedReactApp';
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+  }
+
+  /**
+   * Use `subject` data to make a choice.
+   *
+   * @param {Object} subject data used to decide
+   * @returns {Any}
+   */
+  choose(subject) {
+    let choice = false;
+
+    if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+      choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+
+    return choice;
+  }
+};

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -16,6 +16,7 @@ const experimentGroupingRules = [
   require('./sentry'),
   require('./push'),
   require('./third-party-auth'),
+  require('./generalized-react-app'),
 ].map((ExperimentGroupingRule) => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/generalized-react-app.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/generalized-react-app.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Experiment from 'lib/experiments/grouping-rules/generalized-react-app';
+
+describe('lib/experiments/grouping-rules/generalized-react-app', () => {
+  let experiment;
+
+  beforeEach(() => {
+    experiment = new Experiment();
+  });
+
+  describe('choose', () => {
+    it('returns treatment if valid clientId', () => {
+      const rules = experiment.groups;
+      assert.isTrue(
+        rules.include(
+          experiment.choose({
+            experimentGroupingRules: { choose: () => experiment.name },
+            uniqueUserId: 'user-id',
+          })
+        )
+      );
+    });
+
+    it('returns false if rollout 0%', () => {
+      experiment.rolloutRate = 0;
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 5);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
   });
 
   describe('choose', () => {


### PR DESCRIPTION
## Because:

* The existing Settings React app can only house routes under /settings. We want to create another version of it, which we can progressively add new routes to from the content server. This is a temporary experiment which will be removed after we've successfully and safely rolled out the new React app to users (and before we start adding new major routes, such as reset_password etc)

## This commit:

* Creates a new experiment and checks the experiment status before passing a prop of "showNewReactApp" into the Settings app.

Closes # https://mozilla-hub.atlassian.net/browse/FXA-6061

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

### NB: I'm not actually sure why tests are failing.
In `functional/mocha.js` it's choking when it tries to split the test output, and then to trim a part of that output. I dunno!
