### PR TITLE
feat(gql): add session mutation to verify OTP codes

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -738,7 +738,8 @@ export default class AuthClient {
       scopes?: string[];
       marketingOptIn?: boolean;
       newsletters?: string[];
-    } = {}
+    } = {},
+    headers: Headers = new Headers()
   ): Promise<{}> {
     return this.sessionPost('/session/verify_code', sessionToken, {
       code,

--- a/packages/fxa-graphql-api/src/gql/dto/input/session-verify-code.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/session-verify-code.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class SessionVerifyCodeOptionsInput {
+  @Field({ nullable: true })
+  service?: string;
+
+  @Field((type) => [String], { nullable: true })
+  scopes?: string[];
+
+  @Field((type) => [String], { nullable: true })
+  newsletters?: string[];
+}
+
+@InputType()
+export class SessionVerifyCodeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'The code to check' })
+  public code!: string;
+
+  @Field()
+  public options!: SessionVerifyCodeOptionsInput;
+}

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -108,4 +108,26 @@ describe('#unit - AccountResolver', () => {
       clientMutationId: 'testid',
     });
   });
+
+ it('verifies a OTP code', async () => {
+  const token = 'totallylegit';
+  const headers = new Headers();
+  const mockRespPayload = {};
+  authClient.sessionVerifyCode = jest.fn().mockResolvedValue(mockRespPayload);
+  const result = await resolver.verifyCode(token, headers, {
+   clientMutationId: 'testid',
+   code: '00000000',
+   options: { service: 'testo-co' },
+  });
+  expect(authClient.sessionVerifyCode).toBeCalledTimes(1);
+  expect(authClient.sessionVerifyCode).toBeCalledWith(
+   token,
+   '00000000',
+   { service: 'testo-co' },
+   headers
+  );
+  expect(result).toStrictEqual({
+   clientMutationId: 'testid',
+  });
+ });
 });

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -23,6 +23,7 @@ import { BasicPayload } from './dto/payload';
 import { SessionReauthedAccountPlayload } from './dto/payload/signed-in-account';
 import { CatchGatewayError } from './lib/error';
 import { Session as SessionType, SessionStatus } from './model/session';
+import { SessionVerifyCodeInput } from './dto/input/session-verify-code';
 
 @Resolver((of: any) => SessionType)
 export class SessionResolver {
@@ -96,6 +97,28 @@ export class SessionResolver {
     @Args('input', { type: () => BasicMutationInput }) input: BasicMutationInput
   ): Promise<BasicPayload> {
     await this.authAPI.sessionResendVerifyCode(token, headers);
+    return {
+      clientMutationId: input.clientMutationId,
+    };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description: 'Verify a OTP code.',
+  })
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @CatchGatewayError
+  public async verifyCode(
+   @GqlSessionToken() token: string,
+   @GqlXHeaders() headers: Headers,
+   @Args('input', { type: () => SessionVerifyCodeInput })
+    input: SessionVerifyCodeInput
+  ): Promise<BasicPayload> {
+    await this.authAPI.sessionVerifyCode(
+     token,
+     input.code,
+     input.options,
+     headers
+    );
     return {
       clientMutationId: input.clientMutationId,
     };


### PR DESCRIPTION
Because:
 - gql-api should be able to verify an OTP code

This commit:
 - proxy to the auth-server to verify an OTP code
