### PR TITLE
task(CI): Fix case when test list is empty

### DIFF
--- a/.circleci/run-list-parallel.sh
+++ b/.circleci/run-list-parallel.sh
@@ -12,6 +12,12 @@ if [[ ! -f .lists/$LIST ]]; then
   echo "List isn't a valid file: $LIST"
   exit 1
 fi
+
+if [[ ! -s .lists/$LIST ]]; then
+  echo "$LIST contains no operations. Exiting early!"
+  exit 0
+fi
+
 JOBLOG="--joblog artifacts/tests/$LIST.log"
 
 if [[ $MAX_JOBS == "NONE" ]]; then


### PR DESCRIPTION
## Because
- Code would error out if the operations list was empty.
- Code should gracefully exit if asked to run an empty list of operations.

## This pull request
- Gracefully exists when operations list is empty

## Issue that this pull request solves

Closes: FXA-6681

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was discovered when merging a train branch back to main. As a result it was a PR which had 0 changes, thereby causing an empty .lists file.
