### PR TITLE
fix(payments): display Invoice Amount In Payment Confirmation

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -10,6 +10,7 @@ import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { Meta } from '@storybook/react';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export default {
   title: 'components/PaymentConfirmation',
@@ -79,14 +80,12 @@ const customer: Customer = {
 
 const productUrl = 'https://mozilla.org';
 
-const coupon: CouponDetails = {
-  discountAmount: 200,
-  promotionCode: 'TEST',
-  type: '',
-  durationInMonths: 1,
-  valid: true,
-  expired: false,
-  maximallyRedeemed: false,
+const invoice: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
 };
 
 const storyWithProps = (
@@ -141,10 +140,10 @@ export const WithPasswordlessAccount = storyWithProps({
   accountExists: false,
 });
 
-export const WithCoupon = storyWithProps({
+export const WithInvoicePreview = storyWithProps({
   profile: userProfile,
   selectedPlan: selectedPlan,
   customer: PAYPAL_CUSTOMER,
   productUrl: productUrl,
-  coupon: coupon,
+  invoice: invoice,
 });

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -10,9 +10,9 @@ import { MOCK_PLANS, getLocalizedMessage } from '../../lib/test-utils';
 import { getFtlBundle } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import AppContext, { defaultAppContext } from '../../lib/AppContext';
-import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import { updateConfig } from '../../lib/config';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 const userProfile = {
   avatar: './avatar.svg',
@@ -132,14 +132,12 @@ const paypalCustomer: Customer = {
   ],
 };
 
-const coupon: CouponDetails = {
-  discountAmount: 200,
-  promotionCode: 'TEST',
-  type: '',
-  durationInMonths: 1,
-  valid: true,
-  expired: false,
-  maximallyRedeemed: false,
+const invoice: FirstInvoicePreview = {
+  line_items: [],
+  subtotal: 0,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
 };
 
 afterEach(() => {
@@ -329,7 +327,7 @@ describe('PaymentConfirmation', () => {
     expect(queryByText(defaultButtonLabel)).not.toBeInTheDocument();
   });
 
-  it('renders with a discounted amount when coupon is present', () => {
+  it('renders with the invoice total amount when an invoice is present', () => {
     const subject = () => {
       return render(
         <AppContext.Provider value={{ ...defaultAppContext }}>
@@ -339,7 +337,7 @@ describe('PaymentConfirmation', () => {
               selectedPlan,
               customer,
               productUrl,
-              coupon,
+              invoice,
             }}
           />
         </AppContext.Provider>

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -15,7 +15,7 @@ import './index.scss';
 import { uiContentFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
 import { AppContext } from '../../lib/AppContext';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
-import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type PaymentConfirmationProps = {
   customer: Customer;
@@ -23,7 +23,7 @@ export type PaymentConfirmationProps = {
   selectedPlan: Plan;
   productUrl: string;
   accountExists?: boolean;
-  coupon?: CouponDetails;
+  invoice?: FirstInvoicePreview;
 };
 
 export const PaymentConfirmation = ({
@@ -32,7 +32,7 @@ export const PaymentConfirmation = ({
   selectedPlan,
   productUrl,
   accountExists = true,
-  coupon,
+  invoice,
 }: PaymentConfirmationProps) => {
   const { config, navigatorLanguages } = useContext(AppContext);
   const { amount, currency, interval, interval_count, product_name } =
@@ -54,10 +54,7 @@ export const PaymentConfirmation = ({
     day: 'numeric',
   });
 
-  const finalAmount =
-    coupon && coupon.discountAmount && amount
-      ? amount - coupon.discountAmount
-      : amount;
+  const finalAmount = invoice && amount ? invoice.total : amount;
   const planPrice = formatPlanPricing(
     finalAmount,
     currency,

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -36,6 +36,7 @@ export type PlanDetailsProps = {
   className?: string;
   coupon?: CouponDetails;
   invoicePreview?: FirstInvoicePreview;
+  setInvoice?: (invoice: FirstInvoicePreview) => void;
 };
 
 export const PlanDetails = ({
@@ -45,6 +46,7 @@ export const PlanDetails = ({
   showExpandButton = false,
   coupon,
   invoicePreview,
+  setInvoice,
 }: PlanDetailsProps) => {
   const { navigatorLanguages, config } = useContext(AppContext);
   const [detailsHidden, setDetailsState] = useState(showExpandButton);
@@ -138,6 +140,10 @@ export const PlanDetails = ({
         }
         const latestInvoicePreview = invoice.current;
 
+        if (setInvoice) {
+          setInvoice(latestInvoicePreview);
+        }
+
         const price = formatPlanPricing(
           latestInvoicePreview.total as unknown as number,
           currency,
@@ -168,6 +174,7 @@ export const PlanDetails = ({
     interval_count,
     selectedPlan.plan_id,
     invoicePreview,
+    setInvoice,
   ]);
 
   return (

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { Plan, Customer, Profile } from '../../../store/types';
 import { AppContext } from '../../../lib/AppContext';
 
@@ -9,6 +9,7 @@ import PaymentConfirmation from '../../../components/PaymentConfirmation';
 import Header from '../../../components/Header';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import CouponForm from '../../../components/CouponForm';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 const defaultProductRedirectURL = 'https://mozilla.org';
 
@@ -41,6 +42,8 @@ export const SubscriptionSuccess = ({
     featureFlags.useFirestoreProductConfigs
   );
 
+  const [invoice, setInvoice] = useState<FirstInvoicePreview>();
+
   const productUrl =
     successActionButton ||
     productRedirectURLs[product_id] ||
@@ -57,7 +60,7 @@ export const SubscriptionSuccess = ({
             customer: customer,
             productUrl,
             accountExists,
-            coupon,
+            invoice,
           }}
         />
 
@@ -69,6 +72,7 @@ export const SubscriptionSuccess = ({
               isMobile,
               showExpandButton: isMobile,
               coupon: coupon,
+              setInvoice: setInvoice,
             }}
           />
 


### PR DESCRIPTION
Because:

* we were only taking into account the plan amount and potential discount amount in the payment confirmation component, we were displaying the wrong price if taxes are applied

This commit:

* passes in the invoice fetched from the plan details component rather than the coupon, this will take into account the plan price, potential discount amount, and applicable taxes

Closes #FXA-6364

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

