### PR TITLE
Add back in build story book

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,10 @@ workflows:
           name: Functional Tests - Playwright (PR)
           requires:
             - Build (PR)
-
+      - build-and-deploy-storybooks:
+          name: Deploy Storybooks (PR)
+          requires:
+            - Build (PR)
       - on-complete:
           name: Tests Complete (PR)
           stage: Tests
@@ -740,6 +743,7 @@ workflows:
             - Functional Test - Content 4 (PR)
             - Functional Test - Content 5 (PR)
             - Functional Tests - Playwright (PR)
+            - Deploy Storybooks (PR)
 
   production_smoke_test:
     # This workflow can be useful if we want to run test changes in our functional tests


### PR DESCRIPTION
## Because
- Storybook was removed from the test pr workflow and needs to be restored.

## This pull request
- Adds storybook back into the the test pr workflow.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
