### PR TITLE
storybook(fxa-settings): adding pair view to storybook

### DIFF
--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -15,3 +15,13 @@ export const HubsLink = 'https://hubs.mozilla.com/';
 export const SHOW_BALLOON_TIMEOUT = 500;
 export const HIDE_BALLOON_TIMEOUT = 400;
 export const REACT_ENTRYPOINT = { entrypoint_variation: 'react' };
+
+export enum ENTRYPOINTS {
+  FIREFOX_IOS_OAUTH_ENTRYPOINT = 'ios_settings_manage',
+  FIREFOX_TOOLBAR_ENTRYPOINT = 'fxa_discoverability_native',
+  FIREFOX_MENU_ENTRYPOINT = 'fxa_app_menu',
+  FIREFOX_PREFERENCES_ENTRYPOINT = 'preferences',
+  FIREFOX_SYNCED_TABS_ENTRYPOINT = 'synced-tabs',
+  FIREFOX_TABS_SIDEBAR_ENTRYPOINT = 'tabs-sidebar',
+  FIREFOX_FX_VIEW_ENTRYPOINT = 'fx-view',
+}

--- a/packages/fxa-settings/src/pages/Pair/Index/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/Index/en.ftl
@@ -1,0 +1,18 @@
+## Pair index page
+
+pair-sync-header = Sync { -brand-firefox } on your phone or tablet
+pair-cad-header = Connect { -brand-firefox } on another device
+pair-already-have-firefox-paragraph = Already have { -brand-firefox } on a phone or tablet?
+# Clicking this button initiates the pairing process, usually by directing the user to the `about:preferences` page in Firefox
+pair-sync-your-device-button = Sync your device
+# This is a heading element immediately preceded by "Sync your device" and followed by a link and QR code to download Firefox
+pair-or-download-subheader = Or download
+# Directs user to scan a QR code to download Firefox. <linkExternal> is an anchor tag that directs the user to where they can download the { -brand-firefox } app
+pair-scan-to-download-message = Scan to download { -brand-firefox } for mobile, or send yourself a <linkExternal>download link</linkExternal>.
+# This allows the user to exit the sync/pair flow, and redirects them back to Settings
+pair-not-now-button = Not now
+pair-take-your-data-message = Take your tabs, bookmarks, and passwords anywhere you use { -brand-firefox }.
+# This initiates the pairing process, usually by directing the user to the `about:preferences` page in Firefox
+pair-get-started-button = Get started
+# This is the aria label on the QR code image
+pair-qr-code-aria-label = QR code

--- a/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import Pair from '.';
+import { Meta } from '@storybook/react';
+import AppLayout from '../../../components/AppLayout';
+import { LocationProvider } from '@reach/router';
+import { ENTRYPOINTS } from '../../../constants';
+import { MOCK_ERROR, MOCK_CALLBACK } from './mocks';
+
+export default {
+  title: 'pages/Pair',
+  component: Pair,
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
+    <AppLayout>
+      <Pair
+        entryPoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
+        onSubmit={MOCK_CALLBACK}
+      />
+    </AppLayout>
+  </LocationProvider>
+);
+
+export const WithoutQRCode = () => (
+  <LocationProvider>
+    <AppLayout>
+      <Pair onSubmit={MOCK_CALLBACK} />
+    </AppLayout>
+  </LocationProvider>
+);
+
+export const WithError = () => (
+  <LocationProvider>
+    <AppLayout>
+      <Pair
+        entryPoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
+        error={MOCK_ERROR}
+        onSubmit={MOCK_CALLBACK}
+      />
+    </AppLayout>
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithRouter } from '../../../models/mocks';
+// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+// import { FluentBundle } from '@fluent/bundle';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT, ENTRYPOINTS } from '../../../constants';
+import { MOCK_ERROR } from './mocks';
+import Pair, { viewName } from '.';
+
+jest.mock('../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+describe('Pair', () => {
+  // let bundle: FluentBundle;
+  let mockCallback: Function;
+  //   beforeAll(async () => {
+  //      bundle = await getFtlBundle('settings');
+  //   });
+  beforeEach(() => {
+    mockCallback = jest.fn();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the default view as expected, with no entrypoint submitted', () => {
+    renderWithRouter(<Pair onSubmit={mockCallback} />);
+    // testAllL10n(screen, bundle);
+
+    const headingEl = screen.getByRole('heading', { level: 1 });
+    expect(headingEl).toHaveTextContent('Sync Firefox on your phone or tablet');
+    expect(
+      screen.getByRole('img', {
+        name: 'A computer and a mobile phone and a tablet with a pulsing heart on each',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Get started' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the page with a QR code with a valid entrypoint submitted', () => {
+    renderWithRouter(
+      <Pair
+        entryPoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
+        onSubmit={mockCallback}
+      />
+    );
+    // testAllL10n(screen, bundle);
+
+    const headingEl = screen.getByRole('heading', { level: 1 });
+    expect(headingEl).toHaveTextContent('Connect Firefox on another device');
+    expect(
+      screen.getByText('Already have Firefox on a phone or tablet?')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Sync your device' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Or download' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'QR code' })).toBeInTheDocument();
+  });
+
+  it('accepts a broker-specific onSubmit action', () => {
+    renderWithRouter(
+      <Pair
+        entryPoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
+        onSubmit={mockCallback}
+      />
+    );
+    // testAllL10n(screen, bundle);
+    const submitButton = screen.getByRole('button', {
+      name: 'Sync your device',
+    });
+    fireEvent.click(submitButton);
+    expect(mockCallback).toHaveBeenCalled();
+  });
+
+  it('renders any arising errors', () => {
+    renderWithRouter(<Pair error={MOCK_ERROR} onSubmit={mockCallback} />);
+    // testAllL10n(screen, bundle);
+
+    const headingEl = screen.getByRole('heading', { level: 1 });
+    expect(headingEl).toHaveTextContent('Sync Firefox on your phone or tablet');
+    expect(screen.getByText(MOCK_ERROR)).toBeInTheDocument();
+  });
+
+  it('emits expected metrics event on render', () => {
+    renderWithRouter(<Pair onSubmit={mockCallback} />);
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect } from 'react';
+import { Link, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { useFtlMsgResolver } from '../../../models';
+import Banner, { BannerType } from '../../../components/Banner';
+import CardHeader from '../../../components/CardHeader';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { ENTRYPOINTS, REACT_ENTRYPOINT } from '../../../../src/constants';
+import { HeartsVerifiedImage } from '../../../components/images';
+
+type PairProps = {
+  error?: string;
+  entryPoint?: ENTRYPOINTS;
+  onSubmit: Function; // navigates to `about:preferences` whatever the given broker does that.
+};
+export const viewName = 'pair';
+
+const Pair = ({
+  error,
+  entryPoint,
+  onSubmit,
+}: PairProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedQRCodeLabel = ftlMsgResolver.getMsg(
+    'pair-qr-code-aria-label',
+    'QR code'
+  );
+  const navigate = useNavigate();
+  // TODO: Recreate the QR code logic which previously existed in the content-server.
+  // Probably after that we can remove the fallback styles for the QR code div.
+
+  // TODO: check if we are either using Firefox Desktop ,or if the UA has the `supportPairing` capability
+  const isSupported = () => true;
+
+  // TODO: get the account and check if it is the default account.
+  const isDefaultAccount = () => false;
+
+  // TODO: check if the account is either not verified, or has a falsy value for session token.
+  const accountIsNotVerifiedOrHasNoSessionToken = () => false;
+
+  useEffect(() => {
+    // This will just run at page load.
+    if (!isSupported()) {
+      navigate('/pair/unsupported');
+    }
+    if (isDefaultAccount()) {
+      // we have historically needed the "forceView" option to prevent a loop of redirects.
+      navigate('/connect_another_device', { state: { forceView: true } });
+    }
+    if (accountIsNotVerifiedOrHasNoSessionToken()) {
+      navigate('/signin');
+    }
+  }, [navigate]);
+
+  const showQRCode =
+    entryPoint === ENTRYPOINTS.FIREFOX_MENU_ENTRYPOINT ||
+    entryPoint === ENTRYPOINTS.FIREFOX_PREFERENCES_ENTRYPOINT ||
+    entryPoint === ENTRYPOINTS.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
+    entryPoint === ENTRYPOINTS.FIREFOX_TABS_SIDEBAR_ENTRYPOINT ||
+    entryPoint === ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT ||
+    entryPoint === ENTRYPOINTS.FIREFOX_TOOLBAR_ENTRYPOINT;
+
+  return (
+    <>
+      {showQRCode ? (
+        <CardHeader
+          headingTextFtlId="pair-cad-header"
+          headingText="Connect Firefox on another device"
+        />
+      ) : (
+        <CardHeader
+          headingTextFtlId="pair-sync-header"
+          headingText="Sync Firefox on your phone or tablet"
+        />
+      )}
+
+      <section>
+        {error && (
+          <Banner type={BannerType.error}>
+            <p>{error}</p>
+          </Banner>
+        )}
+        {showQRCode ? (
+          <>
+            <div className="mt-9 mb-5">
+              <FtlMsg id="pair-already-have-firefox-paragraph">
+                <p className="text-sm">
+                  Already have Firefox on a phone or tablet?
+                </p>
+              </FtlMsg>
+            </div>
+            <div className="flex">
+              <FtlMsg id="pair-sync-your-device-button">
+                <button
+                  className="cta-primary cta-xl"
+                  type="button"
+                  onClick={() => {
+                    onSubmit();
+                  }}
+                >
+                  Sync your device
+                </button>
+              </FtlMsg>
+            </div>
+            <FtlMsg id="pair-or-download-subheader">
+              <h2 className="text-lg font-bold mt-10">Or download</h2>
+            </FtlMsg>
+            <FtlMsg
+              id="pair-scan-to-download-message"
+              elems={{
+                linkExternal: (
+                  <LinkExternal
+                    href="https://www.mozilla.org/firefox/mobile/get-app/"
+                    className="link-blue"
+                  >
+                    download link.
+                  </LinkExternal>
+                ),
+              }}
+            >
+              <p className="my-5 px-16 text-sm">
+                Scan to download Firefox for mobile, or send yourself a{' '}
+                <LinkExternal
+                  href="https://www.mozilla.org/firefox/mobile/get-app/"
+                  className="link-blue"
+                >
+                  download link.
+                </LinkExternal>
+              </p>
+            </FtlMsg>
+            <div
+              className="mx-auto w-48 h-48"
+              role="img"
+              aria-label={localizedQRCodeLabel}
+            ></div>
+            <p className="mt-5 text-sm">
+              <FtlMsg id="pair-not-now-button">
+                <Link className="link-blue" to="/settings">
+                  Not now
+                </Link>
+              </FtlMsg>
+            </p>
+          </>
+        ) : (
+          <>
+            <HeartsVerifiedImage />
+            <FtlMsg id="pair-take-your-message">
+              <p className="mt-5 mb-5 px-16 text-sm">
+                Take your tabs, bookmarks, and passwords anywhere you use
+                Firefox.
+              </p>
+            </FtlMsg>
+            <div className="flex">
+              <FtlMsg id="pair-get-started-button">
+                <button
+                  className="cta-primary cta-xl"
+                  onClick={() => onSubmit()}
+                  type="button"
+                >
+                  Get started
+                </button>
+              </FtlMsg>
+            </div>
+          </>
+        )}
+      </section>
+    </>
+  );
+};
+
+export default Pair;

--- a/packages/fxa-settings/src/pages/Pair/Index/mocks.ts
+++ b/packages/fxa-settings/src/pages/Pair/Index/mocks.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const MOCK_ERROR = "They've taken the hobbits to Isengard!";
+
+export const MOCK_CALLBACK = () => {
+  console.log('What do you see with your elf eyes?');
+};

--- a/packages/fxa-settings/src/pages/Pair/Success/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.test.tsx
@@ -8,8 +8,9 @@ import { render, screen } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
 import { MOCK_ERROR } from './mocks';
-import PairSuccess from '.';
+import PairSuccess, { viewName } from '.';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -42,8 +43,6 @@ describe('PairSuccess', () => {
 
   it('emits expected metrics event on render', () => {
     render(<PairSuccess />);
-    expect(usePageViewEvent).toHaveBeenCalledWith('pair-success', {
-      entrypoint_variation: 'react',
-    });
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Pair/Success/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.tsx
@@ -9,12 +9,12 @@ import CardHeader from '../../../components/CardHeader';
 import Banner, { BannerType } from '../../../components/Banner';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { HeartsVerifiedImage } from '../../../components/images';
+import { REACT_ENTRYPOINT } from '../../../constants';
 
 type PairSuccessProps = { error?: string };
-
+export const viewName = 'pair-success';
 const PairSuccess = ({ error }: PairSuccessProps & RouteComponentProps) => {
-  const viewName = 'pair-success';
-  usePageViewEvent(viewName, { entrypoint_variation: 'react' });
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
   // TODO: We'll need to figure out how to localize the error (be it passing in a localized
   // error, or passing in an error id to compose the ftl id)
   return (


### PR DESCRIPTION
## Because:

* The first step in rebuilding all of the Backbone views in react, is adding a react version to Storybook

## This commit:

* Adds the pair view, with l10n, a11y, and basic tests into Storybook

Closes #FXA-6424

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
Before:
<img width="506" alt="Screen Shot 2023-02-09 at 4 16 03 PM" src="https://user-images.githubusercontent.com/11150372/217968324-b607ede2-3b80-48a1-8e9f-528ca20f1dbc.png">

<img width="559" alt="Screen Shot 2023-02-09 at 4 16 30 PM" src="https://user-images.githubusercontent.com/11150372/217968378-97c891fc-2043-4ee6-8d43-7d96cfc872e7.png">

After:
<img width="534" alt="Screen Shot 2023-02-09 at 4 14 10 PM" src="https://user-images.githubusercontent.com/11150372/217968161-749783d7-fc00-4901-afc9-9c5bf9ee16e0.png">

<img width="541" alt="Screen Shot 2023-02-09 at 4 14 32 PM" src="https://user-images.githubusercontent.com/11150372/217968134-dcd4193d-15d0-47ce-aa55-74c892a2e6e2.png">

## Other information (Optional)
I need to enter metrics into the doc, and also need to create a ticket specifically for the QR code logic 
