### PR TITLE
test(functional): rewrite oauth sync tests using playwright

### DIFF
--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -34,6 +34,13 @@ export class RelierPage extends BaseLayout {
     ]);
   }
 
+  clickSignIn() {
+    return Promise.all([
+      this.page.locator('button.sign-in-button.signin').click(),
+      this.page.waitForNavigation({ waitUntil: 'load' }),
+    ]);
+  }
+
   clickForceAuth() {
     return Promise.all([
       this.page.locator('button.force-auth').click(),

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+
+const password = 'passwordzxcv';
+
+test.describe('signin with OAuth after Sync', () => {
+  test.beforeEach(async () => {
+    test.slow();
+  });
+
+  test('signin to OAuth with Sync creds', async ({ target }) => {
+    const { page, login, connectAnotherDevice, relier } = await newPagesForSync(
+      target
+    );
+    const email = login.createEmail('sync{id}');
+    const email2 = login.createEmail();
+    await target.createAccount(email, password);
+    await page.goto(
+      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`
+    );
+    await login.login(email, password);
+    await login.fillOutSignInCode(email);
+    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+    await page.pause();
+
+    // Sign up for a new account via OAuth
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await login.useDifferentAccountLink();
+    await login.fillOutFirstSignUp(email2, password, true);
+
+    // RP is logged in, logout then back in again
+    expect(await relier.isLoggedIn()).toBe(true);
+    await relier.signOut();
+
+    await relier.clickSignIn();
+
+    // By default, we should see the email we signed up for Sync with
+    expect(await login.getPrefilledEmail()).toMatch(email);
+    await login.clickSignIn();
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+});
+
+test.describe('signin to Sync after OAuth', () => {
+  test.beforeEach(async () => {
+    test.slow();
+  });
+
+  test('email-first Sync signin', async ({ target }) => {
+    const { page, login, connectAnotherDevice, relier } = await newPagesForSync(
+      target
+    );
+    const email = login.createEmail('sync{id}');
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await login.fillOutFirstSignUp(email, password, true);
+    expect(await relier.isLoggedIn()).toBe(true);
+    await page.goto(
+      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`
+    );
+    expect(await login.getPrefilledEmail()).toMatch(email);
+    await login.setPassword(password);
+    await login.submit();
+    await login.fillOutSignInCode(email);
+    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+  });
+});

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -31,6 +31,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
 
     //Refresh the page
     await page.reload({ waitUntil: 'load' });
+    await page.waitForTimeout(1000);
 
     // refresh sends the user back to the first step
     expect(await login.isEmailHeader()).toBe(true);


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [Oauth sync sign in](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js) have been rewritten in this PR.

## This pull request 

contains [Oauth sync sign in](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js)

## Issue that this pull request solves

Closes: #[FXA-5895](https://mozilla-hub.atlassian.net/browse/FXA-5895)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-5895]: https://mozilla-hub.atlassian.net/browse/FXA-5895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ