### PR TITLE
fix(content): Another metrics fix for invalid timing values

### DIFF
--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -74,7 +74,7 @@
     "@types/yargs": "^17.0.0",
     "audit-filter": "^0.5.0",
     "chance": "^1.1.8",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^8.18.0",
     "jest": "27.5.1",

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^16.11.3",
     "@types/node-fetch": "^2.5.7",
     "asmcrypto.js": "^0.22.0",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "fast-text-encoding": "^1.0.4",
     "mocha": "^10.0.0",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -173,7 +173,7 @@
     "binary-split": "1.0.5",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
     "eslint-plugin-fxa": "^2.0.2",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -154,7 +154,7 @@
     "copy-webpack-plugin": "^5.1.1",
     "core-js": "^3.26.0",
     "css": "3.0.0",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
     "eslint-plugin-fxa": "^2.0.2",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -91,7 +91,7 @@
     "@typescript-eslint/parser": "^5.45.0",
     "audit-filter": "^0.5.0",
     "chance": "^1.1.8",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -95,7 +95,7 @@
     "@types/yargs": "^17.0.0",
     "audit-filter": "^0.5.0",
     "chance": "^1.1.8",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
     "jest": "29.3.1",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -113,7 +113,7 @@
     "audit-filter": "^0.5.0",
     "chai": "^4.3.6",
     "chance": "^1.1.8",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
     "eslint-plugin-fxa": "^2.0.2",

--- a/packages/fxa-shared/speed-trap/events.js
+++ b/packages/fxa-shared/speed-trap/events.js
@@ -7,7 +7,7 @@ class Events {
     this.events = [];
 
     if (!options || !options.performance) {
-      throw new Error('options.performance is required!')
+      throw new Error('options.performance is required!');
     }
     this.performance = options.performance;
   }
@@ -15,7 +15,9 @@ class Events {
   capture(name) {
     this.events.push({
       type: name,
-      offset: this.performance.now(),
+
+      // Chrome produces floats, but our API expects integers
+      offset: parseInt(this.performance.now()),
     });
   }
 

--- a/packages/fxa-shared/speed-trap/speed-trap.js
+++ b/packages/fxa-shared/speed-trap/speed-trap.js
@@ -15,19 +15,19 @@ var SpeedTrap = {
     // reduced functionality. The exact performance API can also be passed in as option
     // for testing purposes.
     this.performance = options.performance || getPerformanceApi();
-    this.baseTime = this.performance.timeOrigin;
+    this.baseTime = parseInt(this.performance.timeOrigin);
 
     this.navigationTiming = Object.create(NavigationTiming);
     this.navigationTiming.init({
       performance: this.performance,
-      useL1Timings: options.useL1Timings
+      useL1Timings: options.useL1Timings,
     });
 
     this.timers = Object.create(Timers);
-    this.timers.init({performance: this.performance});
+    this.timers.init({ performance: this.performance });
 
     this.events = Object.create(Events);
-    this.events.init({performance: this.performance});
+    this.events.init({ performance: this.performance });
 
     this.uuid = guid();
 
@@ -106,7 +106,7 @@ var SpeedTrap = {
       // performance.timeOrigin or performance.timings.navigationStart and get a valid value.
       // It's very likely the performance API is using a monotonic clock that does not match our
       // current system clock.
-      duration: this.performance.now(),
+      duration: parseInt(this.performance.now()),
       timers: this.timers.get(),
       events: this.events.get(),
     };
@@ -122,8 +122,9 @@ var SpeedTrap = {
    * Note: performance.now() will likely differ from Date.now() and is not expected to be the real
    * time. Please be aware of what underlying implementation is in use when calling this function.
    */
-  now: function() {
-    return this.performance.timeOrigin + this.performance.now();
+  now: function () {
+    // Chrome's performance api returns floats, but our API requires integers.
+    return parseInt(this.performance.timeOrigin + this.performance.now());
   },
 
   /**
@@ -135,7 +136,7 @@ var SpeedTrap = {
       return this.performance.isInSuspectState();
     }
     return false;
-  }
+  },
 };
 
 export default Object.create(SpeedTrap);

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -70,7 +70,7 @@
     "@types/superagent": "4.1.11",
     "@types/supertest": "^2.0.11",
     "audit-filter": "^0.5.0",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
     "jest": "27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4200,160 +4200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-arm64@npm:0.16.17"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-arm@npm:0.16.17"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-x64@npm:0.16.17"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/darwin-arm64@npm:0.16.17"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/darwin-x64@npm:0.16.17"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/freebsd-arm64@npm:0.16.17"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/freebsd-x64@npm:0.16.17"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-arm64@npm:0.16.17"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-arm@npm:0.16.17"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-ia32@npm:0.16.17"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-loong64@npm:0.16.17"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-mips64el@npm:0.16.17"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-ppc64@npm:0.16.17"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-riscv64@npm:0.16.17"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-s390x@npm:0.16.17"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-x64@npm:0.16.17"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/netbsd-x64@npm:0.16.17"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/openbsd-x64@npm:0.16.17"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/sunos-x64@npm:0.16.17"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-arm64@npm:0.16.17"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-ia32@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-ia32@npm:0.16.17"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-x64@npm:0.16.17"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@eslint/eslintrc@npm:^0.4.3":
   version: 0.4.3
   resolution: "@eslint/eslintrc@npm:0.4.3"
@@ -22726,6 +22572,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-android-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-android-arm64@npm:0.14.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-darwin-64@npm:0.14.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-darwin-arm64@npm:0.14.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-freebsd-64@npm:0.14.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-freebsd-arm64@npm:0.14.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-32@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-32@npm:0.14.2"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-64@npm:0.14.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-arm64@npm:0.14.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-arm@npm:0.14.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-mips64le@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-mips64le@npm:0.14.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-ppc64le@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-linux-ppc64le@npm:0.14.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"esbuild-netbsd-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-netbsd-64@npm:0.14.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-openbsd-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-openbsd-64@npm:0.14.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "esbuild-register@npm:^3.2.0":
   version: 3.2.0
   resolution: "esbuild-register@npm:3.2.0"
@@ -22737,80 +22674,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.16.17":
-  version: 0.16.17
-  resolution: "esbuild@npm:0.16.17"
+"esbuild-sunos-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-sunos-64@npm:0.14.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-32@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-windows-32@npm:0.14.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-windows-64@npm:0.14.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-arm64@npm:0.14.2":
+  version: 0.14.2
+  resolution: "esbuild-windows-arm64@npm:0.14.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "esbuild@npm:0.14.2"
   dependencies:
-    "@esbuild/android-arm": 0.16.17
-    "@esbuild/android-arm64": 0.16.17
-    "@esbuild/android-x64": 0.16.17
-    "@esbuild/darwin-arm64": 0.16.17
-    "@esbuild/darwin-x64": 0.16.17
-    "@esbuild/freebsd-arm64": 0.16.17
-    "@esbuild/freebsd-x64": 0.16.17
-    "@esbuild/linux-arm": 0.16.17
-    "@esbuild/linux-arm64": 0.16.17
-    "@esbuild/linux-ia32": 0.16.17
-    "@esbuild/linux-loong64": 0.16.17
-    "@esbuild/linux-mips64el": 0.16.17
-    "@esbuild/linux-ppc64": 0.16.17
-    "@esbuild/linux-riscv64": 0.16.17
-    "@esbuild/linux-s390x": 0.16.17
-    "@esbuild/linux-x64": 0.16.17
-    "@esbuild/netbsd-x64": 0.16.17
-    "@esbuild/openbsd-x64": 0.16.17
-    "@esbuild/sunos-x64": 0.16.17
-    "@esbuild/win32-arm64": 0.16.17
-    "@esbuild/win32-ia32": 0.16.17
-    "@esbuild/win32-x64": 0.16.17
+    esbuild-android-arm64: 0.14.2
+    esbuild-darwin-64: 0.14.2
+    esbuild-darwin-arm64: 0.14.2
+    esbuild-freebsd-64: 0.14.2
+    esbuild-freebsd-arm64: 0.14.2
+    esbuild-linux-32: 0.14.2
+    esbuild-linux-64: 0.14.2
+    esbuild-linux-arm: 0.14.2
+    esbuild-linux-arm64: 0.14.2
+    esbuild-linux-mips64le: 0.14.2
+    esbuild-linux-ppc64le: 0.14.2
+    esbuild-netbsd-64: 0.14.2
+    esbuild-openbsd-64: 0.14.2
+    esbuild-sunos-64: 0.14.2
+    esbuild-windows-32: 0.14.2
+    esbuild-windows-64: 0.14.2
+    esbuild-windows-arm64: 0.14.2
   dependenciesMeta:
-    "@esbuild/android-arm":
+    esbuild-android-arm64:
       optional: true
-    "@esbuild/android-arm64":
+    esbuild-darwin-64:
       optional: true
-    "@esbuild/android-x64":
+    esbuild-darwin-arm64:
       optional: true
-    "@esbuild/darwin-arm64":
+    esbuild-freebsd-64:
       optional: true
-    "@esbuild/darwin-x64":
+    esbuild-freebsd-arm64:
       optional: true
-    "@esbuild/freebsd-arm64":
+    esbuild-linux-32:
       optional: true
-    "@esbuild/freebsd-x64":
+    esbuild-linux-64:
       optional: true
-    "@esbuild/linux-arm":
+    esbuild-linux-arm:
       optional: true
-    "@esbuild/linux-arm64":
+    esbuild-linux-arm64:
       optional: true
-    "@esbuild/linux-ia32":
+    esbuild-linux-mips64le:
       optional: true
-    "@esbuild/linux-loong64":
+    esbuild-linux-ppc64le:
       optional: true
-    "@esbuild/linux-mips64el":
+    esbuild-netbsd-64:
       optional: true
-    "@esbuild/linux-ppc64":
+    esbuild-openbsd-64:
       optional: true
-    "@esbuild/linux-riscv64":
+    esbuild-sunos-64:
       optional: true
-    "@esbuild/linux-s390x":
+    esbuild-windows-32:
       optional: true
-    "@esbuild/linux-x64":
+    esbuild-windows-64:
       optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
+    esbuild-windows-arm64:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 4c2cc609ecfb426554bc3f75beb92d89eb2d0c515cfceebaa36c7599d7dcaab7056b70f6d6b51e72b45951ddf9021ee28e356cf205f8e42cc055d522312ea30c
+  checksum: d786e6330b541d9d79ed81e82c1c35944c007cb38bf30bb021e68cf6bb25023316a45c68a4e94fa8397f4b79c69bb7a3b221afd9fac7725a4a2ca4ad8b55dff8
   languageName: node
   linkType: hard
 
@@ -25466,7 +25416,7 @@ fsevents@~2.1.1:
     convict: ^6.2.4
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^8.18.0
     express: ^4.17.3
@@ -25506,7 +25456,7 @@ fsevents@~2.1.1:
     abab: ^2.0.6
     abort-controller: ^3.0.0
     asmcrypto.js: ^0.22.0
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     fast-text-encoding: ^1.0.4
     mocha: ^10.0.0
@@ -25587,7 +25537,7 @@ fsevents@~2.1.1:
     ejs: ^3.1.8
     email-addresses: 4.0.0
     emittery: ^0.13.1
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
     eslint-plugin-fxa: ^2.0.2
@@ -25734,7 +25684,7 @@ fsevents@~2.1.1:
     css: 3.0.0
     css-loader: 1.0.0
     duration-js: 4.0.0
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
     eslint-plugin-fxa: ^2.0.2
@@ -25958,7 +25908,7 @@ fsevents@~2.1.1:
     convict: ^6.2.4
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
     eslint-config-prettier: ^8.3.0
@@ -26054,7 +26004,7 @@ fsevents@~2.1.1:
     convict: ^6.2.4
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
     express: ^4.17.3
@@ -26498,7 +26448,7 @@ fsevents@~2.1.1:
     class-validator: ^0.14.0
     cldr-localenames-full: 42.0.0
     cors: ^2.8.5
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
     eslint-plugin-fxa: ^2.0.2
@@ -26567,7 +26517,7 @@ fsevents@~2.1.1:
     convict: ^6.2.4
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
-    esbuild: ^0.16.17
+    esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
     express: ^4.17.3


### PR DESCRIPTION
## Because
- Our API expects integer values for all timing related metrics, but chrome can produce floats.

## This pull request
- Ensures that all timing metrics coming from speed strap are integers.
- Reverts the esbuild package upgrade, which appeared to cause a regression and slip through the cracks.

## Issue that this pull request solves

Closes: FXA-6600

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is a follow up to FXA-6600. That PR addressed an issue where the performance API might produce an erroneous value when called. This takes the change a step further and addresses a scenario where the timing API is producing floats instead of integer values. Integers are required by our metrics endpoint. Apparently this effects  webkit based browsers.
