### PR TITLE
storybook(fxa-settings): add pair/auth/totp view to storybook

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -461,9 +461,13 @@ const EVENTS = {
     group: GROUPS.connectDevice,
     event: 'pair_submit',
   },
-  'screen.pair.supp':{
-    group:GROUPS.connectDevice,
-    event: 'pair_supp_view'
+  'screen.pair.supp': {
+    group: GROUPS.connectDevice,
+    event: 'pair_supp_view',
+  },
+  'screen.pair.auth.totp': {
+    group: GROUPS.connectDevice,
+    event: 'view',
   },
   'pair.submit': {
     group: GROUPS.connectDevice,

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.stories.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import AuthTotp from '.';
+import AppLayout from '../../../components/AppLayout';
+import { Meta } from '@storybook/react';
+import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { MozServices } from '../../../lib/types';
+
+export default {
+  title: 'pages/Pair/AuthTotp',
+  component: AuthTotp,
+} as Meta;
+
+const storyWithProps = ({ ...props }) => {
+  const story = () => (
+    <AppLayout>
+      <AuthTotp email={MOCK_ACCOUNT.primaryEmail.email} {...props} />
+    </AppLayout>
+  );
+  return story;
+};
+
+export const Default = storyWithProps({});
+
+export const WithRelyingParty = storyWithProps({
+  serviceName: MozServices.MozillaVPN,
+});

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.test.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+// import { FluentBundle } from '@fluent/bundle';
+import { usePageViewEvent } from '../../../lib/metrics';
+import AuthTotp, { viewName } from '.';
+import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { MozServices } from '../../../lib/types';
+import { REACT_ENTRYPOINT } from '../../../constants';
+
+jest.mock('../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+  logViewEvent: jest.fn(),
+}));
+
+describe('Sign in with TOTP code page', () => {
+  // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
+  // TODO: in FXA-6461
+  // let bundle: FluentBundle;
+  // beforeAll(async () => {
+  //   bundle = await getFtlBundle('settings');
+  // });
+
+  it('renders as expected', () => {
+    render(<AuthTotp email={MOCK_ACCOUNT.primaryEmail.email} />);
+    // testAllL10n(screen, bundle);
+
+    const headingEl = screen.getByRole('heading', { level: 1 });
+    expect(headingEl).toHaveTextContent(
+      'Enter security code to continue to account settings'
+    );
+    screen.getByLabelText('Enter 6-digit code');
+
+    screen.getByRole('button', { name: 'Confirm' });
+    // Yes, this is a clone of SigninTotpCode, but it signficantly does not have these elements!
+    expect(
+      screen.queryByRole('link', { name: 'Use a different account' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Trouble entering code?' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the relying party in the header when a service name is provided', () => {
+    render(
+      <AuthTotp
+        email={MOCK_ACCOUNT.primaryEmail.email}
+        serviceName={MozServices.MozillaVPN}
+      />
+    );
+    const headingEl = screen.getByRole('heading', { level: 1 });
+    expect(headingEl).toHaveTextContent(
+      'Enter security code to continue to Mozilla VPN'
+    );
+  });
+
+  it('emits a metrics event on render', () => {
+    render(<AuthTotp email={MOCK_ACCOUNT.primaryEmail.email} />);
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { Link, RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 // import { useFtlMsgResolver } from '../../../models/hooks';
 import { usePageViewEvent } from '../../../lib/metrics';
@@ -18,25 +18,24 @@ import { REACT_ENTRYPOINT } from '../../../constants';
 
 // --serviceName-- is the relying party
 
-export type SigninTotpCodeProps = {
+export type AuthTotpProps = {
   email: string;
   serviceName?: MozServices;
 };
 
-export const viewName = 'signin-totp-code';
+export const viewName = 'pair.auth.totp';
 
-const SigninTotpCode = ({
+const AuthTotp = ({
   email,
   serviceName,
-}: SigninTotpCodeProps & RouteComponentProps) => {
+}: AuthTotpProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
-  // const alertBar = useAlertBar();
   // const ftlMsgResolver = useFtlMsgResolver();
 
-  // FTL strings in this view are reused in `Pair/AuthTotp` -- if we change them here but not there, we need to split those strings out.
+  // These ftlids match those in `SigninTotpCode`
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-totp-code-input-label-v2',
     inputLabelText: 'Enter 6-digit code',
@@ -57,21 +56,22 @@ const SigninTotpCode = ({
     try {
       // Check security code
       // logViewEvent('flow', `${viewName}.submit`, ENTRYPOINT_REACT);
-      // Check if isForcePasswordChange
+      // redirect to /pair/auth/allow
     } catch (e) {
       // TODO: error handling, error message confirmation
-      //       - decide if alertBar or error div
-      // const errorSigninTotpCode = ftlMsgResolver.getMsg(
+      //
+      // const errorAuthTotp = ftlMsgResolver.getMsg(
       //   'signin-totp-code-error-general',
       //   'Invalid confirmation code'
       // );
-      // alertBar.error(errorSigninTotpCode);
+      // put the error into a <Banner /> element
     }
   };
 
   return (
     // TODO: redirect to force_auth or signin if user has not initiated sign in
     <>
+      {/* Ftl ids match those in signin-totp-code because it uses those strings. */}
       <CardHeader
         headingWithDefaultServiceFtlId="signin-totp-code-heading-w-default-service"
         headingWithCustomServiceFtlId="signin-totp-code-heading-w-custom-service"
@@ -103,21 +103,9 @@ const SigninTotpCode = ({
             setCodeErrorMessage,
           }}
         />
-        <div className="mt-5 link-blue text-sm flex justify-between">
-          <FtlMsg id="signin-totp-code-other-account-link">
-            <Link to="/signin" className="text-start">
-              Use a different account
-            </Link>
-          </FtlMsg>
-          <FtlMsg id="signin-totp-code-recovery-code-link">
-            <Link to="/signin_recovery_code" className="text-end">
-              Trouble entering code?
-            </Link>
-          </FtlMsg>
-        </div>
       </main>
     </>
   );
 };
 
-export default SigninTotpCode;
+export default AuthTotp;


### PR DESCRIPTION
## Because:

* We're recreating the remaining backbone views in React in storybook as a preliminary step to replacing the backbone views. This recreates `pair/auth/totp`. In backbone, this view uses the same template as signin_totp_code. The two main differences are 1. the action which happens on submit, and 2. this view hides the alternatives to totp. I've opted to create a new component since so many of our components have ended up being a bit unwieldy due to reuse, but I'm on the fence as to whether that was the right choice. Let me know your opinions! Happy to change it.

## This commit:

* Copies the `signin_totp_code` code with the needed changes. Since we reuse strings, it doesn't involve any new strings. It does involve slightly different metrics.

Closes #FXA-6751

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
<img width="743" alt="T1mTSoQ3fopK2HU_KrDCBCCwTjX5JlUj8abCDPUvJ1tW1sIzGVzkL4O4zarl_NaA05lOMd5pDQU21nlbHtCmzZFQjjs4LYwnZo4vwZ57Lt-vlN4uTY_UgCr_pm3t8Ed1Rizuzq9hyPLrSfKxGPZEBVY" src="https://user-images.githubusercontent.com/11150372/218601529-2cca8517-0f84-4dbb-b361-a6e906fc833b.png">

After (identical to the Signin Totp Code, but without the options that are an alternative to totp):
<img width="533" alt="Screen Shot 2023-02-13 at 3 57 38 PM" src="https://user-images.githubusercontent.com/11150372/218601426-254469dc-cf0f-416d-af21-e5013f902bd2.png">


## Other information (Optional)

The real question in this PR is whether we make it a reusable component (a la the existing signin_totp_code.mustache template), or whether we copy and paste as done here :/ 
