### PR TITLE
chore(auth-server): ban self-absolute imports

### DIFF
--- a/packages/fxa-auth-server/.eslintrc.json
+++ b/packages/fxa-auth-server/.eslintrc.json
@@ -4,7 +4,14 @@
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", {"vars": "all", "args": "none"}],
     "no-redeclare": "off",
-    "@typescript-eslint/no-redeclare": "error"
+    "@typescript-eslint/no-redeclare": "error",
+    "@typescript-eslint/no-restricted-imports": ["error", {
+      "patterns": [{
+        "group": ["fxa-auth-server/**"],
+        "message": "Please use relative import instead.",
+        "allowTypeImports": true
+      }]
+    }]
   },
   "extends": ["plugin:fxa/server"],
   "plugins": ["@typescript-eslint", "fxa"],

--- a/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscription-manager.ts
+++ b/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscription-manager.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { CollectionReference, Firestore } from '@google-cloud/firestore';
-import { AppConfig, AuthFirestore } from 'fxa-auth-server/lib/types';
+import { AppConfig, AuthFirestore } from '../../lib/types';
 import Container from 'typedi';
 
 export class MockIapSubscriptionManager {

--- a/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
+++ b/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { AuthLogger } from 'fxa-auth-server/lib/types';
+import { AuthLogger } from '../lib/types';
 import { ACTIVE_SUBSCRIPTION_STATUSES } from 'fxa-shared/subscriptions/stripe';
 import { StatsD } from 'hot-shots';
 import stripe from 'stripe';


### PR DESCRIPTION
## Because

* Self-absolute imports currently break deploy since we build with TSC and run with JS which no longer has baseUrl to help out with resolution.

## This pull request

* Bans self-absolute imports with the no-restricted-imports rule. The hope is that we'll move to esbuild soon or if nothing else, implement this rule in other packages when they actually solve their lint issues.

## Issue that this pull request solves

Closes FXA-6138

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
