### PR TITLE
bug(auth): Align confirmation code's window with UI messaging

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1919,13 +1919,13 @@ const convictConf = convict({
   otp: {
     step: {
       doc: 'Default time step size (seconds)',
-      default: 10 * 60,
+      default: 5 * 60,
       format: 'nat',
       env: 'OTP_SIGNUP_STEP_SIZE',
     },
     window: {
       doc: 'Tokens in the previous x-windows that should be considered valid',
-      default: 1,
+      default: 0,
       format: 'nat',
       env: 'OTP_SIGNUP_WINDOW',
     },

--- a/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
@@ -165,7 +165,7 @@ describe('#integration - remote account create with sign-up code', function () {
     );
   });
 
-  it('should verify code from previous code window', async () => {
+  it('should not verify code from previous code window', async () => {
     email = server.uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
@@ -190,9 +190,10 @@ describe('#integration - remote account create with sign-up code', function () {
 
     const previousWindowCode = futureAuthenticator.generate(secret);
 
-    const response = await client.verifyShortCodeEmail(previousWindowCode);
-
-    assert.ok(response);
+    await assert.failsAsync(client.verifyShortCodeEmail(previousWindowCode), {
+      code: 400,
+      errno: 183,
+    });
   });
 
   it('should not verify code from future code window', async () => {


### PR DESCRIPTION

## Because

- The UI states the confirmation code is code is valid for 10 minutes, but given the current config it valid for up to 20 minutes, and there can be two valid codes at a time.

## This pull request

- Switches the configuration to be inline with the messaging in the UI
- Changes the time step to 5 minutes, which means the code is only valid for 5 minutes.
- Changes the window to 0, which means only 1 token is valid at a time.

## Issue that this pull request solves

Closes: FXA-5962

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I am still doing some exploratory testing on this. Also, it might be better to change the UI message. I am a bit torn on this. I do think that only have one code valid at a time makes a lot of sense though.
