### PR TITLE
fix(fxa-settings): Add elems and vars to FtlMsg when missing

### DIFF
--- a/packages/fxa-settings/src/components/ChooseWhatToSync/en.ftl
+++ b/packages/fxa-settings/src/components/ChooseWhatToSync/en.ftl
@@ -5,7 +5,7 @@
 # That users can choose to sync
 choose-what-to-sync-prompt = Choose what to sync:
 choose-what-to-sync-option-bookmarks =
- .label = Bookmarks
+  .label = Bookmarks
 choose-what-to-sync-option-history =
   .label = History
 choose-what-to-sync-option-passwords =

--- a/packages/fxa-settings/src/components/GetDataTrio/en.ftl
+++ b/packages/fxa-settings/src/components/GetDataTrio/en.ftl
@@ -3,9 +3,12 @@
 get-data-trio-title-firefox = { -brand-firefox }
 get-data-trio-title-firefox-recovery-key = { -brand-firefox } account recovery key
 get-data-trio-title-firefox-backup-verification-codes = { -brand-firefox } backup authentication codes
-get-data-trio-download =
+get-data-trio-download-2 =
   .title = Download
-get-data-trio-copy =
+  .aria-label = Download
+get-data-trio-copy-2 =
   .title = Copy
-get-data-trio-print =
+  .aria-label = Copy
+get-data-trio-print-2 =
   .title = Print
+  .aria-label = Print

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -31,7 +31,7 @@ export type GetDataTrioProps = {
 
 export const GetDataCopySingleton = ({ value, onAction }: GetDataTrioProps) => {
   return (
-    <Localized id="get-data-trio-copy" attrs={{ title: true, ariaLabel: true }}>
+    <Localized id="get-data-trio-copy-2" attrs={{ title: true, ariaLabel: true }}>
       <button
         title="Copy"
         type="button"
@@ -100,7 +100,7 @@ export const GetDataTrio = ({
   return (
     <div className="flex justify-between w-4/5 max-w-48">
       <Localized
-        id="get-data-trio-download"
+        id="get-data-trio-download-2"
         attrs={{ title: true, ariaLabel: true }}
       >
         <a
@@ -130,7 +130,7 @@ export const GetDataTrio = ({
        *   for triggering the print screen.
        **/}
       <Localized
-        id="get-data-trio-print"
+        id="get-data-trio-print-2"
         attrs={{ title: true, ariaLabel: true }}
       >
         <button

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -25,9 +25,9 @@ cs-disconnect-sync-heading = Disconnect from Sync
 ##   $device (String) - the name of a device using Firefox Accounts
 ##                      (for example: "Firefox Nightly on Google Pixel 4a")
 
-cs-disconnect-sync-content-2 = Your browsing data will remain on { $device },
+cs-disconnect-sync-content-3 = Your browsing data will remain on <span>{ $device }</span>,
   but it will no longer sync with your account.
-cs-disconnect-sync-reason-2 = What’s the main reason for disconnecting { $device }?
+cs-disconnect-sync-reason-3 = What’s the main reason for disconnecting <span>{ $device }</span>?
 
 ## The following are the options for selecting a reason for disconnecting the
 ## device

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -275,8 +275,9 @@ export const ConnectedServices = () => {
               </Localized>
 
               <Localized
-                id="cs-disconnect-sync-content-2"
+                id="cs-disconnect-sync-content-3"
                 vars={{ device: selectedClient!.name }}
+                elems={{ span: <span className="break-word"></span> }}
               >
                 <p
                   id="connected-devices-sign-out-description"
@@ -289,8 +290,9 @@ export const ConnectedServices = () => {
               </Localized>
 
               <Localized
-                id="cs-disconnect-sync-reason-2"
+                id="cs-disconnect-sync-reason-3"
                 vars={{ device: selectedClient!.name }}
+                elems={{ span: <span className="break-word"></span> }}
               >
                 <p className="my-4 text-center">
                   What's the main reason for disconnecting{' '}

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
@@ -100,7 +100,7 @@ export const ModalVerifySession = ({
         </Localized>
 
         <Localized
-          id="mvs-enter-verification-code-desc"
+          id="mvs-enter-verification-code-desc-2"
           vars={{ email: primaryEmail.email }}
           elems={{
             email: <span className="font-bold"></span>,

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -109,7 +109,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
           >
             <p>
               Please enter the confirmation code that was sent to{' '}
-              <strong>{email}</strong> within 5 minutes.
+              <span className="font-bold">{email}</span> within 5 minutes.
             </p>
           </Localized>
 

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -224,7 +224,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                     attrs={{ alt: true }}
                   >
                     <img
-                      className="mx-auto w-48 h-48 border rounded-xl border-8 border-green-800/10"
+                      className="mx-auto w-48 h-48 rounded-xl border-8 border-green-800/10"
                       data-testid="2fa-qr-code"
                       src={totpInfo.result.qrCodeUrl}
                       alt={`Use the code ${totpInfo.result.secret} to set up two-step authentication in supported applications.`}

--- a/packages/fxa-settings/src/components/images/index.tsx
+++ b/packages/fxa-settings/src/components/images/index.tsx
@@ -39,7 +39,7 @@ export const PreparedImage = (props: PreparedImageProps) => {
   return (
     <>
       {showAriaLabel ? (
-        <FtlMsg id={props.ariaLabelFtlId}>
+        <FtlMsg id={props.ariaLabelFtlId} attrs={{ariaLabel:true}}>
           <Image role="img" aria-label={props.ariaLabel} {...{ className }} />
         </FtlMsg>
       ) : (

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
@@ -8,26 +8,26 @@ inline-totp-setup-continue-button = Continue
 inline-totp-setup-add-security-link = Add a layer of security to your account by requiring authentication codes from one of <authenticationAppsLink>these authentication apps</authenticationAppsLink>.
 
 #  The <enable2StepDefaultSpan> elements are just visual separation here
-inline-totp-setup-enable-two-step-authentication-default-header = Enable two-step authentication <enable2StepDefaultSpan>to continue to account settings</enable2StepDefaultSpan>
+inline-totp-setup-enable-two-step-authentication-default-header-2 = Enable two-step authentication <span>to continue to account settings</span>
 
 # { $serviceName } is the name of the service which the user wants to authenticate to. The <enable2StepCustomServiceSpan> elements are just visual separation
-inline-totp-setup-enable-two-step-authentication-custom-header = Enable two-step authentication <enable2StepCustomServiceSpan>to continue to { $serviceName }</enable2StepCustomServiceSpan>
+inline-totp-setup-enable-two-step-authentication-custom-header-2 = Enable two-step authentication <span>to continue to { $serviceName }</span>
 
 inline-totp-setup-ready-button = Ready
 
 # The authentication code a user is scanning is a QR code.
 # { $serviceName } is the name of the service which the user wants to authenticate to. The <scanAuthCodeHeaderSpan> elements are just visual separation
-inline-totp-setup-show-qr-custom-service-header = Scan authentication code <scanAuthCodeHeaderSpan>to continue to { $serviceName }</scanAuthCodeHeaderSpan>
+inline-totp-setup-show-qr-custom-service-header-2 = Scan authentication code <span>to continue to { $serviceName }</span>
 
 # { $serviceName } is the name of the service which the user wants to authenticate to. The <enterCodeManuallyHeaderSpan> elements are just visual separation
-inline-totp-setup-no-qr-custom-service-header = Enter code manually <enterCodeManuallyHeaderSpan>to continue to { $serviceName }</enterCodeManuallyHeaderSpan>
+inline-totp-setup-no-qr-custom-service-header-2 = Enter code manually <span>to continue to { $serviceName }</span>
 
 # The authentication code a user is scanning is a QR code.
 # The <scanAuthHeaderSpan> elements are just visual separation
-inline-totp-setup-show-qr-default-service-header = Scan authentication code <scanAuthHeaderSpan>to continue to account settings</scanAuthHeaderSpan>
+inline-totp-setup-show-qr-default-service-header-2 = Scan authentication code <span>to continue to account settings</span>
 
 # The <enterCodeManuallyHeaderSpan> elements are just visual separation
-inline-totp-setup-no-qr-default-service-header = Enter code manually <enterCodeManuallyHeaderSpan>to continue to account settings</enterCodeManuallyHeaderSpan>
+inline-totp-setup-no-qr-default-service-header-2 = Enter code manually <span>to continue to account settings</span>
 
 # The <toggleToQRButton> allows the user to use a QR code instead of manually entering a secret key
 inline-totp-setup-enter-key-or-use-qr-instructions = Type this secret key into your authentication app. <toggleToQRButton>Scan QR code instead?</toggleToQRButton>

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -90,8 +90,8 @@ export const InlineTotpSetup = ({
         <>
           <CardHeader
             headingText="Enable two-step authentication"
-            headingWithCustomServiceFtlId="inline-totp-setup-enable-two-step-authentication-custom-header"
-            headingWithDefaultServiceFtlId="inline-totp-setup-enable-two-step-authentication-default-header"
+            headingWithCustomServiceFtlId="inline-totp-setup-enable-two-step-authentication-custom-header-2"
+            headingWithDefaultServiceFtlId="inline-totp-setup-enable-two-step-authentication-default-header-2"
             {...{ serviceName }}
           />
           <section className="flex flex-col items-center">
@@ -144,15 +144,15 @@ export const InlineTotpSetup = ({
           {showQR ? (
             <CardHeader
               headingText="Scan authentication code"
-              headingWithCustomServiceFtlId="inline-totp-setup-show-qr-custom-service-header"
-              headingWithDefaultServiceFtlId="inline-totp-setup-show-qr-default-service-header"
+              headingWithCustomServiceFtlId="inline-totp-setup-show-qr-custom-service-header-2"
+              headingWithDefaultServiceFtlId="inline-totp-setup-show-qr-default-service-header-2"
               {...{ serviceName }}
             />
           ) : (
             <CardHeader
               headingText="Enter code manually"
-              headingWithCustomServiceFtlId="inline-totp-setup-no-qr-custom-service-header"
-              headingWithDefaultServiceFtlId="inline-totp-setup-no-qr-default-service-header"
+              headingWithCustomServiceFtlId="inline-totp-setup-no-qr-custom-service-header-2"
+              headingWithDefaultServiceFtlId="inline-totp-setup-no-qr-default-service-header-2"
               {...{ serviceName }}
             />
           )}

--- a/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.tsx
@@ -36,7 +36,7 @@ const AuthWaitForSupp = ({
     <AppLayout>
       <CardHeader
         headingText="Approval now required"
-        headingAndSubheadingFtlId="pair-wait-for-auth-heading-text"
+        headingAndSubheadingFtlId="pair-wait-for-supp-heading-text"
         subheadingText="from your other device"
       />
       {bannerMessage && (

--- a/packages/fxa-settings/src/pages/Pair/Success/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/Success/en.ftl
@@ -1,6 +1,4 @@
 ## PairSuccess - a view which displays  on successful completion of the device pairing process
 
-pair-success-header =
-  .aria-label =  Device connected
-pair-success-message =
-  .aria-label =  Pairing was successful.
+pair-success-header-2 = Device connected
+pair-success-message-2 = Pairing was successful.

--- a/packages/fxa-settings/src/pages/Pair/Success/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.tsx
@@ -25,11 +25,11 @@ const PairSuccess = ({ error }: PairSuccessProps & RouteComponentProps) => {
         </Banner>
       )}
       <CardHeader
-        headingTextFtlId="pair-success-header"
+        headingTextFtlId="pair-success-header-2"
         headingText="Device connected"
       />
       <HeartsVerifiedImage className="w-3/5 mx-auto" />
-      <FtlMsg id="pair-success-message">
+      <FtlMsg id="pair-success-message-2">
         <p className="text-sm">Pairing was successful.</p>
       </FtlMsg>
     </>

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -125,7 +125,10 @@ const AccountRecoveryConfirmKey = ({
             onSubmit={handleSubmit(onSubmit)}
             data-testid="account-recovery-confirm-key-form"
           >
-            <FtlMsg id="account-recovery-confirm-key-input">
+            <FtlMsg
+              id="account-recovery-confirm-key-input"
+              attrs={{ label: true }}
+            >
               <InputText
                 type="text"
                 label="Enter account recovery key"

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -50,14 +50,26 @@ const SigninBounced = ({
         <div className="flex justify-center mx-auto">
           <EmailBounced className="w-3/5" role="img" />
         </div>
-        <FtlMsg id="signin-bounced-message" vars={{ email: email }}>
+        <FtlMsg id="signin-bounced-message" vars={{ email }}>
           <p className="text-sm mb-6">
             The confirmation email we sent to {email} was returned and we’ve
             locked your account to protect your Firefox data.
           </p>
         </FtlMsg>
 
-        <FtlMsg id="signin-bounced-help">
+        <FtlMsg
+          id="signin-bounced-help"
+          elems={{
+            linkExternal: (
+              <LinkExternal
+                className="link-blue"
+                href="https://support.mozilla.org/"
+              >
+                let us know
+              </LinkExternal>
+            ),
+          }}
+        >
           <p className="text-sm mb-6 text-grey-400">
             If this is a valid email address,{' '}
             <LinkExternal

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -86,7 +86,7 @@ const SigninTokenCode = ({
         <MailImage className="w-3/5" />
       </div>
 
-      <FtlMsg id="signin-token-code-instruction">
+      <FtlMsg id="signin-token-code-instruction" vars={{email}}>
         <p id="verification-email-message" className="m-5 text-sm">
           Enter the code that was sent to {email} within 5 minutes.
         </p>

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -88,7 +88,7 @@ const ConfirmSignupCode = ({
           <MailImage className="w-3/5" />
         </div>
 
-        <FtlMsg id="confirm-signup-code-instruction">
+        <FtlMsg id="confirm-signup-code-instruction" vars={{ email }}>
           <p className="m-5 text-sm">
             Enter the code that was sent to {email} within 5 minutes.
           </p>


### PR DESCRIPTION
## Because

* Localized messages will not render correctly if `elems`, `vars`, `attrs` attributes are omitted from the FtlMsg element.

## This pull request

* Audit fxa-settings ftl files for `</`, `{ $`, and ` .` and correct any corresponding FtlMsg elements that are missing required attributes.
* Correct ftl strings that contain misnamed elements
* Correct ftl id that had not been updated to match new string.

## Issue that this pull request solves

Closes: #FXA-6749

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
