### PR TITLE
feat(api): Add gql resolvers for recovery key bundle

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -692,5 +692,21 @@ describe('#integration - AccountResolver', () => {
         });
       });
     });
+
+    describe('getRecoveryKeyBundle', () => {
+      it('succeeds', async () => {
+        authClient.getRecoveryKey = jest.fn().mockResolvedValue({
+          recoveryData: 'recoveryData'
+        });
+        const result = await resolver.getRecoveryKeyBundle({
+          accountResetToken: 'cooltokenyo',
+          recoveryKeyId: 'recoveryKeyId'
+        });
+        expect(authClient.getRecoveryKey).toBeCalledWith('cooltokenyo', 'recoveryKeyId');
+        expect(result).toStrictEqual({
+          recoveryData: 'recoveryData'
+        });
+      });
+    });
   });
 });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -56,6 +56,7 @@ import {
   PasswordForgotCodeStatusInput,
   AccountResetInput,
   AccountStatusInput,
+  RecoveryKeyBundleInput,
 } from './dto/input';
 import { DeleteAvatarInput } from './dto/input/delete-avatar';
 import { MetricsOptInput } from './dto/input/metrics-opt';
@@ -66,7 +67,6 @@ import {
   BasicPayload,
   ChangeRecoveryCodesPayload,
   CreateTotpPayload,
-  UpdateAvatarPayload,
   UpdateDisplayNamePayload,
   VerifyTotpPayload,
   PasswordForgotSendCodePayload,
@@ -74,6 +74,7 @@ import {
   PasswordForgotCodeStatusPayload,
   AccountResetPayload,
   AccountStatusPayload,
+  RecoveryKeyBundlePayload
 } from './dto/payload';
 import { SignedInAccountPayload } from './dto/payload/signed-in-account';
 import { SignedUpAccountPayload } from './dto/payload/signed-up-account';
@@ -634,6 +635,19 @@ export class AccountResolver {
     return {
       clientMutationId: input.clientMutationId,
     };
+  }
+
+  @Query((returns) => RecoveryKeyBundlePayload, {
+    description:
+     'Retrieves a user recovery key bundle from its recovery key id. The bundle contains an encrypted copy for the sync key.',
+  })
+  @CatchGatewayError
+  public async getRecoveryKeyBundle(
+   @Args('input', { type: () => RecoveryKeyBundleInput }) input: RecoveryKeyBundleInput
+  ): Promise<RecoveryKeyBundlePayload> {
+    const { recoveryData } = await this.authAPI.getRecoveryKey(input.accountResetToken, input.recoveryKeyId);
+
+    return { recoveryData };
   }
 
   @ResolveField()

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -24,3 +24,4 @@ export { VerifyEmailInput, VerifyEmailCodeInput } from './verify-email';
 export { VerifySessionInput } from './verify-session';
 export { VerifyTotpInput } from './verify-totp';
 export { AccountStatusInput } from './account-status';
+export { RecoveryKeyBundleInput } from './recovery-key';

--- a/packages/fxa-graphql-api/src/gql/dto/input/recovery-key.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/recovery-key.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class RecoveryKeyBundleInput {
+  @Field({ description: 'Account reset token' })
+  public accountResetToken!: string;
+  
+  @Field({ description: 'Recovery key to check' })
+  public recoveryKeyId!: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -16,3 +16,4 @@ export { UpdateAvatarPayload } from './update-avatar';
 export { UpdateDisplayNamePayload } from './update-display-name';
 export { VerifyTotpPayload } from './verify-totp';
 export { AccountStatusPayload } from './account-status';
+export { RecoveryKeyBundlePayload } from './recovery-key';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/recovery-key.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/recovery-key.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class RecoveryKeyBundlePayload {
+ @Field()
+ public recoveryData!: string;
+}


### PR DESCRIPTION
## Because

- During password reset, a user should be able to get a recovery bundle that contains their sync key. This is used to during the password reset process to ensure their keys dont change

## This pull request

- Adds gql query to retrieve recovery bundle

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6328

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
