### PR TITLE
storybook(fxa-settings): Recreate CompleteResetPassword in React

### DIFF
--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -134,7 +134,7 @@ export const InputText = ({
       {errorText && (
         <Tooltip
           type="error"
-          anchorStart={anchorStart}
+          {...{ anchorStart }}
           className="-mb-px"
           message={errorText}
         />

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/en.ftl
@@ -1,0 +1,25 @@
+## CompleteResetPassword component
+
+# The user followed a password reset link, but that link is expired and no longer valid
+complete-reset-pw-link-expired-header = Reset password link expired
+complete-reset-pw-link-expired-message = The link you clicked to reset your password is expired.
+# Button to request a new link to reset password if the previous link was expired
+complete-reset-pw-resend-link = Receive new link
+
+# The user followed a password reset link that was received by email
+# but the link is damaged (for example mistyped or broken by the email client)
+complete-reset-pw-link-damaged-header = Reset password link damaged
+# The user followed a "reset password" link received by email.
+complete-reset-pw-link-damaged-message = The link you clicked was missing characters, and may have been broken by your email client. Copy the address carefully, and try again.
+
+# User followed a password reset link and is now prompted to create a new password
+complete-reset-pw-header = Create new password
+reset-password-warning-message = <span>Remember:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and { product-pocket } data will not be affected.
+# This information message is followed by a form to create a new password.
+complete-reset-password-account-recovery-info = You have successfully restored your account using your account recovery key. Create a new password to secure your data, and store it in a safe location.
+# A new password was successfully set for the user's account
+# Displayed in an alert bar
+complete-reset-password-success-alert = Password set
+# An error occured while attempting to set a new password (password reset flow)
+# Displayed in an alert bar
+complete-reset-password-error-alert = Sorry, there was a problem setting your password

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/index.stories.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import AppLayout from '../../components/AppLayout';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+import CompleteResetPassword, { CompleteResetPasswordProps } from '.';
+
+export default {
+  title: 'pages/CompleteResetPassword',
+  component: CompleteResetPassword,
+} as Meta;
+
+const storyWithProps = (props?: CompleteResetPasswordProps) => {
+  const story = () => (
+    <LocationProvider>
+      <AppLayout>
+        <CompleteResetPassword {...props} />
+      </AppLayout>
+    </LocationProvider>
+  );
+  return story;
+};
+
+export const Default = storyWithProps();
+
+export const ValidLinkWithSyncWarning = storyWithProps({
+  showSyncWarning: true,
+});
+
+export const ValidLinkWithAccountRecoveryInfo = storyWithProps({
+  showAccountRecoveryInfo: true,
+});
+
+export const WithExpiredLink = storyWithProps({ isLinkExpired: true });
+
+export const WithDamagedLink = storyWithProps({ isLinkDamaged: true });

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/index.test.tsx
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { mockAppContext, renderWithRouter } from '../../models/mocks';
+import { AppContext, AlertBarInfo } from '../../models';
+import CompleteResetPassword from '.';
+import { usePageViewEvent } from '../../lib/metrics';
+
+jest.mock('../../lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useNavigate: () => mockNavigate,
+}));
+
+const alertBarInfo = {
+  success: jest.fn(),
+  error: jest.fn(),
+} as unknown as AlertBarInfo;
+
+describe('CompleteResetPassword', () => {
+  it('renders the component as expected when the link is valid', () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ alertBarInfo })}>
+        <CompleteResetPassword />
+      </AppContext.Provider>
+    );
+
+    const createNewPasswordHeader = screen.getByRole('heading', {
+      name: 'Create new password',
+    });
+    const passwordRequirements = screen.getByText('Password requirements');
+    const newPasswordField = screen.getByLabelText('Enter new password');
+    const confirmNewPasswordField = screen.getByLabelText(
+      'Confirm new password'
+    );
+    const currentPwField = screen.queryByLabelText('Enter current password');
+    const passwordSaveButton = screen.getByRole('button', { name: 'Save' });
+    const rememberPassword = screen.getByRole('link', {
+      name: 'Remember your password? Sign in',
+    });
+
+    expect(createNewPasswordHeader).toBeInTheDocument();
+    expect(passwordRequirements).toBeInTheDocument();
+    expect(currentPwField).not.toBeInTheDocument();
+    expect(newPasswordField).toBeInTheDocument();
+    expect(confirmNewPasswordField).toBeInTheDocument();
+    expect(passwordSaveButton).toBeInTheDocument();
+    expect(rememberPassword).toBeInTheDocument();
+  });
+
+  it('renders the component as expected when provided with an expired link', () => {
+    render(<CompleteResetPassword isLinkExpired={true} />);
+
+    const expiredLinkHeader = screen.getByRole('heading', {
+      name: 'Reset password link expired',
+    });
+    const expiredLinkMessage = screen.getByText(
+      'The link you clicked to reset your password is expired.'
+    );
+    const receiveNewLink = screen.getByRole('button', {
+      name: 'Receive new link',
+    });
+    const passwordResetWarning = screen.queryByText(
+      'When you reset your password, you reset your account.'
+    );
+    const passwordRequirements = screen.queryByText('Password requirements');
+    const newPasswordField = screen.queryByLabelText('Enter new password');
+
+    expect(expiredLinkHeader).toBeInTheDocument();
+    expect(expiredLinkMessage).toBeInTheDocument();
+    expect(receiveNewLink).toBeInTheDocument();
+    expect(passwordResetWarning).not.toBeInTheDocument();
+    expect(passwordRequirements).not.toBeInTheDocument();
+    expect(newPasswordField).not.toBeInTheDocument();
+  });
+
+  it('renders the component as expected when provided with a damaged link', () => {
+    render(<CompleteResetPassword isLinkDamaged={true} />);
+
+    const damagedLinkHeader = screen.getByRole('heading', {
+      name: 'Reset password link damaged',
+    });
+    const damagedLinkMessage = screen.getByText(
+      'The link you clicked was missing characters, and may have been broken by your email client. Copy the address carefully, and try again.'
+    );
+    const passwordResetWarning = screen.queryByText(
+      'When you reset your password, you reset your account.'
+    );
+    const passwordRequirements = screen.queryByText('Password requirements');
+    const newPasswordField = screen.queryByLabelText('Enter new password');
+    const receiveNewLink = screen.queryByRole('button', {
+      name: 'Receive new link',
+    });
+
+    expect(damagedLinkHeader).toBeInTheDocument();
+    expect(damagedLinkMessage).toBeInTheDocument();
+    expect(receiveNewLink).not.toBeInTheDocument();
+    expect(passwordResetWarning).not.toBeInTheDocument();
+    expect(passwordRequirements).not.toBeInTheDocument();
+    expect(newPasswordField).not.toBeInTheDocument();
+  });
+
+  it('emits the expected metrics on render', async () => {
+    render(<CompleteResetPassword />);
+    expect(usePageViewEvent).toHaveBeenCalledWith('complete-reset-password', {
+      entrypoint_variation: 'react',
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/index.tsx
@@ -1,0 +1,188 @@
+import React, { useCallback, useState } from 'react';
+import { RouteComponentProps, useNavigate } from '@reach/router';
+import { useForm } from 'react-hook-form';
+import { HomePath } from '../../constants';
+import { usePageViewEvent } from '../../lib/metrics';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { useFtlMsgResolver } from '../../models/hooks';
+import { useAccount, useAlertBar } from '../../models';
+import WarningMessage from '../../components/WarningMessage';
+import FormPassword from '../../components/Settings/FormPassword';
+import LinkRememberPassword from '../../components/LinkRememberPassword';
+
+export type CompleteResetPasswordProps = {
+  email?: string;
+  forceEmail?: string;
+  isLinkExpired?: boolean;
+  isLinkDamaged?: boolean;
+  showSyncWarning?: boolean;
+  showAccountRecoveryInfo?: boolean;
+};
+
+type FormData = {
+  newPassword: string;
+  confirmPassword: string;
+};
+
+const CompleteResetPassword = ({
+  email,
+  forceEmail,
+  isLinkExpired,
+  isLinkDamaged,
+  showSyncWarning,
+  showAccountRecoveryInfo,
+}: CompleteResetPasswordProps & RouteComponentProps) => {
+  usePageViewEvent('complete-reset-password', {
+    entrypoint_variation: 'react',
+  });
+
+  const resendLinkHandler = () => {
+    //   TODO: add resend link action
+  };
+
+  const { handleSubmit, register, getValues, errors, formState, trigger } =
+    useForm<FormData>({
+      mode: 'onTouched',
+      criteriaMode: 'all',
+      defaultValues: {
+        newPassword: '',
+        confirmPassword: '',
+      },
+    });
+  const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
+
+  const alertBar = useAlertBar();
+  const account = useAccount();
+  const navigate = useNavigate();
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const alertSuccessAndGoHome = useCallback(() => {
+    const successCompletePwdReset = ftlMsgResolver.getMsg(
+      'complete-reset-password-success-alert',
+      'Password set'
+    );
+    alertBar.success(successCompletePwdReset);
+    navigate(HomePath + '#password', { replace: true });
+  }, [alertBar, ftlMsgResolver, navigate]);
+
+  const onFormSubmit = useCallback(
+    async ({ newPassword }: FormData) => {
+      try {
+        // TODO: add logic to set a new password
+        alertSuccessAndGoHome();
+      } catch (e) {
+        // TODO metrics event for error
+        const errorCompletePwdReset = ftlMsgResolver.getMsg(
+          'complete-reset-password-error-alert',
+          'Sorry, there was a problem setting your password'
+        );
+        alertBar.error(errorCompletePwdReset);
+      }
+    },
+    [ftlMsgResolver, alertSuccessAndGoHome, alertBar]
+  );
+
+  return (
+    <>
+      {isLinkExpired && (
+        <>
+          <FtlMsg id="complete-reset-pw-link-expired-header">
+            <h1 id="fxa-reset-link-expired-header" className="card-header">
+              Reset password link expired
+            </h1>
+          </FtlMsg>
+
+          <FtlMsg id="complete-reset-pw-link-expired-message">
+            <p className="mt-4">
+              The link you clicked to reset your password is expired.
+            </p>
+          </FtlMsg>
+          <FtlMsg id="complete-reset-pw-resend-link">
+            <button
+              onClick={resendLinkHandler}
+              className="cta-primary cta-base-p mt-4"
+            >
+              Receive new link
+            </button>
+          </FtlMsg>
+        </>
+      )}
+      {isLinkDamaged && (
+        <>
+          <FtlMsg id="complete-reset-pw-link-damaged-header">
+            <h1 id="fxa-reset-link-damaged-header" className="card-header">
+              Reset password link damaged
+            </h1>
+          </FtlMsg>
+
+          <FtlMsg id="complete-reset-pw-link-damaged-message">
+            <p className="mt-4">
+              The link you clicked was missing characters, and may have been
+              broken by your email client. Copy the address carefully, and try
+              again.
+            </p>
+          </FtlMsg>
+        </>
+      )}
+
+      {/* With valid password reset link */}
+      {!isLinkExpired && !isLinkDamaged && (
+        <>
+          <FtlMsg id="complete-reset-pw-header">
+            <h1 id="fxa-reset-link-damaged-header" className="card-header">
+              Create new password
+            </h1>
+          </FtlMsg>
+
+          {showSyncWarning && (
+            <WarningMessage
+              warningMessageFtlId="complete-reset-password-warning-message"
+              warningType="Remember:"
+            >
+              When you reset your password, you reset your account. You may lose
+              some of your personal information (including history, bookmarks,
+              and passwords). That’s because we encrypt your data with your
+              password to protect your privacy. You’ll still keep any
+              subscriptions you may have and Pocket data will not be affected.
+            </WarningMessage>
+          )}
+          {showAccountRecoveryInfo && (
+            <FtlMsg id="complete-reset-pw-account-recovery-info">
+              <p className="mb-5 mt-4">
+                You have successfully restored your account using your account
+                recovery key. Create a new password to secure your data, and
+                store it in a safe location.
+              </p>
+            </FtlMsg>
+          )}
+          {/* Hidden email field is to allow Fx password manager
+           to correctly save the updated password. Without it,
+           the password manager tries to save the old password
+           as the username. */}
+          <input type="email" value={email} className="hidden" />
+          <section className="text-start mt-4">
+            <FormPassword
+              {...{
+                formState,
+                errors,
+                trigger,
+                register,
+                getValues,
+                newPasswordErrorText,
+                setNewPasswordErrorText,
+              }}
+              onFocusMetricsEvent="complete-reset-password.engage"
+              onSubmit={handleSubmit(onFormSubmit)}
+              primaryEmail={account.primaryEmail.email}
+              loading={account.loading}
+            />
+          </section>
+          {!forceEmail && <LinkRememberPassword {...{ email }} />}
+          {forceEmail && <LinkRememberPassword {...{ forceEmail }} />}
+        </>
+      )}
+    </>
+  );
+};
+
+export default CompleteResetPassword;


### PR DESCRIPTION
## Because

- We want to recreate views from content-server in React, and are starting by building out the Storybook components.

## This pull request

- Creates a new CompleteResetPassword component, with storybook, metrics, tests and l10n.
- Does not include functionality to set a new password (this will be added in a later issue)

## Issue that this pull request solves

Closes: #FXA-6340

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Valid link (default):
![image](https://user-images.githubusercontent.com/22231637/210015538-c416a70e-1dba-441c-9133-60763b407946.png)

Valid link with warning message:
![image](https://user-images.githubusercontent.com/22231637/210015559-c6acb634-5d70-494a-a9f6-90f06c641055.png)

Valid link with account recovery info:
![image](https://user-images.githubusercontent.com/22231637/210015570-9219e951-0b8e-473e-a41a-666be75344e3.png)

Expired link:
![image](https://user-images.githubusercontent.com/22231637/210015663-29c0f415-1ace-4e38-94a0-f8b5b567a120.png)

Damaged link:
![image](https://user-images.githubusercontent.com/22231637/210015677-55e40f61-92ab-4748-ae12-0a75a5aa52b4.png)

## Other information (Optional)

Any other information that is important to this pull request.
