### PR TITLE
refactor(react): Export viewNames for tests, add entrypoint const

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -277,25 +277,25 @@ const EVENTS = {
     event: 'view',
   },
 
-  'screen.cannot_create_account': {
+  'screen.cannot-create-account': {
     group: GROUPS.registration,
     event: 'cannot_create_account_view',
   },
 
   // cookies_disabled
-  'screen.cookies_disabled': {
+  'screen.cookies-disabled': {
     group: GROUPS.activity,
     event: 'cookies_disabled_view',
   },
-  'cookies_disabled.submit': {
+  'flow.cookies-disabled.submit': {
     group: GROUPS.activity,
     event: 'cookies_disabled_submit',
   },
-  'cookies_disabled.success': {
+  'flow.cookies-disabled.success': {
     group: GROUPS.activity,
     event: 'cookies_disabled_success',
   },
-  'cookies_disabled.fail': {
+  'flow.cookies-disabled.fail': {
     group: GROUPS.activity,
     event: 'cookies_disabled_fail',
   },

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -227,8 +227,8 @@ registerSuite('amplitude', {
       );
     },
 
-    'screen.cannot_create_account': () => {
-      createAmplitudeEvent('screen.cannot_create_account');
+    'screen.cannot-create-account': () => {
+      createAmplitudeEvent('screen.cannot-create-account');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
@@ -237,8 +237,8 @@ registerSuite('amplitude', {
       );
     },
 
-    'screen.cookies_disabled': () => {
-      createAmplitudeEvent('screen.cookies_disabled');
+    'screen.cookies-disabled': () => {
+      createAmplitudeEvent('screen.cookies-disabled');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
@@ -247,8 +247,8 @@ registerSuite('amplitude', {
       );
     },
 
-    'cookies_disabled.submit': () => {
-      createAmplitudeEvent('cookies_disabled.submit');
+    'flow.cookies_disabled.submit': () => {
+      createAmplitudeEvent('flow.cookies-disabled.submit');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
@@ -258,7 +258,7 @@ registerSuite('amplitude', {
     },
 
     'cookies_disabled.success': () => {
-      createAmplitudeEvent('cookies_disabled.success');
+      createAmplitudeEvent('flow.cookies-disabled.success');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
@@ -268,7 +268,7 @@ registerSuite('amplitude', {
     },
 
     'cookies_disabled.fail': () => {
-      createAmplitudeEvent('cookies_disabled.fail');
+      createAmplitudeEvent('flow.cookies-disabled.fail');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import InputText from '../../components/InputText';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 export type FormAttributes = {
   inputLabelText: string;
@@ -46,9 +47,7 @@ const FormVerifyCode = ({
 
   const onFocus = () => {
     if (!isFocused && viewName) {
-      logViewEvent('flow', `${viewName}.engage`, {
-        entrypoint_variation: 'react',
-      });
+      logViewEvent('flow', `${viewName}.engage`, REACT_ENTRYPOINT);
       setIsFocused(true);
     }
   };

--- a/packages/fxa-settings/src/components/Ready/index.test.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.test.tsx
@@ -9,6 +9,7 @@ import { FluentBundle } from '@fluent/bundle';
 import Ready from '.';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -99,10 +100,8 @@ describe('Ready', () => {
   });
 
   it('emits a metrics event on render', () => {
-    render(<Ready viewName={viewName} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, {
-      entrypoint_variation: 'react',
-    });
+    render(<Ready {...{ viewName }} />);
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits a metrics event when a user clicks `Continue`', () => {
@@ -116,11 +115,12 @@ describe('Ready', () => {
       />
     );
     const passwordResetContinueButton = screen.getByText('Continue');
-    const clickViewName = `${viewName}`;
     const fullActionName = `${viewName}.continue`;
     fireEvent.click(passwordResetContinueButton);
-    expect(logViewEvent).toHaveBeenCalledWith(clickViewName, fullActionName, {
-      entrypoint_variation: 'react',
-    });
+    expect(logViewEvent).toHaveBeenCalledWith(
+      viewName,
+      fullActionName,
+      REACT_ENTRYPOINT
+    );
   });
 });

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -9,6 +9,7 @@ import { ReactComponent as PulseHearts } from './account-verified.svg';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { useFtlMsgResolver } from '../../models/hooks';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 // We'll actually be getting the isSignedIn value from a context when this is wired up.
 export type ReadyProps = {
@@ -65,9 +66,7 @@ const Ready = ({
   serviceName,
   viewName,
 }: ReadyProps & RouteComponentProps) => {
-  usePageViewEvent(viewName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const templateValues = getTemplateValues(viewName);
   const ftlMsgResolver = useFtlMsgResolver();
   const pulsingHeartsAltText = ftlMsgResolver.getMsg(
@@ -118,9 +117,7 @@ const Ready = ({
             className="cta-primary cta-base-p font-bold mx-2 flex-1"
             onClick={(e) => {
               const eventName = `${viewName}.continue`;
-              logViewEvent(viewName, eventName, {
-                entrypoint_variation: 'react',
-              });
+              logViewEvent(viewName, eventName, REACT_ENTRYPOINT);
               continueHandler(e);
             }}
           >

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -14,3 +14,4 @@ export const MDNLink = 'https://developer.mozilla.org/';
 export const HubsLink = 'https://hubs.mozilla.com/';
 export const SHOW_BALLOON_TIMEOUT = 500;
 export const HIDE_BALLOON_TIMEOUT = 400;
+export const REACT_ENTRYPOINT = { entrypoint_variation: 'react' };

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.test.tsx
@@ -4,13 +4,14 @@
 
 import React from 'react';
 import { screen, render } from '@testing-library/react';
-import { logPageViewEvent } from '../../lib/metrics';
-import CannotCreateAccount, { routeName } from '.';
+import { usePageViewEvent } from '../../lib/metrics';
+import CannotCreateAccount, { viewName } from '.';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
 }));
 
 describe('CannotCreateAccount', () => {
@@ -23,9 +24,7 @@ describe('CannotCreateAccount', () => {
     render(<CannotCreateAccount />);
     testAllL10n(screen, bundle);
 
-    expect(logPageViewEvent).toHaveBeenCalledWith(routeName, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
 
     screen.getByRole('heading', {
       name: 'Cannot create account',

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.tsx
@@ -8,19 +8,19 @@ import { RouteComponentProps } from '@reach/router';
 import AppLayout from '../../components/AppLayout';
 import CardHeader from '../../components/CardHeader';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { logPageViewEvent } from '../../lib/metrics';
+import { usePageViewEvent } from '../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../constants';
 
-export const routeName = 'cannot_create_account';
+export const viewName = 'cannot_create_account';
 
 const CannotCreateAccount = (_: RouteComponentProps) => {
   /* TODO: get serviceName from relier once FXA-6437 is complete. Or... rethink this issue
    * filed/fixed 8.5 years ago: https://github.com/mozilla/fxa-content-server/issues/1783
    * In some contexts, opening this link in a new tab was not ideal, so we previously set it
    * to open in a new tab _only_ if it was the Sync flow. Is this still true?
+   * Alternatively, do we want to always open this in the same tab since users are locked out?
    */
-  logPageViewEvent(routeName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
   return (
     <AppLayout>
       <CardHeader

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
@@ -3,14 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import CookiesDisabled, { routeName } from '.';
+import CookiesDisabled, { viewName } from '.';
 import { screen, render, fireEvent } from '@testing-library/react';
-import { logViewEvent, logPageViewEvent } from '../../lib/metrics';
+import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { FluentBundle } from '@fluent/bundle';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
 }));
 
@@ -60,9 +61,7 @@ describe('CookiesDisabled', () => {
 
     getTryAgainButton();
 
-    expect(logPageViewEvent).toHaveBeenCalledWith(routeName, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   describe('"Try again" button', () => {
@@ -97,24 +96,32 @@ describe('CookiesDisabled', () => {
     it('emits expected metrics events on success', () => {
       render(<CookiesDisabled />);
       fireEvent.click(getTryAgainButton());
-      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'submit', {
-        entrypoint_variation: 'react',
-      });
-      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'success', {
-        entrypoint_variation: 'react',
-      });
+      expect(logViewEvent).toHaveBeenCalledWith(
+        `flow.${viewName}`,
+        'submit',
+        REACT_ENTRYPOINT
+      );
+      expect(logViewEvent).toHaveBeenCalledWith(
+        `flow.${viewName}`,
+        'success',
+        REACT_ENTRYPOINT
+      );
     });
 
     it('emits expected metrics events on error', () => {
       setLocationSearch('?disable_local_storage=1');
       render(<CookiesDisabled />);
       fireEvent.click(getTryAgainButton());
-      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'submit', {
-        entrypoint_variation: 'react',
-      });
-      expect(logViewEvent).toHaveBeenCalledWith(routeName, 'fail', {
-        entrypoint_variation: 'react',
-      });
+      expect(logViewEvent).toHaveBeenCalledWith(
+        `flow.${viewName}`,
+        'submit',
+        REACT_ENTRYPOINT
+      );
+      expect(logViewEvent).toHaveBeenCalledWith(
+        `flow.${viewName}`,
+        'fail',
+        REACT_ENTRYPOINT
+      );
     });
 
     describe('goes back in history if localStorage and cookies are enabled', () => {

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.tsx
@@ -10,15 +10,14 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import Storage from '../../lib/storage';
 import Banner, { BannerType } from '../../components/Banner';
 import { searchParams } from '../../lib/utilities';
-import { logViewEvent, logPageViewEvent } from '../../lib/metrics';
+import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import CardHeader from '../../components/CardHeader';
+import { REACT_ENTRYPOINT } from '../../constants';
 
-export const routeName = 'cookies_disabled';
+export const viewName = 'cookies-disabled';
 
 const CookiesDisabled = (_: RouteComponentProps) => {
-  logPageViewEvent(routeName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   /* HACK / TODO when sunsetting content-server: if this page is hit through content-server's
    * router instead of hitting it directly via `/cookies_disabled?showReactApp=true`, which
@@ -30,18 +29,12 @@ const CookiesDisabled = (_: RouteComponentProps) => {
   const [stillDisabled, setStillDisabled] = useState(false);
 
   const buttonHandler = useCallback(() => {
-    logViewEvent(routeName, 'submit', {
-      entrypoint_variation: 'react',
-    });
+    logViewEvent(`flow.${viewName}`, 'submit', REACT_ENTRYPOINT);
     if (!Storage.isLocalStorageEnabled(window) || !navigator.cookieEnabled) {
-      logViewEvent(routeName, 'fail', {
-        entrypoint_variation: 'react',
-      });
+      logViewEvent(`flow.${viewName}`, 'fail', REACT_ENTRYPOINT);
       setStillDisabled(true);
     } else {
-      logViewEvent(routeName, 'success', {
-        entrypoint_variation: 'react',
-      });
+      logViewEvent(`flow.${viewName}`, 'success', REACT_ENTRYPOINT);
       if (contentRedirect) {
         window.history.go(-2);
       } else {

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
@@ -7,14 +7,14 @@ import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../models/mocks';
 // import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
-import InlineRecoverySetup from '.';
-import { logPageViewEvent } from '../../lib/metrics';
+import InlineRecoverySetup, { viewName } from '.';
+import { usePageViewEvent } from '../../lib/metrics';
 import { MOCK_RECOVERY_CODES, MOCK_SERVICE_NAME } from './mocks';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
-  logViewEvent: jest.fn(),
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
 }));
 
 describe('InlineRecoverySetup', () => {
@@ -130,8 +130,6 @@ describe('InlineRecoverySetup', () => {
         showConfirmation={false}
       />
     );
-    expect(logPageViewEvent).toHaveBeenCalledWith('inline-recovery-setup', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -4,13 +4,14 @@
 
 import React from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { logPageViewEvent } from '../../lib/metrics';
+import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
 import InputText from '../../components/InputText';
 import DataBlock from '../../components/DataBlock';
 import { ReactComponent as RecoveryCodesGraphic } from '../Signin/SigninRecoveryCode/graphic_recovery_codes.svg';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 export type InlineRecoverySetupProps = {
   isIOS?: boolean;
@@ -19,15 +20,15 @@ export type InlineRecoverySetupProps = {
   showConfirmation: boolean;
 };
 
+export const viewName = 'inline-recovery-setup';
+
 const InlineRecoverySetup = ({
   isIOS,
   recoveryCodes,
   serviceName,
   showConfirmation,
 }: InlineRecoverySetupProps & RouteComponentProps) => {
-  logPageViewEvent('inline-recovery-setup', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedInputTextLabel = ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -6,14 +6,15 @@ import React from 'react';
 import { screen, render, fireEvent } from '@testing-library/react';
 // import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
-import InlineTotpSetup from '.';
-import { logPageViewEvent } from '../../lib/metrics';
+import InlineTotpSetup, { viewName } from '.';
+import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { MOCK_CODE, MOCK_EMAIL } from './mocks';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
 }));
 
 describe('InlineTotpSetup', () => {
@@ -128,8 +129,6 @@ describe('InlineTotpSetup', () => {
 
   it('emits the expected metrics on render', () => {
     render(<InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />);
-    expect(logPageViewEvent).toHaveBeenCalledWith('inline-totp-setup', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -8,11 +8,12 @@ import classNames from 'classnames';
 import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
-import { logPageViewEvent } from '../../lib/metrics';
+import { usePageViewEvent } from '../../lib/metrics';
 import { ReactComponent as TwoFactorImg } from '../Signin/SigninTotpCode/graphic_two_factor_auth.svg';
 import CardHeader from '../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode from '../../components/FormVerifyCode';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 type InlineTotpSetupProps = {
   code: string;
@@ -20,12 +21,14 @@ type InlineTotpSetupProps = {
   serviceName?: MozServices;
 };
 
+export const viewName = 'inline-totp-setup';
+
 export const InlineTotpSetup = ({
   code,
   email,
   serviceName,
 }: InlineTotpSetupProps) => {
-  logPageViewEvent('inline-totp-setup', { entrypoint_variation: 'react' });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   /*
    * TODO:
@@ -74,9 +77,7 @@ export const InlineTotpSetup = ({
     }
     try {
       // Check security code
-      // logViewEvent('flow', inline-totp-setup.submit, {
-      //   entrypoint_variation: 'react',
-      //  });
+      // logViewEvent('flow', `${viewName}.submit`, REACT_ENTRYPOINT);
     } catch (e) {
       // TODO: error handling, error message confirmation
       //       - use the Banner component
@@ -164,29 +165,13 @@ export const InlineTotpSetup = ({
             />
           )}
           <section>
-            <form noValidate>
-              <div id="totp" className="totp-details">
-                {showQR ? (
-                  <>
-                    <FtlMsg
-                      id="inline-totp-setup-use-qr-or-enter-key-instructions"
-                      elems={{
-                        toggleToManualModeButton: (
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setShowQR(false);
-                            }}
-                            className="link-blue inline"
-                          >
-                            Can’t scan code?
-                          </button>
-                        ),
-                      }}
-                    >
-                      <p className="text-sm mb-4">
-                        Scan the QR code in your authentication app and then
-                        enter the authentication code it provides.{' '}
+            <div id="totp" className="totp-details">
+              {showQR ? (
+                <>
+                  <FtlMsg
+                    id="inline-totp-setup-use-qr-or-enter-key-instructions"
+                    elems={{
+                      toggleToManualModeButton: (
                         <button
                           type="button"
                           onClick={() => {
@@ -196,43 +181,45 @@ export const InlineTotpSetup = ({
                         >
                           Can’t scan code?
                         </button>
-                      </p>
-                    </FtlMsg>
-                    <div>
-                      <img
-                        className={classNames({
-                          hidden: !qrCodeSrc,
-                        })}
-                        alt={localizedQRCodeAltText}
-                        src={qrCodeSrc}
-                      />
-                    </div>
-                    <FtlMsg id="inline-totp-setup-on-completion-description">
-                      <p className="text-sm mb-4">
-                        Once complete, it will begin generating authentication
-                        codes for you to enter.
-                      </p>
-                    </FtlMsg>
-                  </>
-                ) : (
-                  <>
-                    <FtlMsg
-                      id="inline-totp-setup-enter-key-or-use-qr-instructions"
-                      elems={{
-                        toggleToQRButton: (
-                          <button
-                            onClick={() => {
-                              setShowQR(true);
-                            }}
-                            className="link-blue inline"
-                          >
-                            Scan QR code instead?
-                          </button>
-                        ),
-                      }}
-                    >
-                      <p className="text-sm m-2">
-                        Type this secret key into your authentication app.{' '}
+                      ),
+                    }}
+                  >
+                    <p className="text-sm mb-4">
+                      Scan the QR code in your authentication app and then enter
+                      the authentication code it provides.{' '}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setShowQR(false);
+                        }}
+                        className="link-blue inline"
+                      >
+                        Can’t scan code?
+                      </button>
+                    </p>
+                  </FtlMsg>
+                  <div>
+                    <img
+                      className={classNames({
+                        hidden: !qrCodeSrc,
+                      })}
+                      alt={localizedQRCodeAltText}
+                      src={qrCodeSrc}
+                    />
+                  </div>
+                  <FtlMsg id="inline-totp-setup-on-completion-description">
+                    <p className="text-sm mb-4">
+                      Once complete, it will begin generating authentication
+                      codes for you to enter.
+                    </p>
+                  </FtlMsg>
+                </>
+              ) : (
+                <>
+                  <FtlMsg
+                    id="inline-totp-setup-enter-key-or-use-qr-instructions"
+                    elems={{
+                      toggleToQRButton: (
                         <button
                           onClick={() => {
                             setShowQR(true);
@@ -241,43 +228,55 @@ export const InlineTotpSetup = ({
                         >
                           Scan QR code instead?
                         </button>
-                      </p>
-                    </FtlMsg>
-                    <div className="qr-code-container">
-                      <div className="qr-code-text">{secret}</div>
-                    </div>
-                    <FtlMsg id="inline-totp-setup-on-completion-description">
-                      <p className="text-sm mb-4">
-                        Once complete, it will begin generating authentication
-                        codes for you to enter.
-                      </p>
-                    </FtlMsg>
-                  </>
-                )}
-                <FormVerifyCode
-                  viewName="inline_totp_setup"
-                  email={email}
-                  onSubmit={handleSubmit(onSubmit)}
-                  formAttributes={{
-                    inputLabelText: 'Authentication code',
-                    inputFtlId: 'inline-totp-setup-security-code-placeholder',
-                    pattern: 'd{6}',
-                    maxLength: 6,
-                    submitButtonText: 'Ready',
-                    submitButtonFtlId: 'inline-totp-setup-ready-button',
-                  }}
-                  code={totpCodeValue}
-                  setCode={setTotpCodeValue}
-                  codeErrorMessage={totpErrorMessage}
-                  setCodeErrorMessage={setTotpErrorMessage}
-                />
-                <button className="link-blue text-sm mt-4">
-                  <FtlMsg id="inline-totp-setup-cancel-setup-button">
-                    Cancel setup
+                      ),
+                    }}
+                  >
+                    <p className="text-sm m-2">
+                      Type this secret key into your authentication app.{' '}
+                      <button
+                        onClick={() => {
+                          setShowQR(true);
+                        }}
+                        className="link-blue inline"
+                      >
+                        Scan QR code instead?
+                      </button>
+                    </p>
                   </FtlMsg>
-                </button>
-              </div>
-            </form>
+                  <div className="qr-code-container">
+                    <div className="qr-code-text">{secret}</div>
+                  </div>
+                  <FtlMsg id="inline-totp-setup-on-completion-description">
+                    <p className="text-sm mb-4">
+                      Once complete, it will begin generating authentication
+                      codes for you to enter.
+                    </p>
+                  </FtlMsg>
+                </>
+              )}
+              <FormVerifyCode
+                viewName="inline_totp_setup"
+                email={email}
+                onSubmit={handleSubmit(onSubmit)}
+                formAttributes={{
+                  inputLabelText: 'Authentication code',
+                  inputFtlId: 'inline-totp-setup-security-code-placeholder',
+                  pattern: 'd{6}',
+                  maxLength: 6,
+                  submitButtonText: 'Ready',
+                  submitButtonFtlId: 'inline-totp-setup-ready-button',
+                }}
+                code={totpCodeValue}
+                setCode={setTotpCodeValue}
+                codeErrorMessage={totpErrorMessage}
+                setCodeErrorMessage={setTotpErrorMessage}
+              />
+              <button className="link-blue text-sm mt-4">
+                <FtlMsg id="inline-totp-setup-cancel-setup-button">
+                  Cancel setup
+                </FtlMsg>
+              </button>
+            </div>
           </section>
         </>
       )}

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -8,8 +8,9 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import AccountRecoveryConfirmKey from '.';
+import AccountRecoveryConfirmKey, { viewName } from '.';
 import { MOCK_SERVICE_NAME } from './mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -71,11 +72,6 @@ describe('PageAccountRecoveryConfirmKey', () => {
 
   it('emits a metrics event on render', () => {
     render(<AccountRecoveryConfirmKey linkStatus="valid" />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(
-      `account-recovery-confirm-key`,
-      {
-        entrypoint_variation: 'react',
-      }
-    );
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -16,6 +16,7 @@ import WarningMessage from '../../../components/WarningMessage';
 import LinkExpired from '../../../components/LinkExpired';
 import LinkDamaged from '../../../components/LinkDamaged';
 import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // --serviceName-- is the relying party
 
@@ -30,21 +31,20 @@ type FormData = {
 
 type LinkStatus = 'damaged' | 'expired' | 'valid';
 
+export const viewName = 'account-recovery-confirm-key';
+
 // eslint-disable-next-line no-empty-pattern
 const AccountRecoveryConfirmKey = ({
   serviceName,
   linkStatus,
 }: AccountRecoveryConfirmKeyProps & RouteComponentProps) => {
   // TODO: confirm event name
-  usePageViewEvent('account-recovery-confirm-key', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [recoveryKey, setRecoveryKey] = useState<string>('');
   const [recoveryKeyErrorText, setRecoveryKeyErrorText] = useState<string>('');
   const [isFocused, setIsFocused] = useState(false);
   const alertBar = useAlertBar();
-  const onFocusMetricsEvent = 'account-recovery-confirm-key.engage';
   const ftlMsgResolver = useFtlMsgResolver();
 
   const { handleSubmit } = useForm<FormData>({
@@ -56,10 +56,8 @@ const AccountRecoveryConfirmKey = ({
   });
 
   const onFocus = () => {
-    if (!isFocused && onFocusMetricsEvent) {
-      logViewEvent('flow', onFocusMetricsEvent, {
-        entrypoint_variation: 'react',
-      });
+    if (!isFocused) {
+      logViewEvent('flow', `${viewName}.engage`, REACT_ENTRYPOINT);
       setIsFocused(true);
     }
   };
@@ -81,9 +79,7 @@ const AccountRecoveryConfirmKey = ({
     }
     try {
       checkRecoveryKey();
-      logViewEvent('flow', 'account-recovery-confirm-key.submit', {
-        entrypoint_variation: 'react',
-      });
+      logViewEvent('flow', `${viewName}.submit`, REACT_ENTRYPOINT);
     } catch (e) {
       const errorAccountRecoveryConfirmKey = ftlMsgResolver.getMsg(
         'account-recovery-confirm-key-error-general',
@@ -138,7 +134,7 @@ const AccountRecoveryConfirmKey = ({
                   setRecoveryKey(e.target.value);
                 }}
                 errorText={recoveryKeyErrorText}
-                onFocusCb={onFocusMetricsEvent ? onFocus : undefined}
+                onFocusCb={onFocus}
                 autoFocus
                 className="text-start"
                 anchorStart

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -8,9 +8,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import AccountRecoveryResetPassword from '.';
+import AccountRecoveryResetPassword, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
-import { SHOW_BALLOON_TIMEOUT } from '../../../constants';
+import { REACT_ENTRYPOINT, SHOW_BALLOON_TIMEOUT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -100,11 +100,6 @@ describe('AccountRecoveryResetPassword page', () => {
         linkStatus="valid"
       />
     );
-    expect(usePageViewEvent).toHaveBeenCalledWith(
-      `account-recovery-reset-password`,
-      {
-        entrypoint_variation: 'react',
-      }
-    );
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -15,6 +15,7 @@ import LinkRememberPassword from '../../../components/LinkRememberPassword';
 import LinkExpired from '../../../components/LinkExpired';
 import LinkDamaged from '../../../components/LinkDamaged';
 import FormPasswordWithBalloons from '../../../components/FormPasswordWithBalloons';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // This page is based on complete_reset_password but has been separated to align with the routes.
 
@@ -23,6 +24,8 @@ import FormPasswordWithBalloons from '../../../components/FormPasswordWithBalloo
 // (recoveryKeyId, accountResetToken, kb)
 
 // If lostRecoveryKey is set, redirect to /complete_reset_password
+
+export const viewName = 'account-recovery-reset-password';
 
 export type AccountRecoveryResetPasswordProps = {
   email: string;
@@ -42,16 +45,13 @@ const AccountRecoveryResetPassword = ({
   linkStatus,
   forceAuth = false,
 }: AccountRecoveryResetPasswordProps & RouteComponentProps) => {
-  usePageViewEvent('account-recovery-reset-password', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [passwordMatchErrorText, setPasswordMatchErrorText] =
     useState<string>('');
   const alertBar = useAlertBar();
   const navigate = useNavigate();
   const ftlMsgResolver = useFtlMsgResolver();
-  const onFocusMetricsEvent = 'account-recovery-reset-password.engage';
 
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<FormData>({
@@ -65,7 +65,7 @@ const AccountRecoveryResetPassword = ({
 
   const alertSuccessAndNavigate = useCallback(() => {
     const successCompletePwdReset = ftlMsgResolver.getMsg(
-      'account-recovery-reset-password-success-alert',
+      `${viewName}-success-alert`,
       'Password set'
     );
     alertBar.success(successCompletePwdReset);
@@ -125,7 +125,7 @@ const AccountRecoveryResetPassword = ({
               onSubmit={handleSubmit(onSubmit)}
               email={email}
               loading={false}
-              onFocusMetricsEvent={onFocusMetricsEvent}
+              onFocusMetricsEvent={`${viewName}.engage`}
             />
           </section>
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -9,7 +9,7 @@ import { AppContext, AlertBarInfo } from '../../../models';
 import CompleteResetPassword from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
-import { SHOW_BALLOON_TIMEOUT } from '../../../constants';
+import { REACT_ENTRYPOINT, SHOW_BALLOON_TIMEOUT } from '../../../constants';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 
@@ -126,8 +126,9 @@ describe('CompleteResetPassword page', () => {
         linkStatus="valid"
       />
     );
-    expect(usePageViewEvent).toHaveBeenCalledWith('complete-reset-password', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(
+      'complete-reset-password',
+      REACT_ENTRYPOINT
+    );
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -15,6 +15,7 @@ import LinkRememberPassword from '../../../components/LinkRememberPassword';
 import LinkExpired from '../../../components/LinkExpired';
 import LinkDamaged from '../../../components/LinkDamaged';
 import FormPasswordWithBalloons from '../../../components/FormPasswordWithBalloons';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // The equivalent complete_reset_password mustache file included account_recovery_reset_password
 // For React, we have opted to separate these into two pages to align with the routes.
@@ -27,6 +28,8 @@ import FormPasswordWithBalloons from '../../../components/FormPasswordWithBalloo
 // navigate to /account_recovery_confirm_key
 //
 // If account recovery was initiated with a key, redirect to account_recovery_reset_password
+
+export const viewName = 'complete-reset-password';
 
 export type CompleteResetPasswordProps = {
   email: string;
@@ -50,16 +53,13 @@ const CompleteResetPassword = ({
   linkStatus,
   resetPasswordConfirm,
 }: CompleteResetPasswordProps & RouteComponentProps) => {
-  usePageViewEvent('complete-reset-password', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [passwordMatchErrorText, setPasswordMatchErrorText] =
     useState<string>('');
   const alertBar = useAlertBar();
   const navigate = useNavigate();
   const ftlMsgResolver = useFtlMsgResolver();
-  const onFocusMetricsEvent = 'complete-password-reset.engage';
 
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<FormData>({
@@ -144,7 +144,7 @@ const CompleteResetPassword = ({
               passwordFormType="reset"
               onSubmit={handleSubmit(onSubmit)}
               loading={false}
-              onFocusMetricsEvent={onFocusMetricsEvent}
+              onFocusMetricsEvent={`${viewName}.engage`}
             />
           </section>
           {/* TODO: Verify if the "Remember password?" should always direct to /signin (current state) */}

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
@@ -4,11 +4,12 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import ConfirmResetPassword from '.';
+import ConfirmResetPassword, { viewName } from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { MOCK_EMAIL } from './mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -54,9 +55,7 @@ describe('ConfirmResetPassword', () => {
 
   it('emits the expected metrics on render', async () => {
     render(<ConfirmResetPassword email={MOCK_EMAIL} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('confirm-reset-password', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('renders a "Remember your password?" link if "canSignIn: true"', () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -10,6 +10,9 @@ import LinkRememberPassword from '../../../components/LinkRememberPassword';
 import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
 } from '../../../components/ConfirmWithLink';
+import { REACT_ENTRYPOINT } from '../../../constants';
+
+export const viewName = 'confirm-reset-password';
 
 export type ConfirmResetPasswordProps = {
   email: string;
@@ -22,9 +25,7 @@ const ConfirmResetPassword = ({
   forceAuth,
   canSignIn,
 }: ConfirmResetPasswordProps & RouteComponentProps) => {
-  usePageViewEvent('confirm-reset-password', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   // TODO check for passwordResetToken (confirms reset password initiated)
   // TODO redirect to reset_password if !passwordResetToken

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -4,8 +4,9 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import ResetPasswordConfirmed from '.';
+import ResetPasswordConfirmed, { viewName } from '.';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -27,9 +28,7 @@ describe('ResetPasswordConfirmed', () => {
 
   it('emits the expected metrics on render', () => {
     render(<ResetPasswordConfirmed />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('reset-password-confirmed', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
@@ -44,11 +43,9 @@ describe('ResetPasswordConfirmed', () => {
 
     fireEvent.click(passwordResetContinueButton);
     expect(logViewEvent).toHaveBeenCalledWith(
-      'reset-password-confirmed',
-      'reset-password-confirmed.continue',
-      {
-        entrypoint_variation: 'react',
-      }
+      viewName,
+      `${viewName}.continue`,
+      REACT_ENTRYPOINT
     );
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
@@ -12,14 +12,13 @@ type ResetPasswordConfirmedProps = {
   serviceName?: MozServices;
 };
 
+export const viewName = 'reset-password-confirmed';
+
 const ResetPasswordConfirmed = ({
   continueHandler,
   serviceName,
-}: ResetPasswordConfirmedProps & RouteComponentProps) => {
-  // This is pretty ridiculously barebones, but the content in here gets expanded on other, similar views.
-  const viewName = 'reset-password-confirmed';
-
-  return <Ready {...{ continueHandler, viewName, serviceName }} />;
-};
+}: ResetPasswordConfirmedProps & RouteComponentProps) => (
+  <Ready {...{ continueHandler, viewName, serviceName }} />
+);
 
 export default ResetPasswordConfirmed;

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -7,8 +7,9 @@ import { fireEvent, screen } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
-import ResetPasswordWithRecoveryKeyVerified from '.';
+import ResetPasswordWithRecoveryKeyVerified, { viewName } from '.';
 import { logViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -41,11 +42,9 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
     );
     fireEvent.click(newAccountRecoveryKeyButton);
     expect(logViewEvent).toHaveBeenCalledWith(
-      'reset-password-with-recovery-key-verified',
-      'reset-password-with-recovery-key-verified.generate-new-key',
-      {
-        entrypoint_variation: 'react',
-      }
+      viewName,
+      `${viewName}.generate-new-key`,
+      REACT_ENTRYPOINT
     );
   });
 
@@ -54,11 +53,9 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
     const continueToAccountLink = screen.getByText('Continue to my account');
     fireEvent.click(continueToAccountLink);
     expect(logViewEvent).toHaveBeenCalledWith(
-      'reset-password-with-recovery-key-verified',
-      'reset-password-with-recovery-key-verified.continue-to-account',
-      {
-        entrypoint_variation: 'react',
-      }
+      viewName,
+      `${viewName}.continue-to-account`,
+      REACT_ENTRYPOINT
     );
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -8,16 +8,18 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../../lib/metrics';
 import Ready from '../../../components/Ready';
 import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 type ResetPasswordWithRecoveryKeyVerifiedProps = {
   serviceName?: MozServices;
 };
 
+export const viewName = 'reset-password-with-recovery-key-verified';
+
 const ResetPasswordWithRecoveryKeyVerified = ({
   serviceName,
 }: ResetPasswordWithRecoveryKeyVerifiedProps & RouteComponentProps) => {
   const navigate = useNavigate();
-  const viewName = 'reset-password-with-recovery-key-verified';
 
   return (
     <>
@@ -27,9 +29,7 @@ const ResetPasswordWithRecoveryKeyVerified = ({
           className="cta-primary cta-xl"
           onClick={() => {
             const eventName = `${viewName}.generate-new-key`;
-            logViewEvent(viewName, eventName, {
-              entrypoint_variation: 'react',
-            });
+            logViewEvent(viewName, eventName, REACT_ENTRYPOINT);
             navigate('/settings/account_recovery');
           }}
         >
@@ -42,9 +42,7 @@ const ResetPasswordWithRecoveryKeyVerified = ({
         className="link-blue text-sm"
         onClick={() => {
           const eventName = `${viewName}.continue-to-account`;
-          logViewEvent(viewName, eventName, {
-            entrypoint_variation: 'react',
-          });
+          logViewEvent(viewName, eventName, REACT_ENTRYPOINT);
           navigate('/settings');
         }}
       >

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -8,9 +8,10 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../lib/metrics';
-import ResetPassword from '.';
+import ResetPassword, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -82,8 +83,6 @@ describe('PageResetPassword', () => {
 
   it('emits a metrics event on render', () => {
     render(<ResetPassword />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`reset-password`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -15,6 +15,7 @@ import CardHeader from '../../components/CardHeader';
 import WarningMessage from '../../components/WarningMessage';
 import LinkRememberPassword from '../../components/LinkRememberPassword';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 // --forceAuth-- is a hint to the signup page that the user should not
 // be given the option to change their address
@@ -25,6 +26,8 @@ import { MozServices } from '../../lib/types';
 // --canGoBack-- determines if the user can navigate back to an fxa entrypoint
 
 // --serviceName-- is the relying party
+
+export const viewName = 'reset-password';
 
 export type ResetPasswordProps = {
   serviceName?: MozServices;
@@ -44,9 +47,7 @@ const ResetPassword = ({
   forceAuth,
   canGoBack,
 }: ResetPasswordProps & RouteComponentProps) => {
-  usePageViewEvent('reset-password', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [email, setEmail] = useState<string>(prefillEmail || '');
   const [emailErrorText, setEmailErrorText] = useState<string>('');
@@ -54,7 +55,6 @@ const ResetPassword = ({
   const alertBar = useAlertBar();
   const account = useAccount();
   const navigate = useNavigate();
-  const onFocusMetricsEvent = 'reset-password.engage';
   const ftlMsgResolver = useFtlMsgResolver();
 
   const { handleSubmit } = useForm<FormData>({
@@ -72,10 +72,8 @@ const ResetPassword = ({
   });
 
   const onFocus = () => {
-    if (!isFocused && onFocusMetricsEvent) {
-      logViewEvent('flow', onFocusMetricsEvent, {
-        entrypoint_variation: 'react',
-      });
+    if (!isFocused) {
+      logViewEvent('flow', `${viewName}.engage`, REACT_ENTRYPOINT);
       setIsFocused(true);
     }
   };
@@ -163,7 +161,7 @@ const ResetPassword = ({
                 setEmailErrorText('');
               }
             }}
-            onFocusCb={onFocusMetricsEvent ? onFocus : undefined}
+            onFocusCb={onFocus}
             autoFocus
             errorText={emailErrorText}
             className="text-start"

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.test.tsx
@@ -4,9 +4,10 @@
 
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import CompleteSignin from '.';
+import CompleteSignin, { viewName } from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { renderWithRouter } from '../../../models/mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -111,8 +112,6 @@ describe('CompleteSignin', () => {
     renderWithRouter(
       <CompleteSignin linkStatus="valid" isForPrimaryEmail={true} />
     );
-    expect(usePageViewEvent).toHaveBeenCalledWith('complete-signin', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { LinkStatus } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // We will probably grab `isSignedIn` off of the Account model in the long run.
 export type CompleteSigninProps = {
@@ -19,14 +20,14 @@ export type CompleteSigninProps = {
   linkStatus: LinkStatus;
 };
 
+export const viewName = 'complete-signin';
+
 const CompleteSignin = ({
   brokerNextAction,
   isForPrimaryEmail,
   linkStatus,
 }: CompleteSigninProps & RouteComponentProps) => {
-  usePageViewEvent('complete-signin', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const navigate = useNavigate();
   const linkType = 'signin';
   const [error, setError] = useState<string>();

--- a/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.test.tsx
@@ -8,12 +8,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import ConfirmSignin from '.';
+import ConfirmSignin, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
-  logViewEvent: jest.fn(),
 }));
 
 const mockGoBackCallback = jest.fn();
@@ -79,8 +79,6 @@ describe('ConfirmSignin', () => {
 
   it('emits a metrics event on render', () => {
     render(<ConfirmSignin email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`confirm-signin`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps } from '@reach/router';
 import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
 } from '../../../components/ConfirmWithLink';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 export type ConfirmSigninProps = {
   email: string;
@@ -15,14 +16,14 @@ export type ConfirmSigninProps = {
   withWebmailLink?: boolean; // TO-DO: Replace broker functionality which gives us this value (provider?)
 };
 
+export const viewName = 'confirm-signin';
+
 const ConfirmSignin = ({
   email,
   goBackCallback,
   withWebmailLink,
 }: RouteComponentProps & ConfirmSigninProps) => {
-  usePageViewEvent('confirm-signin', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const confirmSigninPageText: ConfirmWithLinkPageStrings = {
     headingFtlId: 'confirm-signin-heading',

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
@@ -7,13 +7,13 @@ import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
 // import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
-import SigninBounced from '.';
-import { logPageViewEvent } from '../../../lib/metrics';
+import SigninBounced, { viewName } from '.';
+import { usePageViewEvent } from '../../../lib/metrics';
 import { MOCK_EMAIL } from './mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
-  logViewEvent: jest.fn(),
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
 }));
 
 describe('SigninBounced', () => {
@@ -45,8 +45,6 @@ describe('SigninBounced', () => {
 
   it('emits the expected metrics on render', async () => {
     renderWithRouter(<SigninBounced email={MOCK_EMAIL} />);
-    expect(logPageViewEvent).toHaveBeenCalledWith('signin-bounced', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -4,11 +4,12 @@
 
 import React from 'react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
-import { logPageViewEvent } from '../../../lib/metrics';
+import { usePageViewEvent } from '../../../lib/metrics';
 import { ReactComponent as EmailBounced } from './graphic_email_bounced.svg';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 export type SigninBouncedProps = {
   onBackButtonClick?: (
@@ -18,14 +19,14 @@ export type SigninBouncedProps = {
   email: string;
 };
 
+export const viewName = 'signin-bounced';
+
 const SigninBounced = ({
   canGoBack,
   email,
   onBackButtonClick = () => window.history.back(),
 }: SigninBouncedProps & RouteComponentProps) => {
-  logPageViewEvent('signin-bounced', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMessageResolver = useFtlMsgResolver();
   const backText = ftlMessageResolver.getMsg('back', 'Back');
   const navigate = useNavigate();

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.test.tsx
@@ -6,8 +6,9 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
-import SigninConfirmed from '.';
+import SigninConfirmed, { viewName } from '.';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -37,9 +38,7 @@ describe('SigninConfirmed', () => {
 
   it('emits the expected metrics on render', () => {
     render(<SigninConfirmed />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('signin-confirmed', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
@@ -54,11 +53,9 @@ describe('SigninConfirmed', () => {
 
     fireEvent.click(passwordResetContinueButton);
     expect(logViewEvent).toHaveBeenCalledWith(
-      'signin-confirmed',
-      'signin-confirmed.continue',
-      {
-        entrypoint_variation: 'react',
-      }
+      viewName,
+      `${viewName}.continue`,
+      REACT_ENTRYPOINT
     );
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
@@ -12,13 +12,13 @@ type SigninConfirmedProps = {
   serviceName?: MozServices;
 };
 
+export const viewName = 'signin-confirmed';
+
 const SigninConfirmed = ({
   continueHandler,
   serviceName,
-}: SigninConfirmedProps & RouteComponentProps) => {
-  const viewName = 'signin-confirmed';
-
-  return <Ready {...{ continueHandler, viewName, serviceName }} />;
-};
+}: SigninConfirmedProps & RouteComponentProps) => (
+  <Ready {...{ continueHandler, viewName, serviceName }} />
+);
 
 export default SigninConfirmed;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -8,9 +8,10 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import SigninRecoveryCode from '.';
+import SigninRecoveryCode, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -63,8 +64,6 @@ describe('PageSigninRecoveryCode', () => {
 
   it('emits a metrics event on render', () => {
     render(<SigninRecoveryCode email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`signin-recovery-code`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -15,20 +15,20 @@ import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
 import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 export type SigninRecoveryCodeProps = {
   email: string;
   serviceName?: MozServices;
 };
 
+export const viewName = 'signin-recovery-code';
+
 const SigninRecoveryCode = ({
   email,
   serviceName,
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
-  const viewName = 'signin-recovery-code';
-  usePageViewEvent(viewName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.test.tsx
@@ -6,8 +6,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
-import SigninReported from '.';
+import SigninReported, { viewName } from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -32,8 +33,6 @@ describe('SigninReported', () => {
 
   it('emits the expected metrics on render', () => {
     render(<SigninReported />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('signin-reported', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.tsx
@@ -6,11 +6,12 @@ import React from 'react';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { RouteComponentProps } from '@reach/router';
+import { REACT_ENTRYPOINT } from '../../../constants';
+
+export const viewName = 'signin-reported';
 
 const SigninReported = (props: RouteComponentProps) => {
-  usePageViewEvent('signin-reported', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   return (
     <>

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -8,8 +8,9 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import SigninTokenCode from '.';
+import SigninTokenCode, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -40,8 +41,6 @@ describe('PageSigninTokenCode', () => {
 
   it('emits a metrics event on render', () => {
     render(<SigninTokenCode email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`signin-token-code`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -12,17 +12,17 @@ import { ReactComponent as MailImg } from './graphic_mail.svg';
 import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // email will eventually be obtained from account context
 export type SigninTokenCodeProps = { email: string };
 
+export const viewName = 'signin-token-code';
+
 const SigninTokenCode = ({
   email,
 }: SigninTokenCodeProps & RouteComponentProps) => {
-  const viewName = 'signin-token-code';
-  usePageViewEvent(viewName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -8,9 +8,10 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import SigninTotpCode from '.';
+import SigninTotpCode, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -55,8 +56,6 @@ describe('Sign in with TOTP code page', () => {
 
   it('emits a metrics event on render', () => {
     render(<SigninTotpCode email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`signin-totp-code`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -14,19 +14,19 @@ import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
 import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // --serviceName-- is the relying party
 
 export type SigninTotpCodeProps = { email: string; serviceName?: MozServices };
 
+export const viewName = 'signin-totp-code';
+
 const SigninTotpCode = ({
   email,
   serviceName,
 }: SigninTotpCodeProps & RouteComponentProps) => {
-  const viewName = 'signin-totp-code';
-  usePageViewEvent(viewName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
@@ -52,9 +52,7 @@ const SigninTotpCode = ({
     }
     try {
       // Check security code
-      // logViewEvent('flow', signin-totp-code.submit, {
-      //   entrypoint_variation: 'react',
-      //  });
+      // logViewEvent('flow', `${viewName}.submit`, ENTRYPOINT_REACT);
       // Check if isForcePasswordChange
     } catch (e) {
       // TODO: error handling, error message confirmation

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -4,12 +4,13 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Signin from '.';
+import Signin, { viewName } from '.';
 import { usePageViewEvent } from '../../lib/metrics';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { MOCK_EMAIL, MOCK_SERVICE, MOCK_OTHER_ICON } from './mocks';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
 }));
@@ -136,8 +137,6 @@ describe('Signin', () => {
         serviceName={MOCK_SERVICE}
       />
     );
-    expect(usePageViewEvent).toHaveBeenCalledWith('signin', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -11,6 +11,7 @@ import { RouteComponentProps, Link } from '@reach/router';
 import InputPassword from '../../components/InputPassword';
 import { ReactComponent as PocketLogo } from './pocket.svg';
 import TermsPrivacyAgreement from '../../components/TermsPrivacyAgreement';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 export type SigninProps = {
   email: string;
@@ -19,15 +20,15 @@ export type SigninProps = {
   serviceName?: MozServices;
 };
 
+export const viewName = 'signin';
+
 const Signin = ({
   email,
   isPasswordNeeded,
   ServiceLogo,
   serviceName,
 }: SigninProps & RouteComponentProps) => {
-  usePageViewEvent('signin', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const isPocketClient = serviceName === MozServices.Pocket;
   const [error, setError] = useState('');

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
@@ -8,8 +8,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import Confirm from '.';
+import Confirm, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -75,8 +76,6 @@ describe('Confirm', () => {
 
   it('emits a metrics event on render', () => {
     render(<Confirm email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`confirm`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps } from '@reach/router';
 import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
 } from '../../../components/ConfirmWithLink';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 export type ConfirmProps = {
   email: string;
@@ -20,15 +21,15 @@ export type WebmailValues = {
   link: string;
 };
 
+export const viewName = 'confirm';
+
 const Confirm = ({
   email,
   goBackCallback,
   withWebmailLink,
 }: RouteComponentProps & ConfirmProps) => {
   // TODO: Confirm event name  - could not hit this route
-  usePageViewEvent('confirm', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const confirmSignupPageText: ConfirmWithLinkPageStrings = {
     headingFtlId: 'confirm-signup-heading',

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -8,8 +8,9 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
-import ConfirmSignupCode from '.';
+import ConfirmSignupCode, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -40,8 +41,6 @@ describe('PageSigninTokenCode', () => {
 
   it('emits a metrics event on render', () => {
     render(<ConfirmSignupCode email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`confirm-signup-code`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -12,17 +12,17 @@ import { ReactComponent as MailImg } from './graphic_mail.svg';
 import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 // email will eventually be obtained from account context
 export type ConfirmSignupCodeProps = { email: string };
 
+export const viewName = 'confirm-signup-code';
+
 const ConfirmSignupCode = ({
   email,
 }: ConfirmSignupCodeProps & RouteComponentProps) => {
-  const viewName = 'confirm-signup-code';
-  usePageViewEvent(viewName, {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   // const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
@@ -4,11 +4,12 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import PrimaryEmailVerified from '.';
+import PrimaryEmailVerified, { viewName } from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import { MOCK_SERVICE } from './mocks';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -45,8 +46,6 @@ describe('PrimaryEmailVerified page', () => {
 
   it('emits the expected metrics on render', () => {
     render(<PrimaryEmailVerified />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('primary-email-verified', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
@@ -12,13 +12,13 @@ export type PrimaryEmailVerifiedProps = {
   isSignedIn?: boolean;
 };
 
+export const viewName = 'primary-email-verified';
+
 const PrimaryEmailVerified = ({
   serviceName,
   isSignedIn = false,
-}: PrimaryEmailVerifiedProps & RouteComponentProps) => {
-  const viewName = 'primary-email-verified';
-
-  return <Ready {...{ viewName, serviceName, isSignedIn }} />;
-};
+}: PrimaryEmailVerifiedProps & RouteComponentProps) => (
+  <Ready {...{ viewName, serviceName, isSignedIn }} />
+);
 
 export default PrimaryEmailVerified;

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
@@ -4,10 +4,12 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { getFtlBundle, testAllL10n, testL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
-import SignupConfirmed from '.';
+import SignupConfirmed, { viewName } from '.';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
+import { MozServices } from '../../../lib/types';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -21,10 +23,7 @@ describe('SignupConfirmed', () => {
   });
   it('renders Ready component as expected', () => {
     render(<SignupConfirmed />);
-    const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    testL10n(ftlMsgMock, bundle, {
-      serviceName: 'account settings',
-    });
+    testAllL10n(screen, bundle);
 
     const signupConfirmation = screen.getByText('Account confirmed');
     const serviceAvailabilityConfirmation = screen.getByText(
@@ -40,9 +39,7 @@ describe('SignupConfirmed', () => {
 
   it('emits the expected metrics on render', () => {
     render(<SignupConfirmed />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('signup-confirmed', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
@@ -57,11 +54,9 @@ describe('SignupConfirmed', () => {
 
     fireEvent.click(passwordResetContinueButton);
     expect(logViewEvent).toHaveBeenCalledWith(
-      'signup-confirmed',
-      'signup-confirmed.continue',
-      {
-        entrypoint_variation: 'react',
-      }
+      viewName,
+      `${viewName}.continue`,
+      REACT_ENTRYPOINT
     );
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
@@ -12,13 +12,13 @@ type SignupConfirmedProps = {
   serviceName?: MozServices;
 };
 
+export const viewName = 'signup-confirmed';
+
 const SignupConfirmed = ({
   continueHandler,
   serviceName,
-}: SignupConfirmedProps & RouteComponentProps) => {
-  const viewName = 'signup-confirmed';
-
-  return <Ready {...{ continueHandler, viewName, serviceName }} />;
-};
+}: SignupConfirmedProps & RouteComponentProps) => (
+  <Ready {...{ continueHandler, viewName, serviceName }} />
+);
 
 export default SignupConfirmed;

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -8,9 +8,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../lib/metrics';
-import Signup from '.';
+import Signup, { viewName } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { MozServices } from '../../lib/types';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -137,8 +138,6 @@ describe('Signup page', () => {
 
   it('emits a metrics event on render', () => {
     render(<Signup email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(`signup`, {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -19,6 +19,7 @@ import { newsletters } from '../../components/ChooseNewsletters/newsletters';
 import TermsPrivacyAgreement from '../../components/TermsPrivacyAgreement';
 import Banner, { BannerType } from '../../components/Banner';
 import CardHeader from '../../components/CardHeader';
+import { REACT_ENTRYPOINT } from '../../constants';
 
 interface SharedProps {
   email: string;
@@ -51,6 +52,8 @@ type FormData = {
   userAge: string;
 };
 
+export const viewName = 'signup';
+
 const Signup = ({
   email,
   canChangeEmail = true,
@@ -58,11 +61,9 @@ const Signup = ({
   isCWTSEnabled,
   areNewslettersEnabled,
 }: SignupProps & RouteComponentProps) => {
-  usePageViewEvent('signup', {
-    entrypoint_variation: 'react',
-  });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const onFocusMetricsEvent = 'signup.engage';
+  const onFocusMetricsEvent = `${viewName}.engage`;
   const isPocketClient = serviceName === MozServices.Pocket;
 
   const [ageCheckErrorText, setAgeCheckErrorText] = useState<string>('');
@@ -104,10 +105,8 @@ const Signup = ({
   );
 
   const onFocus = () => {
-    if (!isFocused && onFocusMetricsEvent) {
-      logViewEvent('flow', onFocusMetricsEvent, {
-        entrypoint_variation: 'react',
-      });
+    if (!isFocused) {
+      logViewEvent('flow', onFocusMetricsEvent, REACT_ENTRYPOINT);
       setIsFocused(true);
     }
   };


### PR DESCRIPTION
Because:
* We have some copypasta and inconsistency with the metrics entrypoint and testing for newly Reactified views

This commit:
* Standardizes exporting a 'viewName' to be used in metrics events
* Sets `{ entrypoint_variation: 'react' }` to a const
* Fixes recently landed metrics events using snake_case that should be kebab-case
* Couple other small cleanups

---

This is part 1 of FXA-6711, this felt better in a separate PR.

I'll update the spreadsheet for the `cannot_create_account` and `cookies_disabled` tweaks.