### PR TITLE
fix(payments): detailed Error Message Not Displayed

### DIFF
--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -232,6 +232,16 @@ export const MOCK_GENERAL_PAYPAL_ERROR = {
   code: 'general-paypal-error',
 };
 
+export const MOCK_CURRENCY_ERROR = {
+  code: '400',
+  errno: 130,
+  error: 'Bad Request',
+  message: 'Funding source country does not match plan currency.',
+  info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
+  currency: 'usd',
+  country: 'RO',
+};
+
 export const IAP_GOOGLE_SUBSCRIPTION = {
   _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
   product_id: 'prod_123',

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -31,6 +31,7 @@ import { AppContextType } from '../../lib/AppContext';
 import {
   CONFIRM_CARD_RESULT,
   CUSTOMER,
+  MOCK_CURRENCY_ERROR,
   MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR,
   MOCK_GENERAL_PAYPAL_ERROR,
   MOCK_STRIPE_CARD_ERROR,
@@ -415,6 +416,29 @@ describe('routes/Checkout', () => {
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
         getErrorMessage(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
+      );
+    });
+
+    it('displays an error about the wrong currency if there is a currency mismatch', async () => {
+      (apiCreateSubscriptionWithPaymentMethod as jest.Mock)
+        .mockClear()
+        .mockRejectedValue(MOCK_CURRENCY_ERROR);
+
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+      });
+
+      const paymentErrorComponent = screen.getByTestId('payment-error');
+      expect(paymentErrorComponent).toBeInTheDocument();
+      expect(paymentErrorComponent).toHaveTextContent(
+        getErrorMessage(MOCK_CURRENCY_ERROR)
       );
     });
 

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -197,7 +197,8 @@ export const Checkout = ({
         } else {
           // Some Stripe APIs like `createPaymentMethod` return an object with
           // an error property on error.
-          setSubscriptionError(error?.error || error);
+          const err = typeof error.error === 'string' ? error : error.error;
+          setSubscriptionError(err);
         }
       }
       setInProgress(false);


### PR DESCRIPTION
Because:

* we want to show more specific error information

This commit:

* checks the properties of the error object to pass in the right object, error vs error.error

Closes #FXA-4051

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
