### PR TITLE
chore(GH Actions): auto-close stale PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes PRs that have had no activity for a
+# specified amount of time.
+#
+# This currently use the default values of 60 days before marking a PR stale,
+# and then waiting 7 days to close the stale PR.
+#
+# For more information, see: https://github.com/actions/stale
+name: Auto-close stale pull requests
+
+on:
+  schedule:
+  - cron: '0 13 * * 1'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v6
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # ignore issues
+        days-before-issue-stale: -1
+        stale-pr-message: 'This pull request issue has been marked as stale due to inactivity.  It will be closed in a week if it continues to be stale.'
+        stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
Because:
 - people can always re-open their PRs

This commit:
 - use a GH action to auto-close "stale" PRs
