### PR TITLE
fix(payments-server): Revise className for NewsletterErrorAlertBar

### DIFF
--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -72,7 +72,7 @@ const PaypalButton = React.lazy(() => import('../../components/PayPalButton'));
 const NewsletterErrorAlertBar = () => {
   return (
     <AlertBar
-      className="newsletter-error"
+      className="alert-newsletter-error"
       dataTestId="newsletter-signup-error-message"
       headerId="newsletter-error-alert-bar-header"
       localizedId="newsletter-signup-error"


### PR DESCRIPTION
## Because

- the style for newsletter error alerts were not being applied to `NewsletterErrorAlert`

## This pull request

- corrects the className that applies the style for newsletter error alerts to `NewsletterErrorAlert`

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
<img width="1953" alt="Screen Shot 2022-10-27 at 1 36 21 PM" src="https://user-images.githubusercontent.com/28129806/198359855-8942d343-32c3-4344-af44-0ec352f92d1f.png">
