### PR TITLE
feat(fxa-settings): Update focus border on CTA and GetDataTrio

### DIFF
--- a/packages/fxa-react/styles/ctas.css
+++ b/packages/fxa-react/styles/ctas.css
@@ -57,7 +57,7 @@
 
   .cta-caution:focus,
   .cta-caution:focus-visible {
-    @apply border-transparent outline-dotted outline-black;
+    @apply border-transparent outline outline-2 outline-offset-2 outline-blue-500;
   }
 
   .cta-caution:disabled {

--- a/packages/fxa-settings/src/components/Settings/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/GetDataTrio/index.tsx
@@ -83,7 +83,7 @@ export const GetDataTrio = ({
           )}
           download={`${primaryEmail.email} ${contentType}.txt`}
           data-testid="databutton-download"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-dotted active:outline-black focus:outline-dotted focus:outline-black hover:bg-grey-50"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
           onClick={() => onAction?.('download')}
         >
           <DownloadIcon
@@ -104,7 +104,7 @@ export const GetDataTrio = ({
             onAction?.('copy');
           }}
           data-testid="databutton-copy"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-dotted active:outline-black focus:outline-dotted focus:outline-black hover:bg-grey-50"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
         >
           <CopyIcon
             width="21"
@@ -126,7 +126,7 @@ export const GetDataTrio = ({
             onAction?.('print');
           }}
           data-testid="databutton-print"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-dotted active:outline-black focus:outline-dotted focus:outline-black hover:bg-grey-50"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
         >
           <PrintIcon
             height="24"


### PR DESCRIPTION
## Because

- The focus style applied to caution CTA and GetDataTrio buttons (black dotted outline) did not match the style used for other buttons (solid blue). The discrepancy may have become more obvious with the upgrade to Tailwind v3. We would like all button focus styles to be consistent.

## This pull request

- Replace the focus and active styles used for fxa-settings' caution cta and GetDataTrio buttons.

## Issue that this pull request solves

Closes: #FXA-5507

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots

Before:

![Screen Shot 2022-11-17 at 15 27 49](https://user-images.githubusercontent.com/22231637/202581581-356f8b5a-ad9b-47d0-9d37-0182b281eb12.png)

![Screen Shot 2022-11-17 at 15 27 15](https://user-images.githubusercontent.com/22231637/202581508-8c23252c-19e5-4aef-98c8-1a9d4fb8715a.png)

After:

![Screen Shot 2022-11-17 at 15 24 50](https://user-images.githubusercontent.com/22231637/202581259-70eaed21-c00b-4b4d-8ea5-6bc1897a7caa.png)

![Screen Shot 2022-11-17 at 15 26 02](https://user-images.githubusercontent.com/22231637/202581351-3655ca93-3b62-4e50-b431-4a68a8f2c2fe.png)
