### PR TITLE
refactor(fxa-react): Create FTL files in fxa-react and concat to settings, payments

### DIFF
--- a/packages/fxa-payments-server/Gruntfile.js
+++ b/packages/fxa-payments-server/Gruntfile.js
@@ -5,18 +5,21 @@
 'use strict';
 
 module.exports = function (grunt) {
+  const srcPaths = [
+    // 'src/branding.ftl' is temporary
+    // and will be replaced with '../fxa-shared/lib/l10n/branding.ftl'
+    // in a later ticket - will require coordination with l10n to resolve
+    // conflicting IDs for identical terms.
+    'src/branding.ftl',
+    'src/**/*.ftl',
+    '../fxa-react/components/**/*.ftl',
+  ];
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     concat: {
       ftl: {
-        src: [
-          // 'src/branding.ftl' is temporary
-          // and will be replaced with '../fxa-shared/lib/l10n/branding.ftl'
-          // in a later ticket - will require coordination with l10n to resolve
-          // conflicting IDs for identical terms.
-          'src/branding.ftl',
-          'src/**/*.ftl',
-        ],
+        src: srcPaths,
         dest: 'public/locales/en/payments.ftl',
       },
 
@@ -25,13 +28,13 @@ module.exports = function (grunt) {
       // FTL updates on our side that haven't landed yet on the l10n side. We want to test
       // against _our_ latest, and not necessarily the l10n repo's latest.
       'ftl-test': {
-        src: ['src/branding.ftl', 'src/**/*.ftl'],
+        src: srcPaths,
         dest: 'test/payments.ftl',
       },
     },
     watch: {
       ftl: {
-        files: ['src/**/*.ftl'],
+        files: srcPaths,
         tasks: ['merge-ftl'],
         options: {
           interrupt: true,

--- a/packages/fxa-react/components/Footer/en.ftl
+++ b/packages/fxa-react/components/Footer/en.ftl
@@ -1,0 +1,5 @@
+## FxA React - Strings shared between multiple FxA products for application footer
+
+app-footer-mozilla-logo-label = { -brand-mozilla } logo
+app-footer-privacy-notice = Website Privacy Notice
+app-footer-terms-of-service = Terms of Service

--- a/packages/fxa-react/components/Head/en.ftl
+++ b/packages/fxa-react/components/Head/en.ftl
@@ -1,0 +1,8 @@
+## FxA React - Strings shared between multiple FxA products for application page title
+
+app-default-title = { -product-firefox-accounts }
+# This string is used as the title of the page.
+# Variables:
+#   $title (String) - the name of the current page
+#                      (for example: "Two-step authentication")
+app-page-title = { $title } | { -product-firefox-accounts }

--- a/packages/fxa-settings/Gruntfile.js
+++ b/packages/fxa-settings/Gruntfile.js
@@ -5,11 +5,17 @@
 'use strict';
 
 module.exports = function (grunt) {
+  const srcPaths = [
+    '.license.header',
+    'src/**/*.ftl',
+    '../fxa-react/components/**/*.ftl',
+  ];
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     concat: {
       ftl: {
-        src: ['.license.header', 'src/**/*.ftl'],
+        src: srcPaths,
         dest: 'public/locales/en/settings.ftl',
       },
 
@@ -18,13 +24,13 @@ module.exports = function (grunt) {
       // FTL updates on our side that haven't landed yet on the l10n side. We want to test
       // against _our_ latest, and not necessarily the l10n repo's latest.
       'ftl-test': {
-        src: ['.license.header', 'src/**/*.ftl'],
+        src: srcPaths,
         dest: 'test/settings.ftl',
       },
     },
     watch: {
       ftl: {
-        files: ['src/**/*.ftl'],
+        files: srcPaths,
         tasks: ['merge-ftl'],
         options: {
           interrupt: true,

--- a/packages/fxa-settings/src/components/en.ftl
+++ b/packages/fxa-settings/src/components/en.ftl
@@ -29,17 +29,3 @@ product-firefox-relay = Firefox Relay
 
 -google-play = Google Play
 -app-store = App Store
-
-##  Application page title and footer
-
-app-default-title = { -product-firefox-accounts }
-# This string is used as the title of the page.
-# Variables:
-#   $title (String) - the name of the current page
-#                      (for example: "Two-step authentication")
-app-page-title = { $title } | { -product-firefox-accounts }
-app-footer-mozilla-logo-label = { -brand-mozilla } logo
-app-footer-privacy-notice = Website Privacy Notice
-app-footer-terms-of-service = Terms of Service
-
-##


### PR DESCRIPTION
## Because

- L10n strings used in fxa-react components were stored in other packages (e.g., fxa-settings) and we want to bring them closer to the component where they are used for easier maintenance.

## This pull request

- Create an en.ftl file for each fxa-react component with exisiting l10n
- Move the the FTL IDs and messages contained in other packages to these new files
- Update fxa-settings' merge task to concat all fxa-react FTL files into settings.ftl
- Update fxa-payments-server's merge task to concat all fxa-react FTl files into payments.ftl

## Issue that this pull request solves

Closes: #FXA-5997

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
