### PR TITLE
task(ci): Create docker image for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,24 @@ jobs:
       - test-content-server-part:
           index: 5
 
+  deploy-fxa-ci-image:
+    resource_class: small
+    docker:
+      - image: cimg/node:16.13
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build docker fxa ci image
+          command: docker build . -f ./_dev/docker/ci/Dockerfile -t fxa-circleci
+      - deploy:
+          name: Push fxa ci image
+          command: |
+            docker login -u $DOCKER_USER_fxa_circleci -p $DOCKER_PASS_fxa_circleci
+            docker tag fxa-circleci mozilla/fxa-circleci:ci-latest
+            docker push mozilla/fxa-circleci:ci-latest
+
   deploy-packages:
     resource_class: small
     docker:
@@ -414,6 +432,16 @@ workflows:
                 - /^dockerpush.*/
             tags:
               ignore: /.*/
+
+      - deploy-fxa-ci-image:
+          filters:
+            branches:
+              only:
+                - main
+                - FXA-6260
+            tags:
+              ignore: /.*/
+
       - build-and-deploy-storybooks:
           filters:
             branches:

--- a/_dev/docker/ci/Dockerfile
+++ b/_dev/docker/ci/Dockerfile
@@ -1,0 +1,12 @@
+FROM cimg/node:16.3
+
+# Copy over app code
+COPY --chown=circleci:circleci . /fxa
+WORKDIR /fxa
+
+# Do a yarn install and make backup of yarn lock file.
+# RUN yarn install && cp yarn.lock yarn.lock.base
+
+# Remove unneeded files
+RUN find . -regextype egrep ! -regex '.*(\.|\.\.|packages|node_modules).*' -type d -exec rm -rf {} +;
+RUN for d in ./packages/*/ ; do find $d -regextype egrep ! -regex '.*(dist|node_modules|fxa-content-server-l10n).*' -type d -exec rm -rf {} +; done;


### PR DESCRIPTION
## Because

- We are in the process of experimenting with CI pipeline optimizations

## This pull request

- Creates a new docker image that can be used in other CI jobs.
- This base image comes pre-populated with node_modules, dist folders, and l10n repos.

## Issue that this pull request solves

Closes: FXA-660

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

There will be follow up PRs to apply this across image to our CI jobs and see if there any performance gains.
