### PR TITLE
chore(deps): temporarily ignore esbuild updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,29 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     open-pull-requests-limit: 6
     labels:
-      - "maintenance"
-      - "dependencies"
+      - 'maintenance'
+      - 'dependencies'
     reviewers:
-      - "@mozilla/fxa-devs"
+      - '@mozilla/fxa-devs'
     ignore:
-      - dependency-name: "@types/*"
-      - dependency-name: "web-push"
-      - dependency-name: "jest-watch-typeahead" # To be removed after react-scripts update
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      - dependency-name: '@types/*'
+      - dependency-name: 'web-push'
+      - dependency-name: 'jest-watch-typeahead' # To be removed after react-scripts update
+      - dependency-name: 'esbuild' # See FXA-5948
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 6
     reviewers:
-      - "@mozilla/fxa-devs"
+      - '@mozilla/fxa-devs'
     labels:
-      - "maintenance"
-      - "dependencies"
+      - 'maintenance'
+      - 'dependencies'


### PR DESCRIPTION
Because:

* We were seeing some [CI failures](https://app.circleci.com/pipelines/github/mozilla/fxa/37435/workflows/dfd7a914-a054-4ee8-aa13-ba2fce454788/jobs/399571) after https://github.com/mozilla/fxa/pull/14748 was merged and had to [revert the update](https://github.com/mozilla/fxa/pull/14766).
* Additionally, per FXA-5948, prior updates have caused other issues.

This commit:

* Temporarily ignores esbuild updates.

Closes #No issue

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).