### PR TITLE
Rewrite sign up tests using Playwright

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { EmailHeader, EmailType } from '../lib/email';
 import { BaseLayout } from './layout';
 import { getCode } from 'fxa-settings/src/lib/totp';
@@ -23,7 +27,10 @@ export const selectors = {
   SHOW_PASSWORD: '#password ~ [for="show-password"]',
   RESET_PASSWORD_EXPIRED_HEADER: '#fxa-reset-link-expired-header',
   RESET_PASSWORD_HEADER: '#fxa-reset-password-header',
+  SIGN_UP_CODE_HEADER: '#fxa-confirm-signup-code-header',
+  CONFIRM_EMAIL: '.email',
   SIGNIN_HEADER: '#fxa-signin-header',
+  COPPA_HEADER: '#fxa-cannot-create-account-header',
   SUBMIT: 'button[type=submit]',
   SUBMIT_USER_SIGNED_IN: '#use-logged-in',
   RECOVERY_KEY_TEXT_INPUT: 'input[type=text]',
@@ -190,6 +197,20 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.EMAIL_HEADER).isVisible();
   }
 
+  async cannotCreateAccountHeader() {
+    return this.page.locator(selectors.COPPA_HEADER).isVisible();
+  }
+
+  async isSignUpCodeHeader() {
+    const header = this.page.locator(selectors.SIGN_UP_CODE_HEADER);
+    header.waitFor({ state: 'visible' });
+    return header.isVisible();
+  }
+
+  async confirmEmail() {
+    return this.page.innerText(selectors.CONFIRM_EMAIL);
+  }
+
   setEmail(email: string) {
     return this.page.fill(selectors.EMAIL, email);
   }
@@ -304,6 +325,10 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.SUBMIT_USER_SIGNED_IN).click();
   }
 
+  async clickSubmit() {
+    return this.page.locator(selectors.SUBMIT).click();
+  }
+
   async isSyncConnectedHeader() {
     return this.page.isVisible(selectors.SYNC_CONNECTED_HEADER, {
       timeout: 100,
@@ -373,6 +398,10 @@ export class LoginPage extends BaseLayout {
     return this.page.inputValue(selectors.EMAIL);
   }
 
+  async getPasswordInput() {
+    return this.page.inputValue(selectors.PASSWORD);
+  }
+
   async isCachedLogin() {
     return this.page.isVisible(selectors.SUBMIT_USER_SIGNED_IN, {
       timeout: 1000,
@@ -384,6 +413,10 @@ export class LoginPage extends BaseLayout {
       waitUntil: 'load',
     });
     return this.page.waitForTimeout(1000);
+  }
+
+  async getErrorMessage() {
+    return this.page.innerText(selectors.ERROR);
   }
 
   createEmail(template?: string) {

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -1,0 +1,195 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+const password = 'password12345678';
+
+test.describe('signup here', () => {
+  test.beforeEach(async () => {
+    test.slow();
+  });
+
+  test('with an invalid email', async ({ target, page, pages: { login } }) => {
+    await page.goto(`${target.contentServerUrl}?email=invalid`, {
+      waitUntil: 'networkidle',
+    });
+    expect(await login.getErrorMessage()).toMatch('Invalid parameter: email');
+  });
+
+  test('with an empty email', async ({ target, page, pages: { login } }) => {
+    await page.goto(`${target.contentServerUrl}?email=`, {
+      waitUntil: 'networkidle',
+    });
+    expect(await login.getErrorMessage()).toMatch('Invalid parameter: email');
+  });
+
+  test('signup with email with leading whitespace on the email', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    const email = login.createEmail();
+    const emailWithoutSpace = email;
+    const emailWithSpace = '   ' + email;
+    await page.goto(target.contentServerUrl);
+    await login.fillOutFirstSignUp(emailWithSpace, password, false);
+
+    // Verify the confirm code header and the email
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+    expect(await login.confirmEmail()).toMatch(emailWithoutSpace);
+    await login.clearCache();
+    await page.goto(target.contentServerUrl);
+    await login.fillOutEmailFirstSignIn(emailWithoutSpace, password);
+
+    // Verify the confirm code header
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+  });
+
+  test('signup with email with trailing whitespace on the email', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    const email = login.createEmail();
+    const emailWithoutSpace = email;
+    const emailWithSpace = email + ' ';
+    await page.goto(target.contentServerUrl);
+    await login.fillOutFirstSignUp(emailWithSpace, password, false);
+
+    // Verify the confirm code header and the email
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+    expect(await login.confirmEmail()).toMatch(emailWithoutSpace);
+    await login.clearCache();
+    await page.goto(target.contentServerUrl);
+    await login.fillOutEmailFirstSignIn(emailWithoutSpace, password);
+
+    // Verify the confirm code header
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+  });
+
+  test('signup with invalid email address', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    await page.goto(target.contentServerUrl);
+    await login.setEmail('invalidemail');
+    await login.clickSubmit();
+
+    // Verify the error
+    expect(await login.getTooltipError()).toMatch('Valid email required');
+  });
+
+  test('coppa is empty', async ({ target, page, pages: { login } }) => {
+    const email = login.createEmail();
+    await page.goto(target.contentServerUrl);
+    await login.setEmail(email);
+    await login.clickSubmit();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.clickSubmit();
+
+    // Verify the error
+    expect(await login.getTooltipError()).toMatch(
+      'You must enter your age to sign up'
+    );
+  });
+
+  test('coppa too young', async ({ target, page, pages: { login } }) => {
+    const email = login.createEmail();
+    await page.goto(target.contentServerUrl);
+    await login.setEmail(email);
+    await login.clickSubmit();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.setAge('12');
+    await login.clickSubmit();
+
+    // Verify the error
+    expect(await login.cannotCreateAccountHeader()).toBe(true);
+  });
+
+  test('sign up with non matching passwords', async ({
+    target,
+    page,
+    pages: { login },
+  }) => {
+    const email = login.createEmail();
+    await page.goto(target.contentServerUrl);
+    await login.setEmail(email);
+    await login.clickSubmit();
+    await login.setPassword(password);
+    await login.confirmPassword('wrongpassword');
+    await login.setAge('24');
+    await login.clickSubmit();
+
+    // Verify the error
+    expect(await login.getTooltipError()).toMatch('Passwords do not match');
+  });
+
+  test('form prefill information is cleared after signup->sign out', async ({
+    target,
+    page,
+    pages: { login, settings },
+  }) => {
+    const email = login.createEmail();
+    await page.goto(target.contentServerUrl);
+    await login.fillOutFirstSignUp(email, password, true);
+
+    // The original tab should transition to the settings page w/ success
+    // message.
+    expect(await login.loginHeader()).toBe(true);
+    await settings.signOut();
+
+    // check the email address was cleared
+    expect(await login.isEmailHeader()).toBe(true);
+    expect(await login.getEmailInput()).toMatch('');
+
+    await login.setEmail(login.createEmail());
+    await login.clickSubmit();
+
+    // check the password was cleared
+    expect(await login.getPasswordInput()).toMatch('');
+  });
+
+  test('signup via product page and redirect after confirm', async ({
+    pages: { login, relier },
+  }) => {
+    const email = login.createEmail();
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await login.fillOutFirstSignUp(email, password, true);
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+
+  test('signup, verify and sign out of two accounts, all in the same tab, then sign in to the first account', async ({
+    target,
+    page,
+    pages: { login, settings },
+  }) => {
+    const email = login.createEmail();
+    const secondEmail = login.createEmail();
+    await page.goto(target.contentServerUrl);
+    await login.fillOutFirstSignUp(email, password, true);
+
+    // The original tab should transition to the settings page w/ success
+    // message.
+    expect(await login.loginHeader()).toBe(true);
+    await settings.signOut();
+
+    await login.fillOutFirstSignUp(secondEmail, password, true);
+
+    // The original tab should transition to the settings page w/ success
+    // message.
+    expect(await login.loginHeader()).toBe(true);
+    await settings.signOut();
+
+    await login.setEmail(email);
+    await login.clickSubmit();
+    await login.setPassword(password);
+    await login.submit();
+    expect(await login.loginHeader()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [sign up tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sign_up.js) have been rewritten in this PR.

## This pull request

contains [sign up tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sign_up.js) 

## Issue that this pull request solves

Closes: #[FXA-5922](https://mozilla-hub.atlassian.net/browse/FXA-5922)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-5922]: https://mozilla-hub.atlassian.net/browse/FXA-5922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ