### PR TITLE
Redirect user to `beta/` version of route if they are in experiment

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/cannot_create_account.js
+++ b/packages/fxa-content-server/app/scripts/views/cannot_create_account.js
@@ -4,14 +4,22 @@
 
 import BaseView from './base';
 import CannotCreateAccountTemplate from 'templates/cannot_create_account.mustache';
+import GeneralizedReactAppExperimentMixin from './mixins/generalized-react-app-experiment-mixin';
+import Cocktail from 'cocktail';
 
 const CannotCreateAccountView = BaseView.extend({
   template: CannotCreateAccountTemplate,
   className: 'cannot-create-account',
-
   setInitialContext(context) {
     context.set('isSync', this.relier.isSync());
   },
+  beforeRender() {
+    if (this.isInGeneralizedReactAppExperimentGroup()) {
+      this.navigateAway('/beta/cannot_create_account?showNewReactApp=true');
+    }
+  },
 });
+
+Cocktail.mixin(CannotCreateAccountView, GeneralizedReactAppExperimentMixin);
 
 export default CannotCreateAccountView;

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -209,6 +209,62 @@ const conf = (module.exports = convict({
         format: 'int',
       },
     },
+    betaReact: {
+      simpleRoutes: {
+        default: false,
+        doc: 'Enable users visiting the simple routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_SIMPLE_ROUTES',
+      },
+      resetPassword: {
+        default: false,
+        doc: 'Enable users visiting the routes associated with reset_password behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_RESET_PASSWORD',
+      },
+      oauth: {
+        default: false,
+        doc: 'Enable users visiting the oauth routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_OAUTH',
+      },
+      signIn: {
+        default: false,
+        doc: 'Enable users visiting the signin routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_SIGNIN',
+      },
+      signUp: {
+        default: false,
+        doc: 'Enable users visiting the signup routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_SIGNUP',
+      },
+      pair: {
+        default: false,
+        doc: 'Enable users visiting the pair routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_PAIR',
+      },
+      postVerifyAddRecoveryKey: {
+        default: false,
+        doc: 'Enable users visiting the post-verify add recovery key routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_POST_VERIFY_ADD_RECOVERY_KEY',
+      },
+      postVerifyCADviaQR: {
+        default: false,
+        doc: 'Enable users visiting the post verify CAD via QR code routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR',
+      },
+      signInVerificationViaPush: {
+        default: false,
+        doc: 'Enable users visiting the sign-in verification via push routes behind the beta url',
+        format: Boolean,
+        env: 'REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH',
+      },
+    },
   },
   flow_id_expiry: {
     default: '2 hours',

--- a/packages/fxa-settings/src/components/PageCannotCreateAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageCannotCreateAccount/index.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { RouteComponentProps } from '@reach/router';
+
+export const PageCannotCreateAccount = (_: RouteComponentProps) => {
+  return (
+    <div
+      className={`w-96 mx-auto p-7 pb-7 tablet:my-20 flex flex-col items-start bg-white shadow-lg tablet:rounded-xl`}
+    >
+      <div className="flex items-center flex-col w-full">
+        <h1 className="font-header font-bold mb-4 relative text-xl">
+          Cannot create account
+        </h1>
+        <p className="mb-4 text-sm text-center p-auto max-w-xs">
+          You must meet certain age requirements to create a Firefox account.
+        </p>
+        <LinkExternal
+          className="text-blue-500 underline text-sm mt-4"
+          href="https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy"
+        >
+          Learn more
+        </LinkExternal>
+      </div>
+    </div>
+  );
+};
+
+export default PageCannotCreateAccount;

--- a/packages/fxa-settings/src/components/WrapperBeta/index.tsx
+++ b/packages/fxa-settings/src/components/WrapperBeta/index.tsx
@@ -3,13 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import Footer from 'fxa-react/components/Footer';
+import { PageCannotCreateAccount } from '../PageCannotCreateAccount';
 import { RouteComponentProps } from '@reach/router';
 
 export const WrapperBeta = (props: RouteComponentProps) => {
   return (
-    <>
-      <p>beta</p>
-    </>
+    <div className="flex flex-col justify-between min-h-screen">
+      <PageCannotCreateAccount path="/cannot_create_account" />
+      <Footer />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Because

* We want users in the experiment to be redirected to the React views
  behind the beta url

NB: Still needs tests, l10n, and the addition of the firefox logo

## This pull request

* Checks if the user is in the experiment and duly navigates them to the
  new view

## Issue that this pull request solves

Closes #https://mozilla-hub.atlassian.net/browse/FXA-6118

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="960" alt="Screen Shot 2022-11-09 at 3 36 21 PM" src="https://user-images.githubusercontent.com/11150372/200964968-6b669e5b-0425-4822-860d-b7af28d5687c.png">


## Other information (Optional)

Any other information that is important to this pull request.
