### PR TITLE
fix(fxa-settings): wrap overflowing words to prevent overlapping text

### DIFF
--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
@@ -143,7 +143,7 @@ export const UnitRow = ({
           <h3
             data-testid={formatDataTestId('unit-row-header')}
             id={headerId}
-            className="scroll-mt-32"
+            className="scroll-mt-32 break-word"
           >
             {header}
           </h3>


### PR DESCRIPTION
## Because:

* Currently, very long words (such as in German) are following standard rendering behavior in breaking out past their element containers in the Security panel of the Settings page. This is considered a preferred default because it prevents data loss (for example, from hiding the overflow.) It is undesirable in our situation because the words are currently overlapping with, and obscuring, other elements.

## This commit:

* Applies "break-all", the tailwind class which corresponds to "word-break: break-all", to the h3 label in all UnitRow components. This means that if a label (even a single-word label) exceeds the horizontal bounds of its container, it will wrap, keeping all text within the element visible and non-overlapping.

Closes #https://mozilla-hub.atlassian.net/browse/FXA-6089

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

# Before: 
(Security Panel)
<img width="353" alt="Screen Shot 2022-10-27 at 9 47 33 AM" src="https://user-images.githubusercontent.com/11150372/198351511-c8d7daaf-fc00-40ed-858a-9e56518a8897.png">
(Primary email address)
<img width="422" alt="Screen Shot 2022-10-27 at 9 52 54 AM" src="https://user-images.githubusercontent.com/11150372/198351754-e11d260a-400d-4e66-a21f-4d6b6125bc2d.png">

# After
(Security Panel)
<img width="485" alt="Screen Shot 2022-10-27 at 9 47 09 AM" src="https://user-images.githubusercontent.com/11150372/198351824-f5da0ccd-bee6-4876-82ee-01acd7fdec7f.png">
(Primary email address)
<img width="388" alt="Screen Shot 2022-10-27 at 9 47 15 AM" src="https://user-images.githubusercontent.com/11150372/198351829-9b051e2b-01b9-4616-8e70-ded1b70de10c.png">



## Other information (Optional)
Worth noting -- this solution is a bit of a compromise. If we allow full, un-hyphenated words to be broken, it makes the page look better and be more readable. It also means that hyphenated or multi-word labels break less gracefully (they just break on whatever letter they hit the edge of the element.) Please see attached images for contrast. We _could_ get the best of both worlds (hyphenated words breaking on the hyphen, un-hyphenated words breaking where necessary) by using `break-words` (which corresponds to the more modern `overflow-wrap: break-word` as opposed to `word-break`, which is considered an alias now)... but only if we set a max-width onto the containing element, which feels hacky, and also feels like something that could cause us headaches down the line. I leave it up to reviewers! 
<img width="485" alt="Screen Shot 2022-10-27 at 9 47 09 AM" src="https://user-images.githubusercontent.com/11150372/198351551-0d7d69dd-1fff-45f1-970c-46786261d70b.png">
<img width="374" alt="Screen Shot 2022-10-27 at 9 46 20 AM" src="https://user-images.githubusercontent.com/11150372/198351587-7f2766cb-9e9e-4433-8818-8e5d0145b375.png">
