### PR TITLE
fix(ci): Disable docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ jobs:
       - cache-restore-yarn
       - provision
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           name: Build docker images
           command: ./.circleci/build-all.sh
@@ -340,7 +340,7 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - git-clone
       - cache-restore-yarn
       - run:
@@ -362,7 +362,7 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - browser-tools/install-firefox:
           version: 102.4.0esr
       - browser-tools/install-geckodriver:


### PR DESCRIPTION
## Because

- We've been seeing some odd behavior were 'stale' images are getting used in some cases.

## This pull request

- Disables docker layer caching for now. This seems like the safest thing to do until we fully understand what's happening in FXA-6624

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


