### PR TITLE
fix(payments): update signin redirect to replace url

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -260,8 +260,11 @@ export function useFetchInvoicePreview(
     error: boolean;
     result?: FirstInvoicePreview;
   }>({ loading: false, error: false, result: undefined });
+  const isMounted = useRef(false);
 
   useEffect(() => {
+    isMounted.current = true;
+
     const getSubscriptionPrice = async () => {
       if (!priceId) {
         return setInvoicePreview({
@@ -282,15 +285,19 @@ export function useFetchInvoicePreview(
           error: false,
           result: undefined,
         });
+
         const preview = await apiInvoicePreview({
           priceId,
           promotionCode,
         });
-        setInvoicePreview({
-          loading: false,
-          error: false,
-          result: preview,
-        });
+
+        if (isMounted.current) {
+          setInvoicePreview({
+            loading: false,
+            error: false,
+            result: preview,
+          });
+        }
       } catch (err) {
         setInvoicePreview({
           loading: false,
@@ -301,6 +308,10 @@ export function useFetchInvoicePreview(
     };
 
     getSubscriptionPrice();
+
+    return () => {
+      isMounted.current = false;
+    };
   }, [priceId, customerSubscriptions]);
 
   return invoicePreview;

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -597,10 +597,18 @@ describe('routes/Product', () => {
   });
 
   it('redirects to content server when there is no access token', async () => {
+    const navigateToUrl = jest.fn();
     const appContext = { ...defaultAppContextValue(), accessToken: undefined };
-    render(<Subject productId="fizz" planId="quux" {...{ appContext }} />);
+    render(
+      <Subject
+        productId="fizz"
+        planId="quux"
+        {...{ appContext }}
+        navigateToUrl={navigateToUrl}
+      />
+    );
 
-    expect(mockedNavigate).toHaveBeenCalledWith(
+    expect(navigateToUrl).toHaveBeenCalledWith(
       'https://content.example/subscriptions/products/fizz?plan=quux&signin=yes'
     );
   });

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useContext, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Localized } from '@fluent/react';
 import { AuthServerErrno } from '../../lib/errors';
@@ -149,15 +148,15 @@ export const Product = ({
     accessToken,
     config,
     locationReload,
+    navigateToUrl,
     queryParams,
     matchMediaDefault,
   } = useContext(AppContext);
-  const navigate = useNavigate();
 
   const planId = queryParams.plan;
 
   if (!accessToken) {
-    navigate(
+    navigateToUrl(
       `${config.servers.content.url}/subscriptions/products/${productId}?plan=${planId}&signin=yes`
     );
   }


### PR DESCRIPTION
## Because

- When a customer was signed in and the product page was refreshed, the verified signin url was appended to the existing url instead of replacing it, breaking the page and affecting customer experience

## This pull request

- replaces navigate with navigateToUrl

## Issue that this pull request solves

Closes: FXA-6147

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
