### PR TITLE
fix(safari): Update selector for input focus on mouse up event

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
@@ -106,7 +106,9 @@ export default {
 
   onShowPasswordMouseUp(event) {
     // return focus to input
-    this.$(event.target).siblings('[id*="password"]:not([id^="show-"])').focus();
+    this.$(event.target)
+      .siblings('input[id*="password"]:not([id^="show-"])')
+      .focus();
   },
 
   togglePasswordVisibility($el) {


### PR DESCRIPTION
Because:
* Safari doesn't have some a11y features enabled by default and ignores tabindex="-1" on the PW strength balloon, and our selector resetting focus is not specific enough to exclude the PW strength balloon

This commit:
* Adds 'input' in front of the selector for more specificity

Fixes [FXA-6028](https://mozilla-hub.atlassian.net/browse/FXA-6028)

---

We can't test Safari locally so this is a bit tricky. I was able to repro this in production and quickly hit "enter" to check what the active element was here:

![image](https://user-images.githubusercontent.com/13018240/197902357-b4fc5efe-1e56-4ea3-8da2-e13280b256c6.png)

This shouldn't be possible since we have `tabindex="-1"` on this element but it looks like [Safari ignores this](https://stackoverflow.com/questions/1848390/safari-ignoring-tabindex) unless you explicitly enable some a11y features. Checking what the active element is in FF, it shows the expected PW input.

Without this fix, `onShowPasswordMouseUp` was returning two elements, the input we wanted as well as the PW strength balloon. My best guess is other browsers didn't focus on the PW strength balloon due to this tabindex and Safari ignores it, but, this should force Safari to focus on the right thing.