### PR TITLE
Fixes incorrect name for the id of refreshToken

### DIFF
--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -600,7 +600,7 @@ module.exports = (
             credentials.uid
           )) {
             // OAuth annoyingly returns buffers rather than hex strings.
-            oauthRefreshTokensById.set(hex(token.refreshTokenId), token);
+            oauthRefreshTokensById.set(hex(token.tokenId), token);
           }
         }
 

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -1695,13 +1695,13 @@ describe('/account/devices', () => {
       getRefreshTokensByUid: sinon.spy(async () => {
         return [
           {
-            refreshTokenId: Buffer.from(refreshTokenId, 'hex'),
+            tokenId: Buffer.from(refreshTokenId, 'hex'),
             lastUsedAt: new Date(now),
           },
           // This extra refreshToken should be ignored when listing devices,
           // since it doesn't have a corresponding device record.
           {
-            refreshTokenId: crypto.randomBytes(16),
+            tokenId: crypto.randomBytes(16),
             lastUsedAt: new Date(now),
           },
         ];


### PR DESCRIPTION
## Because

- The Id of a refresh token is called `tokenId` when retrieved from the oauth db and redis store, however, in here there was a bug where we used a `refreshTokenId`, which is the name in the device records not the tokens themselves.
- The above caused us to be unable to match any devices with their refreshTokens, therefore we were also unable to correctly keep the lastAccessTime up to date as we return that to users.
- Downstream this causes the send tab list to display devices with incorrect last access times, and prevents us from being able to filter on that list properly

## This pull request

- Uses the correct name of the id :) It's a simple change

## Issue that this pull request solves

Closes: # (issue number) TODO: @tarikeshaq to find issue

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
   - I should go back and add tests for this if it's feasible
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


cc @vbudhram (and @mhammond since we chatted about this too)
