### PR TITLE
fix(fxa-settings): change duplicate ftl id to a unique id

### DIFF
--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/en.ftl
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/en.ftl
@@ -12,7 +12,7 @@ connect-another-device-signin-link = Sign in
 # A message prompting the user to sign in via a different device than the current one so as to complete the device-syncing process
 connect-another-device-still-adding-devices-message = Still adding devices? Sign in to { -brand-firefox } on another device to complete setup
 # A message prompting the user to sign in via a different device than the current one so as to complete the device-syncing process
-connect-another-device-signin-to-complete-message = Sign in to { -brand-firefox } on another device to complete setup
+connect-another-device-signin-another-device-to-complete-message = Sign in to { -brand-firefox } on another device to complete setup
 # This message is a value-proposition prompting the user to sync another device so as to get tabs, bookmarks, and passwords shared between devices
 connect-another-device-get-data-on-another-device-message = Want to get your tabs, bookmarks, and passwords on another device?
 # This link leads the user back to the `/pair` page so as to connect another device

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
@@ -148,7 +148,7 @@ const ConnectAnotherDevice = ({
                     </p>
                   </FtlMsg>
                 ) : (
-                  <FtlMsg id="connect-another-device-signin-to-complete-message">
+                  <FtlMsg id="connect-another-device-signin-another-device-to-complete-message">
                     <p className="text-sm">
                       Sign in to Firefox on another device to complete set-up
                     </p>


### PR DESCRIPTION
## Because:

* We have two different ftl strings with the same ftl id

## This commit:

* Changes one of the ftl ids in the tsx and also in the ftl file so that all ids are unique

Closes #N/A (Change is so small that I don't think it justifies a ticket -- was requested over slack and also in the original PR for FXA-6752 after the PR was closed.)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
