### PR TITLE
refactor(l10n): Remove l10n configuration file in fxa-payments-server

### DIFF
--- a/packages/fxa-payments-server/l10n.toml
+++ b/packages/fxa-payments-server/l10n.toml
@@ -1,5 +1,0 @@
-basepath = "."
-
-[[paths]]
-  reference = "public/locales/en/*.ftl"
-  l10n = "public/locales/{locale}/*.ftl"


### PR DESCRIPTION
## Because

- Using a config file is not beneficial for the FxA project which uses a separate l10n repo. Fluent configuration files are useful when the same repository needs to support different locales for different files (e.g. https://github.com/mozilla-l10n/android-l10n), or complex paths, but this is not the case for FxA.

## This pull request

- Removes the l10n configuration file in fxa-payments-server

## Issue that this pull request solves

Closes: #FXA-6002

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.