### PR TITLE
fix(tailwind): Update settings and payment to improve LTR/RTL support

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -34,6 +34,7 @@
 }
 
 .breadcrumbs {
+  display:flex;
   margin-top: 0;
   padding-left: 32px;
   width: 100%;
@@ -45,7 +46,6 @@
   }
 
   li {
-    float: left;
     list-style: none;
     margin: 0;
     padding: 0;

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -184,12 +184,12 @@ export const CouponForm = ({
       </h4>
       {hasCoupon ? (
         <div
-          className="flex justify-between items-center"
+          className="flex gap-4 justify-between items-center"
           data-testid="coupon-hascoupon"
         >
-          <div>{promotionCode}</div>
+          <div className="break-all">{promotionCode}</div>
           {readOnly ? null : (
-            <div className="ml-4">
+            <div>
               <button
                 className="button"
                 onClick={removeCoupon}
@@ -203,7 +203,7 @@ export const CouponForm = ({
         </div>
       ) : (
         <form
-          className="flex justify-between items-center"
+          className="flex gap-4 justify-between items-center"
           onSubmit={onSubmit}
           onChange={onChange}
           data-testid="coupon-form"
@@ -226,7 +226,7 @@ export const CouponForm = ({
             </Localized>
           </div>
 
-          <div className="ml-4">
+          <div>
             <button
               name="apply"
               className="button"

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
@@ -1,12 +1,16 @@
 @import '../../../../fxa-content-server/app/styles/variables';
 
 .new-user-email-form {
-    .input-row--checkbox {
-        margin: 24px 0 5px;
+  .input-row--checkbox {
+    margin: 24px 0 5px;
 
-        label input[type="checkbox"] {
-            margin-right: 6px;
-            margin-left: 8px;
-        }
+    label {
+      gap: 0;
     }
+
+    label input[type='checkbox'] {
+      margin-right: 6px;
+      margin-left: 8px;
+    }
+  }
 }

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -96,7 +96,7 @@ export const NewUserEmailForm = ({
         }}
       >
         <p
-          className="font-normal -mt-2 ml-6 text-grey-400"
+          className="font-normal -mt-2 text-grey-400"
           data-testid="sign-in-copy"
         >
           Already have a Firefox account?{' '}

--- a/packages/fxa-payments-server/src/components/PaymentProviderDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentProviderDetails/index.scss
@@ -1,19 +1,12 @@
 .c-card {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .c-card::before {
   height: 27px;
   width: 40px;
-
-  html[dir='ltr'] & {
-    margin-right: 8px;
-  }
-
-  html[dir='rtl'] & {
-    margin-left: 8px;
-  }
 }
 
 .c-card::before,
@@ -85,6 +78,6 @@
 
 .stack-card-details > p.c-card,
 .stack-card-details > .c-card::before {
-  margin-bottom: .55em;
-  margin-block-end: .55em;
+  margin-bottom: 0.55em;
+  margin-block-end: 0.55em;
 }

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -96,7 +96,7 @@ export const Field = ({
         {label && (
           <span
             data-testid="input-label-text"
-            className="font-medium text-sm text-grey-400 block mb-2 text-left"
+            className="font-medium text-sm text-grey-400 block mb-2 text-start"
           >
             {label}
           </span>

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -107,7 +107,7 @@ hr {
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 7px;
-    text-align: left;
+    text-align: start;
   }
 
   .label-text.checkbox {
@@ -130,10 +130,10 @@ hr {
   label {
     display: flex;
     align-items: center;
+    gap: 1rem;
 
     input[type='checkbox'] {
       flex: 0 0 18px;
-      margin-right: 16px;
       transform: scale(1.5);
 
       &:checked {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
@@ -69,7 +69,7 @@
     margin: 0;
 
     > p {
-      text-align: left;
+      text-align: start;
     }
 
     button {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -62,7 +62,6 @@
       font-size: 16px;
       font-weight: 400;
       margin: 13px 0;
-      text-align: left;
     }
   }
 
@@ -250,6 +249,7 @@
 .pocket-external {
   display: flex;
   align-items: baseline;
+  gap: 0.75rem;
 
   p:first-child {
     margin-top: 0;
@@ -263,6 +263,5 @@
 .pocket-icon {
   width: 26px;
   height: 23px;
-  margin-right: 12px;
   vertical-align: text-top;
 }

--- a/packages/fxa-payments-server/src/styles/tailwind.css
+++ b/packages/fxa-payments-server/src/styles/tailwind.css
@@ -16,7 +16,7 @@
 @tailwind utilities;
 
 .label-title {
-  @apply font-semibold my-3 text-base text-grey-600 text-left;
+  @apply font-semibold my-3 text-base text-grey-600 text-start;
 }
 
 /* borders */

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -24,7 +24,7 @@ export function ConnectAnotherDevicePromo() {
       className="my-1 flex flex-col mobileLandscape:flex-row"
       data-testid="connect-another-device-promo"
     >
-      <div className="flex flex-col flex-1 text-center mobileLandscape:text-left mobileLandscape:rtl:text-right">
+      <div className="flex flex-col flex-1 text-center mobileLandscape:text-start">
         <Localized id="connect-another-fx-mobile">
           <p className="text-sm">Get Firefox on mobile or tablet</p>
         </Localized>

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -227,7 +227,7 @@ export const ConnectedServices = () => {
             />
           ))}
 
-        <div className="mt-5 text-center mobileLandscape:text-left mobileLandscape:rtl:text-right">
+        <div className="mt-5 text-center mobileLandscape:text-start">
           <Localized id="cs-missing-device-help">
             <LinkExternal
               href={DEVICES_SUPPORT_URL}
@@ -302,7 +302,7 @@ export const ConnectedServices = () => {
                   setReason((event.target as HTMLInputElement).value);
                 }}
               >
-                <ul className="my-4 ltr:text-left rtl:text-right">
+                <ul className="my-4 text-start">
                   <Localized id="cs-disconnect-sync-opt-prefix">
                     The device is:
                   </Localized>

--- a/packages/fxa-settings/src/components/Settings/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.tsx
@@ -27,7 +27,7 @@ export const Nav = () => {
       className="font-header fixed bg-white w-full inset-0 mt-18 ltr:mr-24 rtl:ml-24 desktop:mt-11 desktop:static desktop:bg-transparent text-xl desktop:text-base"
       data-testid="nav"
     >
-      <ul className="px-6 py-7 tablet:px-8 desktop:p-0 mobileLandscape:mt-8 ltr:text-left rtl:text-right">
+      <ul className="px-6 py-7 tablet:px-8 desktop:p-0 mobileLandscape:mt-8 text-start">
         <li className="mb-5">
           <Localized id="nav-settings">
             <h2 className="font-bold">Settings</h2>

--- a/packages/fxa-settings/src/styles/switch.css
+++ b/packages/fxa-settings/src/styles/switch.css
@@ -21,11 +21,7 @@
   }
 
   &[aria-checked='true'] {
-    @apply text-left border-transparent;
-
-    [dir='rtl'] & {
-      @apply text-right;
-    }
+    @apply text-start border-transparent;
 
     .slider {
       @apply bg-blue-500;
@@ -65,11 +61,7 @@
   }
 
   &[aria-checked='false'] {
-    @apply text-right border-grey-200;
-
-    [dir='rtl'] & {
-      @apply text-left;
-    }
+    @apply text-end border-grey-200;
 
     .slider {
       @apply bg-grey-50;


### PR DESCRIPTION
## Because

- Localizable components must support both LTR and RTL text-directions. Using text-start will align text based on the layout direction(to the left for LTR, to the right for RTL) and eliminates the need to include specific tailwind properties to support LTR/RTL.

## This pull request

- Replace instances of text-left and text-right with either text-start or text-end to maintain intended alignment as tested in Storybook.
- Where component styling included 'ltr:text-left rtl:text-right', replace with only 'text-start'.
- Apply changes to localizable components only in fxa-payments-server and fxa-settings.

## Issue that this pull request solves

Closes #FXA-5738

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] I have verified that my changes render correctly in RTL (if appropriate).
