### PR TITLE
refactor(payments-server): Convert footers to utilize Tailwind

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.scss
@@ -8,10 +8,4 @@
 
 .payment-confirmation {
   @include checkout-view();
-
-  .footer {
-    p {
-      margin-top: 11px;
-    }
-  }
 }

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -172,7 +172,7 @@ export const PaymentConfirmation = ({
           </div>
         )}
 
-        <div className="footer" data-testid="footer">
+        <div className="payment-footer" data-testid="footer">
           <PaymentLegalBlurb provider={payment_provider} />
           <TermsAndPrivacy
             plan={selectedPlan}

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.scss
@@ -8,9 +8,4 @@
 
 .payment-error {
   @include checkout-view();
-
-  // temporary fix and will be removed after FXA-5620
-  p {
-    margin-bottom: 1rem;
-  }
 }

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -138,7 +138,11 @@ export const PaymentErrorView = ({
       );
     }
 
-    return <div className="py-0 px-7 desktop:px-24">{errorMessage}</div>;
+    return (
+      <div className="py-0 px-7 text-grey-400 desktop:px-24">
+        {errorMessage}
+      </div>
+    );
   };
 
   return error ? (
@@ -153,13 +157,16 @@ export const PaymentErrorView = ({
           <PaymentErrorMessage />
         </div>
 
-        <div className="footer" data-testid="footer">
-          {/* This error code means the subscription was created successfully, but
+        {/* This error code means the subscription was created successfully, but
           there was an error loading the information on the success screen. In this
           case, we do not want a "Try again" or "Manage subscription" button. */}
-          {error.code !== 'fxa_fetch_profile_customer_error' ? (
+        {error.code !== 'fxa_fetch_profile_customer_error' && (
+          <div className="options mb-6" data-testid="options">
             <ActionButton data-testid={'error-view-action-button'} />
-          ) : null}
+          </div>
+        )}
+
+        <div className="payment-footer" data-testid="footer">
           <PaymentLegalBlurb provider={undefined} />
           <TermsAndPrivacy
             showFXALinks={showFxaLegalFooterLinks}

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.tsx
@@ -31,10 +31,7 @@ export const PaymentProcessing = ({
           </Localized>
         </div>
 
-        <div
-          className="border-0 flex flex-col justify-center mt-auto pt-16"
-          data-testid="footer"
-        >
+        <div className="payment-footer" data-testid="footer">
           <PaymentLegalBlurb provider={provider} />
         </div>
       </section>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -360,7 +360,7 @@ export const PlanDetails = ({
           )}
 
           {showExpandButton && (
-            <div className="footer text-center" data-testid="footer">
+            <div className="text-center" data-testid="footer">
               {detailsHidden ? (
                 <Localized id="plan-details-show-button">
                   <button

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -84,10 +84,13 @@ export const TermsAndPrivacy = ({
   ) : null;
 
   return (
-    <div className="legal-blurb" data-testid="terms-and-privacy-component">
-      {FXALegal}
-      <p className="legal-heading">{plan?.product_name}</p>
-      {productLegalBlurb}
+    <div data-testid="terms-and-privacy-component">
+      <div className="legal-blurb">{FXALegal}</div>
+
+      <div className="legal-blurb">
+        <p className="legal-heading">{plan?.product_name}</p>
+        {productLegalBlurb}
+      </div>
     </div>
   );
 };

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -459,7 +459,7 @@ export const Checkout = ({
             />
           </div>
 
-          <div className="subscription-create-footer">
+          <div className="payment-footer" data-testid="footer">
             <PaymentLegalBlurb provider={undefined} />
 
             <TermsAndPrivacy

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -319,7 +319,7 @@ export const SubscriptionCreate = ({
             />
           </div>
 
-          <div className="subscription-create-footer">
+          <div className="payment-footer" data-testid="footer">
             <PaymentLegalBlurb provider={paymentProvider} />
             {selectedPlan && <TermsAndPrivacy plan={selectedPlan} />}
           </div>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -191,8 +191,10 @@ export const SubscriptionUpgrade = ({
               </SubmitButton>
             </div>
 
-            <PaymentLegalBlurb provider={paymentProvider} />
-            <TermsAndPrivacy plan={selectedPlan} />
+            <div className="payment-footer" data-testid="footer">
+              <PaymentLegalBlurb provider={paymentProvider} />
+              <TermsAndPrivacy plan={selectedPlan} />
+            </div>
           </Form>
         </div>
         <PlanUpgradeDetails

--- a/packages/fxa-payments-server/src/styles/_mixins.scss
+++ b/packages/fxa-payments-server/src/styles/_mixins.scss
@@ -4,7 +4,7 @@
   box-shadow: 0 -1px white, 0 1px white, -2px 2px 2px -2px rgb(158, 158, 158),
     2px 2px 2px -2px rgb(158, 158, 158);
 
-  @include max-width("tablet") {
+  @include max-width('tablet') {
     position: relative;
   }
 }
@@ -17,12 +17,12 @@
   color: rgba(12, 12, 13, 0.8);
   padding: 16px 16px 60px;
 
-  @include min-width("tablet") {
+  @include min-width('tablet') {
     grid-row: 2/3;
     margin: 0 0 32px;
   }
 
-  @include min-width("desktop") {
+  @include min-width('desktop') {
     min-width: 60%;
     padding: -1px 48px 48px;
   }
@@ -31,11 +31,6 @@
     display: flex;
     flex-direction: column;
     text-align: center;
-  }
-
-  p {
-    margin: 0;
-    color: $grey-50;
   }
 
   .options {
@@ -65,13 +60,5 @@
     .button:active {
       background: #002275;
     }
-  }
-
-  .footer {
-    border: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding-top: 60px;
   }
 }

--- a/packages/fxa-payments-server/src/styles/tailwind.css
+++ b/packages/fxa-payments-server/src/styles/tailwind.css
@@ -26,29 +26,29 @@
 }
 
 /* footer copy */
+.payment-footer {
+  @apply pt-14;
+}
+
 .legal-blurb {
-  @apply clear-both text-xs leading-5 text-center;
+  @apply clear-both mt-5 text-xs leading-5 text-center;
 }
 
 .legal-blurb a {
-  @apply font-normal underline;
+  @apply underline;
+}
+
+.legal-blurb p {
+  @apply m-0 text-grey-400;
 }
 
 .legal-heading {
   @apply font-semibold text-grey-500;
 }
 
-.payment-error .legal-heading {
-  @apply mt-5;
-}
-
 /* shared styles used in Checkout and SubscriptionCreate*/
 .pay-with-heading {
   @apply gap-5 grid grid-cols-[minmax(20px,_1fr)_auto_minmax(20px,_1fr)] items-center mt-0 mx-0 mb-6 text-center text-grey-400 w-full;
-}
-
-.subscription-create-footer {
-  @apply mt-10;
 }
 
 .step-header {


### PR DESCRIPTION
## Because

- the footers were not consistent and also need to be updated to use Tailwind in the following components:
  - Checkout
  - PaymentConfirmation
  - PaymentErrorView
  - PaymentProcessing
  - SubscriptionCreate
  - SubscriptionUpgrade

## This pull request

- provides the footers with consistent styling

## Issue that this pull request solves

Closes: [FXA-5678](https://mozilla-hub.atlassian.net/browse/FXA-5678)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Checkout
<img width="1375" alt="Screen Shot 2022-10-28 at 4 36 27 PM" src="https://user-images.githubusercontent.com/28129806/198727648-cd0d2ebd-b37e-47ae-b448-272c9e0d0a0a.png">

PaymentConfirmation
<img width="1545" alt="Screen Shot 2022-10-28 at 12 09 49 PM" src="https://user-images.githubusercontent.com/28129806/198683394-89aeb967-f902-400a-8da0-d211e561fe11.png">

PaymentErrorView
<img width="1545" alt="Screen Shot 2022-10-28 at 2 42 49 PM" src="https://user-images.githubusercontent.com/28129806/198709413-2022a9d0-a55e-4898-af03-e518782379e5.png">

PaymentProcessing
<img width="1527" alt="Screen Shot 2022-10-28 at 12 14 52 PM" src="https://user-images.githubusercontent.com/28129806/198684330-b50deb24-9b60-4d04-9d84-86a40411b813.png">

SubscriptionCreate
<img width="1401" alt="Screen Shot 2022-10-28 at 4 37 24 PM" src="https://user-images.githubusercontent.com/28129806/198727783-a507defe-f187-498c-a8bf-fa87cc12c593.png">

SubscriptionUpgrade
<img width="1377" alt="Screen Shot 2022-10-28 at 4 37 49 PM" src="https://user-images.githubusercontent.com/28129806/198727834-07657a9b-73a3-4f10-8666-af55c4791ebe.png">

## Other information (Optional)
`PlanDetails` - `footer` class was not defined/applied to this component and therefore was removed - no display changes.
<img width="780" alt="Screen Shot 2022-10-28 at 2 46 53 PM" src="https://user-images.githubusercontent.com/28129806/198710059-944c7ece-390f-4560-b35a-0c4c2dc8c97e.png">
