### PR TITLE
docs(auth): Fix doc - open endpoint was marked as needing authentication

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
@@ -29,7 +29,7 @@ const OAUTH_SUBSCRIPTIONS_IAP_PLAYTOKEN_APPNAME_POST = {
 
 const OAUTH_SUBSCRIPTIONS_IAP_APP_STORE_TRANSACTION_POST = {
   ...TAGS_SUBSCRIPTIONS,
-  description: '🔒 oauthToken',
+  description: '/oauth/subscriptions/iap/app-store-transaction/{appName}',
   notes: [
     dedent`
       🔒 authenticated with OAuth bearer token
@@ -41,6 +41,7 @@ const OAUTH_SUBSCRIPTIONS_IAP_APP_STORE_TRANSACTION_POST = {
 
 const OAUTH_SUBSCRIPTIONS_IAP_APP_STORE_NOTIFICATION_POST = {
   ...TAGS_SUBSCRIPTIONS,
+  description: '/oauth/subscriptions/iap/app-store-notification',
   notes: [
     dedent`
       🔒 payload validated against Apple certificates
@@ -53,13 +54,7 @@ const OAUTH_SUBSCRIPTIONS_IAP_APP_STORE_NOTIFICATION_POST = {
 const OAUTH_SUBSCRIPTIONS_PLANS_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/plans',
-  notes: [
-    dedent`
-      🔒 Authenticated with OAuth bearer token
-
-      Returns a list of available subscription plans.
-    `,
-  ],
+  notes: ['Returns a list of available subscription plans.'],
 };
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_GET = {
@@ -179,6 +174,7 @@ const OAUTH_SUBSCRIPTIONS_IAP_RTDN_POST = {
 const OAUTH_SUBSCRIPTIONS_CLIENTS_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/clients',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_POST = {
@@ -189,6 +185,7 @@ const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_POST = {
 const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_SUBSEQUENT_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/invoice/preview-subsequent',
+  notes: ['🔒 Authenticated with OAuth bearer token'],
 };
 
 const OAUTH_SUBSCRIPTIONS_COUPON_POST = {


### PR DESCRIPTION
## Because

- `/oauth/subscriptions/plans` is an open endpoint, but the documentation noted it needed authentication.

## This pull request

- Removes comment in `/oauth/subscriptions/plans` about needing authentication

- Other updates:
  - Fixed descriptions as it should be the path for:
    - `OAUTH_SUBSCRIPTIONS_IAP_APP_STORE_TRANSACTION_POST`
    - `OAUTH_SUBSCRIPTIONS_IAP_APP_STORE_NOTIFICATION_POST`
  - Adds comment about needing authentication for the following endpoints:
1. [`/oauth/subscriptions/clients`](https://api.accounts.firefox.com/v1/oauth/subscriptions/clients) <-- link
 <img width="632" alt="Screen Shot 2022-11-07 at 11 19 43 AM" src="https://user-images.githubusercontent.com/28129806/200360791-693cbda6-a422-4b57-92d0-179fd9ae50ec.png">

2. [`/oauth/subscriptions/invoice/preview-subsequent`](https://api.accounts.firefox.com/v1/oauth/subscriptions/invoice/preview-subsequent) <-- link
<img width="612" alt="Screen Shot 2022-11-07 at 11 19 16 AM" src="https://user-images.githubusercontent.com/28129806/200360704-eb6e7610-e22d-4a9c-bfa2-1f0a01c9e0fa.png">

## Issue that this pull request solves

Closes: [FXA-6169](https://mozilla-hub.atlassian.net/browse/FXA-6169)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.