### PR TITLE
task(shared): Fix docker network error with otel

### DIFF
--- a/_dev/pm2/create-docker-net.sh
+++ b/_dev/pm2/create-docker-net.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if docker network ls | grep -e "$1 .* local$"; then
+    echo "$1 docker network already exists";
+else
+    echo "$1 docker network doesn't exist. creating fxa network";
+    docker network create $1
+fi

--- a/_dev/pm2/start.sh
+++ b/_dev/pm2/start.sh
@@ -3,6 +3,10 @@
 DIR=$(dirname "$0")
 cd "$DIR/../.."
 
+# Make sure there is a common docker network fxa, so containers can
+# communicate with one another if needed
+_dev/pm2/create-docker-net.sh fxa
+
 pm2 start _dev/pm2/infrastructure.config.js
 
 echo "waiting for containers to start"

--- a/_scripts/configs/otel-collector-config.yaml
+++ b/_scripts/configs/otel-collector-config.yaml
@@ -7,7 +7,7 @@ exporters:
   logging:
     loglevel: debug
   jaeger:
-    endpoint: "jaeger.otel:14250"
+    endpoint: "jaeger.fxa:14250"
     tls:
       insecure: true
   googlecloud:

--- a/_scripts/firestore.sh
+++ b/_scripts/firestore.sh
@@ -5,4 +5,4 @@ cd "$DIR/../_dev/firebase"
 
 # the "demo-" prefix for --project is special
 # see https://firebase.google.com/docs/emulator-suite/connect_firestore#choose_a_firebase_project
-docker run --rm -p 4400:4400 -p 4500:4500 -p 8085:8085 -p 9090:9090 -p 9299:9299 -v "$(pwd)":/home/node --name firebase-tools andreysenov/firebase-tools:latest firebase emulators:start --project demo-fxa
+docker run --rm --net fxa -p 4400:4400 -p 4500:4500 -p 8085:8085 -p 9090:9090 -p 9299:9299 -v "$(pwd)":/home/node --name firebase-tools andreysenov/firebase-tools:latest firebase emulators:start --project demo-fxa

--- a/_scripts/jaeger.sh
+++ b/_scripts/jaeger.sh
@@ -5,11 +5,8 @@ if [ "$TRACING_OTEL_EXPORTER_ENABLED" == "true" ]
 then
   echo -e "Jaeger enabled! Go to http://localhost:16686 to view traces. \n"
 
-  # Create an otel network. If it already exists and error will be shown that can be ignored
-  docker network create otel
-
   docker run --rm --name jaeger \
-    --net otel \
+    --net fxa \
     -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
     -e COLLECTOR_OTLP_ENABLED=true \
     -p 6831:6831/udp \

--- a/_scripts/memcached.sh
+++ b/_scripts/memcached.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run --rm -p 11211:11211 --name memcache memcached
+docker run --rm --net fxa  -p 11211:11211 --name memcache memcached

--- a/_scripts/otel-collector.sh
+++ b/_scripts/otel-collector.sh
@@ -19,11 +19,8 @@ then
 
   echo -e "Starting otel collector to capture client traces.\n exporters=$EXPORTERS\n gcp-proj-id=$TRACING_GCP_PROJECT"
 
-  # Create an otel network. If it already exists and error will be shown that can be ignored
-  docker network create otel
-
   docker run --rm --name otel-collector \
-    --net otel \
+    --net fxa \
     -v $(pwd)/_scripts/configs/otel-collector-config.yaml:/etc/otel/config.yaml \
     -v $HOME/.config/gcloud/application_default_credentials.json:/etc/otel/key.json \
     -e GOOGLE_APPLICATION_CREDENTIALS=/etc/otel/key.json \
@@ -34,5 +31,5 @@ then
     -p 55681:55681 \
     otel/opentelemetry-collector-contrib:0.61.0 --config=/etc/otel/config.yaml
 else
-  echo -e "The open telemtry connector did not start, because it is not enabled. Set env TRACING_OTEL_COLLECTOR_ENABLED=true to enable. Running an open telemetry collector is optional! \n"
+  echo -e "The open telemtry collector did not start, because it is not enabled. Set env TRACING_OTEL_COLLECTOR_ENABLED=true to enable. Running an open telemetry collector is optional! \n"
 fi

--- a/_scripts/pushbox-db.sh
+++ b/_scripts/pushbox-db.sh
@@ -15,6 +15,7 @@ function on_singint() {
 trap on_singint INT
 
 docker run --rm --name pushbox_db \
+  --net fxa \
   -p 4306:3306 \
   -e MYSQL_ROOT_PASSWORD=random \
   -e MYSQL_DATABASE=pushbox \

--- a/_scripts/redis.sh
+++ b/_scripts/redis.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run --rm --name redis-server -p 6379:6379 redis
+docker run --rm --name redis-server --net fxa -p 6379:6379 redis

--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -11,6 +11,7 @@ fi
 "${0%/*}/check-url.sh" "$HOST_ADDR:3030/.well-known/fxa-client-configuration"
 
 docker run --rm --name syncserver \
+  --net fxa \
   -p 5000:5000 \
   -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
   -e SYNCSERVER_IDENTITY_PROVIDER=http://$HOST_ADDR:3030 \


### PR DESCRIPTION
## Because

- When starting tracing with open telemetry the network name would sometimes collide and result in error.

## This pull request

- Sets an 'fxa' network name
- Applies this network to services
- Allows services to communicate by their names

