### PR TITLE
chore(auth): add purchaseDate to AppStoreSubscriptionPurchase

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/subscription-purchase.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/subscription-purchase.js
@@ -36,6 +36,7 @@ describe('SubscriptionPurchase', () => {
   const inAppOwnershipType = 'PURCHASED';
   const originalPurchaseDate = 1627306493000;
   const autoRenewProductId = productId;
+  const purchaseDate = 1649329745000;
   const apiResponse = deepCopy(appStoreApiResponse);
   const decodedTransactionInfo = deepCopy(transactionInfo);
   const decodedRenewalInfo = deepCopy(renewalInfo);
@@ -81,6 +82,7 @@ describe('SubscriptionPurchase', () => {
         inAppOwnershipType,
         originalPurchaseDate,
         autoRenewProductId,
+        purchaseDate,
       };
       assert.deepEqual(expected, subscription);
     });

--- a/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
@@ -103,6 +103,7 @@ export class AppStoreSubscriptionPurchase {
   latestNotificationSubtype?: NotificationSubtype;
   private offerType?: OfferType;
   private offerIdentifier?: string;
+  private purchaseDate?: number;
   private revocationDate?: number;
   private revocationReason?: number;
 
@@ -155,6 +156,9 @@ export class AppStoreSubscriptionPurchase {
     }
     if (renewalInfo.offerType) {
       purchase.offerType = renewalInfo.offerType;
+    }
+    if (transactionInfo.purchaseDate) {
+      purchase.purchaseDate = transactionInfo.purchaseDate;
     }
     if (transactionInfo.revocationDate) {
       purchase.revocationDate = transactionInfo.revocationDate;


### PR DESCRIPTION
Because:

* The Data Science/Engineering team has requested the [purchaseDate](https://developer.apple.com/documentation/appstoreservernotifications/purchasedate) field for analysis purposes, and it wasn't included in the original implementation.

This commit:

* Includes the purchaseDate field.

Closes #FXA-6109

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).