### PR TITLE
test(coupon): write tests for coupon section not displayed when changing plans

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -120,6 +120,12 @@ export class SubscribePage extends BaseLayout {
     await this.page.click('[data-testid="coupon-remove-button"]');
   }
 
+  planUpgradeDetails() {
+    return this.page
+      .locator('[data-testid="plan-upgrade-details-component"]')
+      .textContent();
+  }
+
   submit() {
     return Promise.all([
       this.page.waitForLoadState(),

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -91,6 +91,10 @@ export class SubscriptionManagementPage extends BaseLayout {
       .textContent();
   }
 
+  async subscriptionDetails() {
+    return this.page.locator('[data-testid="subscription-item"]').textContent();
+  }
+
   getResubscriptionPrice() {
     return this.page
       .locator('[data-testid="price-details-standalone"]')

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -32,6 +32,11 @@ test.describe('resubscription test', () => {
     const subscriptionPage = await settings.clickPaidSubscriptions();
     subscriptionManagement.page = subscriptionPage;
 
+    //Verify no coupon details are visible
+    expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
+      'Promo'
+    );
+
     //Cancel subscription and then resubscribe
     await subscriptionManagement.cancelSubscription();
     await subscriptionManagement.resubscribe();
@@ -39,6 +44,11 @@ test.describe('resubscription test', () => {
     //Verify that the resubscription has the same coupon applied
     expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
       total
+    );
+
+    //Verify no coupon details are visible
+    expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
+      'Promo'
     );
   });
 
@@ -67,6 +77,11 @@ test.describe('resubscription test', () => {
     const subscriptionPage = await settings.clickPaidSubscriptions();
     subscriptionManagement.page = subscriptionPage;
 
+    //Verify no coupon details are visible
+    expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
+      'Promo'
+    );
+
     //Cancel subscription and then resubscribe
     await subscriptionManagement.cancelSubscription();
     await subscriptionManagement.resubscribe();
@@ -74,6 +89,11 @@ test.describe('resubscription test', () => {
     //Verify that the resubscription has the same coupon applied
     expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
       total
+    );
+
+    //Verify no coupon details are visible
+    expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
+      'Promo'
     );
   });
 

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -14,4 +14,31 @@ test.describe('ui functionality', () => {
     // Verify discount section is displayed
     expect(await subscribe.discountTextbox()).toBe(true);
   });
+
+  test('verify coupon feature not available when changing plans', async ({
+    page,
+    pages: { relier, subscribe },
+  }) => {
+    await relier.goto();
+    await relier.clickSubscribe6Month();
+
+    // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
+    await subscribe.addCouponCode('auto10pforever');
+
+    // Verify the coupon is applied successfully
+    expect(await subscribe.discountAppliedSuccess()).toBe(true);
+
+    //Subscribe successfully with Stripe
+    await subscribe.setFullName();
+    await subscribe.setCreditCardInfo();
+    await subscribe.clickPayNow();
+    await subscribe.submit();
+    await relier.goto();
+
+    //Change the plan
+    await relier.clickSubscribe12Month();
+
+    //Verify Discount section is not displayed
+    expect(await subscribe.planUpgradeDetails()).not.toContain('Promo');
+  });
 });


### PR DESCRIPTION
## Because

In efforts to increase test coverage for coupon and Subplat regression , added automated tests for:

- [Verify that the discount isn't displayed in the manage subscription page](https://testrail.stage.mozaws.net/index.php?/cases/view/1614025&group_by=cases:section_id&group_id=252172&group_order=asc)
- [Verify that couponing feature isn't available while trying to change the subscription plan](https://testrail.stage.mozaws.net/index.php?/cases/view/1614011&group_by=cases:section_id&group_id=252172&group_order=asc)
 

## This pull request

Contains tests for: 
- Verifying that the discount isn't displayed in the manage subscription page
- Verify that couponing feature isn't available while trying to change the subscription plan

## Issue that this pull request solves

Closes: #[FXA-6577](https://mozilla-hub.atlassian.net/browse/FXA-6577) [FXA-6576](https://mozilla-hub.atlassian.net/browse/FXA-6576)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-6577]: https://mozilla-hub.atlassian.net/browse/FXA-6577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXA-6576]: https://mozilla-hub.atlassian.net/browse/FXA-6576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ