### PR TITLE
feat(gql): add acct sign up mutation to gql-api

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -527,6 +527,36 @@ describe('AccountResolver', () => {
       });
     });
 
+    describe('signUp', () => {
+      it('calls auth-client and proxy the result', async () => {
+        const now = Date.now();
+        const headers = new Headers();
+        const mockRespPayload = {
+          clientMutationId: 'testid',
+          uid: '1337',
+          sessionToken: '2048',
+          verified: true,
+          authAt: now,
+        };
+        authClient.signUpWithAuthPW = jest
+          .fn()
+          .mockResolvedValue(mockRespPayload);
+        const result = await resolver.SignUp(headers, {
+          authPW: '00000000',
+          email: 'testo@example.xyz',
+          options: { service: 'testo-co' },
+        });
+        expect(authClient.signUpWithAuthPW).toBeCalledTimes(1);
+        expect(authClient.signUpWithAuthPW).toBeCalledWith(
+          'testo@example.xyz',
+          '00000000',
+          { service: 'testo-co' },
+          headers
+        );
+        expect(result).toStrictEqual(mockRespPayload);
+      });
+    });
+
     describe('signIn', () => {
       it('calls auth-client and proxy the result', async () => {
         const now = Date.now();
@@ -545,13 +575,13 @@ describe('AccountResolver', () => {
         const result = await resolver.signIn(headers, {
           authPW: '00000000',
           email: 'testo@example.xyz',
-          options: {},
+          options: { service: 'testo-co' },
         });
         expect(authClient.signInWithAuthPW).toBeCalledTimes(1);
         expect(authClient.signInWithAuthPW).toBeCalledWith(
-          '00000000',
           'testo@example.xyz',
-          {},
+          '00000000',
+          { service: 'testo-co' },
           headers
         );
         expect(result).toStrictEqual(mockRespPayload);

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -54,6 +54,7 @@ import {
 import { DeleteAvatarInput } from './dto/input/delete-avatar';
 import { MetricsOptInput } from './dto/input/metrics-opt';
 import { SignInInput } from './dto/input/sign-in';
+import { SignUpInput } from './dto/input/sign-up';
 import {
   BasicPayload,
   ChangeRecoveryCodesPayload,
@@ -67,6 +68,7 @@ import {
   AccountResetPayload,
 } from './dto/payload';
 import { SignedInAccountPayload } from './dto/payload/signed-in-account';
+import { SignedUpAccountPayload } from './dto/payload/signed-up-account';
 import { CatchGatewayError } from './lib/error';
 import { Account as AccountType } from './model/account';
 
@@ -488,6 +490,27 @@ export class AccountResolver {
     );
   }
 
+  @Mutation((returns) => SignedUpAccountPayload, {
+    description: 'Call auth-server to sign up an account',
+  })
+  @CatchGatewayError
+  public async SignUp(
+    @GqlXHeaders() headers: Headers,
+    @Args('input', { type: () => SignUpInput })
+    input: SignUpInput
+  ): Promise<SignedUpAccountPayload> {
+    const result = await this.authAPI.signUpWithAuthPW(
+      input.email,
+      input.authPW,
+      input.options,
+      headers
+    );
+    return {
+      clientMutationId: input.clientMutationId,
+      ...result,
+    };
+  }
+
   @Mutation((returns) => SignedInAccountPayload, {
     description: 'Call auth-server to sign in an account',
   })
@@ -498,8 +521,8 @@ export class AccountResolver {
     input: SignInInput
   ): Promise<SignedInAccountPayload> {
     const result = await this.authAPI.signInWithAuthPW(
-      input.authPW,
       input.email,
+      input.authPW,
       input.options,
       headers
     );

--- a/packages/fxa-graphql-api/src/gql/dto/input/sign-up.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/sign-up.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, InputType } from '@nestjs/graphql';
+import { BoolString } from 'fxa-auth-client';
+import { MetricsContext } from './metrics-context';
+
+@InputType()
+export class SignUpOptionsInput {
+  @Field({ nullable: true })
+  public keys?: boolean;
+
+  @Field({ nullable: true })
+  public service!: string;
+
+  @Field({ nullable: true })
+  public redirectTo?: string;
+
+  @Field({ nullable: true })
+  public resume?: string;
+
+  @Field({ nullable: true })
+  public verificationMethod?: string;
+
+  @Field({ nullable: true })
+  public preVerified?: BoolString;
+
+  @Field((type) => MetricsContext, { nullable: true })
+  public metricsContext?: MetricsContext;
+}
+
+@InputType()
+export class SignUpInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public authPW!: hexstring;
+
+  @Field()
+  public email!: string;
+
+  @Field()
+  public options!: SignUpOptionsInput;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/signed-up-account.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/signed-up-account.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class SignedUpAccountPayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public uid!: hexstring;
+
+  @Field()
+  public sessionToken!: hexstring;
+
+  @Field({ nullable: true })
+  keyFetchToken?: hexstring;
+
+  @Field()
+  authAt!: number;
+
+  @Field({ nullable: true })
+  verificationMethod?: string;
+}


### PR DESCRIPTION
Because:
 - we want to allow front end clients to sign up a user through the gql-api

This commit:
 - add the signUp mutation to the Account resolver
