### PR TITLE
test(functional): rewrite sync v3 email first and sign up tests

### DIFF
--- a/.circleci/run-list-parallel.sh
+++ b/.circleci/run-list-parallel.sh
@@ -76,7 +76,14 @@ echo " - Operation list: .lists/$LIST-$SPLIT_FILE"
 # Make sure the test folder exists in the artifacts dir
 mkdir -p artifacts/tests
 
-# Executes the command in the LIST file in parallel. Some notes on options
-# Setting --load let's us wait for a heavy test suite to finish before starting another one
-# Setting --joblog preserves the output in a log file.
-parallel $MAX_JOBS --load 50% --halt 0 --joblog artifacts/tests/$LIST-$SPLIT_FILE.log < .lists/$LIST-$SPLIT_FILE
+if [[ -f .lists/$LIST-$SPLIT_FILE ]]; then
+  # Executes the command in the LIST file in parallel. Some notes on options
+  # Setting --load let's us wait for a heavy test suite to finish before starting another one
+  # Setting --joblog preserves the output in a log file.
+  parallel $MAX_JOBS --load 50% --halt 0 --joblog artifacts/tests/$LIST-$SPLIT_FILE.log < .lists/$LIST-$SPLIT_FILE
+else
+  # If there weren't enough commands to split up, then the file might not be present. For example, if there
+  # is just one operation to run, and we've requested to split operations into two groups, then second group
+  # will have zero operations and therefore nothing to run.
+  echo "Split test file, $LIST-$SPLIT_FILE, does not exist. Exiting early!"
+fi

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -1,6 +1,7 @@
 import { EmailHeader, EmailType } from '../lib/email';
 import { BaseLayout } from './layout';
 import { getCode } from 'fxa-settings/src/lib/totp';
+import AuthClient from 'fxa-auth-client';
 
 export const selectors = {
   AGE: '#age',
@@ -45,6 +46,11 @@ export class LoginPage extends BaseLayout {
 
   get emailHeader() {
     return this.page.locator(selectors.EMAIL_HEADER);
+  }
+
+  async getFxaClient(target) {
+    const AUTH_SERVER_ROOT = target.authServerUrl;
+    return new AuthClient(AUTH_SERVER_ROOT);
   }
 
   get passwordHeader() {
@@ -192,6 +198,10 @@ export class LoginPage extends BaseLayout {
     return this.page.fill(selectors.PASSWORD, password);
   }
 
+  confirmPassword(password: string) {
+    return this.page.fill(selectors.VPASSWORD, password);
+  }
+
   async clickUseRecoveryCode() {
     return this.page.click(selectors.LINK_USE_RECOVERY_CODE);
   }
@@ -282,6 +292,12 @@ export class LoginPage extends BaseLayout {
     return this.page.isVisible(selectors.SIGNIN_HEADER, {
       timeout: 100,
     });
+  }
+
+  async isPasswordHeader() {
+    const header = await this.page.locator(selectors.PASSWORD_HEADER);
+    await header.waitFor();
+    return header.isVisible();
   }
 
   async clickSignIn() {

--- a/packages/functional-tests/pages/signinTokenCode.ts
+++ b/packages/functional-tests/pages/signinTokenCode.ts
@@ -45,4 +45,8 @@ export class SigninTokenCodePage extends BaseLayout {
   get successMessage() {
     return this.page.locator(this.selectors.SUCCESS);
   }
+
+  async clickSubmitButton() {
+    await this.page.locator(this.selectors.SUBMIT).click();
+  }
 }

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+const PASSWORD = 'passwordzxcv';
+let email;
+
+test.describe('Sign up with code ', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    email = login.createEmail();
+    await login.clearCache();
+  });
+
+  test('bounced email', async ({ target, page, pages: { login } }) => {
+    const client = await login.getFxaClient(target);
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'networkidle',
+    });
+    await login.fillOutFirstSignUp(email, PASSWORD);
+
+    await client.accountDestroy(email, PASSWORD);
+    expect(await login.isPasswordHeader()).toBe(true);
+  });
+
+  test('valid code then click back', async ({
+    target,
+    page,
+    pages: { login, settings },
+  }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'networkidle',
+    });
+    await login.fillOutFirstSignUp(email, PASSWORD);
+    await page.waitForNavigation();
+    await page.goBack({ waitUntil: 'networkidle' });
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('invalid code', async ({
+    target,
+    page,
+    pages: { login, signinTokenCode },
+  }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'networkidle',
+    });
+    await login.fillOutFirstSignUp(email, PASSWORD, false);
+    await login.setCode('1234');
+    await signinTokenCode.clickSubmitButton();
+    expect(await login.getTooltipError()).toMatch(
+      'Invalid or expired confirmation code'
+    );
+  });
+});

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+const password = 'passwordzxcv';
+const incorrectPassword = 'password123';
+let email;
+
+test.describe('Firefox Desktop Sync v3 sign up', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    email = login.createEmail('sync{id}');
+    await login.clearCache();
+  });
+
+  test('sign up', async ({
+    target,
+    page,
+    pages: { login, signinTokenCode, connectAnotherDevice },
+  }) => {
+    await page.goto(
+      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
+      { waitUntil: 'networkidle' }
+    );
+    await login.setEmail(email);
+    await signinTokenCode.clickSubmitButton();
+
+    // Verify the email is correct
+    expect(await login.getPrefilledEmail()).toMatch(email);
+
+    // Passwords do not match should cause an error
+    await login.setPassword(password);
+    await login.confirmPassword(incorrectPassword);
+    await login.setAge('21');
+    await signinTokenCode.clickSubmitButton();
+
+    // Verify the error message
+    expect(await login.getTooltipError()).toMatch('Passwords do not match');
+
+    // Fix the error
+    await login.confirmPassword(password);
+    await login.submit();
+    await login.fillOutSignUpCode(email);
+    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+  });
+
+  test('coppa disabled', async ({
+    target,
+    page,
+    pages: { login, connectAnotherDevice },
+  }) => {
+    const query = { coppa: 'false' };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`,
+      { waitUntil: 'networkidle' }
+    );
+    await login.setEmail(email);
+    await login.submit();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+
+    // Age textbox is not on the page and click submit
+    await login.submit();
+    await login.fillOutSignUpCode(email);
+    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+  });
+
+  test('email specified by relier, invalid', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    const invalidEmail = 'invalid@@';
+    const query = { email: invalidEmail };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`
+    );
+    expect(await login.getTooltipError()).toMatch('Valid email required');
+  });
+
+  test('email specified by relier, empty string', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    const emptyEmail = '';
+    const query = { email: emptyEmail };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`
+    );
+    expect(await login.getTooltipError()).toMatch('Valid email required');
+  });
+
+  test('email specified by relier, not registered', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    const query = { email };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`
+    );
+
+    // Verify user lands on the sign up password page
+    expect(await login.signUpPasswordHeader()).toBe(true);
+
+    // Verify the correct email is displayed
+    expect(await login.getPrefilledEmail()).toMatch(email);
+  });
+
+  test('email specified by relier, registered', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    const query = { email };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`
+    );
+
+    // Verify user lands on the sign in password page
+    expect(await login.isPasswordHeader()).toBe(true);
+
+    // Verify the correct email is displayed
+    expect(await login.getPrefilledEmail()).toMatch(email);
+  });
+});

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+const PASSWORD = 'passwordzxcv';
+let email;
+
+test.describe('Firefox Desktop Sync v3 email first', () => {
+  test.beforeEach(async ({ target, credentials, pages: { login } }) => {
+    test.slow();
+    email = login.createEmail('sync{id}');
+    await login.clearCache();
+  });
+
+  test('open directly to /signup page, refresh on the /signup page', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    await page.goto(
+      `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,
+      { waitUntil: 'networkidle' }
+    );
+    await login.setEmail(email);
+    await login.submit();
+
+    // Verify user is redirected to the set password page
+    expect(await login.signUpPasswordHeader()).toBe(true);
+
+    //Refresh the page
+    await page.reload({ waitUntil: 'load' });
+
+    // refresh sends the user back to the first step
+    expect(await login.isEmailHeader()).toBe(true);
+  });
+
+  test('open directly to /signin page, refresh on the /signin page', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    await target.auth.signUp(email, PASSWORD, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await page.goto(
+      `${target.contentServerUrl}/signin?context=fx_desktop_v3&service=sync&action=email`,
+      { waitUntil: 'networkidle' }
+    );
+    await login.setEmail(email);
+    await login.submit();
+
+    // Verify user is redirected to the password page
+    expect(await login.isPasswordHeader()).toBe(true);
+
+    //Refresh the page
+    await page.reload({ waitUntil: 'load' });
+
+    // refresh sends the user back to the first step
+    expect(await login.isEmailHeader()).toBe(true);
+  });
+
+  test('enter a firefox.com address', async ({
+    target,
+    page,
+    pages: { login, signinTokenCode },
+  }) => {
+    await page.goto(
+      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
+      { waitUntil: 'networkidle' }
+    );
+    await login.setEmail('testuser@firefox.com');
+    await signinTokenCode.clickSubmitButton();
+
+    // Verify the error
+    expect(await login.getTooltipError()).toMatch(
+      'Enter a valid email address. firefox.com does not offer email.'
+    );
+  });
+});

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -6,20 +6,15 @@ const testsSettings = require('./functional_settings');
 module.exports = testsSettings.concat([
   'tests/functional/fx_browser_relier.js',
   'tests/functional/oauth_webchannel.js',
-  'tests/functional/reset_password.js',
   'tests/functional/oauth_require_totp.js',
-  'tests/functional/sign_up_with_code.js',
   // new and flaky tests above here',
   'tests/functional/500.js',
   'tests/functional/back_button_after_start.js',
-  'tests/functional/bounced_email.js',
-  'tests/functional/confirm.js',
   'tests/functional/cookies_disabled.js',
   'tests/functional/email_domain_mx_validation.js',
   'tests/functional/email_opt_in.js',
   'tests/functional/force_auth.js',
   'tests/functional/fx_desktop_handshake.js',
-  'tests/functional/fx_firstrun_v2.js',
   'tests/functional/fx_ios_v1_sign_in.js',
   'tests/functional/fx_ios_v1_sign_up.js',
   'tests/functional/legal.js',
@@ -36,24 +31,30 @@ module.exports = testsSettings.concat([
   'tests/functional/post_verify/account_recovery.js',
   'tests/functional/post_verify/secondary_email.js',
   'tests/functional/push.js',
-  'tests/functional/pp.js',
   'tests/functional/refreshes_metrics.js',
   'tests/functional/robots_txt.js',
   'tests/functional/sign_in.js',
   'tests/functional/sign_in_blocked.js',
   'tests/functional/sign_in_cached.js',
   'tests/functional/sign_up.js',
-  'tests/functional/sync_v1.js',
-  'tests/functional/sync_v2.js',
-  'tests/functional/sync_v3_email_first.js',
   'tests/functional/sync_v3_sign_in.js',
   'tests/functional/sync_v3_sign_up.js',
   'tests/functional/sync_v3_reset_password.js',
   'tests/functional/sync_v3_settings.js',
-  'tests/functional/tos.js',
 
   // Disabled because of https://github.com/mozilla/fxa/issues/9863
   // 'tests/functional/verification_reminders.js',
+
+  // These tests no longer adds value and have been removed as
+  // part of the analysis in
+  // https://docs.google.com/spreadsheets/d/11Wq-Y-ipeNFXqLHbr3GJCh_f_qEAG-CUuqBt5Dcnh5k/edit#gid=0
+  // 'tests/functional/bounced_email.js',
+  // 'tests/functional/sync_v1.js',
+  // 'tests/functional/pp.js',
+  // 'tests/functional/sync_v2.js',
+  // 'tests/functional/fx_firstrun_v2.js',
+  // 'tests/functional/tos.js',
+  // 'tests/functional/confirm.js',
 
   // Disabled because this test migrated to Playwright
   // See `/functional-test`
@@ -72,6 +73,9 @@ module.exports = testsSettings.concat([
   //'tests/functional/settings/recovery_key.js',
   //'tests/functional/settings/secondary_email.js',
   //'tests/functional/settings/two_step_auth.js',
+  //'tests/functional/sign_up_with_code.js',
+  //'tests/functional/sync_v3_email_first.js',
+  // 'tests/functional/reset_password.js',
 ]);
 
 // Mocha tests are only exposed during local dev, not on prod-like


### PR DESCRIPTION
## Because

- As part of the playwright test migration, the [sync v3 email first tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sync_v3_email_first.js)  and [Sign up with code tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sign_up_with_code.js) have been rewritten in this PR.

## This pull request

- contains [sync v3 email first tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sync_v3_email_first.js) split into 2 files.
- [Sign up with code tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sign_up_with_code.js)
  

## Issue that this pull request solves

Closes: #[FXA-5905](https://mozilla-hub.atlassian.net/browse/FXA-5905) [FXA-5916](https://mozilla-hub.atlassian.net/browse/FXA-5916)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-5905]: https://mozilla-hub.atlassian.net/browse/FXA-5905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXA-5916]: https://mozilla-hub.atlassian.net/browse/FXA-5916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ