### PR TITLE
fix(payments): subscription Reactivation Showing Incorrect Amount

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -136,7 +136,6 @@ const ConfirmationDialog = ({
   customer,
   customerSubscription,
   periodEndDate,
-  total,
 }: {
   onDismiss: Function;
   onConfirm: () => void;
@@ -144,7 +143,6 @@ const ConfirmationDialog = ({
   customer: Customer;
   customerSubscription: WebSubscription;
   periodEndDate: number;
-  total?: number;
 }) => {
   const { navigatorLanguages, config } = useContext(AppContext);
   const { webIcon, webIconBackground } = webIconConfigFromProductConfig(
@@ -192,7 +190,7 @@ const ConfirmationDialog = ({
               periodEndDate={periodEndDate}
               currency={plan.currency}
               productName={plan.product_name}
-              amount={total || amount}
+              amount={amount}
               last4={last4}
               webIconURL={webIcon}
               webIconBackground={webIconBackground}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -17,13 +17,11 @@ const ReactivateSubscriptionPanel = ({
   customerSubscription,
   customer,
   reactivateSubscription,
-  total,
 }: {
   plan: Plan;
   customerSubscription: WebSubscription;
   customer: Customer;
   reactivateSubscription: ActionFunctions['reactivateSubscription'];
-  total?: number;
 }) => {
   const { subscription_id } = customerSubscription;
   const [
@@ -53,7 +51,6 @@ const ReactivateSubscriptionPanel = ({
             customer,
             periodEndDate: periodEndTimeStamp,
             customerSubscription,
-            total,
           }}
           onDismiss={hideReactivateConfirmation}
           onConfirm={onReactivateClick}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -134,7 +134,6 @@ export const SubscriptionItem = ({
                 customer,
                 customerSubscription,
                 reactivateSubscription,
-                total: total || plan.amount || undefined,
               }}
             />
           </>


### PR DESCRIPTION
Because:

* we want to reflect the accurate amount a user will be charged for reactivation

This commit:

* makes sure we use the amount from preview invoice in the reactivation modal

Closes #FXA-6258

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
