### PR TITLE
test(functional): add parallelism and circleci split to functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,7 @@ jobs:
 
   playwright-functional-tests:
     resource_class: large
+    parallelism: 5
     docker:
       - image: mcr.microsoft.com/playwright:v1.20.0-focal
       - image: redis

--- a/packages/functional-tests/scripts/test-ci.sh
+++ b/packages/functional-tests/scripts/test-ci.sh
@@ -28,4 +28,7 @@ yarn workspaces foreach \
 
 npx pm2 ls
 
-yarn workspace functional-tests test
+#yarn workspace functional-tests test
+
+circleci tests glob "packages/functional-tests/tests/**/*.spec.ts" | circleci tests split > tests-to-run.txt
+yarn workspace functional-tests test $(cat tests-to-run.txt|awk -F"/" '{ print $NF }')


### PR DESCRIPTION
## Because

- Added `parallelism` var to the `circleci/config.yml` for playwright test job.
- Made use of CircleCi Split functionality and used it in the `test-ci.sh` file.

## This pull request

- Will now run 5 machines parallelly and split the tests running in each machine. It improved the run time by 1min in most cases and 2mins in some. Tried running the playwright test job thrice and each time it took around 8mins to finish.

## Issue that this pull request solves

Closes: [FXA-6321](https://mozilla-hub.atlassian.net/browse/FXA-6321)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
