### PR TITLE
test(functional): update the FF ESR and geckodriver version to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ commands:
         default: 6
     steps:
       - browser-tools/install-firefox:
-          version: 78.9.0esr
+          version: 102.4.0esr
       - browser-tools/install-geckodriver:
-          version: v0.29.1
+          version: v0.32.0
       - base-install
       - run:
           name: Running test section << parameters.index >> of << parameters.total >>
@@ -75,9 +75,9 @@ commands:
   test-settings-server:
     steps:
       - browser-tools/install-firefox:
-          version: 78.9.0esr
+          version: 102.4.0esr
       - browser-tools/install-geckodriver:
-          version: v0.29.1
+          version: v0.32.0
       - base-install
       - run:
           name: Running test...


### PR DESCRIPTION
## Because

`Updating functional tests to FF 102.4.0esr as ESR 91 is not supported anymore`

## This pull request

`Will update the FF to ESR 102.4.0`

## Issue that this pull request solves

Closes: #[FXA-4579](https://mozilla-hub.atlassian.net/browse/FXA-4579)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
