### PR TITLE
task(settings): Add --runInBand option

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -20,7 +20,7 @@
     "test:watch": "SKIP_PREFLIGHT_CHECK=true rescripts test",
     "test:coverage": "yarn test --coverage --watchAll=false",
     "test:unit": "echo No unit tests present for $npm_package_name",
-    "test:integration": "tsc --build ../fxa-react && yarn merge-ftl:test && JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml SKIP_PREFLIGHT_CHECK=true rescripts test --watchAll=false --ci --reporters=default --reporters=jest-junit",
+    "test:integration": "tsc --build ../fxa-react && yarn merge-ftl:test && JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml SKIP_PREFLIGHT_CHECK=true rescripts test --watchAll=false --ci --runInBand --reporters=default --reporters=jest-junit",
     "merge-ftl": "grunt merge-ftl",
     "merge-ftl:test": "grunt merge-ftl:test",
     "watch-ftl": "grunt watch-ftl"


### PR DESCRIPTION
## Because

- Memory is spiking in CI

## This pull request

- Adds `--runInBand` to the integration test commands

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

It appeared that most the jest tests have `--runInBand` applied. Settings uses jest, but does so through rescripts so I am guessing that this just got overlooked. 
