### PR TITLE
fix(content): Fix path reference for close.svg rendering issue

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/account-suggestion.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/account-suggestion.mustache
@@ -3,10 +3,9 @@
     <p class="info-text">
       {{#unsafeTranslate}}Why do I need to create this account? <a %(escapedSuggestionAttrs)s>Find out here</a>{{/unsafeTranslate}}
     </p>
-    <button type="button" class="dismiss" aria-label="{{#t}}Close{{/t}}">
+    <button type="button" class="dismiss bg-close-black" aria-label="{{#t}}Close{{/t}}">
     {{! When this component is converted to React, use the shared close.svg
-    from fxa-react for both black and white versions }}
-      <img src="/images/close.svg" alt="&#10005;" aria-hidden="true"/>
+    from fxa-react for both black and white versions. We currently use a bg-image now. }}
     </button>
   </div>
 {{/showAccountSuggestion}}

--- a/packages/fxa-content-server/app/scripts/templates/partial/sync-suggestion.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/sync-suggestion.mustache
@@ -3,10 +3,9 @@
     <p class="info-text">
       {{#unsafeTranslate}}Looking for Firefox Sync? <a %(escapedSyncSuggestionAttrs)s>Get started here</a>{{/unsafeTranslate}}
     </p>
-    <button class="dismiss" type="button" aria-label="{{#t}}Close{{/t}}">
+    <button class="dismiss bg-close-black" type="button" aria-label="{{#t}}Close{{/t}}">
     {{! When this component is converted to React, use the shared close.svg
-    from fxa-react for both black and white versions }}
-      <img src="/images/close.svg" alt="&#10005;" aria-hidden="true"/>
+    from fxa-react for both black and white versions. We currently use a bg-image now. }}
     </button>
   </div>
 {{/showSyncSuggestion}}

--- a/packages/fxa-content-server/app/scripts/views/tooltip.js
+++ b/packages/fxa-content-server/app/scripts/views/tooltip.js
@@ -80,7 +80,7 @@ const Tooltip = BaseView.extend({
       // When this component is converted to React, use the shared close.svg
       // from fxa-react for both black and white versions
       this.$el.append(
-        `<button type="button" class="dismiss" aria-label=${dismissAriaLabel}><img src="/images/close-white.svg" alt="&#10005;" aria-hidden="true" /></button>`
+        `<button type="button" class="dismiss bg-close-white" aria-label=${dismissAriaLabel}></button>`
       );
     }
 

--- a/packages/fxa-content-server/app/styles/tailwind/state.css
+++ b/packages/fxa-content-server/app/styles/tailwind/state.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .info {
-  @apply flex gap-2 items-center my-3 p-3 rounded bg-grey-50 text-black;
+  @apply flex gap-2 items-center mb-5 p-3 rounded bg-grey-50 text-black;
 }
 
 .info-text {
@@ -34,7 +34,7 @@
 }
 
 .dismiss {
-  @apply h-3 w-3 cursor-pointer fill-current z-[6];
+  @apply bg-contain h-3 w-3;
 }
 
 .dismiss-container {

--- a/packages/fxa-content-server/tailwind.config.js
+++ b/packages/fxa-content-server/tailwind.config.js
@@ -13,6 +13,8 @@ config.content = [
   './app/scripts/views/form.js',
   // for 'opacity-0 opacity-100' classes
   './app/scripts/views/password_strength/password_strength_balloon.js',
+  // for 'bg-close-white' class
+  './app/scripts/views/tooltip.js',
 ];
 
 config.theme.extend = {
@@ -22,6 +24,9 @@ config.theme.extend = {
     'check-white': 'inline("../images/icon-check-white.svg")',
     'show-password': 'inline("../images/icon-show-password.svg")',
     'hide-password': 'inline("../images/icon-show-password-closed.svg")',
+    // TODO: Use 'close' SVGs from 'fxa-react' once using React
+    'close-black': 'inline("../images/close.svg")',
+    'close-white': 'inline("../images/close-white.svg")',
     /* TODO: move this to `fxa-react`, FXA-5745 */
     /* If adding a background-image in content-server, you must refer to "/images" instead of
      * "../images" because our cache bust build step won't find and replace it in `usemin:css` */


### PR DESCRIPTION
This commit:
* Reverts a recent change that updated a bg-image to use an img src and uses TW to load the image. We may have a bug in content-server around updating img src image hashes in at the build step unless it's intentional to always use bg-images, and this commit inlines the SVGs instead as they are tiny and keeps a11y wins
* Adjusts bottom-padding slightly for more consistency with prod

Because:
* The close SVGs are not loading on the build step due to 'img src' path hashes not being updated in the outputted HTML

Closes: FXA-6453

---

This is a similar issue to #14549 where the image loads locally but in staging the image fails to load. You can see in staging on FF, it looks like the image properly loads (but is strangely a few pixels pushed down vs local), but actually it's showing alt text:

![image](https://user-images.githubusercontent.com/13018240/207663773-bce15d53-785d-4da6-8d6f-83e6d5043332.png)
![image](https://user-images.githubusercontent.com/13018240/207663840-7f0450ef-a2a4-4af7-bca2-2b4fa003904e.png)

This is consistent with what the bug describes in Chrome + Safari but the "failed image load" just displays differently. You can also see that no image hash is applied to the URL, when if you run a `yarn build` in content-server, you will see our build steps change the image name to one with this hash in front.

I looked into adding the image hash, but I think maybe for content-server, we just don't have this implemented? Seems odd, but we hardly have _any_ `img` references, and if you [pull this link up](https://accounts.stage.mozaws.net/post_verify/cad_qr/scan_code) which does use an `img`, you can see it loads locally, but doesn't load in staging. I don't know that we ever hit this page so I'm currently not sure if we need an issue created for this (especially since we're converting to React), but it just confirmed that our build steps aren't finding our `img src` references here - I would've expected the `rev:with_children` step to do this for us but it only touches our CSS. It's possible the image path references are just off, but I don't see in any of our build steps where we update any HTML/JS with newly named images. **Edit:** I checked what was built for staging and you can replace the filename with `09eeb10a.graphic_cad_qr_code.svg` and it works without a path tweak, and I tested building with several different path variations and none of them applied the hash to the image references so I don't think that's the issue. 

<img width="524" alt="image" src="https://user-images.githubusercontent.com/13018240/207664635-34d47149-4902-4aa4-a4b0-d57768a23551.png">

Anyway, this might be a bandaid but I changed these new close images to be inlined BG-images which appears to fix the problem. Here's what it looks like locally:

![image](https://user-images.githubusercontent.com/13018240/207665648-9d405748-cc54-496d-9d6b-858e56f5b820.png)
