### PR TITLE
feat(api): Add gql resolvers for change password

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -678,7 +678,7 @@ describe('#integration - AccountResolver', () => {
         authClient.verifyCode = jest.fn().mockResolvedValue({
           uid: 'cooltokenyo',
           code: 'coolcode',
-          options: { service: 'sync' }
+          options: { service: 'sync' },
         });
         const result = await resolver.emailVerifyCode(headers, {
           uid: 'cooltokenyo',
@@ -688,7 +688,42 @@ describe('#integration - AccountResolver', () => {
         });
         expect(authClient.verifyCode).toBeCalledTimes(1);
         expect(result).toStrictEqual({
-          clientMutationId: 'testid'
+          clientMutationId: 'testid',
+        });
+      });
+    });
+
+    describe('changePassword', () => {
+      it('succeeds', async () => {
+        authClient.passwordChangeWithAuthPW = jest.fn().mockResolvedValue({
+          uid: 'cooltokenyo',
+          sessionToken: '000000',
+          verified: true,
+          authAt: 1,
+          unwrapBKey: '000000',
+          keyFetchToken: '000000',
+        });
+        const result = await resolver.passwordChange({
+          clientMutationId: 'testid',
+          email: 'asdf@asdf.com',
+          oldPasswordAuthPW: 'oldPasswordAuthPW',
+          newPasswordAuthPW: 'newPasswordAuthPW',
+          oldUnwrapBKey: 'oldUnwrapBKey',
+          newUnwrapBKey: 'newUnwrapBKey',
+          options: {
+            keys: true,
+            sessionToken: '000000',
+          },
+        });
+        expect(authClient.passwordChangeWithAuthPW).toBeCalledTimes(1);
+        expect(result).toStrictEqual({
+          clientMutationId: 'testid',
+          uid: 'cooltokenyo',
+          sessionToken: '000000',
+          verified: true,
+          authAt: 1,
+          unwrapBKey: '000000',
+          keyFetchToken: '000000',
         });
       });
     });

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -25,3 +25,4 @@ export { VerifySessionInput } from './verify-session';
 export { VerifyTotpInput } from './verify-totp';
 export { AccountStatusInput } from './account-status';
 export { RecoveryKeyBundleInput } from './recovery-key';
+export { PasswordChangeInput } from './password-change';

--- a/packages/fxa-graphql-api/src/gql/dto/input/password-change.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/password-change.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class PasswordChangeInputOptions {
+  @Field({ nullable: true })
+  public keys?: boolean;
+
+  @Field((type) => String,{ nullable: true })
+  public sessionToken?: hexstring;
+}
+
+@InputType()
+export class PasswordChangeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field()
+  public email!: string;
+
+  @Field()
+  public oldPasswordAuthPW!: string;
+
+  @Field()
+  public newPasswordAuthPW!: string;
+
+  @Field()
+  public oldUnwrapBKey!: string;
+
+  @Field()
+  public newUnwrapBKey!: string;
+
+  @Field({ nullable: true })
+  public options?: PasswordChangeInputOptions;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -17,3 +17,4 @@ export { UpdateDisplayNamePayload } from './update-display-name';
 export { VerifyTotpPayload } from './verify-totp';
 export { AccountStatusPayload } from './account-status';
 export { RecoveryKeyBundlePayload } from './recovery-key';
+export { PasswordChangePayload } from './password-change';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/password-change.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/password-change.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class PasswordChangePayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field((type) => String)
+  public uid!: hexstring;
+
+  @Field()
+  public sessionToken!: string;
+
+  @Field()
+  public verified!: boolean;
+
+  @Field()
+  public authAt!: number;
+
+  @Field({ nullable: true })
+  public unwrapBKey?: string;
+
+  @Field({ nullable: true })
+  public keyFetchToken?: string;
+}


### PR DESCRIPTION
## Because

- We want to expose the change password api in gql

## This pull request

- Adds gql resolvers to change a users password
  - The client will still need to generate the authPW for old and new password since we don't want to send the clear password to FxA server

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6334

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
