### PR TITLE
feat(auth): Prompt users to set password during login if none present

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -125,6 +125,8 @@ const ERRNO = {
 
   INVALID_INVOICE_PREVIEW_REQUEST: 209,
 
+  UNABLE_TO_LOGIN_NO_PASSWORD_SET: 210,
+
   INTERNAL_VALIDATION_ERROR: 998,
   UNEXPECTED_ERROR: 999,
 };
@@ -377,6 +379,15 @@ AppError.cannotCreatePassword = function () {
     error: 'Bad Request',
     errno: ERRNO.CANNOT_CREATE_PASSWORD,
     message: 'Can not create password, password already set.',
+  });
+};
+
+AppError.cannotLoginNoPasswordSet = function () {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.UNABLE_TO_LOGIN_NO_PASSWORD_SET,
+    message: 'Complete account setup, please reset password to continue.',
   });
 };
 

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -758,6 +758,12 @@ export class AccountHandler {
     };
 
     const checkEmailAndPassword = async () => {
+      // Third party accounts might not have set a password and
+      // won't be able to login via email/password.
+      if (accountRecord.verifierSetAt <= 0) {
+        throw error.cannotLoginNoPasswordSet();
+      }
+
       await this.signinUtils.checkEmailAddress(
         accountRecord,
         email,
@@ -768,6 +774,7 @@ export class AccountHandler {
         accountRecord.authSalt,
         accountRecord.verifierVersion
       );
+
       const match = await this.signinUtils.checkPassword(
         accountRecord,
         password,

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3566,6 +3566,25 @@ describe('/account/login', () => {
       assert.equal(err.errno, error.ERRNO.DISABLED_CLIENT_ID);
     }
   });
+
+  it('fails login when no password set', () => {
+    mockDB.accountRecord = sinon.spy(() => {
+      return Promise.resolve({
+        verifierSetAt: 0, // no password set
+      });
+    });
+    return runTest(route, mockRequest).then(
+      () => assert.ok(false),
+      (err) => {
+        assert.equal(
+          mockDB.accountRecord.callCount,
+          1,
+          'db.accountRecord was called'
+        );
+        assert.equal(err.errno, 210, 'correct errno called');
+      }
+    );
+  });
 });
 
 describe('/account/keys', () => {

--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -309,6 +309,12 @@ var ERRORS = {
     errno: 116,
     message: t('This endpoint is no longer supported'),
   },
+  UNABLE_TO_LOGIN_NO_PASSWORD_SET: {
+    errno: 210,
+    message: t(
+      'Complete account setup, please <a href="/reset_password">reset password</a> to continue.'
+    ),
+  },
   SERVICE_UNAVAILABLE: {
     errno: 998,
     message: t('System unavailable, try again soon'),

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -76,6 +76,8 @@ const SignInPasswordView = FormView.extend({
       return this.notifyOfResetAccount(account);
     } else if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
       return this.showValidationError(this.$('input[type=password]'), err);
+    } else if (AuthErrors.is(err, 'UNABLE_TO_LOGIN_NO_PASSWORD_SET')) {
+      return this.unsafeDisplayError(err);
     }
 
     // re-throw error, it will be handled at a lower level.


### PR DESCRIPTION
## Because

- Third party auth account don't have a password set and won't be able to login to Sync

## This pull request

- When a users attempts to login using email/password, prompt them to reset their password

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5164

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

<img width="499" alt="image" src="https://user-images.githubusercontent.com/1295288/218515811-0ab574a8-47a0-4ea2-a432-d434430d3f73.png">
