### PR TITLE
storybook(fxa-settings): add inline_totp_setup to storybook

### DIFF
--- a/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
@@ -1,0 +1,42 @@
+## InlineTotpSetup page
+## TOTP (time-based one-time password) is a form of two-factor authentication (2FA).
+
+inline-totp-setup-cancel-setup-button = Cancel setup
+inline-totp-setup-continue-button = Continue
+
+# <authenticationAppsLink> links to a list of security apps
+inline-totp-setup-add-security-link = Add a layer of security to your account by requiring authentication codes from one of <authenticationAppsLink>these authentication apps</authenticationAppsLink>.
+
+#  The <enable2StepDefaultSpan> elements are just visual separation here
+inline-totp-setup-enable-two-step-authentication-default-header = Enable two-step authentication <enable2StepDefaultSpan>to continue to account settings</enable2StepDefaultSpan>
+
+# { $serviceName } is the name of the service which the user wants to authenticate to. The <enable2StepCustomServiceSpan> elements are just visual separation
+inline-totp-setup-enable-two-step-authentication-custom-header = Enable two-step authentication <enable2StepCustomServiceSpan>to continue to { $serviceName }</enable2StepCustomServiceSpan>
+
+inline-totp-setup-ready-button = Ready
+
+# The authentication code a user is scanning is a QR code.
+# { $serviceName } is the name of the service which the user wants to authenticate to. The <scanAuthCodeHeaderSpan> elements are just visual separation
+inline-totp-setup-show-qr-custom-service-header = Scan authentication code <scanAuthCodeHeaderSpan>to continue to { $serviceName }</scanAuthCodeHeaderSpan>
+
+# { $serviceName } is the name of the service which the user wants to authenticate to. The <enterCodeManuallyHeaderSpan> elements are just visual separation
+inline-totp-setup-no-qr-custom-service-header = Enter code manually <enterCodeManuallyHeaderSpan>to continue to { $serviceName }</enterCodeManuallyHeaderSpan>
+
+# The authentication code a user is scanning is a QR code.
+# The <scanAuthHeaderSpan> elements are just visual separation
+inline-totp-setup-show-qr-default-service-header = Scan authentication code <scanAuthHeaderSpan>to continue to account settings</scanAuthHeaderSpan>
+
+# The <enterCodeManuallyHeaderSpan> elements are just visual separation
+inline-totp-setup-no-qr-default-service-header = Enter code manually <enterCodeManuallyHeaderSpan>to continue to account settings</enterCodeManuallyHeaderSpan>
+
+# The <toggleToQRButton> allows the user to use a QR code instead of manually entering a secret key
+inline-totp-setup-enter-key-or-use-qr-instructions = Type this secret key into your authentication app. <toggleToQRButton>Scan QR code instead?</toggleToQRButton>
+
+# The <toggleToManualModeButton> allows the user to manually enter a secret key instead of scanning a QR code
+inline-totp-setup-use-qr-or-enter-key-instructions = Scan the QR code in your authentication app and then enter the authentication code it provides. <toggleToManualModeButton>Can’t scan code?</toggleToManualModeButton>
+
+# The "authentication code" here refers to the code provided by an authentication app.
+inline-totp-setup-on-completion-description = Once complete, it will begin generating authentication codes for you to enter.
+
+# The "authentication code" here refers to the code provided by an authentication app.
+inline-totp-setup-security-code-placeholder = Authentication code

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import InlineTotpSetup from '.';
+import { Meta } from '@storybook/react';
+import { MozServices } from '../../lib/types';
+import AppLayout from '../../components/AppLayout';
+import { MOCK_CODE, MOCK_EMAIL } from './mocks';
+
+export default {
+  title: 'pages/InlineTotpSetup',
+  component: InlineTotpSetup,
+} as Meta;
+
+export const Default = () => (
+  <AppLayout>
+    <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
+  </AppLayout>
+);
+
+export const WithCustomService = () => (
+  <AppLayout>
+    <InlineTotpSetup
+      code={MOCK_CODE}
+      email={MOCK_EMAIL}
+      serviceName={MozServices.FirefoxMonitor}
+    />
+  </AppLayout>
+);

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, render, fireEvent } from '@testing-library/react';
+// import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+// import { FluentBundle } from '@fluent/bundle';
+import InlineTotpSetup from '.';
+import { logPageViewEvent } from '../../lib/metrics';
+import { MozServices } from '../../lib/types';
+import { MOCK_CODE, MOCK_EMAIL } from './mocks';
+
+jest.mock('../../lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+  logPageViewEvent: jest.fn(),
+}));
+
+describe('InlineTotpSetup', () => {
+  // let bundle: FluentBundle;
+  beforeAll(async () => {
+    global.URL.createObjectURL = jest.fn();
+    //   bundle = await getFtlBundle('settings');
+  });
+  it('renders default as expected', () => {
+    render(<InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />);
+    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
+    // testL10n(ftlMsgMock, bundle, {
+    //   email: exampleEmail,
+    // });
+    screen.getByRole('heading', {
+      name: `Enable two-step authentication to continue to ${MozServices.Default}`,
+    });
+    expect(
+      screen.getByLabelText('A device with a hidden 6-digit code.')
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Continue' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel setup' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders intro view as expected with custom service name', () => {
+    render(
+      <InlineTotpSetup
+        code={MOCK_CODE}
+        email={MOCK_EMAIL}
+        serviceName={MozServices.FirefoxMonitor}
+      />
+    );
+    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
+    // testL10n(ftlMsgMock, bundle, {
+    //   email: exampleEmail,
+    // });
+    screen.getByRole('heading', {
+      name: `Enable two-step authentication to continue to ${MozServices.FirefoxMonitor}`,
+    });
+    expect(
+      screen.getByLabelText('A device with a hidden 6-digit code.')
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Continue' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel setup' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders QR code by default when a user clicks "Continue"', async () => {
+    render(<InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />);
+    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
+    // testL10n(ftlMsgMock, bundle, {
+    //   email: exampleEmail,
+    // });
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+    fireEvent.click(continueButton);
+    await screen.findByAltText(
+      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+    );
+  });
+
+  it('toggles from QR code to manual secret code view when user clicks "Can\'t scan code"', async () => {
+    render(<InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />);
+    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
+    // testL10n(ftlMsgMock, bundle, {
+    //   email: exampleEmail,
+    // });
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+    fireEvent.click(continueButton);
+    await screen.findByAltText(
+      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+    );
+
+    const changeToManualModeButton = screen.getByRole('button', {
+      name: 'Can’t scan code?',
+    });
+    fireEvent.click(changeToManualModeButton);
+    await screen.findByRole('button', { name: 'Scan QR code instead?' });
+  });
+
+  it('toggles from secret code to QR code view when user clicks "Scan QR code instead?', async () => {
+    render(<InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />);
+    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
+    // testL10n(ftlMsgMock, bundle, {
+    //   email: exampleEmail,
+    // });
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+    fireEvent.click(continueButton);
+    await screen.findByAltText(
+      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+    );
+    const changeToManualModeButton = screen.getByRole('button', {
+      name: 'Can’t scan code?',
+    });
+    fireEvent.click(changeToManualModeButton);
+    await screen.findByRole('button', { name: 'Scan QR code instead?' });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Scan QR code instead?' })
+    );
+    await screen.findByAltText(
+      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+    );
+  });
+
+  it('emits the expected metrics on render', () => {
+    render(<InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />);
+    expect(logPageViewEvent).toHaveBeenCalledWith('inline-totp-setup', {
+      entrypoint_variation: 'react',
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -1,0 +1,288 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import classNames from 'classnames';
+import { MozServices } from '../../lib/types';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { useFtlMsgResolver } from '../../models';
+import { logPageViewEvent } from '../../lib/metrics';
+import { ReactComponent as TwoFactorImg } from '../Signin/SigninTotpCode/graphic_two_factor_auth.svg';
+import CardHeader from '../../components/CardHeader';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import FormVerifyCode from '../../components/FormVerifyCode';
+
+type InlineTotpSetupProps = {
+  code: string;
+  email: string;
+  serviceName?: MozServices;
+};
+
+export const InlineTotpSetup = ({
+  code,
+  email,
+  serviceName,
+}: InlineTotpSetupProps) => {
+  logPageViewEvent('inline-totp-setup', { entrypoint_variation: 'react' });
+
+  /*
+   * TODO:
+   *  - Write functionality to get TOTP token from account
+   *  - get secret and QR code image src from totp token
+   *  - add in success and error messages (with Banner component)
+   *  - add in actions for `Cancel` `Ready` etc
+   *  - fetch code here if that's preferable
+   */
+
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedQRCodeAltText = ftlMsgResolver.getMsg(
+    'tfa-qr-code-alt',
+    `Use the code ${code} to set up two-step authentication in supported applications.`,
+    { code }
+  );
+  const localizedTwoFactorImgAriaLabel = ftlMsgResolver.getMsg(
+    'signin-totp-code-image-label',
+    'A device with a hidden 6-digit code.'
+  );
+  const [secret, setSecret] = useState<string>();
+  const [qrCodeSrc, setQRCodeSrc] = useState<string>();
+  const [showIntro, setShowIntro] = useState(true);
+  const [totpCodeValue, setTotpCodeValue] = useState('');
+  const [showQR, setShowQR] = useState(true);
+  const [totpErrorMessage, setTotpErrorMessage] = useState('');
+
+  type FormData = {
+    confirmationCode: string;
+  };
+
+  const { handleSubmit } = useForm<FormData>({
+    mode: 'onBlur',
+    criteriaMode: 'all',
+    defaultValues: {
+      confirmationCode: '',
+    },
+  });
+
+  const onSubmit = () => {
+    if (!totpCodeValue) {
+      // TODO: Add l10n for this string
+      // Holding on l10n pending product decision
+      // See FXA-6422, and discussion on PR-14744
+      setTotpErrorMessage('Backup authentication code required');
+    }
+    try {
+      // Check security code
+      // logViewEvent('flow', inline-totp-setup.submit, {
+      //   entrypoint_variation: 'react',
+      //  });
+    } catch (e) {
+      // TODO: error handling, error message confirmation
+      //       - use the Banner component
+      // const errorInlineTotpSetup = ftlMsgResolver.getMsg(
+      //   'inline-totp-setup-error-general',
+      //   'Invalid confirmation code'
+      // );
+    }
+  };
+
+  return (
+    <>
+      {showIntro && (
+        <>
+          <CardHeader
+            headingText="Enable two-step authentication"
+            headingWithCustomServiceFtlId="inline-totp-setup-enable-two-step-authentication-custom-header"
+            headingWithDefaultServiceFtlId="inline-totp-setup-enable-two-step-authentication-default-header"
+            {...{ serviceName }}
+          />
+          <section className="flex flex-col items-center">
+            <TwoFactorImg
+              className="w-1/2"
+              role="img"
+              aria-label={localizedTwoFactorImgAriaLabel}
+            />
+            <FtlMsg
+              id="inline-totp-setup-add-security-link"
+              elems={{
+                authenticationAppsLink: (
+                  <LinkExternal
+                    className="link-blue text-sm"
+                    href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                  >
+                    these authentication apps
+                  </LinkExternal>
+                ),
+              }}
+            >
+              <p className="text-sm">
+                Add a layer of security to your account by requiring
+                authentication codes from one of{' '}
+                <LinkExternal
+                  className="link-blue text-sm"
+                  href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                >
+                  these authentication apps
+                </LinkExternal>
+                .
+              </p>
+            </FtlMsg>
+            <button
+              type="submit"
+              className="cta-primary cta-xl w-full my-4"
+              onClick={() => {
+                // TODO: Add in any further functionality here
+                setShowIntro(false);
+              }}
+            >
+              <FtlMsg id="inline-totp-setup-continue-button">Continue</FtlMsg>
+            </button>
+            <button type="button" className="link-blue text-sm">
+              <FtlMsg id="inline-totp-setup-cancel-setup-button">
+                Cancel setup
+              </FtlMsg>
+            </button>
+          </section>
+        </>
+      )}
+      {!showIntro && (
+        <>
+          {showQR ? (
+            <CardHeader
+              headingText="Scan authentication code"
+              headingWithCustomServiceFtlId="inline-totp-setup-show-qr-custom-service-header"
+              headingWithDefaultServiceFtlId="inline-totp-setup-show-qr-default-service-header"
+              {...{ serviceName }}
+            />
+          ) : (
+            <CardHeader
+              headingText="Enter code manually"
+              headingWithCustomServiceFtlId="inline-totp-setup-no-qr-custom-service-header"
+              headingWithDefaultServiceFtlId="inline-totp-setup-no-qr-default-service-header"
+              {...{ serviceName }}
+            />
+          )}
+          <section>
+            <form noValidate>
+              <div id="totp" className="totp-details">
+                {showQR ? (
+                  <>
+                    <FtlMsg
+                      id="inline-totp-setup-use-qr-or-enter-key-instructions"
+                      elems={{
+                        toggleToManualModeButton: (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setShowQR(false);
+                            }}
+                            className="link-blue inline"
+                          >
+                            Can’t scan code?
+                          </button>
+                        ),
+                      }}
+                    >
+                      <p className="text-sm mb-4">
+                        Scan the QR code in your authentication app and then
+                        enter the authentication code it provides.{' '}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setShowQR(false);
+                          }}
+                          className="link-blue inline"
+                        >
+                          Can’t scan code?
+                        </button>
+                      </p>
+                    </FtlMsg>
+                    <div>
+                      <img
+                        className={classNames({
+                          hidden: !qrCodeSrc,
+                        })}
+                        alt={localizedQRCodeAltText}
+                        src={qrCodeSrc}
+                      />
+                    </div>
+                    <FtlMsg id="inline-totp-setup-on-completion-description">
+                      <p className="text-sm mb-4">
+                        Once complete, it will begin generating authentication
+                        codes for you to enter.
+                      </p>
+                    </FtlMsg>
+                  </>
+                ) : (
+                  <>
+                    <FtlMsg
+                      id="inline-totp-setup-enter-key-or-use-qr-instructions"
+                      elems={{
+                        toggleToQRButton: (
+                          <button
+                            onClick={() => {
+                              setShowQR(true);
+                            }}
+                            className="link-blue inline"
+                          >
+                            Scan QR code instead?
+                          </button>
+                        ),
+                      }}
+                    >
+                      <p className="text-sm m-2">
+                        Type this secret key into your authentication app.{' '}
+                        <button
+                          onClick={() => {
+                            setShowQR(true);
+                          }}
+                          className="link-blue inline"
+                        >
+                          Scan QR code instead?
+                        </button>
+                      </p>
+                    </FtlMsg>
+                    <div className="qr-code-container">
+                      <div className="qr-code-text">{secret}</div>
+                    </div>
+                    <FtlMsg id="inline-totp-setup-on-completion-description">
+                      <p className="text-sm mb-4">
+                        Once complete, it will begin generating authentication
+                        codes for you to enter.
+                      </p>
+                    </FtlMsg>
+                  </>
+                )}
+                <FormVerifyCode
+                  viewName="inline_totp_setup"
+                  email={email}
+                  onSubmit={handleSubmit(onSubmit)}
+                  formAttributes={{
+                    inputLabelText: 'Authentication code',
+                    inputFtlId: 'inline-totp-setup-security-code-placeholder',
+                    pattern: 'd{6}',
+                    maxLength: 6,
+                    submitButtonText: 'Ready',
+                    submitButtonFtlId: 'inline-totp-setup-ready-button',
+                  }}
+                  code={totpCodeValue}
+                  setCode={setTotpCodeValue}
+                  codeErrorMessage={totpErrorMessage}
+                  setCodeErrorMessage={setTotpErrorMessage}
+                />
+                <button className="link-blue text-sm mt-4">
+                  <FtlMsg id="inline-totp-setup-cancel-setup-button">
+                    Cancel setup
+                  </FtlMsg>
+                </button>
+              </div>
+            </form>
+          </section>
+        </>
+      )}
+    </>
+  );
+};
+
+export default InlineTotpSetup;

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
@@ -1,0 +1,2 @@
+export const MOCK_CODE = '123456';
+export const MOCK_EMAIL = 'example@example.com';


### PR DESCRIPTION
## Because:

* We're converting the remaining Backbone views to React. The first step in doing so is to recreate them in React and house the React versions in the fxa settings storybook.

## This commit:

* Recreates the UI elements of inline_totp_setup in React, with localization and tests.

Closes #https://mozilla-hub.atlassian.net/browse/FXA-6629

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="542" alt="Screen Shot 2023-01-31 at 2 36 05 PM" src="https://user-images.githubusercontent.com/11150372/215899496-46f7b956-9e30-443c-8f2f-30c693c0dc31.png">

<img width="535" alt="Screen Shot 2023-01-31 at 2 36 16 PM" src="https://user-images.githubusercontent.com/11150372/215899515-761862bf-0013-477f-80ee-4fda3ca2c10a.png">
## Other information (Optional)

I still need to add events into the metrics doc!
Also, this does *not* implement either getting the code needed, or getting the QR code, so there is no display of either.
