### PR TITLE
fix(payments): show loading spinner on pay change

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -246,69 +246,65 @@ export const PaymentForm = ({
       <Localized id="payment-cancel-btn">
         <button
           data-testid="cancel"
-          className="payment-button h-10 border-0 bg-grey-900/10 mobileLandscape:h-12"
+          className="payment-button h-10 border-0 bg-grey-900/10 hover:bg-grey-900/20 mobileLandscape:h-12"
           onClick={onCancel}
         >
           Cancel
         </button>
       </Localized>
 
-      <Localized
-        id={submitButtonL10nId ? submitButtonL10nId : 'payment-update-btn'}
+      <SubmitButton
+        data-testid="submit"
+        className="payment-button cta-primary h-10 mobileLandscape:h-12"
+        name="submit"
+        disabled={inProgress}
       >
-        <SubmitButton
-          data-testid="submit"
-          className="payment-button cta-primary h-10 mobileLandscape:h-12"
-          name="submit"
-          disabled={inProgress}
-        >
-          {inProgress ? (
-            <LoadingSpinner
-              spinnerType={SpinnerType.White}
-              imageClassName="w-8 h-8 animate-spin"
-            />
-          ) : submitButtonCopy ? (
-            <span>{submitButtonCopy}</span>
-          ) : (
-            <span>Update</span>
-          )}
-        </SubmitButton>
-      </Localized>
+        {inProgress ? (
+          <LoadingSpinner
+            spinnerType={SpinnerType.White}
+            imageClassName="w-8 h-8 animate-spin"
+          />
+        ) : (
+          <Localized
+            id={submitButtonL10nId ? submitButtonL10nId : 'payment-update-btn'}
+          >
+            <span>{submitButtonCopy ? submitButtonCopy : `Update`}</span>
+          </Localized>
+        )}
+      </SubmitButton>
     </div>
   ) : (
     <div className="mb-5">
-      <Localized id="payment-submit-btn">
-        <SubmitButton
-          data-testid="submit"
-          className="payment-button cta-primary !font-bold w-full mt-8 h-12"
-          name="submit"
-          disabled={!allowSubmit}
-        >
-          {showProgressSpinner ? (
-            <LoadingSpinner
-              spinnerType={SpinnerType.White}
-              imageClassName="w-8 h-8 animate-spin"
+      <SubmitButton
+        data-testid="submit"
+        className="payment-button cta-primary !font-bold w-full mt-8 h-12"
+        name="submit"
+        disabled={!allowSubmit}
+      >
+        {showProgressSpinner ? (
+          <LoadingSpinner
+            spinnerType={SpinnerType.White}
+            imageClassName="w-8 h-8 animate-spin"
+          />
+        ) : (
+          <div className="text-center">
+            <img
+              src={LockImage}
+              className="h-4 w-4 my-0 mx-3 relative top-0.5"
+              alt=""
             />
-          ) : (
-            <div className="text-center">
-              <img
-                src={LockImage}
-                className="h-4 w-4 my-0 mx-3 relative top-0.5"
-                alt=""
-              />
-              <Localized
-                id={
-                  submitButtonL10nId
-                    ? submitButtonL10nId
-                    : payButtonL10nId(customer)
-                }
-              >
-                <span>{submitButtonCopy}</span>
-              </Localized>
-            </div>
-          )}
-        </SubmitButton>
-      </Localized>
+            <Localized
+              id={
+                submitButtonL10nId
+                  ? submitButtonL10nId
+                  : payButtonL10nId(customer)
+              }
+            >
+              <span>{submitButtonCopy}</span>
+            </Localized>
+          </div>
+        )}
+      </SubmitButton>
     </div>
   );
 


### PR DESCRIPTION
## Because

- Loading spinner does not show when changing payment method and hitting submit

## This pull request

- Removes loading spinner from Localized component, so that it is rendered separately from localization.

## Issue that this pull request solves

Closes: #FXA-6257

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="672" alt="image" src="https://user-images.githubusercontent.com/10620585/213818035-db1bf94b-d8b4-44bf-a274-8eaaebae09dc.png">


## Other information (Optional)

Any other information that is important to this pull request.
