### PR TITLE
fix(api): update last access time when `/account/devices` route is hit

### DIFF
--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -588,6 +588,12 @@ module.exports = (
         ) {
           throw new error.featureNotEnabled();
         }
+        
+        // If this request is using a session token we bump the last access time
+        if (credentials.id) {
+          credentials.lastAccessTime = Date.now();
+          await db.touchSessionToken(credentials, {} , true);
+        }
 
         const deviceArray = await request.app.devices;
 


### PR DESCRIPTION
## Because

- A request to the `/devices` should update the session token last access time

## This pull request

- Updates the last access time using `db.touchSessionToken` which is designed to be used in frequenlty hit routes

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6595

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
