### PR TITLE
storybook(fxa-settings): Recreate Pair/AuthComplete in React

### DIFF
--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
@@ -8,9 +8,7 @@ import { RemoteMetadata } from '../../lib/types';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import {
-  MOCK_BROWSER_NAME,
-  MOCK_IP_ADDRESS,
-  MOCK_OS_NAME,
+  MOCK_METADATA_UNKNOWN_LOCATION,
   MOCK_DEVICE_NAME,
   MOCK_CITY,
   MOCK_REGION,
@@ -26,9 +24,7 @@ const storyWithProps = (props?: Partial<RemoteMetadata>) => {
   const story = () => (
     <AppLayout>
       <DeviceInfoBlock
-        ipAddress={MOCK_IP_ADDRESS}
-        browserName={MOCK_BROWSER_NAME}
-        genericOSName={MOCK_OS_NAME}
+        remoteMetadata={MOCK_METADATA_UNKNOWN_LOCATION}
         {...props}
       />
     </AppLayout>

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.test.tsx
@@ -7,24 +7,14 @@ import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
 import DeviceInfoBlock from '.';
 import {
-  MOCK_DEVICE_NAME,
-  MOCK_BROWSER_NAME,
-  MOCK_OS_NAME,
-  MOCK_IP_ADDRESS,
-  MOCK_CITY,
-  MOCK_REGION,
-  MOCK_COUNTRY,
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_DEVICE_NAME,
+  MOCK_METADATA_WITH_LOCATION,
 } from './mocks';
 
 describe('DeviceInfoBlock component', () => {
   it('renders as expected when the location is undefined', () => {
-    render(
-      <DeviceInfoBlock
-        browserName={MOCK_BROWSER_NAME}
-        genericOSName={MOCK_OS_NAME}
-        ipAddress={MOCK_IP_ADDRESS}
-      />
-    );
+    render(<DeviceInfoBlock remoteMetadata={MOCK_METADATA_UNKNOWN_LOCATION} />);
 
     screen.getByText('Firefox on macOS');
     screen.getByText('Location unknown');
@@ -32,14 +22,7 @@ describe('DeviceInfoBlock component', () => {
   });
 
   it('renders as expected when a device name is provided', () => {
-    render(
-      <DeviceInfoBlock
-        browserName={MOCK_BROWSER_NAME}
-        genericOSName={MOCK_OS_NAME}
-        ipAddress={MOCK_IP_ADDRESS}
-        deviceName={MOCK_DEVICE_NAME}
-      />
-    );
+    render(<DeviceInfoBlock remoteMetadata={MOCK_METADATA_WITH_DEVICE_NAME} />);
 
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
       'Ultron'
@@ -47,16 +30,7 @@ describe('DeviceInfoBlock component', () => {
   });
 
   it('renders as expected when a location is available', () => {
-    render(
-      <DeviceInfoBlock
-        browserName={MOCK_BROWSER_NAME}
-        genericOSName={MOCK_OS_NAME}
-        ipAddress={MOCK_IP_ADDRESS}
-        city={MOCK_CITY}
-        region={MOCK_REGION}
-        country={MOCK_COUNTRY}
-      />
-    );
+    render(<DeviceInfoBlock remoteMetadata={MOCK_METADATA_WITH_LOCATION} />);
 
     screen.getByText('Vancouver, British Columbia, Canada (estimated)');
   });

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.tsx
@@ -4,20 +4,22 @@
 
 import { FtlMsg } from 'fxa-react/lib/utils';
 import React from 'react';
-import { RemoteMetadata as DeviceInfoBlockProps } from '../../lib/types';
+import { RemoteMetadata } from '../../lib/types';
 
 // Remote metadata is obtained from pairing channel
 // Some of this data may align with the account.ts model but the keys are slightly different (e.g., `state` vs `region`)
+type DeviceInfoBlockProps = { remoteMetadata: RemoteMetadata };
 
-export const DeviceInfoBlock = ({
-  deviceName,
-  browserName,
-  genericOSName,
-  ipAddress,
-  city,
-  region,
-  country,
-}: DeviceInfoBlockProps) => {
+export const DeviceInfoBlock = ({ remoteMetadata }: DeviceInfoBlockProps) => {
+  const {
+    deviceName,
+    deviceFamily,
+    deviceOS,
+    ipAddress,
+    city,
+    region,
+    country,
+  } = remoteMetadata;
   const LocalizedLocation = () => {
     if (city && region && country) {
       return (
@@ -59,8 +61,8 @@ export const DeviceInfoBlock = ({
   return (
     <div className="mt-8 mb-4">
       {deviceName && <h2 className="mb-4 text-base">{deviceName}</h2>}
-      <FtlMsg id="device-info-browser-os" vars={{ browserName, genericOSName }}>
-        <p className="text-xs">{`${browserName} on ${genericOSName}`}</p>
+      <FtlMsg id="device-info-browser-os" vars={{ deviceFamily, deviceOS }}>
+        <p className="text-xs">{`${deviceFamily} on ${deviceOS}`}</p>
       </FtlMsg>
       <p className="text-xs">
         <LocalizedLocation />

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/mocks.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/mocks.tsx
@@ -6,15 +6,15 @@ import { RemoteMetadata } from '../../lib/types';
 
 export const MOCK_IP_ADDRESS = 'XX.XX.XXX.XXX';
 export const MOCK_DEVICE_NAME = 'Ultron';
-export const MOCK_BROWSER_NAME = 'Firefox';
-export const MOCK_OS_NAME = 'macOS';
+export const MOCK_DEVICE_FAMILY = 'Firefox';
+export const MOCK_DEVICE_OS = 'macOS';
 export const MOCK_COUNTRY = 'Canada';
 export const MOCK_REGION = 'British Columbia';
 export const MOCK_CITY = 'Vancouver';
 
 export const MOCK_METADATA_WITH_LOCATION: RemoteMetadata = {
-  browserName: MOCK_BROWSER_NAME,
-  genericOSName: MOCK_OS_NAME,
+  deviceFamily: MOCK_DEVICE_FAMILY,
+  deviceOS: MOCK_DEVICE_OS,
   ipAddress: MOCK_IP_ADDRESS,
   city: MOCK_CITY,
   region: MOCK_REGION,
@@ -23,8 +23,8 @@ export const MOCK_METADATA_WITH_LOCATION: RemoteMetadata = {
 
 export const MOCK_METADATA_WITH_DEVICE_NAME: RemoteMetadata = {
   deviceName: MOCK_DEVICE_NAME,
-  browserName: MOCK_BROWSER_NAME,
-  genericOSName: MOCK_OS_NAME,
+  deviceFamily: MOCK_DEVICE_FAMILY,
+  deviceOS: MOCK_DEVICE_OS,
   ipAddress: MOCK_IP_ADDRESS,
   city: MOCK_CITY,
   region: MOCK_REGION,
@@ -32,7 +32,7 @@ export const MOCK_METADATA_WITH_DEVICE_NAME: RemoteMetadata = {
 };
 
 export const MOCK_METADATA_UNKNOWN_LOCATION: RemoteMetadata = {
-  browserName: MOCK_BROWSER_NAME,
-  genericOSName: MOCK_OS_NAME,
+  deviceFamily: MOCK_DEVICE_FAMILY,
+  deviceOS: MOCK_DEVICE_OS,
   ipAddress: MOCK_IP_ADDRESS,
 };

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -17,8 +17,8 @@ export enum MozServices {
 // Information about a device
 export type RemoteMetadata = {
   deviceName?: string;
-  browserName: string;
-  genericOSName: string;
+  deviceFamily: string;
+  deviceOS: string;
   ipAddress: string;
   country?: string;
   region?: string;

--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.stories.tsx
@@ -21,28 +21,28 @@ export default {
 export const WithLocation = () => (
   <AuthAllow
     email={MOCK_ACCOUNT.primaryEmail.email}
-    authDeviceInfo={MOCK_METADATA_WITH_LOCATION}
+    suppDeviceInfo={MOCK_METADATA_WITH_LOCATION}
   />
 );
 
 export const WithUnknownLocation = () => (
   <AuthAllow
     email={MOCK_ACCOUNT.primaryEmail.email}
-    authDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+    suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
   />
 );
 
 export const WithDeviceName = () => (
   <AuthAllow
     email={MOCK_ACCOUNT.primaryEmail.email}
-    authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
+    suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
   />
 );
 
 export const WithErrorMessage = () => (
   <AuthAllow
     email={MOCK_ACCOUNT.primaryEmail.email}
-    authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
+    suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
     bannerMessage={MOCK_BANNER_MESSAGE}
   />
 );

--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.test.tsx
@@ -40,7 +40,7 @@ describe('Pair/AuthAllow page', () => {
     render(
       <AuthAllow
         email={MOCK_EMAIL}
-        authDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+        suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
       />
     );
     // testAllL10n(screen, bundle, {email:MOCK_EMAIL});
@@ -64,7 +64,7 @@ describe('Pair/AuthAllow page', () => {
     render(
       <AuthAllow
         email={MOCK_EMAIL}
-        authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
+        suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
       />
     );
 
@@ -77,7 +77,7 @@ describe('Pair/AuthAllow page', () => {
     render(
       <AuthAllow
         email={MOCK_EMAIL}
-        authDeviceInfo={MOCK_METADATA_WITH_LOCATION}
+        suppDeviceInfo={MOCK_METADATA_WITH_LOCATION}
       />
     );
 
@@ -88,7 +88,7 @@ describe('Pair/AuthAllow page', () => {
     render(
       <AuthAllow
         email={MOCK_EMAIL}
-        authDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
+        suppDeviceInfo={MOCK_METADATA_WITH_DEVICE_NAME}
       />
     );
 

--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.tsx
@@ -19,7 +19,7 @@ export type BannerMessage = {
 };
 
 export type AuthAllowProps = {
-  authDeviceInfo: RemoteMetadata;
+  suppDeviceInfo: RemoteMetadata;
   // TODO: In FXA-6639 - Listen to broken for error/success messages
   // included in props temporarily for tests/storybook
   bannerMessage?: BannerMessage;
@@ -33,20 +33,11 @@ const handleSubmit = () => {
 };
 
 const AuthAllow = ({
-  authDeviceInfo,
+  suppDeviceInfo,
   bannerMessage,
   email,
 }: AuthAllowProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
-  const {
-    deviceName,
-    browserName,
-    genericOSName,
-    ipAddress,
-    city,
-    region,
-    country,
-  } = authDeviceInfo;
 
   const changePasswordLink = (
     <Link to="/reset_password" className="link-blue">
@@ -68,17 +59,7 @@ const AuthAllow = ({
       )}
       <LocationBalloonImage className="w-3/5 mx-auto mt-8" />
       <form noValidate onSubmit={handleSubmit}>
-        <DeviceInfoBlock
-          {...{
-            deviceName,
-            browserName,
-            genericOSName,
-            ipAddress,
-            city,
-            region,
-            country,
-          }}
-        />
+        <DeviceInfoBlock remoteMetadata={suppDeviceInfo} />
         <div className="flex flex-col justify-center">
           <FtlMsg id="pair-auth-allow-confirm-button">
             <button

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/en.ftl
@@ -1,0 +1,11 @@
+## PairAuthComplete page - part of the device pairing flow
+
+# Heading to confirm the successful pairing of a new device with the user's account
+# Device here is non specific (could be a laptop, tablet, phone, etc.)
+pair-auth-complete-heading = Device connected
+# Variable { $deviceFamily } is generally a browser name, for example "Firefox"
+# Variable { $deviceOS } is an operating system short name, for example "iOS", "Android"
+pair-auth-complete-now-syncing-device-text = You are now syncing with: { $deviceFamily } on { $deviceOS }
+pair-auth-complete-sync-benefits-text = Now you can access your open tabs, passwords, and bookmarks on all your devices.
+pair-auth-complete-see-tabs-button = See tabs from synced devices
+pair-auth-complete-manage-devices-link = Manage devices

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/indes.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/indes.stories.tsx
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import AuthComplete from '.';
+import { Meta } from '@storybook/react';
+import { MOCK_ERROR } from './mocks';
+import { MOCK_METADATA_UNKNOWN_LOCATION } from '../../../components/DeviceInfoBlock/mocks';
+
+export default {
+  title: 'pages/Pair/AuthComplete',
+  component: AuthComplete,
+} as Meta;
+
+// Any metadata mock from DeviceInfoBlock will do, location is not displayed on this page
+export const Default = () => (
+  <AuthComplete suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />
+);
+
+export const SupportsFirefoxView = () => (
+  <AuthComplete
+    suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+    supportsFirefoxView
+  />
+);
+
+export const WithErrorMessage = () => (
+  <AuthComplete
+    suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+    error={MOCK_ERROR}
+  />
+);

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import AuthComplete, { viewName } from '.';
+import { MOCK_METADATA_UNKNOWN_LOCATION } from '../../../components/DeviceInfoBlock/mocks';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
+// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+// import { FluentBundle } from '@fluent/bundle';
+
+jest.mock('../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('AuthComplete page', () => {
+  // TODO: enable l10n tests when FXA-6461 is resolved (handle embedded tags)
+  // let bundle: FluentBundle;
+  // beforeAll(async () => {
+  //   bundle = await getFtlBundle('settings');
+  // });
+  it('renders the default page as expected', () => {
+    render(<AuthComplete suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />);
+    // testAllL10n(screen, bundle);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Device connected'
+    );
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'You are now syncing with: Firefox on macOS'
+    );
+    // TODO expect image - animated vs not-animated
+    screen.getByText(
+      'Now you can access your open tabs, passwords, and bookmarks on all your devices.'
+    );
+    screen.getByRole('link', { name: 'Manage devices' });
+  });
+
+  it('renders the correct button when Firefox view is supported', () => {
+    render(
+      <AuthComplete
+        suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+        supportsFirefoxView
+      />
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Manage devices' })
+    ).not.toBeInTheDocument();
+    screen.getByRole('button', { name: 'See tabs from synced devices' });
+  });
+  // Add tests for button/link handling
+
+  it('emits expected metrics events on render', () => {
+    render(<AuthComplete suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION} />);
+
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.tsx
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Link, RouteComponentProps } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import CardHeader from '../../../components/CardHeader';
+import Banner, { BannerType } from '../../../components/Banner';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { HeartsVerifiedImage } from '../../../components/images';
+import { RemoteMetadata } from '../../../lib/types';
+import AppLayout from '../../../components/AppLayout';
+import { REACT_ENTRYPOINT } from '../../../constants';
+
+export const viewName = 'pair.auth.complete';
+
+type AuthCompleteProps = {
+  suppDeviceInfo: RemoteMetadata;
+  supportsFirefoxView?: boolean;
+  error?: string;
+};
+
+const AuthComplete = ({
+  suppDeviceInfo,
+  // FF View currently only supported in FF Nightly
+  // value to be obtained from user agent browser version
+  supportsFirefoxView = false,
+  error,
+}: AuthCompleteProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  const { deviceFamily, deviceOS } = suppDeviceInfo;
+
+  const handleSeeTabsButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    /**
+     * TODO button functionality (below from auth_complete.js)
+     * - logViewEvent('screen.pair.auth.fx-view', REACT_ENTRYPOINT);
+     * - metrics.flush();
+     * - const channel = this._notificationChannel;
+     * - return channel.send(channel.COMMANDS.FIREFOX_VIEW, {entryPoint: 'preferences',});
+     *   (entrypoint TBD)
+     *  */
+  };
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingTextFtlId="pair-auth-complete-heading"
+        headingText="Device connected"
+      />
+      {/* TODO: Errors will need to be localized */}
+      {error && (
+        <Banner type={BannerType.error}>
+          <p>{error}</p>
+        </Banner>
+      )}
+      {/* HeartsVerifiedImage was previously only shown if user agent supports SVG Transform Origin
+         Current support is at 96.5% as of 02/2023: https://caniuse.com/mdn-css_properties_transform-origin_support_in_svg
+         Non-animated version likely no longer necessary.
+       */}
+      <HeartsVerifiedImage className="w-3/5 mx-auto" />
+      <FtlMsg
+        id="pair-auth-complete-now-syncing-device-text"
+        vars={{ deviceFamily: deviceFamily, deviceOS: deviceOS }}
+      >
+        <h2 className="my-4">
+          {`You are now syncing with: ${deviceFamily} on ${deviceOS}`}
+        </h2>
+      </FtlMsg>
+      <FtlMsg id="pair-auth-complete-sync-benefits-text">
+        <p className="text-sm mb-4">
+          Now you can access your open tabs, passwords, and bookmarks on all
+          your devices.
+        </p>
+      </FtlMsg>
+      {supportsFirefoxView ? (
+        <FtlMsg id="pair-auth-complete-see-tabs-link">
+          <button
+            type="button"
+            onClick={handleSeeTabsButtonClick}
+            className="cta-primary cta-xl w-full"
+          >
+            See tabs from synced devices
+          </button>
+        </FtlMsg>
+      ) : (
+        <FtlMsg id="pair-auth-complete-manage-devices-link">
+          <Link
+            to="/settings#connected-services"
+            className="cta-primary cta-xl w-full"
+          >
+            Manage devices
+          </Link>
+        </FtlMsg>
+      )}
+    </AppLayout>
+  );
+};
+
+export default AuthComplete;

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/mocks.tsx
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_ERROR = 'Something went wrong';

--- a/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.tsx
@@ -31,15 +31,6 @@ const AuthWaitForSupp = ({
   bannerMessage,
 }: AuthWaitForSuppProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
-  const {
-    deviceName,
-    browserName,
-    genericOSName,
-    ipAddress,
-    city,
-    region,
-    country,
-  } = suppDeviceInfo;
 
   return (
     <AppLayout>
@@ -54,17 +45,7 @@ const AuthWaitForSupp = ({
         </Banner>
       )}
 
-      <DeviceInfoBlock
-        {...{
-          deviceName,
-          browserName,
-          genericOSName,
-          ipAddress,
-          city,
-          region,
-          country,
-        }}
-      />
+      <DeviceInfoBlock remoteMetadata={suppDeviceInfo} />
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/pages/Pair/SuppAllow/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppAllow/index.tsx
@@ -39,15 +39,6 @@ const SuppAllow = ({
   email,
 }: SuppAllowProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
-  const {
-    deviceName,
-    browserName,
-    genericOSName,
-    ipAddress,
-    city,
-    region,
-    country,
-  } = authDeviceInfo;
 
   const spanElement: ReactElement = (
     <span className="card-subheader">for {email}</span>
@@ -69,17 +60,7 @@ const SuppAllow = ({
         </Banner>
       )}
       <form noValidate onSubmit={handleSubmit}>
-        <DeviceInfoBlock
-          {...{
-            deviceName,
-            browserName,
-            genericOSName,
-            ipAddress,
-            city,
-            region,
-            country,
-          }}
-        />
+        <DeviceInfoBlock remoteMetadata={authDeviceInfo} />
         <div className="flex flex-col justify-center">
           <FtlMsg id="pair-supp-allow-confirm-button">
             <button

--- a/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.tsx
@@ -31,15 +31,6 @@ const SuppWaitForAuth = ({
   bannerMessage,
 }: SuppWaitForAuthProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
-  const {
-    deviceName,
-    browserName,
-    genericOSName,
-    ipAddress,
-    city,
-    region,
-    country,
-  } = authDeviceInfo;
 
   return (
     <AppLayout>
@@ -54,17 +45,7 @@ const SuppWaitForAuth = ({
         </Banner>
       )}
 
-      <DeviceInfoBlock
-        {...{
-          deviceName,
-          browserName,
-          genericOSName,
-          ipAddress,
-          city,
-          region,
-          country,
-        }}
-      />
+      <DeviceInfoBlock remoteMetadata={authDeviceInfo} />
     </AppLayout>
   );
 };


### PR DESCRIPTION
## Because

* We are converting content-server to React, and are starting by building out the front-end views in Storybook.

## This pull request

* Creates a new AuthComplete page in react, with initial storybook, tests, metrics and l10n.
* Clean up props in DeviceInfoBlock component
* Small error fixes in AuthWaitForSupp, SuppWaitForAuth

## Issue that this pull request solves

Closes: #FXA-6636

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/22231637/217655541-77681687-ccfc-4ff9-ad5a-6a2274d58af7.png)

## Other information (Optional)

Any other information that is important to this pull request.
