### PR TITLE
chore(deps): resolve node-forge to >=1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "http-proxy": "^1.18.1",
     "minimist": "^1.2.6",
     "moment:>2.0.0 <3": ">=2.29.4",
+    "node-forge": ">=1.3.0",
     "plist": "^3.0.6",
     "protobufjs:>6.0.0 <7": ">=6.11.3",
     "tap/typescript": "^4.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35130,21 +35130,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "node-forge@npm:0.10.0"
-  checksum: 5aa6dc9922e424a20ef101d2f517418e2bc9cfc0255dd22e0701c0fad1568445f510ee67f6f3fcdf085812c4ca1b847b8ba45683b34776828e41f5c1794e42e1
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^0.7.1":
-  version: 0.7.6
-  resolution: "node-forge@npm:0.7.6"
-  checksum: 661d420847da736d82f3aad0e8ad2b5fceddc4bd5f4065b923c566e9fd68e568509677374f101c1f4321c541dcbef0864516a2a55ff03a9236d0895195dfa7aa
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^1.3.1":
+"node-forge@npm:>=1.3.0":
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
   checksum: 08fb072d3d670599c89a1704b3e9c649ff1b998256737f0e06fbd1a5bf41cae4457ccaee32d95052d80bbafd9ffe01284e078c8071f0267dc9744e51c5ed42a9


### PR DESCRIPTION
Because:
 - security alerts

This commit:
 - resolve node-forge to >= the min fixed version
