### PR TITLE
chore(l10n): Fix brand references in ftl message

### DIFF
--- a/packages/fxa-settings/src/components/ChooseNewsletters/en.ftl
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/en.ftl
@@ -5,7 +5,7 @@
 choose-newsletters-prompt = Practical knowledge is coming to your inbox. Sign up for more:
 # Newsletter checklist item
 choose-newsletters-option-firefox-accounts-journey =
-  .label = Get the latest news about Mozilla and Firefox
+  .label = Get the latest news about { -brand-mozilla } and { -brand-firefox }
 # Newsletter checklist item
 choose-newsletters-option-take-action-for-the-internet =
   .label = Take action to keep the internet healthy


### PR DESCRIPTION
## Because

- Mozilla and Firefox should use the term instead of string

## This pull request

- Replaces strings with term reference

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
