### PR TITLE
fix(auth/payments): canada tax not reflecting multiple tax rates

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -26,11 +26,14 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
 
   // Add tax if it exists
   if (invoice.total_tax_amounts.length > 0) {
-    const tax = invoice.total_tax_amounts[0];
-    invoicePreview.tax = {
+    invoicePreview.tax = invoice.total_tax_amounts.map((tax) => ({
       amount: tax.amount,
       inclusive: tax.inclusive,
-    };
+      display_name:
+        typeof tax.tax_rate === 'object'
+          ? tax.tax_rate.display_name
+          : undefined,
+    }));
   }
 
   // Add discount if it exists
@@ -61,11 +64,14 @@ export function stripeInvoicesToSubsequentInvoicePreviewsDTO(
     };
 
     if (invoice.total_tax_amounts.length > 0) {
-      const tax = invoice.total_tax_amounts[0];
-      invoicePreview.tax = {
+      invoicePreview.tax = invoice.total_tax_amounts.map((tax) => ({
         amount: tax.amount,
         inclusive: tax.inclusive,
-      };
+        display_name:
+          typeof tax.tax_rate === 'object'
+            ? tax.tax_rate.display_name
+            : undefined,
+      }));
     }
 
     return invoicePreview;

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -694,6 +694,7 @@ export class StripeHelper extends StripeHelperBase {
               price: priceId,
             },
           ],
+          expand: ['total_tax_amounts.tax_rate'],
           ...params,
         });
       } catch (e: any) {

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_preview_tax.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_preview_tax.json
@@ -134,7 +134,9 @@
           {
             "amount": 371,
             "inclusive": true,
-            "tax_rate": "txr_1JALB2BVqmGyQTMa3ltU6p6y"
+            "tax_rate": {
+              "display_name": "GST"
+            }
           }
         ],
         "tax_rates": [],
@@ -181,7 +183,9 @@
     {
       "amount": 371,
       "inclusive": true,
-      "tax_rate": "txr_1JALB2BVqmGyQTMa3ltU6p6y"
+      "tax_rate": {
+        "display_name": "GST"
+      }
     }
   ],
   "transfer_data": null,

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -22,10 +22,14 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     assert.equal(invoice.total, previewInvoiceWithTax.total);
     assert.equal(invoice.subtotal, previewInvoiceWithTax.subtotal);
     assert.equal(
-      invoice.tax.amount,
+      invoice.tax[0].amount,
       previewInvoiceWithTax.total_tax_amounts[0].amount
     );
-    assert.equal(invoice.tax.inclusive, true);
+    assert.equal(
+      invoice.tax[0].display_name,
+      previewInvoiceWithTax.total_tax_amounts[0].tax_rate.display_name
+    );
+    assert.equal(invoice.tax[0].inclusive, true);
     assert.isUndefined(invoice.discount);
   });
 
@@ -36,10 +40,15 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     assert.equal(invoice.total, previewInvoiceWithDiscountAndTax.total);
     assert.equal(invoice.subtotal, previewInvoiceWithDiscountAndTax.subtotal);
     assert.equal(
-      invoice.tax.amount,
+      invoice.tax[0].amount,
       previewInvoiceWithDiscountAndTax.total_tax_amounts[0].amount
     );
-    assert.equal(invoice.tax.inclusive, true);
+    assert.equal(
+      invoice.tax[0].display_name,
+      previewInvoiceWithDiscountAndTax.total_tax_amounts[0].tax_rate
+        .display_name
+    );
+    assert.equal(invoice.tax[0].inclusive, true);
     assert.equal(
       invoice.discount.amount,
       previewInvoiceWithDiscountAndTax.total_discount_amounts[0].amount

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2109,6 +2109,7 @@ describe('#integration - StripeHelper', () => {
             price: 'priceId',
           },
         ],
+        expand: ['total_tax_amounts.tax_rate'],
       });
     });
 

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -63,10 +63,12 @@ const invoicePreviewInclusiveTax: FirstInvoicePreview = {
   subtotal_excluding_tax: 885,
   total: 935,
   total_excluding_tax: 885,
-  tax: {
-    amount: 50,
-    inclusive: true,
-  },
+  tax: [
+    {
+      amount: 50,
+      inclusive: true,
+    },
+  ],
 };
 
 const invoicePreviewExclusiveTax: FirstInvoicePreview = {
@@ -75,10 +77,32 @@ const invoicePreviewExclusiveTax: FirstInvoicePreview = {
   subtotal_excluding_tax: 935,
   total: 985,
   total_excluding_tax: 935,
-  tax: {
-    amount: 50,
-    inclusive: false,
-  },
+  tax: [
+    {
+      amount: 50,
+      inclusive: false,
+    },
+  ],
+};
+
+const invoicePreviewExclusiveMultipleTax: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 935,
+  subtotal_excluding_tax: 935,
+  total: 985,
+  total_excluding_tax: 935,
+  tax: [
+    {
+      amount: 50,
+      inclusive: false,
+      display_name: 'GST',
+    },
+    {
+      amount: 75,
+      inclusive: false,
+      display_name: 'PST',
+    },
+  ],
 };
 
 const storyWithContext = ({
@@ -128,6 +152,17 @@ export const WithExclusiveTax = storyWithContext({
   plan: {
     selectedPlan: selectedPlan,
     invoicePreview: invoicePreviewExclusiveTax,
+  },
+  config: {
+    ...defaultAppContextValue.config,
+    featureFlags: { useStripeAutomaticTax: true },
+  },
+});
+
+export const WithMultipleExclusiveTax = storyWithContext({
+  plan: {
+    selectedPlan: selectedPlan,
+    invoicePreview: invoicePreviewExclusiveMultipleTax,
   },
   config: {
     ...defaultAppContextValue.config,

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -202,8 +202,12 @@ describe('PlanDetails', () => {
       selectedPlan.interval,
       selectedPlan.interval_count
     );
+    const totalTax = INVOICE_PREVIEW_EXCLUSIVE_TAX.tax?.reduce(
+      (total, taxRate) => total + taxRate.amount,
+      0
+    );
     const expectedTaxAmount = getLocalizedCurrencyString(
-      INVOICE_PREVIEW_EXCLUSIVE_TAX.tax?.amount!,
+      totalTax || null,
       selectedPlan.currency
     );
 

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -392,10 +392,13 @@ export const INVOICE_PREVIEW_INCLUSIVE_TAX: FirstInvoicePreview = {
   subtotal_excluding_tax: 377,
   total: 500,
   total_excluding_tax: 377,
-  tax: {
-    amount: 123,
-    inclusive: true,
-  },
+  tax: [
+    {
+      amount: 123,
+      inclusive: true,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 
 export const INVOICE_PREVIEW_EXCLUSIVE_TAX: FirstInvoicePreview = {
@@ -411,8 +414,11 @@ export const INVOICE_PREVIEW_EXCLUSIVE_TAX: FirstInvoicePreview = {
   subtotal_excluding_tax: 500,
   total: 623,
   total_excluding_tax: 500,
-  tax: {
-    amount: 123,
-    inclusive: false,
-  },
+  tax: [
+    {
+      amount: 123,
+      inclusive: false,
+      display_name: 'Sales Tax',
+    },
+  ],
 };

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -642,10 +642,13 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
     subtotal_excluding_tax: 500,
     total: 623,
     total_excluding_tax: 500,
-    tax: {
-      amount: 123,
-      inclusive: false,
-    },
+    tax: [
+      {
+        amount: 123,
+        inclusive: false,
+        display_name: 'Sales Tax',
+      },
+    ],
   },
   // 3 - With Inclusive tax
   {
@@ -655,10 +658,13 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
     subtotal_excluding_tax: 377,
     total: 500,
     total_excluding_tax: 377,
-    tax: {
-      amount: 123,
-      inclusive: true,
-    },
+    tax: [
+      {
+        amount: 123,
+        inclusive: true,
+        display_name: 'Sales Tax',
+      },
+    ],
   },
   // 4 - With Exclusive tax and Discount
   {
@@ -668,10 +674,13 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
     subtotal_excluding_tax: 500,
     total: 573,
     total_excluding_tax: 450,
-    tax: {
-      amount: 123,
-      inclusive: false,
-    },
+    tax: [
+      {
+        amount: 123,
+        inclusive: false,
+        display_name: 'Sales Tax',
+      },
+    ],
   },
   // 5 - With Inclusive tax and Discount
   {
@@ -681,10 +690,13 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
     subtotal_excluding_tax: 377,
     total: 450,
     total_excluding_tax: 327,
-    tax: {
-      amount: 123,
-      inclusive: true,
-    },
+    tax: [
+      {
+        amount: 123,
+        inclusive: true,
+        display_name: 'Sales Tax',
+      },
+    ],
   },
 ];
 
@@ -799,10 +811,13 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE: FirstInvoicePreview = {
       name: 'first invoice',
     },
   ],
-  tax: {
-    amount: 300,
-    inclusive: false,
-  },
+  tax: [
+    {
+      amount: 300,
+      inclusive: false,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 
 export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE: FirstInvoicePreview = {
@@ -818,10 +833,13 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE: FirstInvoicePreview = {
       name: 'first invoice',
     },
   ],
-  tax: {
-    amount: 300,
-    inclusive: true,
-  },
+  tax: [
+    {
+      amount: 300,
+      inclusive: true,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 
 export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT: FirstInvoicePreview =
@@ -838,10 +856,13 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT: FirstInvoicePrevi
         name: 'first invoice',
       },
     ],
-    tax: {
-      amount: 300,
-      inclusive: true,
-    },
+    tax: [
+      {
+        amount: 300,
+        inclusive: true,
+        display_name: 'Sales Tax',
+      },
+    ],
     discount: {
       amount: 50,
       amount_off: 50,
@@ -863,10 +884,13 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT: FirstInvoicePrevi
         name: 'first invoice',
       },
     ],
-    tax: {
-      amount: 300,
-      inclusive: false,
-    },
+    tax: [
+      {
+        amount: 300,
+        inclusive: false,
+        display_name: 'Sales Tax',
+      },
+    ],
     discount: {
       amount: 50,
       amount_off: 50,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -90,10 +90,13 @@ function setupVariantStories(
                   subtotal_excluding_tax: 2000,
                   total: 2300,
                   total_excluding_tax: 2000,
-                  tax: {
-                    amount: 300,
-                    inclusive: false,
-                  },
+                  tax: [
+                    {
+                      amount: 300,
+                      inclusive: false,
+                      display_name: 'Sales Tax',
+                    },
+                  ],
                 },
               ],
             },
@@ -123,10 +126,13 @@ function setupVariantStories(
                   subtotal_excluding_tax: 1700,
                   total: 2000,
                   total_excluding_tax: 1700,
-                  tax: {
-                    amount: 300,
-                    inclusive: true,
-                  },
+                  tax: [
+                    {
+                      amount: 300,
+                      inclusive: true,
+                      display_name: 'Sales Tax',
+                    },
+                  ],
                 },
               ],
             },
@@ -596,10 +602,13 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE: FirstInvoicePreview = {
       name: 'first invoice',
     },
   ],
-  tax: {
-    amount: 300,
-    inclusive: false,
-  },
+  tax: [
+    {
+      amount: 300,
+      inclusive: false,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 
 export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE: FirstInvoicePreview = {
@@ -615,10 +624,13 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE: FirstInvoicePreview = {
       name: 'first invoice',
     },
   ],
-  tax: {
-    amount: 300,
-    inclusive: true,
-  },
+  tax: [
+    {
+      amount: 300,
+      inclusive: true,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 
 const getPreviewInvoiceMockData = (response: FirstInvoicePreview) => [

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -13,6 +13,7 @@ export interface InvoiceLineItem {
 export interface InvoiceTax {
   amount: number;
   inclusive: boolean;
+  display_name?: string;
 }
 
 export interface InvoiceDiscount {
@@ -31,7 +32,7 @@ export interface FirstInvoicePreview {
   subtotal_excluding_tax: number | null;
   total: number;
   total_excluding_tax: number | null;
-  tax?: InvoiceTax;
+  tax?: InvoiceTax[];
   discount?: InvoiceDiscount;
 }
 
@@ -53,9 +54,10 @@ export const firstInvoicePreviewSchema = joi.object({
   subtotal_excluding_tax: joi.number().required().allow(null),
   total: joi.number().required(),
   total_excluding_tax: joi.number().required().allow(null),
-  tax: joi.object({
+  tax: joi.array().items({
     amount: joi.number().required(),
     inclusive: joi.boolean().required(),
+    display_name: joi.string().optional(),
   }),
   discount: joi.object({
     amount: joi.number().required(),
@@ -80,7 +82,8 @@ export type firstInvoicePreviewSchema = {
   tax?: {
     amount: number;
     inclusive: boolean;
-  };
+    display_name?: string;
+  }[];
   discount?: {
     amount: number;
     amount_off: number | null;
@@ -99,7 +102,7 @@ export interface SubsequentInvoicePreview {
   subtotal_excluding_tax: number | null;
   total: number;
   total_excluding_tax: number | null;
-  tax?: InvoiceTax;
+  tax?: InvoiceTax[];
 }
 
 export const subsequentInvoicePreviewsSchema = joi.array().items(
@@ -110,9 +113,10 @@ export const subsequentInvoicePreviewsSchema = joi.array().items(
     subtotal_excluding_tax: joi.number().required().allow(null),
     total: joi.number().required(),
     total_excluding_tax: joi.number().required().allow(null),
-    tax: joi.object({
+    tax: joi.array().items({
       amount: joi.number().required(),
       inclusive: joi.boolean().required(),
+      display_name: joi.string().optional(),
     }),
   })
 );
@@ -127,7 +131,8 @@ export type subsequentInvoicePreview = {
   tax?: {
     amount: number;
     inclusive: boolean;
-  };
+    display_name?: string;
+  }[];
 };
 
 export type subsequentInvoicePreviewsSchema = Array<subsequentInvoicePreview>;


### PR DESCRIPTION
## Because

* Multiple tax rates in Canada were not reflected in the invoice preview.
* Multiple tax rates in Canada were not reflected on the subscription management page.

## This pull request

* Adds support for showing multiple tax rates within the invoice preview.
* Fixes total displayed on subscription management page for subscriptions with multiple tax rates.

## Issue that this pull request solves

Closes FXA-6439

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="337" alt="image" src="https://user-images.githubusercontent.com/7751154/209078007-af659b25-d72b-40c7-aab3-8a6f084c9cef.png">

![image](https://user-images.githubusercontent.com/7751154/210427733-7c0ee5dc-7aa6-45af-bcba-c28f10040828.png)


[FXA-6439]: https://mozilla-hub.atlassian.net/browse/FXA-6439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ