### PR TITLE
fix(l10n): Pocket brand term

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -16,7 +16,7 @@ signin-header = Sign in
 # This message is followed by a bulleted list
 signin-tos-list-intro = By proceeding, you agree to:
 # <linkExternal> links to the Terms of Service and also to the Privacy Notice
-signin-tos-list-pocket = { product-pocket }’s <linkExternal>Terms of Service</linkExternal> and <linkExternal>Privacy Notice</linkExternal>
+signin-tos-list-pocket = { -product-pocket }’s <linkExternal>Terms of Service</linkExternal> and <linkExternal>Privacy Notice</linkExternal>
 # <linkExternal> links to the Terms of Service and also to the Privacy Notice
 signin-tos-list-firefox = { -brand-firefox }’s <linkExternal>Terms of Service</linkExternal> and <linkExternal>Privacy Notice</linkExternal>
 # <linkExternal> links to the Terms of Service and also to the Privacy Notice


### PR DESCRIPTION
## Because

* brand-pocket was recently changed to -brand-pocket brand term

## This pull request

* Update Signin's ftl file to use -brand-pocket (issue spotted by @bcolsson)

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
