### PR TITLE
fix(test): Use playwright locator when expecting to navigate

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -263,14 +263,14 @@ export class LoginPage extends BaseLayout {
 
   async submit() {
     return Promise.all([
-      this.page.click(selectors.SUBMIT),
+      this.page.locator(selectors.SUBMIT).click(),
       this.page.waitForNavigation({ waitUntil: 'load' }),
     ]);
   }
 
   async clickForgotPassword() {
     return Promise.all([
-      this.page.click(selectors.LINK_RESET_PASSWORD),
+      this.page.locator(selectors.LINK_RESET_PASSWORD).click(),
       this.page.waitForNavigation({ waitUntil: 'networkidle' }),
     ]);
   }
@@ -327,7 +327,7 @@ export class LoginPage extends BaseLayout {
 
   async clickDontHaveRecoveryKey() {
     return Promise.all([
-      this.page.click(selectors.LINK_LOST_RECOVERY_KEY),
+      this.page.locator(selectors.LINK_LOST_RECOVERY_KEY).click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -29,14 +29,14 @@ export class RelierPage extends BaseLayout {
 
   clickEmailFirst() {
     return Promise.all([
-      this.page.click('button.email-first-button'),
+      this.page.locator('button.email-first-button').click(),
       this.page.waitForNavigation({ waitUntil: 'load' }),
     ]);
   }
 
   clickForceAuth() {
     return Promise.all([
-      this.page.click('button.force-auth'),
+      this.page.locator('button.force-auth').click(),
       this.page.waitForNavigation({ waitUntil: 'load' }),
     ]);
   }

--- a/packages/functional-tests/pages/settings/avatar.ts
+++ b/packages/functional-tests/pages/settings/avatar.ts
@@ -29,7 +29,7 @@ export class AvatarPage extends SettingsLayout {
 
   clickSave() {
     return Promise.all([
-      this.page.click('[data-testid=save-button]'),
+      this.page.locator('[data-testid=save-button]').click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/settings/changePassword.ts
+++ b/packages/functional-tests/pages/settings/changePassword.ts
@@ -39,8 +39,9 @@ export class ChangePasswordPage extends SettingsLayout {
   }
 
   async validPasswordLength() {
-    const error = this.page.locator('[data-testid=change-password-length]',
-      { has: this.page.locator('[data-testid=icon-unset]') });
+    const error = this.page.locator('[data-testid=change-password-length]', {
+      has: this.page.locator('[data-testid=icon-unset]'),
+    });
     error.locator(':scope', { hasText: 'At least 8 characters' });
     await error.waitFor();
     return error.isVisible();
@@ -79,7 +80,7 @@ export class ChangePasswordPage extends SettingsLayout {
 
   submit() {
     return Promise.all([
-      this.page.click('button[type=submit]'),
+      this.page.locator('button[type=submit]').click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -6,7 +6,7 @@ export class UnitRow {
 
   protected clickCta() {
     return Promise.all([
-      this.page.click(`[data-testid=${this.id}-unit-row-route]`),
+      this.page.locator(`[data-testid=${this.id}-unit-row-route]`).click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/settings/displayName.ts
+++ b/packages/functional-tests/pages/settings/displayName.ts
@@ -17,7 +17,7 @@ export class DisplayNamePage extends SettingsLayout {
 
   submit() {
     return Promise.all([
-      this.page.click('button[type=submit]'),
+      this.page.locator('button[type=submit]').click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -60,7 +60,7 @@ export class SettingsPage extends SettingsLayout {
 
   clickDeleteAccount() {
     return Promise.all([
-      this.page.click('[data-testid=settings-delete-account]'),
+      this.page.locator('[data-testid=settings-delete-account]').click(),
       this.page.waitForNavigation(),
     ]);
   }
@@ -99,7 +99,7 @@ export class SettingsPage extends SettingsLayout {
 
   clickPaidSubscriptions() {
     return Promise.all([
-      this.page.click('[data-testid=nav-link-subscriptions]'),
+      this.page.locator('[data-testid=nav-link-subscriptions]').click(),
       this.page.waitForNavigation({ waitUntil: 'networkidle' }),
     ]);
   }

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -47,11 +47,13 @@ export abstract class SettingsLayout extends BaseLayout {
   }
 
   clickAvatarIcon() {
-    return this.page.click('[data-testid=drop-down-avatar-menu-toggle]');
+    return this.page
+      .locator('[data-testid=drop-down-avatar-menu-toggle]')
+      .click();
   }
 
   clickSignOut() {
-    return this.page.click('[data-testid=avatar-menu-sign-out]');
+    return this.page.locator('[data-testid=avatar-menu-sign-out]').click();
   }
 
   clickSignIn() {

--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -28,17 +28,16 @@ export class RecoveryKeyPage extends SettingsLayout {
     return this.page.click('.lost-recovery-key');
   }
 
-
   submit() {
     return Promise.all([
-      this.page.click('button[type=submit]'),
+      this.page.locator('button[type=submit]').click(),
       this.page.waitForResponse(/recoveryKey$/),
     ]);
   }
 
   clickClose() {
     return Promise.all([
-      this.page.click('[data-testid=close-button]'),
+      this.page.locator('[data-testid=close-button]').click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -14,7 +14,7 @@ export class SecondaryEmailPage extends SettingsLayout {
 
   submit() {
     return Promise.all([
-      this.page.click('button[type=submit]'),
+      this.page.locator('button[type=submit]').click(),
       this.page.waitForNavigation(),
     ]);
   }

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -43,7 +43,7 @@ export class TotpPage extends SettingsLayout {
 
   clickClose() {
     return Promise.all([
-      this.page.click('[data-testid=close-button]'),
+      this.page.locator('[data-testid=close-button]').click(),
       this.page.waitForNavigation(),
     ]);
   }


### PR DESCRIPTION
## Because

- I think we might need to use playwright `Locator` if clicking an element navigates. Using the `click` directly on the page might be causing the `Page is closed` type errors.

## This pull request

- Uses locator and then clicking when pages navigates

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
