### PR TITLE
feat(react): Add password reset confirm page

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -136,7 +136,12 @@ Router = Router.extend({
     'clear(/)': function () {
       this.createReactOrBackboneViewHandler('clear', ClearStorageView);
     },
-    'complete_reset_password(/)': createViewHandler(CompleteResetPasswordView),
+    'complete_reset_password(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'complete_reset_password',
+        CompleteResetPasswordView
+      );
+    },
     'complete_signin(/)': createViewHandler(CompleteSignUpView, {
       type: VerificationReasons.SIGN_IN,
     }),
@@ -266,9 +271,7 @@ Router = Router.extend({
     'reset_password_confirmed(/)': createViewHandler(ReadyView, {
       type: VerificationReasons.PASSWORD_RESET,
     }),
-    'reset_password_verified(/)': createViewHandler(ReadyView, {
-      type: VerificationReasons.PASSWORD_RESET,
-    }),
+
     'reset_password_with_recovery_key_verified(/)': function () {
       this.createReactOrBackboneViewHandler(
         'reset_password_with_recovery_key_verified',
@@ -279,6 +282,18 @@ Router = Router.extend({
         }
       );
     },
+
+    'reset_password_verified(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'reset_password_verified',
+        ReadyView,
+        null,
+        {
+          type: VerificationReasons.PASSWORD_RESET,
+        }
+      );
+    },
+
     'secondary_email_verified(/)': createViewHandler(ReadyView, {
       type: VerificationReasons.SECONDARY_EMAIL_VERIFIED,
     }),

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -35,7 +35,9 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       featureFlagOn: showReactApp.resetPasswordRoutes,
       routes: reactRoute.getRoutes([
         'reset_password',
+        'complete_reset_password',
         'confirm_reset_password',
+        'reset_password_verified',
         'reset_password_with_recovery_key_verified',
       ]),
     },

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -481,12 +481,7 @@ export class AccountResolver {
     @Args('input', { type: () => PasswordForgotVerifyCodeInput })
     input: PasswordForgotVerifyCodeInput
   ) {
-    return this.authAPI.passwordForgotVerifyCode(
-      input.code,
-      input.token,
-      {},
-      headers
-    );
+    return this.authAPI.passwordForgotVerifyCode(input.code, input.token, {});
   }
 
   @Mutation((returns) => PasswordForgotCodeStatusPayload, {
@@ -513,8 +508,8 @@ export class AccountResolver {
       input.email,
       input.newPassword,
       input.accountResetToken,
-      input.options,
-      headers
+      input.options
+      // headers, TODO: Not sure why this request fails when forwarding headers
     );
   }
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -12,10 +12,15 @@ import Clear from '../../pages/Clear';
 import CookiesDisabled from '../../pages/CookiesDisabled';
 import ResetPassword from '../../pages/ResetPassword';
 import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
+
 import ResetPasswordWithRecoveryKeyVerified from '../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified';
 import Legal from '../../pages/Legal';
 import LegalTerms from '../../pages/Legal/Terms';
 import LegalPrivacy from '../../pages/Legal/Privacy';
+
+import CompleteResetPassword from '../../pages/ResetPassword/CompleteResetPassword';
+import ResetPasswordConfirmed from '../../pages/ResetPassword/ResetPasswordConfirmed';
+
 
 export const App = ({
   flowQueryParams,
@@ -34,14 +39,18 @@ export const App = ({
               <CannotCreateAccount path="/cannot_create_account/*" />
               <Clear path="/clear/*" />
               <CookiesDisabled path="/cookies_disabled/*" />
-              <ResetPassword path="/reset_password/*" />
-              <ConfirmResetPassword path="/confirm_reset_password/*" />
-              <ResetPasswordWithRecoveryKeyVerified path="/reset_password_with_recovery_key_verified/*" />
+
               <Legal path="/legal/*" />
               <LegalTerms path="/legal/terms/*" />
               <LegalTerms path="/:locale/legal/terms/*" />
               <LegalPrivacy path="/legal/privacy/*" />
               <LegalPrivacy path="/:locale/legal/privacy/*" />
+
+             <ResetPassword path='/reset_password/*' />
+             <ConfirmResetPassword path='/confirm_reset_password/*' />
+             <CompleteResetPassword path='/complete_reset_password/*' />
+             <ResetPasswordConfirmed path='/reset_password_verified/*' />
+             <ResetPasswordWithRecoveryKeyVerified path='/reset_password_with_recovery_key_verified/*' />
             </>
           )}
           <Settings path="/settings/*" {...{ flowQueryParams }} />

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
@@ -23,9 +23,9 @@ const LinkRememberPassword = ({
   return (
     <div className="text-sm mt-6">
       <FtlMsg id="remember-pw-link">
-        <Link to={target} className="link-blue text-sm" id="remember-password">
+        <a href={target} className="link-blue text-sm" id="remember-password">
           Remember your password? Sign in
-        </Link>
+        </a>
       </FtlMsg>
     </div>
   );

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
@@ -25,7 +25,7 @@ const render = (acct: Account = account) =>
     </AppContext.Provider>
   );
 
-describe.only('Recent Account Activity', () => {
+describe('Recent Account Activity', () => {
   it('renders', async () => {
     await act(async () => {
       await render();

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -114,6 +114,7 @@ export function useInterval(callback: () => void, delay: number | null) {
         savedCallback.current();
       }
     }, delay);
+    
     return () => window.clearInterval(id);
   }, [delay]);
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -13,8 +13,10 @@ import ConfirmWithLink, {
 import { REACT_ENTRYPOINT } from '../../../constants';
 import AppLayout from '../../../components/AppLayout';
 import { useAccount, useInterval } from '../../../models';
-import { FtlMsg } from 'fxa-react/dist/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { logPageViewEvent } from '../../../lib/metrics';
+import { MozServices } from '../../../lib/types';
+import { ResetPasswordProps } from '../index';
 
 export const viewName = 'confirm-reset-password';
 
@@ -36,7 +38,7 @@ const ConfirmResetPassword = (_: RouteComponentProps) => {
   const [isPolling, setIsPolling] = useState<number | null>(
     POLLING_INTERVAL_MS
   );
-
+  
   const navigateToPasswordReset = useCallback(() => {
     navigate('reset_password?showReactApp=true', { replace: true });
   }, [navigate]);
@@ -55,8 +57,8 @@ const ConfirmResetPassword = (_: RouteComponentProps) => {
     try {
       // A bit unconventional but this endpoint will throw an invalid token error
       // that represents the password has been reset.
-      const status = await account.resetPasswordStatus(passwordForgotToken);
-      if (status) {
+      const isValid = await account.resetPasswordStatus(passwordForgotToken);
+      if (!isValid) {
         // TODO: Going from react page to non-react page will require a hard
         // navigate. When signin flow have been converted we should be able
         // to use `navigate`
@@ -68,7 +70,7 @@ const ConfirmResetPassword = (_: RouteComponentProps) => {
   }, isPolling);
 
   const resendHandler = async () => {
-    const result = await account.resetPassword(email);
+    const result = await account.resendResetPassword(email);
     passwordForgotToken = result.passwordForgotToken;
     setPasswordResetResend(true);
   };

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
 import { MozServices } from '../../../lib/types';
+import AppLayout from '../../../components/AppLayout';
 
 type ResetPasswordConfirmedProps = {
   continueHandler?: Function;
@@ -18,7 +19,9 @@ const ResetPasswordConfirmed = ({
   continueHandler,
   serviceName,
 }: ResetPasswordConfirmedProps & RouteComponentProps) => (
-  <Ready {...{ continueHandler, viewName, serviceName }} />
+  <AppLayout>
+    <Ready {...{ continueHandler, viewName, serviceName }} />
+  </AppLayout>
 );
 
 export default ResetPasswordConfirmed;


### PR DESCRIPTION
## Because

- We need to wire in the logic to finish password reset flow

## This pull request

- Updates account model to add functions to complete password reset

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6125
Closes: https://mozilla-hub.atlassian.net/browse/FXA-6122

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
