### PR TITLE
bug(CI): Fix deploy-ci-images job

### DIFF
--- a/_dev/docker/ci/Dockerfile.dockerignore
+++ b/_dev/docker/ci/Dockerfile.dockerignore
@@ -12,4 +12,3 @@
 **/artifacts
 **/configs
 **/temp
-**/test


### PR DESCRIPTION
## Because
- Deploy CI images is failing because fxa-shared now references the test folder during build.

## This pull request
- Removes tests directories from the docker ignore list.

## Issue that this pull request solves

Closes: FXA-6977

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Error encountered:
![image](https://user-images.githubusercontent.com/94418270/216397172-f1de7cb5-8498-4493-9fb1-620c65c1d2d6.png)

![image](https://user-images.githubusercontent.com/94418270/216397113-a9d4a172-93f8-4f2e-bdbf-7e10688f5272.png)

## Other information (Optional)

This change was a regression introduced by [this](https://github.com/mozilla/fxa/pull/14814/files#r1093437748) change.
