### PR TITLE
task(admin-panel): Unsubcribe users from newsletters

### DIFF
--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -77,6 +77,12 @@ export const UNLINK_ACCOUNT = gql`
   }
 `;
 
+export const UNSUBSCRIBE_FROM_MAILING_LISTS = gql`
+  mutation unsubscribeFromMailingLists($uid: String!) {
+    unsubscribeFromMailingLists(uid: $uid)
+  }
+`;
+
 export const LinkedAccount = ({
   uid,
   authAt,
@@ -189,12 +195,35 @@ export const DangerZone = ({
       window.alert('Error in unconfirming email');
     },
   });
-
   const handleUnverify = () => {
     if (!window.confirm('Are you sure? This cannot be undone.')) {
       return;
     }
     unverify({ variables: { email: email.email } });
+  };
+
+  const [unsubscribeFromMailingLists] = useMutation(
+    UNSUBSCRIBE_FROM_MAILING_LISTS,
+    {
+      onCompleted: (data) => {
+        if (data.unsubscribeFromMailingLists) {
+          window.alert(
+            "The user's email has been unsubscribed from mozilla mailing lists."
+          );
+        } else {
+          window.alert('Unsubscribing was not successful.');
+        }
+      },
+      onError: () => {
+        window.alert('Unexpected error encountered!');
+      },
+    }
+  );
+  const handleUnsubscribeFromMailingLists = () => {
+    if (!window.confirm('Are you sure? This cannot be undone.')) {
+      return;
+    }
+    unsubscribeFromMailingLists({ variables: { uid } });
   };
 
   const [disableAccount] = useMutation(DISABLE_ACCOUNT, {
@@ -265,6 +294,7 @@ export const DangerZone = ({
           AdminPanelFeature.UnverifyEmail,
           AdminPanelFeature.DisableAccount,
           AdminPanelFeature.EnableAccount,
+          AdminPanelFeature.UnsubscribeFromMailingLists,
         ]}
       >
         <h3 className="mt-0 mb-1 bg-red-600 font-medium h-8 pb-8 pl-1 pt-1 rounded-sm text-lg text-white">
@@ -348,6 +378,24 @@ export const DangerZone = ({
           </div>
         </Guard>
       )}
+      <Guard features={[AdminPanelFeature.UnsubscribeFromMailingLists]}>
+        <h2 className="text-lg account-header">
+          Unsubscribe From Mailing Lists
+        </h2>
+        <div className="border-l-2 border-red-600 mb-4 pl-4">
+          <p className="text-base leading-6">
+            Unsubscribe user from <b>all</b> mozilla mailing lists.
+          </p>
+          <button
+            className="bg-grey-10 border-2 border-grey-100 font-medium h-12 leading-6 mt-4 mr-4 rounded text-red-700 w-40 hover:border-2 hover:border-grey-10 hover:bg-grey-50 hover:text-red-700"
+            type="button"
+            data-testid="unsubscribe-from-mailing-lists"
+            onClick={handleUnsubscribeFromMailingLists}
+          >
+            Unsubscribe
+          </button>
+        </div>
+      </Guard>
     </>
   );
 };
@@ -706,6 +754,7 @@ export const Account = ({
           disabledAt: disabledAt!,
           email: primaryEmail, // only the primary for now
           onCleared: onCleared,
+          unsubscribeToken: '<USER_TOKEN>',
         }}
       />
     </section>

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/mocks.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/mocks.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MockedResponse } from '@apollo/client/testing';
+import { UNSUBSCRIBE_FROM_MAILING_LISTS } from '.';
+
+export const mockUnsubscribe = (success: boolean): MockedResponse => {
+  const request = {
+    query: UNSUBSCRIBE_FROM_MAILING_LISTS,
+  };
+
+  let result = undefined;
+  let error = undefined;
+  if (success) {
+    result = {
+      data: {
+        status: success,
+      },
+    };
+  } else {
+    error = new Error('Unsubscribe failed.');
+  }
+
+  return {
+    request,
+    result,
+    error,
+  };
+};

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -199,7 +199,7 @@ export const AccountSearch = () => {
     return filteredList.map((item) => (
       <a
         key={item}
-        className="p-2 border-b border-grey-100 block hover:bg-grey-10 focus:bg-grey-10"
+        className="p-2 border-b border-grey-100 block hover:bg-grey-10 focus:bg-grey-10 z-50"
         href="#suggestion"
         onClick={(e: any) => {
           e.preventDefault();
@@ -266,7 +266,7 @@ export const AccountSearch = () => {
           </button>
           {showSuggestion && filteredList.length > 0 && (
             <div
-              className="suggestions-list absolute top-full w-full bg-white border border-grey-100 mt-3 shadow-sm rounded overflow-hidden"
+              className="suggestions-list absolute top-full w-full bg-white border border-grey-100 mt-3 shadow-sm rounded overflow-hidden z-50"
               data-testid="email-suggestions"
             >
               {renderSuggestions()}

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -23,6 +23,7 @@ import { DatabaseService } from './database/database.service';
 import { EventLoggingModule } from './event-logging/event-logging.module';
 import { GqlModule } from './gql/gql.module';
 import { SubscriptionModule } from './subscriptions/subscriptions.module';
+import { NewslettersModule } from './newsletters/newsletters.module';
 import { BackendModule } from './backend/backend.module';
 
 const version = getVersionInfo(__dirname);
@@ -37,6 +38,7 @@ const version = getVersionInfo(__dirname);
     DatabaseModule,
     EventLoggingModule,
     SubscriptionModule,
+    NewslettersModule,
     GqlModule,
     GraphQLModule.forRootAsync({
       imports: [ConfigModule, SentryModule],

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -524,6 +524,26 @@ const conf = convict({
     default: path.resolve(__dirname, '../config/public-key.json'),
     env: 'PUBLIC_KEY_FILE',
   },
+  newsletters: {
+    basketHost: {
+      doc: 'Host where basket api lives',
+      format: String,
+      default: 'basket.mozilla.org',
+      env: 'BASKET_HOST',
+    },
+    basketApiKey: {
+      doc: 'Api key for basket',
+      format: String,
+      default: '',
+      env: 'BASKET_API_KEY',
+    },
+    newsletterHost: {
+      doc: 'Host where newsletter api lives',
+      format: String,
+      default: 'www.mozilla.org',
+      env: 'NEWSLETTER_HOST',
+    },
+  },
 });
 
 const configDir = __dirname;

--- a/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
+++ b/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
@@ -12,6 +12,7 @@ export enum EventNames {
   DisableLogin = 'disable-login',
   AccountSearch = 'account-search',
   EditLocale = 'edit-locale',
+  UnsubscribeFromMailingLists = 'unsubscribe-from-mailing-lists',
 }
 
 /**

--- a/packages/fxa-admin-server/src/gql/gql.module.ts
+++ b/packages/fxa-admin-server/src/gql/gql.module.ts
@@ -10,6 +10,7 @@ import { AccountResolver } from './account/account.resolver';
 import { EmailBounceResolver } from './email-bounce/email-bounce.resolver';
 import { RelyingPartyResolver } from './relying-party/relying-party.resolver';
 import { BackendModule } from '../backend/backend.module';
+import { NewslettersModule } from '../newsletters/newsletters.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { BackendModule } from '../backend/backend.module';
     SubscriptionModule,
     EventLoggingModule,
     BackendModule,
+    NewslettersModule,
   ],
   providers: [AccountResolver, EmailBounceResolver, RelyingPartyResolver],
 })

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -174,6 +174,7 @@ export interface IMutation {
     sendPasswordResetEmail(email: string): boolean | Promise<boolean>;
     recordAdminSecurityEvent(name: string, uid: string): boolean | Promise<boolean>;
     unlinkAccount(uid: string): boolean | Promise<boolean>;
+    unsubscribeFromMailingLists(uid: string): boolean | Promise<boolean>;
     clearEmailBounce(email: string): boolean | Promise<boolean>;
     updateNotes(notes: string, id: string): boolean | Promise<boolean>;
 }

--- a/packages/fxa-admin-server/src/newsletters/basket.service.spec.ts
+++ b/packages/fxa-admin-server/src/newsletters/basket.service.spec.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppConfig } from '../config';
+import { MockConfig, mockConfigOverrides } from '../mocks';
+import { BasketService } from './basket.service';
+
+describe('BasketService', () => {
+  const validEmail = 'success@example.com';
+  const invalidEmail = 'failure@example.com';
+  let service: BasketService;
+  let config: AppConfig['newsletters'];
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BasketService, MockConfig],
+    }).compile();
+    service = module.get<BasketService>(BasketService);
+    config = module.get<ConfigService>(ConfigService).get('').newsletters;
+  });
+
+  it('has api key', () => {
+    // Ensure basket api key is set in config/secrets.json or as env variable
+    expect(config.basketApiKey).toBeDefined();
+  });
+
+  it('looks up uid by valid email', async () => {
+    if (!config.basketApiKey) {
+      return;
+    }
+    const token = await service.getUserToken(validEmail);
+    expect(token).toBeDefined();
+    expect(token.length).toBeGreaterThan(8);
+  });
+
+  it('looks up invalid email', async () => {
+    if (!config.basketApiKey) {
+      return;
+    }
+    const token = await service.getUserToken(invalidEmail);
+    expect(token).toBeUndefined();
+  });
+
+  it('unsubscribes from mailing lists', async () => {
+    if (!config.basketApiKey) {
+      return;
+    }
+    const token = await service.getUserToken(validEmail);
+    const result = await service.unsubscribeAll(token);
+    expect(result).toBeTruthy();
+  });
+
+  describe('Missing api key', () => {
+    beforeAll(async () => {
+      mockConfigOverrides.newsletters = {
+        newsletterHost: '',
+        basketHost: '',
+        basketApiKey: '',
+      };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [BasketService, MockConfig],
+      }).compile();
+
+      service = module.get<BasketService>(BasketService);
+    });
+
+    afterAll(() => {
+      delete mockConfigOverrides.newsletters;
+    });
+
+    it('throws on query', async () => {
+      await expect(async () => {
+        await service.getUserToken(validEmail);
+      }).rejects.toThrowError('No API key configured!');
+    });
+  });
+});

--- a/packages/fxa-admin-server/src/newsletters/basket.service.ts
+++ b/packages/fxa-admin-server/src/newsletters/basket.service.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import fetch from 'node-fetch';
+import { AppConfig } from '../config';
+
+/**
+ * A service for basket and newsletter APIs.
+ */
+@Injectable()
+export class BasketService {
+  /** Basket config */
+  private readonly config: AppConfig['newsletters'];
+
+  private get basketUrl() {
+    return `https://${this.config.basketHost}`;
+  }
+
+  private get newsLetterUrl() {
+    return `https://${this.config.newsletterHost}`;
+  }
+
+  constructor(configService: ConfigService<AppConfig>) {
+    const config = configService.get('newsletters');
+    if (!config) {
+      throw new Error('No basket api key defined!');
+    }
+
+    this.config = config;
+  }
+
+  /**
+   * Locates a user token by email in basket
+   * @param email
+   * @returns User's token or undefined if no user is found.
+   */
+  async getUserToken(email: string) {
+    // Check that API key was configured.
+    if (!this.config.basketApiKey) {
+      throw new Error('No API key configured!');
+    }
+
+    const url = getUrl(this.basketUrl, '/news/lookup-user/', {
+      email,
+      'api-key': this.config.basketApiKey,
+    });
+    const resp = await fetch(url);
+
+    if (resp.status === 200) {
+      const body = await resp.json();
+      return body?.token;
+    }
+  }
+
+  /**
+   * Unsubscribes a user from all email lists
+   * @param userToken - A valid user token. Can be located with getUserToken method.
+   * @returns True if request was successful.
+   */
+  async unsubscribeAll(userToken: string) {
+    const url = getUrl(
+      this.newsLetterUrl,
+      `/en-US/newsletter/existing/${userToken}/`,
+      {}
+    );
+
+    const params = new URLSearchParams();
+    params.append('form-TOTAL_FORMS', '0');
+    params.append('form-INITIAL_FORMS', '0');
+    params.append('form-MIN_NUM_FORMS', '0');
+    params.append('country', 'us');
+    params.append('lang', 'en');
+    params.append('format', 'H');
+    params.append('remove_all', 'on');
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      body: params,
+    });
+    return resp?.status === 200;
+  }
+}
+
+function getUrl<T>(baseUrl: string, path: string, params: Record<string, any>) {
+  const q = Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  return `${baseUrl}${path}?${q}`;
+}

--- a/packages/fxa-admin-server/src/newsletters/newsletters.module.ts
+++ b/packages/fxa-admin-server/src/newsletters/newsletters.module.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Module } from '@nestjs/common';
+import { BasketService } from './basket.service';
+
+@Module({
+  providers: [BasketService],
+  exports: [BasketService],
+})
+export class NewslettersModule {}

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -169,6 +169,7 @@ type Mutation {
   sendPasswordResetEmail(email: String!): Boolean!
   recordAdminSecurityEvent(name: String!, uid: String!): Boolean!
   unlinkAccount(uid: String!): Boolean!
+  unsubscribeFromMailingLists(uid: String!): Boolean!
   clearEmailBounce(email: String!): Boolean!
   updateNotes(notes: String!, id: String!): Boolean!
 }

--- a/packages/fxa-shared/guards/AdminPanelGuard.ts
+++ b/packages/fxa-shared/guards/AdminPanelGuard.ts
@@ -18,6 +18,7 @@ export enum PermissionLevel {
 }
 
 /** Enum of known features */
+
 export enum AdminPanelFeature {
   AccountSearch = 'AccountSearch',
   AccountHistory = 'AccountHistory',
@@ -32,6 +33,7 @@ export enum AdminPanelFeature {
   RelyingParties = 'RelyingParties',
   RelyingPartiesEditNotes = 'RelyingPartiesEditNotes',
   SendPasswordResetEmail = 'SendPasswordResetEmail',
+  UnsubscribeFromMailingLists = 'UnsubscribeFromMailingLists',
 }
 
 /** Enum of known user groups */
@@ -136,6 +138,10 @@ const defaultAdminPanelPermissions: Permissions = {
   },
   [AdminPanelFeature.SendPasswordResetEmail]: {
     name: 'Send Password Reset Email',
+    level: PermissionLevel.Support,
+  },
+  [AdminPanelFeature.UnsubscribeFromMailingLists]: {
+    name: 'Unsubscribe User From Mozilla Mailing Lists',
     level: PermissionLevel.Support,
   },
 };


### PR DESCRIPTION
## Because

- We want support to be able to unsubscribe users from newsletters


## This pull request

- Adds newsletter module
- Adds service for basket api
- Adds graphql mutation for unsubscribing users
- Adds button to admin panel that unsubscribed users

## Issue that this pull request solves

Closes: FXA-5358

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/199069493-a6ee88e1-dc2f-4b99-a959-13f460fbc0ce.png)

## Other information (Optional)

Manually testing this requires an api key for basket. This will need to be added to a secrets.json file in the admin server.
