### PR TITLE
fix(auth): Add time when idempotency key is generated

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -75,7 +75,7 @@ import { CurrencyHelper } from './currencies';
 import { AppStoreSubscriptionPurchase } from './iap/apple-app-store/subscription-purchase';
 import { PlayStoreSubscriptionPurchase } from './iap/google-play/subscription-purchase';
 import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
-import { generateIdempotencyKey } from './utils';
+import { generateIdempotencyKey, roundTime } from './utils';
 
 // Maintains backwards compatibility. Some type defs hoisted to fxa-shared/payments/stripe
 export * from 'fxa-shared/payments/stripe';
@@ -498,6 +498,7 @@ export class StripeHelper extends StripeHelperBase {
       customerId,
       priceId,
       paymentMethod?.card?.fingerprint || '',
+      roundTime(),
     ]);
 
     const createParams: Stripe.SubscriptionCreateParams = {

--- a/packages/fxa-auth-server/lib/payments/utils.ts
+++ b/packages/fxa-auth-server/lib/payments/utils.ts
@@ -8,3 +8,7 @@ export function generateIdempotencyKey(params: string[]) {
   sha.update(params.join(''));
   return sha.digest('base64url');
 }
+
+export function roundTime(date = new Date()) {
+  return Math.round(date.getTime() / (1000 * 60)).toString();
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -40,7 +40,10 @@ const {
   'fxa-shared/db/models/auth': dbStub,
 });
 const { CurrencyHelper } = require('../../../lib/payments/currencies');
-const { generateIdempotencyKey } = require('../../../lib/payments/utils');
+const {
+  generateIdempotencyKey,
+  roundTime,
+} = require('../../../lib/payments/utils');
 
 const customer1 = require('./fixtures/stripe/customer1.json');
 const newCustomer = require('./fixtures/stripe/customer_new.json');
@@ -847,6 +850,16 @@ describe('#integration - StripeHelper', () => {
   });
 
   describe('createSubscriptionWithPMI', () => {
+    it('checks that roundTime() returns time rounded to the nearest minute', async () => {
+      const mockDate = new Date('2023-01-03T17:44:44.400Z');
+      const res = roundTime(mockDate);
+      const actualTime = '27879464.74';
+      const roundedTime = '27879465';
+
+      assert.deepEqual(res, roundedTime);
+      assert.notEqual(res, actualTime);
+    });
+
     it('creates a subscription successfully', async () => {
       const attachExpected = deepCopy(paymentMethodAttach);
       const customerExpected = deepCopy(newCustomerPM);
@@ -870,6 +883,7 @@ describe('#integration - StripeHelper', () => {
         'customerId',
         'priceId',
         attachExpected.card.fingerprint,
+        roundTime(),
       ]);
 
       const actual = await stripeHelper.createSubscriptionWithPMI({
@@ -926,6 +940,7 @@ describe('#integration - StripeHelper', () => {
         'customerId',
         'priceId',
         attachExpected.card.fingerprint,
+        roundTime(),
       ]);
 
       const actual = await stripeHelper.createSubscriptionWithPMI({
@@ -986,6 +1001,7 @@ describe('#integration - StripeHelper', () => {
         'customerId',
         'priceId',
         attachExpected.card.fingerprint,
+        roundTime(),
       ]);
 
       const actual = await stripeHelper.createSubscriptionWithPMI({
@@ -1060,6 +1076,7 @@ describe('#integration - StripeHelper', () => {
         'customerId',
         'priceId',
         attachExpected.card.fingerprint,
+        roundTime(),
       ]);
 
       try {

--- a/packages/fxa-auth-server/test/local/payments/utils.js
+++ b/packages/fxa-auth-server/test/local/payments/utils.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const {
+  roundTime,
+} = require('../../../lib/payments/utils');
+
+it('checks that roundTime() returns time rounded to the nearest minute', async () => {
+  const mockDate = new Date('2023-01-03T17:44:44.400Z');
+  const res = roundTime(mockDate);
+  const actualTime = '27879464.74';
+  const roundedTime = '27879465';
+
+  assert.deepEqual(res, roundedTime);
+  assert.notEqual(res, actualTime);
+});


### PR DESCRIPTION
## Because

- Error is displayed on the Subscription Management page after attempt to resubscribe after cancelling a subscription via Stripe Dashboard

## This pull request

- adds time when idempotency key is generated, as the idempotency key was previously generated using customer id, price id, and payment method fingerprint. This caused Stripe to treat subscribing to the same subscription (after the subscription was cancelled via Stripe) as a duplicate request.

## Issue that this pull request solves

Closes: [FXA-6413](https://mozilla-hub.atlassian.net/browse/FXA-6413)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.