### PR TITLE
Fxa 6694

### DIFF
--- a/.circleci/cancel-jobs.mjs
+++ b/.circleci/cancel-jobs.mjs
@@ -1,0 +1,24 @@
+import fetch from 'node-fetch';
+
+const baseUrl = 'https://circleci.com/api/v2';
+
+async function getJobs() {
+  const url = `${baseUrl}/workflow/${process.env.CIRCLE_WORKFLOW_ID}/job?circle-token=${process.env.CIRCLE_TOKEN}`;
+  const response = await fetch(url);
+  const json = await response.json();
+  const jobs = json?.items || [];
+  console.log(`Got ${jobs.length} jobs.`);
+
+  return jobs;
+}
+
+async function cancelJob(job) {
+  const url = `${baseUrl}/project/gh/mozilla/fxa/job/${job.job_number}/cancel?circle-token=${process.env.CIRCLE_TOKEN}`;
+  const response = await fetch(url, { method: 'POST' });
+  console.log(`Cancelled ${job.name}[${job.job_number}] - ${response.status}`)
+}
+
+const jobs = await getJobs();
+for (const job of jobs) {
+  await cancelJob(job);
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,17 @@ commands:
           command: ./.circleci/run-list-parallel.sh  << parameters.list >> << parameters.max_jobs >> << parameters.index >>:<< parameters.total >>
       - store-artifacts
 
+  fail-fast:
+    steps:
+      - run: sleep 10
+      - run:
+          name: Fail Fast
+          when: on_fail
+          command: |
+            echo "Canceling workflow as a step resulted in failure"
+            node .circleci/cancel-jobs.mjs;
+
+
 jobs:
   deploy-packages:
     parameters:
@@ -377,18 +388,13 @@ jobs:
             docker tag ci-base-browsers-latest << pipeline.parameters.docker-repo >>:ci-base-browsers-latest
             docker push << pipeline.parameters.docker-repo >>:ci-base-browsers-latest
 
-  build-and-validate:
+  build:
     executor: default-executor
     resource_class: large
     steps:
       - git-checkout
       - provision
       - ts-build
-      - lint
-      - run-tests:
-          test_name: Unit Test (many)
-          list: unit-test.list
-      - jira/notify
 
   lint:
     executor: default-executor
@@ -398,6 +404,17 @@ jobs:
       - provision
       - ts-build-restore
       - lint
+
+  unit-test:
+    executor: default-executor
+    resource_class: large
+    steps:
+      - git-checkout
+      - provision
+      - ts-build-restore
+      - run-tests:
+          test_name: Unit Test (many)
+          list: unit-test.list
 
   integration-test-part:
     parameters:
@@ -527,68 +544,84 @@ workflows:
   # run on PR drafts.
   test_pull_request:
     jobs:
-      - build-and-validate:
-          name: Build > Lint > Unit Test
+      - build:
+          name: Build
           filters:
             branches:
               ignore: /main/
             tags:
               ignore: /.*/
 
+      - lint:
+          name: Lint
+          requires:
+            - Build
+
+      - unit-test:
+          name: Unit Test
+          requires:
+            - Build
+          post-steps:
+            - fail-fast
+
       - integration-test-part:
           name: Integration Test Part 1
           index: 0
           total: 2
           requires:
-            - Build > Lint > Unit Test
+            - Build
+          post-steps:
+            - fail-fast
 
       - integration-test-part:
           name: Integration Test Part 2
           index: 1
           total: 2
           requires:
-            - Build > Lint > Unit Test
+            - Build
+          post-steps:
+            - fail-fast
 
       - build-and-deploy-storybooks:
           name: Story Book Build & Deploy
           requires:
-            - Build > Lint > Unit Test
+            - Build
 
       - test-content-server-part:
           name: Content Server Functional Test Part 1
           index: 0
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 2
           index: 1
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 3
           index: 2
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 4
           index: 3
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 5
           index: 4
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
 
       - playwright-functional-tests:
           name: Playwright Functional Tests
           requires:
-            - Build > Lint > Unit Test
+            - Build
 
   # This workflow can be useful if we want to run test changes in our functional tests
   # against deployed code. Simply prefix a branch with run-smoke-tests, and issue a PR.
@@ -672,55 +705,66 @@ workflows:
   # live infrastructure.
   test_and_deploy_tag:
     jobs:
-      - build-and-validate:
-          name: Build > Lint > Unit Test
+      - build:
+          name: Build
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /.*/
+      - lint:
+          name: Lint
+          requires:
+            - Build
+      - unit-test:
+          name: Unit Test
+          requires:
+            - Build
+
       - integration-test-part:
           name: Integration Test Part 1
           index: 0
           total: 1
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - integration-test-part:
           name: Integration Test Part 2
           index: 1
           total: 1
           requires:
-            - Build > Lint > Unit Test
+            - Build
+
       - test-content-server-part:
           name: Content Server Functional Test Part 1
           index: 0
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 2
           index: 1
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 3
           index: 2
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 4
           index: 3
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
       - test-content-server-part:
           name: Content Server Functional Test Part 5
           index: 4
           total: 5
           requires:
-            - Build > Lint > Unit Test
+            - Build
+
       - deploy-packages:
           executor: docker-build-executor
           filters:
@@ -729,7 +773,9 @@ workflows:
             tags:
               only: /.*/
           requires:
-            - Build > Lint > Unit Test
+            - Build
+            - Lint
+            - Unit Test
             - Integration Test Part 1
             - Integration Test Part 2
             - Content Server Functional Test Part 1


### PR DESCRIPTION
## Because

- We want to cancel other jobs when certain test suites fails

## This pull request

- Introduces a fail-fast command that terminates running job
- Adds the fail fast command as post-step to integration tests and unit tests

## Issue that this pull request solves

Closes: FXA-6694

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
![image](https://user-images.githubusercontent.com/94418270/214195762-643b04a3-2869-4afe-88f1-6e831153c53f.png)

## Additional Info

Here is an example of the job in action: https://app.circleci.com/pipelines/github/mozilla/fxa/37603/workflows/6871683c-0d78-47b6-8a8a-d3bd7c402df0

An intentional test failure had to be created to test this, and of course, we didn't want to include that failure in this PR.
