### PR TITLE
feat(auth): allow Partial Refunds For PayPal

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/client.ts
@@ -185,9 +185,16 @@ export type DoReferenceTransactionOptions = {
   ipaddress?: string;
 };
 
+export enum RefundType {
+  full = 'Full',
+  partial = 'Partial',
+}
+
 export type RefundTransactionOptions = {
   idempotencyKey: string;
   transactionId: string;
+  refundType: RefundType;
+  amount?: number;
 };
 
 export type BAUpdateOptions = {
@@ -484,10 +491,21 @@ export class PayPalClient {
   public async refundTransaction(
     options: RefundTransactionOptions
   ): Promise<NVPRefundTransactionResponse> {
-    const data = {
+    const data: {
+      TRANSACTIONID: string;
+      MSGSUBID: string;
+      REFUNDTYPE: string;
+      AMT?: string;
+    } = {
       TRANSACTIONID: options.transactionId,
       MSGSUBID: options.idempotencyKey,
+      REFUNDTYPE: options.refundType,
     };
+
+    if (options.refundType === RefundType.partial) {
+      data.AMT = options.amount!.toString();
+    }
+
     return this.doRequest<NVPRefundTransactionResponse>(
       'RefundTransaction',
       data

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -18,6 +18,7 @@ import {
   PayPalClient,
   PayPalClientError,
   RefundTransactionOptions,
+  RefundType,
   SetExpressCheckoutOptions,
   TransactionSearchOptions,
   TransactionStatus,
@@ -566,10 +567,17 @@ export class PayPalHelper {
     };
   }
 
-  public async issueRefund(invoice: Stripe.Invoice, transactionId: string) {
+  public async issueRefund(
+    invoice: Stripe.Invoice,
+    transactionId: string,
+    refundType: RefundType,
+    amount?: number
+  ) {
     const refundResponse = await this.refundTransaction({
       idempotencyKey: invoice.id!,
       transactionId: transactionId,
+      refundType: refundType,
+      amount: amount,
     });
     const success = ['instant', 'delayed'];
     if (success.includes(refundResponse.refundStatus.toLowerCase())) {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -12,7 +12,11 @@ import Stripe from 'stripe';
 
 import { ConfigType } from '../../../config';
 import error from '../../error';
-import { IpnMerchPmtType, isIpnMerchPmt } from '../../payments/paypal/client';
+import {
+  IpnMerchPmtType,
+  isIpnMerchPmt,
+  RefundType,
+} from '../../payments/paypal/client';
 import { StripeHelper, SUBSCRIPTIONS_RESOURCE } from '../../payments/stripe';
 import { reportSentryError } from '../../sentry';
 import { AuthLogger, AuthRequest } from '../../types';
@@ -59,7 +63,11 @@ export class PayPalNotificationHandler extends PayPalHandler {
             );
 
       if (subscription?.status === 'canceled') {
-        return this.paypalHelper.issueRefund(invoice, message.txn_id);
+        return this.paypalHelper.issueRefund(
+          invoice,
+          message.txn_id,
+          RefundType.full
+        );
       }
     }
 
@@ -91,7 +99,7 @@ export class PayPalNotificationHandler extends PayPalHandler {
       ) {
         // we need to refund the user since the invoice was cancelled
         // but payment was processed
-        this.paypalHelper.issueRefund(invoice, message.txn_id);
+        this.paypalHelper.issueRefund(invoice, message.txn_id, RefundType.full);
       }
       // nothing to do since the invoice is already at its final status
       return;

--- a/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
+++ b/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
@@ -8,7 +8,7 @@ import stripe from 'stripe';
 import Container from 'typedi';
 
 import { CurrencyHelper } from '../lib/payments/currencies';
-import { PayPalClient } from '../lib/payments/paypal/client';
+import { PayPalClient, RefundType } from '../lib/payments/paypal/client';
 import { PayPalHelper } from '../lib/payments/paypal/helper';
 import { STRIPE_INVOICE_METADATA, StripeHelper } from '../lib/payments/stripe';
 import { configureSentry } from '../lib/sentry';
@@ -83,6 +83,7 @@ class PayPalFixer {
     const refundResponse = await this.paypalHelper.refundTransaction({
       idempotencyKey: invoice.id!,
       transactionId: transactionId,
+      refundType: RefundType.full,
     });
     const success = ['instant', 'delayed'];
     if (success.includes(refundResponse.refundStatus.toLowerCase())) {

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -19,6 +19,7 @@ const {
   PAYPAL_SANDBOX_API,
   PAYPAL_LIVE_API,
   PLACEHOLDER_URL,
+  RefundType,
 } = require('../../../lib/payments/paypal/client');
 
 const ERROR_RESPONSE =
@@ -441,6 +442,7 @@ describe('PayPalClient', () => {
     const defaultData = {
       MSGSUBID: 'in_asdf',
       TRANSACTIONID: '9EG80664Y1384290G',
+      REFUNDTYPE: 'Full',
     };
 
     it('calls api with correct method and data', async () => {
@@ -450,6 +452,7 @@ describe('PayPalClient', () => {
       await client.refundTransaction({
         idempotencyKey: defaultData.MSGSUBID,
         transactionId: defaultData.TRANSACTIONID,
+        refundType: RefundType.full,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -32,6 +32,7 @@ const { PayPalNotificationHandler } = proxyquire(
 const { PayPalHelper } = require('../../../../lib/payments/paypal/helper');
 const { CapabilityService } = require('../../../../lib/payments/capability');
 
+import { RefundType } from '../../../../lib/payments/paypal/client';
 import { SUBSCRIPTIONS_RESOURCE } from '../../../../lib/payments/stripe';
 
 const ACCOUNT_LOCALE = 'en-US';
@@ -306,7 +307,8 @@ describe('PayPalNotificationHandler', () => {
       sinon.assert.calledOnceWithExactly(
         paypalHelper.issueRefund,
         invoice,
-        validMessage.txn_id
+        validMessage.txn_id,
+        RefundType.full
       );
       sinon.assert.notCalled(stripeHelper.expandResource);
       sinon.assert.notCalled(stripeHelper.payInvoiceOutOfBand);
@@ -328,7 +330,8 @@ describe('PayPalNotificationHandler', () => {
       sinon.assert.calledOnceWithExactly(
         paypalHelper.issueRefund,
         invoice,
-        validMessage.txn_id
+        validMessage.txn_id,
+        RefundType.full
       );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.expandResource,
@@ -477,7 +480,8 @@ describe('PayPalNotificationHandler', () => {
       sinon.assert.calledOnceWithExactly(
         paypalHelper.issueRefund,
         invoice,
-        completedMerchantPaymentNotification.txn_id
+        completedMerchantPaymentNotification.txn_id,
+        RefundType.full
       );
     });
 
@@ -503,7 +507,8 @@ describe('PayPalNotificationHandler', () => {
       sinon.assert.calledOnceWithExactly(
         paypalHelper.issueRefund,
         invoice,
-        completedMerchantPaymentNotification.txn_id
+        completedMerchantPaymentNotification.txn_id,
+        RefundType.full
       );
     });
   });


### PR DESCRIPTION
Because:

* we want to be able to issue partial refunds for customers that pay with paypal

This commit:

* adds the necessary name-value pairs to the paypal request to issue partial refunds

Closes #FXA-3757

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
