### PR TITLE
fix(payments): only checkIpOnly if no credentials

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -415,7 +415,6 @@ export class StripeHandler {
     request: AuthRequest
   ): Promise<invoiceDTO.firstInvoicePreviewSchema> {
     this.log.begin('subscriptions.previewInvoice', request);
-    await this.customs.checkIpOnly(request, 'previewInvoice');
 
     const { promotionCode, priceId } = request.payload as Record<
       string,
@@ -431,6 +430,8 @@ export class StripeHandler {
       } catch (e: any) {
         this.log.error('previewInvoice.fetchCustomer', { error: e, uid });
       }
+    } else {
+      await this.customs.checkIpOnly(request, 'previewInvoice');
     }
 
     const country = request.app.geo.location?.country || 'US';

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -665,8 +665,9 @@ describe('DirectStripeRoutes', () => {
         VALID_REQUEST
       );
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.checkIpOnly,
+        directStripeRoutesInstance.customs.check,
         VALID_REQUEST,
+        TEST_EMAIL,
         'previewInvoice'
       );
       sinon.assert.calledOnceWithExactly(
@@ -707,8 +708,9 @@ describe('DirectStripeRoutes', () => {
         VALID_REQUEST
       );
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.checkIpOnly,
+        directStripeRoutesInstance.customs.check,
         VALID_REQUEST,
+        TEST_EMAIL,
         'previewInvoice'
       );
       sinon.assert.calledOnceWithExactly(
@@ -747,8 +749,9 @@ describe('DirectStripeRoutes', () => {
       );
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.checkIpOnly,
+        directStripeRoutesInstance.customs.check,
         VALID_REQUEST,
+        TEST_EMAIL,
         'previewInvoice'
       );
       sinon.assert.calledOnceWithExactly(


### PR DESCRIPTION
## Because

- For the invoice preview endpoint, for logged in users, do not perform the customs.checkIpOnly.

## This pull request

- Only performs the customs.checkIpOnly check if auth credentials are not provided.

## Issue that this pull request solves

Closes: # FXA-6543

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).