### PR TITLE
fix(CI): Fix failing tests due to missing types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ commands:
       - run: ./.circleci/base-install.sh
       - run: node .circleci/modules-to-test.js | tee packages/test.list
       - run: ./_scripts/create-version-json.sh
+      - run: ./_scripts/compile-backend-ts-services.sh
 
   cache-save-yarn:
     steps:


### PR DESCRIPTION
## Because

- The graphql-api didn't startup properly. It appears down stream packages were not built.

## This pull request

- Ensures common packages are built.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
