### PR TITLE
fix(sub): invoice preview error not in Sentry

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -123,6 +123,8 @@ const ERRNO = {
 
   IAP_PURCHASE_ALREADY_REGISTERED: 208,
 
+  INVALID_INVOICE_PREVIEW_REQUEST: 209,
+
   INTERNAL_VALIDATION_ERROR: 998,
   UNEXPECTED_ERROR: 999,
 };
@@ -1437,12 +1439,29 @@ AppError.iapPurchaseConflict = (error) => {
   );
 };
 
+AppError.invalidInvoicePreviewRequest = (error, message, priceId, customer) => {
+  const extra = error ? [{}, undefined, error] : [];
+  return new AppError(
+    {
+      code: 500,
+      error: 'Internal Server Error',
+      errno: ERRNO.INVALID_INVOICE_PREVIEW_REQUEST,
+      message,
+    },
+    {
+      priceId,
+      customer,
+    },
+    ...extra
+  );
+};
+
 AppError.iapInternalError = (error) => {
   const extra = error ? [{}, undefined, error] : [];
   return new AppError(
     {
       code: 500,
-      error: 'Internal Error',
+      error: 'Internal Server Error',
       errno: ERRNO.IAP_INTERNAL_OTHER,
       message: 'IAP Internal Error',
     },

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -441,15 +441,28 @@ export class StripeHandler {
       !customer || customer.tax?.automatic_tax === 'supported';
     const automaticTax = this.automaticTax && isCustomerTaxed;
 
-    const previewInvoice = await this.stripeHelper.previewInvoice({
-      automaticTax,
-      country,
-      ipAddress,
-      promotionCode,
-      priceId,
-    });
+    try {
+      const previewInvoice = await this.stripeHelper.previewInvoice({
+        automaticTax,
+        country,
+        ipAddress,
+        promotionCode,
+        priceId,
+      });
 
-    return stripeInvoiceToFirstInvoicePreviewDTO(previewInvoice);
+      return stripeInvoiceToFirstInvoicePreviewDTO(previewInvoice);
+    } catch (err: any) {
+      if (err.type === 'StripeInvalidRequestError') {
+        throw error.invalidInvoicePreviewRequest(
+          err,
+          err.message,
+          priceId,
+          customer?.id
+        );
+      } else {
+        throw err;
+      }
+    }
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -818,6 +818,22 @@ describe('DirectStripeRoutes', () => {
       );
       assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
     });
+
+    it('error with AppError invalidInvoicePreviewRequest', async () => {
+      const appError = new Error('Stripe error');
+      appError.type = 'StripeInvalidRequestError';
+      directStripeRoutesInstance.stripeHelper.previewInvoice.rejects(appError);
+
+      const request = deepCopy(VALID_REQUEST);
+
+      try {
+        await directStripeRoutesInstance.previewInvoice(request);
+        assert.fail('Preview Invoice should fail');
+      } catch (err) {
+        assert.instanceOf(err, WError);
+        assert.equal(err.errno, error.ERRNO.INVALID_INVOICE_PREVIEW_REQUEST);
+      }
+    });
   });
 
   describe('subsequentInvoicePreviews', () => {


### PR DESCRIPTION
## Because

- Even though the /preview/invoice api returns with a 500 Internal Server Error, the error is not reported to Sentry.

## This pull request

- Explicitly throw a 500 error, with relevant data.
- Previous logic would catch the Stripe error and re-throw it. However, since the error received from Stripe is a 400 error, the auth server Sentry reporting logic ignores these errors and does not report it to Sentry.

## Issue that this pull request solves

Closes: #FXA-6693

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).