### PR TITLE
refactor(l10n): Remove l10n configuration file in fxa-payments-server

### DIFF
--- a/packages/fxa-payments-server/l10n.toml
+++ b/packages/fxa-payments-server/l10n.toml
@@ -1,5 +1,0 @@
-basepath = "."
-
-[[paths]]
-  reference = "public/locales/en/*.ftl"
-  l10n = "public/locales/{locale}/*.ftl"


### PR DESCRIPTION
# This is @vpomerleau 's PR, just pushing it up to run CI tests

Because:

- Using a config file is not beneficial for the FxA project which uses a separate l10n repo. Fluent configuration files are useful when the same repository needs to support different locales for different files (e.g. https://github.com/mozilla-l10n/android-l10n), or complex paths, but this is not the case for FxA.

This commit:

- Removes the l10n configuration file in fxa-payments-server

Closes #FXA-6002

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
