### PR TITLE
feat: always run tax id code

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -585,10 +585,11 @@ export class StripeHandler {
             paymentMethodCountry
           );
         }
+        if (!this.stripeHelper.customerTaxId(customer)) {
+          await this.stripeHelper.addTaxIdToCustomer(customer, planCurrency);
+        }
+
         if (!this.automaticTax && paymentMethodCountry) {
-          if (!this.stripeHelper.customerTaxId(customer)) {
-            await this.stripeHelper.addTaxIdToCustomer(customer, planCurrency);
-          }
           taxRateId = (
             await this.stripeHelper.taxRateByCountryCode(paymentMethodCountry)
           )?.id;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -1092,10 +1092,10 @@ describe('DirectStripeRoutes', () => {
       sinon.assert.notCalled(
         directStripeRoutesInstance.stripeHelper.taxRateByCountryCode
       );
-      sinon.assert.notCalled(
+      sinon.assert.calledOnce(
         directStripeRoutesInstance.stripeHelper.customerTaxId
       );
-      sinon.assert.notCalled(
+      sinon.assert.calledOnce(
         directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer
       );
       sinon.assert.notCalled(


### PR DESCRIPTION
Because:

* We should always check if there's a tax id for the currency used and add it.

This commit:

* Updates the tax id code to always check if a tax id is needed for the current currency.

Closes FXA-6386.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
