### PR TITLE
fix(subscription): return sourceCountry for valid tax location status

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -351,7 +351,8 @@ export class PayPalHandler extends StripeWebhookHandler {
     }
 
     return {
-      sourceCountry: customer.address?.country,
+      sourceCountry:
+        customer.tax?.location?.country || customer.address?.country,
       subscription: subscription,
     };
   }


### PR DESCRIPTION
## Because

- When a customer, who uses PayPal as their payment method and who's tax location could be determined by Stripe from their IP, subscribes for their 2nd subscription, the `subscriptions/new-paypal` endpoint returns with a 500 error code.
- After the 500 error code, in Sentry, an issue is shown with message `ValidationError: "sourceCountry" is required`.

## This pull request

- First tries to retrieve the sourceCountry from the tax location, before using the customer address.

## Issue that this pull request solves

Closes: #FXA-6378

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
