### PR TITLE
task(CI): Fix auth server test coverage for unit / integration tests

### DIFF
--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -26,11 +26,7 @@ yarn run merge-ftl:test
 echo
 yarn run emails-scss
 
-if [ "$TEST_TYPE" == 'integration' ]; then
-  TESTS=(oauth remote);
-else
-  TESTS=(local scripts)
-fi;
+TESTS=(local oauth remote scripts)
 
 for t in "${TESTS[@]}"; do
   echo -e "\n\nTesting: $t"


### PR DESCRIPTION
## Because

- A few tests were not being run that should be.
- In general remote and oauth tests are most integration tests, however, it is possible these suites contain a small number of unit tests.

## This pull request

- Runs all tests suites for both unit and integration tests since there maybe unit or integration tests in any of these suites.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is just a small follow up PR trailing FXA-6266.
