### PR TITLE
test(functional): disable all paypal tests

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -141,7 +141,9 @@ test.describe('coupon test', () => {
     expect(await relier.isPro()).toBe(true);
   });
 
-  test('subscribe with paypal and use coupon', async ({
+  //Diabling the test as this is being flaky because Paypal Sandbox is being finicky
+  // FXA - 6786, FXA - 6788
+  /*test('subscribe with paypal and use coupon', async ({
     pages: { relier, login, subscribe },
   }) => {
     await relier.goto();
@@ -155,7 +157,7 @@ test.describe('coupon test', () => {
     await relier.clickEmailFirst();
     await login.submit();
     expect(await relier.isPro()).toBe(true);
-  });
+  });*/
 
   test('remove a coupon and verify', async ({
     pages: { relier, subscribe, login },

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -127,7 +127,7 @@ test.describe('resubscription test', () => {
   });
 
   //Diabling the test as this is being flaky because Paypal Sandbox is being finicky
-  // FXA - 6786
+  // FXA - 6786, FXA - 6788
   /*test('update mode of payment for paypal', async ({
     page,
     pages: { relier, subscribe, login, settings, subscriptionManagement },

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -38,7 +38,9 @@ test.describe('subscription test with cc and paypal', () => {
     expect(await relier.isPro()).toBe(true);
   });
 
-  test('subscribe with paypal and login to product', async ({
+  //Diabling the test as this is being flaky because Paypal Sandbox is being finicky
+  // FXA - 6786, FXA - 6788
+  /*test('subscribe with paypal and login to product', async ({
     pages: { relier, login, subscribe },
   }) => {
     await relier.goto();
@@ -49,5 +51,5 @@ test.describe('subscription test with cc and paypal', () => {
     await relier.clickEmailFirst();
     await login.submit();
     expect(await relier.isPro()).toBe(true);
-  });
+  });*/
 });


### PR DESCRIPTION
## Because

- The Paypal sanbox is having load issues and because of which tests are failing. Currently disabling the current tests until I have a fix ready.
- Created bug [FXA - 6788](https://mozilla-hub.atlassian.net/browse/FXA-6788 )to track the issue 

## This pull request

- Diasbles paypal subscription tests

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
