### PR TITLE
feat(react): Add password reset confirm page functionality

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -514,17 +514,12 @@ export default class AuthClient {
     );
   }
 
-  async passwordForgotStatus(
-    passwordForgotToken: string,
-    headers: Headers = new Headers()
-  ) {
+  async passwordForgotStatus(passwordForgotToken: string) {
     return this.hawkRequest(
       'GET',
       '/password/forgot/status',
       passwordForgotToken,
-      tokenType.passwordForgotToken,
-      undefined,
-      headers
+      tokenType.passwordForgotToken
     );
   }
 

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -146,7 +146,12 @@ Router = Router.extend({
     'confirm(/)': createViewHandler(ConfirmView, {
       type: VerificationReasons.SIGN_UP,
     }),
-    'confirm_reset_password(/)': createViewHandler(ConfirmResetPasswordView),
+    'confirm_reset_password(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'confirm_reset_password',
+        ConfirmResetPasswordView
+      );
+    },
     'confirm_signin(/)': createViewHandler(ConfirmView, {
       type: VerificationReasons.SIGN_IN,
     }),

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -26,7 +26,10 @@ const getReactRouteGroups = (showReactApp, isServer = true) => {
 
     resetPasswordRoutes: {
       featureFlagOn: showReactApp.resetPasswordRoutes,
-      routes: reactRoute.getRoutes(['reset_password']),
+      routes: reactRoute.getRoutes([
+        'reset_password',
+        'confirm_reset_password',
+      ]),
     },
 
     oauthRoutes: {

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -494,11 +494,10 @@ export class AccountResolver {
   })
   @CatchGatewayError
   public async passwordForgotCodeStatus(
-    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => PasswordForgotCodeStatusInput })
     input: PasswordForgotCodeStatusInput
   ) {
-    return this.authAPI.passwordForgotStatus(input.token, headers);
+    return this.authAPI.passwordForgotStatus(input.token);
   }
 
   @Mutation((returns) => AccountResetPayload, {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -12,6 +12,7 @@ import CannotCreateAccount from '../../pages/CannotCreateAccount';
 import Clear from '../../pages/Clear';
 import CookiesDisabled from '../../pages/CookiesDisabled';
 import ResetPassword from '../../pages/ResetPassword';
+import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
 
 export const App = ({
   flowQueryParams,
@@ -32,6 +33,7 @@ export const App = ({
               <Clear path="/clear/*" />
               <CookiesDisabled path="/cookies_disabled/*" />
               <ResetPassword path="/reset_password/*" />
+              <ConfirmResetPassword path="/confirm_reset_password/*" />
             </>
           )}
 

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useContext, useRef, useEffect } from 'react';
+import { AppContext, GET_INITIAL_STATE } from './AppContext';
+import { GET_SESSION_VERIFIED, Session } from './Session';
+import { clearSignedInAccountUid } from '../lib/cache';
 import { gql, useQuery } from '@apollo/client';
 import { useLocalization } from '@fluent/react';
 import { FtlMsgResolver } from 'fxa-react/lib/utils';
-import { useContext, useRef } from 'react';
-import { clearSignedInAccountUid } from '../lib/cache';
 import { getDefault } from '../lib/config';
-import { AppContext, GET_INITIAL_STATE } from './AppContext';
-import { GET_SESSION_VERIFIED, Session } from './Session';
 
 export function useAccount() {
   const { account } = useContext(AppContext);
@@ -90,4 +90,30 @@ export function useFtlMsgResolver() {
 export async function useRelier() {
   const { relierFactory } = useContext(AppContext);
   return await relierFactory?.getRelier();
+}
+
+/**
+ * Hook to run a function on an interval.
+ * @param callback - function to call
+ * @param delay - interval in Ms to run, null to stop poll
+ */
+export function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!delay && delay !== 0) {
+      return;
+    }
+
+    const id = window.setInterval(() => {
+      if (savedCallback.current) {
+        savedCallback.current();
+      }
+    }, delay);
+    return () => window.clearInterval(id);
+  }, [delay]);
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/en.ftl
@@ -7,3 +7,6 @@ confirm-pw-reset-header = Reset email sent
 # Instructions to continue the password reset process
 # { $email } is the email entered by the user and where the password reset instructions were sent
 confirm-pw-reset-instructions = Click the link emailed to { $email } within the next hour to create a new password.
+
+# $accountsEmail is the email address the resent password reset confirmation is sent from. (e.g. accounts@firefox.com)
+resend-pw-reset-banner = Email resent. Add { $accountsEmail } to your contacts to ensure a smooth delivery.

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
@@ -4,34 +4,33 @@
 
 import React from 'react';
 import ConfirmResetPassword from '.';
-import AppLayout from '../../../components/AppLayout';
-import { LocationProvider } from '@reach/router';
+import {
+  LocationProvider,
+  createHistory,
+  createMemorySource,
+} from '@reach/router';
 import { Meta } from '@storybook/react';
-import { MOCK_EMAIL } from './mocks';
+import { MOCK_EMAIL, MOCK_PASSWORD_FORGOT_TOKEN } from './mocks';
 
 export default {
   title: 'pages/ResetPassword/ConfirmResetPassword',
   component: ConfirmResetPassword,
 } as Meta;
 
+const source = createMemorySource('/fake-memories');
+const history = createHistory(source);
+history.location.state = {
+  email: MOCK_EMAIL,
+  passwordForgotToken: MOCK_PASSWORD_FORGOT_TOKEN,
+};
+
 const storyWithProps = ({ ...props }) => {
   const story = () => (
-    <LocationProvider>
-      <AppLayout>
-        <ConfirmResetPassword email={MOCK_EMAIL} {...props} />
-      </AppLayout>
+    <LocationProvider history={history}>
+      <ConfirmResetPassword {...props} />
     </LocationProvider>
   );
   return story;
 };
 
 export const Default = storyWithProps({});
-
-export const WithForceAuth = storyWithProps({
-  forceAuth: true,
-  canSignIn: true,
-});
-
-export const WithLinkRememberPassword = storyWithProps({
-  canSignIn: true,
-});

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
@@ -5,21 +5,42 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ConfirmResetPassword, { viewName } from '.';
-import { usePageViewEvent } from '../../../lib/metrics';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
-import { MOCK_EMAIL } from './mocks';
+import { MOCK_EMAIL, MOCK_PASSWORD_FORGOT_TOKEN } from './mocks';
 import { REACT_ENTRYPOINT } from '../../../constants';
+import { LocationProvider } from '@reach/router';
+import { Account, AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
+import { logPageViewEvent } from '../../../lib/metrics';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
-  usePageViewEvent: jest.fn(),
+  logPageViewEvent: jest.fn(),
 }));
+
+function renderWithAccount(account: Account) {
+  render(
+    <AppContext.Provider value={mockAppContext({ account })}>
+      <LocationProvider>
+        <ConfirmResetPassword />
+      </LocationProvider>
+    </AppContext.Provider>
+  );
+}
 
 const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   useNavigate: () => mockNavigate,
+  useLocation: () => {
+    return {
+      state: {
+        email: MOCK_EMAIL,
+        passwordForgotToken: MOCK_PASSWORD_FORGOT_TOKEN,
+      },
+    };
+  },
 }));
 
 describe('ConfirmResetPassword', () => {
@@ -30,13 +51,16 @@ describe('ConfirmResetPassword', () => {
   // });
 
   it('renders ConfirmResetPassword component as expected', () => {
-    render(<ConfirmResetPassword email={MOCK_EMAIL} />);
+    const account = {
+      resetPasswordStatus: jest.fn().mockResolvedValue(true),
+    } as unknown as Account;
+
+    renderWithAccount(account);
+
     // testAllL10n(screen, bundle);
 
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent('Reset email sent');
-
-    // TODO expect image
 
     const confirmPwResetInstructions = screen.getByText(
       `Click the link emailed to ${MOCK_EMAIL} within the next hour to create a new password.`
@@ -48,18 +72,15 @@ describe('ConfirmResetPassword', () => {
         name: 'Not in inbox or spam folder? Resend',
       })
     ).toBeInTheDocument();
-
-    // when 'canSignIn: false' or not passed as prop, the optional LinkRememberPassword component should not be rendered
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('emits the expected metrics on render', async () => {
-    render(<ConfirmResetPassword email={MOCK_EMAIL} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+    render(<ConfirmResetPassword />);
+    expect(logPageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
-  it('renders a "Remember your password?" link if "canSignIn: true"', () => {
-    render(<ConfirmResetPassword email={MOCK_EMAIL} canSignIn={true} />);
+  it('renders a "Remember your password?" link', () => {
+    render(<ConfirmResetPassword />);
     expect(
       screen.getByRole('link', { name: 'Remember your password? Sign in' })
     ).toBeInTheDocument();

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -2,37 +2,75 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { RouteComponentProps } from '@reach/router';
-import { usePageViewEvent } from '../../../lib/metrics';
+import React, { useCallback, useState } from 'react';
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import Banner, { BannerType } from '../../../components/Banner';
 
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
 import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
 } from '../../../components/ConfirmWithLink';
 import { REACT_ENTRYPOINT } from '../../../constants';
+import AppLayout from '../../../components/AppLayout';
+import { useAccount, useInterval } from '../../../models';
+import { FtlMsg } from 'fxa-react/dist/lib/utils';
+import { logPageViewEvent } from '../../../lib/metrics';
 
 export const viewName = 'confirm-reset-password';
 
 export type ConfirmResetPasswordProps = {
   email: string;
-  forceAuth?: boolean;
-  canSignIn?: boolean;
+  passwordForgotToken: string;
 };
 
-const ConfirmResetPassword = ({
-  email,
-  forceAuth,
-  canSignIn,
-}: ConfirmResetPasswordProps & RouteComponentProps) => {
-  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+const POLLING_INTERVAL_MS = 2000;
+const FIREFOX_NOREPLY_EMAIL = 'accounts@firefox.com';
 
-  // TODO check for passwordResetToken (confirms reset password initiated)
-  // TODO redirect to reset_password if !passwordResetToken
+const ConfirmResetPassword = (_: RouteComponentProps) => {
+  logPageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const resendHandler = () => {
-    // TODO resend code
-    // TODO logViewEvent metric
+  const navigate = useNavigate();
+  let { state = {} } = useLocation();
+  const account = useAccount();
+  const [passwordResetResend, setPasswordResetResend] = useState(false);
+  const [isPolling, setIsPolling] = useState<number | null>(
+    POLLING_INTERVAL_MS
+  );
+
+  const navigateToPasswordReset = useCallback(() => {
+    navigate('reset_password?showReactApp=true', { replace: true });
+  }, [navigate]);
+
+  if (!state) {
+    state = {};
+  }
+
+  let { email, passwordForgotToken } = state as ConfirmResetPasswordProps;
+
+  if (!email || !passwordForgotToken) {
+    navigateToPasswordReset();
+  }
+
+  useInterval(async () => {
+    try {
+      // A bit unconventional but this endpoint will throw an invalid token error
+      // that represents the password has been reset.
+      const status = await account.resetPasswordStatus(passwordForgotToken);
+      if (status) {
+        // TODO: Going from react page to non-react page will require a hard
+        // navigate. When signin flow have been converted we should be able
+        // to use `navigate`
+        window.location.href = '/signin';
+      }
+    } catch (err) {
+      setIsPolling(null);
+    }
+  }, isPolling);
+
+  const resendHandler = async () => {
+    const result = await account.resetPassword(email);
+    passwordForgotToken = result.passwordForgotToken;
+    setPasswordResetResend(true);
   };
 
   const confirmResetPasswordStrings: ConfirmWithLinkPageStrings = {
@@ -43,14 +81,31 @@ const ConfirmResetPassword = ({
   };
 
   return (
-    <>
+    <AppLayout>
+      {passwordResetResend && (
+        <Banner
+          type={BannerType.success}
+          dismissible
+          setIsVisible={setPasswordResetResend}
+        >
+          <FtlMsg
+            id="resend-pw-reset-banner"
+            vars={{ accountsEmail: FIREFOX_NOREPLY_EMAIL }}
+          >
+            <p>
+              Email resent. Add accounts@firefox.com to your contacts to ensure
+              a smooth delivery.
+            </p>
+          </FtlMsg>
+        </Banner>
+      )}
       <ConfirmWithLink
         {...{ email }}
         confirmWithLinkPageStrings={confirmResetPasswordStrings}
         resendEmailCallback={resendHandler}
       />
-      {canSignIn && <LinkRememberPassword {...{ email, forceAuth }} />}
-    </>
+      <LinkRememberPassword {...{ email }} />
+    </AppLayout>
   );
 };
 

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/mocks.tsx
@@ -3,3 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export const MOCK_EMAIL = 'blabidi@blabidiboo.com';
+export const MOCK_PASSWORD_FORGOT_TOKEN = 'abc';

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -115,6 +115,10 @@ describe('PageResetPassword', () => {
     );
     expect(mockNavigate).toHaveBeenCalledWith('confirm_reset_password', {
       replace: true,
+      state: {
+        email: 'johndope@example.com',
+        passwordForgotToken: '123',
+      },
     });
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -21,6 +21,7 @@ import { REACT_ENTRYPOINT } from '../../constants';
 import AppLayout from '../../components/AppLayout';
 import { composeAuthUiErrorTranslationId } from '../../lib/auth-errors/auth-errors';
 import Banner, { BannerType } from '../../components/Banner';
+import { ConfirmResetPasswordProps } from './ConfirmResetPassword';
 
 export const viewName = 'reset-password';
 
@@ -71,15 +72,23 @@ const ResetPassword = ({
     }
   };
 
-  const navigateToConfirmPwReset = useCallback(() => {
-    navigate('confirm_reset_password', { replace: true });
-  }, [navigate]);
+  const navigateToConfirmPwReset = useCallback(
+    (stateData: ConfirmResetPasswordProps) => {
+      navigate('confirm_reset_password', { state: stateData, replace: true });
+    },
+    [navigate]
+  );
 
   const onSubmit = async () => {
     try {
       setErrorTranslationId('');
       await account.resetPassword(email);
-      navigateToConfirmPwReset();
+
+      const result = await account.resetPassword(email);
+      navigateToConfirmPwReset({
+        passwordForgotToken: result.passwordForgotToken,
+        email,
+      });
     } catch (err) {
       setErrorTranslationId(composeAuthUiErrorTranslationId(err));
     }


### PR DESCRIPTION
## Because

- We need to poll the status of password reset state

## This pull request

- Adds `useInterval` hook to setup polling
- Adds gql query to get password forgot status
- Updates password reset page to navigate to confirm password reset page
  - Passes token via `state` params in `useNavigate`, maybe a better way to do this?

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6121

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This still needs some tests
