### PR TITLE
task(CI): Temporarily disable nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -965,86 +965,86 @@ workflows:
             - Functional Test - Content 5
             - Functional Tests - Playwright
 
-  nightly:
-    # This work flow runs a full build, test suite, and deployment of docker images nightly
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only: main
-    jobs:
-      - build:
-          name: Build (nightly)
-          filters:
-            branches:
-              only: main
-            tags:
-              ignore: /.*/
-      - lint:
-          name: Lint (nightly)
-          requires:
-            - Build (nightly)
-      - unit-test:
-          name: Unit Test (nightly)
-          requires:
-            - Build (nightly)
-          post-steps:
-            - fail-fast
-      - integration-test-part:
-          name: Integration Test 1 (nightly)
-          index: 0
-          total: 3
-          requires:
-            - Build (nightly)
-          post-steps:
-            - fail-fast
-      - integration-test-part:
-          name: Integration Test 2 (nightly)
-          index: 1
-          total: 3
-          requires:
-            - Build (nightly)
-          post-steps:
-            - fail-fast
-      - integration-test-part:
-          name: Integration Test 3 (nightly)
-          index: 2
-          total: 3
-          requires:
-            - Build (nightly)
-          post-steps:
-            - fail-fast
-      - playwright-functional-tests:
-          name: Functional Tests - Playwright (nightly)
-          requires:
-            - Build (nightly)
-      - on-complete:
-          name: Tests Complete (nightly)
-          stage: Tests (nightly)
-          job_type: build
-          requires:
-            - Lint (nightly)
-            - Unit Test (nightly)
-            - Integration Test 1 (nightly)
-            - Integration Test 2 (nightly)
-            - Integration Test 3 (nightly)
-            - Functional Tests - Playwright (nightly)
-      - build-and-deploy-storybooks:
-          name: Deploy Storybooks (nightly)
-          requires:
-            - Tests Complete (nightly)
-      - deploy-packages:
-          name: Deploy FxA Packages (nightly)
-          requires:
-            - Tests Complete (nightly)
-      - deploy-fxa-ci-images:
-          name: Deploy CI Images (nightly)
-          executor:
-            name: docker-build-executor
-            image: cimg/node:16.13-browsers
-          # Note, setting force-deploy as true will result in rebuilding the images regardless
-          # of whether or not there are package modifications.
-          force-deploy: true
-          requires:
-            - Tests Complete (nightly)
+  # nightly:
+  #   # This work flow runs a full build, test suite, and deployment of docker images nightly
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 0 * * *"
+  #         filters:
+  #           branches:
+  #             only: main
+  #   jobs:
+  #     - build:
+  #         name: Build (nightly)
+  #         filters:
+  #           branches:
+  #             only: main
+  #           tags:
+  #             ignore: /.*/
+  #     - lint:
+  #         name: Lint (nightly)
+  #         requires:
+  #           - Build (nightly)
+  #     - unit-test:
+  #         name: Unit Test (nightly)
+  #         requires:
+  #           - Build (nightly)
+  #         post-steps:
+  #           - fail-fast
+  #     - integration-test-part:
+  #         name: Integration Test 1 (nightly)
+  #         index: 0
+  #         total: 3
+  #         requires:
+  #           - Build (nightly)
+  #         post-steps:
+  #           - fail-fast
+  #     - integration-test-part:
+  #         name: Integration Test 2 (nightly)
+  #         index: 1
+  #         total: 3
+  #         requires:
+  #           - Build (nightly)
+  #         post-steps:
+  #           - fail-fast
+  #     - integration-test-part:
+  #         name: Integration Test 3 (nightly)
+  #         index: 2
+  #         total: 3
+  #         requires:
+  #           - Build (nightly)
+  #         post-steps:
+  #           - fail-fast
+  #     - playwright-functional-tests:
+  #         name: Functional Tests - Playwright (nightly)
+  #         requires:
+  #           - Build (nightly)
+  #     - on-complete:
+  #         name: Tests Complete (nightly)
+  #         stage: Tests (nightly)
+  #         job_type: build
+  #         requires:
+  #           - Lint (nightly)
+  #           - Unit Test (nightly)
+  #           - Integration Test 1 (nightly)
+  #           - Integration Test 2 (nightly)
+  #           - Integration Test 3 (nightly)
+  #           - Functional Tests - Playwright (nightly)
+  #     - build-and-deploy-storybooks:
+  #         name: Deploy Storybooks (nightly)
+  #         requires:
+  #           - Tests Complete (nightly)
+  #     - deploy-packages:
+  #         name: Deploy FxA Packages (nightly)
+  #         requires:
+  #           - Tests Complete (nightly)
+  #     - deploy-fxa-ci-images:
+  #         name: Deploy CI Images (nightly)
+  #         executor:
+  #           name: docker-build-executor
+  #           image: cimg/node:16.13-browsers
+  #         # Note, setting force-deploy as true will result in rebuilding the images regardless
+  #         # of whether or not there are package modifications.
+  #         force-deploy: true
+  #         requires:
+  #           - Tests Complete (nightly)


### PR DESCRIPTION
## Because
- This workflow triggered an error when invoked with CircleCI api V1
- It appears this caused by a bug in CircleCI V1 https://github.com/CircleCI-Public/slack-orb/issues/148

## This pull request
- Temporarily disables the nightly workflow

## Checklist
_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We went through a couple iterations on this to figure out what was tripping the error. We will re-enable the nightly workflow as soon as this [PR](https://github.com/mozilla-services/cloudops-deployment/pull/4774) lands
