### PR TITLE
fix(build): Update content-server bg path reference for cache bust

### DIFF
--- a/packages/fxa-content-server/tailwind.config.js
+++ b/packages/fxa-content-server/tailwind.config.js
@@ -22,8 +22,10 @@ config.theme.extend = {
     'check-white': 'inline("../images/icon-check-white.svg")',
     'show-password': 'inline("../images/icon-show-password.svg")',
     'hide-password': 'inline("../images/icon-show-password-closed.svg")',
-    /* TODO: move this to `fxa-react` , FXA-5745 */
-    'ff-logo': 'url("../images/firefox-logo.svg")',
+    /* TODO: move this to `fxa-react`, FXA-5745 */
+    /* If adding a background-image in content-server, you must refer to "/images" instead of
+     * "../images" because our cache bust build step won't find and replace it in `usemin:css` */
+    'ff-logo': 'url("/images/firefox-logo.svg")',
   },
   content: {
     ...config.theme.extend.content,


### PR DESCRIPTION
Because:
* The FF logo isn't showing up after build

This commit:
* Updates the background path reference recently introduced in tailwind.css so our usemin:css grunt task finds the path and replaces it at the build step with the hashed version

Fixes FXA-6372

---

You can test this by, on `main`, running `yarn build` in `fxa-content-server` and observing that `main.css` in the `dist` directory has an asset hash applied to each image reference. In `tailwind.out.css`, it does not have this hash, which is what's happening on staging (try replacing the image on staging with `../images/16821f55.firefox-logo.svg` and it'll work). 

Running `yarn build` in my branch you'll see the hash is updated in the `tailwind.out.css` file as well, and thankfully, it still works in development as well.