### PR TITLE
fix(payments): support for multiple tax rates in subscription upgrade

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -35,8 +35,9 @@ export const PlanUpgradeDetails = ({
 
   const showTax = config.featureFlags.useStripeAutomaticTax;
 
-  const taxAmount = invoicePreview.tax?.amount || 0;
-  const taxInclusive = invoicePreview.tax?.inclusive;
+  const exclusiveTaxRates =
+    invoicePreview.tax?.filter((taxRate) => !taxRate.inclusive) || [];
+
   const totalAmount = showTax ? invoicePreview.total : amount;
   const subTotal = invoicePreview.subtotal;
 
@@ -59,7 +60,7 @@ export const PlanUpgradeDetails = ({
       <PlanDetailsCard className="to-plan" plan={selectedPlan} />
 
       <div className="py-6 border-t-0">
-        {showTax && !!subTotal && !!taxAmount && !taxInclusive && (
+        {showTax && !!subTotal && exclusiveTaxRates.length && (
           <>
             <div className="plan-details-item">
               <Localized id="plan-details-list-price">
@@ -73,17 +74,31 @@ export const PlanUpgradeDetails = ({
               />
             </div>
 
-            <div className="plan-details-item">
-              <Localized id="plan-details-tax">
-                <div>Taxes and Fees</div>
-              </Localized>
+            {exclusiveTaxRates.length === 1 && (
+              <div className="plan-details-item">
+                <Localized id="plan-details-tax">
+                  <div>Taxes and Fees</div>
+                </Localized>
 
-              <PriceDetails
-                total={taxAmount}
-                currency={currency}
-                dataTestId="plan-upgrade-tax-amount"
-              />
-            </div>
+                <PriceDetails
+                  total={exclusiveTaxRates[0].amount}
+                  currency={currency}
+                  dataTestId="plan-upgrade-tax-amount"
+                />
+              </div>
+            )}
+            {exclusiveTaxRates.length > 1 &&
+              exclusiveTaxRates.map((taxRate, idx) => (
+                <div className="plan-details-item" key={idx}>
+                  <div>{taxRate.display_name}</div>
+
+                  <PriceDetails
+                    total={taxRate.amount}
+                    currency={currency}
+                    dataTestId="plan-upgrade-tax-amount"
+                  />
+                </div>
+              ))}
           </>
         )}
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -53,10 +53,13 @@ const invoicePreviewInclusiveTax: FirstInvoicePreview = {
   subtotal_excluding_tax: 2804,
   total: 2999,
   total_excluding_tax: 2804,
-  tax: {
-    amount: 195,
-    inclusive: true,
-  },
+  tax: [
+    {
+      amount: 195,
+      inclusive: true,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 const invoicePreviewExclusiveTax: FirstInvoicePreview = {
   line_items: [],
@@ -64,10 +67,13 @@ const invoicePreviewExclusiveTax: FirstInvoicePreview = {
   subtotal_excluding_tax: 2999,
   total: 3194,
   total_excluding_tax: 2999,
-  tax: {
-    amount: 195,
-    inclusive: false,
-  },
+  tax: [
+    {
+      amount: 195,
+      inclusive: false,
+      display_name: 'Sales Tax',
+    },
+  ],
 };
 
 const MOCK_PROPS: SubscriptionUpgradeProps = {


### PR DESCRIPTION
## Because

* A few SubscriptionUpgrade stories had incorrect typings caused by #14684. Strangely #14684 did not fail CI which is something that will need to be investigated separately.
* Because of the above, SubscriptionUpgrade hadn't been updated to support multiple tax rates.

## This pull request

* Fixes the typings.
* Adds support for multiple tax rates to SubscriptionUpgrade.

## Issue that this pull request solves

Closes: FXA-6439

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
<img width="406" alt="image" src="https://user-images.githubusercontent.com/7751154/210633725-b2336321-62e9-4039-b165-78c67453e6f5.png">


[FXA-6439]: https://mozilla-hub.atlassian.net/browse/FXA-6439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ