### PR TITLE
[subplat] test(subplat): add test for resubscription and update mode of payment

### DIFF
--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -18,6 +18,20 @@ export class SubscriptionManagementPage extends BaseLayout {
     ]);
   }
 
+  async changeStripeCardDetails() {
+    await this.page
+      .locator('[data-testid="reveal-payment-update-button"]')
+      .click();
+    await this.page.locator('[data-testid="name"]').fill('Test User');
+    const frame = this.page.frame({ url: /elements-inner-card/ });
+    await frame.fill('.InputElement[name=cardnumber]', '');
+    await frame.fill('.InputElement[name=cardnumber]', '5555555555554444');
+    await frame.fill('.InputElement[name=exp-date]', '444');
+    await frame.fill('.InputElement[name=cvc]', '777');
+    await frame.fill('.InputElement[name=postal]', '88888');
+    await this.page.locator('[data-testid="submit"]').click();
+  }
+
   async resubscribe() {
     return Promise.all([
       await this.page
@@ -30,6 +44,12 @@ export class SubscriptionManagementPage extends BaseLayout {
         .locator('[data-testid="reactivate-subscription-success-button"]')
         .click(),
     ]);
+  }
+
+  getCardInfo() {
+    return this.page
+      .locator('[data-testid="card-logo-and-last-four"]')
+      .textContent();
   }
 
   getResubscriptionPrice() {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -180,41 +180,4 @@ test.describe('coupon test', () => {
     // Verify the discount is removed
     expect(await subscribe.discountLineItem()).toBe(false);
   });
-
-  test('resubscribe successfully with the same coupon after canceling', async ({
-    page,
-    pages: { relier, subscribe, login, settings, subscriptionManagement },
-  }) => {
-    await relier.goto();
-    await relier.clickSubscribe6Month();
-
-    // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-    await subscribe.addCouponCode('auto10pforever');
-
-    // Verify the coupon is applied successfully
-    expect(await subscribe.discountAppliedSuccess()).toBe(true);
-
-    const total = await subscribe.getTotalPrice();
-
-    //Subscribe successfully
-    await subscribe.setFullName();
-    await subscribe.setCreditCardInfo();
-    await subscribe.clickPayNow();
-    await subscribe.submit();
-
-    //Login to FxA account
-    await login.goto();
-    await login.clickSignIn();
-    const subscriptionPage = await settings.clickPaidSubscriptions();
-    subscriptionManagement.page = subscriptionPage;
-
-    //Cancel subscription
-    await subscriptionManagement.cancelSubscription();
-    await subscriptionManagement.resubscribe();
-
-    //Verify that the resubscription has the same coupon applied
-    expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
-      total
-    );
-  });
 });

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '../../../lib/fixtures/standard';
+
+test.describe('resubscription test', () => {
+  test.beforeEach(() => {
+    test.slow();
+  });
+
+  test('resubscribe successfully with the same coupon after canceling for stripe', async ({
+    page,
+    pages: { relier, subscribe, login, settings, subscriptionManagement },
+  }) => {
+    await relier.goto();
+    await relier.clickSubscribe6Month();
+
+    // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
+    await subscribe.addCouponCode('auto10pforever');
+
+    // Verify the coupon is applied successfully
+    expect(await subscribe.discountAppliedSuccess()).toBe(true);
+
+    const total = await subscribe.getTotalPrice();
+
+    //Subscribe successfully with Stripe
+    await subscribe.setFullName();
+    await subscribe.setCreditCardInfo();
+    await subscribe.clickPayNow();
+    await subscribe.submit();
+
+    //Login to FxA account
+    await login.goto();
+    await login.clickSignIn();
+    const subscriptionPage = await settings.clickPaidSubscriptions();
+    subscriptionManagement.page = subscriptionPage;
+
+    //Cancel subscription and then resubscribe
+    await subscriptionManagement.cancelSubscription();
+    await subscriptionManagement.resubscribe();
+
+    //Verify that the resubscription has the same coupon applied
+    expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
+      total
+    );
+  });
+
+  test('resubscribe successfully with the same coupon after canceling for paypal', async ({
+    page,
+    pages: { relier, subscribe, login, settings, subscriptionManagement },
+  }) => {
+    await relier.goto();
+    await relier.clickSubscribe6Month();
+
+    // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
+    await subscribe.addCouponCode('auto10pforever');
+
+    // Verify the coupon is applied successfully
+    expect(await subscribe.discountAppliedSuccess()).toBe(true);
+
+    const total = await subscribe.getTotalPrice();
+
+    //Subscribe successfully using Paypal
+    await subscribe.setPayPalInfo();
+    await subscribe.submit();
+
+    //Login to FxA account
+    await login.goto();
+    await login.clickSignIn();
+    const subscriptionPage = await settings.clickPaidSubscriptions();
+    subscriptionManagement.page = subscriptionPage;
+
+    //Cancel subscription and then resubscribe
+    await subscriptionManagement.cancelSubscription();
+    await subscriptionManagement.resubscribe();
+
+    //Verify that the resubscription has the same coupon applied
+    expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
+      total
+    );
+  });
+
+  test('update mode of payment for stripe', async ({
+    page,
+    pages: { relier, subscribe, login, settings, subscriptionManagement },
+  }) => {
+    await relier.goto();
+    await relier.clickSubscribe6Month();
+
+    // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
+    await subscribe.addCouponCode('auto10pforever');
+
+    //Subscribe successfully
+    await subscribe.setFullName();
+    await subscribe.setCreditCardInfo();
+    await subscribe.clickPayNow();
+    await subscribe.submit();
+
+    //Login to FxA account
+    await login.goto();
+    await login.clickSignIn();
+    const subscriptionPage = await settings.clickPaidSubscriptions();
+    subscriptionManagement.page = subscriptionPage;
+
+    //Change stripe card information
+    await subscriptionManagement.changeStripeCardDetails();
+
+    //Verify that the card info is updated
+    expect(await subscriptionManagement.getCardInfo()).toContain('4444');
+  });
+});


### PR DESCRIPTION
## Because

In efforts to increase test coverage for coupon and Subplat regression , added automated tests for:
- Resubscribing after cancellation with same coupon for Stripe
- Resubscribing after cancellation with same coupon for Paypal
- Update mode of payment for Stripe

## This pull request
- Contains test for:
- Resubscribing after cancellation with same coupon for Stripe
- Resubscribing after cancellation with same coupon for Paypal
- Update mode of payment for Stripe

## Issue that this pull request solves

Closes: #[FXA-6157](https://mozilla-hub.atlassian.net/browse/FXA-6157) [FXA-6246](https://mozilla-hub.atlassian.net/browse/FXA-6246) [FXA-6249](https://mozilla-hub.atlassian.net/browse/FXA-6249) 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
