### PR TITLE
feat(react): Update reset password react view to use gql

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -159,7 +159,7 @@ Router = Router.extend({
         {
           // HACK: this page uses the history API to navigate back and must go back one page
           // further if being redirected from content-server. Flow params are not always
-          // available to check against so we explicitely send in an additional param.
+          // available to check against, so we explicitly send in an additional param.
           contentRedirect: true,
         }
       );
@@ -249,7 +249,14 @@ Router = Router.extend({
       type: VerificationReasons.PRIMARY_EMAIL_VERIFIED,
     }),
     'report_signin(/)': createViewHandler(ReportSignInView),
-    'reset_password(/)': createViewHandler(ResetPasswordView),
+
+    'reset_password(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'reset_password',
+        ResetPasswordView
+      );
+    },
+
     'reset_password_confirmed(/)': createViewHandler(ReadyView, {
       type: VerificationReasons.PASSWORD_RESET,
     }),

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -26,7 +26,7 @@ const getReactRouteGroups = (showReactApp, isServer = true) => {
 
     resetPasswordRoutes: {
       featureFlagOn: showReactApp.resetPasswordRoutes,
-      routes: [],
+      routes: reactRoute.getRoutes(['reset_password']),
     },
 
     oauthRoutes: {

--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -31,7 +31,7 @@ export class FtlMsgResolver {
    *  - There are no missing parameters
    *  - There are no straight quotes
    *
-   * Note, this requires that the default 'en' bundle was loaded and is a available.
+   * Note, this requires that the default 'en' bundle was loaded and is available.
    *
    * @param id - The id of the message to fetch
    * @param fallbackText - The fallback text for the message

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -11,6 +11,7 @@ import { QueryParams } from '../..';
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
 import Clear from '../../pages/Clear';
 import CookiesDisabled from '../../pages/CookiesDisabled';
+import ResetPassword from '../../pages/ResetPassword';
 
 export const App = ({
   flowQueryParams,
@@ -30,6 +31,7 @@ export const App = ({
               <CannotCreateAccount path="/cannot_create_account/*" />
               <Clear path="/clear/*" />
               <CookiesDisabled path="/cookies_disabled/*" />
+              <ResetPassword path="/reset_password/*" />
             </>
           )}
 

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
@@ -7,7 +7,7 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { Link } from '@reach/router';
 
 export type LinkRememberPasswordProps = {
-  email: string;
+  email?: string;
   forceAuth?: boolean;
 };
 
@@ -15,16 +15,15 @@ const LinkRememberPassword = ({
   email,
   forceAuth,
 }: LinkRememberPasswordProps) => {
-  const linkTarget = forceAuth ? '/force_auth' : '/signin';
-
+  const linkTarget = `${forceAuth ? '/force_auth' : '/signin'}`;
+  let target = linkTarget;
+  if (email) {
+    target = `${linkTarget}?email=${encodeURIComponent(email)}`;
+  }
   return (
     <div className="text-sm mt-6">
       <FtlMsg id="remember-pw-link">
-        <Link
-          to={`${linkTarget}?email=${encodeURIComponent(email)}`}
-          className="link-blue text-sm"
-          id="remember-password"
-        >
+        <Link to={target} className="link-blue text-sm" id="remember-password">
           Remember your password? Sign in
         </Link>
       </FtlMsg>

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
@@ -5,7 +5,6 @@
 import { RouteComponentProps } from '@reach/router';
 
 import FlowContainer from '../FlowContainer';
-import { useLocalization } from '@fluent/react';
 import { useAccount, useFtlMsgResolver } from '../../../models';
 import { SecurityEvent as SecurityEventSection } from './SecurityEvent';
 import React, { useState, useEffect } from 'react';
@@ -13,8 +12,6 @@ import React, { useState, useEffect } from 'react';
 export const PageRecentActivity = (_: RouteComponentProps) => {
   const account = useAccount();
   const [securityEvents, setSecurityEvents] = useState(account.securityEvents);
-
-  const { l10n } = useLocalization();
 
   useEffect(() => {
     (async () => {

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -16,5 +16,7 @@ auth-error-138-2 = Unconfirmed session
 auth-error-139 = Secondary email must be different than your account email
 auth-error-155 = TOTP token not found
 auth-error-183-2 = Invalid or expired confirmation code
+auth-error-999 = Unexpected error
 auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different
+

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -18,9 +18,7 @@ export default {
 const storyWithProps = ({ ...props }) => {
   const story = () => (
     <LocationProvider>
-      <AppLayout>
-        <ResetPassword {...props} />
-      </AppLayout>
+      <ResetPassword {...props} />
     </LocationProvider>
   );
   return story;
@@ -35,8 +33,4 @@ export const WithServiceName = storyWithProps({
 export const WithForceAuth = storyWithProps({
   prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
   forceAuth: true,
-});
-
-export const CanGoBack = storyWithProps({
-  canGoBack: true,
 });


### PR DESCRIPTION
## Because

- We need to add the functionality to initate password reset

## This pull request

- Adds the gql resolver to password reset react view

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6123

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This PR also removes the `canGoBack` logic from password reset. Using the browser back navigation does the same.