### PR TITLE
feat(tailwind): Remove custom Tailwind variations provided by v3

### DIFF
--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
@@ -35,7 +35,7 @@ export const SubscriptionTitle = ({
 
   return (
     <div
-      className={`subscription-title bg-white shadow-sm shadow-grey-300 text-center mt-0 mx-4 mb-auto pt-5 px-4 pb-px border-y-auto z-1 row-start-1 row-end-2 tablet:mx-0 ${className}`}
+      className={`subscription-title bg-white shadow-sm shadow-grey-300 text-center mt-0 mx-4 mb-auto pt-5 px-4 pb-px border-y-auto row-start-1 row-end-2 tablet:mx-0 ${className}`}
       data-testid={`subscription-${screenType}-title`}
     >
       <Localized id={`subscription-${screenType}-title`}>

--- a/packages/fxa-payments-server/src/styles/tailwind.css
+++ b/packages/fxa-payments-server/src/styles/tailwind.css
@@ -61,11 +61,11 @@
 
 /* shared styles used in PlanDetails and PlanUpgradeDetails */
 .accordion-btn {
-  @apply bg-transparent border-transparent cursor-pointer text-blue-500 leading-5 my-2 outline-none py-2 pr-2 pl-6 relative w-auto h-auto focus:border focus:border-solid focus:border-blue-400 focus:py-2 focus:pr-4 focus:pl-10 focus:shadow-none;
+  @apply bg-transparent border-transparent cursor-pointer text-blue-500 leading-5 my-2 py-2 pr-2 pl-6 relative focus:border focus:border-solid focus:border-blue-400 focus:py-2 focus:pr-4 focus:pl-10 focus:shadow-none;
 }
 
 .arrow {
-  @apply before:bg-[url('../components/PlanDetails/images/chevron.svg')] before:content-[''] before:absolute before:h-4 before:w-6 before:top-2.5  before:left-0 focus:before:left-3.5;
+  @apply before:bg-[url('../components/PlanDetails/images/chevron.svg')] before:content-[''] before:absolute before:h-4 before:w-6 before:top-[0.6rem]  before:left-0 focus:before:left-[0.87rem];
 }
 
 .coupon-info {

--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -15,20 +15,11 @@ module.exports = {
         9999: '9999',
       },
       padding: {
-        7: '1.75rem',
-        11: '2.75rem',
         18: '4.5rem',
         33: '8.5rem',
       },
       margin: {
-        7: '1.75rem',
-        9: '2.25rem',
-        11: '2.75rem',
         18: '4.5rem',
-        '-18': '-4.5rem',
-      },
-      borderRadius: {
-        xl: '.75rem',
       },
       flex: {
         2: '2',
@@ -40,7 +31,6 @@ module.exports = {
         '80px': '0 0 80px',
       },
       width: {
-        7: '1.75rem',
         18: '4.5rem',
         120: '30rem',
       },
@@ -63,24 +53,9 @@ module.exports = {
         100: '25rem',
       },
       inset: {
-        '1/2': '50%',
-        '-px': '-1px',
-        '-3': '-0.75rem',
-        '-50': '-11.50rem',
-        '-52': '-13rem',
-        0.5: '0.125rem',
-        3: '0.75rem',
-        6: '1.25rem',
-        10: '2.5rem',
+        50: '11.50rem',
         55: '13.75rem',
         ten: '10%',
-        full: '100%',
-      },
-      top: {
-        2.5: '0.6rem',
-      },
-      left: {
-        3.5: '.87rem',
       },
       boxShadow: {
         // Specific-use focus shadows for input elements
@@ -91,14 +66,7 @@ module.exports = {
         'card-grey-drop': '0px 2px 14px rgba(58, 57, 68, 0.2)',
       },
       scale: {
-        80: '.8',
-        '-1': '-1',
-      },
-      backgroundOpacity: {
-        10: '0.1',
-        20: '0.2',
-        30: '0.3',
-        40: '0.4',
+        80: '0.8',
       },
       backgroundImage: {
         /* TODO: be able to reference images here, FXA-5745, this is a workaround/hack
@@ -107,9 +75,6 @@ module.exports = {
          * always be overridden but other packages without this set that use fxa-react shared
          * styles can't build without this */
         'ff-logo': 'none',
-      },
-      outline: {
-        'black-dotted': '1px dotted #000',
       },
       keyframes: {
         'fade-in': {
@@ -123,7 +88,7 @@ module.exports = {
       },
       animation: {
         'delayed-fade-in': 'fade-in 1s linear 5s forwards',
-        spin: 'rotate .8s linear infinite',
+        spin: 'rotate 0.8s linear infinite',
       },
     },
     screens: {
@@ -133,6 +98,9 @@ module.exports = {
       desktopXl: '1441px',
     },
     fontSize: {
+      // These classes must be included here
+      // To be picked up by fxa-settings' Typography design guide
+      // Even if the settings are the same as Tailwind's defaults
       xs: '12px',
       sm: '14px',
       base: '16px',
@@ -312,38 +280,43 @@ module.exports = {
     plugin(function ({ addComponents }) {
       const carets = {
         '.caret-top': {
-          borderLeft: '.75rem solid transparent',
-          borderRight: '.75rem solid transparent',
-          borderBottom: '.75rem solid #fff',
+          borderLeft: '0.75rem solid transparent',
+          borderRight: '0.75rem solid transparent',
+          borderBottom: '0.75rem solid #fff',
         },
         '.caret-top-default': {
-          borderLeft: '.75rem solid transparent',
-          borderRight: '.75rem solid transparent',
-          borderBottom: '.75rem solid #5e5e72',
+          borderLeft: '0.75rem solid transparent',
+          borderRight: '0.75rem solid transparent',
+          borderBottom: '0.75rem solid #5e5e72',
         },
         '.caret-top-error': {
-          borderLeft: '.75rem solid transparent',
-          borderRight: '.75rem solid transparent',
-          borderBottom: '.75rem solid #E22850',
+          borderLeft: '0.75rem solid transparent',
+          borderRight: '0.75rem solid transparent',
+          borderBottom: '0.75rem solid #E22850',
         },
         '.caret-bottom': {
-          borderLeft: '.75rem solid transparent',
-          borderRight: '.75rem solid transparent',
-          borderBottom: '.75rem solid #fff',
+          borderLeft: '0.75rem solid transparent',
+          borderRight: '0.75rem solid transparent',
+          borderBottom: '0.75rem solid #fff',
         },
         '.caret-bottom-default': {
-          borderLeft: '.75rem solid transparent',
-          borderRight: '.75rem solid transparent',
-          borderTop: '.75rem solid #3D3D3D',
+          borderLeft: '0.75rem solid transparent',
+          borderRight: '0.75rem solid transparent',
+          borderTop: '0.75rem solid #3D3D3D',
         },
         '.caret-bottom-error': {
-          borderLeft: '.75rem solid transparent',
-          borderRight: '.75rem solid transparent',
-          borderTop: '.75rem solid #E22850',
+          borderLeft: '0.75rem solid transparent',
+          borderRight: '0.75rem solid transparent',
+          borderTop: '0.75rem solid #E22850',
         },
       };
       addComponents(carets);
     }),
     tailwindcssDir(),
   ],
+  // Workaround for TW's JIT engine, to provide access to all TW classes
+  // for styling/debugging in browser DevTools (in dev mode only)
+  ...(process.env.NODE_ENV === 'development' && {
+    safelist: [{ pattern: /.*/ }],
+  }),
 };

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
@@ -62,7 +62,7 @@ export const BentoMenu = () => {
                 <CloseIcon
                   width="16"
                   height="16"
-                  className="absolute top-6 right-6 mobileLandscape:hidden"
+                  className="absolute top-5 right-5 mobileLandscape:hidden"
                 />
               </button>
               <div className="mt-12 text-center p-8 pt-2 pb-2 mobileLandscape:mt-0">


### PR DESCRIPTION
## Because

- Tailwind v3 provides more classes by default, so many custom variations included in our Tailwind config are no longer needed.
- Tailwind v3 enables JIT engine by default, and purges all unused utilities from the css build. While this reduces file size, it also becomes difficult to debug styling with browser dev tools.

## This pull request

- Removes custom variations in fxa-react's tailwind.js when they are included by default in Tailwind v3.
- Removes custom variations that are no longer in use in fxa packages (zIndex, backgroundOpacity, outline-dotted-black)
- Tested build-css to ensure output css compiles with no errors.
- Does not remove fontSize definitions even though provided by Tailwind v3, as explicit declaration is currently needed for fxa-settings's design guide.
- Safelist all tailwind patterns in `dev mode` to enable in-browser styling with tailwind utilities.
- Refactor Payments' expandable plan details button.

## Issue that this pull request solves

Closes: #FXA-5448, , FXA-6235

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## For reference

[v3 Tailwind docs](https://tailwindcss.com/docs/)
[Enabling in-browser styling without disabling JIT engine](https://github.com/tailwindlabs/tailwindcss/discussions/6347#discussioncomment-2185719)