### PR TITLE
fix(email): Revise SubscriptionUpgrade email to reflect invoice total

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2840,6 +2840,12 @@ export class StripeHelper extends StripeHelperBase {
         }
       : null;
 
+    const previousLatestInvoice: string = previousAttributes.latest_invoice;
+    const invoiceOld: Stripe.Invoice = await this.getInvoice(
+      previousLatestInvoice
+    );
+    const invoiceTotalOldInCents = invoiceOld.total;
+
     const planIdNew = planNew.id;
 
     const cancelAtPeriodEndNew = subscription.cancel_at_period_end;
@@ -2901,6 +2907,7 @@ export class StripeHelper extends StripeHelperBase {
       paymentAmountNewCurrency,
       productPaymentCycleNew,
       closeDate: event.created,
+      invoiceTotalOldInCents,
       productMetadata: productNewMetadata,
       planConfig,
     };
@@ -3113,6 +3120,7 @@ export class StripeHelper extends StripeHelperBase {
       id: invoiceId,
       number: invoiceNumber,
       currency: paymentProratedCurrency,
+      total: invoiceTotalNewInCents,
     } = invoice;
 
     // Using stripes default proration behaviour
@@ -3161,6 +3169,7 @@ export class StripeHelper extends StripeHelperBase {
       paymentAmountOldCurrency,
       invoiceNumber,
       invoiceId,
+      invoiceTotalNewInCents,
       paymentProratedInCents: onetimePaymentAmount,
       paymentProratedCurrency,
     };

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1767,6 +1767,8 @@ module.exports = function (log, config, bounces) {
     const {
       email,
       uid,
+      invoiceTotalNewInCents,
+      invoiceTotalOldInCents,
       productId,
       planId,
       productIconURLNew,
@@ -1808,12 +1810,12 @@ module.exports = function (log, config, bounces) {
         productName: productNameNew,
         productNameOld,
         paymentAmountOld: this._getLocalizedCurrencyString(
-          paymentAmountOldInCents,
+          invoiceTotalOldInCents || paymentAmountOldInCents,
           paymentAmountOldCurrency,
           message.acceptLanguage
         ),
         paymentAmountNew: this._getLocalizedCurrencyString(
-          paymentAmountNewInCents,
+          invoiceTotalNewInCents || paymentAmountNewInCents,
           paymentAmountNewCurrency,
           message.acceptLanguage
         ),

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4942,6 +4942,10 @@ describe('#integration - StripeHelper', () => {
       id: sourceId,
     };
 
+    const mockOldInvoice = {
+      total: 4567,
+    }
+
     const mockInvoice = {
       id: 'inv_0000000000',
       number: '1234567',
@@ -5631,6 +5635,7 @@ describe('#integration - StripeHelper', () => {
       productPaymentCycleNew:
         eventCustomerSubscriptionUpdated.data.object.plan.interval,
       closeDate: 1326853478,
+      invoiceTotalOldInCents: mockOldInvoice.total,
       productMetadata: {
         emailIconURL:
           eventCustomerSubscriptionUpdated.data.object.plan.metadata
@@ -5650,6 +5655,7 @@ describe('#integration - StripeHelper', () => {
       const mockUpgradeDowngradeDetails = 'mockUpgradeDowngradeDetails';
 
       beforeEach(() => {
+        sandbox.stub(stripeHelper, 'getInvoice').resolves(mockOldInvoice);
         sandbox
           .stub(
             stripeHelper,
@@ -5927,6 +5933,7 @@ describe('#integration - StripeHelper', () => {
             productIdNew,
             updateType:
               SUBSCRIPTION_UPDATE_TYPES[isUpgrade ? 'UPGRADE' : 'DOWNGRADE'],
+            invoiceTotalNewInCents: mockInvoice.total,
             productIdOld,
             productNameOld,
             productIconURLOld,


### PR DESCRIPTION
## Because

- the SubscriptionUpgrade email displayed prices without tax. The totals should match their respective invoices.

## This pull request

- updates so that SubscriptionUpgrade uses the totals from the invoices, if applicable.

## Issue that this pull request solves

Closes: [FXA-6375](https://mozilla-hub.atlassian.net/browse/FXA-6375)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
<img width="632" alt="Screenshot 2023-02-06 at 7 01 45 PM" src="https://user-images.githubusercontent.com/28129806/217114309-6a5ce781-9574-4e7f-b636-a652c735d6dd.png">


[FXA-6375]: https://mozilla-hub.atlassian.net/browse/FXA-6375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ