### PR TITLE
fix(l10n): Replace unicode with regular em dash

### DIFF
--- a/packages/fxa-settings/src/components/PasswordStrengthBalloon/en.ftl
+++ b/packages/fxa-settings/src/components/PasswordStrengthBalloon/en.ftl
@@ -4,4 +4,4 @@ password-strength-balloon-heading = Password requirements
 password-strength-balloon-min-length = At least 8 characters
 password-strength-balloon-not-email = Not your email address
 password-strength-balloon-not-common = Not a commonly used password
-password-strength-balloon-stay-safe-tips = Stay safe {"\u2014"} Don’t reuse passwords. See more tips to <LinkExternal>create strong passwords</LinkExternal>.
+password-strength-balloon-stay-safe-tips = Stay safe — Don’t reuse passwords. See more tips to <LinkExternal>create strong passwords</LinkExternal>.


### PR DESCRIPTION
## Because

- Change was accidentally reverted before merging PR-14738 (reported by @bcolsson)

## This pull request

- Fix the em dash in PasswordStrengthBalloon ftl

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
