### PR TITLE
feat(gql): add proxy to acct finish setup

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -556,11 +556,30 @@ export default class AuthClient {
     verified: boolean;
   }> {
     const credentials = await crypto.getCredentials(email, newPassword);
+    return this.finishSetupWithAuthPW(token, credentials.authPW);
+  }
+
+  /**
+   * This function is intended for a service that will proxy the finish setup
+   * (setting a password of a stub account) request.  When setting a password
+   * from a client with access to the plaintext password, use `finishSetup`
+   * above.
+   */
+  async finishSetupWithAuthPW(
+    token: string,
+    authPW: string,
+    headers: Headers = new Headers()
+  ) {
     const payload = {
       token,
-      authPW: credentials.authPW,
+      authPW,
     };
-    return await this.request('POST', '/account/finish_setup', payload);
+    return await this.request(
+      'POST',
+      '/account/finish_setup',
+      payload,
+      headers
+    );
   }
 
   async verifyAccountThirdParty(

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -566,6 +566,32 @@ describe('#integration - AccountResolver', () => {
       });
     });
 
+    describe('finishSetup', () => {
+      it('calls auth-client and proxy the result', async () => {
+        const headers = new Headers();
+        const mockRespPayload = {
+          clientMutationId: 'testid',
+          uid: '1337',
+          sessionToken: '2048',
+          verified: true,
+        };
+        authClient.finishSetupWithAuthPW = jest
+          .fn()
+          .mockResolvedValue(mockRespPayload);
+        const result = await resolver.finishSetup(headers, {
+          token: 'jwttothemax',
+          authPW: '00000000',
+        });
+        expect(authClient.finishSetupWithAuthPW).toBeCalledTimes(1);
+        expect(authClient.finishSetupWithAuthPW).toBeCalledWith(
+          'jwttothemax',
+          '00000000',
+          headers
+        );
+        expect(result).toStrictEqual(mockRespPayload);
+      });
+    });
+
     describe('signIn', () => {
       it('calls auth-client and proxy the result', async () => {
         const now = Date.now();

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -79,6 +79,8 @@ import { SignedUpAccountPayload } from './dto/payload/signed-up-account';
 import { CatchGatewayError } from './lib/error';
 import { Account as AccountType } from './model/account';
 import { uuidTransformer } from 'fxa-shared/db/transformers';
+import { FinishedSetupAccountPayload } from './dto/payload/finished-setup-account';
+import { FinishSetupInput } from './dto/input/finish-setup';
 
 function snakeToCamel(str: string) {
   return str.replace(/(_\w)/g, (m: string) => m[1].toUpperCase());
@@ -511,6 +513,26 @@ export class AccountResolver {
       input.email,
       input.authPW,
       input.options,
+      headers
+    );
+    return {
+      clientMutationId: input.clientMutationId,
+      ...result,
+    };
+  }
+
+  @Mutation((returns) => FinishedSetupAccountPayload, {
+    description: 'Call auth-server to finish signing up a "stub" account',
+  })
+  @CatchGatewayError
+  public async finishSetup(
+    @GqlXHeaders() headers: Headers,
+    @Args('input', { type: () => FinishSetupInput })
+    input: FinishSetupInput
+  ): Promise<FinishedSetupAccountPayload> {
+    const result = await this.authAPI.finishSetupWithAuthPW(
+      input.token,
+      input.authPW,
       headers
     );
     return {

--- a/packages/fxa-graphql-api/src/gql/dto/input/finish-setup.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/finish-setup.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class FinishSetupInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public token!: string;
+
+  @Field()
+  public authPW!: hexstring;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/finished-setup-account.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/finished-setup-account.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class FinishedSetupAccountPayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public uid!: hexstring;
+
+  @Field()
+  public sessionToken!: hexstring;
+
+  @Field()
+  verified!: boolean;
+}


### PR DESCRIPTION
Because:
 - we want gql-api to finish setting up a stub account for the user

This commit:
 - proxy an account finish setup request to the auth-server
