### PR TITLE
chore(docs): Remove Disclaimer in Auth Server API doc

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/swagger-options.ts
+++ b/packages/fxa-auth-server/docs/swagger/swagger-options.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import dedent from 'dedent';
 import { AUTH_SERVER_API_DESCRIPTION } from './auth-server-api';
 import OAUTH_SERVER_DOCS from './oauth-server-api';
 import TAGS from './swagger-tags';
@@ -10,9 +9,6 @@ import TAGS from './swagger-tags';
 export const swaggerOptions = {
   info: {
     title: 'Firefox Accounts API Documentation',
-    description: dedent`
-      [**DISCLAIMER**]: This information may not be up-to-date - it may be worth verifying information in the source code before acting on anything you read here.
-    `,
   },
   basePath: '/v1',
   schemes: ['https'],
@@ -32,13 +28,13 @@ export const swaggerOptions = {
       tags: [
         TAGS.AUTH_SERVER[1],
         TAGS.ACCOUNT[1],
+        TAGS.RECOVERY_KEY[1],
+        TAGS.RECOVERY_CODES[1],
         TAGS.DEVICES_AND_SESSIONS[1],
         TAGS.EMAILS[1],
         TAGS.MISCELLANEOUS[1],
         TAGS.OAUTH[1],
         TAGS.PASSWORD[1],
-        TAGS.RECOVERY_CODES[1],
-        TAGS.RECOVERY_KEY[1],
         TAGS.SECURITY_EVENTS[1],
         TAGS.SESSION[1],
         TAGS.SIGN[1],


### PR DESCRIPTION
## Because

- we don't need this as a disclaimer

## This pull request

- removes disclaimer
- also re-alphabetizes tags as their sections were renamed (see `fxa-auth-server/docs/swagger/swagger-tags.ts`)

## Issue that this pull request solves

Closes: [FXA-6552](https://mozilla-hub.atlassian.net/browse/FXA-6552)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
