### PR TITLE
fix(Subscriptions): add tax to sub management

### DIFF
--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -34,9 +34,7 @@ export class SubscriptionManagementPage extends BaseLayout {
 
   getResubscriptionPrice() {
     return this.page
-      .locator(
-        '//html/body/div/div/div/div[2]/div/div/div/div/section[3]/div/div/div/div[1]/div[1]'
-      )
+      .locator('[data-testid="price-details-standalone"]')
       .textContent();
   }
 }

--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -12,7 +12,9 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
 ): invoiceDTO.FirstInvoicePreview {
   const invoicePreview: invoiceDTO.firstInvoicePreviewSchema = {
     subtotal: invoice.subtotal,
+    subtotal_excluding_tax: invoice.subtotal_excluding_tax,
     total: invoice.total,
+    total_excluding_tax: invoice.total_excluding_tax,
     line_items: invoice.lines.data.map((line) => ({
       amount: line.amount,
       currency: line.currency,
@@ -52,7 +54,10 @@ export function stripeInvoicesToSubsequentInvoicePreviewsDTO(
     const invoicePreview: invoiceDTO.subsequentInvoicePreview = {
       subscriptionId: invoice.subscription as string,
       period_start: invoice.period_end,
+      subtotal: invoice.subtotal,
+      subtotal_excluding_tax: invoice.subtotal_excluding_tax,
       total: invoice.total,
+      total_excluding_tax: invoice.total_excluding_tax,
     };
 
     if (invoice.total_tax_amounts.length > 0) {

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1002,6 +1002,7 @@ export class StripeHelper extends StripeHelperBase {
             couponDetails.discountAmount = total_discount_amounts[0].amount;
           }
         } catch (err) {
+          console.log('REINO');
           if (
             err instanceof error &&
             err.errno === error.ERRNO.INVALID_PROMOTION_CODE
@@ -1019,6 +1020,8 @@ export class StripeHelper extends StripeHelperBase {
           }
         }
       }
+
+      console.log({ couponDetails, verifiedPromotionAndCoupon });
 
       return {
         ...couponDetails,

--- a/packages/fxa-payments-server/.storybook/addons.js
+++ b/packages/fxa-payments-server/.storybook/addons.js
@@ -1,2 +1,3 @@
 import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
+import 'storybook-addon-mock/register';

--- a/packages/fxa-payments-server/.storybook/main.js
+++ b/packages/fxa-payments-server/.storybook/main.js
@@ -14,5 +14,8 @@ module.exports = {
         },
       },
     },
+    {
+      name: 'storybook-addon-mock/register',
+    },
   ],
 };

--- a/packages/fxa-payments-server/Gruntfile.js
+++ b/packages/fxa-payments-server/Gruntfile.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 module.exports = function (grunt) {
   const srcPaths = [
     // 'src/branding.ftl' is temporary

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -105,6 +105,7 @@
     "prettier": "^2.3.1",
     "redux-devtools-extension": "^2.13.9",
     "sinon": "^9.0.3",
+    "storybook-addon-mock": "2.4.1",
     "supertest": "^6.3.0",
     "tailwindcss": "^3.2.0",
     "ts-jest": "^29.0.0",

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -27,7 +27,7 @@ describe('PaymentErrorView test with l10n', () => {
   });
 
   it('renders as expected', () => {
-    const { queryByTestId, queryByAltText } = render(
+    const { queryByTestId } = render(
       <PaymentErrorView
         actionFn={() => {}}
         error={{ code: 'general-paypal-error' }}

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -59,8 +59,10 @@ const selectedPlan = {
 
 const invoicePreviewInclusiveTax: FirstInvoicePreview = {
   line_items: [],
-  subtotal: 885,
+  subtotal: 935,
+  subtotal_excluding_tax: 885,
   total: 935,
+  total_excluding_tax: 885,
   tax: {
     amount: 50,
     inclusive: true,
@@ -70,7 +72,9 @@ const invoicePreviewInclusiveTax: FirstInvoicePreview = {
 const invoicePreviewExclusiveTax: FirstInvoicePreview = {
   line_items: [],
   subtotal: 935,
+  subtotal_excluding_tax: 935,
   total: 985,
+  total_excluding_tax: 935,
   tax: {
     amount: 50,
     inclusive: false,

--- a/packages/fxa-payments-server/src/components/PriceDetails/en.ftl
+++ b/packages/fxa-payments-server/src/components/PriceDetails/en.ftl
@@ -1,0 +1,80 @@
+## Price details including tax
+## $priceAmount (Number) - The amount billed. It will be formatted as currency.
+## $taxAmount (Number) - The tax added on, not included in amount. It will be formatted as currency.
+
+price-details-no-tax = { $priceAmount }
+price-details-tax = { $priceAmount } + { $taxAmount } tax
+
+# $intervalCount (Number) - The interval between payments, in days.
+price-details-no-tax-day = { $intervalCount ->
+  [one] { $priceAmount } daily
+  *[other] { $priceAmount } every { $intervalCount } days
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } daily
+    *[other] { $priceAmount } every { $intervalCount } days
+  }
+# $intervalCount (Number) - The interval between payments, in weeks.
+price-details-no-tax-week = { $intervalCount ->
+  [one] { $priceAmount } weekly
+  *[other] { $priceAmount } every { $intervalCount } weeks
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } weekly
+    *[other] { $priceAmount } every { $intervalCount } weeks
+  }
+# $intervalCount (Number) - The interval between payments, in months.
+price-details-no-tax-month = { $intervalCount ->
+  [one] { $priceAmount } monthly
+  *[other] { $priceAmount } every { $intervalCount } months
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } monthly
+    *[other] { $priceAmount } every { $intervalCount } months
+  }
+# $intervalCount (Number) - The interval between payments, in years.
+price-details-no-tax-year = { $intervalCount ->
+  [one] { $priceAmount } yearly
+  *[other] { $priceAmount } every { $intervalCount } years
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } yearly
+    *[other] { $priceAmount } every { $intervalCount } years
+  }
+
+# $intervalCount (Number) - The interval between payments, in days.
+price-details-tax-day = { $intervalCount ->
+  [one] { $priceAmount } + { $taxAmount } tax daily
+  *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } days
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } + { $taxAmount } tax daily
+    *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } days
+  }
+# $intervalCount (Number) - The interval between payments, in weeks.
+price-details-tax-week = { $intervalCount ->
+  [one] { $priceAmount } + { $taxAmount } tax weekly
+  *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } weeks
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } + { $taxAmount } tax weekly
+    *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } weeks
+  }
+# $intervalCount (Number) - The interval between payments, in months.
+price-details-tax-month = { $intervalCount ->
+  [one] { $priceAmount } + { $taxAmount } tax monthly
+  *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } months
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } + { $taxAmount } tax monthly
+    *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } months
+  }
+# $intervalCount (Number) - The interval between payments, in years.
+price-details-tax-year = { $intervalCount ->
+  [one] { $priceAmount } + { $taxAmount } tax yearly
+  *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } years
+}
+  .title = { $intervalCount ->
+    [one] { $priceAmount } + { $taxAmount } tax yearly
+    *[other] { $priceAmount } + { $taxAmount } tax every { $intervalCount } years
+  }

--- a/packages/fxa-payments-server/src/components/PriceDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PriceDetails/index.stories.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { PriceDetails, PriceDetailsProps } from '.';
+import MockApp from '../../../.storybook/components/MockApp';
+import { SignInLayout } from '../AppLayout';
+
+import Stripe from 'stripe';
+
+export default {
+  title: 'components/PriceDetails',
+  component: PriceDetails,
+} as Meta;
+
+const defaultProps: PriceDetailsProps = {
+  total: 500,
+  currency: 'USD',
+};
+
+type PriceDetailsProps2 = {
+  total: number;
+  currency: string;
+  tax?: number;
+  showTax?: boolean;
+  interval?: Stripe.Plan.Interval;
+  intervalCount?: number;
+  className?: string;
+  dataTestId?: string;
+};
+
+const storyWithParams = ({
+  locale = 'en',
+  props,
+}: {
+  locale?: string;
+  props: PriceDetailsProps;
+}) => {
+  return () => {
+    return (
+      <MockApp languages={[locale || 'auto']}>
+        <SignInLayout>
+          <PriceDetails {...props} />
+        </SignInLayout>
+      </MockApp>
+    );
+  };
+};
+
+export const NoIntervalWithoutTax = storyWithParams({ props: defaultProps });
+
+export const NoIntervalWithTax = storyWithParams({
+  props: { ...defaultProps, tax: 123 },
+});
+
+export const IntervalOneWithoutTax = storyWithParams({
+  props: { ...defaultProps, interval: 'month', intervalCount: 1 },
+});
+
+export const IntervalMultipleWithoutTax = storyWithParams({
+  props: { ...defaultProps, interval: 'month', intervalCount: 6 },
+});
+
+export const IntervalOneWithTax = storyWithParams({
+  props: { ...defaultProps, tax: 123, interval: 'month', intervalCount: 1 },
+});
+
+export const IntervalMultipleWithTax = storyWithParams({
+  props: { ...defaultProps, tax: 123, interval: 'month', intervalCount: 6 },
+});
+
+export const NoIntervalWithTaxEuro = storyWithParams({
+  props: { ...defaultProps, currency: 'EUR', tax: 123 },
+});
+
+export const IntervalMultipleWithTaxGermany = storyWithParams({
+  locale: 'de',
+  props: {
+    ...defaultProps,
+    currency: 'EUR',
+    tax: 123,
+    interval: 'month',
+    intervalCount: 6,
+  },
+});
+
+export const IntervalMultipleWithStyling = storyWithParams({
+  locale: 'de',
+  props: {
+    ...defaultProps,
+    tax: 123,
+    interval: 'month',
+    intervalCount: 6,
+    className: 'font-semibold text-xl',
+  },
+});

--- a/packages/fxa-payments-server/src/components/PriceDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PriceDetails/index.test.tsx
@@ -1,0 +1,389 @@
+import { PriceDetails } from '.';
+
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+const defaultPriceDetailsProps = {
+  total: 2000,
+  currency: 'USD',
+};
+
+describe('PriceDetails', () => {
+  describe('PriceDetails component', () => {
+    it('renders NoInterval component', () => {
+      const subject = () => {
+        return render(<PriceDetails {...defaultPriceDetailsProps} />);
+      };
+
+      const { queryByTestId } = subject();
+      expect(queryByTestId('price-details-no-tax')).toBeInTheDocument();
+    });
+
+    it('renders Interval component', () => {
+      const subject = () => {
+        return render(
+          <PriceDetails
+            {...defaultPriceDetailsProps}
+            interval={'month'}
+            intervalCount={2}
+          />
+        );
+      };
+
+      const { queryByTestId } = subject();
+      expect(
+        queryByTestId('price-details-no-tax-interval')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('NoInterval', () => {
+    it('renders without tax', () => {
+      const subject = () => {
+        return render(<PriceDetails {...defaultPriceDetailsProps} />);
+      };
+
+      const { queryByTestId } = subject();
+      expect(queryByTestId('price-details-no-tax')).toBeInTheDocument();
+      expect(queryByTestId('price-details-no-tax')).toHaveTextContent('$20.00');
+    });
+
+    it('renders with tax with showTax set', () => {
+      const subject = () => {
+        return render(
+          <PriceDetails
+            {...defaultPriceDetailsProps}
+            tax={300}
+            showTax={true}
+          />
+        );
+      };
+
+      const { queryByTestId } = subject();
+      expect(queryByTestId('price-details-tax')).toBeInTheDocument();
+      expect(queryByTestId('price-details-tax')).toHaveTextContent(
+        '$20.00 + $3.00 tax'
+      );
+    });
+
+    it('renders with tax without showTax set', () => {
+      const subject = () => {
+        return render(<PriceDetails {...defaultPriceDetailsProps} tax={300} />);
+      };
+
+      const { queryByTestId } = subject();
+      expect(queryByTestId('price-details-tax')).toBeInTheDocument();
+      expect(queryByTestId('price-details-tax')).toHaveTextContent(
+        '$20.00 + $3.00 tax'
+      );
+    });
+
+    it('renders with tax, even though tax isnt provided', () => {
+      const subject = () => {
+        return render(
+          <PriceDetails {...defaultPriceDetailsProps} showTax={true} />
+        );
+      };
+
+      const { queryByTestId } = subject();
+      expect(queryByTestId('price-details-tax')).toBeInTheDocument();
+      expect(queryByTestId('price-details-tax')).toHaveTextContent(
+        '$20.00 + $0.00 tax'
+      );
+    });
+  });
+
+  describe('Interval', () => {
+    describe('Without tax', () => {
+      it('renders for one day', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'day'}
+              intervalCount={1}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 daily');
+      });
+
+      it('renders for multiple days', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'day'}
+              intervalCount={2}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 every 2 days');
+      });
+
+      it('renders for one week', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'week'}
+              intervalCount={1}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 weekly');
+      });
+
+      it('renders for multiple weeks', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'week'}
+              intervalCount={2}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 every 2 weeks');
+      });
+
+      it('renders for one month', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'month'}
+              intervalCount={1}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 monthly');
+      });
+
+      it('renders for multiple months', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'month'}
+              intervalCount={2}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 every 2 months');
+      });
+
+      it('renders for one year', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'year'}
+              intervalCount={1}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 yearly');
+      });
+
+      it('renders for multiple years', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'year'}
+              intervalCount={2}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-no-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 every 2 years');
+      });
+    });
+
+    describe('With tax', () => {
+      it('renders for one day', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'day'}
+              intervalCount={1}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 + $3.00 tax daily');
+      });
+
+      it('renders for multiple days', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'day'}
+              intervalCount={2}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent(
+          '$20.00 + $3.00 tax every 2 days'
+        );
+      });
+
+      it('renders for one week', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'week'}
+              intervalCount={1}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 + $3.00 tax weekly');
+      });
+
+      it('renders for multiple weeks', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'week'}
+              intervalCount={2}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent(
+          '$20.00 + $3.00 tax every 2 weeks'
+        );
+      });
+
+      it('renders for one month', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'month'}
+              intervalCount={1}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 + $3.00 tax monthly');
+      });
+
+      it('renders for multiple months', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'month'}
+              intervalCount={2}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent(
+          '$20.00 + $3.00 tax every 2 months'
+        );
+      });
+
+      it('renders for one year', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'year'}
+              intervalCount={1}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent('$20.00 + $3.00 tax yearly');
+      });
+
+      it('renders for multiple years', () => {
+        const subject = () => {
+          return render(
+            <PriceDetails
+              {...defaultPriceDetailsProps}
+              interval={'year'}
+              intervalCount={2}
+              tax={300}
+            />
+          );
+        };
+
+        const { queryByTestId } = subject();
+        const intervalText = queryByTestId('price-details-tax-interval');
+        expect(intervalText).toBeInTheDocument();
+        expect(intervalText).toHaveTextContent(
+          '$20.00 + $3.00 tax every 2 years'
+        );
+      });
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/components/PriceDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PriceDetails/index.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { Localized } from '@fluent/react';
+import {
+  formatPlanPricing,
+  getLocalizedCurrency,
+  getLocalizedCurrencyString,
+} from '../../lib/formats';
+import Stripe from 'stripe';
+
+export type PriceDetailsProps = {
+  total: number;
+  currency: string;
+  tax?: number;
+  showTax?: boolean;
+  interval?: Stripe.Plan.Interval;
+  intervalCount?: number;
+  className?: string;
+  dataTestId?: string;
+};
+
+const NoInterval = ({
+  total,
+  currency,
+  tax,
+  showTax,
+  className,
+  dataTestId,
+}: {
+  total: number;
+  currency: string;
+  tax?: number;
+  showTax?: boolean;
+  className?: string;
+  dataTestId?: string;
+}) => {
+  const defaultVars = {
+    priceAmount: getLocalizedCurrency(total, currency),
+  };
+  let vars = {};
+  let fallbackText: string;
+  let l10nId: string;
+  if (showTax) {
+    const taxAmount = tax || 0;
+    vars = {
+      ...defaultVars,
+      taxAmount: getLocalizedCurrency(taxAmount, currency),
+    };
+    l10nId = 'price-details-tax';
+    fallbackText = `${getLocalizedCurrencyString(
+      total,
+      currency
+    )} + ${getLocalizedCurrencyString(taxAmount, currency)} tax`;
+  } else {
+    vars = defaultVars;
+    l10nId = 'price-details-no-tax';
+    fallbackText = getLocalizedCurrencyString(total, currency);
+  }
+  return (
+    <Localized id={l10nId} vars={vars}>
+      <span
+        id="price-details"
+        className={className}
+        data-testid={dataTestId || l10nId}
+      >
+        {fallbackText}
+      </span>
+    </Localized>
+  );
+};
+
+const Interval = ({
+  total,
+  currency,
+  interval,
+  intervalCount,
+  tax,
+  showTax,
+  className,
+  dataTestId,
+}: {
+  total: number;
+  currency: string;
+  interval: Stripe.Plan.Interval;
+  intervalCount: number;
+  tax?: number;
+  showTax?: boolean;
+  className?: string;
+  dataTestId?: string;
+}) => {
+  const defaultVars = {
+    priceAmount: getLocalizedCurrency(total, currency),
+    intervalCount,
+  };
+  let vars = {};
+  let fallbackText: string;
+  let l10nId: string;
+  let testId: string;
+  if (showTax) {
+    const taxAmount = tax || 0;
+    vars = {
+      ...defaultVars,
+      taxAmount: getLocalizedCurrency(taxAmount, currency),
+    };
+    l10nId = `price-details-tax-${interval}`;
+    testId = dataTestId || 'price-details-tax-interval';
+    fallbackText = formatPlanPricing(
+      total,
+      currency,
+      interval,
+      intervalCount,
+      true,
+      taxAmount
+    );
+  } else {
+    vars = defaultVars;
+    l10nId = `price-details-no-tax-${interval}`;
+    testId = dataTestId || 'price-details-no-tax-interval';
+    fallbackText = formatPlanPricing(total, currency, interval, intervalCount);
+  }
+  return (
+    <Localized id={l10nId} attrs={{ title: true }} vars={vars}>
+      <span id="price-details" className={className} data-testid={testId}>
+        {fallbackText}
+      </span>
+    </Localized>
+  );
+};
+
+export const PriceDetails = (props: PriceDetailsProps) => {
+  // If a tax amount is provided, then the component will display the tax value, unless showTax is set to false.
+  // However if showTax is set to true, if no tax amount is provided, it will be set to 0, and the tax value will be shown.
+  const { showTax, tax } = props;
+  const calculatedShowTax = showTax === undefined && tax ? true : showTax;
+  if (props.interval && props.intervalCount) {
+    return (
+      <Interval
+        {...props}
+        interval={props.interval}
+        intervalCount={props.intervalCount}
+        showTax={calculatedShowTax}
+      />
+    );
+  } else {
+    return <NoInterval {...props} showTax={calculatedShowTax} />;
+  }
+};

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -418,7 +418,7 @@ export async function apiRetryInvoice(params: {
 
 export async function apiInvoicePreview(params: {
   priceId: string;
-  promotionCode: string;
+  promotionCode?: string;
 }): Promise<FirstInvoicePreview> {
   return apiFetch(
     'POST',

--- a/packages/fxa-payments-server/src/lib/format.test.ts
+++ b/packages/fxa-payments-server/src/lib/format.test.ts
@@ -1,4 +1,5 @@
 import {
+  formatPriceAmount,
   getLocalizedCurrency,
   getLocalizedCurrencyString,
   getLocalizedDate,
@@ -38,6 +39,29 @@ describe('format.ts', () => {
       it('returns a correctly formatted currency string given a null amount', () => {
         const expected = '$0.00';
         const actual = getLocalizedCurrencyString(null, 'USD');
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('formatPriceAmount', () => {
+      it('returns without tax', () => {
+        const expected = '$1.00';
+        const actual = formatPriceAmount(100, 'USD', false, null);
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('returns with tax', () => {
+        const expected = '$1.00 + $0.40 tax';
+        const actual = formatPriceAmount(100, 'USD', true, 40);
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('returns with tax, even though none is provided', () => {
+        const expected = '$1.00 + $0.00 tax';
+        const actual = formatPriceAmount(100, 'USD', true, null);
 
         expect(actual).toEqual(expected);
       });

--- a/packages/fxa-payments-server/src/lib/formats.ts
+++ b/packages/fxa-payments-server/src/lib/formats.ts
@@ -118,23 +118,43 @@ export function getLocalizedDateString(
  * The following functions are for creating fallback text for Subscription Intervals
  */
 
+export function formatPriceAmount(
+  amount: number | null,
+  currency: string,
+  showTax: boolean,
+  tax: number | null
+) {
+  return showTax
+    ? `${getLocalizedCurrencyString(
+        amount,
+        currency
+      )} + ${getLocalizedCurrencyString(tax, currency)} tax`
+    : getLocalizedCurrencyString(amount, currency);
+}
+
 /**
  * This is the base formatting to describe a plan's pricing:
  * Examples:
  *   '$2.00 daily'
  *   '$2.00 every 6 days'
+ *   '$2.00 + $0.45 tax daily'
+ *   '$2.00 + $0.45 tax every 6 days'
  * @param amount
  * @param currency
  * @param interval
  * @param intervalCount
+ * @param showTax
+ * @param tax
  */
 export function formatPlanPricing(
   amount: number | null,
   currency: string,
   interval: PlanInterval,
-  intervalCount: number
+  intervalCount: number,
+  showTax: boolean = false,
+  tax: number = 0
 ): string {
-  const formattedAmount = getLocalizedCurrencyString(amount, currency);
+  const formattedAmount = formatPriceAmount(amount, currency, showTax, tax);
   switch (interval) {
     case 'day':
       if (intervalCount === 1) return `${formattedAmount} daily`;

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -277,7 +277,9 @@ export const INVOICE_PREVIEW_WITHOUT_DISCOUNT: FirstInvoicePreview = {
     },
   ],
   subtotal: 500,
+  subtotal_excluding_tax: null,
   total: 500,
+  total_excluding_tax: null,
 };
 
 export const INVOICE_PREVIEW_WITH_VALID_DISCOUNT: FirstInvoicePreview = {
@@ -290,7 +292,9 @@ export const INVOICE_PREVIEW_WITH_VALID_DISCOUNT: FirstInvoicePreview = {
     },
   ],
   subtotal: 500,
+  subtotal_excluding_tax: null,
   total: 450,
+  total_excluding_tax: null,
   discount: {
     amount: 50,
     amount_off: null,
@@ -345,7 +349,9 @@ export const INVOICE_PREVIEW_WITH_100_VALID_DISCOUNT: FirstInvoicePreview = {
     },
   ],
   subtotal: 500,
+  subtotal_excluding_tax: null,
   total: 0,
+  total_excluding_tax: null,
   discount: {
     amount: 500,
     amount_off: null,
@@ -363,7 +369,9 @@ export const INVOICE_PREVIEW_WITH_INVALID_DISCOUNT: FirstInvoicePreview = {
     },
   ],
   subtotal: 500,
+  subtotal_excluding_tax: null,
   total: 25,
+  total_excluding_tax: null,
   discount: {
     amount: 475,
     amount_off: 475,

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -17,9 +17,13 @@ import { Customer, Plan, Profile, Token } from '../../src/store/types';
 import {
   MozillaSubscription,
   MozillaSubscriptionTypes,
+  WebSubscription,
 } from 'fxa-shared/subscriptions/types';
 import { MemoryRouter } from 'react-router-dom';
-import { SubsequentInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import {
+  FirstInvoicePreview,
+  SubsequentInvoicePreview,
+} from 'fxa-shared/dto/auth/payments/invoice';
 
 declare global {
   namespace NodeJS {
@@ -617,12 +621,70 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
   {
     subscriptionId: 'sub0.28964929339372136',
     period_start: 1565816388.815,
+    subtotal: 500,
+    subtotal_excluding_tax: null,
     total: 500,
+    total_excluding_tax: null,
   },
   {
     subscriptionId: 'sub0.21234123424',
     period_start: 1565816388.815,
+    subtotal: 0,
+    subtotal_excluding_tax: null,
     total: 0,
+    total_excluding_tax: null,
+  },
+  // 2 - With Exclusive tax
+  {
+    subscriptionId: 'sub0.28964929339372136',
+    period_start: 1565816388.815,
+    subtotal: 500,
+    subtotal_excluding_tax: 500,
+    total: 623,
+    total_excluding_tax: 500,
+    tax: {
+      amount: 123,
+      inclusive: false,
+    },
+  },
+  // 3 - With Inclusive tax
+  {
+    subscriptionId: 'sub0.28964929339372136',
+    period_start: 1565816388.815,
+    subtotal: 500,
+    subtotal_excluding_tax: 377,
+    total: 500,
+    total_excluding_tax: 377,
+    tax: {
+      amount: 123,
+      inclusive: true,
+    },
+  },
+  // 4 - With Exclusive tax and Discount
+  {
+    subscriptionId: 'sub0.28964929339372136',
+    period_start: 1565816388.815,
+    subtotal: 500,
+    subtotal_excluding_tax: 500,
+    total: 573,
+    total_excluding_tax: 450,
+    tax: {
+      amount: 123,
+      inclusive: false,
+    },
+  },
+  // 5 - With Inclusive tax and Discount
+  {
+    subscriptionId: 'sub0.28964929339372136',
+    period_start: 1565816388.815,
+    subtotal: 500,
+    subtotal_excluding_tax: 377,
+    total: 450,
+    total_excluding_tax: 327,
+    tax: {
+      amount: 123,
+      inclusive: true,
+    },
   },
 ];
 
@@ -689,6 +751,128 @@ export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION = {
     },
   ],
 };
+
+const customerWebSubscriptionPlanId = (
+  MOCK_CUSTOMER.subscriptions[0] as WebSubscription
+).plan_id;
+
+export const MOCK_PREVIEW_INVOICE_NO_TAX: FirstInvoicePreview = {
+  total: 2000,
+  total_excluding_tax: null,
+  subtotal: 2000,
+  subtotal_excluding_tax: null,
+  line_items: [
+    {
+      amount: 2000,
+      currency: 'USD',
+      id: customerWebSubscriptionPlanId,
+      name: 'first invoice',
+    },
+  ],
+};
+
+export const MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION: FirstInvoicePreview = {
+  total: 2000,
+  total_excluding_tax: null,
+  subtotal: 2000,
+  subtotal_excluding_tax: null,
+  line_items: [
+    {
+      amount: 2000,
+      currency: 'USD',
+      id: PLAN_ID,
+      name: 'first invoice',
+    },
+  ],
+};
+
+export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE: FirstInvoicePreview = {
+  total: 2300,
+  total_excluding_tax: 2000,
+  subtotal: 2000,
+  subtotal_excluding_tax: 2000,
+  line_items: [
+    {
+      amount: 2000,
+      currency: 'USD',
+      id: customerWebSubscriptionPlanId,
+      name: 'first invoice',
+    },
+  ],
+  tax: {
+    amount: 300,
+    inclusive: false,
+  },
+};
+
+export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE: FirstInvoicePreview = {
+  total: 2000,
+  total_excluding_tax: 1700,
+  subtotal: 2000,
+  subtotal_excluding_tax: 1700,
+  line_items: [
+    {
+      amount: 2000,
+      currency: 'USD',
+      id: customerWebSubscriptionPlanId,
+      name: 'first invoice',
+    },
+  ],
+  tax: {
+    amount: 300,
+    inclusive: true,
+  },
+};
+
+export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT: FirstInvoicePreview =
+  {
+    total: 1950,
+    total_excluding_tax: 1650,
+    subtotal: 2000,
+    subtotal_excluding_tax: 1700,
+    line_items: [
+      {
+        amount: 2000,
+        currency: 'USD',
+        id: customerWebSubscriptionPlanId,
+        name: 'first invoice',
+      },
+    ],
+    tax: {
+      amount: 300,
+      inclusive: true,
+    },
+    discount: {
+      amount: 50,
+      amount_off: 50,
+      percent_off: null,
+    },
+  };
+
+export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT: FirstInvoicePreview =
+  {
+    total: 2250,
+    total_excluding_tax: 1950,
+    subtotal: 2000,
+    subtotal_excluding_tax: 2000,
+    line_items: [
+      {
+        amount: 2000,
+        currency: 'USD',
+        id: customerWebSubscriptionPlanId,
+        name: 'first invoice',
+      },
+    ],
+    tax: {
+      amount: 300,
+      inclusive: false,
+    },
+    discount: {
+      amount: 50,
+      amount_off: 50,
+      percent_off: null,
+    },
+  };
 
 export function getLocalizedMessage(
   bundle: FluentBundle,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/en.ftl
@@ -11,27 +11,3 @@ sub-item-cancel-msg =
 sub-item-cancel-confirm =
     Cancel my access and my saved information within
     { $name } on { $period }
-
-## Subscription billing details
-## $amount (Number) - The amount billed. It will be formatted as currency.
-
-#  $intervalCount (Number) - The interval between payments, in days.
-sub-plan-price-day = { $intervalCount ->
-  [one] { $amount } daily
-  *[other] { $amount } every { $intervalCount } days
-}
-#  $intervalCount (Number) - The interval between payments, in weeks.
-sub-plan-price-week = { $intervalCount ->
-  [one] { $amount } weekly
-  *[other] { $amount } every { $intervalCount } weeks
-}
-#  $intervalCount (Number) - The interval between payments, in months.
-sub-plan-price-month = { $intervalCount ->
-  [one] { $amount } monthly
-  *[other] { $amount } every { $intervalCount } months
-}
-#  $intervalCount (Number) - The interval between payments, in years.
-sub-plan-price-year = { $intervalCount ->
-  [one] { $amount } yearly
-  *[other] { $amount } every { $intervalCount } years
-}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -16,7 +16,10 @@ import CancelSubscriptionPanel from './Cancel/CancelSubscriptionPanel';
 import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 import { PaymentProvider } from 'fxa-payments-server/src/lib/PaymentProvider';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
-import { SubsequentInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import {
+  FirstInvoicePreview,
+  SubsequentInvoicePreview,
+} from 'fxa-shared/dto/auth/payments/invoice';
 
 export type SubscriptionItemProps = {
   customerSubscription: WebSubscription;
@@ -26,6 +29,7 @@ export type SubscriptionItemProps = {
   customer: Customer;
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
   subsequentInvoice: SubsequentInvoicePreview | undefined;
+  invoicePreview: FirstInvoicePreview | undefined;
 };
 
 export const SubscriptionItem = ({
@@ -36,10 +40,11 @@ export const SubscriptionItem = ({
   plan,
   customerSubscription,
   subsequentInvoice,
+  invoicePreview,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
-  const total = subsequentInvoice && subsequentInvoice.total;
-  const period_start = subsequentInvoice && subsequentInvoice.period_start;
+  const total = subsequentInvoice?.total;
+  const period_start = subsequentInvoice?.period_start;
 
   const paymentProvider: PaymentProvider | undefined =
     customer?.payment_provider;
@@ -104,6 +109,33 @@ export const SubscriptionItem = ({
     );
   }
 
+  if (!invoicePreview) {
+    const ariaLabelledBy = 'invoice-preview-not-found-header';
+    const ariaDescribedBy = 'invoice-preview-not-found-description';
+    return (
+      <DialogMessage
+        className="dialog-error"
+        onDismiss={locationReload}
+        headerId={ariaLabelledBy}
+        descId={ariaDescribedBy}
+      >
+        <Localized id="sub-invoice-preview-error-title">
+          <h4
+            id={ariaLabelledBy}
+            data-testid="error-subhub-missing-invoice-preview"
+          >
+            Invoice preview not found
+          </h4>
+        </Localized>
+        <Localized id="sub-invoice-preview-error-text">
+          <p id={ariaDescribedBy}>
+            Invoice preview not found for this subscription
+          </p>
+        </Localized>
+      </DialogMessage>
+    );
+  }
+
   return (
     <section className="settings-unit" aria-labelledby={labelId}>
       <div className="subscription" data-testid="subscription-item">
@@ -122,8 +154,8 @@ export const SubscriptionItem = ({
               plan,
               paymentProvider,
               promotionCode,
-              subsequentInvoiceAmount: total,
-              subsequentInvoiceDate: period_start,
+              subsequentInvoice,
+              invoicePreview,
             }}
           />
         ) : (

--- a/packages/fxa-payments-server/src/routes/Subscriptions/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/en.ftl
@@ -20,6 +20,8 @@ sub-customer-error =
 sub-invoice-error =
   .title = Problem loading invoices
 sub-billing-update-success = Your billing information has been updated successfully
+sub-invoice-previews-error-title = Problem loading invoice previews
+sub-invoice-previews-error-text = Could not load invoice previews
 
 ## Routes - Subscription - ActionButton
 
@@ -27,9 +29,13 @@ pay-update-change-btn = Change
 pay-update-manage-btn = Manage
 
 ## Routes - Subscriptions - Cancel and IapItem
+## $priceAmount (Number) - The amount billed. It will be formatted as currency.
+## $taxAmount (Number) - The tax added on, not included in amount. It will be formatted as currency.
 ## $date (Date) - The date for the next time a charge will occur.
 
 sub-next-bill = Next billed on { $date }
+sub-next-bill-no-tax = Your next bill of <strong>{ $priceAmount }</strong> is due <strong>{ $date }</strong>
+sub-next-bill-tax = Your next bill of <strong>{ $priceAmount } + { $taxAmount }</strong> tax is due <strong>{ $date }</strong>
 sub-expires-on = Expires on { $date }
 
 ## Routes - Subscription - PaymentUpdate
@@ -47,6 +53,8 @@ sub-route-funding-source-payment-alert = Invalid payment information; there is a
 sub-item-no-such-plan = No such plan for this subscription.
 invoice-not-found = Subsequent invoice not found
 sub-item-no-such-subsequent-invoice = Subsequent invoice not found for this subscription.
+sub-invoice-preview-error-title = Invoice preview not found
+sub-invoice-preview-error-text = Invoice preview not found for this subscription
 
 ## Routes - Subscriptions - Pocket Subscription
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -1,5 +1,11 @@
 // React looks unused here, but we need it for Storybook.
-import React, { useEffect, useContext, useCallback, useRef } from 'react';
+import React, {
+  useEffect,
+  useContext,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { connect } from 'react-redux';
 import { Localized } from '@fluent/react';
@@ -37,9 +43,13 @@ import {
 import {
   MozillaSubscription,
   WebSubscription,
+  MozillaSubscriptionTypes,
 } from 'fxa-shared/subscriptions/types';
 import SubscriptionIapItem from './SubscriptionIapItem/SubscriptionIapItem';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { apiInvoicePreview } from '../../lib/apiClient';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import { couponOnSubsequentInvoice } from '../../lib/coupon';
 
 export type SubscriptionsProps = {
   profile: SelectorReturns['profile'];
@@ -76,6 +86,12 @@ export const Subscriptions = ({
 }: SubscriptionsProps) => {
   const { accessToken, config, locationReload, navigateToUrl } =
     useContext(AppContext);
+
+  const [subscriptionPreviews, setSubscriptionPreviews] = useState<
+    FirstInvoicePreview[]
+  >([]);
+  const [subscriptionPreviewsLoading, setSubscriptionPreviewsLoading] =
+    useState(false);
 
   if (!accessToken) {
     window.location.href = `${config.servers.content.url}/subscriptions`;
@@ -145,12 +161,50 @@ export const Subscriptions = ({
     [navigateToUrl, SUPPORT_FORM_URL]
   );
 
+  useEffect(() => {
+    const fetchSubscriptionPreviews = async () => {
+      if (customerSubscriptions?.length) {
+        setSubscriptionPreviewsLoading(true);
+        try {
+          const subs = await Promise.all(
+            customerSubscriptions
+              .filter(
+                (sub) => sub._subscription_type === MozillaSubscriptionTypes.WEB
+              )
+              .map(async (sub) => {
+                const webSub = sub as WebSubscription;
+                const usePromotionCode = couponOnSubsequentInvoice(
+                  webSub.current_period_end,
+                  webSub.promotion_end,
+                  webSub.promotion_duration
+                );
+                return apiInvoicePreview({
+                  priceId: webSub.plan_id,
+                  promotionCode: usePromotionCode
+                    ? webSub.promotion_code
+                    : undefined,
+                });
+              })
+          );
+          setSubscriptionPreviews(subs);
+        } catch (error) {
+          setSubscriptionPreviews([]);
+        } finally {
+          setSubscriptionPreviewsLoading(false);
+        }
+      }
+    };
+
+    fetchSubscriptionPreviews();
+  }, [customerSubscriptions]);
+
   if (
     !accessToken ||
     customer.loading ||
     profile.loading ||
     plans.loading ||
-    subsequentInvoices.loading
+    subsequentInvoices.loading ||
+    subscriptionPreviewsLoading
   ) {
     return <LoadingOverlay isLoading={true} />;
   }
@@ -227,6 +281,29 @@ export const Subscriptions = ({
     customerSubscriptions.find(
       (s) => isWebSubscription(s) && !s.cancel_at_period_end
     );
+
+  if (activeWebSubscription && subscriptionPreviews?.length <= 0) {
+    const ariaLabelledBy = 'invoice-previews-not-found-header';
+    const ariaDescribedBy = 'invoice-previews-not-found-description';
+    return (
+      <DialogMessage
+        className="dialog-error"
+        onDismiss={locationReload}
+        headerId={ariaLabelledBy}
+        descId={ariaDescribedBy}
+      >
+        <Localized id="sub-invoice-previews-error-title">
+          <h4 id={ariaLabelledBy} data-testid="error-loading-invoice-previews">
+            Problem loading invoice previews
+          </h4>
+        </Localized>
+        <Localized id="sub-invoice-previews-error-text">
+          <p id={ariaDescribedBy}>Could not load invoice previews</p>
+        </Localized>
+      </DialogMessage>
+    );
+  }
+
   const showPaymentUpdateForm =
     customer && customer.result && activeWebSubscription;
   const planId =
@@ -373,6 +450,12 @@ export const Subscriptions = ({
                         invoice.subscriptionId ===
                         customerSubscription.subscription_id
                     )}
+                    invoicePreview={subscriptionPreviews.find((preview) => {
+                      return preview.line_items.some(
+                        (lineItem) =>
+                          lineItem.id === customerSubscription.plan_id
+                      );
+                    })}
                     {...{
                       customer: customer.result,
                       cancelSubscription,

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -28,7 +28,9 @@ export interface InvoiceDiscount {
 export interface FirstInvoicePreview {
   line_items: InvoiceLineItem[];
   subtotal: number;
+  subtotal_excluding_tax: number | null;
   total: number;
+  total_excluding_tax: number | null;
   tax?: InvoiceTax;
   discount?: InvoiceDiscount;
 }
@@ -48,7 +50,9 @@ export const firstInvoicePreviewSchema = joi.object({
     )
     .required(),
   subtotal: joi.number().required(),
+  subtotal_excluding_tax: joi.number().required().allow(null),
   total: joi.number().required(),
+  total_excluding_tax: joi.number().required().allow(null),
   tax: joi.object({
     amount: joi.number().required(),
     inclusive: joi.boolean().required(),
@@ -70,7 +74,9 @@ type line_item = {
 export type firstInvoicePreviewSchema = {
   line_items: Array<line_item>;
   subtotal: number;
+  subtotal_excluding_tax: number | null;
   total: number;
+  total_excluding_tax: number | null;
   tax?: {
     amount: number;
     inclusive: boolean;
@@ -89,7 +95,10 @@ export type firstInvoicePreviewSchema = {
 export interface SubsequentInvoicePreview {
   subscriptionId: string;
   period_start: number;
+  subtotal: number;
+  subtotal_excluding_tax: number | null;
   total: number;
+  total_excluding_tax: number | null;
   tax?: InvoiceTax;
 }
 
@@ -97,7 +106,10 @@ export const subsequentInvoicePreviewsSchema = joi.array().items(
   joi.object({
     subscriptionId: joi.string().required(),
     period_start: joi.number().required(),
+    subtotal: joi.number().required(),
+    subtotal_excluding_tax: joi.number().required().allow(null),
     total: joi.number().required(),
+    total_excluding_tax: joi.number().required().allow(null),
     tax: joi.object({
       amount: joi.number().required(),
       inclusive: joi.boolean().required(),
@@ -108,7 +120,10 @@ export const subsequentInvoicePreviewsSchema = joi.array().items(
 export type subsequentInvoicePreview = {
   subscriptionId: string;
   period_start: number;
+  subtotal: number;
+  subtotal_excluding_tax: number | null;
   total: number;
+  total_excluding_tax: number | null;
   tax?: {
     amount: number;
     inclusive: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,6 +3372,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.0.0-rc.0":
+  version: 7.20.6
+  resolution: "@babel/runtime@npm:7.20.6"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 42a8504db21031b1859fbc0f52d698a3d2f5ada9519eb76c6f96a7e657d8d555732a18fe71ef428a67cc9fc81ca0d3562fb7afdc70549c5fec343190cbaa9b03
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.12.1":
   version: 7.17.9
   resolution: "@babel/runtime@npm:7.17.9"
@@ -8151,6 +8160,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:^6.2.9":
+  version: 6.5.14
+  resolution: "@storybook/addons@npm:6.5.14"
+  dependencies:
+    "@storybook/api": 6.5.14
+    "@storybook/channels": 6.5.14
+    "@storybook/client-logger": 6.5.14
+    "@storybook/core-events": 6.5.14
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/router": 6.5.14
+    "@storybook/theming": 6.5.14
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 99d06641bab06a3cc2821f309589d062c0efd8707b451ae24017449034da408bfddce3beda1ccdedadf59669d7d13348bee127f6fd4fc057200c84ff43288312
+  languageName: node
+  linkType: hard
+
 "@storybook/api@npm:6.3.12":
   version: 6.3.12
   resolution: "@storybook/api@npm:6.3.12"
@@ -8207,6 +8238,34 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 49e01f35fa6de776329407533c0449aac84bbc9404bf717b1cebff5dc8961618956d7ba0003361c4e6cdc24e898619f778fea15db5a30eb320fc73a4b53adb40
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:6.5.14, @storybook/api@npm:^6.2.9":
+  version: 6.5.14
+  resolution: "@storybook/api@npm:6.5.14"
+  dependencies:
+    "@storybook/channels": 6.5.14
+    "@storybook/client-logger": 6.5.14
+    "@storybook/core-events": 6.5.14
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/router": 6.5.14
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.5.14
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^6.0.8
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 0d421c3211a49cb8910dea647b898edd60af79755108ed321626a8fc134713dd1b018c830f15c2fc6c863f0528b571c2e2b34bb79df3c2f43497f5ab36fa9bbf
   languageName: node
   linkType: hard
 
@@ -8537,6 +8596,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:6.5.14":
+  version: 6.5.14
+  resolution: "@storybook/channels@npm:6.5.14"
+  dependencies:
+    core-js: ^3.8.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: ff1ee3fea3c7b8591280ba7eabe13c999fc3e12a483ff2c0467cc9cca027662cbbc4676438da567865919157521df8a9a50bd20b35daed6896f39a3a7251a1e5
+  languageName: node
+  linkType: hard
+
 "@storybook/channels@npm:6.5.9":
   version: 6.5.9
   resolution: "@storybook/channels@npm:6.5.9"
@@ -8659,6 +8729,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/client-logger@npm:6.5.14":
+  version: 6.5.14
+  resolution: "@storybook/client-logger@npm:6.5.14"
+  dependencies:
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: 29cc0b58db7a8dc90484320c86b386975580c0e534791b29f6a8c00ce5b156f2bff9513994202f9f9ef99787e8d793988048ae88d2780ba151c6782f3bbf97ff
+  languageName: node
+  linkType: hard
+
 "@storybook/client-logger@npm:6.5.9":
   version: 6.5.9
   resolution: "@storybook/client-logger@npm:6.5.9"
@@ -8741,6 +8821,25 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: f14ee528a44b77c7a362696ef7506678ed656ce53dde3a5207c2391addc5307f9e6f5b21d869e31a864bf8edc8d1a037f3f8793ddf6191a97d92684ef940b6f2
+  languageName: node
+  linkType: hard
+
+"@storybook/components@npm:^6.2.9":
+  version: 6.5.14
+  resolution: "@storybook/components@npm:6.5.14"
+  dependencies:
+    "@storybook/client-logger": 6.5.14
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/theming": 6.5.14
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 73d0ff418f2c5b1fc9f421f089ebee2342ef0684905e4959397a8bc6f67f32ff97f4ec3587847980cb7e4fc8e40278d8ecea11a8d267fea8d94ad3d8265a0c21
   languageName: node
   linkType: hard
 
@@ -9051,6 +9150,15 @@ __metadata:
   dependencies:
     core-js: ^3.8.2
   checksum: 89139f3f34a4ea0f2bbc02ebaa2968664cdc17abd88cc2e0467a0dfb1c11577e85fa402e5804fe4d6a99edd696d365abf93d30c396fc177563478cdbb68bcb85
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:6.5.14":
+  version: 6.5.14
+  resolution: "@storybook/core-events@npm:6.5.14"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: 6787925c520a6ee5aee748d4b7e2ec599c5ee16a87dbb62a94eeec88003ef42683d8e7ac8b98b49ea2a33205e0648805410c4759d16a997ba2f4215f6c8784ce
   languageName: node
   linkType: hard
 
@@ -9930,6 +10038,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/router@npm:6.5.14":
+  version: 6.5.14
+  resolution: "@storybook/router@npm:6.5.14"
+  dependencies:
+    "@storybook/client-logger": 6.5.14
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ec2550568c02f45de5307e77928eaeb39413049944e994adbc397d9c7e083ac7e110886e40517ddae40e3879c172f458167682f1d73d0bb150bc93ab9dd61514
+  languageName: node
+  linkType: hard
+
 "@storybook/router@npm:6.5.9":
   version: 6.5.9
   resolution: "@storybook/router@npm:6.5.9"
@@ -10106,6 +10230,21 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 2082d7847785a307a18eb605282468d844af01f57752916766a60047b5543cf6f0c6664b9c7a693809b4fdc121415989c2170833d3de7ca8b07fa056741787d0
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.5.14":
+  version: 6.5.14
+  resolution: "@storybook/theming@npm:6.5.14"
+  dependencies:
+    "@storybook/client-logger": 6.5.14
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: d139325dd51e8dfa58458a5c033104123b019fc02ddc899898e02de2b5d1358fd318b5def7ef82e6138420f9198e90d50b0fdfbea926987ac6852fc3a2e77c6d
   languageName: node
   linkType: hard
 
@@ -25547,6 +25686,7 @@ fsevents@~2.1.1:
     redux-thunk: ^2.4.1
     serve-static: ^1.14.2
     sinon: ^9.0.3
+    storybook-addon-mock: 2.4.1
     supertest: ^6.3.0
     tailwindcss: ^3.2.0
     ts-jest: ^29.0.0
@@ -34822,6 +34962,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"mock-xmlhttprequest@npm:^7.0.3":
+  version: 7.0.4
+  resolution: "mock-xmlhttprequest@npm:7.0.4"
+  checksum: 64a6fca2094c167a63b387f59d00401f1a804d77a3b257f79f939160f3d3bc0a2a693ec6fcc5502861e7d9ba41d9dab5c052d628adae242efdcf92a675b60c8f
+  languageName: node
+  linkType: hard
+
 "module-deps@npm:^4.0.2":
   version: 4.1.1
   resolution: "module-deps@npm:4.1.1"
@@ -37218,6 +37365,13 @@ fsevents@~2.1.1:
   version: 2.4.0
   resolution: "path-to-regexp@npm:2.4.0"
   checksum: 581175bf2968e51452f2b8c71f10e75c995693668b4ecf7d0b48962fbe0c56830661ca5dd5fd6d8e2f0cc9a045ce07e89af504ab133e1d21887c2712df85b1f4
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "path-to-regexp@npm:6.2.1"
+  checksum: f0227af8284ea13300f4293ba111e3635142f976d4197f14d5ad1f124aebd9118783dd2e5f1fe16f7273743cc3dbeddfb7493f237bb27c10fdae07020cc9b698
   languageName: node
   linkType: hard
 
@@ -40182,6 +40336,18 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"react-json-editor-ajrm@npm:^2.5.13":
+  version: 2.5.13
+  resolution: "react-json-editor-ajrm@npm:2.5.13"
+  dependencies:
+    "@babel/runtime": ^7.0.0-rc.0
+  peerDependencies:
+    react: ">=16.2.0"
+    react-dom: ">=16.2.0"
+  checksum: 44fa7557a5b35b96cebfa639083817c9a4fa775e58347daf8a331bf83b15ba64ee5634ea07fdef889b007bd6df9aa878ec007d1e1a1dad8249299abdee302ca5
+  languageName: node
+  linkType: hard
+
 "react-lifecycles-compat@npm:^3.0.4":
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
@@ -40952,6 +41118,13 @@ fsevents@~2.1.1:
   version: 0.11.1
   resolution: "regenerator-runtime@npm:0.11.1"
   checksum: 3c97bd2c7b2b3247e6f8e2147a002eb78c995323732dad5dc70fac8d8d0b758d0295e7015b90d3d444446ae77cbd24b9f9123ec3a77018e81d8999818301b4f4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
   languageName: node
   linkType: hard
 
@@ -43711,6 +43884,23 @@ resolve@^2.0.0-next.3:
   version: 2.12.0
   resolution: "store2@npm:2.12.0"
   checksum: dd4184a677b11e5efc304b910d08f43e2b0ea018930a4e5ac407cb3472f08a6d42004c43b5f249c7299ba9cfd05cbe1eed998ea3f3388d2ca0f0650a6efb5dc4
+  languageName: node
+  linkType: hard
+
+"storybook-addon-mock@npm:2.4.1":
+  version: 2.4.1
+  resolution: "storybook-addon-mock@npm:2.4.1"
+  dependencies:
+    "@storybook/addons": ^6.2.9
+    "@storybook/api": ^6.2.9
+    "@storybook/components": ^6.2.9
+    mock-xmlhttprequest: ^7.0.3
+    path-to-regexp: ^6.2.0
+    react-json-editor-ajrm: ^2.5.13
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 7a8c4e6c2fada845f4c56f6f848bf0dfb7f9ab4375fb443dab064b4ed883356e12547f9a5174cefbae8a8b8809f3934c23ff72018a0293c8bcec453357b16d32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- For exclusive tax, display the tax amount in subscription management

## This pull request

- Adds a new component, PriceDetails, that can be used to display the
  price with/out tax, and price intervals with/out tax.
- Adds PriceDetails component to Subscription Management, and updates
  the copy used.

## Issue that this pull request solves

Closes: #FXA-6187

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
