### PR TITLE
task(CI): Fix bash warnings coming from run-list-parallel

### DIFF
--- a/.circleci/run-list-parallel.sh
+++ b/.circleci/run-list-parallel.sh
@@ -38,11 +38,11 @@ fi
 
 
 # Quick integrity check on total / index
-if $TOTAL > 24; then
+if [[ "$TOTAL" -gt "24" ]]; then
   echo "Invalid GROUP argument - $GROUP. Total groups must be be less than 24."
   exit 1
 fi
-if $INDEX < 0 || $INDEX >= $TOTAL; then
+if [[ "$INDEX" -lt "0" || "$INDEX" -ge "$TOTAL" ]]; then
   echo "Invalid GROUP argument - $GROUP. INDEX must be positive and less than total."
   exit 1
 fi


### PR DESCRIPTION
## Because
- Bash warnings were being printed out in the CI.

## This pull request

- Changes syntax to address warnings.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
