### PR TITLE
feat(pushbox): delete a device's records on device destroy

### DIFF
--- a/packages/fxa-auth-server/lib/pushbox/db.ts
+++ b/packages/fxa-auth-server/lib/pushbox/db.ts
@@ -59,6 +59,12 @@ export class PushboxDB {
       messages,
     };
   }
+
+  async deleteDevice(x: { uid: string; deviceId: string }) {
+    await Record.query()
+      .delete()
+      .where({ user_id: x.uid, device_id: x.deviceId });
+  }
 }
 
 export default PushboxDB;

--- a/packages/fxa-auth-server/lib/pushbox/index.ts
+++ b/packages/fxa-auth-server/lib/pushbox/index.ts
@@ -79,6 +79,12 @@ export const pushboxApi = (
       store() {
         return Promise.reject(error.featureNotEnabled());
       },
+      deleteDevice() {
+        return Promise.reject(error.featureNotEnabled());
+      },
+      deleteAccount() {
+        return Promise.reject(error.featureNotEnabled());
+      },
     };
   }
 
@@ -278,6 +284,31 @@ export const pushboxApi = (
         throw error.backendServiceFailure();
       }
       return body;
+    },
+
+    async deleteDevice(uid: string, deviceId: string) {
+      if (shouldUseDb()) {
+        const startTime = performance.now();
+        try {
+          await pushboxDb!.deleteDevice({ uid, deviceId });
+          statsd.timing(
+            'pushbox.db.delete.device.success',
+            performance.now() - startTime
+          );
+          statsd.increment('pushbox.db.delete.device', { uid, deviceId });
+        } catch (err) {
+          statsd.timing(
+            'pushbox.db.delete.device.failure',
+            performance.now() - startTime
+          );
+          log.error('pushbox.db.delete.device', { error: err });
+          throw error.unexpectedError();
+        }
+      }
+    },
+
+    async deleteAccount(uid: string) {
+      // TODO to be implemented in FXA-5772
     },
   };
 };

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -26,7 +26,7 @@ module.exports = function (
   const push = require('../push')(log, db, config, statsd);
   const { pushboxApi } = require('../pushbox');
   const pushbox = pushboxApi(log, config, statsd);
-  const devicesImpl = require('../devices')(log, db, push);
+  const devicesImpl = require('../devices')(log, db, push, pushbox);
   const cadReminders = require('../cad-reminders')(config, log);
   const signinUtils = require('./utils/signin')(
     log,

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -184,7 +184,12 @@ const PUSH_METHOD_NAMES = [
   'sendPush',
 ];
 
-const PUSHBOX_METHOD_NAMES = ['retrieve', 'store'];
+const PUSHBOX_METHOD_NAMES = [
+  'retrieve',
+  'store',
+  'deleteDevice',
+  'deleteAccount',
+];
 
 const SUBHUB_METHOD_NAMES = [
   'listPlans',

--- a/packages/fxa-auth-server/test/remote/pushbox/db.ts
+++ b/packages/fxa-auth-server/test/remote/pushbox/db.ts
@@ -111,4 +111,10 @@ describe('pushbox db', () => {
       assert.equal(result.index, insertIdx - 2);
     });
   });
+
+  describe('deleteDevice', () => {
+    it('deletes without error', async () => {
+      await pushboxDb.deleteDevice({ uid: r.uid, deviceId: r.deviceId });
+    });
+  });
 });


### PR DESCRIPTION
Because:
 - we want to delete a device's records from the Pushbox DB when the device is disconnected

This commit:
 - add a Pushbox call to the device's `destroy` function to delete the records from the Pushbox DB
