### PR TITLE
storybook(fxa-settings): Recreate WaitForAuth and WaitForSupp

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -491,6 +491,11 @@ const EVENTS = {
     group: GROUPS.qrConnectDevice,
     event: 'wait_for_supp',
   },
+  // the screen displayed if the pairing supplicant approved first
+  'screen.pair.supp.wait-for-auth': {
+    group: GROUPS.qrConnectDevice,
+    event: 'wait_for_auth',
+  },
   'screen.pair.auth.complete': {
     group: GROUPS.qrConnectDevice,
     event: 'complete',

--- a/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
@@ -11,6 +11,7 @@ import {
   MOCK_CUSTOM_HEADING_FTL_ID,
   MOCK_HEADING,
   MOCK_SERVICE_NAME,
+  MOCK_SUBHEADING,
 } from './mocks';
 
 export default {
@@ -30,6 +31,12 @@ const storyWithProps = (props: React.ComponentProps<typeof CardHeader>) => {
 export const Basic = storyWithProps({
   headingTextFtlId: MOCK_DEFAULT_HEADING_FTL_ID,
   headingText: MOCK_HEADING,
+});
+
+export const BasicWithCustomSubheading = storyWithProps({
+  headingTextFtlId: MOCK_DEFAULT_HEADING_FTL_ID,
+  headingText: MOCK_HEADING,
+  subheadingText: MOCK_SUBHEADING,
 });
 
 export const WithDefaultServiceName = storyWithProps({

--- a/packages/fxa-settings/src/components/CardHeader/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.test.tsx
@@ -36,7 +36,7 @@ describe('CardHeader', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: `${MOCK_HEADING} to continue to ${MozServices.Default}`,
+        name: `${MOCK_HEADING} to continue to account settings`,
       })
     ).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/components/CardHeader/index.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { MozServices } from '../../lib/types';
 
@@ -23,10 +23,16 @@ interface CardHeaderBasicProps extends CardHeaderRequiredProps {
   headingTextFtlId: string;
 }
 
+interface CardHeaderWithCustomSubheadingProps extends CardHeaderRequiredProps {
+  headingTextFtlId: string;
+  subheadingText: string;
+}
+
 type CardHeaderProps =
   | CardHeaderDefaultServiceProps
   | CardHeaderCustomServiceProps
-  | CardHeaderBasicProps;
+  | CardHeaderBasicProps
+  | CardHeaderWithCustomSubheadingProps;
 
 function isCustomService(
   props: CardHeaderProps
@@ -49,17 +55,30 @@ function isDefaultService(
   );
 }
 
+function isBasicWithCustomSubheading(
+  props: CardHeaderProps
+): props is CardHeaderWithCustomSubheadingProps {
+  return (
+    (props as CardHeaderWithCustomSubheadingProps).subheadingText !== undefined
+  );
+}
+
 const CardHeader = (props: CardHeaderProps) => {
   const { headingText } = props;
 
   if (isDefaultService(props)) {
+    const spanElement: ReactElement = (
+      <span className="card-subheader">
+        to continue to {MozServices.Default}
+      </span>
+    );
     return (
-      <FtlMsg id={props.headingWithDefaultServiceFtlId}>
+      <FtlMsg
+        id={props.headingWithDefaultServiceFtlId}
+        elems={{ span: spanElement }}
+      >
         <h1 className="card-header">
-          {headingText}{' '}
-          <span className="card-subheader">
-            to continue to {MozServices.Default}
-          </span>
+          {headingText} {spanElement}
         </h1>
       </FtlMsg>
     );
@@ -67,11 +86,31 @@ const CardHeader = (props: CardHeaderProps) => {
 
   if (isCustomService(props)) {
     const { headingWithCustomServiceFtlId, serviceName } = props;
+    const spanElement: ReactElement = (
+      <span className="card-subheader">to continue to {serviceName}</span>
+    );
     return (
-      <FtlMsg id={headingWithCustomServiceFtlId} vars={{ serviceName }}>
+      <FtlMsg
+        id={headingWithCustomServiceFtlId}
+        vars={{ serviceName }}
+        elems={{ span: spanElement }}
+      >
         <h1 className="card-header">
-          {headingText}{' '}
-          <span className="card-subheader">to continue to {serviceName}</span>
+          {headingText} {spanElement}
+        </h1>
+      </FtlMsg>
+    );
+  }
+
+  if (isBasicWithCustomSubheading(props)) {
+    const { subheadingText, headingTextFtlId } = props;
+    const spanElement: ReactElement = (
+      <span className="card-subheader">{subheadingText}</span>
+    );
+    return (
+      <FtlMsg id={headingTextFtlId} elems={{ span: spanElement }}>
+        <h1 className="card-header">
+          {headingText} {spanElement}
         </h1>
       </FtlMsg>
     );

--- a/packages/fxa-settings/src/components/CardHeader/mocks.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/mocks.tsx
@@ -10,4 +10,6 @@ export const MOCK_CUSTOM_HEADING_FTL_ID = 'custom-heading';
 
 export const MOCK_HEADING = 'Complete this step';
 
+export const MOCK_SUBHEADING = 'on your other device';
+
 export const MOCK_SERVICE_NAME = MozServices.FirefoxMonitor;

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/en.ftl
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/en.ftl
@@ -1,0 +1,24 @@
+## DeviceInfoBlock component
+## The strings here are used to display information about the origin of activity happening on a user's account
+## For example, when connecting another device to the user's account
+
+# Variables { $city }, { $region }, { $country } represent the estimated location of the user's device
+# For example, 'Vancouver, British Columbia, Canada (estimated)'
+device-info-block-location-city-region-country = { $city }, { $region }, { $country } (estimated)
+# Variables { $region }, { $country } represent the estimated location of the user's device
+# For example, 'British Columbia, Canada (estimated)'
+device-info-block-location-region-country = { $region }, { $country } (estimated)
+# Variables { $city }, { $country } represent the estimated location of the user's device
+# For example, 'Vancouver, Canada (estimated)'
+device-info-block-location-city-country = { $city }, { $country } (estimated)
+# Variable { $country } represent the estimated location of the user's device
+# For example, 'Canada (estimated)'
+device-info-block-location-country = { $country } (estimated)
+# When an approximate location for the user's device could not be determined
+device-info-block-location-unknown = Location unknown
+# Variable { $browserName } is the browser that created the request (e.g., Firefox)
+# Variable { $genericOSName } is the name of the operating system that created the request (e.g., MacOS, Windows, iOS)
+device-info-browser-os = { $browserName } on { $genericOSName }
+# Variable { $ipAddress } represents the IP address where the request originated
+# The IP address is a string of numbers separated by periods (e.g., 192.158.1.38)
+device-info-ip-address = IP address: { $ipAddress }

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import DeviceInfoBlock from '.';
+import { RemoteMetadata } from '../../lib/types';
+import AppLayout from '../AppLayout';
+import { Meta } from '@storybook/react';
+import {
+  MOCK_BROWSER_NAME,
+  MOCK_IP_ADDRESS,
+  MOCK_OS_NAME,
+  MOCK_DEVICE_NAME,
+  MOCK_CITY,
+  MOCK_REGION,
+  MOCK_COUNTRY,
+} from './mocks';
+
+export default {
+  title: 'components/DeviceInfoBlock',
+  component: DeviceInfoBlock,
+} as Meta;
+
+const storyWithProps = (props?: Partial<RemoteMetadata>) => {
+  const story = () => (
+    <AppLayout>
+      <DeviceInfoBlock
+        ipAddress={MOCK_IP_ADDRESS}
+        browserName={MOCK_BROWSER_NAME}
+        genericOSName={MOCK_OS_NAME}
+        {...props}
+      />
+    </AppLayout>
+  );
+  return story;
+};
+
+export const WithUnknownLocation = storyWithProps();
+
+export const WithDeviceName = storyWithProps({ deviceName: MOCK_DEVICE_NAME });
+
+export const WithRegionAndCountry = storyWithProps({
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+});
+
+export const WithCityAndCountry = storyWithProps({
+  city: MOCK_CITY,
+  country: MOCK_COUNTRY,
+});
+
+export const WithCountryOnly = storyWithProps({
+  country: MOCK_COUNTRY,
+});
+
+export const WithFullLocation = storyWithProps({
+  city: MOCK_CITY,
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+});

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.test.tsx
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import DeviceInfoBlock from '.';
+import {
+  MOCK_DEVICE_NAME,
+  MOCK_BROWSER_NAME,
+  MOCK_OS_NAME,
+  MOCK_IP_ADDRESS,
+  MOCK_CITY,
+  MOCK_REGION,
+  MOCK_COUNTRY,
+} from './mocks';
+
+describe('DeviceInfoBlock component', () => {
+  it('renders as expected when the location is undefined', () => {
+    render(
+      <DeviceInfoBlock
+        browserName={MOCK_BROWSER_NAME}
+        genericOSName={MOCK_OS_NAME}
+        ipAddress={MOCK_IP_ADDRESS}
+      />
+    );
+
+    screen.getByText('Firefox on macOS');
+    screen.getByText('Location unknown');
+    screen.getByText('IP address: XX.XX.XXX.XXX');
+  });
+
+  it('renders as expected when a device name is provided', () => {
+    render(
+      <DeviceInfoBlock
+        browserName={MOCK_BROWSER_NAME}
+        genericOSName={MOCK_OS_NAME}
+        ipAddress={MOCK_IP_ADDRESS}
+        deviceName={MOCK_DEVICE_NAME}
+      />
+    );
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'Ultron'
+    );
+  });
+
+  it('renders as expected when a location is available', () => {
+    render(
+      <DeviceInfoBlock
+        browserName={MOCK_BROWSER_NAME}
+        genericOSName={MOCK_OS_NAME}
+        ipAddress={MOCK_IP_ADDRESS}
+        city={MOCK_CITY}
+        region={MOCK_REGION}
+        country={MOCK_COUNTRY}
+      />
+    );
+
+    screen.getByText('Vancouver, British Columbia, Canada (estimated)');
+  });
+});

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.tsx
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { FtlMsg } from 'fxa-react/lib/utils';
+import React, { ReactElement } from 'react';
+import { RemoteMetadata as DeviceInfoBlockProps } from '../../lib/types';
+
+// Remote metadata is obtained from pairing channel
+// Some of this data may align with the account.ts model but the keys are slightly different (e.g., `state` vs `region`)
+
+export const DeviceInfoBlock = ({
+  deviceName,
+  browserName,
+  genericOSName,
+  ipAddress,
+  city,
+  region,
+  country,
+}: DeviceInfoBlockProps) => {
+  const LocalizedLocation = () => {
+    if (city && region && country) {
+      return (
+        <FtlMsg
+          id="device-info-block-location-city-region-country"
+          vars={{ city, region, country }}
+        >{`${city}, ${region}, ${country} (estimated)`}</FtlMsg>
+      );
+    }
+    if (region && country) {
+      return (
+        <FtlMsg
+          id="device-info-block-location-region-country"
+          vars={{ region, country }}
+        >{`${region}, ${country} (estimated)`}</FtlMsg>
+      );
+    }
+    if (city && country) {
+      return (
+        <FtlMsg
+          id="device-info-block-location-city-country"
+          vars={{ city, country }}
+        >{`${city}, ${country} (estimated)`}</FtlMsg>
+      );
+    }
+    if (country) {
+      return (
+        <FtlMsg
+          id="device-info-block-location-country"
+          vars={{ country }}
+        >{`${country} (estimated)`}</FtlMsg>
+      );
+    }
+    return (
+      <FtlMsg id="device-info-block-location-unknown">Location unknown</FtlMsg>
+    );
+  };
+
+  return (
+    <div className="mt-9">
+      {deviceName && <h2 className="mb-5 text-base">{deviceName}</h2>}
+      <FtlMsg id="device-info-browser-os" vars={{ browserName, genericOSName }}>
+        <p className="text-xs">{`${browserName} on ${genericOSName}`}</p>
+      </FtlMsg>
+      <p className="text-xs">
+        <LocalizedLocation />
+      </p>
+      <FtlMsg id="device-info-ip-address" vars={{ ipAddress }}>
+        <p className="text-xs">{`IP address: ${ipAddress}`}</p>
+      </FtlMsg>
+    </div>
+  );
+};
+
+export default DeviceInfoBlock;

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/mocks.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/mocks.tsx
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RemoteMetadata } from '../../lib/types';
+
+export const MOCK_IP_ADDRESS = 'XX.XX.XXX.XXX';
+export const MOCK_DEVICE_NAME = 'Ultron';
+export const MOCK_BROWSER_NAME = 'Firefox';
+export const MOCK_OS_NAME = 'macOS';
+export const MOCK_COUNTRY = 'Canada';
+export const MOCK_REGION = 'British Columbia';
+export const MOCK_CITY = 'Vancouver';
+
+export const MOCK_METADATA_WITH_LOCATION: RemoteMetadata = {
+  browserName: MOCK_BROWSER_NAME,
+  genericOSName: MOCK_OS_NAME,
+  ipAddress: MOCK_IP_ADDRESS,
+  city: MOCK_CITY,
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+};
+
+export const MOCK_METADATA_WITH_DEVICE_NAME: RemoteMetadata = {
+  deviceName: MOCK_DEVICE_NAME,
+  browserName: MOCK_BROWSER_NAME,
+  genericOSName: MOCK_OS_NAME,
+  ipAddress: MOCK_IP_ADDRESS,
+  city: MOCK_CITY,
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+};
+
+export const MOCK_METADATA_UNKNOWN_LOCATION: RemoteMetadata = {
+  browserName: MOCK_BROWSER_NAME,
+  genericOSName: MOCK_OS_NAME,
+  ipAddress: MOCK_IP_ADDRESS,
+};

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -13,3 +13,14 @@ export enum MozServices {
   MozillaVPN = 'Mozilla VPN',
   Pocket = 'Pocket',
 }
+
+// Information about a device
+export type RemoteMetadata = {
+  deviceName?: string;
+  browserName: string;
+  genericOSName: string;
+  ipAddress: string;
+  country?: string;
+  region?: string;
+  city?: string;
+};

--- a/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/en.ftl
@@ -1,0 +1,7 @@
+## WaitForSupp page - Part of the devide pairing flow
+## Users see this page when they have started to pair a second (or more) device to their account
+## The pairing must be approved from both devices to succeed
+
+# The "other device" is non-specific and could be a desktop computer, laptop, tablet, mobile phone, etc.
+# Strings within the <span> elements appear as a subheading.
+pair-wait-for-supp-heading-text = Approval now required <span>from your other device</span>

--- a/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/index.stories.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import WaitForSupp from '.';
+import { Meta } from '@storybook/react';
+import {
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_DEVICE_NAME,
+  MOCK_METADATA_WITH_LOCATION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { MOCK_BANNER_MESSAGE } from './mocks';
+
+export default {
+  title: 'pages/Pair/Auth/WaitForSupp',
+  component: WaitForSupp,
+} as Meta;
+
+export const WithLocation = () => (
+  <WaitForSupp suppDeviceInfo={MOCK_METADATA_WITH_LOCATION} />
+);
+
+export const WithUnknownLocation = () => (
+  <WaitForSupp suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />
+);
+
+export const WithDeviceName = () => (
+  <WaitForSupp suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME} />
+);
+
+export const WithErrorMessage = () => (
+  <WaitForSupp
+    suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
+    bannerMessage={MOCK_BANNER_MESSAGE}
+  />
+);

--- a/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/index.test.tsx
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import WaitForSupp, { viewName } from '.';
+import {
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_DEVICE_NAME,
+  MOCK_METADATA_WITH_LOCATION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { usePageViewEvent } from '../../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../../constants';
+
+jest.mock('../../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('DeviceInfoBlock component', () => {
+  it('renders as expected when the location is undefined', () => {
+    render(<WaitForSupp suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Approval now required from your other device'
+    );
+    screen.getByText('Firefox on macOS');
+    screen.getByText('Location unknown');
+    screen.getByText('IP address: XX.XX.XXX.XXX');
+  });
+
+  it('renders as expected when a device name is provided', () => {
+    render(<WaitForSupp suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME} />);
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'Ultron'
+    );
+  });
+
+  it('renders as expected when a location is available', () => {
+    render(<WaitForSupp suppDeviceInfo={MOCK_METADATA_WITH_LOCATION} />);
+
+    screen.getByText('Vancouver, British Columbia, Canada (estimated)');
+  });
+
+  it('emits expected metrics events on success', () => {
+    render(<WaitForSupp suppDeviceInfo={MOCK_METADATA_WITH_LOCATION} />);
+
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/index.tsx
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { ReactElement } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { RemoteMetadata } from '../../../../lib/types';
+import { usePageViewEvent } from '../../../../lib/metrics';
+import CardHeader from '../../../../components/CardHeader';
+import Banner, { BannerType } from '../../../../components/Banner';
+import AppLayout from '../../../../components/AppLayout';
+import { REACT_ENTRYPOINT } from '../../../../constants';
+import DeviceInfoBlock from '../../../../components/DeviceInfoBlock';
+
+export type BannerMessage = {
+  messageType: BannerType;
+  messageElement: ReactElement;
+};
+
+export type WaitForSuppProps = {
+  suppDeviceInfo: RemoteMetadata;
+  // Listen to broken for error/success messages
+  // included in props temporarily for tests/storybook
+  bannerMessage?: BannerMessage;
+};
+
+export const viewName = 'pair.auth.wait-for-supp';
+
+const WaitForSupp = ({
+  suppDeviceInfo,
+  bannerMessage,
+}: WaitForSuppProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  const {
+    deviceName,
+    browserName,
+    genericOSName,
+    ipAddress,
+    city,
+    region,
+    country,
+  } = suppDeviceInfo;
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingText="Approval now required"
+        headingTextFtlId="pair-wait-for-auth-heading-text"
+        subheadingText="from your other device"
+      />
+      {bannerMessage && (
+        <Banner type={bannerMessage.messageType}>
+          {bannerMessage.messageElement}
+        </Banner>
+      )}
+
+      <DeviceInfoBlock
+        {...{
+          deviceName,
+          browserName,
+          genericOSName,
+          ipAddress,
+          city,
+          region,
+          country,
+        }}
+      />
+    </AppLayout>
+  );
+};
+
+export default WaitForSupp;

--- a/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Auth/WaitForSupp/mocks.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { BannerMessage } from '.';
+import { BannerType } from '../../../../components/Banner';
+
+const bannerText = <p>Uh-oh that device is not allowed to connect</p>;
+
+export const MOCK_BANNER_MESSAGE: BannerMessage = {
+  messageType: BannerType.error,
+  messageElement: bannerText,
+};

--- a/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/en.ftl
@@ -1,0 +1,7 @@
+## WaitForAuth page - Part of the devide pairing flow
+## Users see this page when they have started to pair a second (or more) device to their account
+## The pairing must be approved from both devices to succeed
+
+# The "other device" is non-specific and could be a desktop computer, laptop, tablet, mobile phone, etc.
+# Strings within the <span> elements appear as a subheading.
+pair-wait-for-auth-heading-text = Approval now required <span>from your other device</span>

--- a/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/index.stories.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import WaitForAuth from '.';
+import { Meta } from '@storybook/react';
+import {
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_DEVICE_NAME,
+  MOCK_METADATA_WITH_LOCATION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { MOCK_BANNER_MESSAGE } from './mocks';
+
+export default {
+  title: 'pages/Pair/Supp/WaitForAuth',
+  component: WaitForAuth,
+} as Meta;
+
+export const WithLocation = () => (
+  <WaitForAuth authDeviceInfo={MOCK_METADATA_WITH_LOCATION} />
+);
+
+export const WithUnknownLocation = () => (
+  <WaitForAuth authDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />
+);
+
+export const WithDeviceName = () => (
+  <WaitForAuth authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME} />
+);
+
+export const WithErrorMessage = () => (
+  <WaitForAuth
+    authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
+    bannerMessage={MOCK_BANNER_MESSAGE}
+  />
+);

--- a/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/index.test.tsx
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import WaitForAuth, { viewName } from '.';
+import {
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_DEVICE_NAME,
+  MOCK_METADATA_WITH_LOCATION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { usePageViewEvent } from '../../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../../constants';
+
+jest.mock('../../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('DeviceInfoBlock component', () => {
+  it('renders as expected when the location is undefined', () => {
+    render(<WaitForAuth authDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Approval now required from your other device'
+    );
+    screen.getByText('Firefox on macOS');
+    screen.getByText('Location unknown');
+    screen.getByText('IP address: XX.XX.XXX.XXX');
+  });
+
+  it('renders as expected when a device name is provided', () => {
+    render(<WaitForAuth authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME} />);
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'Ultron'
+    );
+  });
+
+  it('renders as expected when a location is available', () => {
+    render(<WaitForAuth authDeviceInfo={MOCK_METADATA_WITH_LOCATION} />);
+
+    screen.getByText('Vancouver, British Columbia, Canada (estimated)');
+  });
+
+  it('emits expected metrics events on success', () => {
+    render(<WaitForAuth authDeviceInfo={MOCK_METADATA_WITH_LOCATION} />);
+
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/index.tsx
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { ReactElement } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { RemoteMetadata } from '../../../../lib/types';
+import { usePageViewEvent } from '../../../../lib/metrics';
+import CardHeader from '../../../../components/CardHeader';
+import Banner, { BannerType } from '../../../../components/Banner';
+import AppLayout from '../../../../components/AppLayout';
+import { REACT_ENTRYPOINT } from '../../../../constants';
+import DeviceInfoBlock from '../../../../components/DeviceInfoBlock';
+
+export type BannerMessage = {
+  messageType: BannerType;
+  messageElement: ReactElement;
+};
+
+export type WaitForAuthProps = {
+  authDeviceInfo: RemoteMetadata;
+  // Listen to broken for error/success messages
+  // included in props temporarily for tests/storybook
+  bannerMessage?: BannerMessage;
+};
+
+export const viewName = 'pair.supp.wait-for-auth';
+
+const WaitForAuth = ({
+  authDeviceInfo,
+  bannerMessage,
+}: WaitForAuthProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  const {
+    deviceName,
+    browserName,
+    genericOSName,
+    ipAddress,
+    city,
+    region,
+    country,
+  } = authDeviceInfo;
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingText="Approval now required"
+        headingTextFtlId="pair-wait-for-auth-heading-text"
+        subheadingText="from your other device"
+      />
+      {bannerMessage && (
+        <Banner type={bannerMessage.messageType}>
+          {bannerMessage.messageElement}
+        </Banner>
+      )}
+
+      <DeviceInfoBlock
+        {...{
+          deviceName,
+          browserName,
+          genericOSName,
+          ipAddress,
+          city,
+          region,
+          country,
+        }}
+      />
+    </AppLayout>
+  );
+};
+
+export default WaitForAuth;

--- a/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/WaitForAuth/mocks.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { BannerMessage } from '.';
+import { BannerType } from '../../../../components/Banner';
+
+const bannerText = <p>Uh-oh that device is not allowed to connect</p>;
+
+export const MOCK_BANNER_MESSAGE: BannerMessage = {
+  messageType: BannerType.error,
+  messageElement: bannerText,
+};


### PR DESCRIPTION
## Because

* We are converting content-server views to React, and are starting by building out the front-end in Storybook with initial tests, metrics, l10n.

## This pull request

* Create a new DeviceInfoBlock component with initial storybook, tests and l10n.
* Create the PairWaitForAuth and PairWaitForSupp pages in React, with initial tests, metrics, l10n.
* Update CardHeader component to include elems in FtlMsg and allow subheadingText.

## Issue that this pull request solves

Closes: #FXA-6633

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

With minimal metadata:
![image](https://user-images.githubusercontent.com/22231637/216522692-87d5f8e3-8dd1-4d0a-aed9-32efca628f28.png)

With complete metadata and error banner:
![image](https://user-images.githubusercontent.com/22231637/216522599-ed91bca5-8cfc-43b0-b2be-4609a7f629b7.png)

## Other information (Optional)

The WaitForSupp and WaitForAuth pages are the same visually, but are endpoints for different routes and have different metric events. I've kept them separate to allow for individual control/changes to each of these routes, and because the functional follow-up ticket may require more differentiation between the pages.

I wanted to combine the mocks, but wasn't sure where would be a good spot to store mocks shared between components/pages.
