### PR TITLE
feat(react): Recreate '/clear' page + functionality in React

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -137,7 +137,9 @@ Router = Router.extend({
       );
     },
     'choose_what_to_sync(/)': createViewHandler(ChooseWhatToSyncView),
-    'clear(/)': createViewHandler(ClearStorageView),
+    'clear(/)': function () {
+      this.createReactOrBackboneViewHandler('clear', ClearStorageView);
+    },
     'complete_reset_password(/)': createViewHandler(CompleteResetPasswordView),
     'complete_signin(/)': createViewHandler(CompleteSignUpView, {
       type: VerificationReasons.SIGN_IN,

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -17,7 +17,7 @@ const getReactRouteGroups = (showReactApp, isServer = true) => {
   return {
     simpleRoutes: {
       featureFlagOn: showReactApp.simpleRoutes,
-      routes: [reactRoute.getRoute('cannot_create_account')],
+      routes: reactRoute.getRoutes(['cannot_create_account', 'clear']),
     },
 
     resetPasswordRoutes: {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -9,6 +9,7 @@ import { ScrollToTop } from '../Settings/ScrollToTop';
 import Settings from '../Settings';
 import { QueryParams } from '../..';
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
+import Clear from '../../pages/Clear';
 
 export const App = ({
   flowQueryParams,
@@ -24,7 +25,10 @@ export const App = ({
            * check since users will be served the Backbone version of pages if either of those
            * are false, but guard with query param anyway since we have it handy */}
           {showReactApp && (
-            <CannotCreateAccount path="/cannot_create_account/*" />
+            <>
+              <CannotCreateAccount path="/cannot_create_account/*" />
+              <Clear path="/clear/*" />
+            </>
           )}
 
           <Settings path="/settings/*" {...{ flowQueryParams }} />

--- a/packages/fxa-settings/src/pages/Clear/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.stories.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import Clear from '.';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'pages/Clear',
+  component: Clear,
+} as Meta;
+
+export const Basic = () => <Clear />;

--- a/packages/fxa-settings/src/pages/Clear/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.test.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import Clear from '.';
+import { screen, render } from '@testing-library/react';
+
+describe('Clear', () => {
+  it('clears localStorage, sessionStorage, and sets cookie', () => {
+    localStorage.setItem('hey', 'ho');
+    sessionStorage.setItem("let's", 'go');
+    expect(localStorage.length).toBe(1);
+    expect(sessionStorage.length).toBe(1);
+
+    let cookieJar = '';
+    jest.spyOn(document, 'cookie', 'set').mockImplementation((cookie) => {
+      cookieJar = cookie;
+    });
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieJar);
+    expect(document.cookie).toBe('');
+
+    render(<Clear />);
+    screen.getByRole('heading', { name: 'Browser storage is cleared' });
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+    expect(document.cookie).toBe(
+      'tooyoung=1; expires=Thu, 01-Jan-1970 00:00:01 GMT'
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Clear/index.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.tsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import AppLayout from '../../components/AppLayout';
+import { RouteComponentProps } from '@reach/router';
+
+/* This page is only used for manual and Playwright tests and does not need l10n */
+const Clear = (_: RouteComponentProps) => {
+  try {
+    localStorage.clear();
+    sessionStorage.clear();
+    document.cookie = 'tooyoung=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+  } catch (e) {
+    // if cookies are disabled, this will blow up some browsers. Catch and do nothing instead.
+  }
+
+  return (
+    <AppLayout>
+      <h1 className="card-header">Browser storage is cleared</h1>
+    </AppLayout>
+  );
+};
+
+export default Clear;


### PR DESCRIPTION
Because:
* We're converting content-server routes into React routes by extending fxa-settings

This commit:
* Creates the React version of the '/clear' page, including tests, stories, and functionality
* Adds this route to the simpleRoutes list to be served by the React app

closes FXA-6113

---

To test this, after enabling the feature flag (see routing doc linked in partner work) create an account under 13. Observe how `/` redirects to `/cannot_create_account`. Now hit ~`cannot_create_account?showReactApp=true`~ `/clear?showReactApp=true` and then hit `/` and see it doesn't redirect you.

I don't **think** we want any metrics data on this page, but I'm going to make a note in the spreadsheet about this page so we can double check with Product.