### PR TITLE
fix(storybook): Add missing branding package in settings storybook

### DIFF
--- a/packages/fxa-settings/.storybook/decorators.tsx
+++ b/packages/fxa-settings/.storybook/decorators.tsx
@@ -12,7 +12,7 @@ import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 export const withLocalization: DecoratorFn = (Story) => (
   <AppLocalizationProvider
     baseDir="./locales"
-    bundles={['settings', 'react']}
+    bundles={['settings', 'react', 'branding']}
     userLocales={navigator.languages}
   >
     <Story />

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -8,6 +8,7 @@ import InputText from '../../components/InputText';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../constants';
+import { useFtlMsgResolver } from '../../models';
 
 export type FormAttributes = {
   inputLabelText: string;
@@ -45,6 +46,12 @@ const FormVerifyCode = ({
 }: FormVerifyCodeProps) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
 
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedLabel = ftlMsgResolver.getMsg(
+    formAttributes.inputFtlId,
+    formAttributes.inputLabelText
+  );
+
   const onFocus = () => {
     if (!isFocused && viewName) {
       logViewEvent('flow', `${viewName}.engage`, REACT_ENTRYPOINT);
@@ -67,32 +74,30 @@ const FormVerifyCode = ({
       onSubmit={handleSubmit(onSubmit)}
     >
       {/* Using `type="text" inputmode="numeric"` shows the numeric pad on mobile and strips out whitespace on desktop. */}
-      <FtlMsg id={formAttributes.inputFtlId}>
-        <InputText
-          type="text"
-          inputMode="numeric"
-          label={formAttributes.inputLabelText}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setCode(e.target.value);
-            // clear error tooltip if user types in the field
-            if (codeErrorMessage) {
-              setCodeErrorMessage('');
-            }
-          }}
-          onFocusCb={viewName ? onFocus : undefined}
-          errorText={codeErrorMessage}
-          autoFocus
-          pattern={formAttributes.pattern}
-          maxLength={formAttributes.maxLength}
-          className="text-start"
-          anchorStart
-          autoComplete="off"
-          spellCheck={false}
-          prefixDataTestId={viewName}
-          required
-          tooltipPosition="bottom"
-        />
-      </FtlMsg>
+      <InputText
+        type="text"
+        inputMode="numeric"
+        label={localizedLabel}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setCode(e.target.value);
+          // clear error tooltip if user types in the field
+          if (codeErrorMessage) {
+            setCodeErrorMessage('');
+          }
+        }}
+        onFocusCb={viewName ? onFocus : undefined}
+        errorText={codeErrorMessage}
+        autoFocus
+        pattern={formAttributes.pattern}
+        maxLength={formAttributes.maxLength}
+        className="text-start"
+        anchorStart
+        autoComplete="off"
+        spellCheck={false}
+        prefixDataTestId={viewName}
+        required
+        tooltipPosition="bottom"
+      />
 
       <FtlMsg id={formAttributes.submitButtonFtlId}>
         <button type="submit" className="cta-primary cta-xl">


### PR DESCRIPTION
## Because

* Branding terms were displayed as variables in the fxa-settings storybook.
* FormVerifyCode's label l10n was getting added as child instead of a label attribute.

## This pull request

* Add 'branding' to fxa-settings' storybook l10n bundle.
* Update FormVerifyCode to use ftlMsgResolver instead of wrapping the input in an FtlMsg.

## Issue that this pull request solves

Issue #FXA-6299

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before - Branding not loading:
![image](https://user-images.githubusercontent.com/22231637/219809455-c2499875-540e-463a-8e12-ddbf3d21cbcc.png)

After - branding now loading:
![image](https://user-images.githubusercontent.com/22231637/219809972-063683c8-c1c9-4c3a-9ec1-52bcf8100c6d.png)

Before - label incorrectly applied:
![image](https://user-images.githubusercontent.com/22231637/219809371-1af4a921-1c36-4285-a332-587385a039a5.png)

After - label correctly applied
![image](https://user-images.githubusercontent.com/22231637/219809789-39a0bf08-0842-4912-8dca-d67c4eecd052.png)

## Other information (Optional)

Any other information that is important to this pull request.
