### PR TITLE
storybook(fxa-settings): Implement PasswordStrengthBalloon in reset password flow pages

### DIFF
--- a/packages/fxa-content-server/app/styles/tailwind/tooltips.css
+++ b/packages/fxa-content-server/app/styles/tailwind/tooltips.css
@@ -10,38 +10,6 @@
   @apply relative;
 }
 
-.input-balloon {
-  @apply absolute text-start w-[calc(100%+.5rem)] -left-1 desktop:w-64 desktop:left-auto px-5 py-4 bg-white rounded-sm top-[calc(100%+.25rem)] desktop:-top-2 border border-grey-100 shadow-sm transition-opacity z-10;
-
-  &::before {
-    @apply absolute w-3 h-3 rotate-45 bg-white border-grey-100 border-l border-t top-[calc(-0.375rem-1px)] content-[''];
-  }
-}
-
-@screen desktop {
-  .input-balloon {
-    @apply before:top-5;
-
-    [dir='ltr'] & {
-      @apply left-[calc(100%+1rem)];
-
-      &::before {
-        /* negative left is half the pseudo width - border-width */
-        @apply border-l border-b border-t-0 left-[calc(-0.375rem-1px)];
-      }
-    }
-
-    [dir='rtl'] & {
-      @apply right-[calc(100%+1rem)];
-
-      &::before {
-        /* negative right is half the pseudo width - border-width */
-        @apply border-r border-l-0 right-[calc(-0.375rem-1px)];
-      }
-    }
-  }
-}
-
 /* REACT NOTE: This should be done with components, these are purely
  * convenience classes in the meantime */
 .password-strength {

--- a/packages/fxa-react/styles/index.css
+++ b/packages/fxa-react/styles/index.css
@@ -11,3 +11,4 @@
 @import './portal.css';
 @import './ctas.css';
 @import './flows.css';
+@import './tooltips.css';

--- a/packages/fxa-react/styles/tooltips.css
+++ b/packages/fxa-react/styles/tooltips.css
@@ -2,14 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* REACT NOTE: We're currently using jQ to look for the "closest" element matching `input-row` to
- * set which element the tooltip should be relative to. If the component is using Tailwind, it's
- * using `tooltip-container` instead, which only has a component class because its purpose is more
- * clear than matching closest "relative" class. This can be done in a nicer way with React. */
-.tooltip-container {
-  @apply relative;
-}
-
 .input-balloon {
   @apply absolute text-start w-[calc(100%+.5rem)] -left-1 desktop:w-64 desktop:left-auto px-5 py-4 bg-white rounded-sm top-[calc(100%+.25rem)] desktop:-top-2 border border-grey-100 shadow-sm transition-opacity z-10;
 

--- a/packages/fxa-settings/src/components/FormResetPasswordWithBalloon/en.ftl
+++ b/packages/fxa-settings/src/components/FormResetPasswordWithBalloon/en.ftl
@@ -4,3 +4,5 @@ form-reset-password-with-balloon-new-password =
   .label = New password
 form-reset-password-with-balloon-confirm-password =
   .label = Re-enter password
+form-reset-password-with-balloon-submit-button = Reset password
+form-reset-password-with-balloon-match-error = Passwords do not match

--- a/packages/fxa-settings/src/components/FormResetPasswordWithBalloon/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormResetPasswordWithBalloon/mocks.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import FormPassword from '.';
+import FormResetPasswordWithBalloon from '.';
 
 export const Subject = () => {
   type FormData = {
@@ -30,7 +30,7 @@ export const Subject = () => {
     });
 
   return (
-    <FormPassword
+    <FormResetPasswordWithBalloon
       {...{
         formState,
         errors,
@@ -43,7 +43,6 @@ export const Subject = () => {
       onSubmit={handleSubmit(onFormSubmit)}
       email="test@example.com"
       loading={false}
-      submitButtonText="Reset password"
       onFocusMetricsEvent="test-event"
     />
   );

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -24,6 +24,8 @@ export const InputPassword = ({
   errorText,
   name,
   prefixDataTestId = '',
+  tooltipPosition,
+  anchorStart,
 }: InputPasswordProps) => {
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
   const [visible, setVisible] = useState<boolean>(false);
@@ -58,6 +60,8 @@ export const InputPassword = ({
         errorText,
         name,
         prefixDataTestId,
+        tooltipPosition,
+        anchorStart,
       }}
     >
       <button

--- a/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.stories.tsx
@@ -19,7 +19,9 @@ const storyWithProps = (
 ) => {
   const story = () => (
     <AppLayout>
-      <div className="tooltip-container">
+      {/* PasswordStrengthBalloon and its associated InputPassword
+          must be wrapped in a relative div for accurate balloon positioning */}
+      <div className="relative">
         <InputPassword
           label="Password (example only, disabled for storybook)"
           defaultValue={passwordExample}

--- a/packages/fxa-settings/src/pages/AccountRecoveryResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/AccountRecoveryResetPassword/en.ftl
@@ -2,5 +2,6 @@
 
 # Header for form to create new password
 create-new-password-header = Create new password
-confirm-account-recovery-key-button = Reset password
 account-restored-success-message = You have successfully restored your account using your account recovery key. Create a new password to secure your data, and store it in a safe location.
+# Feedback displayed in alert bar when password reset is successful
+account-recovery-reset-password-success-alert = Password set

--- a/packages/fxa-settings/src/pages/AccountRecoveryResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/AccountRecoveryResetPassword/index.stories.tsx
@@ -9,6 +9,7 @@ import AccountRecoveryResetPassword, {
 import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { MOCK_EMAIL } from './mocks';
 
 export default {
   title: 'pages/AccountRecoveryResetPassword',
@@ -26,13 +27,17 @@ const storyWithProps = (props: AccountRecoveryResetPasswordProps) => {
   return story;
 };
 
-export const WithValidLink = storyWithProps({ linkStatus: 'valid' });
-
-export const WithBrokenLink = storyWithProps({ linkStatus: 'damaged' });
-
-export const WithExpiredLink = storyWithProps({ linkStatus: 'expired' });
-
-export const CanGoBack = storyWithProps({
-  canGoBack: true,
+export const WithValidLink = storyWithProps({
+  email: MOCK_EMAIL,
   linkStatus: 'valid',
+});
+
+export const WithBrokenLink = storyWithProps({
+  email: MOCK_EMAIL,
+  linkStatus: 'damaged',
+});
+
+export const WithExpiredLink = storyWithProps({
+  email: MOCK_EMAIL,
+  linkStatus: 'expired',
 });

--- a/packages/fxa-settings/src/pages/AccountRecoveryResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/AccountRecoveryResetPassword/mocks.tsx
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_EMAIL = 'text@example.com';

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/en.ftl
@@ -1,10 +1,8 @@
 ## CompleteResetPassword component
+## User followed a password reset link and is now prompted to create a new password
 
-# User followed a password reset link and is now prompted to create a new password
 complete-reset-pw-header = Create new password
 complete-reset-password-warning-message = <span>Remember:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and { product-pocket } data will not be affected.
-# This information message is followed by a form to create a new password.
-complete-reset-password-account-recovery-info = You have successfully restored your account using your account recovery key. Create a new password to secure your data, and store it in a safe location.
 # A new password was successfully set for the user's account
 # Displayed in an alert bar
 complete-reset-password-success-alert = Password set

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/index.stories.tsx
@@ -7,6 +7,7 @@ import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import CompleteResetPassword, { CompleteResetPasswordProps } from '.';
+import { MOCK_EMAIL } from './mocks';
 
 export default {
   title: 'pages/CompleteResetPassword',
@@ -24,18 +25,23 @@ const storyWithProps = (props: CompleteResetPasswordProps) => {
   return story;
 };
 
-export const WithValidLink = storyWithProps({ linkStatus: 'valid' });
-
-export const WithSyncWarning = storyWithProps({
+export const WithValidLink = storyWithProps({
+  email: MOCK_EMAIL,
   linkStatus: 'valid',
-  showSyncWarning: true,
 });
 
-export const WithAccountRecoveryInfo = storyWithProps({
+export const ValidWithSyncWarning = storyWithProps({
+  email: MOCK_EMAIL,
   linkStatus: 'valid',
-  showAccountRecoveryInfo: true,
+  resetPasswordConfirm: true,
 });
 
-export const WithExpiredLink = storyWithProps({ linkStatus: 'expired' });
+export const WithExpiredLink = storyWithProps({
+  email: MOCK_EMAIL,
+  linkStatus: 'expired',
+});
 
-export const WithDamagedLink = storyWithProps({ linkStatus: 'damaged' });
+export const WithDamagedLink = storyWithProps({
+  email: MOCK_EMAIL,
+  linkStatus: 'damaged',
+});

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/index.tsx
@@ -5,23 +5,34 @@
 import React, { useCallback, useState } from 'react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useForm } from 'react-hook-form';
-import { HomePath } from '../../constants';
 import { usePageViewEvent } from '../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models/hooks';
-import { useAccount, useAlertBar } from '../../models';
+import { useAlertBar } from '../../models';
 import WarningMessage from '../../components/WarningMessage';
-import FormPassword from '../../components/FormPassword';
 import LinkRememberPassword from '../../components/LinkRememberPassword';
 import ResetPasswordLinkExpired from '../../components/ResetPasswordLinkExpired';
 import ResetPasswordLinkDamaged from '../../components/ResetPasswordLinkDamaged';
+import FormResetPasswordWithBalloon from '../../components/FormResetPasswordWithBalloon';
+
+// The equivalent complete_reset_password mustache file included account_recovery_reset_password
+// For React, we have opted to separate these into two pages to align with the routes.
+//
+// Users should only see the CompleteResetPassword page on /complete _reset_password if
+//   - there is no account recovery key for their account
+//   - there is an account recovery key for their account, but it was reported as lost
+//
+// If the user has an account recovery key (and it is not reported as lost),
+// navigate to /account_recovery_confirm_key
+//
+// If account recovery was initiated with a key, redirect to account_recovery_reset_password
 
 export type CompleteResetPasswordProps = {
-  email?: string;
-  forceEmail?: string;
+  email: string;
   linkStatus: LinkStatus;
-  showSyncWarning?: boolean;
-  showAccountRecoveryInfo?: boolean;
+  // resetPasswordConfirm will be obtained from the relier
+  // resetPasswordConfirm determines if sync warning is shown
+  resetPasswordConfirm?: boolean;
 };
 
 type FormData = {
@@ -33,14 +44,18 @@ type LinkStatus = 'expired' | 'damaged' | 'valid';
 
 const CompleteResetPassword = ({
   email,
-  forceEmail,
   linkStatus,
-  showSyncWarning,
-  showAccountRecoveryInfo,
+  resetPasswordConfirm,
 }: CompleteResetPasswordProps & RouteComponentProps) => {
   usePageViewEvent('complete-reset-password', {
     entrypoint_variation: 'react',
   });
+
+  const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
+  const alertBar = useAlertBar();
+  const navigate = useNavigate();
+  const ftlMsgResolver = useFtlMsgResolver();
+  const onFocusMetricsEvent = 'complete-password-reset.engage';
 
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<FormData>({
@@ -51,28 +66,24 @@ const CompleteResetPassword = ({
         confirmPassword: '',
       },
     });
-  const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
 
-  const alertBar = useAlertBar();
-  const account = useAccount();
-  const navigate = useNavigate();
-  const ftlMsgResolver = useFtlMsgResolver();
-
-  const alertSuccessAndGoHome = useCallback(() => {
+  const alertSuccessAndNavigate = useCallback(() => {
     const successCompletePwdReset = ftlMsgResolver.getMsg(
       'complete-reset-password-success-alert',
       'Password set'
     );
     alertBar.success(successCompletePwdReset);
-    navigate(HomePath + '#password', { replace: true });
+    navigate('/reset_password_verified', { replace: true });
   }, [alertBar, ftlMsgResolver, navigate]);
 
-  const onFormSubmit = useCallback(
+  const onSubmit = useCallback(
     async ({ newPassword }: FormData) => {
       try {
-        // TODO: add logic to set a new password
-        alertSuccessAndGoHome();
+        // TODO: completeAccountPasswordReset
+        // logViewEvent('verification.success');
+        alertSuccessAndNavigate();
       } catch (e) {
+        // if token expired, re-render and show LinkExpired
         // TODO metrics event for error
         const errorCompletePwdReset = ftlMsgResolver.getMsg(
           'complete-reset-password-error-alert',
@@ -81,14 +92,11 @@ const CompleteResetPassword = ({
         alertBar.error(errorCompletePwdReset);
       }
     },
-    [ftlMsgResolver, alertSuccessAndGoHome, alertBar]
+    [ftlMsgResolver, alertSuccessAndNavigate, alertBar]
   );
 
   return (
     <>
-      {linkStatus === 'expired' && <ResetPasswordLinkExpired />}
-      {linkStatus === 'damaged' && <ResetPasswordLinkDamaged />}
-
       {/* With valid password reset link */}
       {linkStatus === 'valid' && (
         <>
@@ -98,7 +106,8 @@ const CompleteResetPassword = ({
             </h1>
           </FtlMsg>
 
-          {showSyncWarning && (
+          {/* SyncWarning is only shown if resetPasswordConfirm === true */}
+          {resetPasswordConfirm && (
             <WarningMessage
               warningMessageFtlId="complete-reset-password-warning-message"
               warningType="Remember:"
@@ -110,22 +119,14 @@ const CompleteResetPassword = ({
               subscriptions you may have and Pocket data will not be affected.
             </WarningMessage>
           )}
-          {showAccountRecoveryInfo && (
-            <FtlMsg id="complete-reset-pw-account-recovery-info">
-              <p className="mb-5 mt-4 text-sm">
-                You have successfully restored your account using your account
-                recovery key. Create a new password to secure your data, and
-                store it in a safe location.
-              </p>
-            </FtlMsg>
-          )}
+
           {/* Hidden email field is to allow Fx password manager
            to correctly save the updated password. Without it,
            the password manager tries to save the old password
            as the username. */}
-          <input type="email" value={email} className="hidden" />
+          <input type="email" value={email} className="hidden" readOnly />
           <section className="text-start mt-4">
-            <FormPassword
+            <FormResetPasswordWithBalloon
               {...{
                 formState,
                 errors,
@@ -135,16 +136,18 @@ const CompleteResetPassword = ({
                 newPasswordErrorText,
                 setNewPasswordErrorText,
               }}
-              onFocusMetricsEvent="complete-reset-password.engage"
-              onSubmit={handleSubmit(onFormSubmit)}
-              primaryEmail={account.primaryEmail.email}
-              loading={account.loading}
+              onSubmit={handleSubmit(onSubmit)}
+              {...{ email }}
+              loading={false}
+              onFocusMetricsEvent={onFocusMetricsEvent}
             />
           </section>
-          {!forceEmail && <LinkRememberPassword {...{ email }} />}
-          {forceEmail && <LinkRememberPassword {...{ forceEmail }} />}
+          {/* TODO: Verify if the "Remember password?" should always direct to /signin (current state) */}
+          <LinkRememberPassword {...{ email }} />
         </>
       )}
+      {linkStatus === 'expired' && <ResetPasswordLinkExpired />}
+      {linkStatus === 'damaged' && <ResetPasswordLinkDamaged />}
     </>
   );
 };

--- a/packages/fxa-settings/src/pages/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/CompleteResetPassword/mocks.tsx
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_EMAIL = 'text@example.com';

--- a/packages/fxa-settings/src/styles/tailwind.css
+++ b/packages/fxa-settings/src/styles/tailwind.css
@@ -13,7 +13,6 @@
 @import './drop-down-menu';
 @import './slider';
 @import './switch';
-@import './tooltips.css';
 
 body {
   @apply text-base font-body bg-grey-10 text-grey-900;


### PR DESCRIPTION
## Because

- We want to include the PasswordStrengthBalloon component in CompleteResetPassword and AccountRecoveryResetPassword pages to match parity with the content-server views.

## This pull request

* Move tooltips styling to fxa-react
* Update FormResetPasswordWithBalloon to include error feedback when passwords do not match
* Replace FormPassword with FormResetPasswordWithBalloon in CompleteResetPassword
* Replace custom password form in AccountRecoveryResetPassword with FormResetPasswordWithBalloon
* Update l10n, tests for CompleteResetPassword, AccountRecoveryResetPassword
* Review and standardize both pages

## Issue that this pull request solves

Closes: #FXA-6591

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

AccountRecoveryResetPassword:
![image](https://user-images.githubusercontent.com/22231637/212976378-46b3df23-cbae-4729-94b5-7fcd4fce9713.png)

CompleteResetPassword:
![image](https://user-images.githubusercontent.com/22231637/212976531-be5ad880-3547-41ce-be0e-78e9fcbfa9da.png)

## Other information (Optional)

Any other information that is important to this pull request.
