### PR TITLE
feat(mysql): close idling connections in pool

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1268,6 +1268,12 @@ const convictConf = convict({
         default: 0,
         env: 'MYSQL_QUEUE_LIMIT',
       },
+      idleLimitMs: {
+        doc: 'The number of milliseconds a connection can be idle before it is closed.',
+        format: Number,
+        default: 10000,
+        env: 'MYSQL_IDLE_LIMIT_MS',
+      },
       timezone: {
         default: 'Z',
         doc: 'The timezone configured on the MySQL server. This is used to type cast server date/time values to JavaScript `Date` object. Can be `local`, `Z`, or an offset in the form of or an offset in the form +HH:MM or -HH:MM.',

--- a/packages/fxa-shared/db/config.ts
+++ b/packages/fxa-shared/db/config.ts
@@ -60,6 +60,11 @@ export function makeMySQLConfig(envPrefix: string, database: string) {
       default: 30000,
       env: envPrefix + '_MYSQL_ACQUIRE_TIMEOUT',
     },
+    idleLimitMs: {
+      doc: 'The number of milliseconds a connection can be idle before it is closed',
+      default: 60000,
+      env: envPrefix + '_MYSQL_IDLE_LIMIT_MS',
+    },
   };
 }
 

--- a/packages/fxa-shared/test/db/mysql.ts
+++ b/packages/fxa-shared/test/db/mysql.ts
@@ -1,9 +1,13 @@
 import { assert } from 'chai';
+import { StatsD } from 'hot-shots';
+import { Connection } from 'mysql';
+import sinon from 'sinon';
 import { IMysqlStoreSharedEvents, MysqlStoreShared } from '../../db/mysql';
 import { defaultOpts, testDatabaseSetup } from './helpers';
 
 const dbOpts = Object.assign({}, defaultOpts.testDbConfig, {
   connectionLimit: 20,
+  idleLimitMs: 1000,
 });
 
 type TestStats = {
@@ -20,6 +24,9 @@ type TestStats = {
     initializeError: number;
   };
 };
+
+const sandbox = sinon.createSandbox();
+const statsdStub = { increment: sandbox.stub() };
 
 class MysqlStoreTestEvents implements IMysqlStoreSharedEvents {
   /**
@@ -75,8 +82,13 @@ class MysqlStoreTestEvents implements IMysqlStoreSharedEvents {
  * for tracking creation management of connections.
  */
 class MySqlStoreTest extends MysqlStoreShared {
-  constructor(events: IMysqlStoreSharedEvents) {
-    super(dbOpts, events);
+  constructor(
+    options = dbOpts,
+    events: IMysqlStoreSharedEvents = new MysqlStoreTestEvents(),
+    log = undefined,
+    metrics = statsdStub
+  ) {
+    super(options, events, undefined, metrics as unknown as StatsD);
   }
 
   getConnection() {
@@ -98,13 +110,17 @@ describe('mysql', function () {
     const knex = await testDatabaseSetup(defaultOpts);
     await knex.destroy();
     events = new MysqlStoreTestEvents();
-    mysql = new MySqlStoreTest(events);
-    mysql2 = new MySqlStoreTest(events);
+    mysql = new MySqlStoreTest(dbOpts, events);
+    mysql2 = new MySqlStoreTest(dbOpts, events);
   });
 
   after(async () => {
     await mysql.close();
     await mysql2.close();
+  });
+
+  beforeEach(() => {
+    sandbox.reset();
   });
 
   it('releases connections ', async () => {
@@ -142,5 +158,24 @@ describe('mysql', function () {
       Object.keys(events.stats.pool.threadIds).length,
       dbOpts.connectionLimit * 2
     );
+  });
+
+  it('closes connections after idling', async () => {
+    // pass a lower idle limit config value
+    mysql = new MySqlStoreTest({ ...dbOpts, idleLimitMs: 10 });
+    const conn1 = await mysql.getConnection();
+    const conn2 = await mysql.getConnection();
+    assert.notEqual((conn1 as Connection).state, 'disconnected');
+    assert.notEqual((conn2 as Connection).state, 'disconnected');
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    const closeConnCount = statsdStub.increment.args.filter(
+      (x) => x[0] === 'mysql.close_idle_connection'
+    ).length;
+    assert.equal(closeConnCount, 2);
+    assert.equal((conn1 as Connection).state, 'disconnected');
+    assert.equal((conn2 as Connection).state, 'disconnected');
   });
 });


### PR DESCRIPTION
Because:
 - the mysql module's connection pool never close any of its connections

This commit:
 - close a connection after it idles for a configurable amount of time
