### PR TITLE
fix(payments): update stories for PlanDetails to include tax

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import MockApp from '../../../.storybook/components/MockApp';
+import MockApp, {
+  defaultAppContextValue,
+} from '../../../.storybook/components/MockApp';
 import PlanDetails, { PlanDetailsProps } from './index';
 import { Profile } from '../../store/types';
+import { Config } from '../../lib/config';
 import { COUPON_DETAILS_VALID } from '../../lib/mock-data';
 import { Meta } from '@storybook/react';
 import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
@@ -54,12 +57,6 @@ const selectedPlan = {
   },
 };
 
-const invoicePreviewNoTax: FirstInvoicePreview = {
-  subtotal: 935,
-  total: 935,
-  line_items: [],
-};
-
 const invoicePreviewInclusiveTax: FirstInvoicePreview = {
   line_items: [],
   subtotal: 885,
@@ -69,6 +66,7 @@ const invoicePreviewInclusiveTax: FirstInvoicePreview = {
     inclusive: true,
   },
 };
+
 const invoicePreviewExclusiveTax: FirstInvoicePreview = {
   line_items: [],
   subtotal: 935,
@@ -79,18 +77,29 @@ const invoicePreviewExclusiveTax: FirstInvoicePreview = {
   },
 };
 
-const storyWithProps = (
-  plan: PlanDetailsProps,
-  languages?: readonly string[],
-  invoicePreview?: FirstInvoicePreview
-) => {
+const storyWithContext = ({
+  plan = {
+    selectedPlan: selectedPlan,
+  },
+  languages,
+  config = defaultAppContextValue.config,
+}: {
+  plan?: PlanDetailsProps;
+  languages?: readonly string[];
+  config?: Config;
+}) => {
   const story = () => (
-    <MockApp languages={languages}>
+    <MockApp
+      languages={languages}
+      appContextValue={{
+        ...defaultAppContextValue,
+        config,
+      }}
+    >
       <PlanDetails
         {...{
           ...plan,
           profile: userProfile,
-          invoicePreview: invoicePreview || invoicePreviewNoTax,
         }}
       />
     </MockApp>
@@ -98,70 +107,70 @@ const storyWithProps = (
   return story;
 };
 
-export const Default = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: false,
-});
+export const Default = storyWithContext({});
 
-export const DefaultWithInclusiveTax = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: false,
-  invoicePreview: invoicePreviewInclusiveTax,
-});
-
-export const DefaultWithExclusiveTax = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: false,
-  invoicePreview: invoicePreviewExclusiveTax,
-});
-
-export const LocalizedToPirate = storyWithProps(
-  {
-    selectedPlan,
-    isMobile: false,
-    showExpandButton: false,
+export const WithInclusiveTax = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    invoicePreview: invoicePreviewInclusiveTax,
   },
-  ['xx-pirate']
-);
-
-export const WithExpandedButton = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: true,
+  config: {
+    ...defaultAppContextValue.config,
+    featureFlags: { useStripeAutomaticTax: true },
+  },
 });
 
-export const WithCouponTypeForever = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: false,
-  coupon: { ...COUPON_DETAILS_VALID, type: 'forever' },
+export const WithExclusiveTax = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    invoicePreview: invoicePreviewExclusiveTax,
+  },
+  config: {
+    ...defaultAppContextValue.config,
+    featureFlags: { useStripeAutomaticTax: true },
+  },
 });
 
-export const WithCouponTypeOnce = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: false,
-  coupon: { ...COUPON_DETAILS_VALID, type: 'once' },
+export const LocalizedToPirate = storyWithContext({
+  languages: ['xx-pirate'],
+});
+
+export const WithExpandedButton = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    showExpandButton: true,
+  },
+});
+
+export const WithCouponTypeForever = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    coupon: { ...COUPON_DETAILS_VALID, type: 'forever' },
+  },
+});
+
+export const WithCouponTypeOnce = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    coupon: { ...COUPON_DETAILS_VALID, type: 'once' },
+  },
 });
 
 export const WithCouponTypeRepeatingPlanIntervalGreaterThanCouponDuration =
-  storyWithProps({
-    selectedPlan: { ...selectedPlan, interval_count: 6 },
-    isMobile: false,
-    showExpandButton: false,
-    coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
+  storyWithContext({
+    plan: {
+      selectedPlan: { ...selectedPlan, interval_count: 6 },
+      coupon: { ...COUPON_DETAILS_VALID, type: 'repeating' },
+    },
   });
 
-export const WithCouponTypeRepeating = storyWithProps({
-  selectedPlan,
-  isMobile: false,
-  showExpandButton: false,
-  coupon: {
-    ...COUPON_DETAILS_VALID,
-    durationInMonths: 3,
-    type: 'repeating',
+export const WithCouponTypeRepeating = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    coupon: {
+      ...COUPON_DETAILS_VALID,
+      durationInMonths: 3,
+      type: 'repeating',
+    },
   },
 });

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -28,7 +28,7 @@ import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type PlanDetailsProps = {
   selectedPlan: Plan;
-  isMobile: boolean;
+  isMobile?: boolean;
   showExpandButton?: boolean;
   className?: string;
   coupon?: CouponDetails;
@@ -38,7 +38,7 @@ export type PlanDetailsProps = {
 export const PlanDetails = ({
   className = '',
   selectedPlan,
-  isMobile,
+  isMobile = false,
   showExpandButton = false,
   coupon,
   invoicePreview,


### PR DESCRIPTION
## Because

- Taxes were not being shown in stories

## This pull request

- Adds Context so Stripe Tax feature flag can be updated to show taxes in `PlanDetails` stories (where applicable).
- Changes `isMobile` to optional with default set to false so it does not have to be explicitly set in each story.
- Cleans up stories and format by removing redundant and/or unnecessary code.

## Issue that this pull request solves

Closes: FXA-6320

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).