### PR TITLE
refactor(storybook): Restructure Settings Storybook in preparation for content-server refactor

### DIFF
--- a/packages/fxa-settings/.storybook/design-guide/main.stories.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/main.stories.tsx
@@ -10,22 +10,23 @@ import Breakpoints from './pages/Breakpoints';
 
 const fullConfig = resolveConfig(tailwindConfig);
 
-storiesOf('Design Guide/Settings', module).add('Introduction', () => (
+// these have an emoji in front so they appear at the top of the alphabetical sort
+storiesOf('✩Design Guide/Introduction', module).add('Introduction', () => (
   <Introduction />
 ));
 
-storiesOf('Design Guide/Settings', module).add('Colors', () => (
+storiesOf('✩Design Guide/Colors', module).add('Colors', () => (
   <Colors config={fullConfig} />
 ));
 
-storiesOf('Design Guide/Settings', module).add('Typography', () => (
+storiesOf('✩Design Guide/Typography', module).add('Typography', () => (
   <Typography config={fullConfig} />
 ));
 
-storiesOf('Design Guide/Settings', module).add('Spacing', () => (
+storiesOf('✩Design Guide/Spacing', module).add('Spacing', () => (
   <Spacing config={fullConfig} />
 ));
 
-storiesOf('Design Guide/Settings', module).add('Breakpoints', () => (
+storiesOf('✩Design Guide/Breakpoints', module).add('Breakpoints', () => (
   <Breakpoints config={fullConfig} />
 ));

--- a/packages/fxa-settings/.storybook/preview.js
+++ b/packages/fxa-settings/.storybook/preview.js
@@ -8,3 +8,11 @@ import './design-guide/design-guide.css';
 import { initializeRTL } from 'storybook-addon-rtl';
 
 initializeRTL();
+
+export const parameters = {
+  options: {
+    storySort: {
+      method: 'alphabetical',
+    },
+  },
+};

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
@@ -3,7 +3,7 @@ import AppLayout from './index';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'Components/AppLayout',
+  title: 'Components/Settings/AppLayout',
   component: AppLayout,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/Avatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Avatar/index.stories.tsx
@@ -10,7 +10,7 @@ import { MOCK_AVATAR_DEFAULT, MOCK_AVATAR_NON_DEFAULT } from './mocks';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'Components/Avatar',
+  title: 'Components/Settings/Avatar',
   component: Avatar,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.stories.tsx
@@ -7,7 +7,7 @@ import BentoMenu from '.';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'Components/BentoMenu',
+  title: 'Components/Settings/BentoMenu',
   component: BentoMenu,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/ButtonIcon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ButtonIcon/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { ButtonIconTrash, ButtonIconReload } from '.';
 
-storiesOf('Components/ButtonIcon', module)
+storiesOf('Components/Settings/ButtonIcon', module)
   .add('ButtonIconTrash', () => (
     <div className="p-10 max-w-lg">
       <ButtonIconTrash title="Remove email" />

--- a/packages/fxa-settings/src/components/Settings/Checkbox/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Checkbox/index.stories.tsx
@@ -7,7 +7,7 @@ import Checkbox from './index';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'Components/Checkbox',
+  title: 'Components/Settings/Checkbox',
   component: Checkbox,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.stories.tsx
@@ -7,6 +7,6 @@ import { storiesOf } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 import { ConnectAnotherDevicePromo } from '.';
 
-storiesOf('Components/ConnectAnotherDevice', module)
+storiesOf('Components/Settings/ConnectAnotherDevice', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => <ConnectAnotherDevicePromo />);

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
@@ -11,7 +11,7 @@ import { MOCK_SERVICES } from './mocks';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
 
-storiesOf('Components/ConnectedServices', module)
+storiesOf('Components/Settings/ConnectedServices', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/Settings/DataBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataBlock/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import DataBlock from './index';
 
-storiesOf('Components/DataBlock', module)
+storiesOf('Components/Settings/DataBlock', module)
   .add('single', () => (
     <div className="p-10 max-w-lg">
       <DataBlock value="ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F" />

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.stories.tsx
@@ -6,6 +6,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { DataCollection } from '.';
 
-storiesOf('Components/DataCollection', module).add('default', () => (
+storiesOf('Components/Settings/DataCollection', module).add('default', () => (
   <DataCollection />
 ));

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.stories.tsx
@@ -18,7 +18,7 @@ const account = {
   },
 } as any;
 
-storiesOf('Components/DropDownAvatarMenu', module)
+storiesOf('Components/Settings/DropDownAvatarMenu', module)
   .add('default - no avatar or display name', () => (
     <AppContext.Provider value={mockAppContext({ account })}>
       <div className="w-full flex justify-end">

--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.stories.tsx
@@ -7,6 +7,6 @@ import { storiesOf } from '@storybook/react';
 import { FlowContainer } from '.';
 import { LocationProvider } from '@reach/router';
 
-storiesOf('Components/FlowContainer', module)
+storiesOf('Components/Settings/FlowContainer', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => <FlowContainer title="Flow container title" />);

--- a/packages/fxa-settings/src/components/Settings/FormPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FormPassword/index.stories.tsx
@@ -10,7 +10,7 @@ import FormPassword from '.';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'components/FormPassword',
+  title: 'Components/Settings/FormPassword',
   component: FormPassword,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/GetDataTrio/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/GetDataTrio/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import GetDataTrio from './index';
 
-storiesOf('Components/GetDataTrio', module).add('default', () => (
+storiesOf('Components/Settings/GetDataTrio', module).add('default', () => (
   <div className="p-10 max-w-xs">
     <GetDataTrio value="Copy that" />
   </div>

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
@@ -18,7 +18,7 @@ const account = {
   },
 } as any;
 
-storiesOf('Components/HeaderLockup', module)
+storiesOf('Components/Settings/HeaderLockup', module)
   .add('with default avatar', () => (
     <AppContext.Provider value={mockAppContext({ account })}>
       <HeaderLockup />

--- a/packages/fxa-settings/src/components/Settings/InputPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/InputPassword/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import InputPassword from '.';
 
-storiesOf('Components/InputPassword', module).add('default', () => (
+storiesOf('Components/Settings/InputPassword', module).add('default', () => (
   <div className="p-10 max-w-lg">
     <InputPassword label="You think you know how to password? Enter it here." />
   </div>

--- a/packages/fxa-settings/src/components/Settings/InputText/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/InputText/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import InputText from './index';
 
-storiesOf('Components/InputText', module)
+storiesOf('Components/Settings/InputText', module)
   .add('type text (default)', () => (
     <div className="p-10 pt-16 max-w-lg">
       <div className="mb-3">

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.stories.tsx
@@ -10,7 +10,7 @@ import { MOCK_LINKED_ACCOUNTS } from './mocks';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
 
-storiesOf('Components/LinkedAccounts', module).add('default', () => (
+storiesOf('Components/Settings/LinkedAccounts', module).add('default', () => (
   <AppContext.Provider
     value={mockAppContext({
       account: { linkedAccounts: MOCK_LINKED_ACCOUNTS } as any,

--- a/packages/fxa-settings/src/components/Settings/Modal/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.stories.tsx
@@ -8,7 +8,7 @@ import { useBooleanState } from 'fxa-react/lib/hooks';
 import { Modal } from '.';
 import { LocationProvider } from '@reach/router';
 
-storiesOf('Components/Modal', module)
+storiesOf('Components/Settings/Modal', module)
   .add('basic', () => (
     <LocationProvider>
       <ModalToggle>

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
@@ -22,7 +22,7 @@ account.verifySession = (code: string) => {
   return Promise.reject(AuthUiErrors.INVALID_EXPIRED_SIGNUP_CODE);
 };
 
-storiesOf('Components/ModalVerifySession', module).add(
+storiesOf('Components/Settings/ModalVerifySession', module).add(
   'valid code: 123456',
   () => (
     <LocationProvider>

--- a/packages/fxa-settings/src/components/Settings/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.stories.tsx
@@ -13,7 +13,7 @@ import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'Components/Nav',
+  title: 'Components/Settings/Nav',
   component: Nav,
 } as Meta;
 
@@ -38,7 +38,7 @@ const configWithoutNewsletterLink = {
 const storyWithContext = (
   account: Partial<Account>,
   storyName?: string,
-  config?: Config,
+  config?: Config
 ) => {
   const context = config
     ? { account: account as Account, config: config }

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.stories.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LocationProvider } from '@reach/router';
-import { storiesOf } from '@storybook/react';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext, MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
 import React from 'react';
 import { Page2faReplaceRecoveryCodes } from '.';
 import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
+import { LocationProvider } from '@reach/router';
 
 const account = {
   ...MOCK_ACCOUNT,
@@ -27,12 +27,17 @@ const account = {
     }),
 } as any;
 
-storiesOf('Pages/2faReplaceRecoveryCodes', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => (
+export default {
+  title: 'pages/Settings/TwoStepAuthenticationReplaceCodes',
+  component: Page2faReplaceRecoveryCodes,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppContext.Provider value={mockAppContext({ account })}>
       <AppLayout>
         <Page2faReplaceRecoveryCodes />
       </AppLayout>
     </AppContext.Provider>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
@@ -3,17 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
-
+import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
-
 import PageAvatar from './';
 
-storiesOf('Pages/PageAvatar', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => (
+export default {
+  title: 'pages/Settings/Avatar',
+  component: PageAvatar,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppLayout>
       <PageAvatar />
     </AppLayout>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
@@ -6,11 +6,12 @@ import React from 'react';
 import { PageChangePassword } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
 
 export default {
-  title: 'pages/ChangePassword',
+  title: 'pages/Settings/ChangePassword',
   component: PageChangePassword,
-};
+} as Meta;
 
 export const Default = () => (
   <LocationProvider>

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
@@ -9,7 +9,7 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'pages/CreatePassword',
+  title: 'pages/Settings/CreatePassword',
   component: PageCreatePassword,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
@@ -3,15 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { PageDeleteAccount } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
 
-storiesOf('Pages/DeleteAccount', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => (
+export default {
+  title: 'pages/Settings/DeleteAccount',
+  component: PageDeleteAccount,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppLayout>
       <PageDeleteAccount />
     </AppLayout>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
@@ -3,15 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { LocationProvider } from '@reach/router';
-import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { PageDisplayName } from '.';
 import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
 
-storiesOf('Pages/DisplayName', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => (
+export default {
+  title: 'pages/Settings/DisplayName',
+  component: PageDisplayName,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppLayout>
       <PageDisplayName />
     </AppLayout>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.stories.tsx
@@ -3,15 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { PageRecoveryKeyAdd } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
 
-storiesOf('Pages/RecoveryKey', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => (
+export default {
+  title: 'pages/Settings/RecoveryKeyAdd',
+  component: PageRecoveryKeyAdd,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppLayout>
       <PageRecoveryKeyAdd />
     </AppLayout>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
@@ -4,14 +4,19 @@
 
 import React from 'react';
 import { LocationProvider } from '@reach/router';
-import { storiesOf } from '@storybook/react';
 import { AppLayout } from '../AppLayout';
 import { PageSecondaryEmailAdd } from '.';
+import { Meta } from '@storybook/react';
 
-storiesOf('Pages/SecondaryEmailAdd', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('Default empty', () => (
+export default {
+  title: 'pages/Settings/SecondaryEmailAdd',
+  component: PageSecondaryEmailAdd,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppLayout>
       <PageSecondaryEmailAdd />
     </AppLayout>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
@@ -3,21 +3,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import { PageSecondaryEmailVerify } from '.';
 import { AppLayout } from '../AppLayout';
 import { WindowLocation, LocationProvider } from '@reach/router';
+
+export default {
+  title: 'pages/Settings/SecondaryEmailVerify',
+  component: PageSecondaryEmailVerify,
+} as Meta;
 
 const mockLocation = {
   state: { email: 'johndope@example.com' },
 } as unknown as WindowLocation;
 
-storiesOf('Pages/SecondaryEmailVerify', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('valid: 1234, invalid: 4444', () => {
-    return (
-      <AppLayout>
-        <PageSecondaryEmailVerify location={mockLocation} />
-      </AppLayout>
-    );
-  });
+export const Default = () => (
+  <LocationProvider>
+    <AppLayout>
+      <PageSecondaryEmailVerify location={mockLocation} />
+    </AppLayout>
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.stories.tsx
@@ -3,15 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { LocationProvider } from '@reach/router';
-import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { PageTwoStepAuthentication } from '.';
 import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
 
-storiesOf('Pages/TwoStepAuthentication', module)
-  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('default', () => (
+export default {
+  title: 'pages/Settings/TwoStepAuthentication',
+  component: PageTwoStepAuthentication,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
     <AppLayout>
       <PageTwoStepAuthentication />
     </AppLayout>
-  ));
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/components/Settings/Profile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Profile/index.stories.tsx
@@ -15,7 +15,7 @@ import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 
 export default {
-  title: 'components/Profile',
+  title: 'Components/Settings/Profile',
   component: Profile,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
@@ -11,7 +11,7 @@ import { Account } from '../../../models/Account';
 import { Meta } from '@storybook/react';
 
 export default {
-  title: 'components/Security',
+  title: 'Components/Settings/Security',
   component: Security,
 } as Meta;
 

--- a/packages/fxa-settings/src/components/Settings/Switch/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Switch/index.stories.tsx
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react';
 import React, { useState } from 'react';
 import Switch from '.';
 
-storiesOf('Components/Switch', module)
+storiesOf('Components/Settings/Switch', module)
   .add('on', () => <Subject />)
   .add('loading, user switched off', () => <Subject isSubmitting />)
   .add('off', () => <Subject isOn={false} />)

--- a/packages/fxa-settings/src/components/Settings/Tooltip/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Tooltip/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Tooltip from './index';
 
-storiesOf('Components/Tooltip', module)
+storiesOf('Components/Settings/Tooltip', module)
   .add('default', () => (
     <div className="p-20 max-w-md">
       <div className="mb-3">

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.stories.tsx
@@ -11,7 +11,7 @@ import { UnitRow } from '.';
 import { Modal } from '../Modal';
 import { AppContext } from 'fxa-settings/src/models';
 
-storiesOf('Components/UnitRow', module)
+storiesOf('Components/Settings/UnitRow', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('basic, with falsey headerValue', () => (
     <UnitRow header="Some header" headerValue={null} />

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.stories.tsx
@@ -9,7 +9,7 @@ import UnitRowRecoveryKey from '.';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext, mockSession } from 'fxa-settings/src/models/mocks';
 
-storiesOf('Components/UnitRowRecoveryKey', module)
+storiesOf('Components/Settings/UnitRowRecoveryKey', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('with account recovery key', () => (
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.stories.tsx
@@ -10,7 +10,7 @@ import { LocationProvider } from '@reach/router';
 
 import { AppContext } from 'fxa-settings/src/models';
 
-storiesOf('Components/UnitRowSecondaryEmail', module)
+storiesOf('Components/Settings/UnitRowSecondaryEmail', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('No secondary email set', () => <UnitRowSecondaryEmail />)
   .add('One secondary email set, unverified', () => {

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
@@ -9,7 +9,7 @@ import UnitRowTwoStepAuth from '.';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
 
-storiesOf('Components/UnitRowTwoStepAuth', module)
+storiesOf('Components/Settings/UnitRowTwoStepAuth', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default unset', () => (
     <AppContext.Provider


### PR DESCRIPTION
Because:
* We're going to be converting content-server components over into React and will be adding them to Storybook. We previously changed our directory tree paths under components/Settings/ to accommodate and want Storybook to reflect this as well.

This commit:
* Removes the word "Settings" from the top level of design guide
* Moves all components that are in 'components/Settings' into Storybook section 'Components/Settings', and moves Pages around similarly
* Refactors some page level stories to the new Storybook format
* Modifies preview.js so Storybook sorts the stories by alphabetical storybook name instead of component name

Closes FXA-6274