### PR TITLE
feat(gql): add session status query

### DIFF
--- a/packages/fxa-graphql-api/src/gql/model/session.ts
+++ b/packages/fxa-graphql-api/src/gql/model/session.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Field, ObjectType } from '@nestjs/graphql';
+import { SessionVerifiedState } from 'fxa-shared/db/models/auth/session-token';
 
 @ObjectType({ description: 'Session (token) info' })
 export class Session {
@@ -9,4 +10,17 @@ export class Session {
     description: 'Whether the current session is verified',
   })
   public verified!: boolean;
+}
+
+@ObjectType({ description: 'Session status' })
+export class SessionStatus {
+  @Field({
+    description: 'uid of the account',
+  })
+  public uid!: string;
+
+  @Field({
+    description: 'Whether the current session is verified',
+  })
+  public state!: SessionVerifiedState;
 }

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -55,4 +55,9 @@ describe('AccountResolver', () => {
     const result = resolver.session('uid', 'verified');
     expect(result).toStrictEqual({ verified: true });
   });
+
+  it('returns the session status', () => {
+    const result = resolver.sessionStatus('42420000', 'verified');
+    expect(result).toStrictEqual({ state: 'verified', uid: '42420000' });
+  });
 });

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -4,6 +4,7 @@
 import { Inject, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import AuthClient from 'fxa-auth-client';
+import { SessionVerifiedState } from 'fxa-shared/db/models/auth/session-token';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
@@ -12,7 +13,7 @@ import { AuthClientService } from '../backend/auth-client.service';
 import { GqlSessionToken, GqlUserId, GqlUserState } from '../decorators';
 import { DestroySessionInput } from './dto/input';
 import { BasicPayload } from './dto/payload';
-import { Session as SessionType } from './model/session';
+import { Session as SessionType, SessionStatus } from './model/session';
 
 @Resolver((of: any) => SessionType)
 export class SessionResolver {
@@ -43,5 +44,14 @@ export class SessionResolver {
     return {
       verified: state === 'verified',
     } as SessionType;
+  }
+
+  @Query((returns) => SessionStatus)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  public sessionStatus(
+    @GqlUserId() uid: hexstring,
+    @GqlUserState() state: SessionVerifiedState
+  ): SessionStatus {
+    return { state, uid };
   }
 }

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -24,6 +24,7 @@ const VERIFICATION_METHOD = {
 } as const;
 
 export type VerificationMethod = keyof typeof VERIFICATION_METHOD;
+export type SessionVerifiedState = 'verified' | 'unverified';
 
 /** Session Token
  *
@@ -255,11 +256,11 @@ export class SessionToken extends BaseToken {
     return notExpired(token) ? token : null;
   }
 
-  static async findByUid(uid: string, limit= 500): Promise<SessionToken[]> {
+  static async findByUid(uid: string, limit = 500): Promise<SessionToken[]> {
     const { rows } = await this.callProcedure(
       Proc.Sessions,
       uuidTransformer.to(uid),
-      limit,
+      limit
     );
     if (!rows.length) {
       return [];


### PR DESCRIPTION
Because:
 - a front end client should able to query the status of a session

This commit:
 - add the sessionStatus query to the Session resolver
