### PR TITLE
docs(auth-server): Add details to subscription endpoints

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/misc-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/misc-api.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+import dedent from 'dedent';
 import TAGS from './swagger-tags';
 
 const TAGS_MISC = {
@@ -11,7 +11,13 @@ const TAGS_MISC = {
 const ACCOUNT_GET = {
   ...TAGS_MISC,
   description: '/account',
-  notes: ['🔒 Authenticated with session token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Returns account data including subscriptions.
+    `,
+  ],
 };
 
 const ACCOUNT_LOCK_POST = {
@@ -37,23 +43,40 @@ const SUPPORT_TICKET_POST = {
   ...TAGS_MISC,
   description: '/support/ticket',
   notes: [
-    '🔒 Authenticated with support secret or authenticated with OAuth bearer token',
+    dedent`
+      🔒 Authenticated with support secret or authenticated with OAuth bearer token
+
+      Creates a support ticket using the Zendesk client.
+    `,
   ],
 };
 
 const WELLKNOWN_BROWSERID_GET = {
   ...TAGS_MISC,
   description: '/.well-known/browserid',
+  notes: [
+    dedent`
+      Verifies a user is who they say they are using [BrowserID](https://hacks.mozilla.org/2011/07/introducing-browserid-easier-and-safer-authentication-on-the-web/).
+
+      It has been deprecated in newer version of Firefox desktop, though some clients still use it.
+    `,
+  ],
 };
 
 const WELLKNOWN_PUBLIC_KEYS = {
   ...TAGS_MISC,
   description: '/.well-known/public-keys',
+  notes: [
+    'Used by clients to generate JSON web tokens, and allows FxA to verify those tokens.',
+  ],
 };
 
 const OAUTH_ID_TOKEN_VERIFY_POST = {
   ...TAGS_MISC,
   description: '/oauth/id-token-verify',
+  notes: [
+    "Verifies an OIDC ID Token (FxA returns this token at the end of the OAuth flow). The id token contains the user's identification number (uid) plus [other fields](https://openid.net/specs/openid-connect-core-1_0.html#IDToken).",
+  ],
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/subscriptions-api.ts
@@ -144,13 +144,22 @@ const OAUTH_SUBSCRIPTIONS_ACTIVE_SUBSCRIPTIONID_DELETE = {
 const OAUTH_SUBSCRIPTIONS_PAYPAL_CHECKOUT_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/paypal-checkout',
+  notes: [
+    'Retrieves token authorizing transaction to move to the next stage of PayPal checkout.',
+  ],
 };
 
 const OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_BILLING_AND_SUBSCRIPTIONS_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description:
     '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Returns a customer billing details and subscriptions.
+    `,
+  ],
 };
 
 const OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_PLAN_ELIGIBILITY = {
@@ -169,73 +178,126 @@ const OAUTH_MOZILLA_SUBSCRIPTIONS_CUSTOMER_PLAN_ELIGIBILITY = {
 const OAUTH_SUBSCRIPTIONS_IAP_RTDN_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/iap/rtdn',
+  notes: ['Handles a Google Play Real-time Developer Notification.'],
 };
 
 const OAUTH_SUBSCRIPTIONS_CLIENTS_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/clients',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 [Authenticated with OAuth bearer token](https://github.com/mozilla/fxa/blob/95cded6e96e2b20f7593153a428d158001bb8d3b/packages/fxa-shared/oauth/constants.ts#L5)
+
+      Returns a list of clients and their capabilities.
+    `,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/invoice/preview',
+  notes: [
+    `Previews an invoice for a new plan where the user is not yet subscribed (and therefore there is no \`subscriptionId\`); includes estimated tax (based on the user's geolocation) and any discount from a promotion code.`,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_INVOICE_PREVIEW_SUBSEQUENT_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/invoice/preview-subsequent',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Previews a list of subsequent invoices based on existing subscriptions and the customer's \`subscriptionId\`; includes estimated tax (based on the customer's last known geolocation) and any discount from a promotion code.
+    `,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_COUPON_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/coupon',
+  notes: ['Retrieves coupon details of a valid plan and promotion code.'],
 };
 
 const OAUTH_SUBSCRIPTIONS_PAYMENTMETHOD_FAILED_DETACH_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/paymentmethod/failed/detach',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Detaches a payment method from a Stripe customer without any subscriptions. This is only for Stripe customers; excludes customers using PayPal, Apple, Google, etc).
+    `,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_PRODUCTNAME_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/productname',
+  notes: [
+    'Returns the product name of a valid Stripe `productId` (does not apply to IAP).',
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_SUBSCRIPTIONID_PUT = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/active/{subscriptionId}',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Updates an active subscription for Stripe customer based on their Stripe \`subscriptionId\` (does not apply to IAP).
+    `,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_REACTIVATE_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/reactivate',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Reactivate valid Stripe/PayPal customer subscription (does not apply to IAP).
+    `,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_ACTIVE_NEW_PAYPAL_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/active/new-paypal',
+  notes: ['Create subscription for the provided customer using PayPal.'],
 };
 
 const OAUTH_SUBSCRIPTIONS_PAYMENTMETHOD_BILLING_AGREEMENT_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/paymentmethod/billing-agreement',
-  notes: ['🔒 Authenticated with OAuth bearer token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with OAuth bearer token
+
+      Updates the billing agreement for a user with a new PayPal token.
+    `,
+  ],
 };
 
 const OAUTH_SUBSCRIPTIONS_STRIPE_EVENT_POST = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/subscriptions/stripe/event',
+  notes: [
+    'Handles webhook events from Stripe by pre-processing the incoming event and dispatching to the appropriate sub-handler.',
+  ],
 };
 
 const OAUTH_SUPPORTPANEL_SUBSCRIPTIONS_GET = {
   ...TAGS_SUBSCRIPTIONS,
   description: '/oauth/support-panel/subscriptions',
-  notes: ['🔒 Authenticated with support panel secret'],
+  notes: ['This endpoint is deprecated.'],
+  plugins: {
+    'hapi-swagger': {
+      deprecated: true,
+    },
+  },
 };
 
 const API_DOCS = {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -18,6 +18,7 @@ import { PaymentBillingDetails, StripeHelper } from '../../payments/stripe';
 import { AuthLogger, AuthRequest } from '../../types';
 import validators from '../validators';
 import { handleAuth } from './utils';
+import DESCRIPTIONS from '../../../docs/swagger/shared/descriptions';
 
 export class MozillaSubscriptionHandler {
   constructor(
@@ -164,7 +165,9 @@ export const mozillaSubscriptionRoutes = ({
         },
         validate: {
           params: {
-            planId: validators.subscriptionsPlanId.required(),
+            planId: validators.subscriptionsPlanId
+              .required()
+              .description(DESCRIPTIONS.planId),
           },
         },
       },

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -34,6 +34,7 @@ import { handleAuth } from './utils';
 import { deleteAccountIfUnverified } from '../utils/account';
 import SUBSCRIPTIONS_DOCS from '../../../docs/swagger/subscriptions-api';
 import { SubscriptionEligibilityResult } from 'fxa-shared/subscriptions/types';
+import DESCRIPTIONS from '../../../docs/swagger/shared/descriptions';
 
 const METRICS_CONTEXT_SCHEMA = require('../../metrics/context').schema;
 
@@ -595,7 +596,11 @@ export const paypalRoutes = (
         },
         validate: {
           payload: {
-            currencyCode: isA.string().uppercase().required(),
+            currencyCode: isA
+              .string()
+              .uppercase()
+              .required()
+              .description(DESCRIPTIONS.currencyCode),
           },
         },
       },
@@ -619,10 +624,16 @@ export const paypalRoutes = (
         },
         validate: {
           payload: {
-            priceId: isA.string().required(),
-            promotionCode: isA.string().optional(),
+            priceId: isA.string().required().description(DESCRIPTIONS.priceId),
+            promotionCode: isA
+              .string()
+              .optional()
+              .description(DESCRIPTIONS.promotionCode),
             token: validators.paypalPaymentToken.allow(null).optional(),
-            idempotencyKey: isA.string().required(),
+            idempotencyKey: isA
+              .string()
+              .required()
+              .description(DESCRIPTIONS.idempotencyKey),
             metricsContext: METRICS_CONTEXT_SCHEMA,
           },
         },

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -41,6 +41,7 @@ import { generateIdempotencyKey } from '../../payments/utils';
 import { COUNTRIES_LONG_NAME_TO_SHORT_NAME_MAP } from '../../payments/stripe';
 import { deleteAccountIfUnverified } from '../utils/account';
 import SUBSCRIPTIONS_DOCS from '../../../docs/swagger/subscriptions-api';
+import DESCRIPTIONS from '../../../docs/swagger/shared/descriptions';
 import { ALL_RPS_CAPABILITIES_KEY } from 'fxa-shared/subscriptions/configuration/base';
 import { CapabilityService } from '../../payments/capability';
 import Container from 'typedi';
@@ -879,8 +880,11 @@ export const stripeRoutes = (
         response: {
           schema: isA.array().items(
             isA.object().keys({
-              clientId: isA.string(),
-              capabilities: isA.array().items(isA.string()),
+              clientId: isA.string().description(DESCRIPTIONS.clientId),
+              capabilities: isA
+                .array()
+                .items(isA.string())
+                .description(DESCRIPTIONS.capabilities),
             })
           ) as any,
         },
@@ -959,9 +963,14 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            priceId: isA.string().required(),
-            paymentMethodId: validators.stripePaymentMethodId.optional(),
-            promotionCode: isA.string().optional(),
+            priceId: isA.string().required().description(DESCRIPTIONS.priceId),
+            paymentMethodId: validators.stripePaymentMethodId
+              .optional()
+              .description(DESCRIPTIONS.paymentMethodId),
+            promotionCode: isA
+              .string()
+              .optional()
+              .description(DESCRIPTIONS.promotionCode),
             metricsContext: METRICS_CONTEXT_SCHEMA,
           },
         },
@@ -983,9 +992,17 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            invoiceId: isA.string().required(),
-            paymentMethodId: validators.stripePaymentMethodId.required(),
-            idempotencyKey: isA.string().required(),
+            invoiceId: isA
+              .string()
+              .required()
+              .description(DESCRIPTIONS.invoiceId),
+            paymentMethodId: validators.stripePaymentMethodId
+              .required()
+              .description(DESCRIPTIONS.paymentMethodId),
+            idempotencyKey: isA
+              .string()
+              .required()
+              .description(DESCRIPTIONS.idempotencyKey),
           },
         },
       },
@@ -1006,8 +1023,13 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            priceId: validators.subscriptionsPlanId.required(),
-            promotionCode: isA.string().optional(),
+            priceId: validators.subscriptionsPlanId
+              .required()
+              .description(DESCRIPTIONS.priceId),
+            promotionCode: isA
+              .string()
+              .optional()
+              .description(DESCRIPTIONS.promotionCode),
           },
         },
       },
@@ -1040,8 +1062,13 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            priceId: validators.subscriptionsPlanId.required(),
-            promotionCode: isA.string().required(),
+            priceId: validators.subscriptionsPlanId
+              .required()
+              .description(DESCRIPTIONS.priceId),
+            promotionCode: isA
+              .string()
+              .required()
+              .description(DESCRIPTIONS.promotionCode),
           },
         },
       },
@@ -1078,7 +1105,9 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            paymentMethodId: validators.stripePaymentMethodId.required(),
+            paymentMethodId: validators.stripePaymentMethodId
+              .required()
+              .description(DESCRIPTIONS.paymentMethodId),
           },
         },
       },
@@ -1097,13 +1126,17 @@ export const stripeRoutes = (
         response: {
           schema: isA
             .object({
-              id: validators.stripePaymentMethodId.required(),
+              id: validators.stripePaymentMethodId
+                .required()
+                .description(DESCRIPTIONS.paymentMethodId),
             })
             .unknown(true) as any,
         },
         validate: {
           payload: {
-            paymentMethodId: validators.stripePaymentMethodId.required(),
+            paymentMethodId: validators.stripePaymentMethodId
+              .required()
+              .description(DESCRIPTIONS.paymentMethodId),
           },
         },
       },
@@ -1117,12 +1150,18 @@ export const stripeRoutes = (
         ...SUBSCRIPTIONS_DOCS.OAUTH_SUBSCRIPTIONS_PRODUCTNAME_GET,
         response: {
           schema: isA.object({
-            product_name: isA.string().required(),
+            product_name: isA
+              .string()
+              .required()
+              .description(DESCRIPTIONS.productName),
           }) as any,
         },
         validate: {
           query: {
-            productId: isA.string().required(),
+            productId: isA
+              .string()
+              .required()
+              .description(DESCRIPTIONS.productId),
           },
         },
       },
@@ -1139,10 +1178,14 @@ export const stripeRoutes = (
         },
         validate: {
           params: {
-            subscriptionId: validators.subscriptionsSubscriptionId.required(),
+            subscriptionId: validators.subscriptionsSubscriptionId
+              .required()
+              .description(DESCRIPTIONS.subscriptionId),
           },
           payload: {
-            planId: validators.subscriptionsPlanId.required(),
+            planId: validators.subscriptionsPlanId
+              .required()
+              .description(DESCRIPTIONS.planId),
           },
         },
       },
@@ -1160,7 +1203,9 @@ export const stripeRoutes = (
         },
         validate: {
           params: {
-            subscriptionId: validators.subscriptionsSubscriptionId.required(),
+            subscriptionId: validators.subscriptionsSubscriptionId
+              .required()
+              .description(DESCRIPTIONS.subscriptionId),
           },
         },
       },
@@ -1178,7 +1223,9 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            subscriptionId: validators.subscriptionsSubscriptionId.required(),
+            subscriptionId: validators.subscriptionsSubscriptionId
+              .required()
+              .description(DESCRIPTIONS.subscriptionId),
           },
         },
       },

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -22,6 +22,9 @@ const {
   appStoreSubscriptionSchema,
   playStoreSubscriptionSchema,
 } = require('fxa-shared/dto/auth/payments/iap-subscription');
+const {
+  default: DESCRIPTIONS,
+} = require('../../docs/swagger/shared/descriptions');
 
 // Match any non-empty hex-encoded string.
 const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
@@ -317,16 +320,25 @@ module.exports.subscriptionPaymentCountryCode = isA
 
 // This is fxa-auth-db-mysql's perspective on an active subscription
 module.exports.activeSubscriptionValidator = isA.object({
-  uid: isA.string().required(),
-  subscriptionId: module.exports.subscriptionsSubscriptionId.required(),
-  productId: module.exports.subscriptionsProductId.required(),
-  createdAt: isA.number().required(),
-  cancelledAt: isA.alternatives(isA.number(), isA.any().allow(null)),
+  uid: isA.string().required().description(DESCRIPTIONS.uid),
+  subscriptionId: module.exports.subscriptionsSubscriptionId
+    .required()
+    .description(DESCRIPTIONS.subscriptionId),
+  productId: module.exports.subscriptionsProductId
+    .required()
+    .description(DESCRIPTIONS.productId),
+  createdAt: isA.number().required().description(DESCRIPTIONS.createdAt),
+  cancelledAt: isA
+    .alternatives(isA.number(), isA.any().allow(null))
+    .description(DESCRIPTIONS.cancelledAt),
 });
 
 module.exports.subscriptionsSetupIntent = isA
   .object({
-    client_secret: isA.string().required(),
+    client_secret: isA
+      .string()
+      .required()
+      .description(DESCRIPTIONS.clientSecret),
   })
   .unknown(true);
 
@@ -349,7 +361,8 @@ module.exports.subscriptionsSubscriptionExpandedValidator = isA
           .required(),
       })
       .unknown(true)
-      .required(),
+      .required()
+      .description(DESCRIPTIONS.latestInvoice),
   })
   .unknown(true);
 
@@ -370,35 +383,74 @@ module.exports.subscriptionsInvoicePIExpandedValidator = isA
 
 module.exports.subscriptionsSubscriptionValidator = isA.object({
   _subscription_type: MozillaSubscriptionTypes.WEB,
-  created: isA.number().required(),
-  current_period_end: isA.number().required(),
-  current_period_start: isA.number().required(),
-  cancel_at_period_end: isA.boolean().required(),
+  created: isA.number().required().description(DESCRIPTIONS.createdAt),
+  current_period_end: isA
+    .number()
+    .required()
+    .description(DESCRIPTIONS.currentPeriodEnd),
+  current_period_start: isA
+    .number()
+    .required()
+    .description(DESCRIPTIONS.currentPeriodStart),
+  cancel_at_period_end: isA
+    .boolean()
+    .required()
+    .description(DESCRIPTIONS.cancelAtPeriodEnd),
   end_at: isA.alternatives(isA.number(), isA.any().allow(null)),
-  failure_code: isA.string().optional(),
-  failure_message: isA.string().optional(),
-  latest_invoice: isA.string().required(),
-  plan_id: module.exports.subscriptionsPlanId.required(),
-  product_id: module.exports.subscriptionsProductId.required(),
-  product_name: isA.string().required(),
-  status: isA.string().required(),
-  subscription_id: module.exports.subscriptionsSubscriptionId.required(),
-  promotion_code: isA.string().optional().allow(null),
-  promotion_duration: isA.string().optional().allow(null),
+  failure_code: isA.string().optional().description(DESCRIPTIONS.failureCode),
+  failure_message: isA
+    .string()
+    .optional()
+    .description(DESCRIPTIONS.failureMessage),
+  latest_invoice: isA
+    .string()
+    .required()
+    .description(DESCRIPTIONS.latestInvoice),
+  plan_id: module.exports.subscriptionsPlanId
+    .required()
+    .description(DESCRIPTIONS.planId),
+  product_id: module.exports.subscriptionsProductId
+    .required()
+    .description(DESCRIPTIONS.productId),
+  product_name: isA.string().required().description(DESCRIPTIONS.productName),
+  status: isA.string().required().description(DESCRIPTIONS.status),
+  subscription_id: module.exports.subscriptionsSubscriptionId
+    .required()
+    .description(DESCRIPTIONS.subscriptionId),
+  promotion_code: isA
+    .string()
+    .optional()
+    .allow(null)
+    .description(DESCRIPTIONS.promotionCode),
+  promotion_duration: isA
+    .string()
+    .optional()
+    .allow(null)
+    .description(DESCRIPTIONS.promotionDuration),
   promotion_end: isA.number().optional().allow(null),
 });
 
 // This is support-panel's perspective on a subscription
 module.exports.subscriptionsWebSubscriptionSupportValidator = isA
   .object({
-    created: isA.number().required(),
-    current_period_end: isA.number().required(),
-    current_period_start: isA.number().required(),
+    created: isA.number().required().description(DESCRIPTIONS.createdAt),
+    current_period_end: isA
+      .number()
+      .required()
+      .description(DESCRIPTIONS.currentPeriodEnd),
+    current_period_start: isA
+      .number()
+      .required()
+      .description(DESCRIPTIONS.currentPeriodStart),
     plan_changed: isA.alternatives(isA.number(), isA.any().allow(null)),
-    previous_product: isA.alternatives(isA.string(), isA.any().allow(null)),
-    product_name: isA.string().required(),
-    status: isA.string().required(),
-    subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+    previous_product: isA
+      .alternatives(isA.string(), isA.any().allow(null))
+      .description(DESCRIPTIONS.previousProduct),
+    product_name: isA.string().required().description(DESCRIPTIONS.productName),
+    status: isA.string().required().description(DESCRIPTIONS.status),
+    subscription_id: module.exports.subscriptionsSubscriptionId
+      .required()
+      .description(DESCRIPTIONS.subscriptionId),
   })
   .unknown(true);
 
@@ -536,18 +588,32 @@ module.exports.subscriptionProductMetadataValidator = {
 };
 
 module.exports.subscriptionsPlanWithMetaDataValidator = isA.object({
-  plan_id: module.exports.subscriptionsPlanId.required(),
-  plan_metadata: module.exports.subscriptionPlanMetadataValidator.optional(),
-  product_id: module.exports.subscriptionsProductId.required(),
-  product_name: isA.string().required(),
-  plan_name: isA.string().allow('').optional(),
-  product_metadata:
-    module.exports.subscriptionProductMetadataBaseValidator.optional(),
-  interval: isA.string().required(),
-  interval_count: isA.number().required(),
-  amount: isA.number().required(),
-  currency: isA.string().required(),
-  active: isA.boolean().required(),
+  plan_id: module.exports.subscriptionsPlanId
+    .required()
+    .description(DESCRIPTIONS.planId),
+  plan_metadata: module.exports.subscriptionPlanMetadataValidator
+    .optional()
+    .description(DESCRIPTIONS.planMetadata),
+  product_id: module.exports.subscriptionsProductId
+    .required()
+    .description(DESCRIPTIONS.productId),
+  product_name: isA.string().required().description(DESCRIPTIONS.productName),
+  plan_name: isA
+    .string()
+    .allow('')
+    .optional()
+    .description(DESCRIPTIONS.planName),
+  product_metadata: module.exports.subscriptionProductMetadataBaseValidator
+    .optional()
+    .description(DESCRIPTIONS.productMetadata),
+  interval: isA.string().required().description(DESCRIPTIONS.interval),
+  interval_count: isA
+    .number()
+    .required()
+    .description(DESCRIPTIONS.intervalCount),
+  amount: isA.number().required().description(DESCRIPTIONS.amount),
+  currency: isA.string().required().description(DESCRIPTIONS.currency),
+  active: isA.boolean().required().description(DESCRIPTIONS.activePrice),
   configuration: minimalConfigSchema
     .keys(productConfigJoiKeys)
     .keys(planConfigJoiKeys)
@@ -556,17 +622,31 @@ module.exports.subscriptionsPlanWithMetaDataValidator = isA.object({
 });
 
 module.exports.subscriptionsPlanWithProductConfigValidator = isA.object({
-  plan_id: module.exports.subscriptionsPlanId.required(),
-  plan_metadata: isA.object().optional(),
-  product_id: module.exports.subscriptionsProductId.required(),
-  product_name: isA.string().required(),
-  plan_name: isA.string().allow('').optional(),
-  product_metadata: isA.object().optional(),
-  interval: isA.string().required(),
-  interval_count: isA.number().required(),
-  amount: isA.number().required(),
-  currency: isA.string().required(),
-  active: isA.boolean().required(),
+  plan_id: module.exports.subscriptionsPlanId
+    .required()
+    .description(DESCRIPTIONS.planId),
+  plan_metadata: isA.object().optional().description(DESCRIPTIONS.planMetadata),
+  product_id: module.exports.subscriptionsProductId
+    .required()
+    .description(DESCRIPTIONS.productId),
+  product_name: isA.string().required().description(DESCRIPTIONS.productName),
+  plan_name: isA
+    .string()
+    .allow('')
+    .optional()
+    .description(DESCRIPTIONS.planName),
+  product_metadata: isA
+    .object()
+    .optional()
+    .description(DESCRIPTIONS.productMetadata),
+  interval: isA.string().required().description(DESCRIPTIONS.interval),
+  interval_count: isA
+    .number()
+    .required()
+    .description(DESCRIPTIONS.intervalCount),
+  amount: isA.number().required().description(DESCRIPTIONS.amount),
+  currency: isA.string().required().description(DESCRIPTIONS.currency),
+  active: isA.boolean().required().description(DESCRIPTIONS.activePrice),
   configuration: minimalConfigSchema
     .keys(productConfigJoiKeys)
     .keys(planConfigJoiKeys)
@@ -574,30 +654,42 @@ module.exports.subscriptionsPlanWithProductConfigValidator = isA.object({
 });
 
 module.exports.subscriptionsCustomerValidator = isA.object({
-  customerId: isA.string().optional(),
+  customerId: isA.string().optional().description(DESCRIPTIONS.customerId),
   billing_name: isA
     .alternatives(isA.string(), isA.any().allow(null))
-    .optional(),
-  exp_month: isA.number().optional(),
-  exp_year: isA.number().optional(),
-  last4: isA.string().optional(),
-  payment_provider: isA.string().optional(),
-  payment_type: isA.string().optional(),
-  paypal_payment_error: isA.string().optional(),
-  brand: isA.string().optional(),
+    .optional()
+    .description(DESCRIPTIONS.billingName),
+  exp_month: isA.number().optional().description(DESCRIPTIONS.expMonth),
+  exp_year: isA.number().optional().description(DESCRIPTIONS.expYear),
+  last4: isA.string().optional().description(DESCRIPTIONS.last4),
+  payment_provider: isA
+    .string()
+    .optional()
+    .description(DESCRIPTIONS.paymentProvider),
+  payment_type: isA.string().optional().description(DESCRIPTIONS.paymentType),
+  paypal_payment_error: isA
+    .string()
+    .optional()
+    .description(DESCRIPTIONS.paypalPaymentError),
+  brand: isA.string().optional().description(DESCRIPTIONS.brand),
   billing_agreement_id: isA
     .alternatives(isA.string(), isA.any().allow(null))
-    .optional(),
+    .optional()
+    .description(DESCRIPTIONS.billingAgreementId),
   subscriptions: isA
     .array()
     .items(module.exports.subscriptionsSubscriptionValidator)
-    .optional(),
+    .optional()
+    .description(DESCRIPTIONS.subscriptions),
 });
 
 module.exports.subscriptionsStripeIntentValidator = isA
   .object({
-    client_secret: isA.string().optional(),
-    created: isA.number().required(),
+    client_secret: isA
+      .string()
+      .optional()
+      .description(DESCRIPTIONS.clientSecret),
+    created: isA.number().required().description(DESCRIPTIONS.createdAt),
     payment_method: isA
       .alternatives(isA.string(), isA.object({}).unknown(true))
       .optional()
@@ -608,7 +700,7 @@ module.exports.subscriptionsStripeIntentValidator = isA
       then: isA.string().optional(),
       otherwise: isA.any().optional().allow(null),
     }),
-    status: isA.string().required(),
+    status: isA.string().required().description(DESCRIPTIONS.status),
   })
   .unknown(true);
 
@@ -616,10 +708,10 @@ module.exports.subscriptionsStripeSourceValidator = isA
   .object({
     id: isA.string().required(),
     object: isA.string().required(),
-    brand: isA.string().optional(),
-    exp_month: isA.string().optional(),
-    exp_year: isA.string().optional(),
-    last4: isA.string().optional(),
+    brand: isA.string().optional().description(DESCRIPTIONS.brand),
+    exp_month: isA.string().optional().description(DESCRIPTIONS.expMonth),
+    exp_year: isA.string().optional().description(DESCRIPTIONS.expYear),
+    last4: isA.string().optional().description(DESCRIPTIONS.last4),
   })
   .unknown(true);
 
@@ -653,11 +745,22 @@ module.exports.subscriptionsStripeSubscriptionValidator = isA
   .object({
     id: isA.string().required(),
     cancel_at: isA.alternatives(isA.number(), isA.any().valid(null)),
-    canceled_at: isA.alternatives(isA.number(), isA.any().valid(null)),
-    cancel_at_period_end: isA.bool().required(),
-    created: isA.number().required(),
-    current_period_end: isA.number().required(),
-    current_period_start: isA.number().required(),
+    canceled_at: isA
+      .alternatives(isA.number(), isA.any().valid(null))
+      .description(DESCRIPTIONS.cancelledAt),
+    cancel_at_period_end: isA
+      .bool()
+      .required()
+      .description(DESCRIPTIONS.cancelAtPeriodEnd),
+    created: isA.number().required().description(DESCRIPTIONS.createdAt),
+    current_period_end: isA
+      .number()
+      .required()
+      .description(DESCRIPTIONS.currentPeriodEnd),
+    current_period_start: isA
+      .number()
+      .required()
+      .description(DESCRIPTIONS.currentPeriodStart),
     ended_at: isA.alternatives(isA.number(), isA.any().valid(null)),
     items: isA
       .object({
@@ -674,7 +777,7 @@ module.exports.subscriptionsStripeSubscriptionValidator = isA
         module.exports.subscriptionsStripeInvoiceValidator
       )
       .optional(),
-    status: isA.string().required(),
+    status: isA.string().required().description(DESCRIPTIONS.status),
   })
   .unknown(true);
 
@@ -706,20 +809,28 @@ module.exports.subscriptionsStripeCustomerValidator = isA
 
 module.exports.subscriptionsMozillaSubscriptionsValidator = isA
   .object({
-    customerId: isA.string().optional(),
+    customerId: isA.string().optional().description(DESCRIPTIONS.customerId),
     billing_name: isA
       .alternatives(isA.string(), isA.any().allow(null))
-      .optional(),
-    exp_month: isA.number().optional(),
-    exp_year: isA.number().optional(),
-    last4: isA.string().optional(),
-    payment_provider: isA.string().optional(),
-    payment_type: isA.string().optional(),
-    paypal_payment_error: isA.string().optional(),
-    brand: isA.string().optional(),
+      .optional()
+      .description(DESCRIPTIONS.billingName),
+    exp_month: isA.number().optional().description(DESCRIPTIONS.expMonth),
+    exp_year: isA.number().optional().description(DESCRIPTIONS.expYear),
+    last4: isA.string().optional().description(DESCRIPTIONS.last4),
+    payment_provider: isA
+      .string()
+      .optional()
+      .description(DESCRIPTIONS.paymentProvider),
+    payment_type: isA.string().optional().description(DESCRIPTIONS.paymentType),
+    paypal_payment_error: isA
+      .string()
+      .optional()
+      .description(DESCRIPTIONS.paypalPaymentError),
+    brand: isA.string().optional().description(DESCRIPTIONS.brand),
     billing_agreement_id: isA
       .alternatives(isA.string(), isA.any().allow(null))
-      .optional(),
+      .optional()
+      .description(DESCRIPTIONS.billingAgreementId),
     subscriptions: isA
       .array()
       .items(
@@ -727,7 +838,8 @@ module.exports.subscriptionsMozillaSubscriptionsValidator = isA
         module.exports.subscriptionsGooglePlaySubscriptionValidator,
         module.exports.subscriptionsAppStoreSubscriptionValidator
       )
-      .required(),
+      .required()
+      .description(DESCRIPTIONS.subscriptions),
   })
   .unknown(true);
 


### PR DESCRIPTION
## Because

- we need to add details to the subscription endpoints in our API docs.

## This pull request

- adds what each subscription endpoint returns

## Issue that this pull request solves

Closes: [FXA-4902](https://mozilla-hub.atlassian.net/browse/FXA-4902)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

[FXA-4902]: https://mozilla-hub.atlassian.net/browse/FXA-4902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ