### PR TITLE
chore(tests): Remove coveragePathIgnorePatterns from fxa-payments-server

### DIFF
--- a/packages/fxa-payments-server/server/jest.config.js
+++ b/packages/fxa-payments-server/server/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  coveragePathIgnorePatterns: ['<rootDir>'],
-  collectCoverageFrom: ['**/*.js', '!**/jest*js'],
+  // coveragePathIgnorePatterns: ['<rootDir>'],
+  collectCoverageFrom: ['**/*.js', '!bin/*', '!coverage/**', '!**/jest*js'],
   // TO DO: update this file once more server tests are in place
   coverageThreshold: {
     global: {

--- a/packages/fxa-payments-server/server/jest.config.js
+++ b/packages/fxa-payments-server/server/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  // coveragePathIgnorePatterns: ['<rootDir>'],
   collectCoverageFrom: ['**/*.js', '!bin/*', '!coverage/**', '!**/jest*js'],
   // TO DO: update this file once more server tests are in place
   coverageThreshold: {


### PR DESCRIPTION
### Before:

```sh
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |
----------|---------|----------|---------|---------|-------------------
Test Suites: 7 passed, 7 total
Tests:       44 passed, 44 total
Snapshots:   0 total
Time:        3.62 s, estimated 10 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
```

### With `collectCoverageFrom: ['**/*.js', '!**/jest*js']`

```sh
-------------------------|---------|----------|---------|---------|------------------------------------------------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------|---------|----------|---------|---------|------------------------------------------------------------
All files                |   31.09 |    15.49 |   40.71 |   63.94 |
 bin                     |       0 |      100 |     100 |       0 |
  fxa-payments-server.js |       0 |      100 |     100 |       0 | 5-7
 config                  |     100 |      100 |     100 |     100 |
  index.js               |     100 |      100 |     100 |     100 |
 coverage/lcov-report    |       0 |        0 |       0 |       0 |
  block-navigation.js    |       0 |        0 |       0 |       0 | 2-87
  prettify.js            |       0 |        0 |       0 |       0 | 2
  sorter.js              |       0 |        0 |       0 |       0 | 2-196
 lib                     |   77.11 |    56.36 |    69.7 |   77.11 |
  404.js                 |   14.29 |        0 |       0 |   14.29 | 8-18
  amplitude.js           |     100 |      100 |     100 |     100 |
  csp.js                 |     100 |      100 |     100 |     100 |
  html-middleware.js     |     100 |      100 |     100 |     100 |
  no-robots.js           |     100 |      100 |     100 |     100 |
  server.js              |   66.04 |    34.48 |   47.06 |   66.04 | 51,122-137,195-196,203-207,222-235,248-264,291,316,329-338
  version.js             |   88.24 |    83.33 |     100 |   88.24 | 35-36,56-57
 lib/csp                 |   96.97 |       75 |     100 |   96.97 |
  blocking.js            |   96.77 |       75 |     100 |   96.77 | 127
  report-only.js         |     100 |      100 |     100 |     100 |
 lib/logging             |   83.33 |       50 |      60 |   88.24 |
  log.js                 |     100 |      100 |     100 |     100 |
  route-logging.js       |   81.25 |       50 |      60 |   86.67 | 39,58
 lib/routes              |    91.6 |     87.5 |   94.12 |   91.38 |
  index.js               |     100 |      100 |     100 |     100 |
  legal-docs.js          |   98.59 |    96.43 |     100 |   98.57 | 77
  navigation-timing.js   |   77.27 |        0 |      75 |   76.19 | 17-25
  post-metrics.js        |   83.33 |       50 |     100 |   83.33 | 55-60
-------------------------|---------|----------|---------|---------|------------------------------------------------------------
Test Suites: 7 passed, 7 total
Tests:       44 passed, 44 total
Snapshots:   0 total
Time:        10.007 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
```

### With `collectCoverageFrom: ['**/*.js', '!bin/*', '!coverage/**', '!**/jest*js']`

```sh
-----------------------|---------|----------|---------|---------|------------------------------------------------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------|---------|----------|---------|---------|------------------------------------------------------------
All files              |   84.38 |    68.04 |   77.97 |   84.47 |
 config                |     100 |      100 |     100 |     100 |
  index.js             |     100 |      100 |     100 |     100 |
 lib                   |   77.11 |    56.36 |    69.7 |   77.11 |
  404.js               |   14.29 |        0 |       0 |   14.29 | 8-18
  amplitude.js         |     100 |      100 |     100 |     100 |
  csp.js               |     100 |      100 |     100 |     100 |
  html-middleware.js   |     100 |      100 |     100 |     100 |
  no-robots.js         |     100 |      100 |     100 |     100 |
  server.js            |   66.04 |    34.48 |   47.06 |   66.04 | 51,122-137,195-196,203-207,222-235,248-264,291,316,329-338
  version.js           |   88.24 |    83.33 |     100 |   88.24 | 35-36,56-57
 lib/csp               |   96.97 |       75 |     100 |   96.97 |
  blocking.js          |   96.77 |       75 |     100 |   96.77 | 127
  report-only.js       |     100 |      100 |     100 |     100 |
 lib/logging           |   83.33 |       50 |      60 |   88.24 |
  log.js               |     100 |      100 |     100 |     100 |
  route-logging.js     |   81.25 |       50 |      60 |   86.67 | 39,58
 lib/routes            |    91.6 |     87.5 |   94.12 |   91.38 |
  index.js             |     100 |      100 |     100 |     100 |
  legal-docs.js        |   98.59 |    96.43 |     100 |   98.57 | 77
  navigation-timing.js |   77.27 |        0 |      75 |   76.19 | 17-25
  post-metrics.js      |   83.33 |       50 |     100 |   83.33 | 55-60
-----------------------|---------|----------|---------|---------|------------------------------------------------------------
Test Suites: 7 passed, 7 total
Tests:       44 passed, 44 total
Snapshots:   0 total
Time:        3.475 s, estimated 4 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
```

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
