### PR TITLE
feat(oauth): Add support for `prompt=login` and return the `auth_time` in id token

### DIFF
--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -62,6 +62,9 @@ function setupOAuthFlow(req, action, options = {}, cb) {
   if (options.prompt) {
     params.prompt = options.prompt;
   }
+  if (options.max_age >= 0) {
+    params.max_age = options.max_age;
+  }
 
   request.get(
     {
@@ -185,6 +188,23 @@ module.exports = function (app, db) {
         // and asked to sign in as that user.
         req.session.requestedLoginHint =
           req.query.email || req.query.login_hint;
+        return res.redirect(redirectUrl(params, oauthConfig));
+      }
+    );
+  });
+
+  app.get('/api/prompt_login', function (req, res) {
+    setupOAuthFlow(
+      req,
+      null,
+      { prompt: 'login', max_age: 0 },
+      function (err, params, oauthConfig) {
+        console.log('login', err, params, oauthConfig);
+
+        if (err) {
+          console.log('err', err);
+          return res.send(400, err);
+        }
         return res.redirect(redirectUrl(params, oauthConfig));
       }
     );

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -55,6 +55,12 @@
         Sign In (prompt=none)
       </button>
         <button
+          class="btn btn-large btn-info btn-persona prompt-login"
+          type="submit"
+        >
+          Sign In (prompt=login)
+        </button>
+        <button
           class="btn btn-large btn-info btn-persona scope-keys"
           type="submit"
         >

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -296,6 +296,10 @@ $(document).ready(function () {
       authenticate('prompt_none');
     });
 
+    $('button.prompt-login').click(function (ev) {
+      authenticate('prompt_login');
+    });
+
     // upon click of logout link navigator.id.logout()
     $('#logout').click(function (ev) {
       ev.preventDefault();

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
 test.describe('two step auth', () => {
@@ -58,11 +58,9 @@ test.describe('two step auth', () => {
     expect(status).toEqual('Enabled');
   });
 
-  test('add TOTP and confirm sync signin', async ({
-    credentials,
-    target,
-    pages: { login, settings, totp, page, connectAnotherDevice },
-  }) => {
+  test('add TOTP and confirm sync signin', async ({ credentials, target }) => {
+    const { login, settings, totp, page, connectAnotherDevice } =
+      await newPagesForSync(target);
     await settings.goto();
     await settings.totp.clickAdd();
     await totp.enable(credentials);

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -196,8 +196,8 @@ async function generateIdToken(grant, accessToken) {
   // > REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the
   // > OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain
   // > identifiers for other audiences. In the general case, the aud value is an array of
-  // > case sensitive strings. In the common special case when there is one audience, the
-  // > aud value MAY be a single case sensitive string.
+  // > case-sensitive strings. In the common special case when there is one audience, the
+  // > aud value MAY be a single case-sensitive string.
   const audience = grant.resource ? [clientId, grant.resource] : clientId;
 
   const claims = {
@@ -214,6 +214,11 @@ async function generateIdToken(grant, accessToken) {
   if (grant.aal) {
     claims['fxa-aal'] = grant.aal;
     claims.acr = 'AAL' + grant.aal;
+  }
+  // For legacy reasons auth_time was stored as authAt in our db. It also
+  // needs to be converted to seconds.
+  if (grant.authAt) {
+    claims.auth_time = Math.floor(grant.authAt / 1000);
   }
 
   return jwt.sign(claims);

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -58,7 +58,7 @@ module.exports = ({ log, oauthDB, config }) => {
     }
   }
   async function generateAuthorizationCode(client, payload, grant) {
-    // Clients must use PKCE if and only if they are a pubic client.
+    // Clients must use PKCE if and only if they are a public client.
     if (client.publicClient) {
       if (!payload.code_challenge_method || !payload.code_challenge) {
         log.info('client.missingPkceParameters');
@@ -94,11 +94,11 @@ module.exports = ({ log, oauthDB, config }) => {
   }
 
   // N.B. We do not correctly implement the "implicit grant" flow from
-  // RFC6749 which defines `response_type=token`. Instead we have a
+  // RFC6749 which defines `response_type=token`. Instead, we have a
   // privileged set of clients that use `response_type=token` for something
   // approximating the "resource owner password grant" flow, using an identity
   // assertion to just directly grant tokens for their own use. Known current
-  // users of this functinality include:
+  // users of this functionality include:
   //
   //  * Firefox Desktop, for getting "profile"-scoped tokens to access profile data
   //  * Firefox for Android, for getting "profile"-scoped tokens to access profile data
@@ -279,7 +279,6 @@ module.exports = ({ log, oauthDB, config }) => {
               .optional()
               .allow(null)
               .description(DESCRIPTION.acrValues),
-
             resource: validators.resourceUrl
               .when('response_type', {
                 is: RESPONSE_TYPE_TOKEN,

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -401,4 +401,16 @@ describe('generateTokens', () => {
       'https://resource.server1.com',
     ]);
   });
+
+  it('should propagate auth_time in claims', async () => {
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
+    requestedGrant.authAt = Date.now();
+    const result = await generateTokens(requestedGrant);
+    assert.ok(result.id_token);
+    const jwt = decodeJWT(result.id_token);
+    assert.deepEqual(
+      jwt.claims.auth_time,
+      Math.floor(requestedGrant.authAt / 1000)
+    );
+  });
 });

--- a/packages/fxa-content-server/app/scripts/lib/oauth-prompt.ts
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-prompt.ts
@@ -9,6 +9,7 @@
 enum OAuthPrompt {
   CONSENT = 'consent',
   NONE = 'none',
+  LOGIN = 'login',
 }
 
 export default OAuthPrompt;

--- a/packages/fxa-content-server/app/scripts/lib/validate.js
+++ b/packages/fxa-content-server/app/scripts/lib/validate.js
@@ -130,7 +130,7 @@ var Validate = {
    * @returns {Boolean}
    */
   isPromptValid(prompt) {
-    const valid = [OAuthPrompt.CONSENT, OAuthPrompt.NONE];
+    const valid = [OAuthPrompt.CONSENT, OAuthPrompt.NONE, OAuthPrompt.LOGIN];
 
     return _.contains(valid, prompt);
   },

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -196,6 +196,10 @@ export default BaseAuthenticationBroker.extend({
           oauthParams.access_type = Constants.ACCESS_TYPE_OFFLINE; //eslint-disable-line camelcase
         }
 
+        if (relier.get('maxAge') >= 0) {
+          oauthParams.max_age = relier.get('maxAge'); //eslint-disable-line camelcase
+        }
+
         return account.createOAuthCode(
           clientId,
           relier.get('state'),

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -37,6 +37,7 @@ const SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA = {
   keys_jwk: Vat.keysJwk().renameTo('keysJwk'),
   id_token_hint: Vat.idToken().renameTo('idTokenHint'),
   login_hint: Vat.email().renameTo('loginHint'),
+  max_age: Vat.number().min(0).renameTo('maxAge'),
   prompt: Vat.prompt(),
   redirect_uri: Vat.url()
     .allow(Constants.DEVICE_PAIRING_AUTHORITY_REDIRECT_URI)
@@ -88,6 +89,8 @@ var OAuthRelier = Relier.extend({
     scope: null,
     // standard oauth parameters.
     state: null,
+    // Max age since last auth
+    maxAge: null,
   }),
 
   initialize(attributes, options = {}) {
@@ -293,6 +296,18 @@ var OAuthRelier = Relier.extend({
    */
   wantsConsent() {
     return this.get('prompt') === OAuthPrompt.CONSENT;
+  },
+
+  /**
+   * Return `true` if the relier sets `prompt=login` or `maxAge=0`. Per OIDC spec,
+   * specifying `maxAge=0` should act like `prompt=login`, however the RP needs to
+   * verify the `auth_at` value in the id token to confirm that a re-authentication
+   * occurred.
+   *
+   * @returns {Boolean}
+   */
+  wantsLogin() {
+    return this.get('prompt') === OAuthPrompt.LOGIN || this.get('maxAge') === 0;
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -61,6 +61,11 @@ export default {
       return true;
     }
 
+    // Checks to see if relier requesting `prompt=login`
+    if (this.relier.isOAuth() && this.relier.wantsLogin()) {
+      return true;
+    }
+
     // Ask when a prefill email does not match the account email.
     const prefillEmail = this.getPrefillEmail();
     if (prefillEmail && prefillEmail !== account.get('email')) {

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -1055,6 +1055,39 @@ describe('models/reliers/oauth', () => {
     });
   });
 
+  describe('wantsLogin', () => {
+    describe('prompt=login', () => {
+      beforeEach(() => {
+        relier.set('prompt', 'login');
+      });
+
+      it('returns true', () => {
+        assert.isTrue(relier.wantsLogin());
+      });
+    });
+
+    describe('max_age=0', () => {
+      beforeEach(() => {
+        relier.set('maxAge', 0);
+      });
+
+      it('returns true', () => {
+        assert.isTrue(relier.wantsLogin());
+      });
+    });
+
+    describe('otherwise', () => {
+      beforeEach(() => {
+        relier.unset('prompt');
+        relier.unset('maxAge');
+      });
+
+      it('returns false', () => {
+        assert.isFalse(relier.wantsLogin());
+      });
+    });
+  });
+
   describe('wantsTwoStepAuthentication', () => {
     it('return true for acrValues=AAL2', () => {
       relier.set('acrValues', 'AAL2');

--- a/packages/fxa-content-server/docs/query-params.md
+++ b/packages/fxa-content-server/docs/query-params.md
@@ -26,6 +26,8 @@ Untrusted relying parties always show the prompt.
   Only applicable for authorized relying parties that are not requesting
   keys. An error is returned to the RP for all others.
   See the [prompt=none doc][#prompt-none] for more info.
+- `login` - Always prompt the user for their password and re-authenticate
+  regardless if they have signed into the browser or have a cached session.
 
 #### When to specify
 
@@ -81,42 +83,6 @@ an account.
 #### When to specify
 
 When authenticating a user
-
-### `channel`
-
-Force which Firefox release channel should be installed
-after redirecting from `/m/:signinCode`.
-
-#### Options
-
-- `beta`
-- `nightly`
-- `release`
-
-#### When to specify
-
-- /m/:signinCode
-
-### `country`
-
-Force a country to be used when testing the SMS feature.
-
-#### Options
-
-- `AT`
-- `AU`
-- `BE`
-- `DE`
-- `DE`
-- `DK`
-- `ES`
-- `FR`
-- `GB`
-- `IT`
-- `LU`
-- `NL`
-- `RO`
-- `US`
 
 ### `entrypoint`
 


### PR DESCRIPTION
## Because

- RPs need to be able to request a user reauthenticate
- RPs should be able to verify that a user did reauthenticate via the `auth_time` claim

## This pull request

- Adds support for `prompt=login`
- The spec says that `auth_time` is OPTIONAL and only required when `max_age` is set, however this update always returns it in the id token

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6272
Closes: https://mozilla-hub.atlassian.net/browse/FXA-6273

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test, create and account and sign in. Then goto 123Done and click `Sign In (prompt=login)`. You should be prompted for your password.
