### PR TITLE
bug(CI): Fix edge case where there are fewer operations than groups

### DIFF
--- a/.circleci/run-list-parallel.sh
+++ b/.circleci/run-list-parallel.sh
@@ -76,7 +76,14 @@ echo " - Operation list: .lists/$LIST-$SPLIT_FILE"
 # Make sure the test folder exists in the artifacts dir
 mkdir -p artifacts/tests
 
-# Executes the command in the LIST file in parallel. Some notes on options
-# Setting --load let's us wait for a heavy test suite to finish before starting another one
-# Setting --joblog preserves the output in a log file.
-parallel $MAX_JOBS --load 50% --halt 0 --joblog artifacts/tests/$LIST-$SPLIT_FILE.log < .lists/$LIST-$SPLIT_FILE
+if [[ -f .lists/$LIST-$SPLIT_FILE ]]; then
+  # Executes the command in the LIST file in parallel. Some notes on options
+  # Setting --load let's us wait for a heavy test suite to finish before starting another one
+  # Setting --joblog preserves the output in a log file.
+  parallel $MAX_JOBS --load 50% --halt 0 --joblog artifacts/tests/$LIST-$SPLIT_FILE.log < .lists/$LIST-$SPLIT_FILE
+else
+  # If there weren't enough commands to split up, then the file might not be present. For example, if there
+  # is just one operation to run, and we've requested to split operations into two groups, then second group
+  # will have zero operations and therefore nothing to run.
+  echo "Split test file, $LIST-$SPLIT_FILE, does not exist. Exiting early!"
+fi


### PR DESCRIPTION
## Because
- When there was just a single integration test suite to run, the second integration test suite in the CI would fail.

## This pull request
- Checks to make sure the split file exists before running it.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Addresses this scenario:
![image](https://user-images.githubusercontent.com/94418270/215208366-708a1ed0-9b09-4886-97e3-94ed60ad1405.png)

![image](https://user-images.githubusercontent.com/94418270/215208214-e033bb74-faf8-4ebf-8429-d7c4063103b7.png)

