### PR TITLE
test(functional): disable oauth tests until 123done is set up in prod

### DIFF
--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -4,7 +4,11 @@ test.describe('OAuth force auth', () => {
   test('with a registered email', async ({
     credentials,
     pages: { login, relier },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name == 'production',
+      'disabling until 123done is setup in prod'
+    );
     await relier.goto(`email=${credentials.email}`);
     await relier.clickForceAuth();
 
@@ -43,7 +47,7 @@ test.describe('OAuth force auth', () => {
     const blockedEmail = `blocked${Date.now()}@restmail.net`;
     await relier.goto(`email=${blockedEmail}`);
     await relier.clickForceAuth();
-    
+
     await expect(await login.getPrefilledEmail()).toMatch(blockedEmail);
     await login.setAge('21');
     await login.setNewPassword(credentials.password);

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -6,7 +6,7 @@ test.describe('OAuth force auth', () => {
     pages: { login, relier },
   }, { project }) => {
     test.skip(
-      project.name == 'production',
+      project.name === 'production',
       'disabling until 123done is setup in prod'
     );
     await relier.goto(`email=${credentials.email}`);

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -5,7 +5,11 @@ const PASSWORD = 'passwordzxcv';
 test.describe('OAuth `login_hint` and `email` param', () => {
   test('email specified by relier, invalid', async ({
     pages: { login, relier },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name == 'production',
+      'disabling until 123done is setup in prod'
+    );
     const invalidEmail = 'invalid@';
     await relier.goto(`email=${invalidEmail}`);
     await relier.clickEmailFirst();

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -7,7 +7,7 @@ test.describe('OAuth `login_hint` and `email` param', () => {
     pages: { login, relier },
   }, { project }) => {
     test.skip(
-      project.name == 'production',
+      project.name === 'production',
       'disabling until 123done is setup in prod'
     );
     const invalidEmail = 'invalid@';


### PR DESCRIPTION
## Because

- 2 oauth tests were failing in prod because 123done.org (prod site) was shut down : [oauthForceAuth](https://github.com/mozilla/fxa/blob/main/packages/functional-tests/tests/oauth/forceAuth.spec.ts) , [loginHint](https://github.com/mozilla/fxa/blob/main/packages/functional-tests/tests/oauth/loginHint.spec.ts)

## This pull request

- Disables the tests until the prod 123done site is set up again

## Issue that this pull request solves

Closes: [FXA-6399](https://mozilla-hub.atlassian.net/browse/FXA-6399)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
