### PR TITLE
fix(subscriptions): fix copy in IAP roadblock for subscription upgrades

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.stories.tsx
@@ -6,6 +6,7 @@ import { SignInLayout } from '../../../components/AppLayout';
 
 import {
   CUSTOMER,
+  PLAN,
   SELECTED_PLAN,
   PROFILE,
   IAP_GOOGLE_SUBSCRIPTION,
@@ -18,6 +19,7 @@ const MOCK_PROPS: IapRoadblockProps = {
   customer: CUSTOMER,
   isMobile: false,
   profile: PROFILE,
+  currentPlan: PLAN,
   selectedPlan: SELECTED_PLAN,
   subscription: IAP_GOOGLE_SUBSCRIPTION,
   code: 'iap_already_subscribed',

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { MockApp, MOCK_CUSTOMER } from '../../../lib/test-utils';
-import { SELECTED_PLAN, PROFILE } from '../../../lib/mock-data';
+import { PLAN, SELECTED_PLAN, PROFILE } from '../../../lib/mock-data';
 import { SignInLayout } from '../../../components/AppLayout';
 import IapRoadblock, { IapRoadblockProps } from './index';
 import {
@@ -14,6 +14,8 @@ import { Customer } from '../../../store/types';
 const subscription: IapSubscription = {
   _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
   product_id: SELECTED_PLAN.product_id,
+  product_name: 'Better Upgrade Product',
+  price_id: 'plan_123',
   auto_renewing: true,
   expiry_time_millis: Date.now(),
   package_name: 'mozilla.cooking.with.foxkeh.monthly',
@@ -21,6 +23,7 @@ const subscription: IapSubscription = {
 };
 const MOCK_PROPS: IapRoadblockProps = {
   profile: PROFILE,
+  currentPlan: PLAN,
   selectedPlan: SELECTED_PLAN,
   isMobile: false,
   subscription,

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
@@ -19,6 +19,7 @@ export type IapRoadblockProps = {
   isMobile: boolean;
   profile: Profile;
   customer: Customer;
+  currentPlan: Plan;
   selectedPlan: Plan;
   subscription?: IapSubscription;
   code: string;
@@ -39,6 +40,7 @@ const getIapSubscriptionAppStoreL10Id = (
 export const IapRoadblock = ({
   profile,
   isMobile,
+  currentPlan,
   selectedPlan,
   subscription,
   code,
@@ -74,7 +76,7 @@ export const IapRoadblock = ({
             subscriptionTitle: title,
             error: { code },
             actionFn: manageSubscription,
-            plan: selectedPlan,
+            plan: currentPlan,
             contentProps: { mobileAppStore },
           }}
         />


### PR DESCRIPTION
## Because

- Previous copy said you were already subscribed to the new plan (different from current but on same product set)

## This pull request

- Updates error copy to show the current plan name and not the new one
- Updates tests
- Updates stories
- Fixes some other nits/DRY/cleanups that were found while reviewing #14118 

## Issue that this pull request solves

Closes: FXA-5480

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
