### PR TITLE
bug(auth): Debugging missing response body on verify_code calls

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -165,6 +165,27 @@ Lug.prototype.summary = function (request, response) {
     phoneNumber: responseBody.formattedPhoneNumber,
   };
 
+  // TODO: Remove after debugging mysterious empty response body reported in FXA-6573
+  //       is complete.
+  if (
+    config.env !== 'prod' &&
+    line.status === 400 &&
+    line.path === '/v1/session/verify_code'
+  ) {
+    try {
+      const body = JSON.stringify(responseBody);
+      this.info('request.summary.debug', {
+        body,
+        bodySize: body.length,
+      });
+    } catch (error) {
+      this.info('request.summary.debug', {
+        bodySize: -1,
+        error,
+      });
+    }
+  }
+
   if (line.status >= 500) {
     line.trace = request.app.traced;
     line.stack = response.stack;


### PR DESCRIPTION
## Because

- We want better visibility into what happens when a response to the session/verify_code endpoint returns a 400

## This pull request

- Adds some logging around this scenario
- Logging won't be done on production

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is just a temporary change. It will be reverted once we can observe an invalid state and correlate it with our logs.
