### PR TITLE
fix(payments): do Not Display Zero Tax Amounts In Plan Details

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -221,6 +221,42 @@ describe('PlanDetails', () => {
     });
   });
 
+  it('does not render a single tax of 0 amont', async () => {
+    updateConfig({
+      featureFlags: {
+        useStripeAutomaticTax: true,
+      },
+    });
+    (apiInvoicePreview as jest.Mock).mockClear().mockResolvedValue({
+      ...INVOICE_PREVIEW_EXCLUSIVE_TAX,
+      tax: [
+        {
+          amount: 0,
+          inclusive: false,
+          display_name: 'Sales Tax',
+        },
+      ],
+    });
+    const props = {
+      ...{
+        profile: userProfile,
+        showExpandButton: false,
+        isMobile: false,
+        selectedPlan,
+      },
+    };
+    const subject = () => {
+      return render(<PlanDetails {...props} />);
+    };
+
+    const { queryByTestId } = subject();
+
+    await waitFor(() => {
+      const taxAmount = queryByTestId('tax-amount');
+      expect(taxAmount).not.toBeInTheDocument();
+    });
+  });
+
   it('renders as expected using firestore config', () => {
     updateConfig({
       featureFlags: {

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -92,7 +92,7 @@ export const PlanDetails = ({
   );
 
   const exclusiveTaxRates = priceAmounts.taxRates.filter(
-    (taxRate) => !taxRate.inclusive
+    (taxRate) => !taxRate.inclusive && taxRate.amount > 0
   );
 
   useEffect(() => {


### PR DESCRIPTION
Because:

* we do not want to show any 0.00 tax amounts in plan details

This commit:

* adds a check for both single or multiple tax amounts that the amount is not zero

Closes #FXA-6574

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
