### PR TITLE
fix(auth): gen keys workaround for openssl 3.0

### DIFF
--- a/packages/fxa-auth-server/scripts/gen_keys.js
+++ b/packages/fxa-auth-server/scripts/gen_keys.js
@@ -64,10 +64,8 @@ function addKeyProperties(key) {
   return key;
 }
 
-console.log('Generating keypair');
-
-cp.exec(`openssl genrsa 2048`, (err, stdout, stderr) => {
-  const s = pem2jwk(stdout);
+function convertPem2Jwk(pem) {
+  const s = pem2jwk(pem);
   addKeyProperties(s);
   fs.writeFileSync(secretKeyFile, JSON.stringify(s));
   console.error('Secret Key saved:', secretKeyFile);
@@ -80,4 +78,23 @@ cp.exec(`openssl genrsa 2048`, (err, stdout, stderr) => {
   };
   fs.writeFileSync(pubKeyFile, JSON.stringify(pub));
   console.error('Public Key saved:', pubKeyFile);
+}
+
+console.log('Generating keypair');
+
+cp.exec(`openssl genrsa 2048`, (err, stdout, stderr) => {
+  try {
+    convertPem2Jwk(stdout);
+  } catch (err) {
+    // As of OpenSSL v3.0 genrsa uses format PKCS#8, which is not supported by pem-jwk
+    // As a work around, use the --traditional flag which outputs format PKCS#1
+    // https://github.com/dannycoates/pem-jwk/issues/15
+    if (err.message === 'Failed to match tag: "bitstr" at: ["privateKey"]') {
+      cp.exec(`openssl genrsa --traditional 2048`, (err, stdout, stderr) => {
+        convertPem2Jwk(stdout);
+      });
+    } else {
+      throw err;
+    }
+  }
 });


### PR DESCRIPTION
## Because

- Gen keys script fails during pem2jwk conversion due to new pem format used by openssl 3.0

## This pull request

- If pem2jwk conversion fails due to the pem format error, then generate a new pem key using the --traditional flag

## Issue that this pull request solves

Closes: #FXA-5690

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).