### PR TITLE
feat(fxa-settings): Add l10n to storybook

### DIFF
--- a/packages/fxa-settings/.storybook/decorators.tsx
+++ b/packages/fxa-settings/.storybook/decorators.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { DecoratorFn } from '@storybook/react';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
+
+// This decorator makes the localization bundles available in the stories.
+// If a localized string is available, that will be rendered in the storybook,
+// otherwise the fallback strings will be displayed.
+export const withLocalization: DecoratorFn = (Story) => (
+  <AppLocalizationProvider
+    baseDir="./locales"
+    bundles={['settings', 'react']}
+    userLocales={navigator.languages}
+  >
+    <Story />
+  </AppLocalizationProvider>
+);

--- a/packages/fxa-settings/.storybook/main.js
+++ b/packages/fxa-settings/.storybook/main.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   stories: ['./design-guide/main.stories.tsx', '../src/**/*.stories.tsx'],
-  staticDirs: ['./design-guide'],
+  staticDirs: ['../public'],
   addons: [
     '@storybook/addon-actions',
     '@storybook/addon-links',

--- a/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import AppLayout from './index';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
   title: 'Components/AppLayout',
   component: AppLayout,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => (

--- a/packages/fxa-settings/src/components/Banner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.stories.tsx
@@ -7,10 +7,12 @@ import Banner, { BannerType } from '.';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
 import { Subject } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/Banner',
+  title: 'Components/Banner',
   component: Banner,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Info = () => (

--- a/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
@@ -14,10 +14,12 @@ import {
   MOCK_SUBHEADING,
 } from './mocks';
 import { MozServices } from '../../lib/types';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/CardHeader',
+  title: 'Components/CardHeader',
   component: CardHeader,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (

--- a/packages/fxa-settings/src/components/CardHeader/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.test.tsx
@@ -12,7 +12,6 @@ import {
   MOCK_HEADING,
   MOCK_SERVICE_NAME,
 } from './mocks';
-import { MozServices } from '../../lib/types';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 

--- a/packages/fxa-settings/src/components/ChooseNewsletters/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/index.stories.tsx
@@ -7,10 +7,12 @@ import ChooseNewsletters from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { Subject } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/ChooseNewsletters',
+  title: 'Components/ChooseNewsletters',
   component: ChooseNewsletters,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => {

--- a/packages/fxa-settings/src/components/ChooseWhatToSync/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ChooseWhatToSync/index.stories.tsx
@@ -7,10 +7,12 @@ import ChooseWhatToSync from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { Subject } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/ChooseWhatToSync',
+  title: 'Components/ChooseWhatToSync',
   component: ChooseWhatToSync,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => {

--- a/packages/fxa-settings/src/components/ConfirmWithLink/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { DefaultSubject, SubjectCanGoBack, SubjectWithWebmail } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/ConfirmWithLink',
+  title: 'Components/ConfirmWithLink',
   component: ConfirmWithLink,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
@@ -14,10 +14,12 @@ import {
   MOCK_REGION,
   MOCK_COUNTRY,
 } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/DeviceInfoBlock',
+  title: 'Components/DeviceInfoBlock',
   component: DeviceInfoBlock,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props?: Partial<RemoteMetadata>) => {

--- a/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
@@ -8,10 +8,12 @@ import { LocationProvider } from '@reach/router';
 import AppLayout from '../Settings/AppLayout';
 import FormPassword from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
   title: 'Components/FormPassword',
   component: FormPassword,
+  decorators: [withLocalization],
 } as Meta;
 
 export const WithCurrentPassword = () => (

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.stories.tsx
@@ -7,10 +7,12 @@ import { Subject } from './mocks';
 import AppLayout from '../AppLayout';
 import FormPasswordWithBalloons from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
   title: 'Components/FormPasswordWithBalloons',
   component: FormPasswordWithBalloons,
+  decorators: [withLocalization],
 } as Meta;
 
 export const ResetPassword = () => (

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.stories.tsx
@@ -7,10 +7,12 @@ import FormVerifyCode from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { Subject } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/FormVerifyCode',
+  title: 'Components/FormVerifyCode',
   component: FormVerifyCode,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import GetDataTrio, { GetDataCopySingleton } from './index';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
   title: 'Components/GetDataTrio',
   component: GetDataTrio,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/InputCheckboxBlue/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputCheckboxBlue/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import InputCheckboxBlue from './index';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
   title: 'Components/InputCheckboxBlue',
   component: InputCheckboxBlue,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => (

--- a/packages/fxa-settings/src/components/LinkDamaged/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.stories.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import LinkDamaged from '.';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/LinkDamaged',
+  title: 'Components/LinkDamaged',
   component: LinkDamaged,
+  decorators: [withLocalization],
 } as Meta;
 
 export const DamagedResetPasswordLink = () => (

--- a/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import LinkExpired from '.';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/LinkExpired',
+  title: 'Components/LinkExpired',
   component: LinkExpired,
+  decorators: [withLocalization],
 } as Meta;
 
 export const ResetPasswordLinkExpired = () => (

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.stories.tsx
@@ -7,10 +7,12 @@ import LinkRememberPassword from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../models/mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/LinkRememberPassword',
+  title: 'Components/LinkRememberPassword',
   component: LinkRememberPassword,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = ({ ...props }) => {

--- a/packages/fxa-settings/src/components/LinkUsed/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkUsed/index.stories.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import LinkUsed from '.';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/LinkUsed',
+  title: 'Components/LinkUsed',
   component: LinkUsed,
+  decorators: [withLocalization],
 } as Meta;
 
 export const LinkAlreadyUsedForPrimaryEmail = () => (

--- a/packages/fxa-settings/src/components/PasswordInfoBalloon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PasswordInfoBalloon/index.stories.tsx
@@ -7,10 +7,12 @@ import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import PasswordInfoBalloon from '.';
 import InputPassword from '../InputPassword';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/PasswordInfoBalloon',
+  title: 'Components/PasswordInfoBalloon',
   component: PasswordInfoBalloon,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.stories.tsx
@@ -7,10 +7,12 @@ import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import PasswordStrengthBalloon, { PasswordStrengthBalloonProps } from '.';
 import InputPassword from '../InputPassword';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/PasswordStrengthBalloon',
+  title: 'Components/PasswordStrengthBalloon',
   component: PasswordStrengthBalloon,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (

--- a/packages/fxa-settings/src/components/Ready/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.stories.tsx
@@ -7,10 +7,12 @@ import Ready, { ReadyProps } from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/Ready',
+  title: 'Components/Ready',
   component: Ready,
+  decorators: [withLocalization],
 } as Meta;
 
 const ReadyWithLayout = ({

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import AppLayout from './index';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/AppLayout',
   component: AppLayout,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => (

--- a/packages/fxa-settings/src/components/Settings/Avatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Avatar/index.stories.tsx
@@ -8,10 +8,12 @@ import { Account, AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { MOCK_AVATAR_DEFAULT, MOCK_AVATAR_NON_DEFAULT } from './mocks';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/Avatar',
   component: Avatar,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithContext = (account: Account, storyName?: string) => {

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import BentoMenu from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/BentoMenu',
   component: BentoMenu,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => (

--- a/packages/fxa-settings/src/components/Settings/Checkbox/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Checkbox/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import Checkbox from './index';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/Checkbox',
   component: Checkbox,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => (

--- a/packages/fxa-settings/src/components/Settings/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.stories.tsx
@@ -11,10 +11,12 @@ import { mockAppContext } from '../../../models/mocks';
 import { Account } from '../../../models/Account';
 import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/Nav',
   component: Nav,
+  decorators: [withLocalization],
 } as Meta;
 
 const account = {

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.stories.tsx
@@ -9,6 +9,7 @@ import { Page2faReplaceRecoveryCodes } from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 const account = {
   ...MOCK_ACCOUNT,
@@ -28,8 +29,9 @@ const account = {
 } as any;
 
 export default {
-  title: 'pages/Settings/TwoStepAuthenticationReplaceCodes',
+  title: 'Pages/Settings/TwoStepAuthenticationReplaceCodes',
   component: Page2faReplaceRecoveryCodes,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
@@ -7,10 +7,12 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
 import PageAvatar from './';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/Avatar',
+  title: 'Pages/Settings/Avatar',
   component: PageAvatar,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
@@ -7,10 +7,12 @@ import { PageChangePassword } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/ChangePassword',
+  title: 'Pages/Settings/ChangePassword',
   component: PageChangePassword,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
@@ -7,10 +7,12 @@ import React from 'react';
 import AppLayout from '../AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/CreatePassword',
+  title: 'Pages/Settings/CreatePassword',
   component: PageCreatePassword,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
@@ -7,10 +7,12 @@ import { PageDeleteAccount } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/DeleteAccount',
+  title: 'Pages/Settings/DeleteAccount',
   component: PageDeleteAccount,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
@@ -7,10 +7,12 @@ import React from 'react';
 import { PageDisplayName } from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/DisplayName',
+  title: 'Pages/Settings/DisplayName',
   component: PageDisplayName,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.stories.tsx
@@ -8,10 +8,12 @@ import { MOCK_SECURITY_EVENTS } from './mocks';
 import { Meta } from '@storybook/react';
 import { AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/RecentActivity',
+  title: 'Pages/Settings/RecentActivity',
   component: PageRecentActivity,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.stories.tsx
@@ -7,10 +7,12 @@ import { PageRecoveryKeyAdd } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/RecoveryKeyAdd',
+  title: 'Pages/Settings/RecoveryKeyAdd',
   component: PageRecoveryKeyAdd,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
@@ -7,10 +7,12 @@ import { LocationProvider } from '@reach/router';
 import { AppLayout } from '../AppLayout';
 import { PageSecondaryEmailAdd } from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/SecondaryEmailAdd',
+  title: 'Pages/Settings/SecondaryEmailAdd',
   component: PageSecondaryEmailAdd,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
@@ -7,10 +7,12 @@ import { Meta } from '@storybook/react';
 import { PageSecondaryEmailVerify } from '.';
 import { AppLayout } from '../AppLayout';
 import { WindowLocation, LocationProvider } from '@reach/router';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/SecondaryEmailVerify',
+  title: 'Pages/Settings/SecondaryEmailVerify',
   component: PageSecondaryEmailVerify,
+  decorators: [withLocalization],
 } as Meta;
 
 const mockLocation = {

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
@@ -16,12 +16,14 @@ import { MOCK_SERVICES } from '../ConnectedServices/mocks';
 import { AppContext } from 'fxa-settings/src/models';
 import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
 export default {
   title: 'Pages/Settings',
   component: PageSettings,
+  decorators: [withLocalization],
 } as Meta;
 
 const coldStartAccount = {

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.stories.tsx
@@ -7,10 +7,12 @@ import React from 'react';
 import { PageTwoStepAuthentication } from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Settings/TwoStepAuthentication',
+  title: 'Pages/Settings/TwoStepAuthentication',
   component: PageTwoStepAuthentication,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/components/Settings/Profile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Profile/index.stories.tsx
@@ -13,10 +13,12 @@ import {
 } from './mocks';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/Profile',
   component: Profile,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithContext = (account: Account, storyName?: string) => {

--- a/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
@@ -9,10 +9,12 @@ import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
 import { Account } from '../../../models/Account';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
   title: 'Components/Settings/Security',
   component: Security,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithAccount = (account: Partial<Account>, storyName?: string) => {

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
@@ -6,9 +6,12 @@ import React from 'react';
 import TermsPrivacyAgreement from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
+
 export default {
-  title: 'components/TermsPrivacyAgreement',
+  title: 'Components/TermsPrivacyAgreement',
   component: TermsPrivacyAgreement,
+  decorators: [withLocalization],
 } as Meta;
 
 export const FirefoxOnly = () => (

--- a/packages/fxa-settings/src/components/WarningMessage/index.stories.tsx
+++ b/packages/fxa-settings/src/components/WarningMessage/index.stories.tsx
@@ -11,10 +11,12 @@ import {
   MOCK_WARNING_MESSAGE,
   MOCK_WARNING_TYPE,
 } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'components/WarningMessage',
+  title: 'Components/WarningMessage',
   component: WarningMessage,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import CannotCreateAccount from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/CannotCreateAccount',
+  title: 'Pages/CannotCreateAccount',
   component: CannotCreateAccount,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => <CannotCreateAccount />;

--- a/packages/fxa-settings/src/pages/Clear/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.stories.tsx
@@ -6,8 +6,9 @@ import React from 'react';
 import Clear from '.';
 import { Meta } from '@storybook/react';
 
+// This page is only used for testing and does not need the localization decorator
 export default {
-  title: 'pages/Clear',
+  title: 'Pages/Clear',
   component: Clear,
 } as Meta;
 

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
@@ -13,10 +13,12 @@ import {
   MOCK_DEFAULTS,
   MOCK_DEVICE_BASIC_PROPS,
 } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ConnectAnotherDevice',
+  title: 'Pages/ConnectAnotherDevice',
   component: ConnectAnotherDevice,
+  decorators: [withLocalization],
 } as Meta;
 
 export const CanSignInNoSuccessMessage = () => (

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import CookiesDisabled from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/CookiesDisabled',
+  title: 'Pages/CookiesDisabled',
   component: CookiesDisabled,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => <CookiesDisabled />;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_RECOVERY_CODES, MOCK_SERVICE_NAME } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/InlineRecoverySetup',
+  title: 'Pages/InlineRecoverySetup',
   component: InlineRecoverySetup,
+  decorators: [withLocalization],
 } as Meta;
 
 const ComponentWithRouter = (props: InlineRecoverySetupProps) => (

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
@@ -8,10 +8,12 @@ import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
 import AppLayout from '../../components/AppLayout';
 import { MOCK_CODE, MOCK_EMAIL } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/InlineTotpSetup',
+  title: 'Pages/InlineTotpSetup',
   component: InlineTotpSetup,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Legal/Privacy/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Privacy/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import LegalPrivacy from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Legal/Privacy',
+  title: 'Pages/Legal/Privacy',
   component: LegalPrivacy,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => <LegalPrivacy />;

--- a/packages/fxa-settings/src/pages/Legal/Terms/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Terms/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import LegalTerms from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Legal/Terms',
+  title: 'Pages/Legal/Terms',
   component: LegalTerms,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => <LegalTerms />;

--- a/packages/fxa-settings/src/pages/Legal/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Legal/index.stories.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import Legal from '.';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Legal',
+  title: 'Pages/Legal',
   component: Legal,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Basic = () => <Legal />;

--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.stories.tsx
@@ -12,10 +12,12 @@ import {
   MOCK_METADATA_WITH_LOCATION,
 } from '../../../components/DeviceInfoBlock/mocks';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/AuthAllow',
+  title: 'Pages/Pair/AuthAllow',
   component: AuthAllow,
+  decorators: [withLocalization],
 } as Meta;
 
 export const WithLocation = () => (

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/indes.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/indes.stories.tsx
@@ -7,10 +7,12 @@ import AuthComplete from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mocks';
 import { MOCK_METADATA_UNKNOWN_LOCATION } from '../../../components/DeviceInfoBlock/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/AuthComplete',
+  title: 'Pages/Pair/AuthComplete',
   component: AuthComplete,
+  decorators: [withLocalization],
 } as Meta;
 
 // Any metadata mock from DeviceInfoBlock will do, location is not displayed on this page

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/AuthTotp',
+  title: 'Pages/Pair/AuthTotp',
   component: AuthTotp,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = ({ ...props }) => {

--- a/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.stories.tsx
@@ -11,10 +11,12 @@ import {
   MOCK_METADATA_WITH_LOCATION,
 } from '../../../components/DeviceInfoBlock/mocks';
 import { MOCK_BANNER_MESSAGE } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/AuthWaitForSupp',
+  title: 'Pages/Pair/AuthWaitForSupp',
   component: AuthWaitForSupp,
+  decorators: [withLocalization],
 } as Meta;
 
 export const WithLocation = () => (

--- a/packages/fxa-settings/src/pages/Pair/Failure/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Failure/index.stories.tsx
@@ -7,10 +7,12 @@ import PairFailure from '.';
 import { Meta } from '@storybook/react';
 import AppLayout from '../../../components/AppLayout';
 import { MOCK_ERROR } from './mock';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/Failure',
+  title: 'Pages/Pair/Failure',
   component: PairFailure,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
@@ -9,10 +9,12 @@ import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { ENTRYPOINTS } from '../../../constants';
 import { MOCK_ERROR, MOCK_CALLBACK } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair',
+  title: 'Pages/Pair',
   component: Pair,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Pair/Success/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.stories.tsx
@@ -7,10 +7,12 @@ import PairSuccess from '.';
 import { Meta } from '@storybook/react';
 import AppLayout from '../../../components/AppLayout';
 import { MOCK_ERROR } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/Success',
+  title: 'Pages/Pair/Success',
   component: PairSuccess,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import Supp from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/Supp',
+  title: 'Pages/Pair/Supp',
   component: Supp,
+  decorators: [withLocalization],
 } as Meta;
 
 export const DefaultLoadingState = () => <Supp />;

--- a/packages/fxa-settings/src/pages/Pair/SuppAllow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppAllow/index.stories.tsx
@@ -12,10 +12,12 @@ import {
   MOCK_METADATA_WITH_LOCATION,
 } from '../../../components/DeviceInfoBlock/mocks';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/SuppAllow',
+  title: 'Pages/Pair/SuppAllow',
   component: SuppAllow,
+  decorators: [withLocalization],
 } as Meta;
 
 export const WithLocation = () => (

--- a/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.stories.tsx
@@ -11,10 +11,12 @@ import {
   MOCK_METADATA_WITH_LOCATION,
 } from '../../../components/DeviceInfoBlock/mocks';
 import { MOCK_BANNER_MESSAGE } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/SuppWaitForAuth',
+  title: 'Pages/Pair/SuppWaitForAuth',
   component: SuppWaitForAuth,
+  decorators: [withLocalization],
 } as Meta;
 
 export const WithLocation = () => (

--- a/packages/fxa-settings/src/pages/Pair/Unsupported/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Unsupported/index.stories.tsx
@@ -7,10 +7,12 @@ import PairUnsupported from '.';
 import { Meta } from '@storybook/react';
 import AppLayout from '../../../components/AppLayout';
 import { MOCK_ERROR } from './mock';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Pair/Unsupported',
+  title: 'Pages/Pair/Unsupported',
   component: PairUnsupported,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_SERVICE_NAME } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword/AccountRecoveryConfirmKey',
+  title: 'Pages/ResetPassword/AccountRecoveryConfirmKey',
   component: AccountRecoveryConfirmKey,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props: AccountRecoveryConfirmKeyProps) => {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
@@ -10,10 +10,12 @@ import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword/AccountRecoveryResetPassword',
+  title: 'Pages/ResetPassword/AccountRecoveryResetPassword',
   component: AccountRecoveryResetPassword,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props?: Partial<AccountRecoveryResetPasswordProps>) => {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
@@ -13,10 +13,12 @@ import { Meta } from '@storybook/react';
 import CompleteResetPassword from '.';
 import { mockAppContext } from '../../../models/mocks';
 import { AppContext, Account } from '../../../models';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword/CompleteResetPassword',
+  title: 'Pages/ResetPassword/CompleteResetPassword',
   component: CompleteResetPassword,
+  decorators: [withLocalization],
 } as Meta;
 
 const source = createMemorySource('/fake-memories');

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
@@ -11,10 +11,12 @@ import {
 } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_EMAIL, MOCK_PASSWORD_FORGOT_TOKEN } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword/ConfirmResetPassword',
+  title: 'Pages/ResetPassword/ConfirmResetPassword',
   component: ConfirmResetPassword,
+  decorators: [withLocalization],
 } as Meta;
 
 const source = createMemorySource('/fake-memories');

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../../components/AppLayout';
 import { MozServices } from '../../../lib/types';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword/ResetPasswordConfirmed',
+  title: 'Pages/ResetPassword/ResetPasswordConfirmed',
   component: ResetPasswordConfirmed,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
@@ -6,20 +6,22 @@ import React from 'react';
 import ResetPasswordWithRecoveryKeyVerified from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified',
+  title: 'Pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified',
   component: ResetPasswordWithRecoveryKeyVerified,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (
   <LocationProvider>
-      <ResetPasswordWithRecoveryKeyVerified />
+    <ResetPasswordWithRecoveryKeyVerified />
   </LocationProvider>
 );
 
 export const WithSync = () => (
   <LocationProvider>
-      <ResetPasswordWithRecoveryKeyVerified isSync />
+    <ResetPasswordWithRecoveryKeyVerified isSync />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -4,15 +4,16 @@
 
 import React from 'react';
 import ResetPassword from '.';
-import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { MozServices } from '../../lib/types';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/ResetPassword',
+  title: 'Pages/ResetPassword',
   component: ResetPassword,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = ({ ...props }) => {

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.stories.tsx
@@ -7,10 +7,12 @@ import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 import CompleteSignin, { CompleteSigninProps } from '.';
 import AppLayout from '../../../components/AppLayout';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/CompleteSignin',
+  title: 'Pages/Signin/CompleteSignin',
   component: CompleteSignin,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props: CompleteSigninProps) => {

--- a/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.stories.tsx
@@ -9,10 +9,12 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { mockGoBackCallback } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/ConfirmSignin',
+  title: 'Pages/Signin/ConfirmSignin',
   component: ConfirmSignin,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props: ConfirmSigninProps) => {

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.stories.tsx
@@ -7,10 +7,12 @@ import SigninBounced, { SigninBouncedProps } from '.';
 import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/SigninBounced',
+  title: 'Pages/Signin/SigninBounced',
   component: SigninBounced,
+  decorators: [withLocalization],
 } as Meta;
 
 const ComponentWithRouter = (props: SigninBouncedProps) => (

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.stories.tsx
@@ -7,10 +7,12 @@ import SigninConfirmed from '.';
 import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/SigninConfirmed',
+  title: 'Pages/Signin/SigninConfirmed',
   component: SigninConfirmed,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/SigninRecoveryCode',
+  title: 'Pages/Signin/SigninRecoveryCode',
   component: SigninRecoveryCode,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.stories.tsx
@@ -7,10 +7,12 @@ import SigninReported from '.';
 import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/SigninReported',
+  title: 'Pages/Signin/SigninReported',
   component: SigninReported,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
@@ -7,10 +7,12 @@ import SigninTokenCode from '.';
 import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/SigninTokenCode',
+  title: 'Pages/Signin/SigninTokenCode',
   component: SigninTokenCode,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -9,10 +9,12 @@ import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signin/SigninTotpCode',
+  title: 'Pages/Signin/SigninTotpCode',
   component: SigninTotpCode,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = ({ ...props }) => {

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -9,9 +9,12 @@ import { MozServices } from '../../lib/types';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_EMAIL, MOCK_SERVICE } from './mocks';
+import { withLocalization } from '../../../.storybook/decorators';
+
 export default {
-  title: 'pages/Signin',
+  title: 'Pages/Signin',
   component: Signin,
+  decorators: [withLocalization],
 } as Meta;
 
 // TODO: Add in error and success states when the Banner is added in

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.stories.tsx
@@ -9,10 +9,12 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MOCK_GOBACK_CB } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signup/Confirm',
+  title: 'Pages/Signup/Confirm',
   component: Confirm,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props: ConfirmProps) => {

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
@@ -7,10 +7,12 @@ import ConfirmSignupCode from '.';
 import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signup/ConfirmSignupCode',
+  title: 'Pages/Signup/ConfirmSignupCode',
   component: ConfirmSignupCode,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
@@ -8,10 +8,12 @@ import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_SERVICE } from './mocks';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signup/PrimaryEmailVerified',
+  title: 'Pages/Signup/PrimaryEmailVerified',
   component: PrimaryEmailVerified,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props?: PrimaryEmailVerifiedProps) => {

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
@@ -7,10 +7,12 @@ import SignupConfirmed from '.';
 import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signup/SignupConfirmed',
+  title: 'Pages/Signup/SignupConfirmed',
   component: SignupConfirmed,
+  decorators: [withLocalization],
 } as Meta;
 
 export const Default = () => (

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -9,10 +9,12 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
 import { MOCK_ACCOUNT } from '../../models/mocks';
+import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
-  title: 'pages/Signup',
+  title: 'Pages/Signup',
   component: Signup,
+  decorators: [withLocalization],
 } as Meta;
 
 const storyWithProps = (props?: Partial<SignupProps>) => {


### PR DESCRIPTION
## Because

* We want to view localized strings for fxa-settings stories, to make sure that localized strings are correctly rendered with the correct elements. Enabling l10n in storybooks also add a manual testing option to make sure that all strings have associated ftl id (vs loading fallback text).

## This pull request

* Create `withLocalization` decorator to provide `AppLocalizationProvider` settings to stories.
* Add `withLocalization` decorator to all stories using the `Meta` format.
* Does not add l10n to stories using the older `storiesOf` format - l10n support for these stories will be added in FXA-6818
* Standardize the case used for storybook `title` and `component` to PascalCase - this fixed storybook sorting.

## Issue that this pull request solves

Closes: #FXA-6299

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/22231637/219495517-9b146278-605c-4722-a328-12a7a33bb697.png)

## Other information (Optional)

I'm considering adding documentation (maybe a template?) on the recommended storybook format for fxa-settings.
