### PR TITLE
[WIP] feat(l10n): Use global FTL branding file from fxa-shared in fxa-settings

### DIFF
--- a/packages/fxa-settings/.license.header
+++ b/packages/fxa-settings/.license.header
@@ -1,3 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/packages/fxa-settings/Gruntfile.js
+++ b/packages/fxa-settings/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
     pkg: grunt.file.readJSON('package.json'),
     concat: {
       ftl: {
-        src: ['.license.header', 'src/**/*.ftl'],
+        src: ['../fxa-shared/l10n/branding.ftl', 'src/**/*.ftl'],
         // TODO: change dest to `en` in FXA-6003
         dest: 'public/locales/en-US/settings.ftl',
       },
@@ -19,13 +19,13 @@ module.exports = function (grunt) {
       // FTL updates on our side that haven't landed yet on the l10n side. We want to test
       // against _our_ latest, and not necessarily the l10n repo's latest.
       'ftl-test': {
-        src: ['.license.header', 'src/**/*.ftl'],
+        src: ['../fxa-shared/l10n/branding.ftl', 'src/**/*.ftl'],
         dest: 'test/settings.ftl',
       },
     },
     watch: {
       ftl: {
-        files: ['src/**/*.ftl'],
+        files: ['../fxa-shared/l10n/branding.ftl', 'src/**/*.ftl'],
         tasks: ['merge-ftl'],
         options: {
           interrupt: true,

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/en-US.ftl
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/en-US.ftl
@@ -3,10 +3,10 @@
 bento-menu-title = { -brand-firefox } Bento Menu
 bento-menu-firefox-title = { -brand-firefox } is tech that fights for your online privacy.
 
-bento-menu-vpn = { product-mozilla-vpn }
-bento-menu-monitor = { product-firefox-monitor }
-bento-menu-pocket = { product-pocket }
-bento-menu-firefox-relay = { product-firefox-relay }
+bento-menu-vpn = { -product-mozilla-vpn }
+bento-menu-monitor = { -product-firefox-monitor }
+bento-menu-pocket = { -product-pocket }
+bento-menu-firefox-relay = { -product-firefox-relay }
 bento-menu-firefox-desktop = { -brand-firefox } Browser for Desktop
 bento-menu-firefox-mobile = { -brand-firefox } Browser for Mobile
 

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en-US.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en-US.ftl
@@ -11,7 +11,7 @@ delete-account-confirm-title-2 = You’ve connected your { -product-firefox-acco
 delete-account-acknowledge = Please acknowledge that by deleting your account:
 
 delete-account-chk-box-1-v2 =
- .label = Any paid subscriptions you have will be canceled (Except { product-pocket })
+ .label = Any paid subscriptions you have will be canceled (Except { -product-pocket })
 delete-account-chk-box-2 =
  .label = You may lose saved information and features within { -brand-mozilla } products
 delete-account-chk-box-3 =

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -14,17 +14,24 @@ import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { Checkbox } from '../Checkbox';
 import { useLocalization } from '@fluent/react';
 import { Localized } from '@fluent/react';
-import { AuthUiErrors, composeAuthUiErrorTranslationId } from '../../../lib/auth-errors/auth-errors';
+import {
+  AuthUiErrors,
+  composeAuthUiErrorTranslationId,
+} from '../../../lib/auth-errors/auth-errors';
 
 type FormData = {
   password: string;
 };
 
 const checkboxLabels: Record<string, string> = {
-  'delete-account-chk-box-1-v2': 'Any paid subscriptions you have will be canceled (Except Pocket)',
-  'delete-account-chk-box-2': 'You may lose saved information and features within Mozilla products',
-  'delete-account-chk-box-3': 'Reactivating with this email may not restore your saved information',
-  'delete-account-chk-box-4': 'Any extensions and themes that you published to addons.mozilla.org will be deleted',
+  'delete-account-chk-box-1-v2':
+    'Any paid subscriptions you have will be canceled (Except Pocket)',
+  'delete-account-chk-box-2':
+    'You may lose saved information and features within Mozilla products',
+  'delete-account-chk-box-3':
+    'Reactivating with this email may not restore your saved information',
+  'delete-account-chk-box-4':
+    'Any extensions and themes that you published to addons.mozilla.org will be deleted',
 };
 
 export const PageDeleteAccount = (_: RouteComponentProps) => {
@@ -124,12 +131,12 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
               <ul className="list-inside mb-4">
                 <li className="list-disc">
                   <a className="link-blue" href={VPNLink}>
-                    <Localized id="product-mozilla-vpn">Mozilla VPN</Localized>
+                    <Localized id="-product-mozilla-vpn">Mozilla VPN</Localized>
                   </a>
                 </li>
                 <li className="list-disc">
                   <a className="link-blue" href={MonitorLink}>
-                    <Localized id="product-firefox-monitor">
+                    <Localized id="-product-firefox-monitor">
                       Firefox Monitor
                     </Localized>
                   </a>
@@ -148,7 +155,11 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                     <Localized id={label} attrs={{ label: true }}>
                       <Checkbox
                         data-testid="required-confirm"
-                        label={l10n.getString(label, null, checkboxLabels[label])}
+                        label={l10n.getString(
+                          label,
+                          null,
+                          checkboxLabels[label]
+                        )}
                         onChange={handleConfirmChange(label)}
                       />
                     </Localized>

--- a/packages/fxa-settings/src/components/en-US.ftl
+++ b/packages/fxa-settings/src/components/en-US.ftl
@@ -1,35 +1,3 @@
-## Firefox and Mozilla Brand
-##
-## Firefox and Mozilla must be treated as a brand.
-##
-## They cannot be:
-## - Transliterated.
-## - Translated.
-##
-## Declension should be avoided where possible, leaving the original
-## brand unaltered in prominent UI positions.
-##
-## For further details, consult:
-## https://mozilla-l10n.github.io/styleguides/mozilla_general/#brands-copyright-and-trademark
-
--brand-mozilla = Mozilla
--brand-firefox = Firefox
--brand-google = Google
-# “Accounts” can be localized, “Firefox” must be treated as a brand.
--product-firefox-accounts = Firefox Accounts
-# “Account” can be localized, “Firefox” must be treated as a brand.
-# This is used to refer to a user's account, e.g. "update your Firefox account ..."
--product-firefox-account = Firefox account
-product-mozilla-vpn = Mozilla VPN
-product-pocket = Pocket
-product-firefox-monitor = Firefox Monitor
-product-firefox-relay = Firefox Relay
-
-##
-
--google-play = Google Play
--app-store = App Store
-
 ##  Application page title and footer
 
 app-default-title = { -product-firefox-accounts }

--- a/packages/fxa-shared/l10n/branding.ftl
+++ b/packages/fxa-shared/l10n/branding.ftl
@@ -17,9 +17,12 @@
 -brand-mozilla = Mozilla
 -brand-firefox = Firefox
 
+# TODO - can only keep one of the following (pending decision from Legal)
+
 # "accounts" can be localized, "Firefox" must be treated as a brand.
 # 'Firefox accounts' refers to the service
 -product-firefox-accounts = Firefox accounts
+-product-firefox-accounts = Firefox Accounts
 
 # "account" can be localized and should be lowercase, "Firefox" must be treated as a brand.
 # This is used to refer to a user's account, e.g. "update your Firefox account ..."
@@ -27,10 +30,20 @@
 
 # This product should be treated as a brand.
 -product-firefox-cloud = Firefox Cloud
+# This product should be treated as a brand.
+-product-mozilla-vpn = Mozilla VPN
+# This product should be treated as a brand.
+-product-pocket = Pocket
+# This product should be treated as a brand.
+-product-firefox-monitor = Firefox Monitor
+# This product should be treated as a brand.
+-product-firefox-relay = Firefox Relay
 
 # Should should be treated as a brand.
 -brand-paypal = PayPal
 # Should should be treated as a brand.
 -app-store = App Store
+# Should should be treated as a brand.
+-brand-google = Google
 # Should should be treated as a brand.
 -google-play = Google Play


### PR DESCRIPTION
## DRAFT Note
 
- ~~Waiting on decision to use Firefox Accounts or Firefox accounts - usage differs between fxa-settings and fxa-auth-server~~ Decision from content, legal: account is not considered a product (Account), will be changed to 'Firefox accounts' unless in title case
- Need to check on impact of changing brand terms to include dash
  - E.g., product-mozilla-vpn --> -product-mozilla-vpn
- Update 11/30: Waiting for resolution to #FXA-6388 before continuing this PR

## Because

- We want settings to use the global branding file that was established for auth-server to ensure the branding used in both packages is consistent.

## This pull request

- Remove license.header file
- Update gruntfile and merge-ftl task to concatenate the branding file from fxa-shared
- Move terms used in settings to the shared branding file
- Address term conflicts
- Remove terms from settings FTL files
- Update IDs in components when they have changed

## Issue that this pull request solves

Closes: #FXA-5995

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
