### PR TITLE
feat(gql): resend verify code

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -743,8 +743,11 @@ export default class AuthClient {
     });
   }
 
-  async sessionResendVerifyCode(sessionToken: hexstring): Promise<{}> {
-    return this.sessionPost('/session/resend_code', sessionToken, {});
+  async sessionResendVerifyCode(
+    sessionToken: hexstring,
+    headers: Headers = new Headers()
+  ): Promise<{}> {
+    return this.sessionPost('/session/resend_code', sessionToken, {}, headers);
   }
 
   async sessionReauth(

--- a/packages/fxa-graphql-api/src/gql/dto/input/basic-mutation.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/basic-mutation.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Field, InputType } from '@nestjs/graphql';
-import { BasicMutationInput } from './basic-mutation';
 
 @InputType()
-export class ChangeRecoveryCodesInput extends BasicMutationInput {}
+export class BasicMutationInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/input/delete-recovery-key.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/delete-recovery-key.ts
@@ -2,12 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Field, InputType } from '@nestjs/graphql';
+import { BasicMutationInput } from './basic-mutation';
 
 @InputType()
-export class DeleteRecoveryKeyInput {
-  @Field({
-    description: 'A unique identifier for the client performing the mutation.',
-    nullable: true,
-  })
-  public clientMutationId?: string;
-}
+export class DeleteRecoveryKeyInput extends BasicMutationInput {}

--- a/packages/fxa-graphql-api/src/gql/dto/input/delete-totp.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/delete-totp.ts
@@ -1,13 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Field, InputType } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { BasicMutationInput } from './basic-mutation';
 
 @InputType()
-export class DeleteTotpInput {
-  @Field({
-    description: 'A unique identifier for the client performing the mutation.',
-    nullable: true,
-  })
-  public clientMutationId?: string;
-}
+export class DeleteTotpInput extends BasicMutationInput {}

--- a/packages/fxa-graphql-api/src/gql/dto/input/destroy-session.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/destroy-session.ts
@@ -1,13 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Field, InputType } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { BasicMutationInput } from './basic-mutation';
 
 @InputType()
-export class DestroySessionInput {
-  @Field({
-    description: 'A unique identifier for the client performing the mutation.',
-    nullable: true,
-  })
-  public clientMutationId?: string;
-}
+export class DestroySessionInput extends BasicMutationInput {}

--- a/packages/fxa-graphql-api/src/gql/dto/input/send-session-verification.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/send-session-verification.ts
@@ -1,13 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Field, InputType } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { BasicMutationInput } from './basic-mutation';
 
 @InputType()
-export class SendSessionVerificationInput {
-  @Field({
-    description: 'A unique identifier for the client performing the mutation.',
-    nullable: true,
-  })
-  public clientMutationId?: string;
-}
+export class SendSessionVerificationInput extends BasicMutationInput {}

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -90,4 +90,22 @@ describe('#unit - AccountResolver', () => {
     );
     expect(result).toStrictEqual(mockRespPayload);
   });
+
+  it('resends a verify code through the auth-client', async () => {
+    const sessionToken = 'goodtoken';
+    const headers = new Headers();
+    const now = Date.now();
+    authClient.sessionResendVerifyCode = jest.fn().mockResolvedValue({});
+    const result = await resolver.resendVerifyCode(sessionToken, headers, {
+      clientMutationId: 'testid',
+    });
+    expect(authClient.sessionResendVerifyCode).toBeCalledTimes(1);
+    expect(authClient.sessionResendVerifyCode).toBeCalledWith(
+      'goodtoken',
+      headers
+    );
+    expect(result).toStrictEqual({
+      clientMutationId: 'testid',
+    });
+  });
 });

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -17,6 +17,7 @@ import {
   GqlXHeaders,
 } from '../decorators';
 import { DestroySessionInput } from './dto/input';
+import { BasicMutationInput } from './dto/input/basic-mutation';
 import { SessionReauthInput } from './dto/input/session-reauth';
 import { BasicPayload } from './dto/payload';
 import { SessionReauthedAccountPlayload } from './dto/payload/signed-in-account';
@@ -81,6 +82,22 @@ export class SessionResolver {
     return {
       clientMutationId: input.clientMutationId,
       ...result,
+    };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description: 'Resend a verify code.',
+  })
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @CatchGatewayError
+  public async resendVerifyCode(
+    @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
+    @Args('input', { type: () => BasicMutationInput }) input: BasicMutationInput
+  ): Promise<BasicPayload> {
+    await this.authAPI.sessionResendVerifyCode(token, headers);
+    return {
+      clientMutationId: input.clientMutationId,
     };
   }
 }


### PR DESCRIPTION
Because:
 - gql-api should be able to handle a resend verify code request

This commit:
 - proxy to auth-server to resend a verify code
