### PR TITLE
feat(content/react): Conditionally serve React version of Backbone routes

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -504,6 +504,7 @@ Start.prototype = {
         broker: this._authenticationBroker,
         config: this._config,
         createView: this.createView.bind(this),
+        experimentGroupingRules: this._experimentGroupingRules,
         metrics: this._metrics,
         notifier: this._notifier,
         relier: this._relier,

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/generalized-react-app.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/generalized-react-app.js
@@ -20,21 +20,18 @@ const BaseGroupingRule = require('./base');
 const GROUPS = [
   'control',
 
-  // Treatment branches. This one is for users who will see the new, generalized React app which houses more urls than just `/settings`
-  'generalized',
+  // Treatment branches.
+  // This one is for users who will see the React version of content-server pages
+  'react',
 ];
 
-// This experiment is disabled by default. If you would like to go through
-// open the settings page with the following query params:
-// `?forceExperiment=generalizedReactApp&forceExperimentGroup=generalized`
+/* This experiment is disabled by default. If you would like to see the React pages, make sure
+ * 1) your local config is set up to enable feature flags for the set of routes you're interested
+ * in and either 2a) append `showReactApp=true` to the URL _or_ 2b) to see it in a flow, append
+ * the following query params to the page that will navigate to the page you're interested in:
+ * `?forceExperiment=generalizedReactApp&forceExperimentGroup=react` */
 const ROLLOUT_RATE = 0.0;
 
-// This splits users into users who see the original Settings React app,
-// and users who see a generalized version of that app which can also display
-// routes that were previously content-server routes. This is not intended to wrap
-// the entirety of the Content Server React project -- it is a temporary experiment
-// which only wraps the generalization of the React app, and will be removed after
-// successful roll out of those changes.
 module.exports = class GeneralizedReactApp extends BaseGroupingRule {
   constructor() {
     super();

--- a/packages/fxa-content-server/app/scripts/lib/generalized-react-app-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/lib/generalized-react-app-experiment-mixin.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from '../views/mixins/experiment-mixin';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  isInReactExperiment() {
+    const experimentGroup = this.getAndReportExperimentGroup(
+      'generalizedReactApp'
+    );
+    return experimentGroup === 'react';
+  },
+};

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -9,6 +9,7 @@ import Backbone from 'backbone';
 import CannotCreateAccountView from '../views/cannot_create_account';
 import ChooseWhatToSyncView from '../views/choose_what_to_sync';
 import ClearStorageView from '../views/clear_storage';
+import Cocktail from 'cocktail';
 import CompleteResetPasswordView from '../views/complete_reset_password';
 import CompleteSignUpView from '../views/complete_sign_up';
 import ConfirmResetPasswordView from '../views/confirm_reset_password';
@@ -43,6 +44,7 @@ import UserAgent from './user-agent';
 import VerificationReasons from './verification-reasons';
 import WouldYouLikeToSync from '../views/would_you_like_to_sync';
 import { isAllowed } from 'fxa-shared/configuration/convict-format-allow-list';
+import ReactExperimentMixin from './generalized-react-app-experiment-mixin';
 
 const NAVIGATE_AWAY_IN_MOBILE_DELAY_MS = 75;
 
@@ -82,7 +84,38 @@ function createViewModel(data) {
   return new Backbone.Model(data || {});
 }
 
-const Router = Backbone.Router.extend({
+let Router = Backbone.Router.extend({
+  initialize(options = {}) {
+    this.broker = options.broker;
+    this.config = options.config;
+    this.metrics = options.metrics;
+    this.notifier = options.notifier;
+    this.relier = options.relier;
+    this.user = options.user;
+    this.window = options.window || window;
+    this._viewModelStack = [];
+
+    this.notifier.once(
+      'view-shown',
+      this._afterFirstViewHasRendered.bind(this)
+    );
+    this.notifier.on('navigate', this.onNavigate.bind(this));
+    this.notifier.on('navigate-back', this.onNavigateBack.bind(this));
+    this.notifier.on('email-first-flow', () => this._onEmailFirstFlow());
+
+    // If legacy signin/signup flows are disabled, this is obviously
+    // an email-first flow!
+    if (this.broker.getCapability('disableLegacySigninSignup')) {
+      this._isEmailFirstFlow = true;
+    }
+
+    this.storage = Storage.factory('sessionStorage', this.window);
+  },
+});
+
+Cocktail.mixin(Router, ReactExperimentMixin);
+
+Router = Router.extend({
   routes: {
     '(/)': createViewHandler(IndexView),
     'account_recovery_confirm_key(/)': createViewHandler(
@@ -92,7 +125,25 @@ const Router = Backbone.Router.extend({
       CompleteResetPasswordView
     ),
     'authorization(/)': createViewHandler(RedirectAuthView),
-    'cannot_create_account(/)': createViewHandler(CannotCreateAccountView),
+    'cannot_create_account(/)': function () {
+      // TODO: check for what feature flag group this route is in and check `featureFlagOn` so
+      // we don't have to check all of these at the router level. Probably turn this into some
+      // helper function. FXA-6538
+      const showReactApp = this.config.showReactApp.simpleRoutes;
+
+      if (showReactApp && this.isInReactExperiment()) {
+        const link = `${'/cannot_create_account'}${Url.objToSearchString({
+          showReactApp,
+        })}`;
+
+        this.navigateAway(link);
+      } else {
+        // TODO: make a helper function out of this or make `createViewHandler` work
+        return getView(CannotCreateAccountView).then((View) => {
+          return this.showView(View);
+        });
+      }
+    },
     'choose_what_to_sync(/)': createViewHandler(ChooseWhatToSyncView),
     'clear(/)': createViewHandler(ClearStorageView),
     'complete_reset_password(/)': createViewHandler(CompleteResetPasswordView),
@@ -216,20 +267,16 @@ const Router = Backbone.Router.extend({
       // from the content-server app passes along flow parameters.
       const { deviceId, flowBeginTime, flowId } =
         this.metrics.getFlowEventMetadata();
-
       const {
         broker,
         context: ctx,
-        experiments,
         isSampledUser,
         service,
         uniqueUserId,
       } = this.metrics.getFilteredData();
-
       // Our GQL client sets the `redirect_to` param if a user attempts
       // to navigate directly to a section in settings
       const searchParams = new URLSearchParams(this.window.location.search);
-
       let endpoint = searchParams.get('redirect_to');
       if (!endpoint) {
         endpoint = `/settings`;
@@ -238,7 +285,6 @@ const Router = Backbone.Router.extend({
       ) {
         throw new Error('Invalid redirect!');
       }
-
       const settingsLink = `${endpoint}${Url.objToSearchString({
         deviceId,
         flowBeginTime,
@@ -247,7 +293,6 @@ const Router = Backbone.Router.extend({
         context: ctx,
         isSampledUser,
         service,
-        showNewReactApp: experiments.includes('generalizedReactApp'),
         uniqueUserId,
       })}`;
       this.navigateAway(settingsLink);
@@ -295,33 +340,6 @@ const Router = Backbone.Router.extend({
       type: VerificationReasons.SECONDARY_EMAIL_VERIFIED,
     }),
     'would_you_like_to_sync(/)': createViewHandler(WouldYouLikeToSync),
-  },
-
-  initialize(options = {}) {
-    this.broker = options.broker;
-    this.config = options.config;
-    this.metrics = options.metrics;
-    this.notifier = options.notifier;
-    this.relier = options.relier;
-    this.user = options.user;
-    this.window = options.window || window;
-    this._viewModelStack = [];
-
-    this.notifier.once(
-      'view-shown',
-      this._afterFirstViewHasRendered.bind(this)
-    );
-    this.notifier.on('navigate', this.onNavigate.bind(this));
-    this.notifier.on('navigate-back', this.onNavigateBack.bind(this));
-    this.notifier.on('email-first-flow', () => this._onEmailFirstFlow());
-
-    // If legacy signin/signup flows are disabled, this is obviously
-    // an email-first flow!
-    if (this.broker.getCapability('disableLegacySigninSignup')) {
-      this._isEmailFirstFlow = true;
-    }
-
-    this.storage = Storage.factory('sessionStorage', this.window);
   },
 
   onNavigate(event) {

--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -17,6 +17,7 @@ logger.info(`commit hash set to: ${version.commit}`);
 logger.info(`fxa-content-server-l10n commit hash set to: ${version.l10n}`);
 logger.info(`tos-pp (legal-docs) commit hash set to: ${version.tosPp}`);
 const config = require('../lib/configuration');
+const { addAllReactRoutesConditionally } = require('../lib/routes/react-app');
 
 // Tracing must be initialized asap
 const tracing = require('fxa-shared/tracing/node-tracing');
@@ -36,7 +37,7 @@ const sentry = require('../lib/sentry');
 const statsd = require('../lib/statsd');
 const { cors, routing } = require('fxa-shared/express').express();
 const {
-  useSettingsProxy,
+  createSettingsProxy,
   modifySettingsStatic,
 } = require('../lib/beta-settings');
 
@@ -187,22 +188,35 @@ function makeApp() {
   const routes = require('../lib/routes')(config, i18n, statsd);
   const routeLogger = loggerFactory('server.routes');
   const routeHelpers = routing(app, routeLogger);
-  routes.forEach(routeHelpers.addRoute);
 
   if (config.get('env') === 'production') {
     app.get(settingsPath, modifySettingsStatic);
+
+    addAllReactRoutesConditionally(app, routeHelpers, modifySettingsStatic);
   }
+
+  if (config.get('env') === 'development') {
+    app.use(settingsPath, createSettingsProxy);
+
+    addAllReactRoutesConditionally(app, routeHelpers, createSettingsProxy);
+  } else {
+    app.get(settingsPath + '/*', modifySettingsStatic);
+  }
+
+  /* This creates `app.whatever('/path' ...` handlers for every content-server route and
+   * excludes routes in `react-app.js` if corresponding feature flags are on. We manually add
+   * these excluded routes for content-server to serve in checks above if the feature flag is
+   * set to false or if the request does not contain `showReactApp=true`. Adding these routes
+   * must come after React-related route modifications so that `next('route')` skips to these
+   * route implementations. */
+  routes.forEach(routeHelpers.addRoute);
+
+  // must come after route handling
   app.use(
     serveStatic(STATIC_DIRECTORY, {
       maxAge: config.get('static_max_age'),
     })
   );
-
-  if (config.get('env') === 'development') {
-    app.use(settingsPath, useSettingsProxy);
-  } else {
-    app.get(settingsPath + '/*', modifySettingsStatic);
-  }
 
   // it's a four-oh-four not found.
   app.use(fourOhFour);

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -128,7 +128,7 @@ function modifyProxyRes(proxyRes, req, res) {
   });
 }
 
-const useSettingsProxy = createProxyMiddleware({
+const createSettingsProxy = createProxyMiddleware({
   target: 'http://localhost:3000',
   ws: true,
   selfHandleResponse: true, // ensure res.end is not called early
@@ -147,7 +147,7 @@ const modifySettingsStatic = function (req, res) {
 };
 
 module.exports = {
-  useSettingsProxy,
+  createSettingsProxy,
   modifySettingsStatic,
   swapBetaMeta,
   modifyProxyRes,

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -210,6 +210,62 @@ const conf = (module.exports = convict({
       },
     },
   },
+  showReactApp: {
+    simpleRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "simple" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_SIMPLE_ROUTES',
+    },
+    resetPasswordRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "reset_password" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_RESET_PASSWORD_ROUTES',
+    },
+    oauthRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of routes requiring oauth',
+      format: Boolean,
+      env: 'REACT_CONVERSION_OAUTH_ROUTES',
+    },
+    signInRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "signin" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_SIGNIN_ROUTES',
+    },
+    signUpRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "signup" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_SIGNUP_ROUTES',
+    },
+    pairRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "pair" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_PAIR_ROUTES',
+    },
+    postVerifyAddRecoveryKeyRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "post-verify add recovery key" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_POST_VERIFY_ADD_RECOVERY_KEY_ROUTES',
+    },
+    postVerifyCADViaQRRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "post verify CAD via QR code" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES',
+    },
+    signInVerificationViaPushRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "signin verification via push" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH_ROUTES',
+    },
+  },
   flow_id_expiry: {
     default: '2 hours',
     doc: 'Time after which flow ids are considered stale',

--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -13,7 +13,7 @@ module.exports = function (config, i18n, statsd) {
     redirectVersionedToUnversioned('verify_email'),
     require('./routes/get-apple-app-site-association')(),
     require('./routes/get-frontend-pairing')(),
-    require('./routes/get-frontend')(),
+    require('./routes/get-frontend').default(),
     require('./routes/get-oauth-success'),
     require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-update-firefox')(config),

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -3,7 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
-module.exports = function () {
+
+const { simpleRoutes } = require('./react-app');
+const {
+  getFrontEndRouteDefinitions,
+} = require('./react-app/route-definitions');
+
+function getFrontEnd() {
   // The array is converted into a RegExp
   const FRONTEND_ROUTES = [
     'account_recovery_confirm_key',
@@ -81,16 +87,21 @@ module.exports = function () {
     'verify_primary_email',
     'verify_secondary_email',
     'would_you_like_to_sync',
-  ].join('|'); // prepare for use in a RegExp
+  ];
 
-  return {
-    method: 'get',
-    path: new RegExp('^/(' + FRONTEND_ROUTES + ')/?$'),
-    process: function (req, res, next) {
-      // setting the url to / will use the correct
-      // index.html for either dev or prod mode.
-      req.url = '/';
-      next();
-    },
-  };
+  // Remove route from list if feature flag is on and route is in list. Route definitions
+  // for the excluded routes are created separately
+  // TODO: account for other feature flags / React route lists, FXA-6538
+  const FRONTEND_ROUTES_EXCLUDE_REACT = simpleRoutes.featureFlagOn
+    ? FRONTEND_ROUTES.filter(
+        (routeName) =>
+          !simpleRoutes.routes.find((route) => routeName === route.name)
+      )
+    : FRONTEND_ROUTES;
+
+  return getFrontEndRouteDefinitions(FRONTEND_ROUTES_EXCLUDE_REACT);
+}
+
+module.exports = {
+  default: getFrontEnd,
 };

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -48,6 +48,7 @@ module.exports = function (config) {
   const APPLE_AUTH_CONFIG = config.get('appleAuthConfig');
   const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
   const TRACING_CONFIG = config.get('tracing');
+  const SHOW_REACT_APP = config.get('showReactApp');
 
   // Note that this list is only enforced for clients that use login_hint/email
   // with prompt=none. id_token_hint clients are not subject to this check.
@@ -91,6 +92,7 @@ module.exports = function (config) {
     subscriptions: SUBSCRIPTIONS,
     tracing: TRACING_CONFIG,
     webpackPublicPath: WEBPACK_PUBLIC_PATH,
+    showReactApp: SHOW_REACT_APP,
   };
 
   const NO_LONGER_SUPPORTED_CONTEXTS = new Set([

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('../../configuration');
+const { getFrontEndRouteDefinitions } = require('./route-definitions');
+
+/** @type {import("./types").RouteFeatureFlagGroup} */
+const simpleRoutes = {
+  featureFlagOn: config.get('showReactApp.simpleRoutes'),
+  routes: [
+    /* When you're ready to serve the React version of a "simpleRoute", add a new object here
+     * with the route name and definition. Definitions come from route files in `lib/routes/` -
+     * you need to find which file your new route exists in to determine which definition
+     * the route needs.
+     * TODO: Create other get[Descriptor]RouteDefinition functions, FXA-6538 */
+    {
+      name: 'cannot_create_account',
+      definition: getFrontEndRouteDefinitions(['cannot_create_account']),
+    },
+  ],
+};
+
+/** Check if the feature flag passed in is `true` and the request contains `?showReactApp=true`.
+ * If true, use the middleware passed ('createSettingsProxy' in dev, else 'modifySettingsStatic')
+ * for that route, allowing `fxa-settings` to serve the page. If false, skip the middleware and
+ * use the default routing middleware from `fxa-shared/express/routing.ts`.
+ * @param {import("express").Express} app
+ * @param {Object} routeHelpers
+ *  @param {Function} routeHelpers.addRoute
+ *  @param {Function} routeHelpers.validationErrorHandler
+ * @param {import("express").RequestHandler} middleware
+ * @param {import("./types").RouteFeatureFlagGroup}
+ */
+function addReactRoutesConditionally(
+  app,
+  routeHelpers,
+  middleware,
+  { featureFlagOn, routes }
+) {
+  if (featureFlagOn === true) {
+    routes.forEach(({ definition }) => {
+      // possible TODO - `definition.method`s will either be 'get' or 'post'. Not sure if we need
+      // this for any 'post' requests but shouldn't hurt anything; 'get' alone may suffice.
+      app[definition.method](definition.path, (req, res, next) => {
+        if (req.query.showReactApp === 'true') {
+          return middleware(req, res, next);
+        } else {
+          next('route');
+        }
+      });
+      // Manually add route for content-server to serve; occurs when above next('route'); is called
+      routeHelpers.addRoute(definition);
+    });
+  }
+}
+
+/** Add routes from `simpleRoutes` for fxa-settings or fxa-content-server to serve.
+ * @param {import("express").Express} app
+ * @param {Object} routeHelpers
+ *  @param {Function} routeHelpers.addRoute
+ *  @param {Function} routeHelpers.validationErrorHandler
+ * @param {import("express").RequestHandler} middleware
+ */
+function addSimpleRoutes(app, routeHelpers, middleware) {
+  addReactRoutesConditionally(app, routeHelpers, middleware, simpleRoutes);
+}
+
+/** Add all routes routes from all route objects for fxa-settings or fxa-content-server to serve.
+ * @param {import("express").Express} app
+ * @param {Object} routeHelpers
+ *  @param {Function} routeHelpers.addRoute
+ *  @param {Function} routeHelpers.validationErrorHandler
+ * @param {import("express").RequestHandler} middleware
+ */
+function addAllReactRoutesConditionally(app, routeHelpers, middleware) {
+  addSimpleRoutes(app, routeHelpers, middleware);
+  // add other addRoutes functions here when created
+}
+
+module.exports = {
+  simpleRoutes,
+  addAllReactRoutesConditionally,
+};

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definitions.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definitions.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param {Array.<String>} routes
+ * @returns {import("fxa-shared/express/routing").RouteDefinition}
+ */
+function getFrontEndRouteDefinitions(routes) {
+  const path = routes.join('|'); // prepare for use in a RegExp
+  return {
+    method: 'get',
+    path: new RegExp('^/(' + path + ')/?$'),
+    process: function (req, res, next) {
+      // setting the url to / will use the correct
+      // index.html for either dev or prod mode.
+      req.url = '/';
+      next();
+    },
+  };
+}
+
+module.exports = {
+  getFrontEndRouteDefinitions,
+};

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// TS setup for anything outside of `app/` is complex. This file defines types we
+// import for JSDoc instead.
+
+import { RouteDefinition } from 'fxa-shared/express/routing';
+
+export interface RouteFeatureFlagGroup {
+  featureFlagOn: boolean;
+  routes: {
+    name: string;
+    definition: RouteDefinition;
+  }[];
+}

--- a/packages/fxa-content-server/tests/functional/oauth_permissions.js
+++ b/packages/fxa-content-server/tests/functional/oauth_permissions.js
@@ -207,12 +207,8 @@ registerSuite('oauth permissions for untrusted reliers', {
           .then(openSettingsInNewTab())
           .then(switchToWindow(1))
 
-          .then(
-            click(
-              selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON,
-              selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME
-            )
-          )
+          .then(click(selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON))
+          .then(click(selectors.SETTINGS_DISPLAY_NAME.INPUT_LABEL_DISPLAY_NAME))
           .then(
             type(
               selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME,

--- a/packages/fxa-content-server/tests/server/routes/get-index.js
+++ b/packages/fxa-content-server/tests/server/routes/get-index.js
@@ -108,6 +108,10 @@ registerSuite('routes/get-index', {
                 sentConfig.subscriptions,
                 config.get('subscriptions')
               );
+              assert.deepEqual(
+                sentConfig.showReactApp,
+                config.get('showReactApp')
+              );
               assert.equal(
                 sentConfig.webpackPublicPath,
                 `${config.get('static_resource_url')}/${config.get(

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -8,15 +8,25 @@ import Head from 'fxa-react/components/Head';
 import { ScrollToTop } from '../Settings/ScrollToTop';
 import Settings from '../Settings';
 import { QueryParams } from '../..';
+import CannotCreateAccount from '../../pages/CannotCreateAccount';
 
 export const App = ({
   flowQueryParams,
 }: { flowQueryParams: QueryParams } & RouteComponentProps) => {
+  const { showReactApp } = flowQueryParams;
+
   return (
     <>
       <Head />
       <Router basepath={'/'}>
         <ScrollToTop default>
+          {/* We probably don't need a guard here with `showReactApp` or a feature flag/config
+           * check since users will be served the Backbone version of pages if either of those
+           * are false, but guard with query param anyway since we have it handy */}
+          {showReactApp && (
+            <CannotCreateAccount path="/cannot_create_account/*" />
+          )}
+
           <Settings path="/settings/*" {...{ flowQueryParams }} />
         </ScrollToTop>
       </Router>

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -9,7 +9,6 @@ import {
   getTracingHeadersFromDocument,
   init as initTracing,
 } from 'fxa-shared/tracing/browser-tracing';
-import Settings from './components/Settings';
 import App from './components/App';
 import config, { readConfigMeta } from './lib/config';
 import { searchParams } from './lib/utilities';
@@ -30,13 +29,11 @@ interface FlowQueryParams {
 
 // temporary until we can safely direct all users to all routes currently in content-server
 export interface QueryParams extends FlowQueryParams {
-  showNewReactApp?: boolean;
+  showReactApp?: boolean;
 }
 
 try {
   const flowQueryParams = searchParams(window.location.search) as QueryParams;
-
-  const { showNewReactApp } = flowQueryParams;
 
   // Populate config
   readConfigMeta((name: string) => {
@@ -64,11 +61,7 @@ try {
             bundles={['settings', 'react']}
             userLocales={navigator.languages}
           >
-            {showNewReactApp ? (
-              <App {...{ flowQueryParams }} />
-            ) : (
-              <Settings {...{ flowQueryParams }} />
-            )}
+            <App {...{ flowQueryParams }} />
           </AppLocalizationProvider>
         </AppContext.Provider>
       </AppErrorBoundary>

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { RouteComponentProps } from '@reach/router';
+import AppLayout from '../../components/AppLayout';
+
+// NOTE: page is incomplete, was half-hacked together as a first route to serve
+
+const CannotCreateAccount = (_: RouteComponentProps) => {
+  return (
+    <AppLayout>
+      <h1 className="card-header">Cannot create account</h1>
+      <p className="mb-4 text-sm">
+        You must meet certain age requirements to create a Firefox account.
+      </p>
+      <LinkExternal
+        className="link-blue text-sm"
+        href="https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy"
+      >
+        Learn more
+      </LinkExternal>
+    </AppLayout>
+  );
+};
+
+export default CannotCreateAccount;

--- a/packages/fxa-shared/express/routing.ts
+++ b/packages/fxa-shared/express/routing.ts
@@ -15,7 +15,7 @@ type RouteMethod =
   | 'patch'
   | 'options'
   | 'head';
-type RouteDefinition = {
+export type RouteDefinition = {
   method: RouteMethod;
   path: string | RegExp;
   process: Function;


### PR DESCRIPTION
Because:
* We want to be able to access the React version of content-server pages at the same URL when users are actively in our 'generalizedReactApp' experiment and feature flag groups containing these routes are on

This commit:
* Creates new files in content-server routes directory to house feature flag group objects containing new React page routes (for now, simpleRoutes), route definitions (for now, definitions from 'getFrontEnd'), and functions that conditionally allow content-server to serve the route if the feature flag (for now, simpleRoutes) is on and the request contains 'showReactApp'
* Implements these conditional functions in `fxa-content-server.js`, where content-server handles its routing based on env
* Adds feature flags to content-server config
* Modifies the Backbone Router to access a new react app experiment mixin to check if the user is in an experiment
* Modifies 'cannot_create_account' route in the Backbone Router so that users are redirected to the React version via appending 'showReactApp' if users are in the experiment and the simpleRoutes feature flag is on

Closes [FXA-6317](https://mozilla-hub.atlassian.net/browse/FXA-6317)

Note there are also comments in the code that should help explain some things which kind of starts the "documentation" part of this ticket. There will be better documentation once this is cleaned up with all cases accounted for in the ticket noted as FXA-TBD, I'll create that ticket before merging. I tested this in `production` mode too by updating the `env` in `local.json` and running `yarn build` then `yarn start`.

## How to test

1. Check into the branch and hit `localhost:3030/cannot_create_account`. Observe that the page, as well as `/cannot_create_account?showReactApp=true` and `/cannot_create_account?forceExperiment=generalizedReactApp&forceExperimentGroup=react`, show the Backbone version ("Learn more" has `mt-9` class) of the page (no changes).

2. Enable the `simpleRoutes` feature flag by adding this to your `fxa-content-server/server/config/local.json` file:
```
  ...
  "showReactApp": {
    "simpleRoutes": true
  }
```

3. Content-server should restart but you can also `pm2 restart content`. Now, `localhost:3030/cannot_create_account?forceExperiment=generalizedReactApp&forceExperimentGroup=react`, or going to `localhost:3030?forceExperiment=generalizedReactApp&forceExperimentGroup=react` and going through the signup screen and entering an age lower than 13 will redirect you to `localhost:3030/cannot_create_account?showReactApp=true`, which shows you the React version.


## TODO
* Vijay's looking into adding a functional test here, it's really tricky since we need that config value set. This might need to be done in a follow up ticket.

EDIT: we have FXA-6540 filed for that^. I'm not sure why the one failure is happening, it looks like the display name label is blocking the test from clicking the display name input. I'll have to circle back to this later.