### PR TITLE
feat(gql): Add gql resolver for password forgot send code

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -40,7 +40,7 @@ export class SubscribePage extends BaseLayout {
     await paypalButton.waitFor({ state: 'attached' });
     const [paypalWindow] = await Promise.all([
       this.page.waitForEvent('popup'),
-      this.page.click('[data-testid="paypal-button-container"]'),
+      this.page.locator('[data-testid="paypal-button-container"]').click(),
     ]);
     await paypalWindow.waitForLoadState('load');
     await paypalWindow.waitForNavigation({

--- a/packages/functional-tests/pages/settings/avatar.ts
+++ b/packages/functional-tests/pages/settings/avatar.ts
@@ -6,7 +6,7 @@ export class AvatarPage extends SettingsLayout {
   async clickAddPhoto() {
     const [filechooser] = await Promise.all([
       this.page.waitForEvent('filechooser'),
-      this.page.click('[data-testid=add-photo-btn]'),
+      this.page.locator('[data-testid=add-photo-btn]').click(),
     ]);
     return filechooser;
   }

--- a/packages/functional-tests/pages/settings/components/dataTrio.ts
+++ b/packages/functional-tests/pages/settings/components/dataTrio.ts
@@ -6,7 +6,7 @@ export class DataTrioComponent {
   async clickDownload() {
     const [download] = await Promise.all([
       this.page.waitForEvent('download'),
-      this.page.click('[data-testid=databutton-download]'),
+      this.page.locator('[data-testid=databutton-download]').click(),
     ]);
     return download;
   }
@@ -34,7 +34,7 @@ export class DataTrioComponent {
     });
     const [printPage] = await Promise.all([
       this.page.context().waitForEvent('page'),
-      this.page.click('[data-testid=databutton-print]'),
+      this.page.locator('[data-testid=databutton-print]').click(),
     ]);
     //@ts-ignore window.printed
     const printed = await printPage.evaluate(() => window.printed);

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -92,7 +92,7 @@ export class SettingsPage extends SettingsLayout {
   async clickEmailPreferences() {
     const [emailPage] = await Promise.all([
       this.page.context().waitForEvent('page'),
-      this.page.click('[data-testid=nav-link-newsletters]'),
+      this.page.locator('[data-testid=nav-link-newsletters]').click(),
     ]);
     return emailPage;
   }

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -37,7 +37,7 @@ export abstract class SettingsLayout extends BaseLayout {
   async clickHelp() {
     const [helpPage] = await Promise.all([
       this.page.context().waitForEvent('page'),
-      this.page.click('[data-testid=header-sumo-link]'),
+      this.page.locator('[data-testid=header-sumo-link]').click(),
     ]);
     return helpPage;
   }

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -58,6 +58,16 @@ function langHeader(lang?: string) {
   );
 }
 
+function createHeaders(
+  headers: Headers = new Headers(),
+  options: Record<string, any> & { lang?: string }
+) {
+  if (options.lang) {
+    headers.set('Accept-Language', options.lang);
+  }
+  return headers;
+}
+
 function pathWithKeys(path: string, keys?: boolean) {
   return `${path}${keys ? '?keys=true' : ''}`;
 }
@@ -370,7 +380,8 @@ export default class AuthClient {
       resume?: string;
       lang?: string;
       metricsContext?: MetricsContext;
-    } = {}
+    } = {},
+    headers: Headers = new Headers()
   ) {
     const payloadOptions = ({ lang, ...rest }: any) => rest;
     const payload = {
@@ -381,7 +392,7 @@ export default class AuthClient {
       'POST',
       '/password/forgot/send_code',
       payload,
-      langHeader(options.lang)
+      createHeaders(headers, options)
     );
   }
 
@@ -393,7 +404,8 @@ export default class AuthClient {
       redirectTo?: string;
       resume?: string;
       lang?: string;
-    } = {}
+    } = {},
+    headers: Headers = new Headers()
   ) {
     const payloadOptions = ({ lang, ...rest }: any) => rest;
     const payload = {
@@ -406,7 +418,7 @@ export default class AuthClient {
       passwordForgotToken,
       tokenType.passwordForgotToken,
       payload,
-      langHeader(options.lang)
+      createHeaders(headers, options)
     );
   }
 
@@ -415,7 +427,8 @@ export default class AuthClient {
     passwordForgotToken: hexstring,
     options: {
       accountResetWithoutRecoveryKey?: boolean;
-    } = {}
+    } = {},
+    headers: Headers = new Headers()
   ) {
     const payload = {
       code,
@@ -426,16 +439,22 @@ export default class AuthClient {
       '/password/forgot/verify_code',
       passwordForgotToken,
       tokenType.passwordForgotToken,
-      payload
+      payload,
+      headers
     );
   }
 
-  async passwordForgotStatus(passwordForgotToken: string) {
+  async passwordForgotStatus(
+    passwordForgotToken: string,
+    headers: Headers = new Headers()
+  ) {
     return this.hawkRequest(
       'GET',
       '/password/forgot/status',
       passwordForgotToken,
-      tokenType.passwordForgotToken
+      tokenType.passwordForgotToken,
+      undefined,
+      headers
     );
   }
 
@@ -446,7 +465,8 @@ export default class AuthClient {
     options: {
       keys?: boolean;
       sessionToken?: boolean;
-    } = {}
+    } = {},
+    headers: Headers = new Headers()
   ) {
     const credentials = await crypto.getCredentials(email, newPassword);
     const payloadOptions = ({ keys, ...rest }: any) => rest;
@@ -459,7 +479,8 @@ export default class AuthClient {
       pathWithKeys('/account/reset', options.keys),
       accountResetToken,
       tokenType.accountResetToken,
-      payload
+      payload,
+      headers
     );
     if (options.keys && accountData.keyFetchToken) {
       accountData.unwrapBKey = credentials.unwrapBKey;

--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -66,8 +66,8 @@ module.exports = (printLogs) => {
             console.log(`Notification email: ${template}`);
           } else {
             console.error('\x1B[31mNo verify code match\x1B[39m');
-            console.error(mail);
           }
+          console.error(mail);
           if (users[name]) {
             users[name].push(mail);
           } else {

--- a/packages/fxa-graphql-api/src/decorators.ts
+++ b/packages/fxa-graphql-api/src/decorators.ts
@@ -34,3 +34,14 @@ export const GqlUserState = createParamDecorator(
     return (ctx.req?.user as SessionTokenResult).session.state;
   }
 );
+
+/**
+ * Extracts headers to be sent to auth-server
+ */
+export const GqlXHeaders = createParamDecorator(
+  (data: unknown, context: ExecutionContext): Headers => {
+    const ctx = GqlExecutionContext.create(context).getContext();
+    const headers = ctx.req?.headers;
+    return new Headers(headers);
+  }
+);

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -423,11 +423,106 @@ describe('AccountResolver', () => {
         const result = await resolver.createPassword('token', {
           email: 'howdy@yo.com',
           password: 'passwordzxcv',
-          clientMutationId: 'testid'
+          clientMutationId: 'testid',
         });
         expect(authClient.createPassword).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
+        });
+      });
+    });
+
+    describe('passwordForgotSendCode', () => {
+      it('succeeds', async () => {
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
+        });
+        authClient.passwordForgotSendCode = jest.fn().mockResolvedValue({
+          clientMutationId: 'testid',
+          passwordForgotToken: 'cooltokenyo',
+        });
+        const result = await resolver.passwordForgotSendCode(headers, {
+          email: 'howdy@yo.com',
+        });
+        expect(authClient.passwordForgotSendCode).toBeCalledTimes(1);
+        expect(result).toStrictEqual({
+          clientMutationId: 'testid',
+          passwordForgotToken: 'cooltokenyo',
+        });
+      });
+    });
+
+    describe('passwordForgotVerifyCode', () => {
+      it('succeeds', async () => {
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
+        });
+        authClient.passwordForgotVerifyCode = jest.fn().mockResolvedValue({
+          clientMutationId: 'testid',
+          accountResetToken: 'cooltokenyo',
+        });
+        const result = await resolver.passwordForgotVerifyCode(headers, {
+          token: 'passwordforgottoken',
+          code: 'code',
+        });
+        expect(authClient.passwordForgotVerifyCode).toBeCalledTimes(1);
+        expect(result).toStrictEqual({
+          clientMutationId: 'testid',
+          accountResetToken: 'cooltokenyo',
+        });
+      });
+    });
+
+    describe('passwordForgotCodeStatus', () => {
+      it('succeeds', async () => {
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
+        });
+        authClient.passwordForgotStatus = jest.fn().mockResolvedValue({
+          clientMutationId: 'testid',
+          tries: 1,
+          ttl: 2,
+        });
+        const result = await resolver.passwordForgotCodeStatus(headers, {
+          token: 'passwordforgottoken',
+        });
+        expect(authClient.passwordForgotStatus).toBeCalledTimes(1);
+        expect(result).toStrictEqual({
+          clientMutationId: 'testid',
+          tries: 1,
+          ttl: 2,
+        });
+      });
+    });
+
+    describe('accountReset', () => {
+      it('succeeds', async () => {
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
+        });
+        const now = Date.now();
+        authClient.accountReset = jest.fn().mockResolvedValue({
+          clientMutationId: 'testid',
+          uid: 'uid',
+          verified: true,
+          sessionToken: 'sessionToken',
+          authAt: now,
+          keyFetchToken: 'keyFetchToken',
+        });
+        const result = await resolver.accountReset(headers, {
+          email: 'up@dog.com',
+          newPassword: 'password',
+          accountResetToken: 'token',
+          options: {},
+        });
+        expect(authClient.accountReset).toBeCalledTimes(1);
+        expect(result).toStrictEqual({
+          clientMutationId: 'testid',
+          uid: 'uid',
+          verified: true,
+          sessionToken: 'sessionToken',
+          authAt: now,
+          keyFetchToken: 'keyFetchToken',
         });
       });
     });

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -15,3 +15,9 @@ export { VerifySessionInput } from './verify-session';
 export { DeleteRecoveryKeyInput } from './delete-recovery-key';
 export { DestroySessionInput } from './destroy-session';
 export { CreatePassword } from './create-password';
+export {
+  PasswordForgotSendCodeInput,
+  PasswordForgotVerifyCodeInput,
+  PasswordForgotCodeStatusInput,
+  AccountResetInput,
+} from './password-forgot';

--- a/packages/fxa-graphql-api/src/gql/dto/input/password-forgot.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/password-forgot.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+import { MetricsContext } from './metrics-context';
+
+@InputType()
+export class PasswordForgotSendCodeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'Users email' })
+  public email!: string;
+
+  @Field((type) => MetricsContext, { nullable: true })
+  public metricsContext?: MetricsContext;
+
+  @Field({ nullable: true })
+  public resume?: string;
+
+  @Field({ nullable: true })
+  public service?: string;
+
+  @Field({ nullable: true })
+  public lang?: string;
+
+  @Field({ nullable: true })
+  public redirectTo?: string;
+}
+
+@InputType()
+export class PasswordForgotVerifyCodeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'Password forgot token' })
+  public token!: string;
+
+  @Field({ description: 'Code' })
+  public code!: string;
+}
+
+@InputType()
+export class PasswordForgotCodeStatusInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'Password forgot token' })
+  public token!: string;
+}
+
+@InputType()
+export class AccountResetInputOptions {
+  @Field({ nullable: true })
+  public keys?: boolean;
+
+  @Field({ nullable: true })
+  public sessionToken?: boolean;
+}
+
+@InputType()
+export class AccountResetInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public accountResetToken!: string;
+
+  @Field()
+  public email!: string;
+
+  @Field()
+  public newPassword!: string;
+
+  @Field({ nullable: true })
+  public options?: AccountResetInputOptions;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -7,3 +7,9 @@ export { UpdateDisplayNamePayload } from './update-display-name';
 export { ChangeRecoveryCodesPayload } from './change-recovery-codes';
 export { CreateTotpPayload } from './create-totp';
 export { VerifyTotpPayload } from './verify-totp';
+export {
+  PasswordForgotSendCodePayload,
+  PasswordForgotVerifyCodePayload,
+  PasswordForgotCodeStatusPayload,
+  AccountResetPayload,
+} from './password-forgot';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/password-forgot.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/password-forgot.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class PasswordForgotSendCodePayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public passwordForgotToken!: string;
+}
+
+@ObjectType()
+export class PasswordForgotVerifyCodePayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public accountResetToken!: string;
+}
+
+@ObjectType()
+export class PasswordForgotCodeStatusPayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public tries!: number;
+
+  @Field()
+  public ttl!: number;
+}
+
+@ObjectType()
+export class AccountResetPayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ nullable: true })
+  public uid?: string;
+
+  @Field({ nullable: true })
+  public sessionToken?: string;
+
+  @Field({ nullable: true })
+  public verified?: boolean;
+
+  @Field({ nullable: true })
+  public authAt?: number;
+
+  @Field({ nullable: true })
+  public keyFetchToken?: string;
+}

--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -290,8 +290,8 @@ export function logEvents(
     const now = Date.now();
     // This is ok for now because there is no batching. But each event should
     // have its own offset.
-    const eventOffset = now - configurableProperties.startTime;
-    const duration = now - configurableProperties.startTime;
+    const eventOffset = Math.ceil(now - configurableProperties.startTime);
+    const duration = Math.ceil(now - configurableProperties.startTime);
     // Amplitude events emitted from new Settings should have this property.
     eventProperties['settingsVersion'] = 'new';
 


### PR DESCRIPTION
## Because

- We need a way for a user to initate the the password forgot flow from the gql-api

## This pull request

- Adds an account resolver that can be used to reset a users password
  - `passwordForgotSendCode` sends an email password reset link (password forgot token and code are in url params of link
  - `passwordForgotVerifyCode` uses the password forgot token and code and returns account reset token
  - `passwordForgotCodeStatus` checks to see if password forgot token is still good
  - `accountReset` uses the account reset token to set a new password
- Propagates headers from the original request to the auth-server, this is needed to that auth-server can determine the correct ip address for email

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6326

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/1295288/204700126-28853eac-b1cb-450e-8154-f793f3f2674c.png)

## Other information (Optional)

Some additional context, our password reset flows were created before FxA support JWT. If we used a JWT we could replace having to go through the extra hoops with password forgot token and account reset token. I opted not to do this in this PR since that would require security reviews.
