### PR TITLE
storybook(fxa-settings): add signup_confirmed to storybook

### DIFF
--- a/packages/fxa-settings/src/components/Ready/en.ftl
+++ b/packages/fxa-settings/src/components/Ready/en.ftl
@@ -8,4 +8,5 @@ ready-use-service = You’re now ready to use { $serviceName }
 ready-account-ready = Your account is ready!
 ready-continue = Continue
 sign-in-complete-header = Sign-in confirmed
+sign-up-complete-header = Account confirmed
 pulsing-hearts-description = A pink laptop and a purple mobile device each with a pulsing heart

--- a/packages/fxa-settings/src/components/Ready/index.test.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.test.tsx
@@ -26,14 +26,14 @@ describe('Ready', () => {
     render(<Ready {...{ viewName }} />);
     const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
     testL10n(ftlMsgMock, bundle, {
-      serviceName: 'Account Settings',
+      serviceName: 'account settings',
     });
 
     const passwordResetConfirmation = screen.getByText(
       'Your password has been reset'
     );
     const serviceAvailabilityConfirmation = screen.getByText(
-      'You’re now ready to use Account Settings'
+      'You’re now ready to use account settings'
     );
     const passwordResetContinueButton = screen.queryByText('Continue');
     // Calling `getByText` will fail if the first two elements aren't in the document,

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -20,6 +20,8 @@ type ReadyProps = {
 export type ViewNameType =
   | 'signin-confirmed'
   | 'signin-verified'
+  | 'signup-confirmed'
+  | 'signup-verified'
   | 'reset-password-confirmed'
   | 'reset-password-verified'
   | 'reset-password-with-recovery-key-verified';
@@ -35,6 +37,11 @@ const getTemplateValues = (viewName: ViewNameType) => {
       templateValues.headerId = 'sign-in-complete-header';
       templateValues.headerText = 'Sign-in confirmed';
       break;
+    case 'signup-confirmed':
+    case 'signup-verified':
+      templateValues.headerId = 'sign-up-complete-header';
+      templateValues.headerText = 'Account confirmed';
+      break;
     case 'reset-password-confirmed':
     case 'reset-password-with-recovery-key-verified':
       templateValues.headerId = 'reset-password-complete-header';
@@ -49,7 +56,7 @@ const getTemplateValues = (viewName: ViewNameType) => {
 const Ready = ({
   continueHandler,
   isSignedIn = true,
-  serviceName = 'Account Settings',
+  serviceName = 'account settings',
   viewName,
 }: ReadyProps & RouteComponentProps) => {
   usePageViewEvent(viewName, {

--- a/packages/fxa-settings/src/pages/CompleteSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CompleteSignin/index.test.tsx
@@ -61,7 +61,7 @@ describe('CompleteSignin', () => {
     // Components that should not be rendered when the link is expired
     const signinConfirmation = screen.queryByText('Sign-in confirmed');
     const serviceAvailabilityConfirmation = screen.queryByText(
-      'You’re now ready to use Account Settings'
+      'You’re now ready to use account settings'
     );
     expect(signinConfirmation).not.toBeInTheDocument();
     expect(serviceAvailabilityConfirmation).not.toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('CompleteSignin', () => {
     expect(receiveNewLink).not.toBeInTheDocument();
     const signinConfirmation = screen.queryByText('Sign-in confirmed');
     const serviceAvailabilityConfirmation = screen.queryByText(
-      'You’re now ready to use Account Settings'
+      'You’re now ready to use account settings'
     );
     expect(signinConfirmation).not.toBeInTheDocument();
     expect(serviceAvailabilityConfirmation).not.toBeInTheDocument();

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -19,7 +19,7 @@ describe('ResetPasswordConfirmed', () => {
       'Your password has been reset'
     );
     const serviceAvailabilityConfirmation = screen.getByText(
-      'You’re now ready to use Account Settings'
+      'You’re now ready to use account settings'
     );
     expect(passwordResetConfirmation).toBeInTheDocument();
     expect(serviceAvailabilityConfirmation).toBeInTheDocument();

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -24,7 +24,7 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
     renderWithRouter(<ResetPasswordWithRecoveryKeyVerified />);
     const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
     testL10n(ftlMsgMock, bundle, {
-      serviceName: 'Account Settings',
+      serviceName: 'account settings',
     });
 
     const newAccountRecoveryKeyButton = screen.getByText(

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import SignupConfirmed from '.';
+import AppLayout from '../../../components/AppLayout';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'pages/Signup/SignupConfirmed',
+  component: SignupConfirmed,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
+    <AppLayout>
+      <SignupConfirmed />
+    </AppLayout>
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
@@ -6,48 +6,48 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
-import SigninConfirmed from '.';
-import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
+import SignupConfirmed from '.';
+import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 
-jest.mock('../../lib/metrics', () => ({
+jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
   usePageViewEvent: jest.fn(),
 }));
 
-describe('SigninConfirmed', () => {
+describe('SignupConfirmed', () => {
   let bundle: FluentBundle;
   beforeAll(async () => {
     bundle = await getFtlBundle('settings');
   });
   it('renders Ready component as expected', () => {
-    render(<SigninConfirmed />);
+    render(<SignupConfirmed />);
     const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
     testL10n(ftlMsgMock, bundle, {
       serviceName: 'account settings',
     });
 
-    const signinConfirmation = screen.getByText('Sign-in confirmed');
+    const signupConfirmation = screen.getByText('Account confirmed');
     const serviceAvailabilityConfirmation = screen.getByText(
       'You’re now ready to use account settings'
     );
-    const signinContinueButton = screen.queryByText('Continue');
+    const signupContinueButton = screen.queryByText('Continue');
     // Calling `getByText` will fail if these elements aren't in the document,
     // but we test anyway to make the intention of the test explicit
-    expect(signinContinueButton).not.toBeInTheDocument();
-    expect(signinConfirmation).toBeInTheDocument();
+    expect(signupContinueButton).not.toBeInTheDocument();
+    expect(signupConfirmation).toBeInTheDocument();
     expect(serviceAvailabilityConfirmation).toBeInTheDocument();
   });
 
   it('emits the expected metrics on render', () => {
-    render(<SigninConfirmed />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('signin-confirmed', {
+    render(<SignupConfirmed />);
+    expect(usePageViewEvent).toHaveBeenCalledWith('signup-confirmed', {
       entrypoint_variation: 'react',
     });
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
     render(
-      <SigninConfirmed
+      <SignupConfirmed
         continueHandler={() => {
           console.log('beepboop');
         }}
@@ -57,8 +57,8 @@ describe('SigninConfirmed', () => {
 
     fireEvent.click(passwordResetContinueButton);
     expect(logViewEvent).toHaveBeenCalledWith(
-      'signin-confirmed',
-      'signin-confirmed.continue',
+      'signup-confirmed',
+      'signup-confirmed.continue',
       {
         entrypoint_variation: 'react',
       }

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import Ready from '../../../components/Ready';
+
+type SignupConfirmedProps = {
+  continueHandler?: Function;
+  serviceName?: string;
+};
+
+const SignupConfirmed = ({
+  continueHandler,
+  serviceName,
+}: SignupConfirmedProps & RouteComponentProps) => {
+  const viewName = 'signup-confirmed';
+
+  return <Ready {...{ continueHandler, viewName, serviceName }} />;
+};
+
+export default SignupConfirmed;


### PR DESCRIPTION
## Because:

* We're converting the remaining content-server Backbone views to React. The first step in doing so is to recreate each view in React and house it in storybook.

## This commit:

* Recreates the signup_confirmed/signup_verified views in React, adds basic tests, and adds the view to views accepted by the Ready component.

Closes #https://mozilla-hub.atlassian.net/browse/FXA-6433

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="603" alt="Screen Shot 2023-01-24 at 11 43 26 AM" src="https://user-images.githubusercontent.com/11150372/214392744-ca71ecb7-0c2d-4307-96d7-6e81b0fadbe9.png">


After:
<img width="600" alt="Screen Shot 2023-01-24 at 11 42 44 AM" src="https://user-images.githubusercontent.com/11150372/214392688-53769f37-bd72-4647-b095-df2cb60964de.png">


## Other information (Optional)
Still needs all events added to the metrics excel doc

Any other information that is important to this pull request.
