### PR TITLE
chore(keys): add statsd metrics to scoped keys metadata endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -73,7 +73,14 @@ module.exports = function (
     stripeHelper,
     pushbox
   );
-  const oauth = require('./oauth')(log, config, db, mailer, devicesImpl);
+  const oauth = require('./oauth')(
+    log,
+    config,
+    db,
+    mailer,
+    devicesImpl,
+    statsd
+  );
   const devicesSessions = require('./devices-and-sessions')(
     log,
     db,

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -1,6 +1,6 @@
 const oauthDB = require('../../oauth/db');
 
-module.exports = (log, config, db, mailer, devices) => {
+module.exports = (log, config, db, mailer, devices, statsd) => {
   const routes = [
     require('./authorization')({ log, oauthDB, config }),
     require('./authorized-clients/destroy')({ oauthDB }),
@@ -10,7 +10,7 @@ module.exports = (log, config, db, mailer, devices) => {
     require('./id_token_verify')(),
     require('./introspect')({ oauthDB }),
     require('./jwks')(),
-    require('./key_data')({ log, oauthDB }),
+    require('./key_data')({ log, oauthDB, statsd }),
     require('./token')({ log, oauthDB, db, mailer, devices }),
     require('./verify')({ log }),
   ].flat();

--- a/packages/fxa-auth-server/lib/routes/oauth/key_data.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/key_data.js
@@ -38,7 +38,7 @@ function checkDisabledClientId(payload) {
   }
 }
 
-module.exports = ({ log, oauthDB }) => {
+module.exports = ({ log, oauthDB, statsd }) => {
   async function keyDataHandler(req) {
     const claims = await verifyAssertion(req.payload.assertion);
 
@@ -154,6 +154,9 @@ module.exports = ({ log, oauthDB }) => {
         checkDisabledClientId(req.payload);
         const sessionToken = req.auth.credentials;
         req.payload.assertion = await makeAssertionJWT(config, sessionToken);
+        statsd.increment('oauth.rp.scoped-keys-metadata', {
+          clientId: req.payload.client_id,
+        });
         try {
           return await keyDataHandler(req);
         } catch (err) {


### PR DESCRIPTION
Because:
 - we want to be certain what RPs are using the scoped keys endpoint

This commit:
 - add statsd to the endpoint to learn what RPs are using it
