### PR TITLE
feat(fxa-react): Add missing l10n to fxa-react

### DIFF
--- a/packages/fxa-payments-server/src/en.ftl
+++ b/packages/fxa-payments-server/src/en.ftl
@@ -7,9 +7,6 @@ document =
 close-aria =
   .aria-label = Close modal
 
-# Aria label for spinner image indicating data is loading
-app-loading-spinner-aria-label-loading = Loading…
-
 settings-subscriptions-title = Subscriptions
 
 # Title of container where a user can input a coupon code to get a discount on a subscription.

--- a/packages/fxa-react/components/AppErrorDialog/en.ftl
+++ b/packages/fxa-react/components/AppErrorDialog/en.ftl
@@ -1,0 +1,4 @@
+## FxA React - Strings shared between multiple FxA products for application error dialog
+
+app-general-err-heading = General application error
+app-general-err-message = Something went wrong. Please try again later.

--- a/packages/fxa-react/components/AppErrorDialog/index.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.tsx
@@ -3,20 +3,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import { Localized } from '@fluent/react';
 
 const AppErrorDialog = ({ error }: { error: Error }) => {
   return (
     <div className="bg-grey-20 flex items-center flex-col justify-center h-screen">
       <div className="text-center max-w-lg">
-        <h2
-          className="text-grey-900 font-header text-lg font-bold mb-3"
-          data-testid="error-loading-app"
-        >
-          General application error
-        </h2>
-        <p className="text-grey-400">
-          Something went wrong. Please try again later.
-        </p>
+        <Localized id="app-general-err-heading">
+          <h2
+            className="text-grey-900 font-header text-lg font-bold mb-3"
+            data-testid="error-loading-app"
+          >
+            General application error
+          </h2>
+        </Localized>
+        <Localized id="app-general-err-message">
+          <p className="text-grey-400">
+            Something went wrong. Please try again later.
+          </p>
+        </Localized>
       </div>
     </div>
   );

--- a/packages/fxa-react/components/LinkExternal/en.ftl
+++ b/packages/fxa-react/components/LinkExternal/en.ftl
@@ -1,0 +1,4 @@
+## FxA React - Strings shared between multiple FxA products for external link
+
+# Message for screen readers, to announce that external link will open in new window
+link-sr-new-window = Opens in new window

--- a/packages/fxa-react/components/LinkExternal/index.tsx
+++ b/packages/fxa-react/components/LinkExternal/index.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import { Localized } from '@fluent/react';
 
 type LinkExternalProps = {
   className?: string;
@@ -32,7 +33,9 @@ export const LinkExternal = ({
     }}
   >
     {children}
-    <span className="sr-only">Opens in new window</span>
+    <Localized id="link-sr-new-window">
+      <span className="sr-only">Opens in new window</span>
+    </Localized>
   </a>
 );
 

--- a/packages/fxa-react/components/LoadingSpinner/en.ftl
+++ b/packages/fxa-react/components/LoadingSpinner/en.ftl
@@ -1,0 +1,4 @@
+## FxA React - Strings shared between multiple FxA products for loading spinner
+
+# Aria label for spinner image indicating data is loading
+app-loading-spinner-aria-label-loading = Loading…

--- a/packages/fxa-react/components/LogoLockup/en.ftl
+++ b/packages/fxa-react/components/LogoLockup/en.ftl
@@ -1,0 +1,4 @@
+## FxA React - Strings shared between multiple FxA products for logo lockup
+
+app-logo-alt =
+  .alt = { -brand-firefox } logo

--- a/packages/fxa-react/components/LogoLockup/index.tsx
+++ b/packages/fxa-react/components/LogoLockup/index.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ReactElement } from 'react';
+import { Localized } from '@fluent/react';
 import logo from '../../images/ff-logo.svg';
 
 type LogoLockupProps = {
@@ -10,21 +11,25 @@ type LogoLockupProps = {
   className?: string;
 };
 
-export const LogoLockup = ({ children, className = '' }: LogoLockupProps) => (
-  <>
-    <img
-      src={logo}
-      data-testid="logo"
-      className="h-10 w-10 ltr:mr-4 rtl:ml-4"
-      alt="Firefox logo"
-    />
-    <h1
-      data-testid="logo-text"
-      className={`hidden tablet:inline-flex self-center text-xl ${className}`}
-    >
-      {children}
-    </h1>
-  </>
-);
+export const LogoLockup = ({ children, className = '' }: LogoLockupProps) => {
+  return (
+    <>
+      <Localized id="app-logo-alt">
+        <img
+          src={logo}
+          data-testid="logo"
+          className="h-10 w-10 ltr:mr-4 rtl:ml-4"
+          alt="Firefox logo"
+        />
+      </Localized>
+      <h1
+        data-testid="logo-text"
+        className={`hidden tablet:inline-flex self-center text-xl ${className}`}
+      >
+        {children}
+      </h1>
+    </>
+  );
+};
 
 export default LogoLockup;


### PR DESCRIPTION
## Because

- All messages served to the user should be localized, including screen reader messages. Fxa-react components were partially localized, but some messages were missed.

## This pull request

- Add l10n to AppErrorDialog, LinkExternal, LoadingSpinner and LogoLockup for all messages, including alt text, aria labels and screen-reader only messages.
- Create en.ftl for each component, when needed.

## Issue that this pull request solves

Closes: #FXA-5998

## Checklist

- [x] My commit is GPG signed.
