### PR TITLE
task(settings): Make relier factory synchronous

### DIFF
--- a/packages/fxa-settings/src/lib/reliers/relier-factory.test.ts
+++ b/packages/fxa-settings/src/lib/reliers/relier-factory.test.ts
@@ -237,10 +237,10 @@ describe('lib/reliers/relier-factory', () => {
       );
     });
 
-    it('has correct state', () => {
+    it('has correct state', async () => {
       expect(relier.name).toEqual('pairing-supplicant');
       expect(relier.isOAuth()).toBeTruthy();
-      expect(relier.isSync()).toBeFalsy();
+      expect(await relier.isSync()).toBeFalsy();
       expect(relier.wantsKeys()).toBeFalsy();
       expect(relier.pickResumeTokenInfo()).toEqual({});
       expect(relier.isTrusted()).toBeFalsy();

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -87,9 +87,12 @@ export function useFtlMsgResolver() {
   return new FtlMsgResolver(l10n, config.l10n.strict);
 }
 
-export async function useRelier() {
+export function useRelier() {
   const { relierFactory } = useContext(AppContext);
-  return await relierFactory?.getRelier();
+  if (relierFactory == null) {
+    throw new Error('Relier factory never initialized!')
+  }
+  return relierFactory.getRelier();
 }
 
 /**
@@ -114,7 +117,7 @@ export function useInterval(callback: () => void, delay: number | null) {
         savedCallback.current();
       }
     }, delay);
-    
+
     return () => window.clearInterval(id);
   }, [delay]);
 }

--- a/packages/fxa-settings/src/models/reliers/base-relier.test.ts
+++ b/packages/fxa-settings/src/models/reliers/base-relier.test.ts
@@ -19,8 +19,8 @@ describe('BaseRelier Model', function () {
   });
 
   describe('isSync', function () {
-    it('returns `false`', function () {
-      expect(model.isSync()).toBeFalsy();
+    it('returns `false`', async function () {
+      expect(await model.isSync()).toBeFalsy();
     });
   });
 

--- a/packages/fxa-settings/src/models/reliers/browser-relier.ts
+++ b/packages/fxa-settings/src/models/reliers/browser-relier.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Constants } from '../../lib/constants';
 import { bind, ContextValidation as V } from '../../lib/context';
 import { ModelContext } from '../../lib/context/interfaces/model-context';
 import { BaseRelier } from './base-relier';
@@ -18,6 +19,14 @@ export interface BrowserRelierData {
 export class BrowserRelier extends BaseRelier implements BrowserRelierData {
   get name() {
     return 'browser';
+  }
+
+  get serviceName() {
+    if (this.service === 'sync') {
+      return Constants.RELIER_SYNC_SERVICE_NAME;
+    } else {
+      return 'Firefox';
+    }
   }
 
   @bind([V.isValidCountry])
@@ -42,7 +51,7 @@ export class BrowserRelier extends BaseRelier implements BrowserRelierData {
     super(curContext);
   }
 
-  isSync() {
+  async isSync() {
     return true;
   }
 

--- a/packages/fxa-settings/src/models/reliers/oauth-relier.ts
+++ b/packages/fxa-settings/src/models/reliers/oauth-relier.ts
@@ -170,8 +170,13 @@ export class OAuthRelier extends BaseRelier implements OAuthRelierData {
     return true;
   }
 
-  isSync() {
-    return this.serviceName === Constants.RELIER_SYNC_SERVICE_NAME;
+  async isSync() {
+    if (this.clientInfo == null) {
+      return false;
+    }
+
+    const clientInfo = await this.clientInfo;
+    return clientInfo.serviceName === Constants.RELIER_SYNC_SERVICE_NAME;
   }
 
   isTrusted() {


### PR DESCRIPTION
## Because

- The async nature of the relier factory was causing some problems

## This pull request

- Updates BaseRelier model so that async operations aren't necessary for creation.
- Adds async clientInfo and subscriptionInfo properties.
- Kicks off resolution of clientInfo and subscriptionInfo properties in factory, but doesn't await them.
- Controls should now ensure async properties have been resolved. This can be done with useEffect.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

This is a nice to have for some of the react conversion work such as FXA-6127.
