### PR TITLE
task(CI): Disable fail-fast step for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,24 +674,18 @@ workflows:
           total: 3
           requires:
             - Build (PR)
-          post-steps:
-            - fail-fast
       - integration-test-part:
           name: Integration Test 2 (PR)
           index: 1
           total: 3
           requires:
             - Build (PR)
-          post-steps:
-            - fail-fast
       - integration-test-part:
           name: Integration Test 3 (PR)
           index: 2
           total: 3
           requires:
             - Build (PR)
-          post-steps:
-            - fail-fast
       - test-content-server-part:
           name: Functional Test - Content 1 (PR)
           index: 0


### PR DESCRIPTION
## Because

- Flaky integration tests are a drag
- Flaky integration tests are resulting in functional test job cancellations make it hard to validate changes

## This pull request

- Disables the fail-fast step, so that functional tests run despite integration test failures.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is a temporary change. Hopefully, FXA-6781 uncovers the actual issue.
