### PR TITLE
Train 248 uplift 2 -> Train 248

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,8 @@ commands:
       - run: node .circleci/modules-to-test.js | tee packages/test.list
       - run: ./_scripts/create-version-json.sh
       - run: ./_scripts/compile-backend-ts-services.sh
+      - store_artifacts:
+          path: artifacts
 
   cache-save-yarn:
     steps:
@@ -198,7 +200,6 @@ commands:
 
   test-settings-server:
     steps:
-      - provision
       - run:
           name: Running test...
           command: ./.circleci/test-package.sh fxa-settings
@@ -392,17 +393,13 @@ jobs:
 
   # This job is manually triggered for now. see .circleci/README.md
   test-content-server-remote:
-    parameters:
-      executor:
-        type: executor
-    executor: << parameters.executor >>
+    executor: smoke-test-executor
     steps:
       - git-checkout
       - provision
-      - wait-for-infrastructure
       - run:
           name: Running test section against a remote target
-          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh 3
+          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh
       - store_artifacts:
           path: ~/screenshots
           destination: screenshots
@@ -560,25 +557,44 @@ workflows:
   # against deployed code. Simply prefix a branch with run-smoke-tests, and issue a PR.
   smoke_test:
     jobs:
-      - request-smoke-testing:
+      - request-production-smoke-tests:
           type: approval
           filters:
             branches:
-              only: /^run-smoke-tests-/
+              only: /^run-smoke-tests-.*/
             tags:
               ignore: /.*/
       - production-smoke-tests:
           requires:
-            - request-smoke-testing
+            - request-production-smoke-tests
+
+      - request-test-content-server-remote:
+          type: approval
+          filters:
+            branches:
+              only: /^run-smoke-tests-.*/
+            tags:
+              ignore: /.*/
+      - test-content-server-remote:
+          requires:
+            - request-test-content-server-remote
+
+      - request-test-content-server-remote-parts:
+          type: approval
+          filters:
+            branches:
+              only: /^run-smoke-tests-.*/
+            tags:
+              ignore: /.*/
       - test-content-server-remote-part-0:
           requires:
-            - request-smoke-testing
+            - request-test-content-server-remote-parts
       - test-content-server-remote-part-1:
           requires:
-            - request-smoke-testing
+            - request-test-content-server-remote-parts
       - test-content-server-remote-part-2:
           requires:
-            - request-smoke-testing
+            - request-test-content-server-remote-parts
 
   deploy_branch:
     jobs:

--- a/_scripts/compile-backend-ts-services.sh
+++ b/_scripts/compile-backend-ts-services.sh
@@ -20,7 +20,7 @@ echo "checking for affected services..."
 ORIGINAL_IFS=$IFS
 IFS=$'\n'
 # We don't need to worry about front-end services that use TS, since they must build successfully for CI to pass.
-BACKEND_PACKAGES=( "fxa-admin-server" "fxa-auth-server" "fxa-event-broker" "fxa-graphql-api" "fxa-shared" "fxa-support-panel" )
+BACKEND_PACKAGES=( "fxa-admin-server" "fxa-auth-server" "fxa-event-broker" "fxa-graphql-api" "fxa-shared" "fxa-auth-client" "fxa-support-panel" )
 INCLUDE_ARGS=''
 AFFECTED_PACKAGES=''
 for package_modified in $PACKAGES_MODIFIED; do
@@ -41,6 +41,7 @@ echo -e "$AFFECTED_PACKAGES" | sed '1d'
 echo "compiling all modified and dependent backend TS services..."
 echo -e "\nNote: if fxa-shared was modified and has any TS errors, the script will exit before compiling other services, since all other backend TS services depend on fxa-shared."
 INCLUDE_ARGS=`echo "$INCLUDE_ARGS" | xargs` # trim whitespace at beginning of string
+
 # We don't need to write files to disk, so `compile` uses `tsc --noEmit` here instead of `tsc --build` for speed.
 if ! `yarn workspaces foreach --verbose --topological-dev --parallel ${INCLUDE_ARGS} run compile > artifacts/compiling-affected-backend-services.log`;
 then

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "postinstall": "(tsc --build tsconfig.browser.json && tsc --build) || true",
     "build": "tsc --build tsconfig.browser.json && tsc --build",
+    "compile": "yarn build",
     "test": "mocha -r esbuild-register test/*",
     "test:unit": "yarn test",
     "test:integration": "echo 'No integration tests present!'"


### PR DESCRIPTION
Because:
- We cannot add parameters to job triggered through circleci's API

This Commit:
- Removes parameters from the `test-content-server-remote` job

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
