### PR TITLE
fix(fxa-settings): change focussed to focused in Checkbox component

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Checkbox/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Checkbox/index.tsx
@@ -20,17 +20,17 @@ export const Checkbox = ({
   onChange,
   prefixDataTestId,
 }: CheckboxProps) => {
-  const [focused, setFocussed] = useState<boolean>(false);
+  const [focused, setFocused] = useState<boolean>(false);
   const [checked, setChecked] = useState<boolean>(defaultChecked === true);
   const [hovered, setHovered] = useState<boolean>(false);
 
   const checkboxFocus = useCallback(() => {
-    setFocussed(true);
-  }, [setFocussed]);
+    setFocused(true);
+  }, [setFocused]);
 
   const checkboxBlur = useCallback(() => {
-    setFocussed(false);
-  }, [setFocussed]);
+    setFocused(false);
+  }, [setFocused]);
 
   const checkboxChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Because

- We want to standardize spelling to the standard "focused"

## This pull request

- Change setFocussed to setFocused in Checkbox component

## Issue that this pull request solves

Closes: #FXA-6475

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
