### PR TITLE
task(ci): Run content server smoke tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,17 @@ executors:
       PAYPAL_SANDBOX: true
       FXA_MX_RECORD_EXCLUSIONS: restmail.dev.lcip.org
 
+  # For anything that needs browsers for ui automation, but doesn't need a full stack.
+  # Perfect running smoke tests deployed code.
+  smoke-test-executor:
+    parameters:
+      resource_class:
+          type: string
+          default: medium+
+    resource_class: << parameters.resource_class >>
+    docker:
+      - image: << pipeline.parameters.docker-repo >>:ci-base-browsers-latest
+
 commands:
 
   # Note: Cloning this way allows us to run a git fetch later on download the road. This type of
@@ -151,6 +162,30 @@ commands:
             CIRCLE_NODE_INDEX: << parameters.index >>
             CIRCLE_NODE_TOTAL: << parameters.total >>
           command: ./.circleci/test-package.sh fxa-content-server
+      - store_artifacts:
+          path: ~/.pm2/logs
+          destination: logs
+      - store_artifacts:
+          path: ~/screenshots
+          destination: screenshots
+      - store_test_results:
+          path: artifacts/tests
+
+  test-content-server-remote-part:
+    parameters:
+      index:
+        type: integer
+      total:
+        type: integer
+    steps:
+      - git-checkout
+      - provision
+      - run:
+          name: Running test section << parameters.index >> of << parameters.total >>
+          environment:
+            CIRCLE_NODE_INDEX: << parameters.index >>
+            CIRCLE_NODE_TOTAL: << parameters.total >>
+          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh
       - store_artifacts:
           path: ~/.pm2/logs
           destination: logs
@@ -384,16 +419,36 @@ jobs:
       - wait-for-infrastructure
       - run:
           name: Running test section against a remote target
-          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh
+          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh 3
       - store_artifacts:
           path: ~/screenshots
           destination: screenshots
       - store_test_results:
           path: artifacts/tests
 
+  # These jobs are manually triggered for now. see .circleci/README.md
+  test-content-server-remote-part-0:
+    executor: smoke-test-executor
+    steps:
+      - test-content-server-remote-part:
+          index: 0
+          total: 3
+  test-content-server-remote-part-1:
+    executor: smoke-test-executor
+    steps:
+      - test-content-server-remote-part:
+          index: 1
+          total: 3
+  test-content-server-remote-part-2:
+    executor: smoke-test-executor
+    steps:
+      - test-content-server-remote-part:
+          index: 2
+          total: 3
+
   # This job is manually triggered for now. see .circleci/README.md
   production-smoke-tests:
-    executor: default-executor
+    executor: smoke-test-executor
     steps:
       - git-checkout
       - provision
@@ -527,6 +582,30 @@ workflows:
               ignore: main
             tags:
               ignore: /.*/
+
+  # This workflow can be useful if we want to run test changes in our functional tests
+  # against deployed code. Simply prefix a branch with run-smoke-tests, and issue a PR.
+  smoke_test:
+    jobs:
+      - request-smoke-testing:
+          type: approval
+          filters:
+            branches:
+              only: /^run-smoke-tests-/
+            tags:
+              ignore: /.*/
+      - production-smoke-tests:
+          requires:
+            - request-smoke-testing
+      - test-content-server-remote-part-0:
+          requires:
+            - request-smoke-testing
+      - test-content-server-remote-part-1:
+          requires:
+            - request-smoke-testing
+      - test-content-server-remote-part-2:
+          requires:
+            - request-smoke-testing
 
   deploy_branch:
     jobs:

--- a/packages/functional-tests/lib/fixtures/README.md
+++ b/packages/functional-tests/lib/fixtures/README.md
@@ -4,7 +4,7 @@ Fixtures make writing tests nicer so that they have less boilerplate.
 
 ## Standard
 
-The standard fixure provides
+The standard fixture provides
 
 - `target`: the [Target](../targets/README.md) object
 - `credentials`: provides the `email` and `password` of a fresh account created and logged in for each test

--- a/packages/fxa-content-server/scripts/test-ci-remote.sh
+++ b/packages/fxa-content-server/scripts/test-ci-remote.sh
@@ -10,6 +10,9 @@ env | sort
 
 function test_suite() {
   local suite=$1
+  local numGroups=$2
+  local i=$3
+
   node tests/intern.js \
     --suites="${suite}" \
     --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
@@ -19,9 +22,10 @@ function test_suite() {
     --fxaEmailRoot=http://restmail.net \
     --fxaProduction=true \
     --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \
-    --firefoxBinary=./firefox/firefox \
     --testProductId="prod_FiJ42WCzZNRSbS" \
     --testPlanId="plan_HJyNT4gbuyyZ0G" \
+    --groups=${numGroups} \
+    --groupIndex=${i} \
     || \
   node tests/intern.js \
     --suites="${suite}" \
@@ -32,19 +36,21 @@ function test_suite() {
     --fxaEmailRoot=http://restmail.net \
     --fxaProduction=true \
     --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \
-    --firefoxBinary=./firefox/firefox \
     --grep="$(<rerun.txt)" \
     --testProductId="prod_FiJ42WCzZNRSbS" \
-    --testPlanId="plan_HJyNT4gbuyyZ0G"
+    --testPlanId="plan_HJyNT4gbuyyZ0G" \
+    --groups=${numGroups} \
+    --groupIndex=${i}
 }
 
+# TODO: Move to step in CI
 yarn lint
 
 cd ../../
 mkdir -p artifacts/tests
 
 cd packages/fxa-content-server
-mozinstall /firefox.tar.bz2
-test_suite functional_smoke && test_suite functional_regression
+
+test_suite functional_smoke $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX && test_suite functional_regression $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX
 # TODO: Re-enable once configuration in stage is updated
 # test_suite pairing


### PR DESCRIPTION
## Because

- We want decrease the time it takes to deploy

## This pull request

- Adds ability to divide smoke tests
- Creates jobs that divide content server smoke tests into three parts
- Jobs can be run in parallel
- Creates a new executor for running smoke tests
- Removes mozinstall command (found in test-ci-remote.sh) since there is already a firefox browser installed in the base image
- Removes internjs argument --firefoxBinary, because there is now a firefox binary available in /usr/local/bin/firefox.

## Issue that this pull request solves

Closes: FXA-6264

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

- Playwright tests run pretty quickly so they were not split
- The remote content server tests seem to have some flake. I am still trying to determine if it is worse when they run in parallel. 
