### PR TITLE
fix(CI): initialize empty lists

### DIFF
--- a/.circleci/create-lists.sh
+++ b/.circleci/create-lists.sh
@@ -5,13 +5,13 @@ node .circleci/modules-to-test.js | tee packages/test.list
 
 # Create empty files
 mkdir -p .lists
-echo '' > .lists/ts-build-includes.list
-echo '' > .lists/lint.list
-echo '' > .lists/lint-includes.list
-echo '' > .lists/unit-test.list
-echo '' > .lists/unit-test-includes.list
-echo '' > .lists/integration-test.list
-echo '' > .lists/integration-test-includes.list
+touch .lists/ts-build-includes.list
+touch .lists/lint.list
+touch .lists/lint-includes.list
+touch .lists/unit-test.list
+touch .lists/unit-test-includes.list
+touch .lists/integration-test.list
+touch .lists/integration-test-includes.list
 
 function genWorkspaceCmd() {
   if [ -f "packages/$1/package.json" ]; then


### PR DESCRIPTION
## Because

- There is logic to gracefully exit when an operations list is empty.

## This pull request

- Creates an empty file when operations lists are created.

## Issue that this pull request solves

Closes: #FXA-6701

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
