### PR TITLE
storybook(fxa-settings): Recreate pair/supp view in React

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -461,6 +461,10 @@ const EVENTS = {
     group: GROUPS.connectDevice,
     event: 'pair_submit',
   },
+  'screen.pair.supp':{
+    group:GROUPS.connectDevice,
+    event: 'pair_supp_view'
+  },
   'pair.submit': {
     group: GROUPS.connectDevice,
     event: 'pair_submit',
@@ -490,6 +494,10 @@ const EVENTS = {
   'screen.pair.auth.wait-for-supp': {
     group: GROUPS.qrConnectDevice,
     event: 'wait_for_supp',
+  },
+  'screen.pair.supp.allow': {
+    group: GROUPS.qrConnectDevice,
+    event: 'supp_allow_view',
   },
   // the screen displayed if the pairing supplicant approved first
   'screen.pair.supp.wait-for-auth': {

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import Supp from '.';
+import { Meta } from '@storybook/react';
+import { MOCK_ERROR } from './mocks';
+
+export default {
+  title: 'pages/Pair/Supp',
+  component: Supp,
+} as Meta;
+
+export const DefaultLoadingState = () => <Supp />;
+
+export const WithErrorMessage = () => <Supp error={MOCK_ERROR} />;

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import Supp from '.';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
+import { MOCK_ERROR } from './mocks';
+
+jest.mock('../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('Pair/Supp page', () => {
+  it('renders the default loading state as expected', () => {
+    render(<Supp />);
+
+    screen.queryByTestId('loading-spinner');
+  });
+
+  it('renders as expected when an error is received', () => {
+    render(<Supp error={MOCK_ERROR} />);
+
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    screen.getByText('You shall not pass');
+  });
+
+  it('emits the expected metrics event on render', () => {
+    render(<Supp />);
+
+    expect(usePageViewEvent).toHaveBeenCalledWith(
+      'pair.supp',
+      REACT_ENTRYPOINT
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { usePageViewEvent } from '../../../lib/metrics';
+import Banner, { BannerType } from '../../../components/Banner';
+import AppLayout from '../../../components/AppLayout';
+import { REACT_ENTRYPOINT } from '../../../constants';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+
+// pair/supp is the gateway to the supplicant pairing flow
+// see pairing-architecture.md for functionality to be implemented in FXA-6502
+
+export type SuppProps = {
+  // TODO: In FXA-6502 - Listen to broken for error/success messages
+  // included in props temporarily for tests/storybook
+  error?: string;
+};
+
+export const viewName = 'pair.supp';
+
+const Supp = ({ error }: SuppProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+
+  return (
+    <AppLayout>
+      {error ? (
+        <Banner type={BannerType.error}>
+          <p>{error}</p>
+        </Banner>
+      ) : (
+        <LoadingSpinner className="flex flex-col justify-center items-center select-none" />
+      )}
+    </AppLayout>
+  );
+};
+
+export default Supp;

--- a/packages/fxa-settings/src/pages/Pair/Supp/mocks.ts
+++ b/packages/fxa-settings/src/pages/Pair/Supp/mocks.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ export const MOCK_ERROR='You shall not pass'


### PR DESCRIPTION
## Because

* We are converting content-server views to React, and are starting by documenting the front-end in storybook

## This pull request

* Create a new Supp component in React, with initial tests and metrics.
* Add new metrics event for page view.

## Issue that this pull request solves

Closes: #FXA-6427

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/22231637/217913538-6fa63b45-ac82-406b-b528-059e9de878fd.png)

![image](https://user-images.githubusercontent.com/22231637/217913604-e00c8d7f-257c-466a-b8a2-3f25736768b7.png)

## Other information (Optional)

Any other information that is important to this pull request.
