### PR TITLE
feat(auth): Enable third party auth for non-sync service (used only in stage)

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/third-party-auth.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/third-party-auth.js
@@ -9,21 +9,12 @@ const GROUPS = [
   'control',
 
   // Treatment branches
-  'google',
+  'treatment',
 ];
-
-// For each client specify which experiment group to show
-const ROLLOUT_CONFIG = {
-  // 123Done
-  dcdb5ae7add825d2: GROUPS,
-  // Pocket
-  '7377719276ad44ee': GROUPS,
-  '749818d3f2e7857f': GROUPS,
-};
 
 // This experiment is disabled by default. If you would like to go through
 // the flow, load email-first screen and append query params
-// `?forceExperiment=thirdPartyAuth&forceExperimentGroup=google`
+// `?forceExperiment=thirdPartyAuth&forceExperimentGroup=treatment`
 const ROLLOUT_RATE = 0.0;
 
 module.exports = class ThirdPartyAuth extends BaseGroupingRule {
@@ -34,7 +25,6 @@ module.exports = class ThirdPartyAuth extends BaseGroupingRule {
     // Easier to set class properties for testability
     this.groups = GROUPS;
     this.rolloutRate = ROLLOUT_RATE;
-    this.rolloutConfig = ROLLOUT_CONFIG;
   }
 
   /**
@@ -46,19 +36,18 @@ module.exports = class ThirdPartyAuth extends BaseGroupingRule {
    */
   choose(subject = {}) {
     let choice = false;
-    const { clientId } = subject;
+    const { relier } = subject;
 
-    if (!clientId) {
+    if (!relier) {
       return;
     }
 
-    const clientConfig = this.rolloutConfig[clientId];
-    if (!clientConfig) {
+    if (relier.isSync()) {
       return;
     }
 
     if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
-      choice = this.uniformChoice(clientConfig, subject.uniqueUserId);
+      choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
     }
 
     return choice;

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-experiment-mixin.js
@@ -10,9 +10,9 @@ export default {
 
   isInThirdPartyAuthExperiment() {
     const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
-      clientId: this.relier.get('clientId'),
+      relier: this.relier,
     });
 
-    return experimentGroup === 'google';
+    return experimentGroup === 'treatment';
   },
 };

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/third-party-auth.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/third-party-auth.js
@@ -7,15 +7,13 @@ import Experiment from 'lib/experiments/grouping-rules/third-party-auth';
 
 describe('lib/experiments/grouping-rules/third-party-auth', () => {
   let experiment;
-  const validClientID = 'dcdb5ae7add825d2';
-  const invalidClientID = 'notvalid';
 
   beforeEach(() => {
     experiment = new Experiment();
   });
 
   describe('choose', () => {
-    it('returns false if no clientId', () => {
+    it('returns false if no relier', () => {
       assert.isFalse(
         experiment.choose({
           experimentGroupingRules: { choose: () => experiment.name },
@@ -24,23 +22,23 @@ describe('lib/experiments/grouping-rules/third-party-auth', () => {
       );
     });
 
-    it('returns false if invalid clientId', () => {
+    it('returns false if sync service', () => {
       assert.isFalse(
         experiment.choose({
           experimentGroupingRules: { choose: () => experiment.name },
-          clientId: invalidClientID,
+          relier: { isSync: () => true },
           uniqueUserId: 'user-id',
         })
       );
     });
 
-    it('returns treatment if valid clientId', () => {
+    it('returns treatment if valid', () => {
       const rules = experiment.groups;
       assert.isTrue(
         rules.include(
           experiment.choose({
             experimentGroupingRules: { choose: () => experiment.name },
-            clientId: validClientID,
+            relier: { isSync: () => false },
             uniqueUserId: 'user-id',
           })
         )
@@ -52,7 +50,7 @@ describe('lib/experiments/grouping-rules/third-party-auth', () => {
       assert.isFalse(
         experiment.choose({
           experimentGroupingRules: { choose: () => experiment.name },
-          clientId: validClientID,
+          relier: { isSync: () => true },
           uniqueUserId: 'user-id',
         })
       );


### PR DESCRIPTION
## Because

- We want to enable third party auth in stage to let QA test

## This pull request

- This enables third party auth for all non-sync services

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6592

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other

To test this, you will need to force the experiment via `http://localhost:3030/signin?forceExperiment=thirdPartyAuth&forceExperimentGroup=treatment`. In stage/prod we still want the rollout to be 0%.
