### PR TITLE
task(auth): Only audit fxa db for now

### DIFF
--- a/packages/fxa-auth-server/test/scripts/audit-tokens.js
+++ b/packages/fxa-auth-server/test/scripts/audit-tokens.js
@@ -10,7 +10,6 @@ const path = require('path');
 const {
   auditRowCounts,
   auditAge,
-  auditOrphanedDeviceRows,
   auditOrphanedRows,
 } = require('../../scripts/audit-tokens');
 const mocks = require(`../../test/mocks`);
@@ -72,23 +71,6 @@ describe('scripts/audit-tokens', () => {
       assert.equal(result.percent_missing, 100);
       assert.equal(result.total_missing, 1);
       assert.equal(result.table_size, 1);
-    });
-
-    it('finds orphaned devices', async () => {
-      await auditRowCounts('fxa.sessionTokens');
-      await auditRowCounts('fxa.devices');
-      const result = await auditOrphanedDeviceRows();
-
-      assert.equal(result.total, 1);
-      assert.equal(result.table_size, 1);
-
-      assert.equal(result.total_missing_both, 1);
-      assert.equal(result.total_missing_refresh_token, 1);
-      assert.equal(result.total_missing_session_token, 1);
-
-      assert.equal(result.percent_missing_both, 100);
-      assert.equal(result.percent_missing_refresh_token, 100);
-      assert.equal(result.percent_missing_session_token, 100);
     });
   });
 


### PR DESCRIPTION
## Because

- In prod the fxa_oauth and fxa databases are in separate instances.
- Queries conducting audits across fxa and fxa_oauth databases therefore wouldn't work.

## This pull request

- Removes fxa_oauth audits for now

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

This is a quick follow up PR that resulted from a discussion with SRE about the feasibility of some of these audits.
