### PR TITLE
refactor(content-server): Prep for easier addition of Reactified routes

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -17,7 +17,9 @@ logger.info(`commit hash set to: ${version.commit}`);
 logger.info(`fxa-content-server-l10n commit hash set to: ${version.l10n}`);
 logger.info(`tos-pp (legal-docs) commit hash set to: ${version.tosPp}`);
 const config = require('../lib/configuration');
-const { addAllReactRoutesConditionally } = require('../lib/routes/react-app');
+const {
+  addAllReactRoutesConditionally,
+} = require('../lib/routes/react-app/add-routes');
 
 // Tracing must be initialized asap
 const tracing = require('fxa-shared/tracing/node-tracing');

--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -4,17 +4,20 @@
 
 'use strict';
 
+const { getReactRouteGroups } = require('./routes/react-app');
+
 module.exports = function (config, i18n, statsd) {
   const redirectVersionedToUnversioned = require('./routes/redirect-versioned-to-unversioned');
+  const reactRouteGroups = getReactRouteGroups(config.get('showReactApp'));
 
   const routes = [
     redirectVersionedToUnversioned('complete_reset_password'),
     redirectVersionedToUnversioned('reset_password'),
     redirectVersionedToUnversioned('verify_email'),
     require('./routes/get-apple-app-site-association')(),
-    require('./routes/get-frontend-pairing')(),
-    require('./routes/get-frontend').default(),
-    require('./routes/get-oauth-success'),
+    require('./routes/get-frontend-pairing').default(reactRouteGroups),
+    require('./routes/get-frontend').default(reactRouteGroups),
+    require('./routes/get-oauth-success').default(reactRouteGroups),
     require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-update-firefox')(config),
     require('./routes/get-index')(config),
@@ -33,7 +36,7 @@ module.exports = function (config, i18n, statsd) {
     require('./routes/post-third-party-auth-redirect')(config),
     require('./routes/get-500')(config),
     require('./routes/validate-email-domain')(config),
-  ];
+  ].filter((routeDefinition) => routeDefinition); // get rid of null values
 
   if (config.get('csp.enabled')) {
     routes.push(

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -4,104 +4,119 @@
 
 'use strict';
 
-const { simpleRoutes } = require('./react-app');
-const {
-  getFrontEndRouteDefinitions,
-} = require('./react-app/route-definitions');
+const { getFrontEndRouteDefinition } = require('./react-app/route-definitions');
 
-function getFrontEnd() {
-  // The array is converted into a RegExp
-  const FRONTEND_ROUTES = [
-    'account_recovery_confirm_key',
-    'account_recovery_reset_password',
-    'authorization',
-    'cannot_create_account',
-    'choose_what_to_sync',
-    'clear',
-    'complete_reset_password',
-    'complete_signin',
-    'confirm',
-    'confirm_reset_password',
-    'confirm_signin',
-    'confirm_signup_code',
-    'connect_another_device',
-    'cookies_disabled',
-    'force_auth',
-    'inline_totp_setup',
-    'inline_recovery_setup',
-    'legal',
-    'oauth',
-    'oauth/force_auth',
-    'oauth/signin',
-    'oauth/signup',
-    'pair',
-    'pair/failure',
-    'pair/success',
-    'pair/supp',
-    'pair/unsupported',
-    'post_verify/account_recovery/add_recovery_key',
-    'post_verify/account_recovery/confirm_password',
-    'post_verify/account_recovery/confirm_recovery_key',
-    'post_verify/account_recovery/save_recovery_key',
-    'post_verify/account_recovery/verified_recovery_key',
-    'post_verify/cad_qr/get_started',
-    'post_verify/cad_qr/ready_to_scan',
-    'post_verify/cad_qr/scan_code',
-    'post_verify/cad_qr/connected',
-    'post_verify/finish_account_setup/set_password',
-    'post_verify/newsletters/add_newsletters',
-    'post_verify/password/force_password_change',
-    'post_verify/secondary_email/add_secondary_email',
-    'post_verify/secondary_email/confirm_secondary_email',
-    'post_verify/secondary_email/verified_secondary_email',
-    'post_verify/third_party_auth/callback',
-    'primary_email_verified',
-    'push/completed',
-    'push/confirm_login',
-    'push/send_login',
-    'report_signin',
-    'reset_password',
-    'reset_password_confirmed',
-    'reset_password_verified',
-    'reset_password_with_recovery_key_verified',
-    'security_events',
-    'signin',
-    'signin_bounced',
-    'signin_token_code',
-    'signin_totp_code',
-    'signin_recovery_code',
-    'signin_confirmed',
-    'signin_permissions',
-    'signin_reported',
-    'signin_unblock',
-    'signin_verified',
-    'signup',
-    'signup_confirmed',
-    'signup_permissions',
-    'signup_verified',
-    'secondary_email_verified',
-    'subscriptions',
-    'subscriptions/products/[\\w_]+',
-    'support',
-    'verify_email',
-    'verify_primary_email',
-    'verify_secondary_email',
-    'would_you_like_to_sync',
-  ];
+const FRONTEND_ROUTES = [
+  'account_recovery_confirm_key',
+  'account_recovery_reset_password',
+  'authorization',
+  'cannot_create_account',
+  'choose_what_to_sync',
+  'clear',
+  'complete_reset_password',
+  'complete_signin',
+  'confirm',
+  'confirm_reset_password',
+  'confirm_signin',
+  'confirm_signup_code',
+  'connect_another_device',
+  'cookies_disabled',
+  'force_auth',
+  'inline_totp_setup',
+  'inline_recovery_setup',
+  'legal',
+  'oauth',
+  'oauth/force_auth',
+  'oauth/signin',
+  'oauth/signup',
+  'pair',
+  'pair/failure',
+  'pair/success',
+  'pair/supp',
+  'pair/unsupported',
+  'post_verify/account_recovery/add_recovery_key',
+  'post_verify/account_recovery/confirm_password',
+  'post_verify/account_recovery/confirm_recovery_key',
+  'post_verify/account_recovery/save_recovery_key',
+  'post_verify/account_recovery/verified_recovery_key',
+  'post_verify/cad_qr/get_started',
+  'post_verify/cad_qr/ready_to_scan',
+  'post_verify/cad_qr/scan_code',
+  'post_verify/cad_qr/connected',
+  'post_verify/finish_account_setup/set_password',
+  'post_verify/newsletters/add_newsletters',
+  'post_verify/password/force_password_change',
+  'post_verify/secondary_email/add_secondary_email',
+  'post_verify/secondary_email/confirm_secondary_email',
+  'post_verify/secondary_email/verified_secondary_email',
+  'post_verify/third_party_auth/callback',
+  'primary_email_verified',
+  'push/completed',
+  'push/confirm_login',
+  'push/send_login',
+  'report_signin',
+  'reset_password',
+  'reset_password_confirmed',
+  'reset_password_verified',
+  'reset_password_with_recovery_key_verified',
+  'security_events',
+  'signin',
+  'signin_bounced',
+  'signin_token_code',
+  'signin_totp_code',
+  'signin_recovery_code',
+  'signin_confirmed',
+  'signin_permissions',
+  'signin_reported',
+  'signin_unblock',
+  'signin_verified',
+  'signup',
+  'signup_confirmed',
+  'signup_permissions',
+  'signup_verified',
+  'secondary_email_verified',
+  'subscriptions',
+  'subscriptions/products/[\\w_]+',
+  'support',
+  'verify_email',
+  'verify_primary_email',
+  'verify_secondary_email',
+  'would_you_like_to_sync',
+];
 
-  // Remove route from list if feature flag is on and route is in list. Route definitions
-  // for the excluded routes are created separately
-  // TODO: account for other feature flags / React route lists, FXA-6538
-  const FRONTEND_ROUTES_EXCLUDE_REACT = simpleRoutes.featureFlagOn
-    ? FRONTEND_ROUTES.filter(
-        (routeName) =>
-          !simpleRoutes.routes.find((route) => routeName === route.name)
-      )
-    : FRONTEND_ROUTES;
+/**
+ * Remove route from list if React feature flag is set to true and route is included in
+ * any react route group. Route definitions for the excluded routes are created
+ * separately in `fxa-content-server.js`. */
+function getRoutesExcludingAllReact(reactRouteGroups, routeNames) {
+  return routeNames.filter((routeName) => {
+    for (const routeGroup in reactRouteGroups) {
+      if (
+        reactRouteGroups[routeGroup].featureFlagOn &&
+        !!reactRouteGroups[routeGroup].routes.find(
+          (route) => routeName === route.name
+        )
+      ) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
 
-  return getFrontEndRouteDefinitions(FRONTEND_ROUTES_EXCLUDE_REACT);
+/** @type {import("./react-app/types").GetBackboneRouteDefinition} */
+function getFrontEnd(reactRouteGroups, routeNames = FRONTEND_ROUTES) {
+  const routesExcludingAllReact = getRoutesExcludingAllReact(
+    reactRouteGroups,
+    routeNames
+  );
+  return routesExcludingAllReact.length > 0
+    ? getFrontEndRouteDefinition(routesExcludingAllReact)
+    : null;
 }
 
 module.exports = {
   default: getFrontEnd,
+  FRONTEND_ROUTES,
+  getRoutesExcludingAllReact, // exported for testing
 };

--- a/packages/fxa-content-server/server/lib/routes/get-oauth-success.js
+++ b/packages/fxa-content-server/server/lib/routes/get-oauth-success.js
@@ -4,9 +4,37 @@
 
 'use strict';
 
-exports.path = '/oauth/success/:clientId';
-exports.method = 'get';
-exports.process = function (req, res, next) {
-  req.url = '/';
-  next();
+const {
+  getOAuthSuccessRouteDefinition,
+} = require('./react-app/route-definitions');
+
+const OAUTH_SUCCESS_ROUTES = ['/oauth/success/:clientId'];
+
+function getRoutesExcludingOAuthSuccessReact({ oauthRoutes }, routeNames) {
+  return oauthRoutes.featureFlagOn
+    ? routeNames.filter(
+        (routeName) =>
+          !oauthRoutes.routes.find((route) => routeName === route.name)
+      )
+    : routeNames;
+}
+
+/** @type {import("./react-app/types").GetBackboneRouteDefinition} */
+function getOAuthSuccessRoutes(
+  reactRouteGroups,
+  routeNames = OAUTH_SUCCESS_ROUTES
+) {
+  const routesExcludingOAuthSuccessReact = getRoutesExcludingOAuthSuccessReact(
+    reactRouteGroups,
+    routeNames
+  );
+  return routesExcludingOAuthSuccessReact.length > 0
+    ? getOAuthSuccessRouteDefinition(routesExcludingOAuthSuccessReact)
+    : null;
+}
+
+module.exports = {
+  default: getOAuthSuccessRoutes,
+  OAUTH_SUCCESS_ROUTES,
+  getRoutesExcludingOAuthSuccessReact, // exported for testing
 };

--- a/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { getReactRouteGroups } = require('.');
+const config = require('../../configuration');
+
+/** Add all routes routes from all route objects for fxa-settings or fxa-content-server to serve.
+ * @type {import("./types").AddRoutes}
+ */
+function addAllReactRoutesConditionally(app, routeHelpers, middleware) {
+  /** Check if the feature flag passed in is `true` and the request contains `?showReactApp=true`.
+   * If true, use the middleware passed ('createSettingsProxy' in dev, else 'modifySettingsStatic')
+   * for that route, allowing `fxa-settings` to serve the page. If false, skip the middleware and
+   * use the default routing middleware from `fxa-shared/express/routing.ts`.
+   * @param {import("./types").ReactRouteGroup}
+   */
+  function addReactRoutesConditionally({ featureFlagOn, routes }) {
+    if (featureFlagOn === true) {
+      routes.forEach(({ definition }) => {
+        // possible TODO - `definition.method`s will either be 'get' or 'post'. Not sure if we need
+        // this for any 'post' requests but shouldn't hurt anything; 'get' alone may suffice.
+        app[definition.method](definition.path, (req, res, next) => {
+          if (req.query.showReactApp === 'true') {
+            return middleware(req, res, next);
+          } else {
+            next('route');
+          }
+        });
+        // Manually add route for content-server to serve; occurs when above next('route'); is called
+        routeHelpers.addRoute(definition);
+      });
+    }
+  }
+
+  const reactRouteGroups = getReactRouteGroups(config.get('showReactApp'));
+  for (const routeGroup in reactRouteGroups) {
+    addReactRoutesConditionally(reactRouteGroups[routeGroup]);
+  }
+}
+module.exports = {
+  addAllReactRoutesConditionally,
+};

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -2,83 +2,66 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const config = require('../../configuration');
-const { getFrontEndRouteDefinitions } = require('./route-definitions');
+const { ReactRoute } = require('./react-route');
 
-/** @type {import("./types").RouteFeatureFlagGroup} */
-const simpleRoutes = {
-  featureFlagOn: config.get('showReactApp.simpleRoutes'),
-  routes: [
-    /* When you're ready to serve the React version of a "simpleRoute", add a new object here
-     * with the route name and definition. Definitions come from route files in `lib/routes/` -
-     * you need to find which file your new route exists in to determine which definition
-     * the route needs.
-     * TODO: Create other get[Descriptor]RouteDefinition functions, FXA-6538 */
-    {
-      name: 'cannot_create_account',
-      definition: getFrontEndRouteDefinitions(['cannot_create_account']),
+/**
+ * When you're ready to serve the React version of a page, identify which feature flag
+ * group object it should go in and add a new object in `routes` by calling `.getRoute`
+ * or setting `routes` with `.getRoutes` on the react route class. See tests for examples.
+ *
+ *  @type {import("./types").GetReactRouteGroups}
+ */
+const getReactRouteGroups = (showReactApp, isServer = true) => {
+  const reactRoute = new ReactRoute(isServer);
+
+  return {
+    simpleRoutes: {
+      featureFlagOn: showReactApp.simpleRoutes,
+      routes: [reactRoute.getRoute('cannot_create_account')],
     },
-  ],
+
+    resetPasswordRoutes: {
+      featureFlagOn: showReactApp.resetPasswordRoutes,
+      routes: [],
+    },
+
+    oauthRoutes: {
+      featureFlagOn: showReactApp.oauthRoutes,
+      routes: [reactRoute.getRoute('/oauth/success/:clientId')],
+    },
+
+    signInRoutes: {
+      featureFlagOn: showReactApp.signInRoutes,
+      routes: [],
+    },
+
+    signUpRoutes: {
+      featureFlagOn: showReactApp.signUpRoutes,
+      routes: [],
+    },
+
+    pairRoutes: {
+      featureFlagOn: showReactApp.pairRoutes,
+      routes: [],
+    },
+
+    postVerifyAddRecoveryKeyRoutes: {
+      featureFlagOn: showReactApp.postVerifyAddRecoveryKeyRoutes,
+      routes: [],
+    },
+
+    postVerifyCADViaQRRoutes: {
+      featureFlagOn: showReactApp.postVerifyCADViaQRRoutes,
+      routes: [],
+    },
+
+    signInVerificationViaPushRoutes: {
+      featureFlagOn: showReactApp.signInVerificationViaPushRoutes,
+      routes: [],
+    },
+  };
 };
 
-/** Check if the feature flag passed in is `true` and the request contains `?showReactApp=true`.
- * If true, use the middleware passed ('createSettingsProxy' in dev, else 'modifySettingsStatic')
- * for that route, allowing `fxa-settings` to serve the page. If false, skip the middleware and
- * use the default routing middleware from `fxa-shared/express/routing.ts`.
- * @param {import("express").Express} app
- * @param {Object} routeHelpers
- *  @param {Function} routeHelpers.addRoute
- *  @param {Function} routeHelpers.validationErrorHandler
- * @param {import("express").RequestHandler} middleware
- * @param {import("./types").RouteFeatureFlagGroup}
- */
-function addReactRoutesConditionally(
-  app,
-  routeHelpers,
-  middleware,
-  { featureFlagOn, routes }
-) {
-  if (featureFlagOn === true) {
-    routes.forEach(({ definition }) => {
-      // possible TODO - `definition.method`s will either be 'get' or 'post'. Not sure if we need
-      // this for any 'post' requests but shouldn't hurt anything; 'get' alone may suffice.
-      app[definition.method](definition.path, (req, res, next) => {
-        if (req.query.showReactApp === 'true') {
-          return middleware(req, res, next);
-        } else {
-          next('route');
-        }
-      });
-      // Manually add route for content-server to serve; occurs when above next('route'); is called
-      routeHelpers.addRoute(definition);
-    });
-  }
-}
-
-/** Add routes from `simpleRoutes` for fxa-settings or fxa-content-server to serve.
- * @param {import("express").Express} app
- * @param {Object} routeHelpers
- *  @param {Function} routeHelpers.addRoute
- *  @param {Function} routeHelpers.validationErrorHandler
- * @param {import("express").RequestHandler} middleware
- */
-function addSimpleRoutes(app, routeHelpers, middleware) {
-  addReactRoutesConditionally(app, routeHelpers, middleware, simpleRoutes);
-}
-
-/** Add all routes routes from all route objects for fxa-settings or fxa-content-server to serve.
- * @param {import("express").Express} app
- * @param {Object} routeHelpers
- *  @param {Function} routeHelpers.addRoute
- *  @param {Function} routeHelpers.validationErrorHandler
- * @param {import("express").RequestHandler} middleware
- */
-function addAllReactRoutesConditionally(app, routeHelpers, middleware) {
-  addSimpleRoutes(app, routeHelpers, middleware);
-  // add other addRoutes functions here when created
-}
-
 module.exports = {
-  simpleRoutes,
-  addAllReactRoutesConditionally,
+  getReactRouteGroups,
 };

--- a/packages/fxa-content-server/server/lib/routes/react-app/react-route.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/react-route.js
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { FRONTEND_ROUTES } = require('../get-frontend');
+const { PAIRING_ROUTES } = require('../get-frontend-pairing');
+const { OAUTH_SUCCESS_ROUTES } = require('../get-oauth-success');
+const {
+  getFrontEndRouteDefinition,
+  getFrontEndPairingRouteDefinition,
+  getOAuthSuccessRouteDefinition,
+} = require('./route-definitions');
+
+/**
+ * Returns a route object with the `name` of the route and the route `definition`
+ * if used on the server-side.
+ */
+class ReactRoute {
+  /** @param {Boolean} isServer Is access coming from the server? The client
+   * doesn't need route definitions. */
+  constructor(isServer) {
+    this.isServer = isServer;
+  }
+
+  /** @param {String} name */
+  getRoute(name) {
+    if (FRONTEND_ROUTES.includes(name)) {
+      return this.getFrontEnd(name);
+    }
+    if (PAIRING_ROUTES.includes(name)) {
+      return this.getFrontEndPairing(name);
+    }
+    if (OAUTH_SUCCESS_ROUTES.includes(name)) {
+      return this.getOAuthSuccess(name);
+    }
+
+    throw new Error(
+      `"${name}" was not found in any existing content-server routes. Check for typos and path slash mismatches. Otherwise, the route might need to be accounted for in "server/lib/routes/react-app/".`
+    );
+  }
+
+  /** @param {Array<string>} names */
+  getRoutes(names) {
+    const routes = [];
+    for (const name of names) {
+      routes.push(this.getRoute(name));
+    }
+    return routes;
+  }
+
+  /**
+   * @type {import("./types").GetRoute}
+   * @private
+   * */
+  getRouteObject(name, definition) {
+    return {
+      name,
+      ...(this.isServer && { definition }),
+    };
+  }
+
+  /** @private */
+  getFrontEnd(name) {
+    return this.getRouteObject(name, getFrontEndRouteDefinition([name]));
+  }
+
+  /** @private */
+  getFrontEndPairing(name) {
+    return this.getRouteObject(name, getFrontEndPairingRouteDefinition([name]));
+  }
+
+  /** @private */
+  getOAuthSuccess(name) {
+    return this.getRouteObject(name, getOAuthSuccessRouteDefinition([name]));
+  }
+}
+
+module.exports = {
+  ReactRoute,
+};

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definitions.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definitions.js
@@ -2,11 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/**
- * @param {Array.<String>} routes
- * @returns {import("fxa-shared/express/routing").RouteDefinition}
- */
-function getFrontEndRouteDefinitions(routes) {
+/** @type {import("./types").GetRouteDefinition} */
+function getFrontEndRouteDefinition(routes) {
   const path = routes.join('|'); // prepare for use in a RegExp
   return {
     method: 'get',
@@ -20,6 +17,33 @@ function getFrontEndRouteDefinitions(routes) {
   };
 }
 
+/** @type {import("./types").GetRouteDefinition} */
+function getFrontEndPairingRouteDefinition(routes) {
+  const path = routes.join('|'); // prepare for use in a RegExp
+  return {
+    method: 'get',
+    path: new RegExp('^/(' + path + ')/?$'),
+    process: function (req, res) {
+      res.redirect(302, '/pair/failure');
+    },
+  };
+}
+
+/** @type {import("./types").GetRouteDefinition} */
+function getOAuthSuccessRouteDefinition(routes) {
+  const path = routes.join('|'); // prepare for use in a RegExp
+  return {
+    method: 'get',
+    path,
+    process: function (req, res, next) {
+      req.url = '/';
+      next();
+    },
+  };
+}
+
 module.exports = {
-  getFrontEndRouteDefinitions,
+  getFrontEndRouteDefinition,
+  getFrontEndPairingRouteDefinition,
+  getOAuthSuccessRouteDefinition,
 };

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -5,12 +5,72 @@
 // TS setup for anything outside of `app/` is complex. This file defines types we
 // import for JSDoc instead.
 
+import {
+  Express,
+  Request,
+  Response,
+  NextFunction,
+  RequestHandler,
+} from 'express';
 import { RouteDefinition } from 'fxa-shared/express/routing';
 
-export interface RouteFeatureFlagGroup {
+export interface ReactRouteGroup {
   featureFlagOn: boolean;
   routes: {
     name: string;
     definition: RouteDefinition;
   }[];
+}
+
+export interface GetRouteDefinition {
+  (routes: string[]): RouteDefinition;
+}
+
+export interface GetRouteDefinitionSingle {
+  (route: string): RouteDefinition;
+}
+
+export interface RouteHelpers {
+  addRoute: (routeDefinition: RouteDefinition) => void;
+  validationErrorHandler: (
+    err: Error,
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => void;
+}
+
+export interface AddRoutes {
+  (app: Express, routeHelpers: RouteHelpers, middleware: RequestHandler): void;
+}
+
+type ShowReactApp = {
+  simpleRoutes: boolean;
+  resetPasswordRoutes: boolean;
+  oauthRoutes: boolean;
+  signInRoutes: boolean;
+  signUpRoutes: boolean;
+  pairRoutes: boolean;
+  postVerifyAddRecoveryKeyRoutes: boolean;
+  postVerifyCADViaQRRoutes: boolean;
+  signInVerificationViaPushRoutes: boolean;
+};
+
+export interface ReactRouteGroups {
+  [key: string]: ReactRouteGroup;
+}
+
+export interface GetReactRouteGroups {
+  (showReactApp: ShowReactApp, isServer: boolean): ReactRouteGroups;
+}
+
+export interface GetRoute {
+  (name: string, definition: RouteDefinition): {
+    name: string;
+    definition?: RouteDefinition;
+  };
+}
+
+export interface GetBackboneRouteDefinition {
+  (reactRouteGroups: ReactRouteGroups, routeNames: string[]): RouteDefinition;
 }

--- a/packages/fxa-content-server/tests/server/routes/react-app.js
+++ b/packages/fxa-content-server/tests/server/routes/react-app.js
@@ -1,0 +1,239 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {
+  getRoutesExcludingAllReact,
+  FRONTEND_ROUTES,
+} = require('../../../server/lib/routes/get-frontend');
+const {
+  getRoutesExcludingPairingReact,
+  PAIRING_ROUTES,
+} = require('../../../server/lib/routes/get-frontend-pairing');
+const {
+  getRoutesExcludingOAuthSuccessReact,
+  OAUTH_SUCCESS_ROUTES,
+} = require('../../../server/lib/routes/get-oauth-success');
+const { getReactRouteGroups } = require('../../../server/lib/routes/react-app');
+const {
+  ReactRoute,
+} = require('../../../server/lib/routes/react-app/react-route');
+
+const sinon = require('sinon');
+const { registerSuite } = intern.getInterface('object');
+const assert = intern.getPlugin('chai').assert;
+
+const showReactAppAll = {
+  simpleRoutes: true,
+  resetPasswordRoutes: true,
+  oauthRoutes: true,
+  signInRoutes: true,
+  signUpRoutes: true,
+  pairRoutes: true,
+  postVerifyAddRecoveryKeyRoutes: true,
+  postVerifyCADViaQRRoutes: true,
+  signInVerificationViaPushRoutes: true,
+};
+
+function getEmptyReactRouteGroups(showReactApp = showReactAppAll) {
+  const reactRouteGroups = getReactRouteGroups(showReactApp);
+  for (const routeGroup in reactRouteGroups) {
+    reactRouteGroups[routeGroup].routes = []; // start fresh
+  }
+  return reactRouteGroups;
+}
+
+const reactRoute = new ReactRoute();
+let routeName = '';
+let routeNames = [''];
+let mockReactRoute;
+
+registerSuite('routes/react-app', {
+  tests: {
+    ReactRoute: {
+      'route definitions are omitted if option is passed': function () {
+        const reactRouteWithoutDefinitions = new ReactRoute(false);
+        const route = reactRouteWithoutDefinitions.getRoute(
+          'cannot_create_account'
+        );
+        assert.isUndefined(route.definition);
+      },
+      getRoute: {
+        beforeEach: function () {
+          mockReactRoute = new ReactRoute();
+          mockReactRoute.getFrontEnd = sinon.spy();
+          mockReactRoute.getFrontEndPairing = sinon.spy();
+          mockReactRoute.getOAuthSuccess = sinon.spy();
+        },
+        'calls getFrontEnd correctly based on route name': function () {
+          mockReactRoute.getRoutes(FRONTEND_ROUTES);
+          assert.equal(
+            mockReactRoute.getFrontEnd.callCount,
+            FRONTEND_ROUTES.length
+          );
+        },
+        'calls getFrontEndPairing correctly based on route name': function () {
+          mockReactRoute.getRoutes(PAIRING_ROUTES);
+          assert.equal(
+            mockReactRoute.getFrontEndPairing.callCount,
+            PAIRING_ROUTES.length
+          );
+        },
+        'calls getOAuthSuccess correctly based on route name': function () {
+          mockReactRoute.getRoutes(OAUTH_SUCCESS_ROUTES);
+          assert.equal(
+            mockReactRoute.getOAuthSuccess.callCount,
+            OAUTH_SUCCESS_ROUTES.length
+          );
+        },
+        'throws when an unknown route is provided': function () {
+          assert.throws(() => mockReactRoute.getRoute('whatever'));
+        },
+      },
+    },
+    'get-frontend': {
+      before: function () {
+        routeName = 'cannot_create_account';
+        routeNames = [routeName];
+      },
+      'excludes route present in React route group with feature flag on': {
+        'single route': function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+          reactRouteGroups.simpleRoutes.routes = [
+            reactRoute.getRoute(routeName),
+          ];
+          const routesWithExclusion = getRoutesExcludingAllReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.notIncludeMembers(routesWithExclusion, routeNames);
+        },
+        'multiple routes': function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+          routeNames = [
+            'reset_password',
+            'complete_reset_password',
+            'confirm_reset_password',
+          ];
+          reactRouteGroups.resetPasswordRoutes.routes =
+            reactRoute.getRoutes(routeNames);
+          const routesWithExclusion = getRoutesExcludingAllReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.notIncludeMembers(routesWithExclusion, routeNames);
+        },
+      },
+      'does not exclude route present in React route group with feature flag off':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups({
+            ...showReactAppAll,
+            simpleRoutes: false,
+          });
+          reactRouteGroups.simpleRoutes.routes = [
+            reactRoute.getRoute(routeName),
+          ];
+
+          const routesWithExclusion = getRoutesExcludingAllReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.includeMembers(routesWithExclusion, routeNames);
+        },
+      'does not exclude route if not present in React route group with feature flag on':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+
+          const routesWithExclusion = getRoutesExcludingAllReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.includeMembers(routesWithExclusion, routeNames);
+        },
+    },
+    'get-frontend-pairing': {
+      before: function () {
+        routeName = 'pair/auth/complete';
+        routeNames = [routeName];
+      },
+      'excludes route present in React route group with feature flag on':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+          reactRouteGroups.pairRoutes.routes = [reactRoute.getRoute(routeName)];
+          const routesWithExclusion = getRoutesExcludingPairingReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.notIncludeMembers(routesWithExclusion, routeNames);
+        },
+      'does not exclude route present in React route group with feature flag off':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups({
+            ...showReactAppAll,
+            pairRoutes: false,
+          });
+          reactRouteGroups.pairRoutes.routes = [reactRoute.getRoute(routeName)];
+
+          const routesWithExclusion = getRoutesExcludingPairingReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.includeMembers(routesWithExclusion, routeNames);
+        },
+      'does not exclude route if not present in React route group with feature flag on':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+
+          const routesWithExclusion = getRoutesExcludingPairingReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.includeMembers(routesWithExclusion, routeNames);
+        },
+    },
+    'get-oauth-success': {
+      before: function () {
+        routeName = '/oauth/success/:clientId';
+        routeNames = [routeName];
+      },
+      'excludes route present in React route group with feature flag on':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+          reactRouteGroups.oauthRoutes.routes = [
+            reactRoute.getRoute(routeName),
+          ];
+          const routesWithExclusion = getRoutesExcludingOAuthSuccessReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.notIncludeMembers(routesWithExclusion, routeNames);
+        },
+      'does not exclude route present in React route group with feature flag off':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups({
+            ...showReactAppAll,
+            oauthRoutes: false,
+          });
+          reactRouteGroups.oauthRoutes.routes = [
+            reactRoute.getRoute(routeName),
+          ];
+
+          const routesWithExclusion = getRoutesExcludingOAuthSuccessReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.includeMembers(routesWithExclusion, routeNames);
+        },
+      'does not exclude route if not present in React route group with feature flag on':
+        function () {
+          const reactRouteGroups = getEmptyReactRouteGroups();
+
+          const routesWithExclusion = getRoutesExcludingOAuthSuccessReact(
+            reactRouteGroups,
+            routeNames
+          );
+          assert.includeMembers(routesWithExclusion, routeNames);
+        },
+    },
+  },
+});

--- a/packages/fxa-content-server/tests/tests_server.js
+++ b/packages/fxa-content-server/tests/tests_server.js
@@ -36,6 +36,7 @@ module.exports = [
   'tests/server/routes/post-csp.js',
   'tests/server/routes/post-metrics.js',
   'tests/server/routes/post-third-party-auth-redirect.js',
+  'tests/server/routes/react-app.js',
   'tests/server/routes/redirect-download-firefox.js',
   'tests/server/routes/validate-email-domain.js',
   'tests/server/logging/route_logging.js',


### PR DESCRIPTION
This commit:
* Refactors route-related files and creates helper functions so we can more easily add routes ready to be served on the React side instead of the Backbone side

Because:
* As we refactor to React, we need to be able to easily add route names to be served by fxa-settings

Closes FXA-6538

--

I'll write this in tickets, but when we want to show the React version of a page, we'll add the route in Settings, identify the feature flag the route should go under, and then in `routes/react-app/index.js`, we can add the route with either `reactRoute.getRoute('whatever')` or `reactRoute.getRoutes(['hello', 'world'])`. Then, in `router.js`, we'll use the new `createReactOrBackboneViewHandler` method, and (after your `local.json` file is updated to set the feature flags) whabam! This method will probably need to be modified as we move along to pass needed parameters in similar to what we do for `/settings`.

I started [this doc](https://docs.google.com/document/d/119YNxFLk9ZUvx7Jis2sOigYIfnF21CZ-WzsmaqZkKQ8/edit#) to make note of any route-related files we'll still need to poke at. I could have possibly done `get-terms-privacy` as well, but there's some l10n / i18n stuff in there so I'm going to leave that for when we work on the legal pages, it shouldn't be too bad to follow the pattern set here, and I'll make a comment on that ticket.