### PR TITLE
task(CI): Increase test timeout on feature flag tests

### DIFF
--- a/packages/fxa-shared/test/scripts/feature-flags.js
+++ b/packages/fxa-shared/test/scripts/feature-flags.js
@@ -28,7 +28,12 @@ const SCRIPT = `node scripts${path.sep}feature-flags`;
 
 const cwd = path.resolve(__dirname, ROOT_DIR);
 
-describe('#integration - scripts/feature-flags:', () => {
+describe('#integration - scripts/feature-flags:', function () {
+
+  // NOTE: In low resource situations each test takes about 1.8s, we need more
+  //       overhead to account for this.
+  this.timeout(5000);
+
   let current, previous, redis;
 
   before(async () => {


### PR DESCRIPTION
## Because

- There wasn't much headroom on feature flag tests that used cp.exec in lower resource scenarios

## This pull request

- Increases test timeout for feature flags to 5s

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/219474975-4ce528dc-8785-42b7-9568-c2071229e467.png)

## Other information (Optional)

This is part of FXA-6781. Not the silver bullet, but definitely a potential source of random flakiness.
