### PR TITLE
feat(gql): re-auth an existing session

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -71,6 +71,12 @@ export type SignedInAccountData = {
   unwrapBKey?: hexstring;
 };
 
+export type SessionReauthOptions = SignInOptions;
+export type SessionReauthedAccountData = Omit<
+  SignedInAccountData,
+  'sessionToken'
+>;
+
 export type AuthServerError = Error & {
   error?: string;
   errno?: number;
@@ -726,39 +732,15 @@ export default class AuthClient {
     sessionToken: hexstring,
     email: string,
     password: string,
-    options: {
-      keys?: boolean;
-      skipCaseError?: boolean;
-      service?: string;
-      reason?: string;
-      redirectTo?: string;
-      resume?: string;
-      originalLoginEmail?: string;
-      verificationMethod?: string;
-      metricsContext?: MetricsContext;
-    } = {}
-  ): Promise<{
-    uid: string;
-    verified: boolean;
-    authAt: number;
-    metricsEnabled: boolean;
-    verificationMethod?: string;
-    verificationReason?: string;
-    keyFetchToken?: hexstring;
-    unwrapBKey?: hexstring;
-  }> {
+    options: SessionReauthOptions = {}
+  ): Promise<SessionReauthedAccountData> {
     const credentials = await crypto.getCredentials(email, password);
-    const payloadOptions = ({ keys, ...rest }: any) => rest;
-    const payload = {
-      email,
-      authPW: credentials.authPW,
-      ...payloadOptions(options),
-    };
     try {
-      const accountData = await this.sessionPost(
-        pathWithKeys('/session/reauth', options.keys),
+      const accountData = await this.sessionReauthWithAuthPW(
         sessionToken,
-        payload
+        email,
+        credentials.authPW,
+        options
       );
       if (options.keys) {
         accountData.unwrapBKey = credentials.unwrapBKey;
@@ -779,6 +761,28 @@ export default class AuthClient {
         throw error;
       }
     }
+  }
+
+  async sessionReauthWithAuthPW(
+    sessionToken: hexstring,
+    email: string,
+    authPW: string,
+    options: Omit<SessionReauthOptions, 'skipCaseError'> = {},
+    headers: Headers = new Headers()
+  ): Promise<SessionReauthedAccountData> {
+    const payloadOptions = ({ keys, ...rest }: any) => rest;
+    const payload = {
+      email,
+      authPW,
+      ...payloadOptions(options),
+    };
+    const accountData = await this.sessionPost(
+      pathWithKeys('/session/reauth', options.keys),
+      sessionToken,
+      payload,
+      headers
+    );
+    return accountData;
   }
 
   async certificateSign(

--- a/packages/fxa-graphql-api/src/gql/dto/input/session-reauth.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/session-reauth.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, InputType } from '@nestjs/graphql';
+import { SignInInput, SignInOptionsInput } from './sign-in';
+
+@InputType()
+export class SessionReauthOptionsInput extends SignInOptionsInput {}
+
+@InputType()
+export class SessionReauthInput extends SignInInput {
+  @Field()
+  public sessionToken!: hexstring;
+
+  @Field()
+  public options!: SessionReauthOptionsInput;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/signed-in-account.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/signed-in-account.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType, OmitType } from '@nestjs/graphql';
 
 @ObjectType()
 export class SignedInAccountPayload {
@@ -35,3 +35,9 @@ export class SignedInAccountPayload {
   @Field({ nullable: true })
   verificationReason?: string;
 }
+
+@ObjectType()
+export class SessionReauthedAccountPlayload extends OmitType(
+  SignedInAccountPayload,
+  ['sessionToken']
+) {}

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -60,4 +60,34 @@ describe('#unit - AccountResolver', () => {
     const result = resolver.sessionStatus('42420000', 'verified');
     expect(result).toStrictEqual({ state: 'verified', uid: '42420000' });
   });
+
+  it('reauthenticates a given session with auth-client', async () => {
+    const headers = new Headers();
+    const now = Date.now();
+    const mockRespPayload = {
+      clientMutationId: 'testid',
+      uid: '1337',
+      verified: true,
+      authAt: now,
+      metricsEnabled: true,
+    };
+    authClient.sessionReauthWithAuthPW = jest
+      .fn()
+      .mockResolvedValue(mockRespPayload);
+    const result = await resolver.reauthSession(headers, {
+      sessionToken: 'goodtoken',
+      authPW: '00000000',
+      email: 'testo@example.xyz',
+      options: { service: 'testo-co' },
+    });
+    expect(authClient.sessionReauthWithAuthPW).toBeCalledTimes(1);
+    expect(authClient.sessionReauthWithAuthPW).toBeCalledWith(
+      'goodtoken',
+      'testo@example.xyz',
+      '00000000',
+      { service: 'testo-co' },
+      headers
+    );
+    expect(result).toStrictEqual(mockRespPayload);
+  });
 });


### PR DESCRIPTION
Because:
 - we want to re-auth an existing session through the gql-api

This commit:
 - proxy a session reauth request through the gql-api to the auth-server
