### PR TITLE
feat(events): Add basic support for account email events (sent, delivered, bounced)

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -8,6 +8,7 @@ import {
   Totp as TotpType,
   RecoveryKeys as RecoveryKeysType,
   LinkedAccount as LinkedAccountType,
+  AccountEvent as AccountEventType,
 } from 'fxa-admin-server/src/graphql';
 import { AdminPanelFeature } from 'fxa-shared/guards';
 import Guard from '../../Guard';
@@ -105,6 +106,7 @@ export const Account = ({
   query,
   securityEvents,
   linkedAccounts,
+  accountEvents,
 }: AccountProps) => {
   const createdAtDate = getFormattedDate(createdAt);
   const disabledAtDate = getFormattedDate(disabledAt);
@@ -348,6 +350,23 @@ export const Account = ({
         ) : (
           <p data-testid="account-security-events" className="result-none">
             This account doesn't have any account history.
+          </p>
+        )}
+
+        <h3 className="header-lg">Email History</h3>
+        {accountEvents && accountEvents.length > 0 ? (
+          <TableXHeaders rowHeaders={['Event', 'Template', 'Timestamp']}>
+            {accountEvents.map((accountEvent: AccountEventType) => (
+              <TableRowXHeader key={accountEvent.createdAt}>
+                <>{accountEvent.name}</>
+                <>{accountEvent.template}</>
+                <>{getFormattedDate(accountEvent.createdAt)}</>
+              </TableRowXHeader>
+            ))}
+          </TableXHeaders>
+        ) : (
+          <p data-testid="account-events" className="result-none">
+            This account doesn't have any email history.
           </p>
         )}
 

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/index.test.tsx
@@ -107,6 +107,7 @@ class GetAccountsByEmail {
             linkedAccounts: [],
             attachedClients: [],
             subscriptions: [],
+            accountEvents: [],
           },
         },
       };
@@ -180,6 +181,15 @@ class GetAccountsByEmail {
           linkedAccounts: [],
           securityEvents: [],
           subscriptions: [],
+          accountEvents: [
+            {
+              name: 'emailSent',
+              createdAt: new Date(Date.now() - 60 * 60 * 1e3).getTime(),
+              template: 'recovery',
+              eventType: 'emailEvent',
+              service: 'sync',
+            },
+          ],
         },
       },
     };

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/index.tsx
@@ -52,6 +52,13 @@ const ACCOUNT_SCHEMA = `
     authAt
     enabled
   }
+  accountEvents {
+    name
+    service    
+    eventType
+    createdAt
+    template
+  }
   attachedClients {
     createdTime
     createdTimeFormatted

--- a/packages/fxa-admin-server/src/backend/backend.module.ts
+++ b/packages/fxa-admin-server/src/backend/backend.module.ts
@@ -4,9 +4,10 @@
 import { Module } from '@nestjs/common';
 
 import { AuthClientFactory, AuthClientService } from './auth-client.service';
+import { FirestoreFactory, FirestoreService } from './firestore.service';
 
 @Module({
-  providers: [AuthClientFactory],
-  exports: [AuthClientService],
+  providers: [AuthClientFactory, FirestoreFactory],
+  exports: [AuthClientService, FirestoreService],
 })
 export class BackendModule {}

--- a/packages/fxa-admin-server/src/backend/firestore.service.spec.ts
+++ b/packages/fxa-admin-server/src/backend/firestore.service.spec.ts
@@ -5,6 +5,7 @@
 import { Firestore } from '@google-cloud/firestore';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockConfig, MockFirestoreFactory } from '../mocks';
+import { FirestoreService } from './firestore.service';
 
 describe('Firestore Service', () => {
   let service: Firestore;
@@ -14,7 +15,7 @@ describe('Firestore Service', () => {
       providers: [MockConfig, MockFirestoreFactory],
     }).compile();
 
-    service = module.get<Firestore>('FIRESTORE');
+    service = module.get<Firestore>(FirestoreService);
   });
 
   it('should be defined', () => {

--- a/packages/fxa-admin-server/src/backend/firestore.service.ts
+++ b/packages/fxa-admin-server/src/backend/firestore.service.ts
@@ -42,8 +42,9 @@ export function setupFirestore(config: FirebaseFirestore.Settings) {
 /**
  * Factory for providing access to firestore
  */
+export const FirestoreService = Symbol('FIRESTORE');
 export const FirestoreFactory: Provider<Firestore> = {
-  provide: 'FIRESTORE',
+  provide: FirestoreService,
   useFactory: (configService: ConfigService) => {
     const firestoreConfig = configService.get('authFirestore');
     if (firestoreConfig == null) {

--- a/packages/fxa-admin-server/src/gql/model/account-events.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/account-events.model.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class AccountEvent {
+  @Field({ nullable: true })
+  public name!: string;
+
+  @Field({ nullable: true })
+  public createdAt!: number;
+
+  @Field({ nullable: true })
+  eventType!: string;
+
+  // Email event based properties
+  @Field({ nullable: true })
+  template!: string;
+
+  // Metrics properties
+  @Field({ nullable: true })
+  flowId!: string;
+
+  @Field({ nullable: true })
+  service!: string;
+}

--- a/packages/fxa-admin-server/src/gql/model/account.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/account.model.ts
@@ -10,6 +10,7 @@ import { RecoveryKeys } from './recovery-keys.model';
 import { SecurityEvents } from './security-events.model';
 import { Totp } from './totp.model';
 import { LinkedAccount } from './linked-account.model';
+import { AccountEvent } from './account-events.model';
 import { MozSubscription } from './moz-subscription.model';
 
 @ObjectType()
@@ -58,4 +59,7 @@ export class Account {
 
   @Field((type) => [LinkedAccount], { nullable: true })
   public linkedAccounts!: LinkedAccount[];
+
+  @Field((type) => [AccountEvent], { nullable: true })
+  public accountEvents!: AccountEvent[];
 }

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -113,6 +113,15 @@ export interface LinkedAccount {
     enabled: boolean;
 }
 
+export interface AccountEvent {
+    name?: Nullable<string>;
+    createdAt?: Nullable<number>;
+    eventType?: Nullable<string>;
+    template?: Nullable<string>;
+    flowId?: Nullable<string>;
+    service?: Nullable<string>;
+}
+
 export interface MozSubscription {
     created: number;
     currentPeriodEnd: number;
@@ -144,6 +153,7 @@ export interface Account {
     attachedClients?: Nullable<AttachedClient[]>;
     subscriptions?: Nullable<MozSubscription[]>;
     linkedAccounts?: Nullable<LinkedAccount[]>;
+    accountEvents?: Nullable<AccountEvent[]>;
 }
 
 export interface RelyingParty {

--- a/packages/fxa-admin-server/src/mocks.ts
+++ b/packages/fxa-admin-server/src/mocks.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '@nestjs/config';
 import { Path } from 'convict';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import config, { AppConfig } from './config';
+import { FirestoreService } from './backend/firestore.service';
 
 export const mockConfigOverrides: any = {};
 export const MockConfig: Provider = {
@@ -29,7 +30,7 @@ export const MockMetricsFactory: Provider = {
 
 export const mockFirestoreCollection = jest.fn();
 export const MockFirestoreFactory: Provider = {
-  provide: 'FIRESTORE',
+  provide: FirestoreService,
   useFactory: () => {
     return {
       collection: mockFirestoreCollection,

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -108,6 +108,15 @@ enum ProviderId {
   APPLE
 }
 
+type AccountEvent {
+  name: String
+  createdAt: Float
+  eventType: String
+  template: String
+  flowId: String
+  service: String
+}
+
 type MozSubscription {
   created: Float!
   currentPeriodEnd: Float!
@@ -139,6 +148,7 @@ type Account {
   attachedClients: [AttachedClient!]
   subscriptions: [MozSubscription!]
   linkedAccounts: [LinkedAccount!]
+  accountEvents: [AccountEvent!]
 }
 
 type RelyingParty {

--- a/packages/fxa-admin-server/src/subscriptions/appstore.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/appstore.service.spec.ts
@@ -10,7 +10,7 @@ import {
   AppStorePurchaseManagerService,
   AppStoreService,
 } from './appstore.service';
-import { FirestoreFactory } from './firestore.service';
+import { FirestoreFactory } from '../backend/firestore.service';
 
 describe('AppStoreHelperService', () => {
   let service: AppStoreHelperService;

--- a/packages/fxa-admin-server/src/subscriptions/appstore.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/appstore.service.ts
@@ -9,6 +9,7 @@ import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { AppStoreHelper } from 'fxa-shared/payments/iap/apple-app-store/app-store-helper';
 import { PurchaseManager } from 'fxa-shared/payments/iap/apple-app-store/purchase-manager';
 import { AppConfig } from '../config';
+import { FirestoreService } from '../backend/firestore.service';
 
 /**
  * Extends AppStoreHelper to be service like
@@ -30,7 +31,7 @@ export class AppStorePurchaseManagerService extends PurchaseManager {
     appStoreHelper: AppStoreHelperService,
     configService: ConfigService<AppConfig>,
     logger: MozLoggerService,
-    @Inject('FIRESTORE') firestore: Firestore
+    @Inject(FirestoreService) firestore: Firestore
   ) {
     const config = {
       authFirestore: configService.get('authFirestore'),

--- a/packages/fxa-admin-server/src/subscriptions/playstore.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/playstore.service.ts
@@ -9,6 +9,7 @@ import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { PurchaseManager } from 'fxa-shared/payments/iap/google-play/purchase-manager';
 import { UserManager } from 'fxa-shared/payments/iap/google-play/user-manager';
 import { Auth, google } from 'googleapis';
+import { FirestoreService } from '../backend/firestore.service';
 
 /**
  * Extends PurchaseManager to be service like
@@ -17,7 +18,7 @@ import { Auth, google } from 'googleapis';
 export class PlayStorePurchaseManagerService extends PurchaseManager {
   constructor(
     configService: ConfigService,
-    @Inject('FIRESTORE') firestore: Firestore,
+    @Inject(FirestoreService) firestore: Firestore,
     logger: MozLoggerService
   ) {
     const prefix = `${configService.get('authFirestore.prefix')}iap-`;
@@ -53,7 +54,7 @@ export class PlayStoreUserManagerService extends UserManager {
     configService: ConfigService,
     logger: MozLoggerService,
     purchaseManager: PlayStorePurchaseManagerService,
-    @Inject('FIRESTORE') firestore: Firestore
+    @Inject(FirestoreService) firestore: Firestore
   ) {
     const prefix = `${configService.get('authFirestore.prefix')}iap-`;
     const purchasesDbRef = firestore.collection(`${prefix}play-purchases`);

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -25,6 +25,7 @@ import {
 import { StatsD } from 'hot-shots';
 import Stripe from 'stripe';
 import { AppConfig } from '../config';
+import { FirestoreService } from '../backend/firestore.service';
 
 export const StripeFactory: Provider<Stripe> = {
   provide: 'STRIPE',
@@ -46,7 +47,7 @@ export class StripePaymentConfigManagerService extends PaymentConfigManager {
   constructor(
     configService: ConfigService<AppConfig>,
     logger: MozLoggerService,
-    @Inject('FIRESTORE') firestore: Firestore
+    @Inject(FirestoreService) firestore: Firestore
   ) {
     const config = {
       subscriptions: configService.get('subscriptions'),
@@ -64,7 +65,7 @@ export class StripePaymentConfigManagerService extends PaymentConfigManager {
 export class StripeFirestoreService extends StripeFirestore {
   constructor(
     configService: ConfigService<AppConfig>,
-    @Inject('FIRESTORE') firestore: Firestore,
+    @Inject(FirestoreService) firestore: Firestore,
     @Inject('STRIPE') stripe: Stripe
   ) {
     const config = {

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.module.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.module.ts
@@ -9,7 +9,7 @@ import {
   AppStorePurchaseManagerService,
   AppStoreService,
 } from './appstore.service';
-import { FirestoreFactory } from './firestore.service';
+import { FirestoreFactory } from '../backend/firestore.service';
 import {
   PlayStorePurchaseManagerService,
   PlayStoreService,

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -28,6 +28,7 @@ const {
 } = require('../lib/types');
 const { setupFirestore } = require('../lib/firestore-db');
 const { AppleIAP } = require('../lib/payments/iap/apple-app-store/apple-iap');
+const { AccountEventsManager } = require('../lib/account-events');
 
 async function run(config) {
   Container.set(AppConfig, config);
@@ -58,6 +59,13 @@ async function run(config) {
     const authFirestore = setupFirestore(config);
     Container.set(AuthFirestore, authFirestore);
   }
+
+  const accountEventsManager = config.accountEvents.enabled
+    ? new AccountEventsManager()
+    : {
+        recordEmailEvent: async () => Promise.resolve(),
+      };
+  Container.set(AccountEventsManager, accountEventsManager);
 
   const redis = require('../lib/redis')(
     { ...config.redis, ...config.redis.sessionTokens },

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -97,6 +97,12 @@ const convictConf = convict({
       env: 'AUTH_FIRESTORE_PROJECT_ID',
       format: String,
     },
+    ebPrefix: {
+      default: 'fxa-eb-',
+      doc: 'Event broker Firestore collection prefix',
+      env: 'AUTH_EB_FIRESTORE_COLLECTION_PREFIX',
+      format: String,
+    },
   },
   pubsub: {
     audience: {
@@ -1953,6 +1959,14 @@ const convictConf = convict({
     },
   },
   tracing: tracingConfig,
+  accountEvents: {
+    enabled: {
+      default: true,
+      doc: 'Flag to enable account event logging. Currently only email based events',
+      env: 'ACCOUNT_EVENTS_ENABLED',
+      format: Boolean,
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-auth-server/lib/account-events.ts
+++ b/packages/fxa-auth-server/lib/account-events.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Firestore } from '@google-cloud/firestore';
+import { Container } from 'typedi';
+
+import { AuthFirestore, AppConfig } from '../lib/types';
+import { StatsD } from 'hot-shots';
+
+type AccountEvent = {
+  name: string;
+  createdAt: number;
+  eventType: 'emailEvent' | 'securityEvent';
+
+  // Email event properties
+  template?: string;
+
+  // General metric properties
+  deviceId?: string;
+  flowId?: string;
+  service?: string;
+};
+
+export class AccountEventsManager {
+  private firestore: Firestore;
+  private usersDbRef;
+  private statsd;
+  readonly prefix: string;
+  readonly name: string;
+
+  constructor() {
+    // Users are already stored in the event broker Firebase collection, so we
+    // need to grab that prefix.
+    const { authFirestore } = Container.get(AppConfig);
+    this.prefix = authFirestore.ebPrefix;
+    this.name = `${this.prefix}users`;
+
+    this.firestore = Container.get(AuthFirestore);
+    this.usersDbRef = this.firestore.collection(this.name);
+
+    this.statsd = Container.get(StatsD);
+  }
+
+  /**
+   * Records a new email event for the user.
+   */
+  public async recordEmailEvent(
+    uid: string,
+    message: AccountEvent,
+    name: 'emailSent' | 'emailDelivered' | 'emailBounced' | 'emailComplaint'
+  ) {
+    try {
+      const { template, deviceId, flowId, service } = message;
+
+      const emailEvent = {
+        name,
+        createdAt: Date.now(),
+        eventType: 'emailEvent',
+        template,
+        deviceId,
+        flowId,
+        service,
+      };
+
+      // Firestore can be configured to ignore undefined keys, but we do it here
+      // since it is a global config
+      const filteredEmailEvent = {};
+      Object.keys(emailEvent).forEach((key) => {
+        // @ts-ignore
+        if (emailEvent[key]) {
+          // @ts-ignore
+          filteredEmailEvent[key] = emailEvent[key];
+        }
+      });
+
+      await this.usersDbRef
+        .doc(uid)
+        .collection('events')
+        .add(filteredEmailEvent);
+      this.statsd.increment('accountEvents.recordEmailEvent.write');
+    } catch (err) {
+      // Failing to write to events shouldn't break anything
+      this.statsd.increment('accountEvents.recordEmailEvent.error');
+    }
+  }
+}

--- a/packages/fxa-auth-server/lib/email/bounces.js
+++ b/packages/fxa-auth-server/lib/email/bounces.js
@@ -144,6 +144,8 @@ module.exports = function (log, error) {
         // Log the bounced flowEvent and emailEvent metrics
         utils.logFlowEventFromMessage(log, message, 'bounced');
         utils.logEmailEventFromMessage(log, message, 'bounced', emailDomain);
+        utils.logAccountEventFromMessage(message, 'emailBounced');
+
         log.info('handleBounce', logData);
 
         /**

--- a/packages/fxa-auth-server/lib/email/delivery.js
+++ b/packages/fxa-auth-server/lib/email/delivery.js
@@ -39,6 +39,7 @@ module.exports = function (log) {
         // Log the delivery flowEvent and emailEvent metrics if available
         utils.logFlowEventFromMessage(log, message, 'delivered');
         utils.logEmailEventFromMessage(log, message, 'delivered', emailDomain);
+        utils.logAccountEventFromMessage(message, 'emailDelivered');
 
         log.info('handleDelivery', logData);
       }

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -410,6 +410,7 @@ module.exports = function (
         const ip = request.app.clientAddress;
 
         request.emitMetricsEvent('session.resend_code');
+        const metricsContext = await request.gatherMetricsContext({});
 
         // Check to see if this account has a verified TOTP token. If so, then it should
         // not be allowed to bypass TOTP requirement by sending a sign-in confirmation email.
@@ -444,6 +445,9 @@ module.exports = function (
           uaOSVersion: sessionToken.uaOSVersion,
           uaDeviceType: sessionToken.uaDeviceType,
           uid: sessionToken.uid,
+          flowId: metricsContext.flow_id,
+          flowBeginTime: metricsContext.flowBeginTime,
+          deviceId: metricsContext.device_id,
         };
 
         if (account.primaryEmail.isVerified) {

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -486,6 +486,15 @@ module.exports = function (log, config, bounces) {
           headers,
         });
 
+        emailUtils.logAccountEventFromMessage(
+          {
+            headers: {
+              ...headers,
+            },
+          },
+          'emailSent'
+        );
+
         return resolve(status);
       });
     });

--- a/packages/fxa-auth-server/test/local/account-events.js
+++ b/packages/fxa-auth-server/test/local/account-events.js
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const { StatsD } = require('hot-shots');
+const { AccountEventsManager } = require('../../lib/account-events');
+const { default: Container } = require('typedi');
+const { AppConfig, AuthFirestore } = require('../../lib/types');
+
+const UID = 'uid';
+
+describe('Account Events', () => {
+  let usersDbRefMock;
+  let firestore;
+  let accountEventsManager;
+  let addMock;
+  let statsd;
+
+  beforeEach(() => {
+    addMock = sinon.stub();
+    usersDbRefMock = {
+      doc: sinon.stub().returns({
+        collection: sinon.stub().returns({
+          add: addMock,
+        }),
+      }),
+    };
+    firestore = {
+      collection: sinon.stub().returns(usersDbRefMock),
+    };
+    const mockConfig = {
+      authFirestore: {
+        enabled: true,
+        ebPrefix: 'fxa-eb-',
+      },
+      accountEvents: {
+        enabled: true,
+      },
+    };
+    Container.set(AppConfig, mockConfig);
+    Container.set(AuthFirestore, firestore);
+    statsd = { increment: sinon.spy() };
+    Container.set(StatsD, statsd);
+
+    accountEventsManager = new AccountEventsManager();
+  });
+
+  afterEach(() => {
+    Container.reset();
+  });
+
+  it('can be instantiated', () => {
+    assert.ok(accountEventsManager);
+  });
+
+  describe('email events', function () {
+    it('can record email event', async () => {
+      const message = {
+        template: 'verifyLoginCode',
+        deviceId: 'deviceId',
+        flowId: 'flowId',
+        service: 'service',
+      };
+      await accountEventsManager.recordEmailEvent(UID, message, 'emailSent');
+
+      const assertMessage = {
+        ...message,
+        eventType: 'emailEvent',
+        name: 'emailSent',
+      };
+      assert.calledOnceWithMatch(addMock, assertMessage);
+      assert.calledOnceWithExactly(usersDbRefMock.doc, UID);
+
+      assert.isAtLeast(Date.now(), addMock.firstCall.firstArg.createdAt);
+      assert.calledOnceWithExactly(
+        statsd.increment,
+        'accountEvents.recordEmailEvent.write'
+      );
+    });
+
+    it('logs and does not throw on failure', async () => {
+      usersDbRefMock.doc = sinon.stub().throws();
+      const message = {
+        template: 'verifyLoginCode',
+        deviceId: 'deviceId',
+        flowId: 'flowId',
+        service: 'service',
+      };
+      await accountEventsManager.recordEmailEvent(UID, message, 'emailSent');
+      assert.isFalse(addMock.called);
+      assert.calledOnceWithExactly(
+        statsd.increment,
+        'accountEvents.recordEmailEvent.error'
+      );
+    });
+
+    it('strips falsy values', async () => {
+      const message = {
+        template: null,
+        deviceId: undefined,
+        flowId: '',
+      };
+      await accountEventsManager.recordEmailEvent(UID, message, 'emailSent');
+      assert.isTrue(addMock.called);
+      assert.isUndefined(addMock.firstCall.firstArg.template);
+      assert.isUndefined(addMock.firstCall.firstArg.deviceId);
+      assert.isUndefined(addMock.firstCall.firstArg.flowId);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -10,6 +10,8 @@ const getRoute = require('../routes_helpers').getRoute;
 const mocks = require('../mocks');
 const proxyquire = require('proxyquire');
 const uuid = require('uuid');
+const { default: Container } = require('typedi');
+const { ProfileClient } = require('../../lib/types');
 
 const TEST_EMAIL = 'foo@gmail.com';
 const MS_ONE_DAY = 1000 * 60 * 60 * 24;
@@ -98,11 +100,16 @@ describe('IP Profiling', function () {
         keys: 'true',
       },
     });
+    Container.set(ProfileClient, {});
     accountRoutes = makeRoutes({
       db: mockDB,
       mailer: mockMailer,
     });
     route = getRoute(accountRoutes, '/account/login');
+  });
+
+  afterEach(() => {
+    Container.remove(ProfileClient);
   });
 
   it('no previously verified session', () => {


### PR DESCRIPTION
## Because

- We want to be able to see emails that were sent, delivered and bounced for a user in the admin panel

## This pull request

- Emits a new account metrics for delivered, sent, bounced emails
- Adds a subcollection (events) to the `fxa-eb-users` firestore root collection

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5727

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Example of data sent to Firestore
![Screen Shot 2022-11-07 at 3 38 22 PM](https://user-images.githubusercontent.com/1295288/200410525-3f45aeca-7e4e-4c88-9eaf-55946ff8916b.png)

In Admin panel
<img width="646" alt="Screen Shot 2022-11-07 at 11 23 15 PM" src="https://user-images.githubusercontent.com/1295288/200615087-d3f81197-07ed-4255-bc54-9bfff8ba1762.png">

## Other information (Optional)

Please note the distinction between "Security events" and "Account events", security events are stored in our mysql database and have not been updated in a very long time. It didn't seem to make sense to try to update this since our goal was to use Firestore to eventually store security related account events. This is how I ended up settling on the name "Account events".

I wasn't able to test the bounce events locally but I have good confidence that it should work as expected based on the unit tests.