### PR TITLE
chore(l10n): fix ellipsis

### DIFF
--- a/packages/fxa-payments-server/src/en.ftl
+++ b/packages/fxa-payments-server/src/en.ftl
@@ -8,7 +8,7 @@ close-aria =
   .aria-label = Close modal
 
 # Aria label for spinner image indicating data is loading
-app-loading-spinner-aria-label-loading = Loading...
+app-loading-spinner-aria-label-loading = Loading…
 
 settings-subscriptions-title = Subscriptions
 


### PR DESCRIPTION
## Because:

* According to mozilla l10n guidelines strings should use a unicode ellipsis (…) instead of three periods (...)

## This  pull request

* Fixes a missing ellipsis in fxa-payments-server/src/en.ftl

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

