### PR TITLE
feat(payments): hide taxes for inclusive tax

### DIFF
--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -378,3 +378,41 @@ export const INVOICE_PREVIEW_WITH_INVALID_DISCOUNT: FirstInvoicePreview = {
     percent_off: null,
   },
 };
+
+export const INVOICE_PREVIEW_INCLUSIVE_TAX: FirstInvoicePreview = {
+  line_items: [
+    {
+      amount: 500,
+      currency: 'usd',
+      id: 'plan_GqM9N64ksvxaVk',
+      name: '1 x 123Done Pro (at $5.00 / month)',
+    },
+  ],
+  subtotal: 500,
+  subtotal_excluding_tax: 377,
+  total: 500,
+  total_excluding_tax: 377,
+  tax: {
+    amount: 123,
+    inclusive: true,
+  },
+};
+
+export const INVOICE_PREVIEW_EXCLUSIVE_TAX: FirstInvoicePreview = {
+  line_items: [
+    {
+      amount: 500,
+      currency: 'usd',
+      id: 'plan_GqM9N64ksvxaVk',
+      name: '1 x 123Done Pro (at $5.00 / month)',
+    },
+  ],
+  subtotal: 500,
+  subtotal_excluding_tax: 500,
+  total: 623,
+  total_excluding_tax: 500,
+  tax: {
+    amount: 123,
+    inclusive: false,
+  },
+};


### PR DESCRIPTION
## Because

- we want to hide the Taxes & Fees for countries with inclusive tax.

## This pull request

- updates the PlanDetails component to hide Taxes & Fees when tax is inclusive.
- adds basic tests for Taxes & Fees.

## Issue that this pull request solves

Closes: #FXA-6391

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Inclusive Tax
![image](https://user-images.githubusercontent.com/10620585/207458782-d117d6ba-2748-42c8-887d-6bb9926c186e.png)

Exclusive Tax
![image](https://user-images.githubusercontent.com/10620585/207458801-c06b48c3-9e3d-4e75-a736-1be22df45c39.png)


## Other information (Optional)

Any other information that is important to this pull request.
