### PR TITLE
feat(api): Add gql resolvers for security events

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -83,6 +83,9 @@ describe('#integration - AccountResolver', () => {
         (resolver as any).shouldIncludeLinkedAccounts = jest
           .fn()
           .mockReturnValue(true);
+        (resolver as any).shouldIncludeSecurityEvents = jest
+          .fn()
+          .mockReturnValue(true);
         const result = await resolver.account(USER_1.uid, {} as any);
         expect(result?.createdAt).toBe(USER_1.createdAt);
       });
@@ -161,6 +164,20 @@ describe('#integration - AccountResolver', () => {
         const linkedAccounts = resolver.linkedAccounts(user!);
         expect(linkedAccounts).toStrictEqual([
           { providerId: 1, enabled: true, authAt },
+        ]);
+      });
+
+      it('resolves security events when included', async () => {
+        const user = await Account.findByUid(USER_1.uid, {
+          include: ['securityEvents'],
+        });
+        const createdAt = Date.now();
+        (user!.securityEvents as any) = [
+          { name: 'account.created', verified: true, createdAt },
+        ];
+        const securityEvents = resolver.securityEvents(user!);
+        expect(securityEvents).toStrictEqual([
+          { name: 'account.created', verified: true, createdAt },
         ]);
       });
     });
@@ -731,15 +748,18 @@ describe('#integration - AccountResolver', () => {
     describe('getRecoveryKeyBundle', () => {
       it('succeeds', async () => {
         authClient.getRecoveryKey = jest.fn().mockResolvedValue({
-          recoveryData: 'recoveryData'
+          recoveryData: 'recoveryData',
         });
         const result = await resolver.getRecoveryKeyBundle({
           accountResetToken: 'cooltokenyo',
-          recoveryKeyId: 'recoveryKeyId'
+          recoveryKeyId: 'recoveryKeyId',
         });
-        expect(authClient.getRecoveryKey).toBeCalledWith('cooltokenyo', 'recoveryKeyId');
+        expect(authClient.getRecoveryKey).toBeCalledWith(
+          'cooltokenyo',
+          'recoveryKeyId'
+        );
         expect(result).toStrictEqual({
-          recoveryData: 'recoveryData'
+          recoveryData: 'recoveryData',
         });
       });
     });

--- a/packages/fxa-graphql-api/src/gql/model/account.ts
+++ b/packages/fxa-graphql-api/src/gql/model/account.ts
@@ -9,6 +9,7 @@ import { Email } from './emails';
 import { Subscription } from './subscription';
 import { Totp } from './totp';
 import { LinkedAccount } from './linkedAccount';
+import { SecurityEvent } from './securityEvent';
 
 @ObjectType({
   description: "The current authenticated user's Firefox Account record.",
@@ -60,4 +61,9 @@ export class Account {
     description: 'Linked accounts',
   })
   public linkedAccounts!: LinkedAccount;
+
+  @Field((type) => [SecurityEvent], {
+    description: 'Security events',
+  })
+  public securityEvents!: SecurityEvent[];
 }

--- a/packages/fxa-graphql-api/src/gql/model/securityEvent.ts
+++ b/packages/fxa-graphql-api/src/gql/model/securityEvent.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class SecurityEvent {
+  @Field()
+  public name!: string;
+
+  @Field()
+  public createdAt!: number;
+
+  @Field({ nullable: true })
+  public verified?: boolean;
+}

--- a/packages/fxa-graphql-api/test/helpers.ts
+++ b/packages/fxa-graphql-api/test/helpers.ts
@@ -29,6 +29,14 @@ export const linkedAccountsTable = fs.readFileSync(
   path.join(thisDir, './linked-accounts.sql'),
   'utf8'
 );
+export const securityEventsTable = fs.readFileSync(
+  path.join(thisDir, './security-events.sql'),
+  'utf8'
+);
+export const securityEventsNameTable = fs.readFileSync(
+  path.join(thisDir, './security-events-names.sql'),
+  'utf8'
+);
 export const sessionsTable = fs.readFileSync(
   path.join(thisDir, './sessions.sql'),
   'utf8'
@@ -106,6 +114,8 @@ export async function testDatabaseSetup(): Promise<Knex> {
   await instance.raw(emailsTable);
   await instance.raw(linkedAccountsTable);
   await instance.raw(sessionsTable);
+  await instance.raw(securityEventsNameTable);
+  await instance.raw(securityEventsTable);
 
   /* Debugging Assistance
    knex.on('query', (data) => {

--- a/packages/fxa-graphql-api/test/security-events-names.sql
+++ b/packages/fxa-graphql-api/test/security-events-names.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `securityEventNames` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `securityEventNamesUnique` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/packages/fxa-graphql-api/test/security-events.sql
+++ b/packages/fxa-graphql-api/test/security-events.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `securityEvents` (
+  `uid` binary(16) NOT NULL,
+  `nameId` int NOT NULL,
+  `verified` tinyint(1) DEFAULT NULL,
+  `ipAddrHmac` binary(32) NOT NULL,
+  `createdAt` bigint NOT NULL,
+  `tokenVerificationId` binary(16) DEFAULT NULL,
+  KEY `nameId` (`nameId`),
+  KEY `securityEvents_uid_tokenVerificationId` (`uid`,`tokenVerificationId`),
+  KEY `securityEvents_uid_ipAddrHmac_createdAt` (`uid`,`ipAddrHmac`,`createdAt`),
+  CONSTRAINT `securityEvents_ibfk_1` FOREIGN KEY (`nameId`) REFERENCES `securityEventNames` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;

--- a/packages/fxa-shared/db/models/auth/account.ts
+++ b/packages/fxa-shared/db/models/auth/account.ts
@@ -8,11 +8,12 @@ import { BaseAuthModel, Proc } from './base-auth';
 import { Email } from './email';
 import { Device } from './device';
 import { LinkedAccount } from './linked-account';
+import { SecurityEvent } from './security-event';
 import { intBoolTransformer, uuidTransformer } from '../../transformers';
 import { convertError, notFound } from '../../mysql';
 
 export type AccountOptions = {
-  include?: Array<'emails' | 'linkedAccounts'>;
+  include?: Array<'emails' | 'linkedAccounts' | 'securityEvents'>;
 };
 
 const selectFields = [
@@ -70,6 +71,7 @@ export class Account extends BaseAuthModel {
   devices?: Device[];
   emails?: Email[];
   linkedAccounts?: LinkedAccount[];
+  securityEvents?: SecurityEvent[];
 
   static relationMappings = {
     emails: {
@@ -94,6 +96,14 @@ export class Account extends BaseAuthModel {
         to: 'linkedAccounts.uid',
       },
       modelClass: LinkedAccount,
+      relation: BaseAuthModel.HasManyRelation,
+    },
+    securityEvents: {
+      join: {
+        from: 'accounts.uid',
+        to: 'securityEvents.uid',
+      },
+      modelClass: SecurityEvent,
       relation: BaseAuthModel.HasManyRelation,
     },
   };
@@ -475,6 +485,10 @@ export class Account extends BaseAuthModel {
       account.linkedAccounts = await LinkedAccount.findByUid(uid);
     }
 
+    if (options?.include?.includes('securityEvents')) {
+      account.securityEvents = await SecurityEvent.findByUid(uid);
+    }
+
     return account;
   }
 
@@ -502,5 +516,9 @@ export class Account extends BaseAuthModel {
       // err on caution / don't throw
       return false;
     }
+  }
+
+  static async securityEvents(uid: string) {
+    return SecurityEvent.findByUid(uid);
   }
 }


### PR DESCRIPTION
## Because

- In order to view security events we need to add them to account resolver

## This pull request

- Adds gql account resolver to retrieve security events

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6112

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1001" alt="Screenshot 2023-01-17 at 1 56 45 PM" src="https://user-images.githubusercontent.com/1295288/212988251-29a4c35e-df8f-4ea6-862f-499956db42e6.png">


## Other information (Optional)

We still need to add react views for security events