### PR TITLE
chore(deps): resolve underscore to newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "minimist": "^1.2.6",
     "moment:>2.0.0 <3": ">=2.29.4",
     "tap/typescript": "^4.5.2",
+    "underscore": ">=1.13.2",
     "url-parse": "^1.5.8"
   },
   "packageManager": "yarn@3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -46175,24 +46175,10 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"underscore@npm:>=1.3.1, underscore@npm:>=1.8.3, underscore@npm:^1.13.1, underscore@npm:^1.8.3":
-  version: 1.13.1
-  resolution: "underscore@npm:1.13.1"
-  checksum: 69bb4e6dd92c387ad322dd5b105f496fa64896d92ff1eea987610920d452667a12bca0938def4c4d60acd12da62410540fd268e7ca4f2480d89324498382fcac
-  languageName: node
-  linkType: hard
-
-"underscore@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "underscore@npm:1.6.0"
-  checksum: bfb837d95164077bd2751247dd9797546287c060d86c3a730f590948dbc132b426238e37df7bea28f39d3e3abf571de5b974809ee3c32d309280fed851588ef9
-  languageName: node
-  linkType: hard
-
-"underscore@npm:~1.8.3":
-  version: 1.8.3
-  resolution: "underscore@npm:1.8.3"
-  checksum: 46d9ea25c8b9f6f21080438f5abc1c8be3063efca5154670bf7ef6e61587660113581b258aea07ccab4045b9ab6e9293ef89103210a3491b64ef03c2d8051a36
+"underscore@npm:>=1.13.2":
+  version: 1.13.6
+  resolution: "underscore@npm:1.13.6"
+  checksum: d5cedd14a9d0d91dd38c1ce6169e4455bb931f0aaf354108e47bd46d3f2da7464d49b2171a5cf786d61963204a42d01ea1332a903b7342ad428deaafaf70ec36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
 - older versions of underscore is causing security alerts

This commit:
 - resolve underscore to patched versions
