### PR TITLE
chore(l10n): Fix brand reference

### DIFF
--- a/packages/fxa-settings/src/pages/SigninBounced/en.ftl
+++ b/packages/fxa-settings/src/pages/SigninBounced/en.ftl
@@ -1,6 +1,6 @@
 signin-bounced-header = Sorry. We’ve locked your account.
 # $email (string) - The user's email.
-signin-bounced-message = The confirmation email we sent to { $email } was returned and we’ve locked your account to protect your Firefox data.
+signin-bounced-message = The confirmation email we sent to { $email } was returned and we’ve locked your account to protect your { -brand-firefox } data.
 # linkExternal is a link to a mozilla support
 signin-bounced-help = If this is a valid email address, <linkExternal>let us know</linkExternal> and we can help unlock your account.
 signin-bounced-create-new-account = No longer own that email? Create a new account


### PR DESCRIPTION
## Because

- An FTL contains a brand reference but does not use a brand placeable.

## This pull request

- Replaces the hard coded reference with the brand placeable.

## Issue that this pull request solves

Closes: #14753 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
