### PR TITLE
feat(pushbox): delete all db records on account delete

### DIFF
--- a/packages/fxa-auth-server/lib/pushbox/db.ts
+++ b/packages/fxa-auth-server/lib/pushbox/db.ts
@@ -65,6 +65,10 @@ export class PushboxDB {
       .delete()
       .where({ user_id: x.uid, device_id: x.deviceId });
   }
+
+  async deleteAccount(uid: string) {
+    await Record.query().delete().where({ user_id: uid });
+  }
 }
 
 export default PushboxDB;

--- a/packages/fxa-auth-server/lib/pushbox/index.ts
+++ b/packages/fxa-auth-server/lib/pushbox/index.ts
@@ -308,7 +308,24 @@ export const pushboxApi = (
     },
 
     async deleteAccount(uid: string) {
-      // TODO to be implemented in FXA-5772
+      if (shouldUseDb()) {
+        const startTime = performance.now();
+        try {
+          await pushboxDb!.deleteAccount(uid);
+          statsd.timing(
+            'pushbox.db.delete.account.success',
+            performance.now() - startTime
+          );
+          statsd.increment('pushbox.db.delete.account');
+        } catch (err) {
+          statsd.timing(
+            'pushbox.db.delete.account.failure',
+            performance.now() - startTime
+          );
+          log.error('pushbox.db.delete.account', { error: err });
+          throw error.unexpectedError();
+        }
+      }
     },
   };
 };

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -70,7 +70,8 @@ module.exports = function (
     verificationReminders,
     subscriptionAccountReminders,
     oauthRawDB,
-    stripeHelper
+    stripeHelper,
+    pushbox
   );
   const oauth = require('./oauth')(log, config, db, mailer, devicesImpl);
   const devicesSessions = require('./devices-and-sessions')(

--- a/packages/fxa-auth-server/test/remote/pushbox/db.ts
+++ b/packages/fxa-auth-server/test/remote/pushbox/db.ts
@@ -117,4 +117,10 @@ describe('pushbox db', () => {
       await pushboxDb.deleteDevice({ uid: r.uid, deviceId: r.deviceId });
     });
   });
+
+  describe('deleteAccount', () => {
+    it('deletes without error', async () => {
+      await pushboxDb.deleteAccount(r.uid);
+    });
+  });
 });


### PR DESCRIPTION
Because:
 - we should delete the remaining pushbox records for an account when the account is deleted

This commit:
 - delete the pushbox db records of an account

