### PR TITLE
feat(gql): add acct sign in thru gql-api

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -526,5 +526,36 @@ describe('AccountResolver', () => {
         });
       });
     });
+
+    describe('signIn', () => {
+      it('calls auth-client and proxy the result', async () => {
+        const now = Date.now();
+        const headers = new Headers();
+        const mockRespPayload = {
+          clientMutationId: 'testid',
+          uid: '1337',
+          sessionToken: '2048',
+          verified: true,
+          authAt: now,
+          metricsEnabled: true,
+        };
+        authClient.signInWithAuthPW = jest
+          .fn()
+          .mockResolvedValue(mockRespPayload);
+        const result = await resolver.signIn(headers, {
+          authPW: '00000000',
+          email: 'testo@example.xyz',
+          options: {},
+        });
+        expect(authClient.signInWithAuthPW).toBeCalledTimes(1);
+        expect(authClient.signInWithAuthPW).toBeCalledWith(
+          '00000000',
+          'testo@example.xyz',
+          {},
+          headers
+        );
+        expect(result).toStrictEqual(mockRespPayload);
+      });
+    });
   });
 });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -53,6 +53,7 @@ import {
 } from './dto/input';
 import { DeleteAvatarInput } from './dto/input/delete-avatar';
 import { MetricsOptInput } from './dto/input/metrics-opt';
+import { SignInInput } from './dto/input/sign-in';
 import {
   BasicPayload,
   ChangeRecoveryCodesPayload,
@@ -65,6 +66,7 @@ import {
   PasswordForgotCodeStatusPayload,
   AccountResetPayload,
 } from './dto/payload';
+import { SignedInAccountPayload } from './dto/payload/signed-in-account';
 import { CatchGatewayError } from './lib/error';
 import { Account as AccountType } from './model/account';
 
@@ -484,6 +486,27 @@ export class AccountResolver {
       input.options,
       headers
     );
+  }
+
+  @Mutation((returns) => SignedInAccountPayload, {
+    description: 'Call auth-server to sign in an account',
+  })
+  @CatchGatewayError
+  public async signIn(
+    @GqlXHeaders() headers: Headers,
+    @Args('input', { type: () => SignInInput })
+    input: SignInInput
+  ): Promise<SignedInAccountPayload> {
+    const result = await this.authAPI.signInWithAuthPW(
+      input.authPW,
+      input.email,
+      input.options,
+      headers
+    );
+    return {
+      clientMutationId: input.clientMutationId,
+      ...result,
+    };
   }
 
   @ResolveField()

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -1,23 +1,25 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-export { EmailInput } from './email';
-export { UpdateAvatarInput } from './update-avatar';
-export { UpdateDisplayNameInput } from './update-display-name';
-export { CreateTotpInput } from './create-totp';
+
 export { AttachedClientDisconnectInput } from './attached-client-disconnect';
 export { ChangeRecoveryCodesInput } from './change-recovery-codes';
-export { DeleteTotpInput } from './delete-totp';
-export { VerifyTotpInput } from './verify-totp';
-export { VerifyEmailInput } from './verify-email';
-export { SendSessionVerificationInput } from './send-session-verification';
-export { VerifySessionInput } from './verify-session';
-export { DeleteRecoveryKeyInput } from './delete-recovery-key';
-export { DestroySessionInput } from './destroy-session';
 export { CreatePassword } from './create-password';
+export { CreateTotpInput } from './create-totp';
+export { DeleteRecoveryKeyInput } from './delete-recovery-key';
+export { DeleteTotpInput } from './delete-totp';
+export { DestroySessionInput } from './destroy-session';
+export { EmailInput } from './email';
 export {
+  AccountResetInput,
+  PasswordForgotCodeStatusInput,
   PasswordForgotSendCodeInput,
   PasswordForgotVerifyCodeInput,
-  PasswordForgotCodeStatusInput,
-  AccountResetInput,
 } from './password-forgot';
+export { SendSessionVerificationInput } from './send-session-verification';
+export { SignInInput } from './sign-in';
+export { UpdateAvatarInput } from './update-avatar';
+export { UpdateDisplayNameInput } from './update-display-name';
+export { VerifyEmailInput } from './verify-email';
+export { VerifySessionInput } from './verify-session';
+export { VerifyTotpInput } from './verify-totp';

--- a/packages/fxa-graphql-api/src/gql/dto/input/sign-in.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/sign-in.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, InputType } from '@nestjs/graphql';
+import { MetricsContext } from './metrics-context';
+
+@InputType()
+export class SignInOptionsInput {
+  @Field({ nullable: true })
+  public keys?: boolean;
+
+  @Field({ nullable: true })
+  public service?: string;
+
+  @Field({ nullable: true })
+  public reason?: string;
+
+  @Field({ nullable: true })
+  public redirectTo?: string;
+
+  @Field({ nullable: true })
+  public resume?: string;
+
+  @Field({ nullable: true })
+  public verificationMethod?: string;
+
+  @Field({ nullable: true })
+  public unblockCode?: string;
+
+  @Field((type) => MetricsContext, { nullable: true })
+  public metricsContext?: MetricsContext;
+}
+
+@InputType()
+export class SignInInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public authPW!: hexstring;
+
+  @Field()
+  public email!: string;
+
+  @Field()
+  public options!: SignInOptionsInput;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -1,15 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export { BasicPayload } from './basic';
-export { UpdateAvatarPayload } from './update-avatar';
-export { UpdateDisplayNamePayload } from './update-display-name';
 export { ChangeRecoveryCodesPayload } from './change-recovery-codes';
 export { CreateTotpPayload } from './create-totp';
-export { VerifyTotpPayload } from './verify-totp';
 export {
+  AccountResetPayload,
+  PasswordForgotCodeStatusPayload,
   PasswordForgotSendCodePayload,
   PasswordForgotVerifyCodePayload,
-  PasswordForgotCodeStatusPayload,
-  AccountResetPayload,
 } from './password-forgot';
+export { SignedInAccountPayload } from './signed-in-account';
+export { UpdateAvatarPayload } from './update-avatar';
+export { UpdateDisplayNamePayload } from './update-display-name';
+export { VerifyTotpPayload } from './verify-totp';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/signed-in-account.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/signed-in-account.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class SignedInAccountPayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public uid!: hexstring;
+
+  @Field()
+  public sessionToken!: hexstring;
+
+  @Field()
+  verified!: boolean;
+
+  @Field()
+  authAt!: number;
+
+  @Field()
+  metricsEnabled!: boolean;
+
+  @Field({ nullable: true })
+  keyFetchToken?: hexstring;
+
+  @Field({ nullable: true })
+  verificationMethod?: string;
+
+  @Field({ nullable: true })
+  verificationReason?: string;
+}


### PR DESCRIPTION
Because:
 - we might want to sign in through the gql-api instead of auth-server

This commit:
 - add a mutation to proxy a sign in request to the auth-server
