### PR TITLE
fix(admin-server): ignore case for IAP to Stripe plan mappings

### DIFF
--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.spec.ts
@@ -244,6 +244,17 @@ describe('Stripe Service', () => {
       expect(appStoreResult?.plan_id).toEqual('appstore-plan-123');
     });
 
+    it('maps iap purchase to plan ignoring case', () => {
+      const appStoreResult = iapPurchaseToPlan(
+        'PRODUCT-123',
+        'iap_apple',
+        plans
+      );
+
+      expect(appStoreResult).toBeDefined();
+      expect(appStoreResult?.plan_id).toEqual('appstore-plan-123');
+    });
+
     it('returns undefined iap purchase for unknown plan', () => {
       const result = iapPurchaseToPlan('product-123', 'iap_google', [plans[2]]);
       expect(result).toBeUndefined();

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -164,7 +164,7 @@ export function iapPurchaseToPlan(
 ) {
   return plans.find((plan) => {
     const identifiers = determineIapIdentifiers(iapType, plan);
-    return identifiers.some((id) => id === purchaseId);
+    return identifiers.some((id) => id === purchaseId.toLowerCase());
   });
 }
 


### PR DESCRIPTION
Because:

* Mappings were failing due to the case of the identifiers.

This commit:

* Ensures the comparisons are case-insensitive.

Closes #FXA-6224

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
