### PR TITLE
fix(metrics): Use `visibilitychange` and `pagehide` to emit metrics in iOS

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -208,11 +208,12 @@ _.extend(Metrics.prototype, Backbone.Events, {
   initialize() {
     this._flush = () => this.flush(true);
     $(this._window).on('unload', this._flush);
-    // iOS will not send events once the window is in the background,
-    // meaning the `unload` handler is ineffective. Send events on blur
-    // instead, so events are not lost when a user goes to verify their
-    // email.
+    // The latest Safari/iOS do not always handle `unload` events, and it is now
+    // recommended to use `visibilitychange` and `pagehide`.
+    // Ref: https://www.ctrl.blog/entry/safari-beacon-issues.html
     $(this._window).on('blur', this._flush);
+    $(this._window).on('visibilitychange', this._flush);
+    $(this._window).on('pagehide', this._flush);
 
     // Set the initial inactivity timeout to clear navigation timing data.
     this._resetInactivityFlushTimeout();
@@ -223,6 +224,8 @@ _.extend(Metrics.prototype, Backbone.Events, {
   destroy() {
     $(this._window).off('unload', this._flush);
     $(this._window).off('blur', this._flush);
+    $(this._window).off('visibilitychange', this._flush);
+    $(this._window).off('pagehide', this._flush);
     this._clearInactivityFlushTimeout();
   },
 

--- a/packages/fxa-content-server/app/tests/spec/lib/metrics.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/metrics.js
@@ -972,6 +972,22 @@ describe('lib/metrics', () => {
 
       assert.isTrue(metrics.flush.calledOnceWith(true));
     });
+
+    it('flushes on window visibilitychange', () => {
+      sinon.stub(metrics, 'flush');
+      metrics.logEvent('wibble');
+      $(windowMock).trigger('visibilitychange');
+
+      assert.isTrue(metrics.flush.calledOnceWith(true));
+    });
+
+    it('flushes on window pagehide', () => {
+      sinon.stub(metrics, 'flush');
+      metrics.logEvent('wibble');
+      $(windowMock).trigger('pagehide');
+
+      assert.isTrue(metrics.flush.calledOnceWith(true));
+    });
   });
 
   describe('inactivity timeout', () => {


### PR DESCRIPTION
## Because

- FxiOS appears to not always emit metrics properly when using beacon api

## This pull request

- Uses `visibilitychange` and `pagehide`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6259

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I'm not sure if this will 100% fix the issue but it won't hurt anything if the metrics were correctly flushed before.
