### PR TITLE
test(functional): disable flaky paypal test

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -126,7 +126,9 @@ test.describe('resubscription test', () => {
     expect(await subscriptionManagement.getCardInfo()).toContain('4444');
   });
 
-  test('update mode of payment for paypal', async ({
+  //Diabling the test as this is being flaky because Paypal Sandbox is being finicky
+  // FXA - 6786
+  /*test('update mode of payment for paypal', async ({
     page,
     pages: { relier, subscribe, login, settings, subscriptionManagement },
   }) => {
@@ -163,5 +165,5 @@ test.describe('resubscription test', () => {
 
     //Verify that the payment info is updated
     expect(await subscriptionManagement.checkPaypalAccount()).toMatch('Visa');
-  });
+  });*/
 });

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -57,6 +57,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
 
     //Refresh the page
     await page.reload({ waitUntil: 'load' });
+    await page.waitForTimeout(1000);
 
     // refresh sends the user back to the first step
     expect(await login.isEmailHeader()).toBe(true);


### PR DESCRIPTION
## Because

- The Paypal sanbox is having load issues and because of which tests are failing. Currently disabling the current tests until I have a fix ready.

## This pull request

- Diasbles paypal subscription tests

## Issue that this pull request solves

Closes: #[FXA-6786](https://mozilla-hub.atlassian.net/browse/FXA-6786)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-6786]: https://mozilla-hub.atlassian.net/browse/FXA-6786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ