### PR TITLE
task(CI): Constrain mysql memory usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,9 @@ executors:
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
+      MYSQL_MEM_LIMIT: 1.2g
+      MYSQL_MEM_RES: 1g
+      NODE_OPTIONS: --max-old-space-size=6000
 
   # For anything that needs a full stack to run and needs browsers available for
   # ui test automation. This image requires a restored workspace state.
@@ -119,6 +122,8 @@ executors:
       REACT_CONVERSION_POST_VERIFY_ADD_RECOVERY_KEY_ROUTES: true
       REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES: true
       REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH_ROUTES: true
+      MYSQL_MEM_LIMIT: 1.2g
+      MYSQL_MEM_RES: 1g
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
   # automation. Perfect for running smoke tests against remote targets.

--- a/_scripts/mysql.sh
+++ b/_scripts/mysql.sh
@@ -16,12 +16,22 @@ function on_sigint() {
 
 trap on_sigint INT
 
+if [ -z "MYSQL_MEM_LIMIT"]; then
+  MYSQL_MEM_LIMIT=2g
+fi
+
+if [ -z "MYSQL_MEM_RES"]; then
+  MYSQL_MEM_RES=1.8g
+fi
+
 # Create pushbox db on start (because pushbox doesn't create it)
 docker run --rm --name=mydb \
   -e MYSQL_ALLOW_EMPTY_PASSWORD=true \
   -e MYSQL_ROOT_HOST=% \
   -e MYSQL_DATABASE=pushbox \
   -p 3306:3306 \
+  --memory="$MYSQL_MEM_LIMIT" \
+  --memory-reservation="$MYSQL_MEM_RES" \
   mysql/mysql-server:8.0.28 --default-authentication-plugin=mysql_native_password &
 
 cd "$DIR"


### PR DESCRIPTION
## Because
- We are seeing mysql exit the CI with a 137 error code.
- A 137 error code indicates a memory limit was hit.

## This pull request

- Applies a configurable memory limit to mysql when run in the CI.
- Sets node options max-old-space-size to 6 GB, which might also help with memory spikes.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/94418270/219477128-bebc54ce-5aa0-4e0e-9a73-58f766b4086f.png)

## Other information (Optional)

It is still very strange that this state occurs at all. Sometimes the memory spikes, but other times it does not. This is not a silver bullet but may help. This issue is an ongoing to effort to reduce flakiness described in FXA-6781.
