### PR TITLE
Train 248 uplift 1 -> Train 248

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ commands:
       - run: ./.circleci/base-install.sh
       - run: node .circleci/modules-to-test.js | tee packages/test.list
       - run: ./_scripts/create-version-json.sh
+      - run: ./_scripts/compile-backend-ts-services.sh
 
   cache-save-yarn:
     steps:


### PR DESCRIPTION
Because:
- The graphql api didn't startup properly. It appears down stream packages were not built.

This Commit:
- Ensures common packages are built.
