### PR TITLE
task(fxa-react): Create l10n.getString wrapper

### DIFF
--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -697,7 +697,7 @@ export function getLocalizedMessage(
 ): string {
   let localizedMessage = bundle.getMessage(msgId);
   if (localizedMessage === undefined || localizedMessage.value === null) {
-    throw Error(`unable to locate fluent message with id: ${msgId}`);
+    throw new Error(`unable to locate fluent message with id: ${msgId}`);
   }
 
   return bundle.formatPattern(localizedMessage.value, { ...args });

--- a/packages/fxa-react/lib/test-utils/index.test.tsx
+++ b/packages/fxa-react/lib/test-utils/index.test.tsx
@@ -2,19 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { FtlMsg, FtlMsgProps } from '../utils';
-import { getFtlBundle, testL10n } from '.';
 import { FluentBundle } from '@fluent/bundle';
+import { ReactLocalization } from '@fluent/react';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { getFtlBundle, testL10n } from '.';
+import { FtlMsg, FtlMsgProps, FtlMsgResolver } from '../utils';
 
-jest.mock('fxa-react/lib/utils', () => ({
-  FtlMsg: (props: FtlMsgProps) => (
-    <div data-testid="ftlmsg-mock" id={props.id}>
-      {props.children}
-    </div>
-  ),
-}));
+jest.mock('fxa-react/lib/utils', () => {
+  const originalModule = jest.requireActual('fxa-react/lib/utils');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    FtlMsg: (props: FtlMsgProps) => (
+      <div data-testid="ftlmsg-mock" id={props.id}>
+        {props.children}
+      </div>
+    ),
+  };
+});
 
 const simpleComponent = (id: string, fallbackText = '') => (
   <FtlMsg {...{ id }}>{fallbackText}</FtlMsg>
@@ -146,6 +153,138 @@ describe('testL10n', () => {
         const ftlMsgMock = screen.getByTestId('ftlmsg-mock');
         testL10n(ftlMsgMock, bundle, { name });
       }).not.toThrow();
+    });
+  });
+
+  describe('test getFtlMsg', () => {
+    let ftlMsgResolver: FtlMsgResolver;
+    let l10n: ReactLocalization;
+
+    beforeAll(() => {
+      l10n = new ReactLocalization([bundle]);
+      ftlMsgResolver = new FtlMsgResolver(l10n, true);
+    });
+
+    it('throws if there are no en bundles', () => {
+      const emptyL10n = new ReactLocalization([]);
+      const emptyResolver = new FtlMsgResolver(emptyL10n, true);
+      expect(() => {
+        emptyResolver.getMsg('test-foo', 'foo-bar');
+      }).toThrow(
+        `No 'en' bundles loaded. The 'en' bundle is the default and should always be loaded.`
+      );
+    });
+
+    it('throws if ftl message does not exist', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-foo', 'foo-bar');
+      }).toThrow('Could not locate message in en bundle. Message id: test-foo');
+    });
+
+    it('throws if no id is provided', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('', '');
+      }).toThrow('An l10n id must be provided.');
+    });
+
+    it('throws if fallback text is not provided', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-simple', '');
+      }).toThrow('Fallback text must be provided.');
+    });
+
+    it('throws if fallback text contains straight single quote', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg(
+          'test-straight-apostrophe',
+          `you don't hear me say`
+        );
+      }).toThrow(
+        `Fluent message contains a straight apostrophe (') and must be updated to its curly equivalent (’). Fluent message: you don't hear me say`
+      );
+    });
+
+    it('throws if fallback text contains straight double quote', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-straight-quote', `"please, don’t go"`);
+      }).toThrow(
+        `Fluent message contains a straight quote (") and must be updated to its curly equivalent (“”). Fluent message: \"please, don’t go\"`
+      );
+    });
+
+    it('throws if attributes are missing', () => {
+      const name = 'foo';
+      expect(() => {
+        ftlMsgResolver.getMsg('test-var', `${name} smiled at me`, { n: name });
+      }).toThrow(
+        'Errors encountered formatting fluent message. Fluent errors: Unknown variable: $name'
+      );
+    });
+
+    it('returns translated string with updated attribute values', () => {
+      const name = 'foo';
+      const msg = ftlMsgResolver.getMsg('test-var', `${name} smiled at me`, {
+        name,
+      });
+      expect(msg).toContain('foo smiled at me');
+    });
+
+    it('handles dom overlays', () => {
+      const msg = ftlMsgResolver.getMsg(
+        'test-dom-overlay',
+        `<img data-l10n-name='devices-image' alt="Devices">`
+      );
+      expect(msg).toContain(
+        `<img data-l10n-name='devices-image' alt="Devices">`
+      );
+    });
+
+    it('Detects bad dom case 1', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-bad-dom-overlay-1', `<img`);
+      }).toThrow(
+        'Fluent message contains start of dom overlay with no end tag. Ensue dom overlay is well formed.'
+      );
+    });
+
+    it('Detects bad dom case 2', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-bad-dom-overlay-2', `img>`);
+      }).toThrow(
+        `Fluent message contains a '>' character that doesn't appear to be part of a dom tag. Either encode with html entity or check dom overlay is well formed.`
+      );
+    });
+
+    it('Detects bad dom case 3', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-bad-dom-overlay-3', `<img> >`);
+      }).toThrow(
+        `Fluent message contains a '>' character that doesn't appear to be part of a dom tag. Either encode with html entity or check dom overlay is well formed.`
+      );
+    });
+
+    it('Detects bad dom case 4', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-bad-dom-overlay-4', `<img< >`);
+      }).toThrow(
+        `Fluent message contains a '<' character inside a dom overlay tag. Check that dom overlay is well formed.`
+      );
+    });
+
+    it('Detects bad dom case 5', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-bad-dom-overlay-5', `< <img>`);
+      }).toThrow(
+        `Fluent message contains a '<' character inside a dom overlay tag. Check that dom overlay is well formed.`
+      );
+    });
+
+    it('Detects bad dom case 6', () => {
+      expect(() => {
+        ftlMsgResolver.getMsg('test-bad-dom-overlay-6', `> <img>`);
+      }).toThrow(
+        `Fluent message contains a '>' character that doesn't appear to be part of a dom tag. Either encode with html entity or check dom overlay is well formed.`
+      );
     });
   });
 });

--- a/packages/fxa-react/lib/test-utils/test.ftl
+++ b/packages/fxa-react/lib/test-utils/test.ftl
@@ -9,3 +9,10 @@ test-straight-apostrophe = you don't hear me say
 test-straight-quote = "please, don’t go"
 test-var = { $name } smiled at me
 test-term = Lately, { -term } is all I need
+test-dom-overlay = <img data-l10n-name='devices-image' alt="Devices">
+test-bad-dom-overlay-1 = <img
+test-bad-dom-overlay-2 = img>
+test-bad-dom-overlay-3 = <img> >
+test-bad-dom-overlay-4 = <img< >
+test-bad-dom-overlay-5 = < <img>
+test-bad-dom-overlay-6 = > <img>

--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { FluentBundle, FluentVariable } from '@fluent/bundle';
+import { Message, Pattern } from '@fluent/bundle/esm/ast';
+import { Localized, LocalizedProps, ReactLocalization } from '@fluent/react';
 import React from 'react';
-import { Localized, LocalizedProps } from '@fluent/react';
 
 export type FtlMsgProps = {
   children: React.ReactNode;
@@ -12,3 +14,183 @@ export type FtlMsgProps = {
 export const FtlMsg = (props: FtlMsgProps) => (
   <Localized {...props}>{props.children}</Localized>
 );
+
+export class FtlMsgResolver {
+  /**
+   * @param l10n - The current l10n instance. This can be resolved via a call to useLocalization().
+   * @param strict - Indicates if an error should be generated in the event the message cannot be resolved
+   */
+  constructor(
+    public readonly l10n: ReactLocalization,
+    public readonly strict: boolean
+  ) {}
+
+  /**
+   * A wrapper around l10n.getString that provides more safety. When strict is true, using this function ensures:
+   *  - The fallback text is in alignment with the default 'en' text
+   *  - There are no missing parameters
+   *  - There are no straight quotes
+   *
+   * Note, this requires that the default 'en' bundle was loaded and is a available.
+   *
+   * @param id - The id of the message to fetch
+   * @param fallbackText - The fallback text for the message
+   * @param args - Any arguments for parameterization of message.
+   * @returns The formatted language translation string.
+   */
+  public getMsg(
+    id: string,
+    fallbackText: string,
+    args?: Record<string, FluentVariable>
+  ) {
+    // If strict, perform checks to validate that state of request is valid.
+    if (this.strict) {
+      if (!id) {
+        throw new Error('An l10n id must be provided.');
+      }
+
+      // Find an 'en' bundle with the message id. The 'en' bundle should be the default and always exist.
+      const enBundles = [...this.l10n.bundles].filter((x) =>
+        x?.locales?.includes('en')
+      );
+
+      if (enBundles.length === 0) {
+        throw new Error(
+          `No 'en' bundles loaded. The 'en' bundle is the default and should always be loaded.`
+        );
+      }
+
+      // Make sure en bundle has the target message
+      const enBundle = enBundles.find((x) => x.hasMessage(id));
+      const enMessage = enBundle?.getMessage(id);
+      if (!enBundle || !enMessage) {
+        throw new Error(
+          `Could not locate message in en bundle. Message id: ${id}`
+        );
+      }
+
+      // Make sure the fallback text and message render cleanly.
+      checkMessage(enBundle, enMessage, fallbackText, args);
+    }
+
+    // If the above checks pass, we can safely return the language string.
+    return this.l10n.getString(id, args, fallbackText);
+  }
+}
+
+/**
+ * Validates a message. Checks that:
+ *  - fallback text matches ftl text
+ *  - there are not straight quotes
+ *  - there are no missing ftlArgs
+ * @param bundle - The default bundle, typically a bundle with 'en' locale.
+ * @param message - The fluent message to check.
+ * @param fallbackText - The fallback text
+ * @param ftlArgs - Arguments for updating parameterized messages
+ */
+export function checkMessage(
+  bundle: FluentBundle,
+  message: Message,
+  fallbackText: string | null,
+  ftlArgs?: Record<string, FluentVariable>
+) {
+  if (!fallbackText) {
+    throw new Error('Fallback text must be provided.');
+  }
+
+  // nested attributes can happen when we define something like:
+  // `profile-picture =
+  //   .header = Picture`
+  const nestedAttrValues = Object.values(message?.attributes || {});
+
+  if (
+    message === undefined ||
+    (message.value === null && nestedAttrValues.length === 0)
+  ) {
+    throw new Error(`Invalid message. Message has no value.`);
+  }
+
+  if (message.value) {
+    _checkPattern(bundle, message.value, fallbackText, ftlArgs);
+  }
+
+  if (nestedAttrValues) {
+    nestedAttrValues.forEach((nestedAttrValue) =>
+      _checkPattern(bundle, nestedAttrValue, fallbackText, ftlArgs)
+    );
+  }
+}
+
+function _checkPattern(
+  bundle: FluentBundle,
+  pattern: Pattern,
+  fallbackText: string,
+  ftlArgs?: Record<string, FluentVariable>
+) {
+  const errors: Error[] = [];
+  const ftlMsg = bundle.formatPattern(pattern, ftlArgs, errors);
+
+  // Try to render the message, and check for any errors. This will catch things like missing parameters.
+  if (errors.length > 0) {
+    throw new Error(
+      `Errors encountered formatting fluent message. Fluent errors: ${errors
+        .map((x) => x.message)
+        .join('\n')}`
+    );
+  }
+
+  // We allow for .includes because fallback text comes from `textContent` within the `FtlMsg` wrapper which may contain
+  // more than one component and string. Also note that strings must be 'cleaned' because the ftlMsg may have invisible
+  // control characters that can break the includes check.
+  if (!_clean(fallbackText).includes(_clean(ftlMsg))) {
+    throw new Error(
+      `Fallback text does not match Fluent message.\nFallback text: ${fallbackText}\nFluent message: ${ftlMsg}`
+    );
+  }
+
+  let inDomOverlay = false;
+  for (let i = 0; i < ftlMsg.length; i++) {
+    if (!inDomOverlay && ftlMsg[i] === '<') {
+      // Start of dom overlay tag
+      inDomOverlay = true;
+    } else if (inDomOverlay && ftlMsg[i] === '>') {
+      // End of dom overlay tag
+      inDomOverlay = false;
+    } else if (inDomOverlay && ftlMsg[i] === '<') {
+      throw new Error(
+        `Fluent message contains a '<' character inside a dom overlay tag. Check that dom overlay is well formed. Fluent message: ${ftlMsg}`
+      );
+    } else if (!inDomOverlay && ftlMsg[i] === '>') {
+      throw new Error(
+        `Fluent message contains a '>' character that doesn't appear to be part of a dom tag. Either encode with html entity or check dom overlay is well formed. Fluent message: ${ftlMsg}`
+      );
+    } else if (!inDomOverlay && ftlMsg[i] === "'") {
+      throw new Error(
+        `Fluent message contains a straight apostrophe (') and must be updated to its curly equivalent (’). Fluent message: ${ftlMsg}`
+      );
+    } else if (!inDomOverlay && ftlMsg[i] === '"') {
+      throw new Error(
+        `Fluent message contains a straight quote (") and must be updated to its curly equivalent (“”). Fluent message: ${ftlMsg}`
+      );
+    }
+  }
+
+  // Edge case non-closed dom overlay tag
+  if (inDomOverlay) {
+    throw new Error(
+      `Fluent message contains start of dom overlay with no end tag. Ensue dom overlay is well formed. Fluent message: ${ftlMsg}`
+    );
+  }
+}
+
+/**
+ * Removes any hidden control characters from strings.
+ * @param msg - message to clean
+ * @returns clean version of message
+ */
+function _clean(msg: string) {
+  return msg.replace(
+    /[\u0000-\u001F\u007F-\u009F\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/g,
+    ''
+  );
+}

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
@@ -16,8 +16,9 @@ import relayIcon from './relay.svg';
 import vpnIcon from './vpn-logo.svg';
 import { ReactComponent as BentoIcon } from './bento.svg';
 import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
-import { Localized, useLocalization } from '@fluent/react';
+import { Localized } from '@fluent/react';
 import { FtlMsg } from 'fxa-react/lib/utils';
+import { useFtlMsgResolver } from '../../../models/hooks';
 
 export const BentoMenu = () => {
   const [isRevealed, setRevealed] = useState(false);
@@ -27,10 +28,10 @@ export const BentoMenu = () => {
   useEscKeydownEffect(setRevealed);
   const dropDownId = 'drop-down-bento-menu';
   const iconClassNames = 'inline-block w-5 -mb-1 ltr:pr-1 rtl:pl-1';
-  const { l10n } = useLocalization();
-  const bentoMenuTitle = l10n.getString(
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const bentoMenuTitle = ftlMsgResolver.getMsg(
     'bento-menu-title',
-    null,
     'Firefox Bento Menu'
   );
 

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -314,6 +314,7 @@ describe('App component', () => {
       } as unknown as Account;
 
       const config = {
+        l10n: { strict: true },
         metrics: { navTiming: { enabled: true, endpoint: '/foobar' } },
       } as Config;
 

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -9,6 +9,9 @@ export const META_CONFIG = 'fxa-config';
 
 export interface Config {
   env: string;
+  l10n: {
+    strict: boolean;
+  };
   marketingEmailPreferencesUrl: string;
   metrics: {
     navTiming: {
@@ -49,6 +52,9 @@ export interface Config {
 export function getDefault() {
   return {
     env: 'development',
+    l10n: {
+      strict: true,
+    },
     marketingEmailPreferencesUrl: 'https://basket.mozilla.org/fxa/',
     metrics: {
       navTiming: { enabled: false, endpoint: '/check-your-metrics-config' },

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -4,6 +4,8 @@ import { GET_SESSION_VERIFIED, Session } from './Session';
 import { clearSignedInAccountUid } from '../lib/cache';
 import { gql, useQuery } from '@apollo/client';
 import { getDefault } from '../lib/config';
+import { useLocalization } from '@fluent/react';
+import { FtlMsgResolver } from 'fxa-react/lib/utils';
 
 export function useAccount() {
   const { account } = useContext(AppContext);
@@ -14,7 +16,7 @@ export function useAccount() {
 }
 
 export function useSession() {
-  const ref = useRef(({} as unknown) as Session);
+  const ref = useRef({} as unknown as Session);
   const { apolloClient, session } = useContext(AppContext);
   if (session) {
     return session;
@@ -73,4 +75,10 @@ export function useAlertBar() {
     throw new Error('Are you forgetting an AppContext.Provider?');
   }
   return alertBarInfo;
+}
+
+export function useFtlMsgResolver() {
+  const config = useConfig();
+  const { l10n } = useLocalization();
+  return new FtlMsgResolver(l10n, config.l10n.strict);
 }

--- a/packages/fxa-settings/src/setupTests.tsx
+++ b/packages/fxa-settings/src/setupTests.tsx
@@ -2,13 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReactLocalization } from '@fluent/react';
 import '@testing-library/jest-dom/extend-expect';
+import { getFtlBundleSync } from 'fxa-react/lib/test-utils';
 import { FtlMsgProps } from 'fxa-react/lib/utils';
 
-jest.mock('fxa-react/lib/utils', () => ({
-  FtlMsg: (props: FtlMsgProps) => (
-    <div data-testid="ftlmsg-mock" id={props.id}>
-      {props.children}
-    </div>
-  ),
-}));
+jest.mock('fxa-react/lib/utils', () => {
+  const originalModule = jest.requireActual('fxa-react/lib/utils');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    FtlMsg: (props: FtlMsgProps) => (
+      <div data-testid="ftlmsg-mock" id={props.id}>
+        {props.children}
+      </div>
+    ),
+  };
+});
+
+const mockBundle = getFtlBundleSync('settings', 'en');
+const l10n = new ReactLocalization([mockBundle]);
+const mockL10n = { l10n, test: 'what!' };
+jest.mock('@fluent/react', () => {
+  const originalModule = jest.requireActual('@fluent/react');
+  return {
+    __esModule: true,
+    ...originalModule,
+    useLocalization: () => {
+      return mockL10n;
+    },
+  };
+});


### PR DESCRIPTION
## Because

- We want to ensure that calls to l10n.getString are safe
- We want to catch errors preemptively

## This pull request
- Adds a new class for resolving l10n strings. Resolving strings through this class:
  - Ensures there are no straight quotes
  - Ensures l10n id exists in the 'en' bundle
  - Ensures fallback text matches text in 'en' bundle
  - Ensures there are no errors resolving parameters in the l10n string
- Adds a hook for easy access to the FtlMsgResolver.
- Adds config that controls whether or not we run in strict mode. Note, that run time errors will result if a violation is detected when `strict=true`.
- Applies mechanism to one component in settings, the bento box.

## Issue that this pull request solves

Closes: FXA-6001

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that by default config.l10n.strict will be set to true. This means any discrepancies between fallback text and the underlying language string will result in a runtime error.

In general, I don't see a reason to ever run this in a mode other than `strict=true`; however, since a violation will result in a runtime, we might consider turning this off in production, and rely on the strict mode catching most issues during development, testing, and staging. I'd start out optimistic though, and make this call only if we see issues with this approach.
