### PR TITLE
fix(settings): Disable 'strict' mode by default

### DIFF
--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -53,7 +53,7 @@ export function getDefault() {
   return {
     env: 'development',
     l10n: {
-      strict: true,
+      strict: false,
     },
     marketingEmailPreferencesUrl: 'https://basket.mozilla.org/fxa/',
     metrics: {


### PR DESCRIPTION
## Because

- This was throwing an error on stage.

## This pull request

- Disables strict mode by default.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Note this PR was due to an error encountered on stage. The error looked like this:

![image](https://user-images.githubusercontent.com/94418270/206524314-e9c0926f-dd4e-4801-aa4d-be701701f01b.png)


## Other information (Optional)

Note, this mode should still be manually enabled during testing, and when developing locally. A follow up PR will be issued for this.
