### PR TITLE
storybook(fxa-settings): add signin_reported to storybook

### DIFF
--- a/packages/fxa-settings/src/pages/SigninReported/en.ftl
+++ b/packages/fxa-settings/src/pages/SigninReported/en.ftl
@@ -1,0 +1,2 @@
+signin-reported-header = Thank you for your vigilance
+signin-reported-message = Our team has been notified. Reports like this help us fend off intruders.

--- a/packages/fxa-settings/src/pages/SigninReported/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/SigninReported/index.stories.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import SigninReported from '.';
+import AppLayout from '../../components/AppLayout';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'pages/SigninReported',
+  component: SigninReported,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
+    <AppLayout>
+      <SigninReported />
+    </AppLayout>
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/pages/SigninReported/index.test.tsx
+++ b/packages/fxa-settings/src/pages/SigninReported/index.test.tsx
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { FluentBundle } from '@fluent/bundle';
+import SigninReported from '.';
+import { usePageViewEvent } from '../../lib/metrics';
+
+jest.mock('../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('SigninReported', () => {
+  let bundle: FluentBundle;
+  beforeAll(async () => {
+    bundle = await getFtlBundle('settings');
+  });
+  it('renders Ready component as expected', () => {
+    render(<SigninReported />);
+    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
+    testL10n(ftlMsgMock, bundle);
+
+    const reportHeader = screen.getByText('Thank you for your vigilance');
+    const reportMessage = screen.getByText(
+      'Our team has been notified. Reports like this help us fend off intruders.'
+    );
+    expect(reportHeader).toBeInTheDocument();
+    expect(reportMessage).toBeInTheDocument();
+  });
+
+  it('emits the expected metrics on render', () => {
+    render(<SigninReported />);
+    expect(usePageViewEvent).toHaveBeenCalledWith('signin-reported', {
+      entrypoint_variation: 'react',
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/SigninReported/index.tsx
+++ b/packages/fxa-settings/src/pages/SigninReported/index.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { usePageViewEvent } from '../../lib/metrics';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { RouteComponentProps } from '@reach/router';
+
+const SigninReported = (props: RouteComponentProps) => {
+  usePageViewEvent('signin-reported', {
+    entrypoint_variation: 'react',
+  });
+
+  return (
+    <>
+      <div className="mb-4">
+        <h1 className="card-header">
+          <FtlMsg id="signin-reported-header">
+            Thank you for your vigilance
+          </FtlMsg>
+        </h1>
+      </div>
+      <section>
+        <div className="error"></div>
+        <FtlMsg id="signin-reported-message">
+          <p className="my-4 text-sm">
+            Our team has been notified. Reports like this help us fend off
+            intruders.
+          </p>
+        </FtlMsg>
+      </section>
+    </>
+  );
+};
+
+export default SigninReported;


### PR DESCRIPTION
## Because:

* We're going through the remaining fxa-content-server Backbone views and adding React versions of them into Storybook as a first step to moving them into the React app.

## This commit:

* Adds basic l10n, metrics, tests, and a React version for the `signin_reported` view

Closes #https://mozilla-hub.atlassian.net/browse/FXA-6418

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="588" alt="Screen Shot 2022-12-29 at 2 17 00 PM" src="https://user-images.githubusercontent.com/11150372/210016207-647a0c0a-ebdb-4c3b-a498-6b6d7e4ae3ca.png">
