### PR TITLE
chore(auth/shared): differentiate free trials in AppStoreSubscriptionPurchases

### DIFF
--- a/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
@@ -104,6 +104,8 @@ export class AppStoreSubscriptionPurchase {
   private offerType?: OfferType;
   private offerIdentifier?: string;
   private purchaseDate?: number;
+  private renewalOfferType?: OfferType;
+  private renewalOfferIdentifier?: string;
   private revocationDate?: number;
   private revocationReason?: number;
 
@@ -151,11 +153,20 @@ export class AppStoreSubscriptionPurchase {
     if (transactionInfo.hasOwnProperty('isUpgraded')) {
       purchase.isUpgraded = transactionInfo.isUpgraded;
     }
+    // Some offers (like introductory free trials) only apply to the current
+    // billing period. In these cases, the offerType and (if applicable)
+    // offerIdentifier would only be on transactionInfo, not renewalInfo.
+    if (transactionInfo.offerIdentifier) {
+      purchase.offerIdentifier = transactionInfo.offerIdentifier;
+    }
+    if (transactionInfo.offerType) {
+      purchase.offerType = transactionInfo.offerType;
+    }
     if (renewalInfo.offerIdentifier) {
-      purchase.offerIdentifier = renewalInfo.offerIdentifier;
+      purchase.renewalOfferIdentifier = renewalInfo.offerIdentifier;
     }
     if (renewalInfo.offerType) {
-      purchase.offerType = renewalInfo.offerType;
+      purchase.renewalOfferType = renewalInfo.offerType;
     }
     if (transactionInfo.purchaseDate) {
       purchase.purchaseDate = transactionInfo.purchaseDate;


### PR DESCRIPTION
Because:

* offerType and offerIdentifier can exist on both transactionInfo and/or renewalInfo.
* We were only recording these properties on renewalInfo.

This commit:

* Records offerType and offerIdentifier on both transactionInfo and renewalInfo and differentiates them.

Closes #FXA-6108

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
