### PR TITLE
fix(auth/shared): only list the first matching plan for a given IAP p…

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -7272,6 +7272,24 @@ describe('StripeHelper', () => {
         );
         assert.isEmpty(result);
       });
+
+      it('returns the first matching plan if more than one matches a purchase', async () => {
+        mockAllAbbrevPlans.push({
+          ...mockPrice,
+          plan_id: 'plan_same_apple_config',
+        });
+        const result = await stripeHelper.addPriceInfoToIapPurchases(
+          [mockAppStorePurchase],
+          MozillaSubscriptionTypes.IAP_APPLE
+        );
+        const expected = {
+          ...mockAppStorePurchase,
+          price_id: priceId,
+          product_id: productId,
+          product_name: productName,
+        };
+        assert.deepEqual([expected], result);
+      });
     });
   });
 

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -308,13 +308,18 @@ export abstract class StripeHelper {
       )[]
   > {
     const plans = await this.allAbbrevPlans();
+    const iapIdentifierKey =
+      iapType === MozillaSubscriptionTypes.IAP_GOOGLE
+        ? STRIPE_PRICE_ID_TO_IAP_ANALOG.PLAY_STORE
+        : STRIPE_PRICE_ID_TO_IAP_ANALOG.APP_STORE;
     const appendedPurchases = [];
     for (const plan of plans) {
+      // There may be more than one plan with matching config; in that case,
+      // take the first one for each IAP purchase.
+      if (appendedPurchases.length === purchases.length) {
+        break;
+      }
       const iapIdentifiers = this.priceToIapIdentifiers(plan, iapType);
-      const iapIdentifierKey =
-        iapType === MozillaSubscriptionTypes.IAP_GOOGLE
-          ? STRIPE_PRICE_ID_TO_IAP_ANALOG.PLAY_STORE
-          : STRIPE_PRICE_ID_TO_IAP_ANALOG.APP_STORE;
       // @ts-ignore
       const matchingPurchases = purchases.filter((purchase) =>
         iapIdentifiers.includes(purchase[iapIdentifierKey].toLowerCase())


### PR DESCRIPTION
…urchase

Because:

* Multiple Stripe plans can be configured to match a given IAP identifier (productId for Apple IAP and sku for Google IAP).
* We were listing every single matching plan for the same IAP purchase as a separate subscription in the Subscription Management page.

This commit:

* Takes the first matching plan for a given purchase and returns that in the addPriceInfoToIapPurchases helper.

Closes #FXA-6287

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To reproduce this locally, run the [IAP fake subscription loader script](https://mozilla.github.io/ecosystem-platform/tutorials/subscription-platform#configure-the-auth-server-and-create-mock-iap-subscriptions) for a local FxA user with a `productId` arg of `"org.mozilla.ios.FirefoxVPN.product.6_mo_subscription"`. There are two dev Stripe plans that match this Apple IAP config.
