### PR TITLE
feat(gql): consume unblock code

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -628,5 +628,20 @@ describe('AccountResolver', () => {
         expect(result.exists).toEqual(false);
       });
     });
+
+    describe('rejectUnblockCode', () => {
+      it('calls the db to consume the unblock code', async () => {
+        const spy = jest
+          .spyOn(Account, 'consumeUnblockCode')
+          .mockResolvedValue({});
+        await resolver.rejectUnblockCode({
+          uid: '1337',
+          unblockCode: 'oops',
+        });
+        expect(Account.consumeUnblockCode).toBeCalledTimes(1);
+        expect(Account.consumeUnblockCode).toBeCalledWith('1337', 'OOPS');
+        spy.mockRestore();
+      });
+    });
   });
 });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -58,6 +58,7 @@ import {
 } from './dto/input';
 import { DeleteAvatarInput } from './dto/input/delete-avatar';
 import { MetricsOptInput } from './dto/input/metrics-opt';
+import { RejectUnblockCodeInput } from './dto/input/reject-unblock-code';
 import { SignInInput } from './dto/input/sign-in';
 import { SignUpInput } from './dto/input/sign-up';
 import {
@@ -565,6 +566,28 @@ export class AccountResolver {
     }
 
     return { exists: false };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description:
+      'Used to reject and report unblock codes that were not requested by the user.',
+  })
+  @CatchGatewayError
+  public async rejectUnblockCode(
+    @Args('input', { type: () => RejectUnblockCodeInput })
+    input: RejectUnblockCodeInput
+  ): Promise<BasicPayload> {
+    await Account.consumeUnblockCode(
+      input.uid,
+      input.unblockCode.toUpperCase()
+    );
+    this.log.info('account.login.rejectedUnblockCode', {
+      uid: input.uid,
+      unblockCode: input.unblockCode,
+    });
+    return {
+      clientMutationId: input.clientMutationId,
+    };
   }
 
   @ResolveField()

--- a/packages/fxa-graphql-api/src/gql/dto/input/reject-unblock-code.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/reject-unblock-code.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class RejectUnblockCodeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public uid!: string;
+
+  @Field()
+  public unblockCode!: string;
+}


### PR DESCRIPTION
Because:
 - gql-api should be able to consume an unblock code

This commit:
 - enable the gql-api to consume an unblock code by calling a db sproc
