### PR TITLE
chore(auth-server): cleanup lint warnings from non-null assertions

### DIFF
--- a/packages/fxa-auth-server/.eslintrc.json
+++ b/packages/fxa-auth-server/.eslintrc.json
@@ -4,6 +4,7 @@
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", {"vars": "all", "args": "none"}],
     "no-redeclare": "off",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-restricted-imports": ["error", {
       "patterns": [{

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1175,7 +1175,7 @@ export class AccountHandler {
       scope = { contains: () => true };
     } else {
       uid = auth.credentials.user;
-      scope = ScopeSet.fromArray(auth.credentials.scope!);
+      scope = ScopeSet.fromArray(auth.credentials.scope);
     }
 
     const res: Record<string, any> = {};

--- a/packages/fxa-auth-server/lib/routes/subscriptions/apple.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/apple.ts
@@ -101,7 +101,7 @@ export class AppleIapHandler {
       // once VPN migration is complete (FXA-5848).
       'profile:subscriptions',
     ];
-    const scope = ScopeSet.fromArray(auth.credentials.scope!);
+    const scope = ScopeSet.fromArray(auth.credentials.scope);
     if (!scopes.some((requiredScope) => scope.contains(requiredScope))) {
       throw error.invalidScopes();
     }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
@@ -15,7 +15,7 @@ export async function handleAuth(
   auth: AuthRequest['auth'],
   fetchEmail = false
 ) {
-  const scope = ScopeSet.fromArray(auth.credentials.scope!);
+  const scope = ScopeSet.fromArray(auth.credentials.scope);
   if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
@@ -36,7 +36,7 @@ export async function handleAuth(
 }
 
 export function handleUidAuth(auth: AuthRequest['auth']): string {
-  const scope = ScopeSet.fromArray(auth.credentials.scope!);
+  const scope = ScopeSet.fromArray(auth.credentials.scope);
   if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
@@ -44,7 +44,7 @@ export function handleUidAuth(auth: AuthRequest['auth']): string {
 }
 
 export function handleAuthScoped(auth: AuthRequest['auth'], scopes: string[]) {
-  const scope = ScopeSet.fromArray(auth.credentials.scope!);
+  const scope = ScopeSet.fromArray(auth.credentials.scope);
   for (const requiredScope of scopes) {
     if (!scope.contains(requiredScope)) {
       throw error.invalidScopes();

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -44,6 +44,11 @@ export interface AuthApp extends RequestApplicationState {
 }
 
 export interface AuthRequest extends Request {
+  auth: Request['auth'] & {
+    // AuthRequest will always have scopes present provided by
+    // the auth-oauth scheme
+    credentials: Request['auth']['credentials'] & { scope: string[] };
+  };
   // eslint-disable-next-line no-use-before-define
   log: AuthLogger;
   app: AuthApp;


### PR DESCRIPTION
## Because

* The initial PR (#14508) did not include the changes made in #14547 which included some non-null assertions.

## This pull request

* Fixes those non-null assertions plus upgrades the non-null assertion lint to an error rather than a warning.

## Issue that this pull request solves

Closes FXA-6137

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
