### PR TITLE
feat(subscription): immediate sub cancel email

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2269,6 +2269,16 @@ export class StripeHelper extends StripeHelperBase {
   }
 
   /**
+   * Check if a subscription is past due
+   */
+  checkSubscriptionPastDue(subscription: Stripe.Subscription) {
+    return (
+      subscription.status === 'past_due' &&
+      subscription.collection_method === 'charge_automatically'
+    );
+  }
+
+  /**
    * Formats Stripe subscriptions for a customer into an appropriate response.
    */
   async subscriptionsToResponse(
@@ -2299,8 +2309,7 @@ export class StripeHelper extends StripeHelperBase {
       // calls by passing ['data.subscriptions.data.latest_invoice'] to `fetchCustomer`
       // as the `expand` argument or this will not fetch the failure code/message.
       if (
-        sub.status === 'past_due' &&
-        sub.collection_method === 'charge_automatically' &&
+        this.checkSubscriptionPastDue(sub) &&
         latestInvoice &&
         latestInvoice.charge
       ) {
@@ -2541,6 +2550,7 @@ export class StripeHelper extends StripeHelperBase {
       subtotal: invoiceSubtotalInCents,
       hosted_invoice_url: invoiceLink,
       tax: invoiceTaxAmountInCents,
+      status: invoiceStatus,
     } = invoice;
 
     const nextInvoiceDate = lineItem.period.end;
@@ -2586,6 +2596,7 @@ export class StripeHelper extends StripeHelperBase {
       payment_provider,
       invoiceLink,
       invoiceNumber,
+      invoiceStatus,
       invoiceTotalInCents,
       invoiceTotalCurrency,
       invoiceSubtotalInCents: showSubtotal ? invoiceSubtotalInCents : null,

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2106,6 +2106,7 @@ module.exports = function (log, config, bounces) {
       invoiceTotalCurrency,
       serviceLastActiveDate,
       showOutstandingBalance,
+      cancelAtEnd = true,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -2153,6 +2154,7 @@ module.exports = function (log, config, bounces) {
           message.acceptLanguage
         ),
         showOutstandingBalance,
+        cancelAtEnd,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -10,7 +10,7 @@
   "subscriptionsPaymentProviderCancelled": 2,
   "subscriptionPaymentFailed": 2,
   "subscriptionAccountDeletion": 2,
-  "subscriptionCancellation": 2,
+  "subscriptionCancellation": 3,
   "subscriptionFailedPaymentsCancellation": 2,
   "subscriptionSubsequentInvoice": 3,
   "subscriptionFirstInvoice": 3,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
@@ -1,11 +1,16 @@
 # Variables
 #   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionCancellation-subject = Your { $productName } subscription has been cancelled
+subscriptionCancellation-subject = Your { $productName } subscription has been canceled
 subscriptionCancellation-title = Sorry to see you go
+
+## Variables
+##   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+##   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+##   $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
+
+subscriptionCancellation-content-2 = We’ve canceled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.
+subscriptionCancellation-outstanding-content-2 = We’ve canceled your { $productName } subscription. Your final payment of { $invoiceTotal } will be paid on { $invoiceDateOnly }.
+
 # Variables
-#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-#   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
-#   $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
 #   $serviceLastActiveDateOnly (String) - The date of last active service, e.g. 01/20/2016
-subscriptionCancellation-content = We’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.
-subscriptionCancellation-outstanding-content = We’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } will be paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.
+subscriptionCancellation-content-continue = Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
@@ -14,13 +14,18 @@
   <mj-column>
     <mj-text css-class="text-body">
       <% if (!showOutstandingBalance) { %>
-        <span data-l10n-id="subscriptionCancellation-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
-          We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+        <span data-l10n-id="subscriptionCancellation-content-2" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
+          We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
       </span>
       <% } else { %>
-        <span data-l10n-id="subscriptionCancellation-outstanding-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
-          We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> will be paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+        <span data-l10n-id="subscriptionCancellation-outstanding-content-2" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
+          We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> will be paid on <%- invoiceDateOnly %>.
       </span>
+      <% } %>
+      <% if (cancelAtEnd) { %>
+        <span data-l10n-id="subscriptionCancellation-content-continue" data-l10n-args="<%= JSON.stringify({serviceLastActiveDateOnly}) %>">
+          Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+        </span>
       <% } %>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
@@ -3,9 +3,12 @@ subscriptionCancellation-subject = "Your <%- productName %> subscription has bee
 subscriptionCancellation-title = "Sorry to see you go"
 
 <% if (!showOutstandingBalance) { %>
-subscriptionCancellation-content = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+subscriptionCancellation-content-2 = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
 <% } else { %>
-subscriptionCancellation-outstanding-content = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> will be paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+subscriptionCancellation-outstanding-content-2 = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> will be paid on <%- invoiceDateOnly %>."
+<% } %>
+<% if (cancelAtEnd) { %>
+subscriptionCancellation-content-continue = "Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
 <% } %>
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4860,6 +4860,29 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('checkSubscriptionPastDue', () => {
+    const subscription = {
+      status: 'past_due',
+      collection_method: 'charge_automatically',
+    };
+    it('return true for a subscription past due', () => {
+      assert.isTrue(stripeHelper.checkSubscriptionPastDue(subscription));
+    });
+
+    it('return false for a subscription not past due', () => {
+      assert.isFalse(
+        stripeHelper.checkSubscriptionPastDue({
+          ...subscription,
+          status: 'active',
+        })
+      );
+    });
+
+    it('return false for an invalid subscription', () => {
+      assert.isFalse(stripeHelper.checkSubscriptionPastDue({}));
+    });
+  });
+
   describe('extract details for billing emails', () => {
     const uid = '1234abcd';
     const email = 'test+20200324@example.com';
@@ -5103,6 +5126,7 @@ describe('StripeHelper', () => {
         invoiceLink:
           'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
         invoiceNumber: 'AAF2CECC-0001',
+        invoiceStatus: 'paid',
         invoiceTotalCurrency: 'usd',
         invoiceTotalInCents: 500,
         invoiceSubtotalInCents: null,
@@ -5330,7 +5354,7 @@ describe('StripeHelper', () => {
         assert.isTrue(stripeHelper.allAbbrevProducts.called);
         assert.isFalse(mockStripe.products.retrieve.called);
         sinon.assert.calledTwice(expandMock);
-        assert.deepEqual(result, expected);
+        assert.deepEqual(result, { ...expected, invoiceStatus: 'draft' });
       });
 
       it('throws an exception for deleted customer', async () => {

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1532,6 +1532,39 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ],
 
   ['subscriptionCancellationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionCancellation') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionCancellation' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionCancellation }],
+    ])],
+    ['html', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: 'Sorry to see you go' },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-cancellation', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-cancellation', 'subscription-terms')) },
+      { test: 'include', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} will be paid on 03/20/2020.` },
+      { test: 'notInclude', expected: `billing period, which is 04/19/2020.` },
+      { test: 'notInclude', expected: `alt="${MESSAGE.productName}"`},
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: 'Sorry to see you go' },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} will be paid on 03/20/2020.` },
+      { test: 'notInclude', expected: `billing period, which is 04/19/2020.` },
+      { test: 'include', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]),
+    {updateTemplateValues: x => (
+      {...x, showOutstandingBalance: true, cancelAtEnd: false})}
+  ],
+
+  ['subscriptionCancellationEmail', new Map<string, Test | any>([
     ['html', [
       { test: 'include', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL_CUSTOM },
       { test: 'notInclude', expected: SUBSCRIPTION_CANCELLATION_SURVEY_URL },


### PR DESCRIPTION
## Because

- When a subscription is cancelled immediately, an failed payments email is sent to the customer, even when no failed payments ocurred.

## This pull request

- Update the customer.subscription.deletion event handler, to send subscriptionCancellation emails when a subscription is cancelled immediately
- Update subscriptionCancellation email copy to support immediate cancellation.

## Issue that this pull request solves

Closes: #FXA-6165

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
