### PR TITLE
feat(api): Add accountStatus check in graphql api

### DIFF
--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -66,8 +66,9 @@ module.exports = (printLogs) => {
             console.log(`Notification email: ${template}`);
           } else {
             console.error('\x1B[31mNo verify code match\x1B[39m');
+            console.error(mail);
           }
-          console.error(mail);
+
           if (users[name]) {
             users[name].push(mail);
           } else {

--- a/packages/fxa-graphql-api/src/gql/dto/input/account-status.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/account-status.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class AccountStatusInput {
+  @Field({ description: 'The uid to apply this operation to.', nullable: true })
+  public uid?: string;
+
+  @Field({
+    description: 'The token id to apply this operation to.',
+    nullable: true,
+  })
+  public token?: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -23,3 +23,4 @@ export { UpdateDisplayNameInput } from './update-display-name';
 export { VerifyEmailInput } from './verify-email';
 export { VerifySessionInput } from './verify-session';
 export { VerifyTotpInput } from './verify-totp';
+export { AccountStatusInput } from './account-status';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/account-status.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/account-status.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class AccountStatusPayload {
+  @Field({ description: 'Whether or not the account exists' })
+  public exists!: boolean;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -15,3 +15,4 @@ export { SignedInAccountPayload } from './signed-in-account';
 export { UpdateAvatarPayload } from './update-avatar';
 export { UpdateDisplayNamePayload } from './update-display-name';
 export { VerifyTotpPayload } from './verify-totp';
+export { AccountStatusPayload } from './account-status';

--- a/packages/fxa-graphql-api/test/sessions.sql
+++ b/packages/fxa-graphql-api/test/sessions.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `sessionTokens` (
+  `tokenId` binary(32) NOT NULL,
+  `tokenData` binary(32) NOT NULL,
+  `uid` binary(16) NOT NULL,
+  `createdAt` bigint unsigned NOT NULL,
+  `uaBrowser` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `uaBrowserVersion` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `uaOS` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `uaOSVersion` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `uaDeviceType` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `lastAccessTime` bigint unsigned NOT NULL DEFAULT '0',
+  `uaFormFactor` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `authAt` bigint unsigned DEFAULT NULL,
+  `verificationMethod` int DEFAULT NULL,
+  `verifiedAt` bigint DEFAULT NULL,
+  `mustVerify` tinyint(1) DEFAULT '1',
+  PRIMARY KEY (`tokenId`),
+  KEY `session_uid` (`uid`),
+  KEY `sessionTokens_createdAt` (`createdAt`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
## Because

- We want to expose this functionality in graphql

## This pull request

- Adds the eqalivent `GET /account/status` endpoint in graphql

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6332

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
