### PR TITLE
task(admin-panel): Add ability to see canceled/inactive subscriptions

### DIFF
--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
@@ -16,12 +16,17 @@ import {
 import { AppStoreService } from './appstore.service';
 import { PlayStoreService } from './playstore.service';
 import { StripeService } from './stripe.service';
-import { SubscriptionsService } from './subscriptions.service';
+import {
+  SubscriptionsService,
+  VALID_SUBSCRIPTION_STATUSES,
+} from './subscriptions.service';
 import { addDays, created } from './test.util';
 
 describe('Subscription Service', () => {
   // Stripe Service Mock
   const mockFetchCustomers = jest.fn();
+  const subscriptionStatusTypes = VALID_SUBSCRIPTION_STATUSES;
+
   const mockLookupLatestInvoice = jest.fn();
   const mockAllAbbrevPlans = jest.fn();
   const mockCreateManageSubscriptionLink = jest.fn();
@@ -145,7 +150,11 @@ describe('Subscription Service', () => {
     const subscriptions = await service.getSubscriptions(uid);
     expect(subscriptions).toEqual([]);
     expect(mockAllAbbrevPlans).toBeCalledTimes(1);
-    expect(mockFetchCustomers).toBeCalledWith(uid, ['subscriptions']);
+    expect(mockFetchCustomers).toBeCalledWith(
+      uid,
+      ['subscriptions'],
+      subscriptionStatusTypes
+    );
     expect(mockAppStoreGetSubscriptions).toBeCalledWith(uid);
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
   });
@@ -213,7 +222,11 @@ describe('Subscription Service', () => {
       },
     ]);
     expect(mockAllAbbrevPlans).toBeCalledTimes(1);
-    expect(mockFetchCustomers).toBeCalledWith(uid, ['subscriptions']);
+    expect(mockFetchCustomers).toBeCalledWith(
+      uid,
+      ['subscriptions'],
+      subscriptionStatusTypes
+    );
     expect(mockCreateManageSubscriptionLink).toBeCalledWith(customerId);
     expect(mockAppStoreGetSubscriptions).toBeCalledWith(uid);
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
@@ -274,7 +287,11 @@ describe('Subscription Service', () => {
       },
     ]);
     expect(mockAllAbbrevPlans).toBeCalledTimes(1);
-    expect(mockFetchCustomers).toBeCalledWith(uid, ['subscriptions']);
+    expect(mockFetchCustomers).toBeCalledWith(
+      uid,
+      ['subscriptions'],
+      subscriptionStatusTypes
+    );
     expect(mockAppStoreGetSubscriptions).toBeCalledWith(uid);
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
   });
@@ -377,7 +394,11 @@ describe('Subscription Service', () => {
       },
     ]);
     expect(mockAllAbbrevPlans).toBeCalledTimes(1);
-    expect(mockFetchCustomers).toBeCalledWith(uid, ['subscriptions']);
+    expect(mockFetchCustomers).toBeCalledWith(
+      uid,
+      ['subscriptions'],
+      subscriptionStatusTypes
+    );
     expect(mockAppStoreGetSubscriptions).toBeCalledWith(uid);
     expect(mockPlayStoreGetSubscriptions).toBeCalledWith(uid);
   });

--- a/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
@@ -621,28 +621,46 @@ describe('StripeFirestore', () => {
   });
 
   describe('retrieveCustomerSubscriptions', () => {
-    it('retrieves customer subscriptions', async () => {
-      const subscriptionSnap = {
-        docs: [{ data: () => ({ ...customer.subscriptions.data[0] }) }],
-      };
-      customerCollectionDbRef.where = sinon.fake.returns({
-        get: sinon.fake.resolves({
-          empty: false,
-          docs: [
-            {
-              ref: {
-                collection: sinon.fake.returns({
-                  get: sinon.fake.resolves(subscriptionSnap),
-                }),
+    describe('retrieves customer subscriptions', () => {
+      beforeEach(() => {
+        const subscriptionSnap = {
+          docs: [{ data: () => ({ ...customer.subscriptions.data[0] }) }],
+        };
+        customerCollectionDbRef.where = sinon.fake.returns({
+          get: sinon.fake.resolves({
+            empty: false,
+            docs: [
+              {
+                ref: {
+                  collection: sinon.fake.returns({
+                    get: sinon.fake.resolves(subscriptionSnap),
+                  }),
+                },
               },
-            },
-          ],
-        }),
+            ],
+          }),
+        });
       });
-      const subscriptions = await stripeFirestore.retrieveCustomerSubscriptions(
-        customer.id
-      );
-      assert.deepEqual(subscriptions, [customer.subscriptions.data[0]]);
+
+      it('without status filter', async () => {
+        const subscriptions =
+          await stripeFirestore.retrieveCustomerSubscriptions(customer.id);
+        assert.deepEqual(subscriptions, [customer.subscriptions.data[0]]);
+      });
+
+      it('with status filter', async () => {
+        const subscriptions =
+          await stripeFirestore.retrieveCustomerSubscriptions(customer.id, [
+            'active',
+          ]);
+        assert.deepEqual(subscriptions, [customer.subscriptions.data[0]]);
+      });
+
+      it('with empty status filter', async () => {
+        const subscriptions =
+          await stripeFirestore.retrieveCustomerSubscriptions(customer.id, []);
+        assert.deepEqual(subscriptions, []);
+      });
     });
 
     it('retrieves only active customer subscriptions', async () => {

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -6275,7 +6275,8 @@ describe('StripeHelper', () => {
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveCustomerSubscriptions,
-        customer.id
+        customer.id,
+        undefined
       );
     });
 
@@ -6298,7 +6299,8 @@ describe('StripeHelper', () => {
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveCustomerSubscriptions,
-        customer.id
+        customer.id,
+        undefined
       );
     });
 

--- a/packages/fxa-shared/payments/stripe-firestore.ts
+++ b/packages/fxa-shared/payments/stripe-firestore.ts
@@ -258,8 +258,15 @@ export class StripeFirestore {
 
   /**
    * Retrieve all the customer subscriptions from Firestore.
+   * @param customerId - The target customer
+   * @param statusFilter - Optional list of subscription statuses to filter by. Only
+   *                       subscriptions with status contained in this list will be
+   *                       returned. Defaults to ACTIVE_SUBSCRIPTION_STATUSES.
    */
-  async retrieveCustomerSubscriptions(customerId: string) {
+  async retrieveCustomerSubscriptions(
+    customerId: string,
+    statusFilter: Stripe.Subscription.Status[] = ACTIVE_SUBSCRIPTION_STATUSES
+  ) {
     const customerSnap = await this.customerCollectionDbRef
       .where('id', '==', customerId)
       .get();
@@ -275,7 +282,7 @@ export class StripeFirestore {
       .get();
     return subscriptionSnap.docs
       .map((doc) => doc.data() as Stripe.Subscription)
-      .filter((sub) => ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status));
+      .filter((sub) => statusFilter.includes(sub.status));
   }
 
   /**


### PR DESCRIPTION
## Because

- Support needs to see all of a customer's potential subscriptions, not just active ones.

## This pull request

- Adds an optional status filter to StripeFirestore.retrieveCustomerSubscriptions
- Applies a filter that includes all subscription statuses in the admin server’s SubscriptionsService and ensures this filter is passed down the call chain.

## Issue that this pull request solves

Closes: FXA-5594

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="522" alt="image" src="https://user-images.githubusercontent.com/94418270/199301800-455debd1-012c-4291-ada2-9008f2358d45.png">

## Other information (Optional)

The following stripe subscription statuses, which should be all subscriptions, are now visible in the admin panel:
  - active
  - canceled
  - incomplete
  - incomplete_expired
  - past_due
  - trialing
  - unpaid
