### PR TITLE
fix(tailwind): Updates settings and payments to support LTR/RTL

### DIFF
--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -184,12 +184,12 @@ export const CouponForm = ({
       </h4>
       {hasCoupon ? (
         <div
-          className="flex justify-between items-center"
+          className="flex gap-4 justify-between items-center"
           data-testid="coupon-hascoupon"
         >
-          <div>{promotionCode}</div>
+          <div className="break-all">{promotionCode}</div>
           {readOnly ? null : (
-            <div className="ml-4">
+            <div>
               <button
                 className="button"
                 onClick={removeCoupon}
@@ -203,7 +203,7 @@ export const CouponForm = ({
         </div>
       ) : (
         <form
-          className="flex justify-between items-center"
+          className="flex gap-4 justify-between items-center"
           onSubmit={onSubmit}
           onChange={onChange}
           data-testid="coupon-form"
@@ -226,7 +226,7 @@ export const CouponForm = ({
             </Localized>
           </div>
 
-          <div className="ml-4">
+          <div>
             <button
               name="apply"
               className="button"

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
@@ -1,12 +1,16 @@
 @import '../../../../fxa-content-server/app/styles/variables';
 
 .new-user-email-form {
-    .input-row--checkbox {
-        margin: 24px 0 5px;
+  .input-row--checkbox {
+    margin: 24px 0 5px;
 
-        label input[type="checkbox"] {
-            margin-right: 6px;
-            margin-left: 8px;
-        }
+    label {
+      gap: 0;
     }
+
+    label input[type='checkbox'] {
+      margin-right: 6px;
+      margin-left: 8px;
+    }
+  }
 }

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -96,7 +96,7 @@ export const NewUserEmailForm = ({
         }}
       >
         <p
-          className="font-normal -mt-2 ml-6 text-grey-400"
+          className="font-normal -mt-2 text-grey-400"
           data-testid="sign-in-copy"
         >
           Already have a Firefox account?{' '}

--- a/packages/fxa-payments-server/src/components/PaymentProviderDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentProviderDetails/index.scss
@@ -1,19 +1,12 @@
 .c-card {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .c-card::before {
   height: 27px;
   width: 40px;
-
-  html[dir='ltr'] & {
-    margin-right: 8px;
-  }
-
-  html[dir='rtl'] & {
-    margin-left: 8px;
-  }
 }
 
 .c-card::before,
@@ -85,6 +78,6 @@
 
 .stack-card-details > p.c-card,
 .stack-card-details > .c-card::before {
-  margin-bottom: .55em;
-  margin-block-end: .55em;
+  margin-bottom: 0.55em;
+  margin-block-end: 0.55em;
 }

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -170,7 +170,7 @@ export const PlanDetails = ({
       <div className="plan-details-component-inner">
         <div className="plan-details-component-card">
           <div className="plan-details-header row-divider-grey-200">
-            <div className="flex">
+            <div className="flex gap-4">
               <div
                 className="plan-details-logo-wrap"
                 style={{ ...setWebIconBackground }}
@@ -207,7 +207,7 @@ export const PlanDetails = ({
 
           {!detailsHidden && productDetails.details && (
             <div
-              className="mt-2 pt-0 px-4 pb-px tablet:border-b-0 text-left"
+              className="mt-2 pt-0 px-4 pb-px tablet:border-b-0 text-start"
               data-testid="list"
             >
               <Localized id="plan-details-header">

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -96,7 +96,7 @@ export const Field = ({
         {label && (
           <span
             data-testid="input-label-text"
-            className="font-medium text-sm text-grey-400 block mb-2 text-left"
+            className="font-medium text-sm text-grey-400 block mb-2 text-start"
           >
             {label}
           </span>

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -107,7 +107,7 @@ hr {
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 7px;
-    text-align: left;
+    text-align: start;
   }
 
   .label-text.checkbox {
@@ -130,10 +130,10 @@ hr {
   label {
     display: flex;
     align-items: center;
+    gap: 1rem;
 
     input[type='checkbox'] {
       flex: 0 0 18px;
-      margin-right: 16px;
       transform: scale(1.5);
 
       &:checked {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -109,7 +109,7 @@ export const PlanDetailsCard = ({
   return (
     <div className={`plan-details-component-card ${className}`}>
       <div className="plan-details-header">
-        <div className="flex">
+        <div className="flex gap-4">
           <div
             className="plan-details-logo-wrap"
             style={{ ...setWebIconBackground }}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
@@ -69,7 +69,7 @@
     margin: 0;
 
     > p {
-      text-align: left;
+      text-align: start;
     }
 
     button {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -62,7 +62,6 @@
       font-size: 16px;
       font-weight: 400;
       margin: 13px 0;
-      text-align: left;
     }
   }
 

--- a/packages/fxa-payments-server/src/styles/tailwind.css
+++ b/packages/fxa-payments-server/src/styles/tailwind.css
@@ -16,7 +16,7 @@
 @tailwind utilities;
 
 .label-title {
-  @apply font-semibold my-3 text-base text-grey-600 text-left;
+  @apply font-semibold my-3 text-base text-grey-600 text-start;
 }
 
 /* borders */
@@ -93,7 +93,7 @@
 }
 
 .plan-details-heading-wrap {
-  @apply pl-4 text-left;
+  @apply text-start;
 }
 
 .plan-details-logo-wrap {
@@ -101,7 +101,7 @@
 }
 
 .plan-details-product {
-  @apply text-grey-600 text-sm leading-5 my-0 mr-1 ml-0 break-words;
+  @apply text-grey-600 text-sm leading-5 my-0 break-words;
 }
 
 .plan-details-total {

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -24,7 +24,7 @@ export function ConnectAnotherDevicePromo() {
       className="my-1 flex flex-col mobileLandscape:flex-row"
       data-testid="connect-another-device-promo"
     >
-      <div className="flex flex-col flex-1 text-center mobileLandscape:text-left mobileLandscape:rtl:text-right">
+      <div className="flex flex-col flex-1 text-center mobileLandscape:text-start">
         <Localized id="connect-another-fx-mobile">
           <p className="text-sm">Get Firefox on mobile or tablet</p>
         </Localized>

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -227,7 +227,7 @@ export const ConnectedServices = () => {
             />
           ))}
 
-        <div className="mt-5 text-center mobileLandscape:text-left mobileLandscape:rtl:text-right">
+        <div className="mt-5 text-center mobileLandscape:text-start">
           <Localized id="cs-missing-device-help">
             <LinkExternal
               href={DEVICES_SUPPORT_URL}
@@ -302,7 +302,7 @@ export const ConnectedServices = () => {
                   setReason((event.target as HTMLInputElement).value);
                 }}
               >
-                <ul className="my-4 ltr:text-left rtl:text-right">
+                <ul className="my-4 text-start">
                   <Localized id="cs-disconnect-sync-opt-prefix">
                     The device is:
                   </Localized>

--- a/packages/fxa-settings/src/components/Settings/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.tsx
@@ -27,7 +27,7 @@ export const Nav = () => {
       className="font-header fixed bg-white w-full inset-0 mt-18 ltr:mr-24 rtl:ml-24 desktop:mt-11 desktop:static desktop:bg-transparent text-xl desktop:text-base"
       data-testid="nav"
     >
-      <ul className="px-6 py-7 tablet:px-8 desktop:p-0 mobileLandscape:mt-8 ltr:text-left rtl:text-right">
+      <ul className="px-6 py-7 tablet:px-8 desktop:p-0 mobileLandscape:mt-8 text-start">
         <li className="mb-5">
           <Localized id="nav-settings">
             <h2 className="font-bold">Settings</h2>

--- a/packages/fxa-settings/src/styles/switch.css
+++ b/packages/fxa-settings/src/styles/switch.css
@@ -21,11 +21,7 @@
   }
 
   &[aria-checked='true'] {
-    @apply text-left border-transparent;
-
-    [dir='rtl'] & {
-      @apply text-right;
-    }
+    @apply text-start border-transparent;
 
     .slider {
       @apply bg-blue-500;
@@ -65,11 +61,7 @@
   }
 
   &[aria-checked='false'] {
-    @apply text-right border-grey-200;
-
-    [dir='rtl'] & {
-      @apply text-left;
-    }
+    @apply text-end border-grey-200;
 
     .slider {
       @apply bg-grey-50;


### PR DESCRIPTION
### This is [vpomerleau's](https://github.com/vpomerleau) PR, just putting this up to run the CI tests.
Because:

- Localizable components must support both LTR and RTL text-directions. Using text-start will align text based on the layout direction(to the left for LTR, to the right for RTL) and eliminates the need to include specific tailwind properties to support LTR/RTL.

This commit:

- Replace instances of text-left and text-right with either text-start or text-end to maintain intended alignment.
- Where component styling included 'ltr:text-left rtl:text-right', replace with only 'text-start'.
- Modify other left-right specific styling like ml/mr to support both LTR and RTL layouts.
- Apply changes to localizable components only in fxa-payments-server and fxa-settings.
- Does not change fxa-settings design guide styling as this is not a localized component.

Closes #FXA-5738

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
