### PR TITLE
test(functional): remove flaky pairing test

### DIFF
--- a/packages/fxa-content-server/scripts/test-ci.sh
+++ b/packages/fxa-content-server/scripts/test-ci.sh
@@ -51,5 +51,6 @@ test_suite circle 3
 # The last node currently has the least work to do in the above tests
 if [[ "${CIRCLE_NODE_INDEX}" == "2" ]]; then
   node tests/intern.js --suites='server' --output='../../artifacts/tests/server-results.xml'
-  node tests/intern.js --suites='pairing' --output='../../artifacts/tests/pairing-results.xml'
+  #Removing the flaky pairing suite, to be addressed in https://mozilla-hub.atlassian.net/browse/FXA-6558
+  #node tests/intern.js --suites='pairing' --output='../../artifacts/tests/pairing-results.xml'
 fi

--- a/packages/fxa-content-server/tests/functional_pairing.js
+++ b/packages/fxa-content-server/tests/functional_pairing.js
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = ['tests/functional/pairing.js'];
+ //Disabling the suite as the tests are being flaky,
+ //We will revisit this later, ticket created https://mozilla-hub.atlassian.net/browse/FXA-6558
+//module.exports = ['tests/functional/pairing.js'];


### PR DESCRIPTION
## Because

- The pairing tests were being flaky for quite sometime. Currently disabling it and created a ticket [FXA-6558](https://mozilla-hub.atlassian.net/browse/FXA-6558) to later address the issue.

## This pull request

- Removed the pairing suite out of the test runs for Content-server-2

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-6558]: https://mozilla-hub.atlassian.net/browse/FXA-6558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXA-6558]: https://mozilla-hub.atlassian.net/browse/FXA-6558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ