### PR TITLE
fix(tests): Tweaks playwright tests to not use `preverified`

### DIFF
--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -69,16 +69,10 @@ test.describe('OAuth `login_hint` and `email` param', () => {
     pages: { login, relier },
   }) => {
     const email = login.createEmail();
-    await target.auth.signUp(email, PASSWORD, {
-      lang: 'en',
-      preVerified: 'true',
-    });
+    await target.createAccount(email, PASSWORD);
 
     const loginHintEmail = login.createEmail();
-    await target.auth.signUp(loginHintEmail, PASSWORD, {
-      lang: 'en',
-      preVerified: 'true',
-    });
+    await target.createAccount(loginHintEmail, PASSWORD);
 
     // Create a cached login
     await relier.goto();

--- a/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
+++ b/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
@@ -11,10 +11,7 @@ test.describe('OAuth scopeKeys', () => {
     pages: { login },
   }) => {
     const email = login.createEmail('sync{id}');
-    await target.auth.signUp(email, PASSWORD, {
-      lang: 'en',
-      preVerified: 'true',
-    });
+    await target.createAccount(email, PASSWORD);
 
     const query = new URLSearchParams({
       client_id: '7f368c6886429f19', // eslint-disable-line camelcase

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -139,10 +139,7 @@ test.describe('OAuth signin', () => {
 
   test('verified, blocked', async ({ target, pages: { login, relier } }) => {
     const blockedEmail = login.createEmail('blocked{id}');
-    await target.auth.signUp(blockedEmail, PASSWORD, {
-      lang: 'en',
-      preVerified: 'true',
-    });
+    await target.createAccount(blockedEmail, PASSWORD);
 
     await relier.goto();
     await relier.clickEmailFirst();
@@ -157,10 +154,7 @@ test.describe('OAuth signin', () => {
     pages: { login, relier },
   }) => {
     const blockedEmail = login.createEmail('blocked{id}');
-    await target.auth.signUp(blockedEmail, PASSWORD, {
-      lang: 'en',
-      preVerified: 'true',
-    });
+    await target.createAccount(blockedEmail, PASSWORD);
 
     await relier.goto();
     await relier.clickEmailFirst();

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -29,7 +29,6 @@ module.exports = testsSettings.concat([
   'tests/functional/oauth_query_param_validation.js',
   'tests/functional/oauth_reset_password.js',
   'tests/functional/oauth_settings_clients.js',
-  'tests/functional/oauth_sign_in.js',
   'tests/functional/oauth_sign_up.js',
   'tests/functional/oauth_sync_sign_in.js',
   'tests/functional/pages.js',
@@ -67,6 +66,7 @@ module.exports = testsSettings.concat([
   // 'tests/functional/oauth_handshake.js',
   // 'tests/functional/oauth_force_auth.js',
   // 'tests/functional/sync_v3_force_auth.js',
+  // 'tests/functional/oauth_sign_in.js',
 ]);
 
 // Mocha tests are only exposed during local dev, not on prod-like


### PR DESCRIPTION
## Because

- The `preverified` option is disabled in prod, which allows account to be created and verified at once

## This pull request

- Uses `target.createAccount` which goes through the process of checking email, getting code and verifying account

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
