### PR TITLE
fix(metrics): Add missing legal events, tweak cookies_disabled events

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -287,17 +287,39 @@ const EVENTS = {
     group: GROUPS.activity,
     event: 'cookies_disabled_view',
   },
-  'flow.cookies-disabled.submit': {
+  'flow.cookies-disabled.try-again-submit': {
     group: GROUPS.activity,
-    event: 'cookies_disabled_submit',
+    event: 'cookies_disabled_try_again_submit',
   },
-  'flow.cookies-disabled.success': {
+  'flow.cookies-disabled.try-again-success': {
     group: GROUPS.activity,
-    event: 'cookies_disabled_success',
+    event: 'cookies_disabled_try_again_success',
   },
-  'flow.cookies-disabled.fail': {
+  'flow.cookies-disabled.try-again-fail': {
     group: GROUPS.activity,
-    event: 'cookies_disabled_fail',
+    event: 'cookies_disabled_try_again_fail',
+  },
+
+  // legal
+  'screen.legal': {
+    group: GROUPS.activity,
+    event: 'legal_view',
+  },
+  'screen.legal-terms': {
+    group: GROUPS.activity,
+    event: 'legal_terms_view',
+  },
+  'screen.legal-privacy': {
+    group: GROUPS.activity,
+    event: 'legal_privacy_view',
+  },
+  'flow.legal-terms.back': {
+    group: GROUPS.activity,
+    event: 'legal_terms_back',
+  },
+  'flow.legal-privacy.back': {
+    group: GROUPS.activity,
+    event: 'legal_privacy_back',
   },
 
   /* Everything under this point should be Settings events, aka 'fxa_pref' group */

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -247,33 +247,83 @@ registerSuite('amplitude', {
       );
     },
 
-    'flow.cookies_disabled.submit': () => {
-      createAmplitudeEvent('flow.cookies-disabled.submit');
+    'flow.cookies_disabled.try-again-submit': () => {
+      createAmplitudeEvent('flow.cookies-disabled.try-again-submit');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
         logger.info.args[0][1].event_type,
-        'fxa_activity - cookies_disabled_submit'
+        'fxa_activity - cookies_disabled_try_again_submit'
       );
     },
 
-    'cookies_disabled.success': () => {
-      createAmplitudeEvent('flow.cookies-disabled.success');
+    'cookies_disabled.try-again-success': () => {
+      createAmplitudeEvent('flow.cookies-disabled.try-again-success');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
         logger.info.args[0][1].event_type,
-        'fxa_activity - cookies_disabled_success'
+        'fxa_activity - cookies_disabled_try_again_success'
       );
     },
 
-    'cookies_disabled.fail': () => {
-      createAmplitudeEvent('flow.cookies-disabled.fail');
+    'cookies_disabled.try-again-fail': () => {
+      createAmplitudeEvent('flow.cookies-disabled.try-again-fail');
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(
         logger.info.args[0][1].event_type,
-        'fxa_activity - cookies_disabled_fail'
+        'fxa_activity - cookies_disabled_try_again_fail'
+      );
+    },
+
+    'screen.legal': () => {
+      createAmplitudeEvent('screen.legal');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - legal_view'
+      );
+    },
+
+    'screen.legal-terms': () => {
+      createAmplitudeEvent('screen.legal-terms');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - legal_terms_view'
+      );
+    },
+
+    'flow.legal-terms.back': () => {
+      createAmplitudeEvent('flow.legal-terms.back');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - legal_terms_back'
+      );
+    },
+
+    'screen.legal-privacy': () => {
+      createAmplitudeEvent('screen.legal-privacy');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - legal_privacy_view'
+      );
+    },
+
+    'flow.legal-privacy.back': () => {
+      createAmplitudeEvent('flow.legal-privacy.back');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_activity - legal_privacy_back'
       );
     },
 

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
@@ -98,12 +98,12 @@ describe('CookiesDisabled', () => {
       fireEvent.click(getTryAgainButton());
       expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
-        'submit',
+        'try-again-submit',
         REACT_ENTRYPOINT
       );
       expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
-        'success',
+        'try-again-success',
         REACT_ENTRYPOINT
       );
     });
@@ -114,12 +114,12 @@ describe('CookiesDisabled', () => {
       fireEvent.click(getTryAgainButton());
       expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
-        'submit',
+        'try-again-submit',
         REACT_ENTRYPOINT
       );
       expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
-        'fail',
+        'try-again-fail',
         REACT_ENTRYPOINT
       );
     });

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.tsx
@@ -29,12 +29,12 @@ const CookiesDisabled = (_: RouteComponentProps) => {
   const [stillDisabled, setStillDisabled] = useState(false);
 
   const buttonHandler = useCallback(() => {
-    logViewEvent(`flow.${viewName}`, 'submit', REACT_ENTRYPOINT);
+    logViewEvent(`flow.${viewName}`, 'try-again-submit', REACT_ENTRYPOINT);
     if (!Storage.isLocalStorageEnabled(window) || !navigator.cookieEnabled) {
-      logViewEvent(`flow.${viewName}`, 'fail', REACT_ENTRYPOINT);
+      logViewEvent(`flow.${viewName}`, 'try-again-fail', REACT_ENTRYPOINT);
       setStillDisabled(true);
     } else {
-      logViewEvent(`flow.${viewName}`, 'success', REACT_ENTRYPOINT);
+      logViewEvent(`flow.${viewName}`, 'try-again-success', REACT_ENTRYPOINT);
       if (contentRedirect) {
         window.history.go(-2);
       } else {


### PR DESCRIPTION
Because:
* We need our new legal events mapped to 'amplitude' events
* cookies_disabled events are also new and were a little ambiguous, so these were updated with purpose of the button in the descriptor

This commit:
* Adds missing events to amplitude.js with tests
* Tweaks cookies_disabled event names

Fixes FXA-6813

---

I was looking at updating the metrics doc after my legal PR was merged and realized I'd forgotten to add them in `amplitude.js`.