### PR TITLE
fix(payments): resubscribe Modal Not Reflecting Invoice Amount

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -253,7 +253,6 @@ describe('NewUserEmailForm test', () => {
   it('Notifies the user if domain does not provide email', async () => {
     const checkAccountExists = (userAccount: string) =>
       Promise.resolve({ exists: false, invalidDomain: true });
-    debugger;
     const result = await emailInputValidationAndAccountCheck(
       'foxy@mozilla.com',
       false,

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -171,8 +171,7 @@ export function useInfoBoxMessage(
 }
 
 export function useHandleConfirmationDialog(
-  customerSubscription: WebSubscription,
-  plan: Plan
+  customerSubscription: WebSubscription
 ) {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
@@ -188,35 +187,30 @@ export function useHandleConfirmationDialog(
         promotion_duration,
       } = customerSubscription;
 
-      if (
+      const includeCoupon =
         promotionCode &&
         couponOnSubsequentInvoice(
           current_period_end,
           promotion_end,
           promotion_duration
-        )
-      ) {
-        try {
-          setLoading(true);
-          const preview = await apiInvoicePreview({ priceId, promotionCode });
-          setAmount(preview.total);
-        } catch (err) {
-          setError(true);
-        } finally {
-          setLoading(false);
-        }
-      } else {
-        if (plan.amount) {
-          setAmount(plan.amount);
-        } else {
-          setError(true);
-        }
+        );
+
+      try {
+        setLoading(true);
+        const preview = await apiInvoicePreview({
+          priceId,
+          promotionCode: includeCoupon ? promotionCode : undefined,
+        });
+        setAmount(preview.total);
+      } catch (err) {
+        setError(true);
+      } finally {
         setLoading(false);
       }
     };
 
     getSubscriptionPrice();
-  }, [customerSubscription, plan]);
+  }, [customerSubscription]);
 
   return { loading, error, amount };
 }

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -152,10 +152,8 @@ const ConfirmationDialog = ({
   );
   const { last4 } = customer;
 
-  const { loading, error, amount } = useHandleConfirmationDialog(
-    customerSubscription,
-    plan
-  );
+  const { loading, error, amount } =
+    useHandleConfirmationDialog(customerSubscription);
 
   const ariaLabelledByError = 'error-content-header';
   const ariaDescribedByError = 'error-content-description';


### PR DESCRIPTION
Because:

* once a subscription is cancelled we cannot retrieve a subsequent invoice and were other wise defaulting to the plan amount unless a coupon was originally used in the resubcribe modal hook

This commit:

* removes the logic that tests for a promotion code/coupon and always queries the api for the invoice amount if the subscription were to be re-activated

Closes #FXA-6377

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).