### PR TITLE
fix(speed-trap): replace `function` with `=>`

### DIFF
--- a/packages/fxa-shared/speed-trap/navigation-timing.js
+++ b/packages/fxa-shared/speed-trap/navigation-timing.js
@@ -62,7 +62,7 @@ class NavigationTiming {
     const l2Timings = this.getL2Timings();
     const l1Timings = this.getL1Timings();
 
-    function diffL1() {
+    const diffL1 = () => {
       // Make navigation timings relative to navigation start.
       for (const key in NAVIGATION_TIMING_FIELDS) {
         const timing = l1Timings[key];
@@ -81,16 +81,16 @@ class NavigationTiming {
           diff[key] = timing - this.performance.timing.navigationStart;
         }
       }
-    }
+    };
 
-    function diffL2() {
+    const diffL2 = () => {
       // If we have level 2 timings we can almost return the timings directly. We just have massage
       // a couple fields to keep it backwards compatible.
       for (const key in NAVIGATION_TIMING_FIELDS) {
         const mappedKey = L2TimingsMap[key] || key;
         diff[key] = l2Timings[mappedKey];
       }
-    }
+    };
 
     // Case for testing. We should always try to use l2, but if explicitly requested use L1.
     if (this.useL1Timings && l1Timings) {


### PR DESCRIPTION
## Because
- `this` @ line 76 in `diffL1` in `diff` may be undefined rather than the class instance object since `diffL1` is a `function`.

## This pull request

- Replaces `function diffL{1,2} ()` with `const diffL{1, 2} = () =>`.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Thanks @ionathanch
