### PR TITLE
bug(CI): test-content-server-remote must not have parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,17 +391,13 @@ jobs:
 
   # This job is manually triggered for now. see .circleci/README.md
   test-content-server-remote:
-    parameters:
-      executor:
-        type: executor
-    executor: << parameters.executor >>
+    executor: smoke-test-executor
     steps:
       - git-checkout
       - provision
-      - wait-for-infrastructure
       - run:
           name: Running test section against a remote target
-          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh 3
+          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh
       - store_artifacts:
           path: ~/screenshots
           destination: screenshots
@@ -559,25 +555,44 @@ workflows:
   # against deployed code. Simply prefix a branch with run-smoke-tests, and issue a PR.
   smoke_test:
     jobs:
-      - request-smoke-testing:
+      - request-production-smoke-tests:
           type: approval
           filters:
             branches:
-              only: /^run-smoke-tests-/
+              only: /^run-smoke-tests-.*/
             tags:
               ignore: /.*/
       - production-smoke-tests:
           requires:
-            - request-smoke-testing
+            - request-production-smoke-tests
+
+      - request-test-content-server-remote:
+          type: approval
+          filters:
+            branches:
+              only: /^run-smoke-tests-.*/
+            tags:
+              ignore: /.*/
+      - test-content-server-remote:
+          requires:
+            - request-test-content-server-remote
+
+      - request-test-content-server-remote-parts:
+          type: approval
+          filters:
+            branches:
+              only: /^run-smoke-tests-.*/
+            tags:
+              ignore: /.*/
       - test-content-server-remote-part-0:
           requires:
-            - request-smoke-testing
+            - request-test-content-server-remote-parts
       - test-content-server-remote-part-1:
           requires:
-            - request-smoke-testing
+            - request-test-content-server-remote-parts
       - test-content-server-remote-part-2:
           requires:
-            - request-smoke-testing
+            - request-test-content-server-remote-parts
 
   deploy_branch:
     jobs:


### PR DESCRIPTION
## Because

- We cannot add parameters to job triggered through circleci's API

## This pull request

- Removes parameters from the `test-content-server-remote` job

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

