### PR TITLE
chore(l10n): fix clone script for masOS post-Ventura

### DIFF
--- a/_scripts/clone-l10n.sh
+++ b/_scripts/clone-l10n.sh
@@ -26,7 +26,7 @@ fi
 backup_ifs="$IFS"
 
 get_realpath_missing() {
-    if hash -- realpath 2>/dev/null; then
+    if hash -- realpath -m 2>/dev/null; then
         realpath -m "$1"
         return
     fi


### PR DESCRIPTION
Because:
 - `realpath` is now in macOS but it does not have a `-m` option

This commit:
 - add minimal extra check for the `-m`
