### PR TITLE
fix(l10n): Duplicated FTL id in CompleteResetPassword

### DIFF
--- a/packages/fxa-settings/src/pages/CompleteResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/en.ftl
@@ -2,7 +2,7 @@
 
 # User followed a password reset link and is now prompted to create a new password
 complete-reset-pw-header = Create new password
-reset-password-warning-message = <span>Remember:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and { product-pocket } data will not be affected.
+complete-reset-password-warning-message = <span>Remember:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and { product-pocket } data will not be affected.
 # This information message is followed by a form to create a new password.
 complete-reset-password-account-recovery-info = You have successfully restored your account using your account recovery key. Create a new password to secure your data, and store it in a safe location.
 # A new password was successfully set for the user's account


### PR DESCRIPTION
## Because

- FTL ids need to be unique, and one ID had not been updated for the CompleteResetPassword page and reused an ID from ResetPassword (but with different messages).

## This pull request

- Fix the FTL ID name

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
