### PR TITLE
fix(tests): Increase playwright ci worker to 4

### DIFF
--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -64,7 +64,7 @@ const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
         ],
       ]
     : 'list',
-  workers: CI ? 2 : undefined,
+  workers: CI ? 4 : undefined,
   maxFailures: CI ? 2 : 0,
 };
 


### PR DESCRIPTION
## Because

- Playwright runs with default of 2 workers and completes tests in roughly 9 mins, lets see what happens when increased to 4

## This pull request

- Increases workers to 4 

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6149

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other

Looks like we have a 30 second improvement in https://app.circleci.com/pipelines/github/mozilla/fxa/34838/workflows/e88224e8-4b49-404c-aef3-bb49a40b4467/jobs/377215 vs https://app.circleci.com/pipelines/github/mozilla/fxa/34865/workflows/19d3ed37-c408-4729-b7b9-a60a2c227fc1/jobs/377426. Seems like a win to me 😅