### PR TITLE
Adds user agent information to refresh token credentials

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
@@ -55,11 +55,19 @@ module.exports = function schemeRefreshTokenScheme(config, db) {
           return h.unauthenticated(AppError.invalidScopes(refreshToken.scope));
         }
 
+        const { ua } = request.app;
+
         const credentials = {
           uid: hex(refreshToken.userId),
           emailVerified: true,
           tokenVerified: true,
           refreshTokenId: hex(tokenId),
+          uaBrowser: ua.browser,
+          uaBrowserVersion: ua.browserVersion,
+          uaOS: ua.os,
+          uaOSVersion: ua.osVersion,
+          uaDeviceType: ua.deviceType,
+          uaFormFactor: ua.formFactor,
         };
 
         credentials.client = await client.getClientById(refreshToken.clientId);

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/refresh-token.js
@@ -37,6 +37,14 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
   let config;
   let db;
   let response;
+  const ua = {
+    browser: 'firefox',
+    browserVersion: '100',
+    os: 'iOS',
+    osVersion: '16.2',
+    deviceType: 'mobile',
+    formFactor: null,
+  };
 
   beforeEach(() => {
     config = { oauth: {} };
@@ -77,6 +85,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
         headers: {
           authorization: 'Bad Auth',
         },
+        app: {
+          ua: ua,
+        },
       });
       assert.fail('should have thrown');
     } catch (err) {
@@ -90,6 +101,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
       await scheme().authenticate({
         headers: {
           authorization: 'Bearer Foo',
+        },
+        app: {
+          ua: ua,
         },
       });
       assert.fail('should have thrown');
@@ -105,6 +119,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
         headers: {
           authorization:
             'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
+        },
+        app: {
+          ua: ua,
         },
       },
       response
@@ -128,6 +145,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
         headers: {
           authorization:
             'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
+        },
+        app: {
+          ua: ua,
         },
       },
       response
@@ -158,6 +178,12 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
       deviceCallbackPublicKey: undefined,
       deviceCallbackURL: undefined,
       deviceCreatedAt: undefined,
+      uaBrowser: ua.browser,
+      uaBrowserVersion: ua.browserVersion,
+      uaOS: ua.os,
+      uaOSVersion: ua.osVersion,
+      uaDeviceType: ua.deviceType,
+      uaFormFactor: ua.formFactor,
     });
   });
 
@@ -198,6 +224,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
           authorization:
             'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
         },
+        app: {
+          ua: ua,
+        },
       },
       response
     );
@@ -220,6 +249,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
           authorization:
             'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
         },
+        app: {
+          ua: ua,
+        },
       },
       response
     );
@@ -241,6 +273,9 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
           headers: {
             authorization:
               'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
+          },
+          app: {
+            ua: ua,
           },
         },
         response


### PR DESCRIPTION
## Because

- The operating system information of the requesting device is parsed from the user-agent header
- For session tokens, the operating system is a part of the token object. (When we create the tokens, we read the user agent at the time, and persist data from it, like the operating system with the tokens)
- For refresh tokens, the information we get from the user-agent is not there.
- [There is at least one API that assumes that the credentials object always has the `uaOS` (the operating system)](https://github.com/mozilla/fxa/blob/7cdd496834e0355e1f909f65f606b82eca3fbb2f/packages/fxa-auth-server/lib/routes/devices-and-sessions.js#L348)
- Downstream, this causes our metrics to have **many** null "sender operating systems" for send tab. See https://sql.telemetry.mozilla.org/queries/88640/source#219536 
## This pull request

- As a part of authorization, attach the user agent information to the credentials object
- **Alternatively**, we can read the user agent information directly from `request.app.ua` in the handler of `/account/invoke_command`, but we'll need to also double check that there are no other APIs depending on `credentials.uaOS` (or similar user agent information that's available through the sessionToken strategy). Happy to take this alternative path if it makes more sense!

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


I verified locally that my local iOS simulator is accurately getting it's operating system `iOS` into the `credentials.uaOS`
