### PR TITLE
fix(auth-server): stripe tax not applied to PayPal subscriptions

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -434,10 +434,10 @@ export class StripeHandler {
     }
 
     const country = request.app.geo.location?.country || 'US';
-    const ipAddress = request.auth.credentials
-      ? customer?.tax?.ip_address || ''
-      : request.app.clientAddress;
-    const automaticTax = this.automaticTax;
+    const ipAddress = customer?.tax?.ip_address || request.app.clientAddress;
+    const isCustomerTaxed =
+      !customer || customer.tax?.automatic_tax === 'supported';
+    const automaticTax = this.automaticTax && isCustomerTaxed;
 
     const previewInvoice = await this.stripeHelper.previewInvoice({
       automaticTax,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -679,7 +679,49 @@ describe('DirectStripeRoutes', () => {
         {
           automaticTax: false,
           country: 'US',
-          ipAddress: '',
+          ipAddress: '127.0.0.1',
+          promotionCode: 'promotionCode',
+          priceId: 'priceId',
+        }
+      );
+      assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
+    });
+
+    it('returns the preview invoice when Stripe tax is enabled', async () => {
+      directStripeRoutesInstance.automaticTax = true;
+      const mockCustomer = deepCopy(customerFixture);
+      mockCustomer.tax = {
+        automatic_tax: 'supported',
+      };
+      directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
+        mockCustomer
+      );
+      const expected = deepCopy(invoicePreviewTax);
+      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves(expected);
+      VALID_REQUEST.payload = {
+        promotionCode: 'promotionCode',
+        priceId: 'priceId',
+      };
+      VALID_REQUEST.app.geo = {};
+      const actual = await directStripeRoutesInstance.previewInvoice(
+        VALID_REQUEST
+      );
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.customs.checkIpOnly,
+        VALID_REQUEST,
+        'previewInvoice'
+      );
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.stripeHelper.fetchCustomer,
+        UID,
+        ['tax']
+      );
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.stripeHelper.previewInvoice,
+        {
+          automaticTax: true,
+          country: 'US',
+          ipAddress: '127.0.0.1',
           promotionCode: 'promotionCode',
           priceId: 'priceId',
         }
@@ -723,7 +765,7 @@ describe('DirectStripeRoutes', () => {
         {
           automaticTax: false,
           country: 'US',
-          ipAddress: '',
+          ipAddress: '127.0.0.1',
           promotionCode: 'promotionCode',
           priceId: 'priceId',
         }


### PR DESCRIPTION
## Because

* QA noticed that Stripe tax was not being applied to PayPal subscriptions.
* I also found that PR #14492 broke invoice calculation for new customers.

## This pull request

* Fixes Stripe tax for PayPal subscriptions where Stripe was throwing an error due to a partial address present on the customer record.
* Fixes the invoice calculation for new customers.

## Issue that this pull request solves

Closes FXA-6297

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
