### PR TITLE
fix(subscriptions): fix amounts for same interval

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2809,6 +2809,33 @@ export class StripeHelper extends StripeHelperBase {
 
     const productPaymentCycleNew = this.stripePlanToPaymentCycle(planNew);
 
+    // During upgrades it's possible that an invoice isn't created when the
+    // subscription is updated. Instead there will be pending invoice items
+    // which will be added to next invoice once its generated.
+    // For more info see https://stripe.com/docs/api/subscriptions/update
+    let upcomingInvoiceWithInvoiceitem: Stripe.Invoice | undefined;
+    try {
+      const upcomingInvoice = await this.stripe.invoices.retrieveUpcoming({
+        customer: customer.id,
+        subscription: subscription.id,
+      });
+      // Only use upcomingInvoice if there are `invoiceitems`
+      upcomingInvoiceWithInvoiceitem = upcomingInvoice?.lines.data.some(
+        (line) => line.type === 'invoiceitem'
+      )
+        ? upcomingInvoice
+        : undefined;
+    } catch (error) {
+      if (
+        error.type === 'StripeInvalidRequestError' &&
+        error.code === 'invoice_upcoming_none'
+      ) {
+        upcomingInvoiceWithInvoiceitem = undefined;
+      } else {
+        throw error;
+      }
+    }
+
     const baseDetails = {
       uid,
       email,
@@ -2838,7 +2865,8 @@ export class StripeHelper extends StripeHelperBase {
       return this.extractSubscriptionUpdateCancellationDetailsForEmail(
         subscription,
         baseDetails,
-        invoice
+        invoice,
+        upcomingInvoiceWithInvoiceitem
       );
     } else if (cancelAtPeriodEndOld && !cancelAtPeriodEndNew && !planOld) {
       return this.extractSubscriptionUpdateReactivationDetailsForEmail(
@@ -2850,6 +2878,7 @@ export class StripeHelper extends StripeHelperBase {
         subscription,
         baseDetails,
         invoice,
+        upcomingInvoiceWithInvoiceitem,
         productOrderNew,
         planOld
       );
@@ -2866,7 +2895,8 @@ export class StripeHelper extends StripeHelperBase {
   async extractSubscriptionUpdateCancellationDetailsForEmail(
     subscription: Stripe.Subscription,
     baseDetails: any,
-    invoice: Stripe.Invoice
+    invoice: Stripe.Invoice,
+    upcomingInvoiceWithInvoiceitem: Stripe.Invoice | undefined
   ) {
     const { current_period_end: serviceLastActiveDate } = subscription;
 
@@ -2885,7 +2915,7 @@ export class StripeHelper extends StripeHelperBase {
       total: invoiceTotalInCents,
       currency: invoiceTotalCurrency,
       created: invoiceDate,
-    } = invoice;
+    } = upcomingInvoiceWithInvoiceitem || invoice;
 
     return {
       updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,
@@ -2899,6 +2929,7 @@ export class StripeHelper extends StripeHelperBase {
       invoiceTotalInCents,
       invoiceTotalCurrency,
       serviceLastActiveDate: new Date(serviceLastActiveDate * 1000),
+      showOutstandingBalance: !!upcomingInvoiceWithInvoiceitem,
       productMetadata,
       planConfig,
     };
@@ -3021,6 +3052,7 @@ export class StripeHelper extends StripeHelperBase {
     subscription: Stripe.Subscription,
     baseDetails: any,
     invoice: Stripe.Invoice,
+    upcomingInvoiceWithInvoiceitem: Stripe.Invoice | undefined,
     productOrderNew: string,
     planOld: Stripe.Plan
   ) {
@@ -3028,8 +3060,22 @@ export class StripeHelper extends StripeHelperBase {
       id: invoiceId,
       number: invoiceNumber,
       currency: paymentProratedCurrency,
-      amount_due: paymentProratedInCents,
     } = invoice;
+
+    // Using stripes default proration behaviour
+    // (https://stripe.com/docs/billing/subscriptions/upgrade-downgrade#immediate-payment)
+    // an invoice is only created at time of upgrade, if the billing period changes.
+    // In the case that the billing period is the same, we sum the pending invoiceItems
+    // retrieved in upcomingInvoiceWithInvoiceitem.
+    // The actual recuring charge, for the next billing cycle, shows up as a type = 'subscription'
+    // line item.
+    const onetimePaymentAmount = upcomingInvoiceWithInvoiceitem
+      ? upcomingInvoiceWithInvoiceitem.lines.data.reduce(
+          (acc, line) =>
+            line.type === 'invoiceitem' ? acc + line.amount : acc,
+          0
+        )
+      : invoice.amount_due;
 
     // https://github.com/mozilla/subhub/blob/e224feddcdcbafaf0f3cd7d52691d29d94157de5/src/hub/vendor/customer.py#L643
     const abbrevProductOld = await this.expandAbbrevProductForPlan(planOld);
@@ -3062,7 +3108,7 @@ export class StripeHelper extends StripeHelperBase {
       paymentAmountOldCurrency,
       invoiceNumber,
       invoiceId,
-      paymentProratedInCents,
+      paymentProratedInCents: onetimePaymentAmount,
       paymentProratedCurrency,
     };
   }

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2096,6 +2096,7 @@ module.exports = function (log, config, bounces) {
       invoiceTotalInCents,
       invoiceTotalCurrency,
       serviceLastActiveDate,
+      showOutstandingBalance,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2142,6 +2143,7 @@ module.exports = function (log, config, bounces) {
           invoiceTotalCurrency,
           message.acceptLanguage
         ),
+        showOutstandingBalance,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
@@ -8,3 +8,4 @@ subscriptionCancellation-title = Sorry to see you go
 #   $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
 #   $serviceLastActiveDateOnly (String) - The date of last active service, e.g. 01/20/2016
 subscriptionCancellation-content = We’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.
+subscriptionCancellation-outstanding-content = We’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } will be paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
@@ -13,9 +13,15 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionCancellation-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
+      <% if (!showOutstandingBalance) { %>
+        <span data-l10n-id="subscriptionCancellation-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
           We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
       </span>
+      <% } else { %>
+        <span data-l10n-id="subscriptionCancellation-outstanding-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
+          We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> will be paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+      </span>
+      <% } %>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
@@ -2,6 +2,10 @@ subscriptionCancellation-subject = "Your <%- productName %> subscription has bee
 
 subscriptionCancellation-title = "Sorry to see you go"
 
+<% if (!showOutstandingBalance) { %>
 subscriptionCancellation-content = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+<% } else { %>
+subscriptionCancellation-outstanding-content = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> will be paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+<% } %>
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1497,6 +1497,40 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
+
+  ['subscriptionCancellationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionCancellation') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionCancellation' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionCancellation }],
+    ])],
+    ['html', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: 'Sorry to see you go' },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-cancellation', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-cancellation', 'subscription-terms')) },
+      { test: 'include', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} will be paid on 03/20/2020.` },
+      { test: 'include', expected: `billing period, which is 04/19/2020.` },
+      { test: 'notInclude', expected: `alt="${MESSAGE.productName}"`},
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: 'Sorry to see you go' },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} will be paid on 03/20/2020.` },
+      { test: 'include', expected: `billing period, which is 04/19/2020.` },
+      { test: 'include', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]),
+    {updateTemplateValues: x => (
+      {...x, showOutstandingBalance: true})}
+  ],
+
   ['subscriptionCancellationEmail', new Map<string, Test | any>([
     ['html', [
       { test: 'include', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL_CUSTOM },


### PR DESCRIPTION
## Because

- The wrong amount is displayed on a subscription change between two prices with the same interval, since an invoice isn't immediately generated by Stripe.
- Cancellation emails do not inform the customer when they still have an oustanding amount at the end of their subscription.

## This pull request

- Checks if there are any pending invoice items, and if there are, retrieves the upcoming invoice.
- For upgrade emails, the upcoming invoice is used to get the proration amounts only.
- For cancellation emails the upcoming invoice is used in favor of the currently latest invoice.

## Issue that this pull request solves

Closes: #FXA-6170

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).