### PR TITLE
feat(react): Add security events to settings page

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -55,4 +55,6 @@ cs-disconnect-suspicious-advice-content = If the disconnected device is indeed
 
 cs-sign-out-button = Sign out
 
+cs-recent-activity = Recent Activity
+
 ##

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -17,6 +17,7 @@ import { Service } from './Service';
 import { VerifiedSessionGuard } from '../VerifiedSessionGuard';
 import { clearSignedInAccountUid } from '../../../lib/cache';
 import { Localized, useLocalization } from '@fluent/react';
+import { Link } from '@reach/router';
 
 const UTM_PARAMS =
   '?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-devices';
@@ -236,6 +237,18 @@ export const ConnectedServices = () => {
             >
               Missing or duplicate items?
             </LinkExternal>
+          </Localized>
+        </div>
+
+        <div className="mt-5 text-center mobileLandscape:text-start">
+          <Localized id="cs-recent-activity">
+            <Link
+              data-testid="settings-recent-activity"
+              className="link-blue text-sm"
+              to="/settings/security_events"
+            >
+              Recent Activity
+            </Link>
           </Localized>
         </div>
 

--- a/packages/fxa-settings/src/components/Settings/PageSecurityEvents/SecurityEvent.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecurityEvents/SecurityEvent.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+
+export function SecurityEvent({
+  name,
+  createdAt,
+  verified,
+}: {
+  name: string;
+  createdAt: number;
+  verified?: boolean;
+}) {
+  const createdAtDateText = Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(new Date(createdAt));
+
+  const formattedName = `security-events-${name.split('.').join('-')}`;
+
+  return (
+    <li className="mt-5 ml-4" data-testid={formattedName}>
+      <div className="absolute w-3 h-3 bg-green-600 rounded-full mt-1.5 -left-1.5 border border-green-700"></div>
+      <time className="text-grey-900 text-s mobileLandscape:mt-3">
+        {createdAtDateText}
+      </time>
+      <FtlMsg id={formattedName}>
+        <p className="text-grey-400 text-xs mobileLandscape:mt-3">
+          {formattedName}
+        </p>
+      </FtlMsg>
+    </li>
+  );
+}
+export default SecurityEvent;

--- a/packages/fxa-settings/src/components/Settings/PageSecurityEvents/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageSecurityEvents/en.ftl
@@ -1,0 +1,11 @@
+## Security Events
+
+security-events-title = Recent Activity
+
+security-events-account-create = Account was created
+security-events-account-disable = Account was disabled
+security-events-account-enable = Account was enabled
+security-events-account-login = Account initiated login
+security-events-account-reset = Account initiated password reset
+security-events-emails-clearBounces = Account cleared email bounces
+

--- a/packages/fxa-settings/src/components/Settings/PageSecurityEvents/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecurityEvents/index.stories.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { PageSecurityEvents } from '.';
+import { MOCK_SECURITY_EVENTS } from './mocks';
+import { Meta } from '@storybook/react';
+import { AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
+
+export default {
+  title: 'pages/Settings/SecurityEvents',
+  component: PageSecurityEvents,
+} as Meta;
+
+export const Default = () => (
+  <AppContext.Provider
+    value={mockAppContext({
+      account: {
+        getSecurityEvents: () => Promise.resolve(MOCK_SECURITY_EVENTS),
+      } as any,
+    })}
+  >
+    <PageSecurityEvents />
+  </AppContext.Provider>
+);
+
+export const NoEvents = () => (
+  <AppContext.Provider
+    value={mockAppContext({
+      account: { getSecurityEvents: () => Promise.resolve([]) } as any,
+    })}
+  >
+    <PageSecurityEvents />
+  </AppContext.Provider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageSecurityEvents/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecurityEvents/index.test.tsx
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'mutationobserver-shim';
+import '@testing-library/jest-dom/extend-expect';
+import { act, screen } from '@testing-library/react';
+import { renderWithRouter, mockAppContext } from '../../../models/mocks';
+import React from 'react';
+import PageSecurityEvents from '.';
+import { Account, AppContext } from '../../../models';
+import { MOCK_SECURITY_EVENTS } from './mocks';
+import { logViewEvent, settingsViewName } from '../../../lib/metrics';
+
+const account = {
+  primaryEmail: {
+    email: 'foxy@mozilla.com',
+  },
+  getSecurityEvents: jest.fn().mockResolvedValue(MOCK_SECURITY_EVENTS),
+} as unknown as Account;
+
+const render = (acct: Account = account) =>
+  renderWithRouter(
+    <AppContext.Provider value={mockAppContext({ account: acct })}>
+      <PageSecurityEvents />
+    </AppContext.Provider>
+  );
+
+describe.only('Security Events', () => {
+  it('renders', async () => {
+    await act(async () => {
+      await render();
+    });
+    expect(screen.getByTestId('flow-container')).toBeInTheDocument();
+    expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+
+    expect(account.getSecurityEvents).toBeCalled();
+
+    expect(
+      screen.getByTestId('security-events-account-create')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('security-events-account-disable')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('security-events-account-enable')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('security-events-account-login')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('security-events-account-reset')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('security-events-emails-clearBounces')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/PageSecurityEvents/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecurityEvents/index.tsx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+
+import FlowContainer from '../FlowContainer';
+import { useLocalization } from '@fluent/react';
+import { useAccount } from '../../../models';
+import { SecurityEvent as SecurityEventSection } from './SecurityEvent';
+import { useState, useEffect } from 'react';
+
+export const PageSecurityEvents = (_: RouteComponentProps) => {
+  const account = useAccount();
+  const [securityEvents, setSecurityEvents] = useState(account.securityEvents);
+
+  const { l10n } = useLocalization();
+
+  useEffect(() => {
+    account.getSecurityEvents().then((events) => {
+      setSecurityEvents(events);
+    });
+  }, []);
+
+  return (
+    <FlowContainer
+      title={l10n.getString('security-events-title', null, 'Recent Activity')}
+    >
+      <ol className="mt-5 relative border-l border-gray-100">
+        {!!securityEvents &&
+          securityEvents.map((securityEvent) => (
+            <SecurityEventSection
+              {...{
+                key: securityEvent.name + securityEvent.createdAt,
+                name: securityEvent.name,
+                createdAt: securityEvent.createdAt,
+              }}
+            />
+          ))}
+      </ol>
+    </FlowContainer>
+  );
+};
+
+export default PageSecurityEvents;

--- a/packages/fxa-settings/src/components/Settings/PageSecurityEvents/mocks.ts
+++ b/packages/fxa-settings/src/components/Settings/PageSecurityEvents/mocks.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_SECURITY_EVENTS = [
+  {
+    name: 'account.create',
+    createdAt: Date.now(),
+    verified: true,
+  },
+  {
+    name: 'account.disable',
+    createdAt: Date.now(),
+    verified: true,
+  },
+  {
+    name: 'account.enable',
+    createdAt: Date.now(),
+    verified: true,
+  },
+  {
+    name: 'account.login',
+    createdAt: Date.now(),
+    verified: true,
+  },
+  {
+    name: 'account.reset',
+    createdAt: Date.now(),
+    verified: true,
+  },
+  {
+    name: 'emails.clearBounces',
+    createdAt: Date.now(),
+    verified: true,
+  },
+];

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -26,6 +26,7 @@ import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
 import sentryMetrics from 'fxa-shared/lib/sentry';
 import PageAvatar from './PageAvatar';
 import { QueryParams } from '../..';
+import PageSecurityEvents from './PageSecurityEvents';
 
 export const Settings = ({
   flowQueryParams,
@@ -122,6 +123,7 @@ export const Settings = ({
           )}
           <PageSecondaryEmailAdd path="/emails" />
           <PageSecondaryEmailVerify path="/emails/verify" />
+          <PageSecurityEvents path="/security_events" />
           <PageDeleteAccount path="/delete_account" />
           <Redirect from="/clients" to="/settings#connected-services" noThrow />
           {/* NOTE: `/settings/avatar/change` is used to link directly to the avatar page within Sync preferences settings on Firefox browsers */}

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -46,6 +46,7 @@ export const MOCK_ACCOUNT: AccountData = {
     verified: true,
   },
   linkedAccounts: [],
+  securityEvents: [],
 };
 
 export function renderWithRouter(


### PR DESCRIPTION
## Because

- We want to be able to show the security events for an account from settings

## This pull request

- Adds the supporting react view

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6644

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="851" alt="Screenshot 2023-01-19 at 11 02 40 AM" src="https://user-images.githubusercontent.com/1295288/213542623-9b0223e2-c7b7-473b-8299-9c42989c03c3.png">

<img width="634" alt="Screenshot 2023-01-19 at 11 02 23 AM" src="https://user-images.githubusercontent.com/1295288/213542658-56edc50f-d331-4905-860b-7b0be3b60fa6.png">



## Other information (Optional)

The biggest question I had here is what to call this section from settings and/or if we should expose a link to it. Currently it is hidden away and we can kept it like that. I don't think there is harm in having a link.