### PR TITLE
fix(totp): Redirect to product page after signing in with 2FA

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -98,7 +98,7 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
       }
     ),
     afterCompleteSignIn: new NavigateBehavior('signin_verified'),
-    afterCompleteSignInWithCode: new NavigateBehavior('settings'),
+    afterCompleteSignInWithCode: new NavigateOrRedirectBehavior('settings'),
     afterCompleteSignUp: new NavigateOrRedirectBehavior('signup_verified'),
     afterDeleteAccount: new NullBehavior(),
     afterForceAuth: new NavigateBehavior('signin_confirmed'),


### PR DESCRIPTION
## Because

- When a user has TOTP enabled and signs in from the subscription page, it redirects them to settings instead of subscription
- I didn't add an explicit test because this is covered by https://github.com/mozilla/fxa/blob/37f41dbc54c25e189305dbe72b9edcc727be96ed/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js#L166

## This pull request

- Currently redirects to the subscription page

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6052

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test

1. Create an account and enable TOTP
2. Launch private browser and goto `http://localhost:8080` or product page
3. Click `Sign in`
4. Enter password and 2FA code

