### PR TITLE
fix(subscription): on pm.attached skip tax where automatic tax enabled

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -349,6 +349,10 @@ export class StripeHelper extends StripeHelperBase {
 
     const subUpdates = customer.subscriptions.data
       .filter((sub) => {
+        // If subscription automatic_tax enabled, do not set tax rates
+        if (sub.automatic_tax) {
+          return false;
+        }
         const subTaxRates = new Set(
           (sub.default_tax_rates ?? []).map((tr) => tr.id)
         );

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3188,6 +3188,19 @@ describe('#integration - StripeHelper', () => {
       assert.deepEqual(result2, undefined);
     });
 
+    it('ignores subscriptions where automatic tax is enabled', async () => {
+      const customer = deepCopy(customer1);
+      customer.subscriptions.data[0].automatic_tax = true;
+      const paymentMethod = deepCopy(paymentMethodAttach);
+      sinon.stub(stripeHelper.stripe.subscriptions, 'update');
+      const result = await stripeHelper.updateCustomerPaymentMethodTaxRates(
+        customer,
+        paymentMethod
+      );
+      assert.deepEqual(result, []);
+      assert(stripeHelper.stripe.subscriptions.update.notCalled);
+    });
+
     it('updates the subscription tax rates from one rate to a different one', async () => {
       const customer = deepCopy(customer1);
       const paymentMethod = deepCopy(paymentMethodAttach);


### PR DESCRIPTION
## Because

- When a new payment method is attached, and subscriptions have automatic tax enabled, do not add tax rates.

## This pull request

- Updates payment_method.attached webhook logic to skip updating subscription taxes when automatic tax is enabled for that subscription

## Issue that this pull request solves

Closes: #FXA-6587

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional Information
To easily reproduce this bug follow these listed steps.
1. Create a new FxA account and subscribe to a European price. (e.g. [123 Done Pro - EU](http://localhost:3030/subscriptions/products/prod_GqM9ToKK62qjkK?plan=price_1H8NnnBVqmGyQTMaLwLRKbF3))
2. Navigate to Subscription Management page and add new Payment Method. (Can be same as before)
3. Note response from webhook event `payment_method.attached`
  - Before fix: Webhook returns with status code 500, and there are attempts to update the subscription, which fails with error code 400.
  - After fix: Webhook returns with status code 200. Subs with automatic tax enabled are not updated.