### PR TITLE
fix(auth): subsequent Invoice Preview Needs To Check SUbscription For…

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -741,7 +741,7 @@ export class StripeHelper extends StripeHelperBase {
   }) {
     if (automaticTax) {
       try {
-        return this.stripe.invoices.retrieveUpcoming({
+        return await this.stripe.invoices.retrieveUpcoming({
           subscription: subscriptionId,
           automatic_tax: {
             enabled: true,
@@ -755,7 +755,7 @@ export class StripeHelper extends StripeHelperBase {
         throw e;
       }
     } else {
-      return this.stripe.invoices.retrieveUpcoming({
+      return await this.stripe.invoices.retrieveUpcoming({
         subscription: subscriptionId,
       });
     }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -456,20 +456,16 @@ export class StripeHandler {
       return [];
     }
 
-    const subsequentInvoicePreviews = (
-      await Promise.all(
-        customer.subscriptions.data.map((sub) => {
-          if (!sub.canceled_at) {
-            return this.stripeHelper.previewInvoiceBySubscriptionId({
-              automaticTax,
-              subscriptionId: sub.id,
-            });
-          } else {
-            return Promise.resolve(null);
-          }
+    const subsequentInvoicePreviews = await Promise.all(
+      customer.subscriptions.data
+        .filter((sub) => !sub.canceled_at)
+        .map((sub) => {
+          return this.stripeHelper.previewInvoiceBySubscriptionId({
+            automaticTax: automaticTax && sub.automatic_tax.enabled,
+            subscriptionId: sub.id,
+          });
         })
-      )
-    ).filter((sub): sub is Stripe.Response<Stripe.Invoice> => sub !== null);
+    );
 
     return stripeInvoicesToSubsequentInvoicePreviewsDTO(
       subsequentInvoicePreviews

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -805,7 +805,10 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves({
         id: 'cus_id',
         subscriptions: {
-          data: [{ id: 'sub_id1' }, { id: 'sub_id2' }],
+          data: [
+            { id: 'sub_id1', automatic_tax: { enabled: true } },
+            { id: 'sub_id2', automatic_tax: { enabled: true } },
+          ],
         },
       });
       VALID_REQUEST.app.geo = {};


### PR DESCRIPTION
… Automatic Tax

Because:

* preview-subsequent will fail if the subscription has manually calculated tax when automaticTax is enabled

This commit:

* checks both that the feature and subscription have automatic tax enabled

Closes #FXA-6294

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
