### PR TITLE
fix(test): Update 123Done production urls

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -75,7 +75,7 @@ $(document).ready(function () {
         pwdlessURL: pwdlessPaymentURL.stage,
       };
       break;
-    case '123done-prod.dev.lcip.org':
+    case 'stage-123done.herokuapp.com':
       paymentConfig = {
         env: 'prod',
         contentEnv: contentURL.prod,

--- a/packages/functional-tests/lib/targets/production.ts
+++ b/packages/functional-tests/lib/targets/production.ts
@@ -5,7 +5,7 @@ export class ProductionTarget extends RemoteTarget {
   static readonly target = 'production';
   readonly name: TargetName = ProductionTarget.target;
   readonly contentServerUrl = 'https://accounts.firefox.com';
-  readonly relierUrl = 'https://123done.org';
+  readonly relierUrl = 'https://production-123done.herokuapp.com/';
 
   constructor() {
     super('https://api.accounts.firefox.com');

--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -19,7 +19,6 @@ test.describe('severity-1', () => {
     credentials,
     pages: { page, relier, login },
   }, { project }) => {
-    test.skip(project.name === 'production', 'no 123done relier in prod');
     await relier.goto('prompt=consent');
     await relier.clickEmailFirst();
     await login.login(credentials.email, credentials.password);

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -36,7 +36,6 @@ test.describe('severity-1 #smoke', () => {
     pages: { relier, login, settings },
     target,
   }, { project }) => {
-    test.skip(project.name === 'production', 'no 123done in production');
     await relier.goto();
     await relier.clickEmailFirst();
 


### PR DESCRIPTION
## Because

- We now have 123Done in production env

## This pull request

- Updates urls to point to that
- Enables test that use it

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6301

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] 
## Other information (Optional)

@ashrivastava-qa I tested this and it is working as expected. The production 123Done client is https://production-123done.herokuapp.com/

I am fairly certain that the subplat tests will fail since the product info might not be valid? But maybe we can enable those later once ready.
