### PR TITLE
feat(react): Recreate '/cookies_disabled' page + functionality in React

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/storage.ts
+++ b/packages/fxa-content-server/app/scripts/lib/storage.ts
@@ -82,7 +82,7 @@ class Storage {
       if (type === 'sessionStorage') {
         storage = win.sessionStorage;
       } else {
-        // HACK: Allows the functional tests to simulate disabled local storage.
+        // HACK: Allows the functional and unit tests to simulate disabled local storage.
         if (
           Url.searchParam('disable_local_storage', win.location.search) === '1'
         ) {

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -527,6 +527,7 @@ describe('lib/router', () => {
     });
     describe('createReactOrBackboneViewHandler', () => {
       const viewConstructorOptions = {};
+      const additionalParams = {};
       let routeHandler;
 
       beforeEach(() => {
@@ -553,6 +554,7 @@ describe('lib/router', () => {
         routeHandler = router.createReactOrBackboneViewHandler(
           'cannot_create_account',
           CannotCreateAccountView,
+          additionalParams,
           viewConstructorOptions
         );
         assert.equal(router.navigateAway.callCount, 0);

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -277,6 +277,24 @@ const EVENTS = {
     event: 'view',
   },
 
+  // cookies_disabled
+  'screen.cookies_disabled': {
+    group: GROUPS.activity,
+    event: 'cookies_disabled_view',
+  },
+  'cookies_disabled.submit': {
+    group: GROUPS.activity,
+    event: 'cookies_disabled_submit',
+  },
+  'cookies_disabled.success': {
+    group: GROUPS.activity,
+    event: 'cookies_disabled_success',
+  },
+  'cookies_disabled.fail': {
+    group: GROUPS.activity,
+    event: 'cookies_disabled_fail',
+  },
+
   /* Everything under this point should be Settings events, aka 'fxa_pref' group */
   // Account recovery key
   'screen.settings.account-recovery': {

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -17,7 +17,11 @@ const getReactRouteGroups = (showReactApp, isServer = true) => {
   return {
     simpleRoutes: {
       featureFlagOn: showReactApp.simpleRoutes,
-      routes: reactRoute.getRoutes(['cannot_create_account', 'clear']),
+      routes: reactRoute.getRoutes([
+        'cannot_create_account',
+        'clear',
+        'cookies_disabled',
+      ]),
     },
 
     resetPasswordRoutes: {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -227,6 +227,46 @@ registerSuite('amplitude', {
       );
     },
 
+    'screen.cookies_disabled': () => {
+      createAmplitudeEvent('screen.cookies_disabled');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - cookies_disabled_view'
+      );
+    },
+
+    'cookies_disabled.submit': () => {
+      createAmplitudeEvent('cookies_disabled.submit');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - cookies_disabled_submit'
+      );
+    },
+
+    'cookies_disabled.success': () => {
+      createAmplitudeEvent('cookies_disabled.success');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - cookies_disabled_success'
+      );
+    },
+
+    'cookies_disabled.fail': () => {
+      createAmplitudeEvent('cookies_disabled.fail');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - cookies_disabled_fail'
+      );
+    },
+
     'flow.reset-password.submit': () => {
       amplitude(
         {

--- a/packages/fxa-react/components/LinkExternal/index.test.tsx
+++ b/packages/fxa-react/components/LinkExternal/index.test.tsx
@@ -12,9 +12,7 @@ it('renders without imploding', () => {
   const textContent = 'Keep the internet open and accessible to all.';
 
   const renderResult = render(
-    <LinkExternal {...{ className }} {...{ href }}>
-      {textContent}
-    </LinkExternal>
+    <LinkExternal {...{ className, href }}>{textContent}</LinkExternal>
   );
 
   const link = renderResult.getByTestId('link-external');
@@ -22,5 +20,9 @@ it('renders without imploding', () => {
   expect(link).toBeInTheDocument();
   expect(link).toHaveClass(className);
   expect(link).toHaveProperty('href', href);
+  expect(link).toHaveProperty('target', '_blank');
+  expect(link).toHaveProperty('rel', 'noopener noreferrer');
   expect(link).toHaveTextContent(textContent);
+  // 'Opens in new window' is sr-only text added for for accessibility
+  expect(link).toHaveTextContent('Opens in new window');
 });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -10,6 +10,7 @@ import Settings from '../Settings';
 import { QueryParams } from '../..';
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
 import Clear from '../../pages/Clear';
+import CookiesDisabled from '../../pages/CookiesDisabled';
 
 export const App = ({
   flowQueryParams,
@@ -28,6 +29,7 @@ export const App = ({
             <>
               <CannotCreateAccount path="/cannot_create_account/*" />
               <Clear path="/clear/*" />
+              <CookiesDisabled path="/cookies_disabled/*" />
             </>
           )}
 

--- a/packages/fxa-settings/src/components/Banner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.stories.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import Banner, { BannerType } from '.';
+import { Meta } from '@storybook/react';
+import AppLayout from '../AppLayout';
+
+export default {
+  title: 'components/Banner',
+  component: Banner,
+} as Meta;
+
+export const Info = () => (
+  <AppLayout>
+    <Banner type={BannerType.info}>
+      <p>This is an "info" type banner inside our AppLayout.</p>
+    </Banner>
+  </AppLayout>
+);
+
+export const Success = () => (
+  <AppLayout>
+    <Banner type={BannerType.success}>
+      <p>This is a "success" type banner inside our AppLayout.</p>
+    </Banner>
+  </AppLayout>
+);
+
+export const Error = () => (
+  <AppLayout>
+    <Banner type={BannerType.error}>
+      <p>This is an "error" type banner inside our AppLayout.</p>
+    </Banner>
+  </AppLayout>
+);

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import classNames from 'classnames';
+import React, { ReactElement } from 'react';
+
+export enum BannerType {
+  info = 'info',
+  success = 'success',
+  error = 'error',
+}
+
+const Banner = ({
+  type,
+  children,
+}: {
+  type: BannerType;
+  children: ReactElement;
+}) => {
+  const baseClassNames = 'text-xs font-bold p-3 my-3 rounded';
+
+  return (
+    <div
+      className={classNames(
+        baseClassNames,
+        type === BannerType.info && 'bg-grey-50 text-black',
+        type === BannerType.success && 'bg-green-500 text-grey-900',
+        type === BannerType.error && 'bg-red-700 text-white'
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+export default Banner;

--- a/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
@@ -18,22 +18,27 @@ export default {
   component: CardHeader,
 } as Meta;
 
-const storyWithProps = ({ ...props }) => {
+const storyWithProps = (props: React.ComponentProps<typeof CardHeader>) => {
   const story = () => (
     <AppLayout>
-      <CardHeader
-        {...props}
-        headingWithDefaultServiceFtlId={MOCK_DEFAULT_HEADING_FTL_ID}
-        headingText={MOCK_HEADING}
-      />
+      <CardHeader {...props} />
     </AppLayout>
   );
   return story;
 };
 
-export const Default = storyWithProps({});
+export const Basic = storyWithProps({
+  headingTextFtlId: MOCK_DEFAULT_HEADING_FTL_ID,
+  headingText: MOCK_HEADING,
+});
 
-export const WithServiceName = storyWithProps({
+export const WithDefaultServiceName = storyWithProps({
+  headingWithDefaultServiceFtlId: MOCK_DEFAULT_HEADING_FTL_ID,
+  headingText: MOCK_HEADING,
+});
+
+export const WithCustomServiceName = storyWithProps({
   serviceName: MOCK_SERVICE_NAME,
   headingWithCustomServiceFtlId: MOCK_CUSTOM_HEADING_FTL_ID,
+  headingText: MOCK_HEADING,
 });

--- a/packages/fxa-settings/src/components/CardHeader/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.test.tsx
@@ -12,6 +12,7 @@ import {
   MOCK_HEADING,
   MOCK_SERVICE_NAME,
 } from './mocks';
+import { MozServices } from '../../lib/types';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 
@@ -35,7 +36,7 @@ describe('CardHeader', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: `${MOCK_HEADING} to continue to account settings`,
+        name: `${MOCK_HEADING} to continue to ${MozServices.Default}`,
       })
     ).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/components/CardHeader/mocks.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/mocks.tsx
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { MozServices } from '../../lib/types';
+
 export const MOCK_DEFAULT_HEADING_FTL_ID = 'default-heading';
 
 export const MOCK_CUSTOM_HEADING_FTL_ID = 'custom-heading';
 
 export const MOCK_HEADING = 'Complete this step';
 
-export const MOCK_SERVICE_NAME = 'Super Service';
+export const MOCK_SERVICE_NAME = MozServices.FirefoxMonitor;

--- a/packages/fxa-settings/src/components/Ready/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.stories.tsx
@@ -3,29 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import Ready from '.';
-import { ViewNameType } from '.';
+import Ready, { ReadyProps } from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';
+import { MozServices } from '../../lib/types';
 
 export default {
   title: 'components/Ready',
   component: Ready,
 } as Meta;
 
-type ReadyWithLayoutPropsType = {
-  continueHandler?: Function;
-  isSignedIn?: boolean;
-  serviceName?: string;
-  viewName: ViewNameType;
-};
-
 const ReadyWithLayout = ({
   continueHandler,
   isSignedIn,
   serviceName,
   viewName,
-}: ReadyWithLayoutPropsType) => {
+}: ReadyProps) => {
   return (
     <AppLayout>
       <Ready {...{ continueHandler, isSignedIn, serviceName, viewName }} />
@@ -43,18 +36,21 @@ export const ResetPasswordConfirmForLoggedOutUser = () => (
 
 export const ResetPasswordConfirmedWithRelyingParty = () => (
   <ReadyWithLayout
-    serviceName="Example Service"
+    serviceName={MozServices.FirefoxSync}
     viewName="reset-password-confirmed"
   />
 );
 
 export const WithRelyingPartyNoContinueAction = () => (
-  <ReadyWithLayout serviceName="Example Service" viewName="signin-confirmed" />
+  <ReadyWithLayout
+    serviceName={MozServices.FirefoxSync}
+    viewName="signin-confirmed"
+  />
 );
 
 export const WithRelyingPartyAndContinueAction = () => (
   <ReadyWithLayout
-    serviceName={'Example Service'}
+    serviceName={MozServices.FirefoxSync}
     viewName="reset-password-confirmed"
     continueHandler={() => {
       console.log('Arbitrary action');

--- a/packages/fxa-settings/src/components/Ready/index.test.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.test.tsx
@@ -8,6 +8,7 @@ import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import Ready from '.';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
+import { MozServices } from '../../lib/types';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -15,7 +16,7 @@ jest.mock('../../lib/metrics', () => ({
 }));
 
 describe('Ready', () => {
-  const customServiceName = 'Example Service';
+  const customServiceName = MozServices.FirefoxSync;
   const viewName = 'reset-password-confirmed';
   let bundle: FluentBundle;
   beforeAll(async () => {

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -8,12 +8,13 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { ReactComponent as PulseHearts } from './account-verified.svg';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { useFtlMsgResolver } from '../../models/hooks';
+import { MozServices } from '../../lib/types';
 
 // We'll actually be getting the isSignedIn value from a context when this is wired up.
-type ReadyProps = {
+export type ReadyProps = {
   continueHandler?: Function;
   isSignedIn?: boolean;
-  serviceName?: string;
+  serviceName?: MozServices;
   viewName: ViewNameType;
 };
 

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -16,4 +16,5 @@ auth-error-138-2 = Unconfirmed session
 auth-error-139 = Secondary email must be different than your account email
 auth-error-155 = TOTP token not found
 auth-error-183-2 = Invalid or expired confirmation code
+auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different

--- a/packages/fxa-settings/src/pages/CookiesDisabled/en.ftl
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/en.ftl
@@ -1,0 +1,9 @@
+## Cookies disabled page
+## Users will see this page if they have local storage or cookies disabled.
+
+cookies-disabled-header = Local storage and cookies are required
+cookies-disabled-enable-prompt = Please enable cookies and local storage in your browser to access { -product-firefox-accounts }. Doing so will enable functionality such as remembering you between sessions.
+# A button users may click to check if cookies and local storage are enabled and be directed to the previous page if so.
+cookies-disabled-button-try-again = Try again
+# An external link going to: https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer
+cookies-disabled-learn-more = Learn more

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.stories.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import CookiesDisabled from '.';
+import { Meta } from '@storybook/react';
+
+export default {
+  title: 'pages/CookiesDisabled',
+  component: CookiesDisabled,
+} as Meta;
+
+export const Basic = () => <CookiesDisabled />;

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import CookiesDisabled, { routeName } from '.';
+import { screen, render, fireEvent } from '@testing-library/react';
+import { logViewEvent, logPageViewEvent } from '../../lib/metrics';
+
+jest.mock('../../lib/metrics', () => ({
+  logPageViewEvent: jest.fn(),
+  logViewEvent: jest.fn(),
+}));
+
+const originalWindow = window;
+function setLocationSearch(search = '') {
+  // @ts-ignore
+  delete window.location;
+  window.location = {
+    ...originalWindow.location,
+    search,
+  };
+}
+
+function setCookieEnabled(cookieEnabled = true) {
+  // @ts-ignore
+  delete window.navigator;
+  window.navigator = {
+    ...originalWindow.navigator,
+    cookieEnabled,
+  };
+}
+
+describe('CookiesDisabled', () => {
+  const getTryAgainButton = () =>
+    screen.getByRole('button', { name: 'Try again' });
+
+  it('renders as expected', () => {
+    render(<CookiesDisabled />);
+
+    screen.getByRole('heading', {
+      name: 'Local storage and cookies are required',
+    });
+    screen.getByText(
+      'Please enable cookies and local storage in your browser',
+      { exact: false }
+    );
+    expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer'
+    );
+
+    getTryAgainButton();
+
+    expect(logPageViewEvent).toHaveBeenCalledWith(routeName, {
+      entrypoint_variation: 'react',
+    });
+  });
+
+  describe('"Try again" button', () => {
+    let historyGoSpy: jest.SpyInstance, historyBackSpy: jest.SpyInstance;
+    const mockHistoryGo = jest.fn();
+    const mockHistoryBack = jest.fn();
+
+    beforeAll(() => {
+      setLocationSearch();
+      setCookieEnabled();
+    });
+
+    afterAll(() => {
+      window.location = originalWindow.location;
+      window.navigator = originalWindow.navigator;
+    });
+
+    beforeEach(() => {
+      historyGoSpy = jest.spyOn(window.history, 'go');
+      historyBackSpy = jest.spyOn(window.history, 'back');
+
+      historyGoSpy.mockImplementation(mockHistoryGo);
+      historyBackSpy.mockImplementation(mockHistoryBack);
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      setLocationSearch();
+      setCookieEnabled();
+    });
+
+    it('emits expected metrics events on success', () => {
+      render(<CookiesDisabled />);
+      fireEvent.click(getTryAgainButton());
+      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'submit', {
+        entrypoint_variation: 'react',
+      });
+      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'success', {
+        entrypoint_variation: 'react',
+      });
+    });
+
+    it('emits expected metrics events on error', () => {
+      setLocationSearch('?disable_local_storage=1');
+      render(<CookiesDisabled />);
+      fireEvent.click(getTryAgainButton());
+      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'submit', {
+        entrypoint_variation: 'react',
+      });
+      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'fail', {
+        entrypoint_variation: 'react',
+      });
+    });
+
+    describe('goes back in history if localStorage and cookies are enabled', () => {
+      it('when redirected from content-server', () => {
+        setLocationSearch('?contentRedirect=true');
+
+        render(<CookiesDisabled />);
+        fireEvent.click(getTryAgainButton());
+        expect(mockHistoryGo).toBeCalledWith(-2);
+      });
+
+      it('when hit directly', () => {
+        render(<CookiesDisabled />);
+        fireEvent.click(getTryAgainButton());
+        expect(mockHistoryBack).toBeCalled();
+      });
+    });
+
+    describe('shows an error', () => {
+      it('if cookies are still disabled', async () => {
+        setCookieEnabled(false);
+
+        render(<CookiesDisabled />);
+        fireEvent.click(getTryAgainButton());
+        await screen.findByText('Local storage or cookies are still disabled');
+      });
+
+      it('if localStorage is still disabled', async () => {
+        setLocationSearch('?disable_local_storage=1');
+
+        render(<CookiesDisabled />);
+        fireEvent.click(getTryAgainButton());
+        await screen.findByText('Local storage or cookies are still disabled');
+      });
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.tsx
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState } from 'react';
+import AppLayout from '../../components/AppLayout';
+import { RouteComponentProps } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import Storage from '../../lib/storage';
+import Banner, { BannerType } from '../../components/Banner';
+import { searchParams } from '../../lib/utilities';
+import { logViewEvent, logPageViewEvent } from '../../lib/metrics';
+import CardHeader from '../../components/CardHeader';
+
+export const routeName = 'cookies_disabled';
+
+const CookiesDisabled = (_: RouteComponentProps) => {
+  logPageViewEvent(routeName, {
+    entrypoint_variation: 'react',
+  });
+
+  /* HACK / TODO when sunsetting content-server: if this page is hit through content-server's
+   * router instead of hitting it directly via `/cookies_disabled?showReactApp=true`, which
+   * is useful for manual and possibly functional testing, we must navigate back _two_ pages.
+   * Flow params are not always available to check against so we explicitely send in an
+   * additional param. Remove this check when we don't handle the redirect `router.js`.
+   */
+  const { contentRedirect } = searchParams(window.location.search);
+  const [stillDisabled, setStillDisabled] = useState(false);
+
+  const buttonHandler = useCallback(() => {
+    logViewEvent(routeName, 'submit', {
+      entrypoint_variation: 'react',
+    });
+    if (!Storage.isLocalStorageEnabled(window) || !navigator.cookieEnabled) {
+      logViewEvent(routeName, 'fail', {
+        entrypoint_variation: 'react',
+      });
+      setStillDisabled(true);
+    } else {
+      logViewEvent(routeName, 'success', {
+        entrypoint_variation: 'react',
+      });
+      if (contentRedirect) {
+        window.history.go(-2);
+      } else {
+        window.history.back();
+      }
+    }
+  }, [contentRedirect]);
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingTextFtlId="cookies-disabled-header"
+        headingText="Local storage and cookies are required"
+      />
+
+      {stillDisabled && (
+        <Banner type={BannerType.error}>
+          <FtlMsg id="auth-error-1003">
+            <p>Local storage or cookies are still disabled</p>
+          </FtlMsg>
+        </Banner>
+      )}
+
+      <FtlMsg id="cookies-disabled-enable-prompt">
+        <p className="text-sm">
+          Please enable cookies and local storage in your browser to access
+          Firefox Accounts. Doing so will enable functionality such as
+          remembering you between sessions.
+        </p>
+      </FtlMsg>
+
+      <p className="my-6">
+        <LinkExternal
+          className="link-blue text-sm"
+          href="https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer"
+        >
+          <FtlMsg id="cookies-disabled-learn-more">Learn more</FtlMsg>
+        </LinkExternal>
+      </p>
+
+      <div className="flex">
+        <FtlMsg id="cookies-disabled-button-try-again">
+          <button className="cta-primary cta-xl" onClick={buttonHandler}>
+            Try again
+          </button>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default CookiesDisabled;

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -53,7 +53,7 @@ describe('PageAccountRecoveryConfirmKey', () => {
     );
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      `Reset password with account recovery key to continue to Example Service`
+      `Reset password with account recovery key to continue to ${MOCK_SERVICE_NAME}`
     );
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -15,11 +15,12 @@ import CardHeader from '../../../components/CardHeader';
 import WarningMessage from '../../../components/WarningMessage';
 import LinkExpired from '../../../components/LinkExpired';
 import LinkDamaged from '../../../components/LinkDamaged';
+import { MozServices } from '../../../lib/types';
 
 // --serviceName-- is the relying party
 
 export type AccountRecoveryConfirmKeyProps = {
-  serviceName?: string;
+  serviceName?: MozServices;
   linkStatus: LinkStatus;
 };
 
@@ -104,7 +105,7 @@ const AccountRecoveryConfirmKey = ({
           <CardHeader
             headingWithDefaultServiceFtlId="account-recovery-confirm-key-heading-w-default-service"
             headingWithCustomServiceFtlId="account-recovery-confirm-key-heading-w-custom-service"
-            headingText={`Reset password with account recovery key`}
+            headingText="Reset password with account recovery key"
             {...{ serviceName }}
           />
           <FtlMsg id="account-recovery-confirm-key-instructions">

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_SERVICE_NAME = 'Example Service';
+import { MozServices } from '../../../lib/types';
+
+export const MOCK_SERVICE_NAME = MozServices.FirefoxSync;

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.tsx
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps, useNavigate } from '@reach/router';
 import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from '@reach/router';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { useAccount, useAlertBar } from '../../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
@@ -15,6 +14,7 @@ import { InputText } from '../../../components/InputText';
 import CardHeader from '../../../components/CardHeader';
 import WarningMessage from '../../../components/WarningMessage';
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
+import { MozServices } from '../../../lib/types';
 
 // --forceEmail-- is a hint to the signup page that the user should not
 // be given the option to change their address
@@ -27,7 +27,7 @@ import LinkRememberPassword from '../../../components/LinkRememberPassword';
 // --serviceName-- is the relying party
 
 export type ResetPasswordProps = {
-  serviceName?: string;
+  serviceName?: MozServices;
   forceEmail?: string;
   canGoBack?: boolean;
 };

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/mocks.tsx
@@ -2,5 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_SERVICE_NAME = 'Example Service';
+import { MozServices } from '../../../lib/types';
+
+export const MOCK_SERVICE_NAME = MozServices.FirefoxSync;
 export const MOCK_EMAIL = 'blabidi@blabidiboo.com';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
@@ -8,6 +8,7 @@ import AppLayout from '../../../components/AppLayout';
 import { MozServices } from '../../../lib/types';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { MOCK_SERVICE_NAME } from '../ResetPassword/mocks';
 
 export default {
   title: 'pages/ResetPassword/ResetPasswordConfirmed',
@@ -25,7 +26,7 @@ export const Default = () => (
 export const WithRelyingPartyNoContinueAction = () => (
   <LocationProvider>
     <AppLayout>
-      <ResetPasswordConfirmed serviceName={'ExampleService'} />
+      <ResetPasswordConfirmed serviceName={MOCK_SERVICE_NAME} />
     </AppLayout>
   </LocationProvider>
 );
@@ -34,7 +35,7 @@ export const WithRelyingPartyAndContinueAction = () => (
   <LocationProvider>
     <AppLayout>
       <ResetPasswordConfirmed
-        serviceName={MozServices.FirefoxMonitor}
+        serviceName={MOCK_SERVICE_NAME}
         continueHandler={() => {
           console.log('Arbitrary action');
         }}

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
@@ -5,10 +5,11 @@
 import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
+import { MozServices } from '../../../lib/types';
 
 type ResetPasswordConfirmedProps = {
   continueHandler?: Function;
-  serviceName?: string;
+  serviceName?: MozServices;
 };
 
 const ResetPasswordConfirmed = ({

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -7,9 +7,10 @@ import { RouteComponentProps, useNavigate } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../../lib/metrics';
 import Ready from '../../../components/Ready';
+import { MozServices } from '../../../lib/types';
 
 type ResetPasswordWithRecoveryKeyVerifiedProps = {
-  serviceName?: string;
+  serviceName?: MozServices;
 };
 
 const ResetPasswordWithRecoveryKeyVerified = ({

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
@@ -31,10 +31,8 @@ describe('SigninBounced', () => {
     screen.getByRole('heading', {
       name: 'Sorry. We’ve locked your\xa0account.',
     });
-    // 'let us know' is what is visible when the user reads this visually.
-    // 'Opens in new window' is text appended automatically by the LinkExternal component for screenreaders
     const supportLink = screen.getByRole('link', {
-      name: 'let us know Opens in new window',
+      name: /let us know/,
     });
     expect(supportLink).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
@@ -5,10 +5,11 @@
 import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
+import { MozServices } from '../../../lib/types';
 
 type SigninConfirmedProps = {
   continueHandler?: Function;
-  serviceName?: string;
+  serviceName?: MozServices;
 };
 
 const SigninConfirmed = ({

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -42,10 +42,8 @@ describe('PageSigninRecoveryCode', () => {
 
     screen.getByRole('button', { name: 'Confirm' });
     screen.getByRole('link', { name: 'Back' });
-    // 'Opens in new window' is sr-only text added by the LinkExternal component
-    // This should always be included for accessibility
     screen.getByRole('link', {
-      name: 'Are you locked out? Opens in new window',
+      name: /Are you locked out?/,
     });
   });
 
@@ -53,7 +51,7 @@ describe('PageSigninRecoveryCode', () => {
     render(<SigninRecoveryCode serviceName={MOCK_SERVICE} />);
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      'Enter backup authentication code to continue to Example Service'
+      `Enter backup authentication code to continue to ${MOCK_SERVICE}`
     );
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -13,8 +13,9 @@ import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ReactComponent as RecoveryCodesImg } from './graphic_recovery_codes.svg';
 import CardHeader from '../../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { MozServices } from '../../../lib/types';
 
-export type SigninRecoveryCodeProps = { serviceName?: string };
+export type SigninRecoveryCodeProps = { serviceName?: MozServices };
 
 type FormData = {
   recoveryCode: string;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/mocks.tsx
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_SERVICE = 'Example Service';
+import { MozServices } from '../../../lib/types';
+
+export const MOCK_SERVICE = MozServices.MozillaVPN;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -43,7 +43,7 @@ describe('Sign in with TOTP code page', () => {
     render(<SigninTotpCode serviceName={MOCK_SERVICE} />);
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      'Enter security code to continue to Example Service'
+      `Enter security code to continue to ${MOCK_SERVICE}`
     );
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -7,15 +7,16 @@ import { useForm } from 'react-hook-form';
 import { RouteComponentProps } from '@reach/router';
 import InputText from '../../../components/InputText';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver } from '../../../models/hooks';
+// import { useFtlMsgResolver } from '../../../models/hooks';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 // import { useAlertBar } from '../../models';
 import { ReactComponent as TwoFactorImg } from './graphic_two_factor_auth.svg';
 import CardHeader from '../../../components/CardHeader';
+import { MozServices } from '../../../lib/types';
 
 // --serviceName-- is the relying party
 
-export type SigninTotpCodeProps = { serviceName?: string };
+export type SigninTotpCodeProps = { serviceName?: MozServices };
 
 type FormData = {
   confirmationCode: string;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_SERVICE = 'Example Service';
+import { MozServices } from '../../../lib/types';
+
+export const MOCK_SERVICE = MozServices.MozillaVPN;

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
@@ -40,7 +40,7 @@ describe('PrimaryEmailVerified page', () => {
   it('show the service name when it is passed in', () => {
     render(<PrimaryEmailVerified isSignedIn serviceName={MOCK_SERVICE} />);
 
-    screen.getByText('You’re now ready to use Example Service');
+    screen.getByText(`You’re now ready to use ${MOCK_SERVICE}`);
   });
 
   it('emits the expected metrics on render', () => {

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
@@ -5,9 +5,10 @@
 import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
+import { MozServices } from '../../../lib/types';
 
 export type PrimaryEmailVerifiedProps = {
-  serviceName?: string;
+  serviceName?: MozServices;
   isSignedIn?: boolean;
 };
 

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/mocks.tsx
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_SERVICE = 'Example Service';
+import { MozServices } from '../../../lib/types';
+
+export const MOCK_SERVICE = MozServices.MozillaVPN;

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
@@ -5,10 +5,11 @@
 import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
+import { MozServices } from '../../../lib/types';
 
 type SignupConfirmedProps = {
   continueHandler?: Function;
-  serviceName?: string;
+  serviceName?: MozServices;
 };
 
 const SignupConfirmed = ({


### PR DESCRIPTION
Because:
* We're converting content-server routes into React routes by extending settings

This commit:
* Creates the React version of the '/cookies_disabled' page including tests, stories, metrics events, and functionality
* Adds this route to the simpleRoutes list to be served by the React app, edits router.js to send in flow params
* Modifies LinkExternal related tests to test for "Opens in new window" in one place
* Modifies 'CardHeader' to take in a basic heading, updates many related serviceNames to MozService enum

closes FXA-6645

---

To test this, go to `about:config` and flip `dom.storage.enabled` to `false`. To check the existing functionality, hit `localhost:3030/`, see the redirect, click "try again", and see the error. Flip the config on, click "try again", and... well, nothing happens. This appears to be a bug in content-server.¹

To test the new page, flip the config back off and hit `http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`. See the redirect to `/cookies_disabled`. Click “Try again” and see the error message. Flip the config on, and see you're taken back to the page prior to hitting `localhost:3030`.² You can try flipping the config back off and hitting the page directly with `localhost:3030/cookies_disabled?showReactApp=true` as well and see the same behavior.

²This also feels like a bug, as I would expect to go back to `localhost:3030`. This can be fixed by modifying `app-start.js` - check [this line](https://github.com/mozilla/fxa/blob/1e75dac5351a165398760f4c06319efcb19dca0a/packages/fxa-content-server/app/scripts/lib/app-start.js#L610) which exclusively removes an item from the history. At first I thought this was a bug that would also fix ¹ and so I adjusted this to check for `cookies_disabled` but.. we purposefully do this. Otherwise, users can be redirected to `cookies_disabled`, and then just click "back" and be at `localhost:3030` like nothing happened. Plus, the bug in content-server persisted anyway. I think we can achieve what we want when we fully switch to the React app, but, not while we're still using `app-start.js`. Also, If you disable cookies, the entire app breaks and we actually don’t even have a check for cookies on the page itself when clicking on “try again” in the old version of this page. I’ve filed FXA-6704 with a note about these things.

Before: 
![image](https://user-images.githubusercontent.com/13018240/215535650-a80db13f-9ad5-4524-8fab-cbfb4387d3b8.png)

After (I got approval for this altered error copy from Vesta):
![image](https://user-images.githubusercontent.com/13018240/215549474-28f43562-a405-4433-97d2-2fad6ece8776.png)
