### PR TITLE
chore(deps): resolve moment to a patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,18 +87,19 @@
     "packages/*"
   ],
   "resolutions": {
-    "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
-    "tap/typescript": "^4.5.2",
+    "@grpc/grpc-js": "~1.6.0",
     "@nestjs/cli/typescript": "^4.5.2",
     "@types/node": "^16.11.3",
-    "http-proxy": "^1.18.1",
     "browserid-crypto": "https://github.com/mozilla-fxa/browserid-crypto.git#5979544d13eeb15a02d0b9a6a7a08a698d54d37d",
-    "fbjs/isomorphic-fetch": "^3.0.0",
     "eslint-plugin-import": "^2.25.2",
-    "minimist": "^1.2.6",
-    "url-parse": "^1.5.8",
+    "fbjs/isomorphic-fetch": "^3.0.0",
+    "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
     "google-gax": "2.30.5",
-    "@grpc/grpc-js": "~1.6.0"
+    "http-proxy": "^1.18.1",
+    "minimist": "^1.2.6",
+    "moment:>2.0.0 <3": ">=2.29.4",
+    "tap/typescript": "^4.5.2",
+    "url-parse": "^1.5.8"
   },
   "packageManager": "yarn@3.1.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -34581,14 +34581,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"moment@npm:>= 2.9.0, moment@npm:^2.19.3, moment@npm:^2.29.1":
-  version: 2.29.1
-  resolution: "moment@npm:2.29.1"
-  checksum: 1e14d5f422a2687996be11dd2d50c8de3bd577c4a4ca79ba5d02c397242a933e5b941655de6c8cb90ac18f01cc4127e55b4a12ae3c527a6c0a274e455979345e
-  languageName: node
-  linkType: hard
-
-"moment@npm:^2.29.4":
+"moment@npm:>= 2.9.0, moment@npm:^2.19.3, moment@npm:^2.29.1, moment@npm:^2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e


### PR DESCRIPTION
Because:
 - older versions of moment are causing security alerts

This commit:
 - resolve moment 2.x to a >= a patched version
