### PR TITLE
feat(react): Recreate PrimaryEmailVerified in React

### DIFF
--- a/packages/fxa-react/lib/test-utils/index.ts
+++ b/packages/fxa-react/lib/test-utils/index.ts
@@ -139,11 +139,12 @@ function _createFtlBundle(messages: string, locale: string) {
  */
 export function testAllL10n(
   { getAllByTestId }: Screen<typeof queries>,
-  bundle: FluentBundle
+  bundle: FluentBundle,
+  ftlArgs?: Record<string, FluentVariable>
 ) {
   const ftlMsgMocks = getAllByTestId('ftlmsg-mock');
   ftlMsgMocks.forEach((ftlMsgMock) => {
-    testL10n(ftlMsgMock, bundle);
+    testL10n(ftlMsgMock, bundle, ftlArgs);
   });
 }
 

--- a/packages/fxa-settings/src/components/Ready/en.ftl
+++ b/packages/fxa-settings/src/components/Ready/en.ftl
@@ -1,12 +1,16 @@
 ## Ready component
 
 reset-password-complete-header = Your password has been reset
-# This is a string that tells the user they can use whatever service prompted them to reset their password
+# This is a string that tells the user they can use whatever service prompted them to reset their password or to verify their email
 # Variables:
 # { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable
 ready-use-service = You’re now ready to use { $serviceName }
+# The user successfully accomplished a task (password reset, confirm email) that lets them use their account
+ready-use-service-default = You’re now ready to use account settings
+# Message shown when the account is ready but the user is not signed in
 ready-account-ready = Your account is ready!
 ready-continue = Continue
 sign-in-complete-header = Sign-in confirmed
 sign-up-complete-header = Account confirmed
 pulsing-hearts-description = A pink laptop and a purple mobile device each with a pulsing heart
+primary-email-verified-header = Primary email confirmed

--- a/packages/fxa-settings/src/components/Ready/index.test.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import Ready from '.';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
@@ -24,10 +24,7 @@ describe('Ready', () => {
 
   it('renders as expected with default values', () => {
     render(<Ready {...{ viewName }} />);
-    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    testL10n(ftlMsgMock, bundle, {
-      serviceName: 'account settings',
-    });
+    testAllL10n(screen, bundle);
 
     const passwordResetConfirmation = screen.getByText(
       'Your password has been reset'

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -24,7 +24,8 @@ export type ViewNameType =
   | 'signup-verified'
   | 'reset-password-confirmed'
   | 'reset-password-verified'
-  | 'reset-password-with-recovery-key-verified';
+  | 'reset-password-with-recovery-key-verified'
+  | 'primary-email-verified';
 
 const getTemplateValues = (viewName: ViewNameType) => {
   let templateValues = {
@@ -47,6 +48,10 @@ const getTemplateValues = (viewName: ViewNameType) => {
       templateValues.headerId = 'reset-password-complete-header';
       templateValues.headerText = 'Your password has been reset';
       break;
+    case 'primary-email-verified':
+      templateValues.headerId = 'primary-email-verified-header';
+      templateValues.headerText = 'Primary email confirmed';
+      break;
     default:
       throw new Error('Invalid view name submitted to Ready component');
   }
@@ -56,7 +61,7 @@ const getTemplateValues = (viewName: ViewNameType) => {
 const Ready = ({
   continueHandler,
   isSignedIn = true,
-  serviceName = 'account settings',
+  serviceName,
   viewName,
 }: ReadyProps & RouteComponentProps) => {
   usePageViewEvent(viewName, {
@@ -88,9 +93,17 @@ const Ready = ({
       <section>
         <div className="error"></div>
         {isSignedIn ? (
-          <FtlMsg id="ready-use-service" vars={{ serviceName }}>
-            <p className="my-4 text-sm">{`You’re now ready to use ${serviceName}`}</p>
-          </FtlMsg>
+          serviceName ? (
+            <FtlMsg id="ready-use-service" vars={{ serviceName }}>
+              <p className="my-4 text-sm">{`You’re now ready to use ${serviceName}`}</p>
+            </FtlMsg>
+          ) : (
+            <FtlMsg id="ready-use-service-default">
+              <p className="my-4 text-sm">
+                You’re now ready to use account settings
+              </p>
+            </FtlMsg>
+          )
         ) : (
           <FtlMsg id="ready-account-ready">
             <p className="my-4 text-sm">Your account is ready!</p>

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import ResetPasswordWithRecoveryKeyVerified from '.';
 import { logViewEvent } from '../../../lib/metrics';
@@ -22,10 +22,7 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
   });
   it('renders default content as expected', () => {
     renderWithRouter(<ResetPasswordWithRecoveryKeyVerified />);
-    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    testL10n(ftlMsgMock, bundle, {
-      serviceName: 'account settings',
-    });
+    testAllL10n(screen, bundle);
 
     const newAccountRecoveryKeyButton = screen.getByText(
       'Generate a new account recovery key'

--- a/packages/fxa-settings/src/pages/SigninBounced/index.test.tsx
+++ b/packages/fxa-settings/src/pages/SigninBounced/index.test.tsx
@@ -5,10 +5,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../models/mocks';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
-import { FluentBundle } from '@fluent/bundle';
+// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+// import { FluentBundle } from '@fluent/bundle';
 import SigninBounced from '.';
 import { logPageViewEvent } from '../../lib/metrics';
+import { MOCK_EMAIL } from './mocks';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -16,18 +17,17 @@ jest.mock('../../lib/metrics', () => ({
 }));
 
 describe('SigninBounced', () => {
-  let bundle: FluentBundle;
-  let exampleEmail: string;
-  beforeAll(async () => {
-    bundle = await getFtlBundle('settings');
-    exampleEmail = 'example@domain.com';
-  });
+  // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
+  //       in FXA-6461
+  // let bundle: FluentBundle;
+  // beforeAll(async () => {
+  //   bundle = await getFtlBundle('settings');
+  // });
   it('renders default content as expected', () => {
-    renderWithRouter(<SigninBounced email={exampleEmail} />);
-    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    testL10n(ftlMsgMock, bundle, {
-      email: exampleEmail,
-    });
+    renderWithRouter(<SigninBounced email={MOCK_EMAIL} />);
+    // testAllL10n(screen, bundle, {
+    //   email:MOCK_EMAIL,
+    // });
     screen.getByRole('heading', {
       name: 'Sorry. We’ve locked your\xa0account.',
     });
@@ -40,13 +40,13 @@ describe('SigninBounced', () => {
   });
 
   it('renders the "Back" button when a user can go back', () => {
-    renderWithRouter(<SigninBounced email={exampleEmail} canGoBack={true} />);
+    renderWithRouter(<SigninBounced email={MOCK_EMAIL} canGoBack={true} />);
     const backButton = screen.getByRole('button', { name: 'Back' });
     expect(backButton).toBeInTheDocument();
   });
 
   it('emits the expected metrics on render', async () => {
-    renderWithRouter(<SigninBounced email={exampleEmail} />);
+    renderWithRouter(<SigninBounced email={MOCK_EMAIL} />);
     expect(logPageViewEvent).toHaveBeenCalledWith('signin-bounced', {
       entrypoint_variation: 'react',
     });

--- a/packages/fxa-settings/src/pages/SigninBounced/mocks.tsx
+++ b/packages/fxa-settings/src/pages/SigninBounced/mocks.tsx
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_EMAIL = 'text@example.com';

--- a/packages/fxa-settings/src/pages/SigninConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/SigninConfirmed/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import SigninConfirmed from '.';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
@@ -21,10 +21,7 @@ describe('SigninConfirmed', () => {
   });
   it('renders Ready component as expected', () => {
     render(<SigninConfirmed />);
-    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    testL10n(ftlMsgMock, bundle, {
-      serviceName: 'account settings',
-    });
+    testAllL10n(screen, bundle);
 
     const signinConfirmation = screen.getByText('Sign-in confirmed');
     const serviceAvailabilityConfirmation = screen.getByText(

--- a/packages/fxa-settings/src/pages/SigninReported/index.test.tsx
+++ b/packages/fxa-settings/src/pages/SigninReported/index.test.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { render, screen } from '@testing-library/react';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import SigninReported from '.';
 import { usePageViewEvent } from '../../lib/metrics';
@@ -20,8 +20,7 @@ describe('SigninReported', () => {
   });
   it('renders Ready component as expected', () => {
     render(<SigninReported />);
-    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    testL10n(ftlMsgMock, bundle);
+    testAllL10n(screen, bundle);
 
     const reportHeader = screen.getByText('Thank you for your vigilance');
     const reportMessage = screen.getByText(

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import PrimaryEmailVerified, { PrimaryEmailVerifiedProps } from '.';
+import AppLayout from '../../../components/AppLayout';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+import { MOCK_SERVICE } from './mocks';
+
+export default {
+  title: 'pages/Signup/PrimaryEmailVerified',
+  component: PrimaryEmailVerified,
+} as Meta;
+
+const storyWithProps = (props?: PrimaryEmailVerifiedProps) => {
+  const story = () => (
+    <LocationProvider>
+      <AppLayout>
+        <PrimaryEmailVerified {...props} />
+      </AppLayout>
+    </LocationProvider>
+  );
+  return story;
+};
+
+export const NotSignedIn = storyWithProps();
+
+export const SignedIn = storyWithProps({ isSignedIn: true });
+
+export const SignedInWithServiceName = storyWithProps({
+  isSignedIn: true,
+  serviceName: MOCK_SERVICE,
+});

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PrimaryEmailVerified from '.';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+import { FluentBundle } from '@fluent/bundle';
+import { MOCK_SERVICE } from './mocks';
+
+jest.mock('../../../lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('PrimaryEmailVerified page', () => {
+  let bundle: FluentBundle;
+  beforeAll(async () => {
+    bundle = await getFtlBundle('settings');
+  });
+
+  it('renders the page as expected when the user is signed in', () => {
+    render(<PrimaryEmailVerified />);
+    testAllL10n(screen, bundle);
+
+    screen.getByText('Primary email confirmed');
+    screen.getByText('Your account is ready!');
+    const signinContinueButton = screen.queryByText('Continue');
+    expect(signinContinueButton).not.toBeInTheDocument();
+  });
+
+  it('renders the page as expected when the user is not signed in', () => {
+    render(<PrimaryEmailVerified isSignedIn />);
+
+    screen.getByText('You’re now ready to use account settings');
+  });
+
+  it('show the service name when it is passed in', () => {
+    render(<PrimaryEmailVerified isSignedIn serviceName={MOCK_SERVICE} />);
+
+    screen.getByText('You’re now ready to use Example Service');
+  });
+
+  it('emits the expected metrics on render', () => {
+    render(<PrimaryEmailVerified />);
+    expect(usePageViewEvent).toHaveBeenCalledWith('primary-email-verified', {
+      entrypoint_variation: 'react',
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import Ready from '../../../components/Ready';
+
+export type PrimaryEmailVerifiedProps = {
+  serviceName?: string;
+  isSignedIn?: boolean;
+};
+
+const PrimaryEmailVerified = ({
+  serviceName,
+  isSignedIn = false,
+}: PrimaryEmailVerifiedProps & RouteComponentProps) => {
+  const viewName = 'primary-email-verified';
+
+  return <Ready {...{ viewName, serviceName, isSignedIn }} />;
+};
+
+export default PrimaryEmailVerified;

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/mocks.tsx
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_SERVICE = 'Example Service';


### PR DESCRIPTION
## Because

* We are converting existing content-server routes to React by extending fxa-settings

## This pull request

* Create the React version of the `/primary_email_verified` page, with initial metrics, tests and l10n
* Modify the Ready component to render the primary_email_verified strings, and add l10n for default (no serviceName)
* Update TestAllL10n function to support ftl vars
* Replace instances of TestL10n with TestAllL10n in all pages that use the Ready component (excluding components that have strings with embedded tags, not yet supported by TestAllL10n) to ensure all ftl strings are tested

## Issue that this pull request solves

Closes: #FXA-6431

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/22231637/214451302-4abc7073-f166-4e4e-8cf7-6de22637a792.png)

## Other information (Optional)

Any other information that is important to this pull request.
