### PR TITLE
feat(fxa-content-server, fxa-settings): setup experiment

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -92,6 +92,45 @@ const Router = Backbone.Router.extend({
       CompleteResetPasswordView
     ),
     'authorization(/)': createViewHandler(RedirectAuthView),
+    'beta(/)': function () {
+      // Because this directs us to a separate js app, we need to ensure navigating
+      // from the content-server app passes along flow parameters.
+      const { deviceId, flowBeginTime, flowId } =
+        this.metrics.getFlowEventMetadata();
+
+      const {
+        broker,
+        context: ctx,
+        isSampledUser,
+        service,
+        uniqueUserId,
+      } = this.metrics.getFilteredData();
+
+      // Our GQL client sets the `redirect_to` param if a user attempts
+      // to navigate directly to a section in /beta
+      const searchParams = new URLSearchParams(this.window.location.search);
+
+      let endpoint = searchParams.get('redirect_to');
+      if (!endpoint) {
+        endpoint = `/beta`;
+      } else if (
+        !this.isValidRedirect(endpoint, this.config.redirectAllowlist)
+      ) {
+        throw new Error('Invalid redirect!');
+      }
+
+      const betaLink = `${endpoint}${Url.objToSearchString({
+        deviceId,
+        flowBeginTime,
+        flowId,
+        broker,
+        context: ctx,
+        isSampledUser,
+        service,
+        uniqueUserId,
+      })}`;
+      this.navigateAway(betaLink);
+    },
     'cannot_create_account(/)': createViewHandler(CannotCreateAccountView),
     'choose_what_to_sync(/)': createViewHandler(ChooseWhatToSyncView),
     'clear(/)': createViewHandler(ClearStorageView),

--- a/packages/fxa-content-server/app/scripts/views/mixins/generalized-react-app-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/generalized-react-app-experiment-mixin.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from './experiment-mixin';
+const EXPERIMENT_NAME = 'generalizedReactApp';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  isInGeneralizedReactAppExperimentGroup() {
+    const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
+      clientId: this.relier.get('clientId'),
+    });
+    return experimentGroup === 'generalized';
+  },
+};

--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -87,6 +87,7 @@ logger.info('page_template_directory: %s', PAGE_TEMPLATE_DIRECTORY);
 function makeApp() {
   const app = express();
   const settingsPath = '/settings';
+  const betaPath = '/beta';
 
   if (config.get('env') === 'development') {
     const webpack = require('webpack');
@@ -191,6 +192,7 @@ function makeApp() {
 
   if (config.get('env') === 'production') {
     app.get(settingsPath, modifySettingsStatic);
+    app.get(betaPath, modifySettingsStatic);
   }
   app.use(
     serveStatic(STATIC_DIRECTORY, {
@@ -200,8 +202,10 @@ function makeApp() {
 
   if (config.get('env') === 'development') {
     app.use(settingsPath, useSettingsProxy);
+    app.use(betaPath, useSettingsProxy);
   } else {
     app.get(settingsPath + '/*', modifySettingsStatic);
+    app.get(betaPath + '/*', modifySettingsStatic);
   }
 
   // it's a four-oh-four not found.

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -7,6 +7,7 @@ import { RouteComponentProps, Router } from '@reach/router';
 import Head from 'fxa-react/components/Head';
 import { ScrollToTop } from '../Settings/ScrollToTop';
 import Settings from '../Settings';
+import WrapperBeta from '../WrapperBeta';
 import { QueryParams } from '../..';
 
 export const App = ({
@@ -18,6 +19,7 @@ export const App = ({
       <Router basepath={'/'}>
         <ScrollToTop default>
           <Settings path="/settings/*" {...{ flowQueryParams }} />
+          <WrapperBeta path="/beta/*" />
         </ScrollToTop>
       </Router>
     </>

--- a/packages/fxa-settings/src/components/WrapperBeta/index.tsx
+++ b/packages/fxa-settings/src/components/WrapperBeta/index.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+
+export const WrapperBeta = (props: RouteComponentProps) => {
+  return (
+    <>
+      <p>beta</p>
+    </>
+  );
+};
+
+export default WrapperBeta;


### PR DESCRIPTION
Because:

* We want to be able to temporarily create React versions of routes behind the beta url, and we want to be able to redirect users within an experiment to those new views from the original pages. This allows us to access the status of the user's membership from within a backbone view, and sets up the beta space for the new views.

This commit:

* Adds the beta url to the React app and adds mixin to check experiment status

Closes #https://mozilla-hub.atlassian.net/browse/FXA-6111

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
