### PR TITLE
Revert "chore(deps): bump babel-loader from 8.2.2 to 9.0.0"

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -167,7 +167,7 @@
     "acorn": "^8.8.0",
     "async-retry": "^1.3.3",
     "audit-filter": "^0.5.0",
-    "babel-loader": "^9.0.0",
+    "babel-loader": "^8.2.2",
     "binary-split": "1.0.5",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -45,7 +45,7 @@
     "@sentry/node": "^6.19.1",
     "asmcrypto.js": "^0.22.0",
     "autoprefixer": "^10.4.7",
-    "babel-loader": "^9.0.0",
+    "babel-loader": "^8.2.2",
     "backbone": "^1.4.1",
     "backbone.cocktail": "0.5.15",
     "base32-decode": "1.0.0",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -64,7 +64,7 @@
     "@types/rimraf": "3.0.0",
     "@types/sinon": "^10",
     "babel-eslint": "^10.1.0",
-    "babel-loader": "^9.0.0",
+    "babel-loader": "^8.2.2",
     "babel-preset-react-app": "^10.0.1",
     "camelcase": "^6.3.0",
     "eslint": "^7.32.0",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -110,7 +110,7 @@
     "@types/uuid": "^8",
     "@types/webpack": "5.28.0",
     "autoprefixer": "^10.4.7",
-    "babel-loader": "^9.0.0",
+    "babel-loader": "^8.2.2",
     "css-loader": "^3.6.0",
     "eslint": "^7.32.0",
     "eslint-config-react-app": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15034,19 +15034,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "babel-loader@npm:9.0.0"
-  dependencies:
-    find-cache-dir: ^3.3.2
-    schema-utils: ^4.0.0
-  peerDependencies:
-    "@babel/core": ^7.12.0
-    webpack: ">=5"
-  checksum: 6b146e33c81fd948ffdefa8a6319efa1bea6e17c946bfac4641375710e51831aeb7f4a20c88604eaa00f5ecd4b6591da5a65ade326feba792609f932df150645
-  languageName: node
-  linkType: hard
-
 "babel-messages@npm:^6.23.0":
   version: 6.23.0
   resolution: "babel-messages@npm:6.23.0"
@@ -23439,17 +23426,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-cache-dir@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "find-cache-dir@npm:3.3.2"
-  dependencies:
-    commondir: ^1.0.1
-    make-dir: ^3.0.2
-    pkg-dir: ^4.1.0
-  checksum: 1e61c2e64f5c0b1c535bd85939ae73b0e5773142713273818cc0b393ee3555fb0fd44e1a5b161b8b6c3e03e98c2fcc9c227d784850a13a90a8ab576869576817
-  languageName: node
-  linkType: hard
-
 "find-my-way@npm:^7.3.0":
   version: 7.3.1
   resolution: "find-my-way@npm:7.3.1"
@@ -24517,7 +24493,7 @@ fsevents@~2.1.1:
     async-retry: ^1.3.3
     audit-filter: ^0.5.0
     aws-sdk: ^2.1242.0
-    babel-loader: ^9.0.0
+    babel-loader: ^8.2.2
     base64url: 3.0.1
     binary-split: 1.0.5
     buf: 0.1.1
@@ -24660,7 +24636,7 @@ fsevents@~2.1.1:
     audit-filter: ^0.5.0
     autoprefixer: ^10.4.7
     babel-eslint: ^10.1.0
-    babel-loader: ^9.0.0
+    babel-loader: ^8.2.2
     babel-plugin-dynamic-import-webpack: 1.1.0
     backbone: ^1.4.1
     backbone.cocktail: 0.5.15
@@ -25256,7 +25232,7 @@ fsevents@~2.1.1:
     "@types/sinon": ^10
     async-wait-until: ^2.0.12
     babel-eslint: ^10.1.0
-    babel-loader: ^9.0.0
+    babel-loader: ^8.2.2
     babel-preset-react-app: ^10.0.1
     camelcase: ^6.3.0
     classnames: ^2.3.1
@@ -25323,7 +25299,7 @@ fsevents@~2.1.1:
     "@types/uuid": ^8
     "@types/webpack": 5.28.0
     autoprefixer: ^10.4.7
-    babel-loader: ^9.0.0
+    babel-loader: ^8.2.2
     base32-decode: ^1.0.0
     base32-encode: ^1.2.0
     classnames: ^2.3.1


### PR DESCRIPTION
Reverts mozilla/fxa#14372

This seems to be breaking out Storybook builds. Seems after this bump, storybook builds fail with a bunch of console errors.

![image](https://user-images.githubusercontent.com/10620585/199620082-0fadcf71-ff47-4bd9-8274-cca2de682828.png)

![image](https://user-images.githubusercontent.com/10620585/199620135-21707a11-1254-4588-a3ab-82271c5c9090.png)
