### PR TITLE
fix(tests): assign options to auth signUp

### DIFF
--- a/packages/functional-tests/lib/targets/remote.ts
+++ b/packages/functional-tests/lib/targets/remote.ts
@@ -7,12 +7,11 @@ export abstract class RemoteTarget extends BaseTarget {
     password: string,
     options?: any
   ): Promise<Credentials> {
-    const creds = await this.auth.signUp(email, password);
+    const creds = await this.auth.signUp(email, password, options || {});
     const code = await this.email.waitForEmail(
       email,
       EmailType.verify,
-      EmailHeader.verifyCode,
-      ...(options || {})
+      EmailHeader.verifyCode
     );
     await this.auth.verifyCode(creds.uid, code);
     await this.email.clear(email);


### PR DESCRIPTION
## Because

- Functional tests are failing with error `TypeError: Found non-callable @@iterator`.
- Options added to createAccount should be passed to auth.signUp.

## This pull request

- Assign options parameter to auth.signUp.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
