### PR TITLE
fix(payments): payment method customer null

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -3250,6 +3250,14 @@ export class StripeHelper extends StripeHelperBase {
     const paymentMethod = await this.stripe.paymentMethods.retrieve(
       (event.data.object as Stripe.PaymentMethod).id
     );
+
+    // If this payment method is not attached, we can't store it in firestore as
+    // the customer may not exist. It is possible that a payment_method.detached
+    // event has already been processed, detaching the payment method.
+    if (!paymentMethod.customer) {
+      return;
+    }
+
     try {
       await this.stripeFirestore.insertPaymentMethodRecordWithBackfill(
         paymentMethod

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/payment_method.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/payment_method.json
@@ -29,9 +29,7 @@
     "generated_from": null,
     "last4": "4242",
     "networks": {
-      "available": [
-        "visa"
-      ],
+      "available": ["visa"],
       "preferred": null
     },
     "three_d_secure_usage": {
@@ -40,7 +38,7 @@
     "wallet": null
   },
   "created": 123456789,
-  "customer": null,
+  "customer": "cus_32kfds093ks",
   "livemode": false,
   "metadata": {
     "order_id": "123456789"


### PR DESCRIPTION
## Because

- payment_method.attached is processed when the payment method in stripe no longer has a customer attached.
- In some circumstances, such as seen during blocking many fraudulent payments, it is possible that the payment_method.detached event is processed before the payment_method.attached method. In this scenario, the payment method customer field would already be null.

## This pull request

- Return early if the customer field is null on the payment method.

## Issue that this pull request solves

Closes: #FXA-6564

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
