### PR TITLE
chore(l10n): Add kk locale

### DIFF
--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -31,6 +31,7 @@
   "ja",
   "ka",
   "kab",
+  "kk",
   "ko",
   "nl",
   "nn-NO",


### PR DESCRIPTION
## Because

-  Kazakh locale (kk) raised their threshold from 30% to above threshold of 70%

## This pull request

- Enables kk locale in the supportedLanguages.json

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
