### PR TITLE
fix(auth): pass App Store Server API error message to registration en…

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1418,7 +1418,7 @@ AppError.iapInvalidToken = (error) => {
       code: 400,
       error: 'Bad Request',
       errno: ERRNO.IAP_INVALID_TOKEN,
-      message: 'Invalid token',
+      message: `Invalid IAP token${error?.message ? `: ${error.message}` : ''}`,
     },
     ...extra
   );

--- a/packages/fxa-auth-server/test/local/error.js
+++ b/packages/fxa-auth-server/test/local/error.js
@@ -139,6 +139,27 @@ describe('AppErrors', () => {
     assert(!result.output.payload.retryAfterLocalized);
   });
 
+  it('iapInvalidToken', () => {
+    const defaultErrorMessage = 'Invalid IAP token';
+    let result = AppError.iapInvalidToken();
+    assert.ok(result instanceof AppError, 'instanceof AppError');
+    assert.equal(result.errno, 196);
+    assert.equal(result.message, defaultErrorMessage);
+    assert.equal(result.output.statusCode, 400);
+    assert.equal(result.output.payload.error, 'Bad Request');
+
+    let iapAPIError = { someProp: 123 };
+    result = AppError.iapInvalidToken(iapAPIError);
+    assert.equal(result.message, defaultErrorMessage);
+
+    iapAPIError = { message: 'Wow helpful extra info' };
+    result = AppError.iapInvalidToken(iapAPIError);
+    assert.equal(
+      result.message,
+      `${defaultErrorMessage}: ${iapAPIError.message}`
+    );
+  });
+
   it('unexpectedError without request data', () => {
     const err = AppError.unexpectedError();
     assert.instanceOf(err, AppError);


### PR DESCRIPTION
…dpoint caller

Because:

* When migrating existing Apple IAP users, some users failed to migrate, and any App Store Server API error we got would be transformed into a 400 "Invalid token" with no additional details.

This commit:

* Passes the exact App Store Server API error message to the registration endpoint caller, which will indicate if the error is retryable for example.

Closes #FXA-6459

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).