### PR TITLE
fix(payments): don't call /invoice/preview in Subscription Management

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -16,10 +16,6 @@ import {
   MOCK_CUSTOMER,
   MOCK_SUBSEQUENT_INVOICES,
   MOCK_PREVIEW_INVOICE_NO_TAX,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT,
 } from '../../../lib/test-utils';
 import { Plan } from 'fxa-payments-server/src/store/types';
 import {
@@ -52,7 +48,6 @@ describe('CancelSubscriptionPanel', () => {
     cancelSubscription: jest.fn().mockResolvedValue(null),
     cancelSubscriptionStatus: defaultState.cancelSubscription,
     subsequentInvoice: MOCK_SUBSEQUENT_INVOICES[0],
-    invoicePreview: MOCK_PREVIEW_INVOICE_NO_TAX,
     promotionCode: undefined,
     paymentProvider: undefined,
   };
@@ -73,7 +68,7 @@ describe('CancelSubscriptionPanel', () => {
           render(<CancelSubscriptionPanel {...props} />);
 
           const planPrice = formatPlanPricing(
-            props.invoicePreview.total,
+            props.subsequentInvoice.total,
             props.plan.currency,
             props.plan.interval,
             props.plan.interval_count
@@ -232,7 +227,7 @@ describe('CancelSubscriptionPanel', () => {
             />
           </LocalizationProvider>
         );
-        expect(queryByText('$20.00 fooly')).toBeInTheDocument();
+        expect(queryByText('$5.00 fooly')).toBeInTheDocument();
         expect(queryByText('quuz 09/13/2019')).toBeInTheDocument();
         expect(queryByText('blee')).toBeInTheDocument();
       });
@@ -252,7 +247,7 @@ describe('CancelSubscriptionPanel', () => {
             <CancelSubscriptionPanel {...baseProps} plan={plan} />
           </LocalizationProvider>
         );
-        expect(queryByText('$20.00 barly 8 24hrs')).toBeInTheDocument();
+        expect(queryByText('$5.00 barly 8 24hrs')).toBeInTheDocument();
       });
 
       it('displays the correct pricing and exclusive tax info with interval of 1', () => {
@@ -276,12 +271,11 @@ describe('CancelSubscriptionPanel', () => {
                 ...MOCK_SUBSEQUENT_INVOICES[2],
                 period_start: 1568408388.815,
               }}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE}
             />
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 + $3.00 tax fooly'
+          '$5.00 + $1.23 tax fooly'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Your next bill of $5.00 + $1.23 taxes is due due 09/13/2019'
@@ -307,12 +301,11 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[2]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE}
             />
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 + $3.00 tax barly 8 24hrs'
+          '$5.00 + $1.23 tax barly 8 24hrs'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Your next bill of $5.00 + $1.23 taxes is due due 08/14/2019'
@@ -336,12 +329,11 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[4]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT}
             />
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$19.50 + $3.00 tax barly 8 24hrs'
+          '$4.50 + $1.23 tax barly 8 24hrs'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Your next bill of $4.50 + $1.23 taxes is due due 08/14/2019'
@@ -368,12 +360,11 @@ describe('CancelSubscriptionPanel', () => {
                 ...MOCK_SUBSEQUENT_INVOICES[3],
                 period_start: 1568408388.815,
               }}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE}
             />
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 fooly'
+          '$5.00 fooly'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Your next bill of $5.00 prices is due due 09/13/2019'
@@ -388,7 +379,7 @@ describe('CancelSubscriptionPanel', () => {
             [one] { $priceAmount } fooly
             *[other] { $priceAmount } barly { $intervalCount } 24hrs
           }`,
-          `sub-next-bill-no-tax = Your next bill of { $priceAmount } prices is due due <strong>{ $date }</strong>`,
+          `sub-next-bill-no-tax = Your next bill of { $priceAmount } prices is due <strong>{ $date }</strong>`,
         ].forEach((x) => bundle.addResource(new FluentResource(x)));
         const plan = { ...findMockPlan('plan_daily'), interval_count: 8 };
 
@@ -398,15 +389,14 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[3]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE}
             />
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 barly 8 24hrs'
+          '$5.00 barly 8 24hrs'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
-          'Your next bill of $5.00 prices is due due 08/14/2019'
+          'Your next bill of $5.00 prices is due 08/14/2019'
         );
       });
 
@@ -427,12 +417,11 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[5]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT}
             />
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$19.50 barly 8 24hrs'
+          '$4.50 barly 8 24hrs'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Your next bill of $4.50 prices is due due 08/14/2019'

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -99,7 +99,6 @@ export type CancelSubscriptionPanelProps = {
   paymentProvider: PaymentProvider | undefined;
   promotionCode: string | undefined;
   subsequentInvoice: SubsequentInvoicePreview;
-  invoicePreview: FirstInvoicePreview;
 };
 
 const CancelSubscriptionPanel = ({
@@ -110,7 +109,6 @@ const CancelSubscriptionPanel = ({
   paymentProvider,
   promotionCode,
   subsequentInvoice,
-  invoicePreview,
 }: CancelSubscriptionPanelProps) => {
   const { navigatorLanguages, config } = useContext(AppContext);
   const [cancelRevealed, revealCancel, hideCancel] = useBooleanState();
@@ -187,7 +185,8 @@ const CancelSubscriptionPanel = ({
     [onConfirmationChanged, engage]
   );
 
-  const intervalPriceDetailsData = getIntervalPriceDetailsData(invoicePreview);
+  const intervalPriceDetailsData =
+    getIntervalPriceDetailsData(subsequentInvoice);
   const { nextBillL10nId, nextBillAmount, nextBillDate, nextBillL10nVars } =
     getNextBillData(plan, subsequentInvoice);
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -16,10 +16,7 @@ import CancelSubscriptionPanel from './Cancel/CancelSubscriptionPanel';
 import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 import { PaymentProvider } from 'fxa-payments-server/src/lib/PaymentProvider';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
-import {
-  FirstInvoicePreview,
-  SubsequentInvoicePreview,
-} from 'fxa-shared/dto/auth/payments/invoice';
+import { SubsequentInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type SubscriptionItemProps = {
   customerSubscription: WebSubscription;
@@ -29,7 +26,6 @@ export type SubscriptionItemProps = {
   customer: Customer;
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
   subsequentInvoice: SubsequentInvoicePreview | undefined;
-  invoicePreview: FirstInvoicePreview | undefined;
 };
 
 export const SubscriptionItem = ({
@@ -40,7 +36,6 @@ export const SubscriptionItem = ({
   plan,
   customerSubscription,
   subsequentInvoice,
-  invoicePreview,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
   const total = subsequentInvoice?.total;
@@ -109,33 +104,6 @@ export const SubscriptionItem = ({
     );
   }
 
-  if (!invoicePreview) {
-    const ariaLabelledBy = 'invoice-preview-not-found-header';
-    const ariaDescribedBy = 'invoice-preview-not-found-description';
-    return (
-      <DialogMessage
-        className="dialog-error"
-        onDismiss={locationReload}
-        headerId={ariaLabelledBy}
-        descId={ariaDescribedBy}
-      >
-        <Localized id="sub-invoice-preview-error-title">
-          <h4
-            id={ariaLabelledBy}
-            data-testid="error-subhub-missing-invoice-preview"
-          >
-            Invoice preview not found
-          </h4>
-        </Localized>
-        <Localized id="sub-invoice-preview-error-text">
-          <p id={ariaDescribedBy}>
-            Invoice preview not found for this subscription
-          </p>
-        </Localized>
-      </DialogMessage>
-    );
-  }
-
   return (
     <section className="settings-unit" aria-labelledby={labelId}>
       <div className="subscription" data-testid="subscription-item">
@@ -155,7 +123,6 @@ export const SubscriptionItem = ({
               paymentProvider,
               promotionCode,
               subsequentInvoice,
-              invoicePreview,
             }}
           />
         ) : (

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -162,9 +162,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, mockSubsequentInvoices),
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, mockPreviewInvoice),
   ];
 
   it('uses PaymentUpdateForm', async () => {
@@ -173,9 +170,6 @@ describe('routes/Subscriptions', () => {
       mockActiveSubscriptions: MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION,
       mockPreviewInvoice: MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     render(<Subject />);
     await screen.findByTestId('subscription-management-loaded');
     await waitForExpect(() => {
@@ -192,9 +186,6 @@ describe('routes/Subscriptions', () => {
       mockSubsequentInvoices: MOCK_SUBSEQUENT_INVOICES,
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
 
     const { findByTestId, queryAllByTestId, queryByTestId } = render(
       <Subject />
@@ -214,9 +205,6 @@ describe('routes/Subscriptions', () => {
     initApiMocks({
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { findByTestId } = render(<Subject />);
     await findByTestId('manage-pocket-title');
     await findByTestId('manage-pocket-link');
@@ -238,9 +226,6 @@ describe('routes/Subscriptions', () => {
         },
       })),
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { findByTestId, queryAllByTestId } = render(<Subject />);
     await findByTestId('subscription-management-loaded');
     expect(queryAllByTestId('upgrade-cta').length).toBe(2);
@@ -265,9 +250,6 @@ describe('routes/Subscriptions', () => {
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
       mockActiveSubscriptions: MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { getAllByTestId, findByTestId } = render(<Subject />);
     await findByTestId('subscription-management-loaded');
     fireEvent.click(getAllByTestId('reveal-cancel-subscription-button')[0]);
@@ -308,9 +290,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-profile');
   });
@@ -329,9 +308,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-plans');
   });
@@ -350,9 +326,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-customer');
   });
@@ -371,32 +344,8 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(500, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-invoice');
-  });
-
-  it('displays an error if preview invoice fetch fails', async () => {
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/active')
-      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
-    nock(authServer)
-      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
-      .reply(200, MOCK_CUSTOMER);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-      .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(500, MOCK_PREVIEW_INVOICE_NO_TAX);
-    const { findByTestId } = render(<Subject />);
-    await findByTestId('error-loading-invoice-previews');
   });
 
   it('displays an error if subsequent invoice response is an empty array', async () => {
@@ -413,32 +362,8 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, []);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-subhub-missing-subsequent-invoice');
-  });
-
-  it('displays an error if invoice preview doesnt match any subscription', async () => {
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/active')
-      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
-    nock(authServer)
-      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
-      .reply(200, MOCK_CUSTOMER);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-      .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
-    const { findByTestId } = render(<Subject />);
-    await findByTestId('error-subhub-missing-invoice-preview');
   });
 
   it('redirects to settings if customer fetch fails with 404', async () => {
@@ -457,9 +382,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
 
     const navigateToUrl = jest.fn();
     render(<Subject navigateToUrl={navigateToUrl} />);
@@ -534,9 +456,6 @@ describe('routes/Subscriptions', () => {
           },
         ],
       });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
 
     const {
       findByTestId,
@@ -600,9 +519,6 @@ describe('routes/Subscriptions', () => {
     });
 
     nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
-    nock(authServer)
       .delete('/v1/oauth/subscriptions/active/sub0.28964929339372136')
       .reply(200, {});
     nock(authServer)
@@ -646,12 +562,6 @@ describe('routes/Subscriptions', () => {
           },
         ],
       });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
 
     const { findByTestId, queryAllByTestId, queryByTestId, getAllByTestId } =
       render(<Subject />);
@@ -911,9 +821,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-subhub-missing-plan');
   });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -43,13 +43,9 @@ import {
 import {
   MozillaSubscription,
   WebSubscription,
-  MozillaSubscriptionTypes,
 } from 'fxa-shared/subscriptions/types';
 import SubscriptionIapItem from './SubscriptionIapItem/SubscriptionIapItem';
 import LinkExternal from 'fxa-react/components/LinkExternal';
-import { apiInvoicePreview } from '../../lib/apiClient';
-import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
-import { couponOnSubsequentInvoice } from '../../lib/coupon';
 
 export type SubscriptionsProps = {
   profile: SelectorReturns['profile'];
@@ -86,12 +82,6 @@ export const Subscriptions = ({
 }: SubscriptionsProps) => {
   const { accessToken, config, locationReload, navigateToUrl } =
     useContext(AppContext);
-
-  const [subscriptionPreviews, setSubscriptionPreviews] = useState<
-    FirstInvoicePreview[]
-  >([]);
-  const [subscriptionPreviewsLoading, setSubscriptionPreviewsLoading] =
-    useState(false);
 
   if (!accessToken) {
     window.location.href = `${config.servers.content.url}/subscriptions`;
@@ -161,50 +151,12 @@ export const Subscriptions = ({
     [navigateToUrl, SUPPORT_FORM_URL]
   );
 
-  useEffect(() => {
-    const fetchSubscriptionPreviews = async () => {
-      if (customerSubscriptions?.length) {
-        setSubscriptionPreviewsLoading(true);
-        try {
-          const subs = await Promise.all(
-            customerSubscriptions
-              .filter(
-                (sub) => sub._subscription_type === MozillaSubscriptionTypes.WEB
-              )
-              .map(async (sub) => {
-                const webSub = sub as WebSubscription;
-                const usePromotionCode = couponOnSubsequentInvoice(
-                  webSub.current_period_end,
-                  webSub.promotion_end,
-                  webSub.promotion_duration
-                );
-                return apiInvoicePreview({
-                  priceId: webSub.plan_id,
-                  promotionCode: usePromotionCode
-                    ? webSub.promotion_code
-                    : undefined,
-                });
-              })
-          );
-          setSubscriptionPreviews(subs);
-        } catch (error) {
-          setSubscriptionPreviews([]);
-        } finally {
-          setSubscriptionPreviewsLoading(false);
-        }
-      }
-    };
-
-    fetchSubscriptionPreviews();
-  }, [customerSubscriptions]);
-
   if (
     !accessToken ||
     customer.loading ||
     profile.loading ||
     plans.loading ||
-    subsequentInvoices.loading ||
-    subscriptionPreviewsLoading
+    subsequentInvoices.loading
   ) {
     return <LoadingOverlay isLoading={true} />;
   }
@@ -281,28 +233,6 @@ export const Subscriptions = ({
     customerSubscriptions.find(
       (s) => isWebSubscription(s) && !s.cancel_at_period_end
     );
-
-  if (activeWebSubscription && subscriptionPreviews?.length <= 0) {
-    const ariaLabelledBy = 'invoice-previews-not-found-header';
-    const ariaDescribedBy = 'invoice-previews-not-found-description';
-    return (
-      <DialogMessage
-        className="dialog-error"
-        onDismiss={locationReload}
-        headerId={ariaLabelledBy}
-        descId={ariaDescribedBy}
-      >
-        <Localized id="sub-invoice-previews-error-title">
-          <h4 id={ariaLabelledBy} data-testid="error-loading-invoice-previews">
-            Problem loading invoice previews
-          </h4>
-        </Localized>
-        <Localized id="sub-invoice-previews-error-text">
-          <p id={ariaDescribedBy}>Could not load invoice previews</p>
-        </Localized>
-      </DialogMessage>
-    );
-  }
 
   const showPaymentUpdateForm =
     customer && customer.result && activeWebSubscription;
@@ -450,12 +380,6 @@ export const Subscriptions = ({
                         invoice.subscriptionId ===
                         customerSubscription.subscription_id
                     )}
-                    invoicePreview={subscriptionPreviews.find((preview) => {
-                      return preview.line_items.some(
-                        (lineItem) =>
-                          lineItem.id === customerSubscription.plan_id
-                      );
-                    })}
                     {...{
                       customer: customer.result,
                       cancelSubscription,


### PR DESCRIPTION
Because:

* /invoice/preview is intended to preview an invoice for a subscription that has yet to be created (i.e. we don't have a subscription ID, only a price ID).
* The Stripe API call to preview the invoice fails, since the parameters used are to update an invoice subscription_item by its price ID, which is not possible for an archived price, since new subscriptions cannot be created for archived prices.

This commit:

* Removes the call to /invoice/preview in the Subscription Management page, as we are already fetching invoice information from the invoice/preview-subsequent endpoint by the subscription ID, which works for both archived and unarchived prices.

Closes #FXA-6547

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

@StaberindeZA : It would be great to chat with you about this tomorrow, as it's possible I am missing some critical detail for why we were calling `/invoice/preview` in SubMan instead of relying on `/invoice/subsequent-preview` (the naming is confusing).
