### PR TITLE
[subplat] test(subplat): resubscribe with same coupon after canceling

### DIFF
--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -16,6 +16,7 @@ import { SignInPage } from './signin';
 import { SigninTokenCodePage } from './signinTokenCode';
 import { SubscribePage } from './products';
 import { TotpPage } from './settings/totp';
+import { SubsciptionManagementPage } from './products/subscriptionManagement';
 
 export function create(page: Page, target: BaseTarget) {
   return {
@@ -36,5 +37,6 @@ export function create(page: Page, target: BaseTarget) {
     signinTokenCode: new SigninTokenCodePage(page, target),
     subscribe: new SubscribePage(page, target),
     totp: new TotpPage(page, target),
+    subscriptionManagement: new SubsciptionManagementPage(page, target),
   };
 }

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -16,7 +16,7 @@ import { SignInPage } from './signin';
 import { SigninTokenCodePage } from './signinTokenCode';
 import { SubscribePage } from './products';
 import { TotpPage } from './settings/totp';
-import { SubsciptionManagementPage } from './products/subscriptionManagement';
+import { SubscriptionManagementPage } from './products/subscriptionManagement';
 
 export function create(page: Page, target: BaseTarget) {
   return {

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -37,6 +37,6 @@ export function create(page: Page, target: BaseTarget) {
     signinTokenCode: new SigninTokenCodePage(page, target),
     subscribe: new SubscribePage(page, target),
     totp: new TotpPage(page, target),
-    subscriptionManagement: new SubsciptionManagementPage(page, target),
+    subscriptionManagement: new SubscriptionManagementPage(page, target),
   };
 }

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -281,6 +281,10 @@ export class LoginPage extends BaseLayout {
     });
   }
 
+  async clickSignIn() {
+    return this.page.locator(this.selectors.SUBMIT_USER_SIGNED_IN).click();
+  }
+
   async isSyncConnectedHeader() {
     return this.page.isVisible(selectors.SYNC_CONNECTED_HEADER, {
       timeout: 100,

--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -104,6 +104,10 @@ export class SubscribePage extends BaseLayout {
     return disc.isVisible();
   }
 
+  getTotalPrice() {
+    return this.page.locator('[data-testid="total-price"]').textContent();
+  }
+
   async discountTextbox() {
     const discount = this.page.locator(
       '.coupon-component:has-text("Promo Code")'

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -1,6 +1,6 @@
 import { BaseLayout } from '../layout';
 
-export class SubsciptionManagementPage extends BaseLayout {
+export class SubscriptionManagementPage extends BaseLayout {
   readonly path = '/subscription';
 
   async cancelSubscription() {

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -1,0 +1,42 @@
+import { BaseLayout } from '../layout';
+
+export class SubsciptionManagementPage extends BaseLayout {
+  readonly path = '/subscription';
+
+  async cancelSubscription() {
+    return Promise.all([
+      await this.page
+        .locator('[data-testid="reveal-cancel-subscription-button"]')
+        .click(),
+      await this.page
+        .locator('[data-testid="confirm-cancel-subscription-checkbox"]')
+        .click(),
+      await this.page
+        .locator('[data-testid="cancel-subscription-button"]')
+        .click(),
+      await this.page.locator('[data-testid="dialog-dismiss"]').click(),
+    ]);
+  }
+
+  async resubscribe() {
+    return Promise.all([
+      await this.page
+        .locator('[data-testid="reactivate-subscription-button"]')
+        .click(),
+      await this.page
+        .locator('[data-testid="reactivate-subscription-confirm-button"]')
+        .click(),
+      await this.page
+        .locator('[data-testid="reactivate-subscription-success-button"]')
+        .click(),
+    ]);
+  }
+
+  getResubscriptionPrice() {
+    return this.page
+      .locator(
+        '//html/body/div/div/div/div[2]/div/div/div/div/section[3]/div/div/div/div[1]/div[1]'
+      )
+      .textContent();
+  }
+}

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -97,10 +97,11 @@ export class SettingsPage extends SettingsLayout {
     return emailPage;
   }
 
-  clickPaidSubscriptions() {
-    return Promise.all([
-      this.page.click('[data-testid=nav-link-subscriptions]'),
-      this.page.waitForNavigation({ waitUntil: 'networkidle' }),
+  async clickPaidSubscriptions() {
+    const [subscriptionPage] = await Promise.all([
+      this.page.context().waitForEvent('page'),
+      this.page.locator('[data-testid=nav-link-subscriptions]').click(),
     ]);
+    return subscriptionPage;
   }
 }


### PR DESCRIPTION
## Because

- In efforts to reduce the manual testing on Subplat coupon, added automated tests for the [Manual Test](https://testrail.stage.mozaws.net/index.php?/cases/view/1716624&group_by=cases:section_id&group_id=252171&group_order=asc)
- The test is to re-subscribe with the same coupon after canceling the subscription.

## This pull request

- Contains test for re-subscription with the same coupon after canceling the subscription.

## Issue that this pull request solves

Closes: #[FXA-6159](https://mozilla-hub.atlassian.net/browse/FXA-6159)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
