### PR TITLE
fix(fxa-admin-panel): Update CSS in Account Search to remove conflicting classes

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -267,7 +267,7 @@ export const DangerZone = ({
           AdminPanelFeature.EnableAccount,
         ]}
       >
-        <h3 className="mt-0 my-0 mb-1 bg-red-600 font-medium h-8 pb-8 pl-1 pt-1 rounded-sm text-lg text-white">
+        <h3 className="mt-0 mb-1 bg-red-600 font-medium h-8 pb-8 pl-1 pt-1 rounded-sm text-lg text-white">
           Danger Zone
         </h3>
         <p className="text-base leading-6 mb-4">
@@ -276,7 +276,7 @@ export const DangerZone = ({
         </p>
       </Guard>
       <Guard features={[AdminPanelFeature.UnverifyEmail]}>
-        <h2 className="text-lg account-header">Email Confirmation</h2>
+        <h2 className="account-header">Email Confirmation</h2>
         <div className="border-l-2 border-red-600 mb-4 pl-4">
           <p className="text-base leading-6">
             Reset email confirmation. User needs to re-confirm on next login.
@@ -293,7 +293,7 @@ export const DangerZone = ({
         </div>
       </Guard>
       <Guard features={[AdminPanelFeature.DisableAccount]}>
-        <h2 className="text-lg account-header">Disable Login</h2>
+        <h2 className="account-header">Disable Login</h2>
         <div className="border-l-2 border-red-600 mb-4 pl-4">
           <p className="text-base leading-6 ">
             Stops this account from logging in.
@@ -314,7 +314,7 @@ export const DangerZone = ({
         </div>
       </Guard>
       <Guard features={[AdminPanelFeature.SendPasswordResetEmail]}>
-        <h2 className="text-lg account-header">Send Password Reset Email</h2>
+        <h2 className="account-header">Send Password Reset Email</h2>
         <div className="border-l-2 border-red-600 mb-4 pl-4">
           <p className="text-base leading-6 ">
             Send the user a password reset email to all verified emails. For
@@ -333,7 +333,7 @@ export const DangerZone = ({
       </Guard>
       {disabledAt && (
         <Guard features={[AdminPanelFeature.EnableAccount]}>
-          <h2 className="text-lg account-header">Enable Login</h2>
+          <h2 className="account-header">Enable Login</h2>
           <div className="border-l-2 border-red-600 mb-4 pl-4">
             <p className="text-base leading-6">
               Allows this account to log in.

--- a/packages/fxa-admin-panel/src/styles/tailwind.css
+++ b/packages/fxa-admin-panel/src/styles/tailwind.css
@@ -18,9 +18,8 @@ th {
   @apply italic text-grey-500;
 }
 
-/* TODO: move this into AccountSearch/index.css. Can't seem to use @import here */
 .account-header {
-  @apply mt-0 my-0 mb-1 text-lg;
+  @apply mt-0 mb-1 text-lg;
 }
 
 .account-li {


### PR DESCRIPTION
## Because

- We want to fix a tailwind lint error (tailwindcss/enforces-shorthand) caused by redundant (or conflicting) classes being applied to the same component (e.g., mt-0 my-0 mb-1 applied to the same class or element)

## This pull request

- Remove my-0 where mt and mb are explicitely set to different values
- Remove redundant use of text-lg where account-header class is also applied (already includes text-lg)

## Issue that this pull request solves

Closes: #FXA-5621

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

CSS updates applied to account headers in fxa-admin-panel, account search

![image](https://user-images.githubusercontent.com/22231637/197871833-40b081e9-180f-4129-a7a7-0d439d968b46.png)

## Other information (Optional)

`yarn test:frontend` tested and passed locally
