### PR TITLE
fix(scripts): add pushbox dep to delete acct script

### DIFF
--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -78,6 +78,8 @@ DB.connect(config).then(async (db) => {
 
   const push = require('../lib/push')(log, db, config);
   const oauthDB = require('../lib/oauth/db');
+  const { pushboxApi } = require('../lib/pushbox');
+  const pushbox = pushboxApi(log, config, statsd);
 
   const verificationReminders = require('../lib/verification-reminders')(
     log,
@@ -127,7 +129,8 @@ DB.connect(config).then(async (db) => {
       verificationReminders,
       subscriptionAccountReminders,
       oauthDB,
-      stripeHelper
+      stripeHelper,
+      pushbox
     )
     .find((r) => r.path === '/account/destroy');
 


### PR DESCRIPTION
Because:
 - we delete from the pushbox db directly when deleting an account now

This commit:
 - add the pushbox module to the account routes when used from the delete account script
