### PR TITLE
fix(payments): remove class causing layout issues in Payment pages

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -30,7 +30,7 @@ export const SignInLayoutContext = React.createContext({
 
 export const SignInLayout = ({ children }: { children: ReactNode }) => {
   const [hideLogo, setHideLogo] = useState(false);
-  const mainContentClassNames = classNames('card', 'payments-card', {
+  const mainContentClassNames = classNames('payments-card', {
     'hide-logo': hideLogo,
   });
   return (
@@ -90,9 +90,7 @@ export const SettingsLayout = ({ children }: { children: ReactNode }) => {
         </div>
 
         <div id="fxa-settings" className="mb-12">
-          <div id="fxa-settings-content" className="card">
-            {children}
-          </div>
+          <div id="fxa-settings-content">{children}</div>
         </div>
       </div>
     </AppLayout>

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -178,8 +178,7 @@ hr {
   }
 }
 
-#fxa-settings-content .subscription-management,
-#main-content.card {
+#fxa-settings-content .subscription-management {
   max-width: 640px;
   width: 100%;
 


### PR DESCRIPTION
## Because

- Minor regression caused by #14500 where a class was not removed in payments AppLayout template

## This pull request

- Removes class `card` from payments `AppLayout` template
- Removes unnecessary selector in payments `index.scss` file

## Issue that this pull request solves

Closes: FXA-6316

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
