### PR TITLE
chore(l10n): fix ellipsis

### DIFF
--- a/packages/fxa-payments-server/src/en.ftl
+++ b/packages/fxa-payments-server/src/en.ftl
@@ -8,7 +8,7 @@ close-aria =
   .aria-label = Close modal
 
 # Aria label for spinner image indicating data is loading
-app-loading-spinner-aria-label-loading = Loading...
+app-loading-spinner-aria-label-loading = Loading…
 
 settings-subscriptions-title = Subscriptions
 

--- a/packages/fxa-react/components/LoadingSpinner/index.tsx
+++ b/packages/fxa-react/components/LoadingSpinner/index.tsx
@@ -21,7 +21,7 @@ export const LoadingSpinner = ({
   const loadingAriaLabel = l10n.getString(
     'app-loading-spinner-aria-label-loading',
     null,
-    'Loading...'
+    'Loading…'
   );
   let spinnerImage;
   switch (spinnerType) {

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -135,7 +135,7 @@ describe('App component', () => {
       <App {...{ flowQueryParams }} />
     );
 
-    expect(getByLabelText('Loading...')).toBeInTheDocument();
+    expect(getByLabelText('Loading…')).toBeInTheDocument();
   });
 
   it('renders `LoadingSpinner` component when the error message includes "Invalid token"', () => {
@@ -146,7 +146,7 @@ describe('App component', () => {
       <App {...{ flowQueryParams }} />
     );
 
-    expect(getByLabelText('Loading...')).toBeInTheDocument();
+    expect(getByLabelText('Loading…')).toBeInTheDocument();
   });
 
   it('renders `AppErrorDialog` component when there is an error other than "Invalid token"', () => {


### PR DESCRIPTION
## Because:

* According to mozilla l10n guidelines strings should use a unicode ellipsis (…) instead of three periods (...)

## This pull request:

* Fixes a missing ellipsis in fxa-payments-server/src/en.ftl

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
