### PR TITLE
fix(tests): Use random account data for script tests

### DIFF
--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const mocks = require(`${ROOT_DIR}/test/mocks`);
 const path = require('path');
 const rimraf = require('rimraf');
+const crypto = require('crypto');
 
 const cwd = path.resolve(__dirname, ROOT_DIR);
 cp.execAsync = promisify(cp.exec);
@@ -54,13 +55,13 @@ function createAccount(email, uid, locale = 'en') {
 }
 
 const account1Mock = createAccount(
-  'user1@test.com',
-  'f9916686c226415abd06ae550f073cec',
+  `user${Math.random()}@test.com`,
+  `${crypto.randomUUID().replaceAll('-','')}`,
   'en'
 );
 const account2Mock = createAccount(
-  'user2@test.com',
-  'f9916686c226415abd06ae550f073ced',
+  `user${Math.random()}@test.com`,
+  `${crypto.randomUUID().replaceAll('-','')}`,
   'es'
 );
 

--- a/packages/fxa-auth-server/test/scripts/dump-users.js
+++ b/packages/fxa-auth-server/test/scripts/dump-users.js
@@ -22,6 +22,7 @@ const UnblockCode = require('../../lib/crypto/random').base32(
   config.signinUnblock.codeLength
 );
 const TestServer = require('../test_server');
+const crypto = require('crypto');
 
 const zeroBuffer16 = Buffer.from(
   '00000000000000000000000000000000',
@@ -48,12 +49,14 @@ function createAccount(email, uid) {
 }
 
 const account1Mock = createAccount(
-  'user1@test.com',
-  'f9916686c226415abd06ae550f073cec'
+  `user${Math.random()}@test.com`,
+  `${crypto.randomUUID().replaceAll('-','')}`,
+  'en'
 );
 const account2Mock = createAccount(
-  'user2@test.com',
-  'f9916686c226415abd06ae550f073ced'
+  `user${Math.random()}@test.com`,
+  `${crypto.randomUUID().replaceAll('-','')}`,
+  'es'
 );
 
 const DB = require('../../lib/db')(config, log, Token, UnblockCode);

--- a/packages/fxa-auth-server/test/scripts/must-reset.js
+++ b/packages/fxa-auth-server/test/scripts/must-reset.js
@@ -22,6 +22,7 @@ const UnblockCode = require('../../lib/crypto/random').base32(
   config.signinUnblock.codeLength
 );
 const TestServer = require('../test_server');
+const crypto = require('crypto');
 
 const twoBuffer16 = Buffer.from(
   '22222222222222222222222222222222',
@@ -48,12 +49,14 @@ function createAccount(email, uid) {
 }
 
 const account1Mock = createAccount(
-  'user1@test.com',
-  'f9916686c226415abd06ae550f073cec'
+  `user${Math.random()}@test.com`,
+  `${crypto.randomUUID().replaceAll('-','')}`,
+  'en'
 );
 const account2Mock = createAccount(
-  'user2@test.com',
-  'f9916686c226415abd06ae550f073ced'
+  `user${Math.random()}@test.com`,
+  `${crypto.randomUUID().replaceAll('-','')}`,
+  'es'
 );
 
 const DB = require('../../lib/db')(config, log, Token, UnblockCode);


### PR DESCRIPTION
## Because

- We have a lot of flaky auth-server script tests, [Ref](https://app.circleci.com/insights/github/mozilla/fxa/workflows/test_pull_request/tests?branch=try-ci-changes)
- We use the same email and uid when running tests, we should have something different

## This pull request

- Generates random account data for the tests

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Not sure if this will help but certainly shouldn't hurt.
