### PR TITLE
fix(auth-server): Capture error in updateStripeNameFromBA if billing agreement was cancelled

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -410,6 +410,11 @@ export class PayPalHelper {
     const agreementDetails = await this.agreementDetails({
       billingAgreementId,
     });
+    if (agreementDetails.status === 'cancelled') {
+      throw error.internalValidationError('updateStripeNameFromBA', {
+        message: 'Billing agreement was cancelled.',
+      });
+    }
     const name = `${agreementDetails.firstName} ${agreementDetails.lastName}`;
     return this.stripeHelper.updateCustomerBillingAddress({
       customerId: customer.id,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -541,10 +541,24 @@ export class StripeWebhookHandler extends StripeHandler {
         this.stripeHelper.getCustomerPaypalAgreement(customer);
       // The customer needs to be updated for their name.
       if (billingAgreementId) {
-        await this.paypalHelper.updateStripeNameFromBA(
-          customer,
-          billingAgreementId
-        );
+        try {
+          await this.paypalHelper.updateStripeNameFromBA(
+            customer,
+            billingAgreementId
+          );
+        } catch (err) {
+          if (err.errno === error.ERRNO.INTERNAL_VALIDATION_ERROR) {
+            this.log.error(
+              `handleInvoiceCreatedEvent - Billing agreement (id: ${billingAgreementId}) was cancelled.`,
+              {
+                request,
+                customer,
+              }
+            );
+          } else {
+            throw err;
+          }
+        }
       }
     }
 

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -627,6 +627,30 @@ describe('PayPalHelper', () => {
       );
       sinon.assert.calledOnce(paypalHelper.metrics.increment);
     });
+
+    it('throws error if billing agreement status is cancelled', async () => {
+      mockStripeHelper.updateCustomerBillingAddress = sinon.fake.resolves({});
+      paypalHelper.agreementDetails = sinon.fake.resolves({
+        firstName: 'Test',
+        lastName: 'User',
+        status: 'cancelled',
+      });
+
+      try {
+        await paypalHelper.updateStripeNameFromBA(
+          mockCustomer,
+          'mock-agreement-id'
+        );
+        assert.fail('Error should throw billing agreement was cancelled.');
+      } catch (err) {
+        assert.deepEqual(
+          err,
+          error.internalValidationError('updateStripeNameFromBA', {
+            message: 'Billing agreement was cancelled.',
+          })
+        );
+      }
+    });
   });
 
   describe('processZeroInvoice', () => {


### PR DESCRIPTION
## Because

- PayPalClientError reports error due to billing agreement being cancelled

## This pull request

- captures error in `updateStripeNameFromBA` if billing agreement was cancelled

## Issue that this pull request solves

Closes: [FXA-5936](https://mozilla-hub.atlassian.net/browse/FXA-5936)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.