### PR TITLE
fix(auth-server): rename automatic_tax to automaticTax

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -587,7 +587,7 @@ export class StripeHandler {
       }
 
       const taxOptions = this.automaticTax
-        ? { automatic_tax: taxSubscription }
+        ? { automaticTax: taxSubscription }
         : { taxRateId };
 
       const subscription: any =

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -1022,7 +1022,7 @@ describe('DirectStripeRoutes', () => {
           priceId: 'Jane Doe',
           paymentMethodId: 'pm_asdf',
           promotionCode: undefined,
-          automatic_tax: true,
+          automaticTax: true,
         }
       );
     });
@@ -1044,7 +1044,7 @@ describe('DirectStripeRoutes', () => {
           priceId: 'Jane Doe',
           paymentMethodId: 'pm_asdf',
           promotionCode: undefined,
-          automatic_tax: false,
+          automaticTax: false,
         }
       );
     });


### PR DESCRIPTION
## Because

* There was a typo in the original implementation that caused automatic tax not be applied to any subscription created with automatic tax enabled.

## This pull request

* Fixes the typo.

## Issue that this pull request solves

Closes FXA-6277

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
