### PR TITLE
fix(payments): display tax amount on subscription upgrades

### DIFF
--- a/packages/fxa-payments-server/src/components/PriceDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PriceDetails/index.tsx
@@ -7,17 +7,6 @@ import {
 } from '../../lib/formats';
 import Stripe from 'stripe';
 
-export type PriceDetailsProps = {
-  total: number;
-  currency: string;
-  tax?: number;
-  showTax?: boolean;
-  interval?: Stripe.Plan.Interval;
-  intervalCount?: number;
-  className?: string;
-  dataTestId?: string;
-};
-
 const NoInterval = ({
   total,
   currency,
@@ -124,6 +113,17 @@ const Interval = ({
       </span>
     </Localized>
   );
+};
+
+export type PriceDetailsProps = {
+  total: number;
+  currency: string;
+  tax?: number;
+  showTax?: boolean;
+  interval?: Stripe.Plan.Interval;
+  intervalCount?: number;
+  className?: string;
+  dataTestId?: string;
 };
 
 export const PriceDetails = (props: PriceDetailsProps) => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -1,101 +1,29 @@
 import React from 'react';
+
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
-import { storiesOf } from '@storybook/react';
-import { APIError } from '../../../lib/apiClient';
+import { Meta } from '@storybook/react';
+
 import MockApp from '../../../../.storybook/components/MockApp';
-import { defaultAppContext, AppContextType } from '../../../lib/AppContext';
-
 import { SignInLayout } from '../../../components/AppLayout';
+import { SubscriptionUpgrade, SubscriptionUpgradeProps } from './index';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
+import { APIError } from '../../../lib/apiClient';
+import { defaultAppContext, AppContextType } from '../../../lib/AppContext';
 import {
   CUSTOMER,
-  PAYPAL_CUSTOMER,
   SELECTED_PLAN,
   UPGRADE_FROM_PLAN,
   PROFILE,
 } from '../../../lib/mock-data';
 
-import SubscriptionUpgrade, { SubscriptionUpgradeProps } from './index';
-import { WebSubscription } from 'fxa-shared/subscriptions/types';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
-function init() {
-  storiesOf('routes/Product/SubscriptionUpgrade', module)
-    .add('upgrade offer - Visa', () => (
-      <SubscriptionUpgradeView
-        props={{
-          ...MOCK_PROPS,
-          updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
-        }}
-      />
-    ))
-    .add('upgrade offer - PayPal', () => (
-      <SubscriptionUpgradeView
-        props={{
-          ...MOCK_PROPS_PAYPAL,
-          updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
-        }}
-      />
-    ))
-    .add('upgrade offer localized to xx-pirate', () => (
-      <SubscriptionUpgradeView
-        appContextValue={{
-          ...defaultAppContext,
-          navigatorLanguages: ['xx-pirate'],
-        }}
-        props={{
-          ...MOCK_PROPS,
-          updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
-        }}
-      />
-    ))
-    .add('submitting', () => (
-      <SubscriptionUpgradeView
-        props={{
-          ...MOCK_PROPS,
-          updateSubscriptionPlanStatus: {
-            loading: true,
-            result: null,
-            error: null,
-          },
-        }}
-      />
-    ));
-
-  storiesOf('routes/Product/SubscriptionUpgrade/failures', module).add(
-    'internal server error',
-    () => (
-      <SubscriptionUpgradeView
-        props={{
-          ...MOCK_PROPS,
-          updateSubscriptionPlanStatus: {
-            loading: false,
-            result: null,
-            error: new APIError({
-              statusCode: 500,
-              message: 'Internal Server Error',
-            }),
-          },
-          resetUpdateSubscriptionPlan: linkToUpgradeOffer,
-        }}
-      />
-    )
-  );
-}
-
-const SubscriptionUpgradeView = ({
-  props = MOCK_PROPS,
-  appContextValue = defaultAppContext,
-}: {
-  props?: SubscriptionUpgradeProps;
-  appContextValue?: AppContextType;
-}) => (
-  <MockApp appContextValue={appContextValue}>
-    <SignInLayout>
-      <SubscriptionUpgrade {...props} />
-    </SignInLayout>
-  </MockApp>
-);
+export default {
+  title: 'routes/Product/SubscriptionUpgrade',
+  component: SubscriptionUpgrade,
+} as Meta;
 
 const linkToUpgradeSuccess = linkTo('routes/Product', 'success');
 
@@ -103,6 +31,44 @@ const linkToUpgradeOffer = linkTo(
   'routes/Product/SubscriptionUpgrade',
   'upgrade offer'
 );
+
+const invoicePreviewNoTax: FirstInvoicePreview = {
+  total: 2000,
+  total_excluding_tax: null,
+  subtotal: 2000,
+  subtotal_excluding_tax: null,
+  line_items: [
+    {
+      amount: 2000,
+      currency: 'USD',
+      id: SELECTED_PLAN.plan_id,
+      name: 'first invoice',
+    },
+  ],
+};
+
+const invoicePreviewInclusiveTax: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 2999,
+  subtotal_excluding_tax: 2804,
+  total: 2999,
+  total_excluding_tax: 2804,
+  tax: {
+    amount: 195,
+    inclusive: true,
+  },
+};
+const invoicePreviewExclusiveTax: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 2999,
+  subtotal_excluding_tax: 2999,
+  total: 3194,
+  total_excluding_tax: 2999,
+  tax: {
+    amount: 195,
+    inclusive: false,
+  },
+};
 
 const MOCK_PROPS: SubscriptionUpgradeProps = {
   isMobile: false,
@@ -116,13 +82,101 @@ const MOCK_PROPS: SubscriptionUpgradeProps = {
     loading: false,
     result: null,
   },
+  invoicePreview: invoicePreviewNoTax,
   updateSubscriptionPlanAndRefresh: action('updateSubscriptionPlanAndRefresh'),
   resetUpdateSubscriptionPlan: action('resetUpdateSubscriptionPlan'),
 };
 
-const MOCK_PROPS_PAYPAL: SubscriptionUpgradeProps = {
-  ...MOCK_PROPS,
-  customer: PAYPAL_CUSTOMER,
+const storyWithContext = ({
+  props = MOCK_PROPS,
+  appContextValue = defaultAppContext,
+}: {
+  props?: SubscriptionUpgradeProps;
+  appContextValue?: AppContextType;
+}) => {
+  const story = () => (
+    <MockApp appContextValue={appContextValue}>
+      <SignInLayout>
+        <SubscriptionUpgrade {...props} />
+      </SignInLayout>
+    </MockApp>
+  );
+
+  return story;
 };
 
-init();
+export const Default = storyWithContext({
+  props: {
+    ...MOCK_PROPS,
+    updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
+  },
+});
+
+export const DefaultWithInclusiveTax = storyWithContext({
+  props: {
+    ...MOCK_PROPS,
+    invoicePreview: invoicePreviewInclusiveTax,
+    updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
+  },
+  appContextValue: {
+    ...defaultAppContext,
+    navigatorLanguages: ['xx-pirate'],
+    config: {
+      ...defaultAppContext.config,
+      featureFlags: { useStripeAutomaticTax: true },
+    },
+  },
+});
+
+export const DefaultWithExclusiveTax = storyWithContext({
+  props: {
+    ...MOCK_PROPS,
+    invoicePreview: invoicePreviewExclusiveTax,
+    updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
+  },
+  appContextValue: {
+    ...defaultAppContext,
+    navigatorLanguages: ['xx-pirate'],
+    config: {
+      ...defaultAppContext.config,
+      featureFlags: { useStripeAutomaticTax: true },
+    },
+  },
+});
+
+export const LocalizedToPirate = storyWithContext({
+  props: {
+    ...MOCK_PROPS,
+    updateSubscriptionPlanAndRefresh: () => linkToUpgradeSuccess(),
+  },
+  appContextValue: {
+    ...defaultAppContext,
+    navigatorLanguages: ['xx-pirate'],
+  },
+});
+
+export const Submitting = storyWithContext({
+  props: {
+    ...MOCK_PROPS,
+    updateSubscriptionPlanStatus: {
+      loading: true,
+      result: null,
+      error: null,
+    },
+  },
+});
+
+export const InternalServerError = storyWithContext({
+  props: {
+    ...MOCK_PROPS,
+    updateSubscriptionPlanStatus: {
+      loading: false,
+      result: null,
+      error: new APIError({
+        statusCode: 500,
+        message: 'Internal Server Error',
+      }),
+    },
+    resetUpdateSubscriptionPlan: linkToUpgradeOffer,
+  },
+});

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -26,29 +26,32 @@ import { ProductProps } from '../index';
 import { PaymentConsentCheckbox } from '../../../components/PaymentConsentCheckbox';
 import { PaymentProviderDetails } from '../../../components/PaymentProviderDetails';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type SubscriptionUpgradeProps = {
-  isMobile: boolean;
   profile: Profile;
   customer: Customer;
   selectedPlan: Plan;
   upgradeFromPlan: Plan;
   upgradeFromSubscription: WebSubscription;
+  invoicePreview: FirstInvoicePreview;
+  isMobile?: boolean;
   updateSubscriptionPlanStatus: SelectorReturns['updateSubscriptionPlanStatus'];
   updateSubscriptionPlanAndRefresh: ProductProps['updateSubscriptionPlanAndRefresh'];
   resetUpdateSubscriptionPlan: ProductProps['resetUpdateSubscriptionPlan'];
 };
 
 export const SubscriptionUpgrade = ({
-  isMobile,
+  isMobile = false,
   profile,
   customer,
   selectedPlan,
   upgradeFromPlan,
   upgradeFromSubscription,
+  invoicePreview,
+  updateSubscriptionPlanStatus,
   updateSubscriptionPlanAndRefresh,
   resetUpdateSubscriptionPlan,
-  updateSubscriptionPlanStatus,
 }: SubscriptionUpgradeProps) => {
   const ariaLabelledBy = 'error-plan-change-failed-header';
   const ariaDescribedBy = 'error-plan-change-failed-description';
@@ -120,18 +123,6 @@ export const SubscriptionUpgrade = ({
       )}
       <Header {...{ profile }} />
       <div className="main-content">
-        <div className="payment-panel">
-          <PlanUpgradeDetails
-            {...{
-              profile,
-              selectedPlan,
-              upgradeFromPlan,
-              isMobile,
-              showExpandButton: isMobile,
-            }}
-          />
-        </div>
-
         <div
           className="product-payment product-upgrade rounded-lg tablet:rounded-t-none"
           data-testid="subscription-upgrade"
@@ -159,7 +150,7 @@ export const SubscriptionUpgrade = ({
             className="payment upgrade"
             {...{ validator, onSubmit }}
           >
-            <hr />
+            <hr className="my-6" />
             <Localized
               id="sub-update-copy"
               vars={{
@@ -178,11 +169,11 @@ export const SubscriptionUpgrade = ({
               </p>
             </Localized>
 
-            <hr />
+            <hr className="my-6" />
 
             <PaymentConsentCheckbox plan={selectedPlan} onClick={engageOnce} />
 
-            <hr />
+            <hr className="my-6" />
 
             <div className="button-row">
               <SubmitButton
@@ -209,6 +200,16 @@ export const SubscriptionUpgrade = ({
             </div>
           </Form>
         </div>
+        <PlanUpgradeDetails
+          {...{
+            profile,
+            selectedPlan,
+            upgradeFromPlan,
+            isMobile,
+            showExpandButton: isMobile,
+            invoicePreview,
+          }}
+        />
         {mobileUpdateHeading}
       </div>
     </>

--- a/packages/fxa-payments-server/src/routes/Product/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Product/en.ftl
@@ -1,0 +1,2 @@
+product-invoice-preview-error-title = Problem loading invoice preview
+product-invoice-preview-error-text = Could not load invoice preview


### PR DESCRIPTION
## Because

- We want to display the amount of tax charged or included on upgrades
  (if applicable)

## This pull request

- Updates PlanUpgradeDetails to include tax details
- Updates SubscriptionUpgrade to pass tax details to PlanUpgradeDetails
- Updates tests for both
- Updates StoryBook for SubscriptionUpgrade to CSF and adds inclusive
  and exclusive tax stories
- Adds custom hook to fetch invoicePreview and added to `routes/Product`

Closes FXA-6376

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally. (WIP)
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate). (WIP)

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/10620585/208987917-4b6429c7-45a0-4a93-a481-5805c293def1.png)

## Other information (Optional)

This can be tested by subscribing to 123Pro Plans listed below.
- [Subscribe to Pro (USD)](http://localhost:3030/subscriptions/products/prod_GqM9ToKK62qjkK?plan=plan_GqM9N6qyhvxaVk)
- Upgrade to [Subscribe to Pro 12m (USD)](http://localhost:3030/subscriptions/products/prod_GqM9ToKK62qjkK?plan=price_1KbomlBVqmGyQTMaa0Tq7UaW)
