### PR TITLE
feat(react): Add functionality to ResetPasswordWithRecoveryKeyVerified

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -268,12 +268,16 @@ Router = Router.extend({
     'reset_password_verified(/)': createViewHandler(ReadyView, {
       type: VerificationReasons.PASSWORD_RESET,
     }),
-    'reset_password_with_recovery_key_verified(/)': createViewHandler(
-      ReadyView,
-      {
-        type: VerificationReasons.PASSWORD_RESET_WITH_RECOVERY_KEY,
-      }
-    ),
+    'reset_password_with_recovery_key_verified(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'reset_password_with_recovery_key_verified',
+        ReadyView,
+        null,
+        {
+          type: VerificationReasons.PASSWORD_RESET_WITH_RECOVERY_KEY,
+        }
+      );
+    },
     'secondary_email_verified(/)': createViewHandler(ReadyView, {
       type: VerificationReasons.SECONDARY_EMAIL_VERIFIED,
     }),

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -29,6 +29,7 @@ const getReactRouteGroups = (showReactApp, isServer = true) => {
       routes: reactRoute.getRoutes([
         'reset_password',
         'confirm_reset_password',
+        'reset_password_with_recovery_key_verified',
       ]),
     },
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { RouteComponentProps, Router } from '@reach/router';
-import Head from 'fxa-react/components/Head';
 import { ScrollToTop } from '../Settings/ScrollToTop';
 import Settings from '../Settings';
 import { QueryParams } from '../..';
@@ -13,6 +12,7 @@ import Clear from '../../pages/Clear';
 import CookiesDisabled from '../../pages/CookiesDisabled';
 import ResetPassword from '../../pages/ResetPassword';
 import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
+import ResetPasswordWithRecoveryKeyVerified from '../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified';
 
 export const App = ({
   flowQueryParams,
@@ -21,7 +21,6 @@ export const App = ({
 
   return (
     <>
-      <Head />
       <Router basepath={'/'}>
         <ScrollToTop default>
           {/* We probably don't need a guard here with `showReactApp` or a feature flag/config
@@ -34,6 +33,7 @@ export const App = ({
               <CookiesDisabled path="/cookies_disabled/*" />
               <ResetPassword path="/reset_password/*" />
               <ConfirmResetPassword path="/confirm_reset_password/*" />
+              <ResetPasswordWithRecoveryKeyVerified path="/reset_password_with_recovery_key_verified/*" />
             </>
           )}
 

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -6,37 +6,47 @@ import React from 'react';
 import mozLogo from 'fxa-react/images/moz-logo.svg';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useLocalization } from '@fluent/react';
+import Head from 'fxa-react/components/Head';
 
 type AppLayoutProps = {
+  // TODO: FXA-6803 - the title prop should be made mandatory
+  // the string should be localized
+  title?: string;
   children: React.ReactNode;
 };
 
-export const AppLayout = ({ children }: AppLayoutProps) => {
+export const AppLayout = ({ title, children }: AppLayoutProps) => {
   const { l10n } = useLocalization();
   return (
-    <div className="flex min-h-screen flex-col items-center" data-testid="app">
-      <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1">
-        <section>
-          <div className="card">{children}</div>
-        </section>
-      </main>
-      <footer className="hidden mobileLandscape:block w-full p-8">
-        <LinkExternal
-          rel="author"
-          href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
-        >
-          <img
-            src={mozLogo}
-            alt={l10n.getString(
-              'app-footer-mozilla-logo-label',
-              null,
-              'Mozilla logo'
-            )}
-            className="w-32"
-          />
-        </LinkExternal>
-      </footer>
-    </div>
+    <>
+      <Head {...{ title }} />
+      <div
+        className="flex min-h-screen flex-col items-center"
+        data-testid="app"
+      >
+        <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1">
+          <section>
+            <div className="card">{children}</div>
+          </section>
+        </main>
+        <footer className="hidden mobileLandscape:block w-full p-8">
+          <LinkExternal
+            rel="author"
+            href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+          >
+            <img
+              src={mozLogo}
+              alt={l10n.getString(
+                'app-footer-mozilla-logo-label',
+                null,
+                'Mozilla logo'
+              )}
+              className="w-32"
+            />
+          </LinkExternal>
+        </footer>
+      </div>
+    </>
   );
 };
 

--- a/packages/fxa-settings/src/components/Ready/en.ftl
+++ b/packages/fxa-settings/src/components/Ready/en.ftl
@@ -1,6 +1,8 @@
 ## Ready component
 
 reset-password-complete-header = Your password has been reset
+ready-complete-set-up-instruction = Complete setup by entering your new password on your other { -brand-firefox } devices.
+ready-start-browsing-button = Start browsing
 # This is a string that tells the user they can use whatever service prompted them to reset their password or to verify their email
 # Variables:
 # { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable

--- a/packages/fxa-settings/src/components/Ready/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.stories.tsx
@@ -18,10 +18,21 @@ const ReadyWithLayout = ({
   isSignedIn,
   serviceName,
   viewName,
+  isSync,
+  errorMessage,
 }: ReadyProps) => {
   return (
     <AppLayout>
-      <Ready {...{ continueHandler, isSignedIn, serviceName, viewName }} />
+      <Ready
+        {...{
+          viewName,
+          continueHandler,
+          isSignedIn,
+          serviceName,
+          isSync,
+          errorMessage,
+        }}
+      />
     </AppLayout>
   );
 };
@@ -55,5 +66,20 @@ export const WithRelyingPartyAndContinueAction = () => (
     continueHandler={() => {
       console.log('Arbitrary action');
     }}
+  />
+);
+
+export const IsSync = () => (
+  <ReadyWithLayout
+    viewName="reset-password-with-recovery-key-verified"
+    isSync
+  />
+);
+
+export const WithErrorMessage = () => (
+  <ReadyWithLayout
+    viewName="reset-password-with-recovery-key-verified"
+    isSync
+    errorMessage="But something else went wrong"
   />
 );

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -3,13 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { RouteComponentProps } from '@reach/router';
+import { navigate, RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { REACT_ENTRYPOINT } from '../../constants';
 import { HeartsVerifiedImage } from '../../components/images';
 import CardHeader from '../CardHeader';
+import Banner, { BannerType } from '../Banner';
 
 // We'll actually be getting the isSignedIn value from a context when this is wired up.
 export type ReadyProps = {
@@ -17,6 +18,8 @@ export type ReadyProps = {
   isSignedIn?: boolean;
   serviceName?: MozServices;
   viewName: ViewNameType;
+  isSync?: boolean;
+  errorMessage?: string;
 };
 
 export type ViewNameType =
@@ -65,9 +68,16 @@ const Ready = ({
   isSignedIn = true,
   serviceName,
   viewName,
+  isSync = false,
+  errorMessage,
 }: ReadyProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const templateValues = getTemplateValues(viewName);
+
+  const startBrowsing = () => {
+    const FXA_PRODUCT_PAGE_URL = 'https://www.mozilla.org/firefox/accounts';
+    navigate(FXA_PRODUCT_PAGE_URL, { replace: true });
+  };
 
   return (
     <>
@@ -75,34 +85,55 @@ const Ready = ({
         headingText={templateValues.headerText}
         headingTextFtlId={templateValues.headerId}
       />
+      {errorMessage && (
+        <Banner type={BannerType.error}>
+          <p>{errorMessage}</p>
+        </Banner>
+      )}
       <div className="flex justify-center mx-auto">
         <HeartsVerifiedImage className="w-3/5" />
       </div>
       <section>
-        <div className="error"></div>
-        {isSignedIn ? (
-          serviceName ? (
-            <FtlMsg id="ready-use-service" vars={{ serviceName }}>
-              <p className="my-4 text-sm">{`You’re now ready to use ${serviceName}`}</p>
-            </FtlMsg>
-          ) : (
-            <FtlMsg id="ready-use-service-default">
+        {isSync && (
+          <>
+            <FtlMsg id="ready-complete-set-up-instruction">
               <p className="my-4 text-sm">
-                You’re now ready to use account settings
+                Complete setup by entering your new password on your other
+                Firefox devices.
               </p>
             </FtlMsg>
-          )
-        ) : (
+            <div className="flex justify-center mx-auto mt-6">
+              <FtlMsg id="ready-start-browsing-button">
+                <button className="cta-primary cta-xl" onClick={startBrowsing}>
+                  Start browsing
+                </button>
+              </FtlMsg>
+            </div>
+          </>
+        )}
+        {!isSync && isSignedIn && serviceName && (
+          <FtlMsg id="ready-use-service" vars={{ serviceName }}>
+            <p className="my-4 text-sm">{`You’re now ready to use ${serviceName}`}</p>
+          </FtlMsg>
+        )}
+        {!isSync && isSignedIn && !serviceName && (
+          <FtlMsg id="ready-use-service-default">
+            <p className="my-4 text-sm">
+              You’re now ready to use account settings
+            </p>
+          </FtlMsg>
+        )}
+        {!isSync && !isSignedIn && (
           <FtlMsg id="ready-account-ready">
             <p className="my-4 text-sm">Your account is ready!</p>
           </FtlMsg>
         )}
       </section>
       {continueHandler && (
-        <div className="flex justify-center mx-auto mt-6 max-w-64">
+        <div className="flex justify-center mx-auto mt-6">
           <button
             type="submit"
-            className="cta-primary cta-base-p font-bold mx-2 flex-1"
+            className="cta-primary cta-xl font-bold mx-2 flex-1"
             onClick={(e) => {
               const eventName = `${viewName}.continue`;
               logViewEvent(viewName, eventName, REACT_ENTRYPOINT);

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/en.ftl
@@ -1,2 +1,3 @@
+reset-password-with-recovery-key-verified-page-title = Password reset successful
 reset-password-with-recovery-key-verified-generate-new-key = Generate a new account recovery key
 reset-password-with-recovery-key-verified-continue-to-account = Continue to my account

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import ResetPasswordWithRecoveryKeyVerified from '.';
-import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 
@@ -15,8 +14,12 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
       <ResetPasswordWithRecoveryKeyVerified />
-    </AppLayout>
+  </LocationProvider>
+);
+
+export const WithSync = () => (
+  <LocationProvider>
+      <ResetPasswordWithRecoveryKeyVerified isSync />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -16,6 +16,10 @@ jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
 }));
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('ResetPasswordWithRecoveryKeyVerified', () => {
   // let bundle: FluentBundle;
   // beforeAll(async () => {
@@ -42,8 +46,8 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
     );
     fireEvent.click(newAccountRecoveryKeyButton);
     expect(logViewEvent).toHaveBeenCalledWith(
-      viewName,
-      `${viewName}.generate-new-key`,
+      `flow.${viewName}`,
+      'generate-new-key',
       REACT_ENTRYPOINT
     );
   });
@@ -53,8 +57,8 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
     const continueToAccountLink = screen.getByText('Continue to my account');
     fireEvent.click(continueToAccountLink);
     expect(logViewEvent).toHaveBeenCalledWith(
-      viewName,
-      `${viewName}.continue-to-account`,
+      `flow.${viewName}`,
+      'continue-to-account',
       REACT_ENTRYPOINT
     );
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -9,48 +9,65 @@ import { logViewEvent } from '../../../lib/metrics';
 import Ready from '../../../components/Ready';
 import { MozServices } from '../../../lib/types';
 import { REACT_ENTRYPOINT } from '../../../constants';
+import AppLayout from '../../../components/AppLayout';
+import { useFtlMsgResolver } from '../../../models';
 
 type ResetPasswordWithRecoveryKeyVerifiedProps = {
   serviceName?: MozServices;
+  // TODO: FXA-6804
+  // Verify if relier is Sync with the useRelier hook that will be implemented in FXA-6437
+  // instead of using a prop
+  isSync?: boolean;
 };
 
 export const viewName = 'reset-password-with-recovery-key-verified';
 
+// TODO: FXA-6805
+// This page does not currently perform a check to verify that the password has indeed been reset.
+// It is possible to directly hit this route when no password reset has been initiated/completed,
+// even when the user is not signed in.
+
 const ResetPasswordWithRecoveryKeyVerified = ({
   serviceName,
+  isSync,
 }: ResetPasswordWithRecoveryKeyVerifiedProps & RouteComponentProps) => {
   const navigate = useNavigate();
 
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const localizedPageTitle = ftlMsgResolver.getMsg(
+    'reset-password-with-recovery-key-verified-page-title',
+    'Password reset successful'
+  );
+
+  const goToGenerateNewKey = () => {
+    const eventName = `generate-new-key`;
+    logViewEvent(`flow.${viewName}`, eventName, REACT_ENTRYPOINT);
+    navigate('/settings/account_recovery', { replace: true });
+  };
+
+  const goToAccountSettings = () => {
+    const eventName = `continue-to-account`;
+    logViewEvent(`flow.${viewName}`, eventName, REACT_ENTRYPOINT);
+    navigate('/settings', { replace: true });
+  };
+
   return (
-    <>
-      <Ready {...{ viewName, serviceName }} />
+    <AppLayout title={localizedPageTitle}>
+      <Ready {...{ viewName, serviceName, isSync }} />
       <div className="flex justify-center mx-auto m-6">
-        <button
-          className="cta-primary cta-xl"
-          onClick={() => {
-            const eventName = `${viewName}.generate-new-key`;
-            logViewEvent(viewName, eventName, REACT_ENTRYPOINT);
-            navigate('/settings/account_recovery');
-          }}
-        >
+        <button className="cta-primary cta-xl" onClick={goToGenerateNewKey}>
           <FtlMsg id="reset-password-with-recovery-key-verified-generate-new-key">
             Generate a new account recovery key
           </FtlMsg>
         </button>
       </div>
-      <button
-        className="link-blue text-sm"
-        onClick={() => {
-          const eventName = `${viewName}.continue-to-account`;
-          logViewEvent(viewName, eventName, REACT_ENTRYPOINT);
-          navigate('/settings');
-        }}
-      >
+      <button className="link-blue text-sm" onClick={goToAccountSettings}>
         <FtlMsg id="reset-password-with-recovery-key-verified-continue-to-account">
           Continue to my account
         </FtlMsg>
       </button>
-    </>
+    </AppLayout>
   );
 };
 


### PR DESCRIPTION
## Because

* We want to activate the ResetPasswordWithRecoveryKeyVerified page behind a feature flag

## This pull request


* Activate React version of ResetPasswordWithRecoveryKeyVerified behind showReactApp flag
* Add isSync variation and optional error Banner to the Ready component
* Move Head component from App to AppLayout to pass in page title prop
* Fix ResetPasswordWithRecoveryKeyVerified metrics tests

## Issue that this pull request solves

Closes: #FXA-6128

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Current (default) content-server view:
![image](https://user-images.githubusercontent.com/22231637/218826002-4e2497e5-ff5a-4454-a60b-cb2b8339a731.png)

New React default page:
![image](https://user-images.githubusercontent.com/22231637/218825864-692ac732-f07f-4090-83c3-06209320bd6a.png)

New React isSync page:
![image](https://user-images.githubusercontent.com/22231637/218826130-fdeb1bbc-c62e-4887-8b76-655c785901f2.png)

## Other information (Optional)

Any other information that is important to this pull request.
