### PR TITLE
Revert "chore(deps): bump @opentelemetry/sdk-trace-web from 1.7.0 to 1.9.1"

### DIFF
--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -156,7 +156,7 @@
     "@opentelemetry/plugin-react-load": "^0.28.0",
     "@opentelemetry/sdk-trace-base": "^1.7.0",
     "@opentelemetry/sdk-trace-node": "^1.7.0",
-    "@opentelemetry/sdk-trace-web": "^1.9.1",
+    "@opentelemetry/sdk-trace-web": "^1.7.0",
     "@sentry/browser": "^6.19.7",
     "@sentry/integrations": "^6.19.1",
     "@sentry/node": "^6.19.1",


### PR DESCRIPTION
Reverts mozilla/fxa#14820

Looks like this is causing some build errors in main.