### PR TITLE
feat(gql): Add verify email code gql

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -403,13 +403,16 @@ export default class AuthClient {
       marketingOptIn?: boolean;
       newsletters?: string[];
       style?: string;
-    } = {}
+    } = {},
+    headers: Headers = new Headers()
   ) {
-    return this.request('POST', '/recovery_email/verify_code', {
-      uid,
-      code,
-      ...options,
-    });
+    return this.request('POST', '/recovery_email/verify_code',
+     {
+       uid,
+       code,
+       ...options,
+     },
+     headers);
   }
 
   async recoveryEmailStatus(sessionToken: hexstring) {

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -669,5 +669,28 @@ describe('#integration - AccountResolver', () => {
         spy.mockRestore();
       });
     });
+
+    describe('emailVerifyCode', () => {
+      it('succeeds', async () => {
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
+        });
+        authClient.verifyCode = jest.fn().mockResolvedValue({
+          uid: 'cooltokenyo',
+          code: 'coolcode',
+          options: { service: 'sync' }
+        });
+        const result = await resolver.emailVerifyCode(headers, {
+          uid: 'cooltokenyo',
+          code: 'coolcode',
+          service: 'sync',
+          clientMutationId: 'testid',
+        });
+        expect(authClient.verifyCode).toBeCalledTimes(1);
+        expect(result).toStrictEqual({
+          clientMutationId: 'testid'
+        });
+      });
+    });
   });
 });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -47,6 +47,7 @@ import {
   UpdateAvatarInput,
   UpdateDisplayNameInput,
   VerifyEmailInput,
+  VerifyEmailCodeInput,
   VerifySessionInput,
   VerifyTotpInput,
   CreatePassword,
@@ -607,6 +608,29 @@ export class AccountResolver {
       uid: input.uid,
       unblockCode: input.unblockCode,
     });
+    return {
+      clientMutationId: input.clientMutationId,
+    };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description:
+     'Used to verify a users primary email address.',
+  })
+  @CatchGatewayError
+  public async emailVerifyCode(
+   @GqlXHeaders() headers: Headers,
+   @Args('input', { type: () => VerifyEmailCodeInput }) input: VerifyEmailCodeInput
+  ): Promise<BasicPayload> {
+    await this.authAPI.verifyCode(
+     input.uid,
+     input.code,
+     {
+       service: input.service
+     },
+     headers
+    );
+    
     return {
       clientMutationId: input.clientMutationId,
     };

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -20,7 +20,7 @@ export { SendSessionVerificationInput } from './send-session-verification';
 export { SignInInput } from './sign-in';
 export { UpdateAvatarInput } from './update-avatar';
 export { UpdateDisplayNameInput } from './update-display-name';
-export { VerifyEmailInput } from './verify-email';
+export { VerifyEmailInput, VerifyEmailCodeInput } from './verify-email';
 export { VerifySessionInput } from './verify-session';
 export { VerifyTotpInput } from './verify-totp';
 export { AccountStatusInput } from './account-status';

--- a/packages/fxa-graphql-api/src/gql/dto/input/verify-email.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/verify-email.ts
@@ -17,3 +17,21 @@ export class VerifyEmailInput {
   @Field({ description: 'The code to check' })
   public code!: string;
 }
+
+@InputType()
+export class VerifyEmailCodeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'The code to check' })
+  public code!: string;
+
+  @Field({ description: 'Account uid' })
+  public uid!: string;
+
+  @Field({ nullable: true })
+  public service?: string;
+}


### PR DESCRIPTION
## Because

- We need to be able to verify an email via a code since its used in our frontend routes

## This pull request

- Adds gql mutation to verify an email via code

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6333

## Checklist


- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
