### PR TITLE
bug(auth): Fix missing traceids in logs

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -51,7 +51,7 @@ async function run(config) {
   const log = require('../lib/log')({
     ...config.log,
     statsd,
-    nodeTracer: TracingProvider.nodeTracing,
+    nodeTracer: TracingProvider.getCurrent(),
   });
   Container.set(AuthLogger, log);
 

--- a/packages/fxa-shared/tracing/node-tracing.ts
+++ b/packages/fxa-shared/tracing/node-tracing.ts
@@ -137,7 +137,7 @@ export function init(opts: TracingOpts, logger: ILogger) {
   return nodeTracing;
 }
 
-/** Resets the current tracing instance. Use only for testing purposes. */
+/** Get the current instance of the node tracing provider. */
 export function getCurrent() {
   return nodeTracing;
 }


### PR DESCRIPTION
## Because

- During a previous refactor the ability to add traceIds to logs broke.

## This pull request

- Uses TracingProvider.getCurrent() instead of trying to directly access TracingProvider.nodeTracing which is private.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
