### PR TITLE
fix(payments): some checkout links do not open a new tab

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
@@ -1,4 +1,5 @@
 import { Localized } from '@fluent/react';
+import LinkExternal from 'fxa-react/components/LinkExternal';
 import { urlsFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
 import React, { useContext } from 'react';
 
@@ -27,16 +28,20 @@ export const PaymentConsentCheckbox = ({
     <Localized
       id="payment-confirm-with-legal-links-static"
       elems={{
-        termsOfServiceLink: <a href={termsOfService}>Terms of Service</a>,
-        privacyNoticeLink: <a href={privacyNotice}>Privacy Notice</a>,
+        termsOfServiceLink: (
+          <LinkExternal href={termsOfService}>Terms of Service</LinkExternal>
+        ),
+        privacyNoticeLink: (
+          <LinkExternal href={privacyNotice}>Privacy Notice</LinkExternal>
+        ),
       }}
     >
       <Checkbox name="confirm" data-testid="confirm" onClick={onClick} required>
         I authorize Mozilla, maker of Firefox products, to charge my payment
         method for the amount shown, according to{' '}
-        <a href={termsOfService}>Terms of Service</a> and{' '}
-        <a href={privacyNotice}>Privacy Notice</a>, until I cancel my
-        subscription.
+        <LinkExternal href={termsOfService}>Terms of Service</LinkExternal> and{' '}
+        <LinkExternal href={privacyNotice}>Privacy Notice</LinkExternal>, until
+        I cancel my subscription.
       </Checkbox>
     </Localized>
   );

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -97,7 +97,7 @@ describe('components/PaymentMethodHeader', () => {
         MOCK_PLANS.find((p) => p.plan_id === 'plan_daily') || MOCK_PLANS[0];
       const props = { plan, onClick: () => {} };
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to Terms of Service and Privacy Notice, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to Terms of ServiceOpens in new window and Privacy NoticeOpens in new window, until I cancel my subscription.';
 
       const { findByTestId } = render(<PaymentMethodHeader {...props} />);
 


### PR DESCRIPTION
## Because

- Links to Terms of Service or Privacy Notice docs in the payment consent box would open on the same page, instead of opening a new tab.

## This pull request

- The HTML a tags were replaced with the LinkExternal component and now open in a new tab.

## Issue that this pull request solves

Closes: #FXA-6753

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
