### PR TITLE
feat(auth): pass tax amount into PayPal DoReferenceTransaction

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/client.ts
@@ -449,7 +449,15 @@ export class PayPalClient {
       PAYMENTACTION: 'Sale',
       PAYMENTTYPE: 'instant',
       REFERENCEID: options.billingAgreementId,
-      ...(options.taxAmount && { TAXAMT: options.taxAmount }),
+      ...(options.taxAmount && {
+        TAXAMT: options.taxAmount,
+        // PayPal wants all of this when you include taxes 🤷
+        L_AMT0: options.amount,
+        L_TAXAMT0: options.taxAmount,
+        ITEMAMT: (Number(options.amount) - Number(options.taxAmount)).toFixed(
+          2
+        ),
+      }),
     };
     return this.doRequest<NVPDoReferenceTransactionResponse>(
       'DoReferenceTransaction',

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -53,7 +53,7 @@ export type ChargeCustomerOptions = {
   idempotencyKey: string;
   invoiceNumber: string;
   ipaddress?: string;
-  taxAmount?: string;
+  taxAmountInCents?: number;
 };
 
 export type ChargeResponse = {
@@ -268,7 +268,11 @@ export class PayPalHelper {
       idempotencyKey: options.idempotencyKey,
       invoiceNumber: options.invoiceNumber,
       ...(options.ipaddress && { ipaddress: options.ipaddress }),
-      ...(options.taxAmount && { taxAmount: options.taxAmount }),
+      ...(options.taxAmountInCents && {
+        taxAmount: this.currencyHelper.getPayPalAmountStringFromAmountInCents(
+          options.taxAmountInCents
+        ),
+      }),
     };
     const response = await this.client.doReferenceTransaction(
       doReferenceTransactionOptions
@@ -469,6 +473,7 @@ export class PayPalHelper {
         currencyCode: invoice.currency,
         idempotencyKey,
         ...(ipaddress && { ipaddress }),
+        ...(invoice.tax && { taxAmountInCents: invoice.tax }),
       }),
     ];
     if (invoice.status === 'draft') {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -235,7 +235,7 @@ export class PayPalHandler extends StripeWebhookHandler {
         await this.paypalHelper.processInvoice({
           customer,
           invoice: latestInvoice,
-          ipaddress: request.info.remoteAddress,
+          ipaddress: request.app.clientAddress,
         });
       } catch (err) {
         // We must delete the subscription and billing agreement if the transaction
@@ -294,7 +294,7 @@ export class PayPalHandler extends StripeWebhookHandler {
         await this.paypalHelper.processInvoice({
           customer,
           invoice: latestInvoice,
-          ipaddress: request.info.remoteAddress,
+          ipaddress: request.app.clientAddress,
         });
       } catch (err) {
         // We must delete the subscription since we cannot have 'incomplete'
@@ -396,7 +396,7 @@ export class PayPalHandler extends StripeWebhookHandler {
         await this.paypalHelper.processInvoice({
           customer,
           invoice,
-          ipaddress: request.info.remoteAddress,
+          ipaddress: request.app.clientAddress,
         });
       }
     } catch (err) {

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -379,7 +379,10 @@ describe('PayPalClient', () => {
 
     it('calls api with requested optional tax amount', async () => {
       const data = deepCopy(defaultData);
-      data.TAXAMT = '500';
+      data.TAXAMT = '5.00';
+      data.L_AMT0 = data.AMT;
+      data.L_TAXAMT0 = data.TAXAMT;
+      data.ITEMAMT = '0.99';
       client.doRequest = sandbox.fake.resolves(
         successfulDoReferenceTransactionResponse
       );


### PR DESCRIPTION
Because:

* We want to charge users sales tax and ensure it shows up on PayPal invoices.

This commit:

* Passes the optional tax amount argument into DoReferenceTransaction along with other amounts now required by PayPal when tax is added.

Closes #FXA-5765

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screen Shot 2022-10-20 at 12 35 35 PM](https://user-images.githubusercontent.com/17437436/197020379-963b5d30-c7df-4528-a40c-8bcc9c8e4d22.png)

## Other information (Optional)

DRYed up the `processInvoice` describe block while I was at it.
