### PR TITLE
[CI ONLY] Fixes incorrect name for the id of refreshToken

### DIFF
--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -600,7 +600,7 @@ module.exports = (
             credentials.uid
           )) {
             // OAuth annoyingly returns buffers rather than hex strings.
-            oauthRefreshTokensById.set(hex(token.refreshTokenId), token);
+            oauthRefreshTokensById.set(hex(token.tokenId), token);
           }
         }
 

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -1695,13 +1695,13 @@ describe('/account/devices', () => {
       getRefreshTokensByUid: sinon.spy(async () => {
         return [
           {
-            refreshTokenId: Buffer.from(refreshTokenId, 'hex'),
+            tokenId: Buffer.from(refreshTokenId, 'hex'),
             lastUsedAt: new Date(now),
           },
           // This extra refreshToken should be ignored when listing devices,
           // since it doesn't have a corresponding device record.
           {
-            refreshTokenId: crypto.randomBytes(16),
+            tokenId: crypto.randomBytes(16),
             lastUsedAt: new Date(now),
           },
         ];


### PR DESCRIPTION
running CI for https://github.com/mozilla/fxa/pull/14433