### PR TITLE
Fix(test): fix failing subscription test

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -54,6 +54,7 @@ export class SubscribePage extends BaseLayout {
     await paypalWindow.waitForLoadState('load');
     await paypalWindow.fill('input[type=password]', 'Ah4SboP6UDZx95I');
     await paypalWindow.click('button[id=btnLogin]');
+    await paypalWindow.waitForLoadState();
     await paypalWindow.click('button[id=consentButton]');
   }
 

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -66,7 +66,7 @@ export class SubscriptionManagementPage extends BaseLayout {
 
   async checkPaypalAccount() {
     const account = this.page.locator('#fundingLink');
-    await account.waitFor();
+    await account.waitFor({ state: 'visible' });
     return account.textContent();
   }
 

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -159,7 +159,7 @@ test.describe('resubscription test', () => {
     await subscriptionManagement.updatePaypalAccount();
 
     //Added this timeout wait for page to be loaded correctly
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(2000);
 
     //Verify that the payment info is updated
     expect(await subscriptionManagement.checkPaypalAccount()).toMatch('Visa');


### PR DESCRIPTION
## Because

- Paypal subscription tests were failing in CircleCi very consistently and upon looking closer it was found that it was happening mostly because paypal sandbox site was taking alot of time to load or was not loading properly.

## This pull request

- Adds 'state' to the load statements where ever the issue was found. 
- Made sure that now all the tests passes in CircleCi (ran the workflow thrice and it passed each time)

## Issue that this pull request solves

Closes: #[FXA-6780](https://mozilla-hub.atlassian.net/browse/FXA-6780)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-6780]: https://mozilla-hub.atlassian.net/browse/FXA-6780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ