### PR TITLE
feature(fxa-settings): add functionality to primary_email_verified

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -256,9 +256,16 @@ Router = Router.extend({
     'push/confirm_login(/)': createViewHandler('push/confirm_login'),
     'push/send_login(/)': createViewHandler('push/send_login'),
     'push/completed(/)': createViewHandler('push/completed'),
-    'primary_email_verified(/)': createViewHandler(ReadyView, {
-      type: VerificationReasons.PRIMARY_EMAIL_VERIFIED,
-    }),
+    'primary_email_verified(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'primary_email_verified',
+        ReadyView,
+        null,
+        {
+          type: VerificationReasons.PRIMARY_EMAIL_VERIFIED,
+        }
+      );
+    },
     'report_signin(/)': createViewHandler(ReportSignInView),
 
     'reset_password(/)': function () {

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -203,6 +203,12 @@ const EVENTS = {
     event: 'verified_recovery_key_submit',
   },
 
+  // Primary email verified - Primary email confirmed
+  'screen.primary-email-verified': {
+    group: GROUPS.signup,
+    event: 'primary_email_verified_view',
+  },
+
   'screen.account-recovery-confirm-key': {
     group: GROUPS.login,
     event: 'forgot_password_confirm_recovery_key_view',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -54,7 +54,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
 
     signUpRoutes: {
       featureFlagOn: showReactApp.signUpRoutes,
-      routes: [],
+      routes: [reactRoute.getRoute('primary_email_verified')],
     },
 
     pairRoutes: {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { RouteComponentProps, Router } from '@reach/router';
 import { ScrollToTop } from '../Settings/ScrollToTop';
+import { PageWithLoggedInStatusState } from '../PageWithLoggedInStatusState';
 import Settings from '../Settings';
 import { QueryParams } from '../..';
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
@@ -18,9 +19,10 @@ import Legal from '../../pages/Legal';
 import LegalTerms from '../../pages/Legal/Terms';
 import LegalPrivacy from '../../pages/Legal/Privacy';
 
+import PrimaryEmailVerified from '../../pages/Signup/PrimaryEmailVerified';
+
 import CompleteResetPassword from '../../pages/ResetPassword/CompleteResetPassword';
 import ResetPasswordConfirmed from '../../pages/ResetPassword/ResetPasswordConfirmed';
-
 
 export const App = ({
   flowQueryParams,
@@ -46,11 +48,25 @@ export const App = ({
               <LegalPrivacy path="/legal/privacy/*" />
               <LegalPrivacy path="/:locale/legal/privacy/*" />
 
-             <ResetPassword path='/reset_password/*' />
-             <ConfirmResetPassword path='/confirm_reset_password/*' />
-             <CompleteResetPassword path='/complete_reset_password/*' />
-             <ResetPasswordConfirmed path='/reset_password_verified/*' />
-             <ResetPasswordWithRecoveryKeyVerified path='/reset_password_with_recovery_key_verified/*' />
+              <ResetPassword path="/reset_password/*" />
+              <ConfirmResetPassword path="/confirm_reset_password/*" />
+              <CompleteResetPassword path="/complete_reset_password/*" />
+              {/* Pages using the Ready view need to be accessible to logged out viewers,
+               * but need to be able to check if the user is logged in or logged out,
+               * so they are wrapped in this component.
+               */}
+              <PageWithLoggedInStatusState
+                Page={ResetPasswordConfirmed}
+                path="/reset_password_verified/*"
+              />
+              <PageWithLoggedInStatusState
+                Page={ResetPasswordWithRecoveryKeyVerified}
+                path="/reset_password_with_recovery_key_verified/*"
+              />
+              <PageWithLoggedInStatusState
+                Page={PrimaryEmailVerified}
+                path="/primary_email_verified/*"
+              />
             </>
           )}
           <Settings path="/settings/*" {...{ flowQueryParams }} />

--- a/packages/fxa-settings/src/components/PageWithLoggedInStatusState/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageWithLoggedInStatusState/index.test.tsx
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PageWithLoggedInStatusState } from '.';
+import { MockComponent } from './mocks';
+import { Account, AppContext, useInitialState } from '../../models';
+import { mockAppContext } from '../../models/mocks';
+
+jest.mock('../../models', () => ({
+  ...jest.requireActual('../../models'),
+  useInitialState: jest.fn(),
+}));
+
+describe('PageWithLoggedInStatusState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  (useInitialState as jest.Mock).mockReturnValue({ loading: false });
+
+  it('passes the `isSignedIn` prop on to the child component', () => {
+    const account = {
+      metricsEnabled: false,
+      hasPassword: true,
+    } as unknown as Account;
+    render(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <PageWithLoggedInStatusState
+          path="/arbitrary_path/*"
+          Page={MockComponent}
+        />
+      </AppContext.Provider>
+    );
+    expect(screen.getByText('You are signed in!')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/PageWithLoggedInStatusState/index.tsx
+++ b/packages/fxa-settings/src/components/PageWithLoggedInStatusState/index.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from 'react';
+import { useInitialState } from '../../models';
+import { RouteComponentProps } from '@reach/router';
+
+export const PageWithLoggedInStatusState = (
+  props: any & RouteComponentProps & { Page: React.ElementType }
+) => {
+  const { Page } = props;
+  const { loading, error } = useInitialState();
+
+  const [isSignedIn, setIsSignedIn] = useState<boolean>();
+
+  useEffect(() => {
+    if (!loading && error?.message.includes('Invalid token')) {
+      setIsSignedIn(false);
+    } else if (!loading && !error) {
+      setIsSignedIn(true);
+    }
+  }, [error, loading]);
+
+  return <Page {...props} {...{ isSignedIn }} />;
+};
+
+export default PageWithLoggedInStatusState;

--- a/packages/fxa-settings/src/components/PageWithLoggedInStatusState/mocks.tsx
+++ b/packages/fxa-settings/src/components/PageWithLoggedInStatusState/mocks.tsx
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+
+export const MockComponent = ({ isSignedIn }: { isSignedIn: boolean }) => {
+  return (
+    <>
+      {isSignedIn ? <p>You are signed in!</p> : <p>You are not signed in.</p>}
+    </>
+  );
+};
+
+export default MockComponent;

--- a/packages/fxa-settings/src/components/Ready/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.stories.tsx
@@ -4,9 +4,9 @@
 
 import React from 'react';
 import Ready, { ReadyProps } from '.';
-import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
+import { AppLayout } from '../AppLayout';
 import { withLocalization } from '../../../.storybook/decorators';
 
 export default {
@@ -40,7 +40,7 @@ const ReadyWithLayout = ({
 };
 
 export const SigninConfirmedOrSigninVerified = () => (
-  <ReadyWithLayout viewName="signin-confirmed" />
+  <ReadyWithLayout viewName="signin-confirmed" isSignedIn />
 );
 
 export const ResetPasswordConfirmForLoggedOutUser = () => (
@@ -49,6 +49,7 @@ export const ResetPasswordConfirmForLoggedOutUser = () => (
 
 export const ResetPasswordConfirmedWithRelyingParty = () => (
   <ReadyWithLayout
+    isSignedIn
     serviceName={MozServices.FirefoxSync}
     viewName="reset-password-confirmed"
   />
@@ -56,6 +57,7 @@ export const ResetPasswordConfirmedWithRelyingParty = () => (
 
 export const WithRelyingPartyNoContinueAction = () => (
   <ReadyWithLayout
+    isSignedIn
     serviceName={MozServices.FirefoxSync}
     viewName="signin-confirmed"
   />
@@ -63,6 +65,7 @@ export const WithRelyingPartyNoContinueAction = () => (
 
 export const WithRelyingPartyAndContinueAction = () => (
   <ReadyWithLayout
+    isSignedIn
     serviceName={MozServices.FirefoxSync}
     viewName="reset-password-confirmed"
     continueHandler={() => {
@@ -73,6 +76,7 @@ export const WithRelyingPartyAndContinueAction = () => (
 
 export const IsSync = () => (
   <ReadyWithLayout
+    isSignedIn
     viewName="reset-password-with-recovery-key-verified"
     isSync
   />
@@ -80,6 +84,7 @@ export const IsSync = () => (
 
 export const WithErrorMessage = () => (
   <ReadyWithLayout
+    isSignedIn
     viewName="reset-password-with-recovery-key-verified"
     isSync
     errorMessage="But something else went wrong"

--- a/packages/fxa-settings/src/components/Ready/index.test.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.test.tsx
@@ -19,13 +19,14 @@ jest.mock('../../lib/metrics', () => ({
 describe('Ready', () => {
   const customServiceName = MozServices.FirefoxSync;
   const viewName = 'reset-password-confirmed';
+  const isSignedIn = true;
   // let bundle: FluentBundle;
   // beforeAll(async () => {
   //   bundle = await getFtlBundle('settings');
   // });
 
   it('renders as expected with default values', () => {
-    render(<Ready {...{ viewName }} />);
+    render(<Ready {...{ viewName, isSignedIn }} />);
     // testAllL10n(screen, bundle);
 
     const passwordResetConfirmation = screen.getByText(
@@ -43,7 +44,9 @@ describe('Ready', () => {
   });
 
   it('renders as expected when given a service name', () => {
-    render(<Ready {...{ viewName }} serviceName={customServiceName} />);
+    render(
+      <Ready {...{ viewName, isSignedIn }} serviceName={customServiceName} />
+    );
 
     const passwordResetConfirmation = screen.getByText(
       'Your password has been reset'
@@ -77,6 +80,7 @@ describe('Ready', () => {
       <Ready
         {...{
           viewName,
+          isSignedIn,
         }}
         serviceName={customServiceName}
         continueHandler={() => {
@@ -100,7 +104,7 @@ describe('Ready', () => {
   });
 
   it('emits a metrics event on render', () => {
-    render(<Ready {...{ viewName }} />);
+    render(<Ready {...{ viewName, isSignedIn }} />);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
@@ -111,7 +115,7 @@ describe('Ready', () => {
           console.log('beepboop');
         }}
         serviceName={customServiceName}
-        {...{ viewName }}
+        {...{ viewName, isSignedIn }}
       />
     );
     const passwordResetContinueButton = screen.getByText('Continue');

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -15,7 +15,7 @@ import Banner, { BannerType } from '../Banner';
 // We'll actually be getting the isSignedIn value from a context when this is wired up.
 export type ReadyProps = {
   continueHandler?: Function;
-  isSignedIn?: boolean;
+  isSignedIn: boolean;
   serviceName?: MozServices;
   viewName: ViewNameType;
   isSync?: boolean;
@@ -65,7 +65,7 @@ const getTemplateValues = (viewName: ViewNameType) => {
 
 const Ready = ({
   continueHandler,
-  isSignedIn = true,
+  isSignedIn,
   serviceName,
   viewName,
   isSync = false,

--- a/packages/fxa-settings/src/components/images/index.test.tsx
+++ b/packages/fxa-settings/src/components/images/index.test.tsx
@@ -30,7 +30,7 @@ it('applies a11y by default', () => {
 });
 
 it('can be hidden from screenreaders when desired', () => {
-  render(<HeartsVerifiedImage ariaHidden={true} />);
+  render(<HeartsVerifiedImage ariaHidden />);
   const image = screen.getByTestId('aria-hidden-image');
   expect(image).toBeInTheDocument();
   expect(image).toHaveAttribute('aria-hidden');

--- a/packages/fxa-settings/src/components/images/index.tsx
+++ b/packages/fxa-settings/src/components/images/index.tsx
@@ -39,13 +39,13 @@ export const PreparedImage = (props: PreparedImageProps) => {
   return (
     <>
       {showAriaLabel ? (
-        <FtlMsg id={props.ariaLabelFtlId} attrs={{ariaLabel:true}}>
+        <FtlMsg id={props.ariaLabelFtlId} attrs={{ ariaLabel: true }}>
           <Image role="img" aria-label={props.ariaLabel} {...{ className }} />
         </FtlMsg>
       ) : (
         <Image
           className={className}
-          aria-hidden={true}
+          aria-hidden
           data-testid="aria-hidden-image"
         />
       )}

--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -39,8 +39,8 @@ describe('errorHandler', () => {
   it('redirects to /signin if called with a GQL authentication error', () => {
     errorResponse = {
       graphQLErrors: [new GraphQLError('Invalid token')],
-      operation: (null as any) as Operation,
-      forward: (null as any) as NextLink,
+      operation: null as any as Operation,
+      forward: null as any as NextLink,
     };
 
     errorHandler(errorResponse);
@@ -56,8 +56,8 @@ describe('errorHandler', () => {
     networkError.statusCode = 401;
     errorResponse = {
       networkError,
-      operation: (null as any) as Operation,
-      forward: (null as any) as NextLink,
+      operation: null as any as Operation,
+      forward: null as any as NextLink,
     };
 
     errorHandler(errorResponse);
@@ -72,8 +72,8 @@ describe('errorHandler', () => {
     networkError.statusCode = 500;
     errorResponse = {
       networkError,
-      operation: (null as any) as Operation,
-      forward: (null as any) as NextLink,
+      operation: null as any as Operation,
+      forward: null as any as NextLink,
     };
 
     errorHandler(errorResponse);

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
@@ -16,10 +16,18 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
+export const DefaultSignedIn = () => (
   <LocationProvider>
     <AppLayout>
-      <ResetPasswordConfirmed />
+      <ResetPasswordConfirmed isSignedIn />
+    </AppLayout>
+  </LocationProvider>
+);
+
+export const DefaultSignedOut = () => (
+  <LocationProvider>
+    <AppLayout>
+      <ResetPasswordConfirmed isSignedIn={false} />
     </AppLayout>
   </LocationProvider>
 );
@@ -27,7 +35,7 @@ export const Default = () => (
 export const WithRelyingPartyNoContinueAction = () => (
   <LocationProvider>
     <AppLayout>
-      <ResetPasswordConfirmed serviceName={MozServices.MozillaVPN} />
+      <ResetPasswordConfirmed isSignedIn serviceName={MozServices.MozillaVPN} />
     </AppLayout>
   </LocationProvider>
 );
@@ -36,6 +44,7 @@ export const WithRelyingPartyAndContinueAction = () => (
   <LocationProvider>
     <AppLayout>
       <ResetPasswordConfirmed
+        isSignedIn
         serviceName={MozServices.MozillaVPN}
         continueHandler={() => {
           console.log('Arbitrary action');

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -15,7 +15,7 @@ jest.mock('../../../lib/metrics', () => ({
 
 describe('ResetPasswordConfirmed', () => {
   it('renders Ready component as expected', () => {
-    render(<ResetPasswordConfirmed />);
+    render(<ResetPasswordConfirmed isSignedIn />);
     const passwordResetConfirmation = screen.getByText(
       'Your password has been reset'
     );
@@ -27,13 +27,14 @@ describe('ResetPasswordConfirmed', () => {
   });
 
   it('emits the expected metrics on render', () => {
-    render(<ResetPasswordConfirmed />);
+    render(<ResetPasswordConfirmed isSignedIn />);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
     render(
       <ResetPasswordConfirmed
+        isSignedIn
         continueHandler={() => {
           console.log('beepboop');
         }}

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
@@ -10,6 +10,7 @@ import AppLayout from '../../../components/AppLayout';
 
 type ResetPasswordConfirmedProps = {
   continueHandler?: Function;
+  isSignedIn: boolean;
   serviceName?: MozServices;
 };
 
@@ -17,10 +18,11 @@ export const viewName = 'reset-password-confirmed';
 
 const ResetPasswordConfirmed = ({
   continueHandler,
+  isSignedIn,
   serviceName,
 }: ResetPasswordConfirmedProps & RouteComponentProps) => (
   <AppLayout>
-    <Ready {...{ continueHandler, viewName, serviceName }} />
+    <Ready {...{ continueHandler, isSignedIn, viewName, serviceName }} />
   </AppLayout>
 );
 

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
@@ -14,14 +14,20 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
+export const DefaultSignedIn = () => (
   <LocationProvider>
-    <ResetPasswordWithRecoveryKeyVerified />
+    <ResetPasswordWithRecoveryKeyVerified isSignedIn />
+  </LocationProvider>
+);
+
+export const DefaultSignedOut = () => (
+  <LocationProvider>
+    <ResetPasswordWithRecoveryKeyVerified isSignedIn={false} />
   </LocationProvider>
 );
 
 export const WithSync = () => (
   <LocationProvider>
-    <ResetPasswordWithRecoveryKeyVerified isSync />
+    <ResetPasswordWithRecoveryKeyVerified isSignedIn isSync />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -13,6 +13,7 @@ import AppLayout from '../../../components/AppLayout';
 import { useFtlMsgResolver } from '../../../models';
 
 type ResetPasswordWithRecoveryKeyVerifiedProps = {
+  isSignedIn: boolean;
   serviceName?: MozServices;
   // TODO: FXA-6804
   // Verify if relier is Sync with the useRelier hook that will be implemented in FXA-6437
@@ -29,6 +30,7 @@ export const viewName = 'reset-password-with-recovery-key-verified';
 
 const ResetPasswordWithRecoveryKeyVerified = ({
   serviceName,
+  isSignedIn,
   isSync,
 }: ResetPasswordWithRecoveryKeyVerifiedProps & RouteComponentProps) => {
   const navigate = useNavigate();
@@ -54,7 +56,7 @@ const ResetPasswordWithRecoveryKeyVerified = ({
 
   return (
     <AppLayout title={localizedPageTitle}>
-      <Ready {...{ viewName, serviceName, isSync }} />
+      <Ready {...{ viewName, serviceName, isSync, isSignedIn }} />
       <div className="flex justify-center mx-auto m-6">
         <button className="cta-primary cta-xl" onClick={goToGenerateNewKey}>
           <FtlMsg id="reset-password-with-recovery-key-verified-generate-new-key">

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.stories.tsx
@@ -15,10 +15,18 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
+export const DefaultSignedIn = () => (
   <LocationProvider>
     <AppLayout>
-      <SigninConfirmed />
+      <SigninConfirmed isSignedIn />
+    </AppLayout>
+  </LocationProvider>
+);
+
+export const DefaultSignedOut = () => (
+  <LocationProvider>
+    <AppLayout>
+      <SigninConfirmed isSignedIn={false} />
     </AppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.test.tsx
@@ -21,7 +21,7 @@ describe('SigninConfirmed', () => {
   //   bundle = await getFtlBundle('settings');
   // });
   it('renders Ready component as expected', () => {
-    render(<SigninConfirmed />);
+    render(<SigninConfirmed isSignedIn />);
     // testAllL10n(screen, bundle);
 
     const signinConfirmation = screen.getByText('Sign-in confirmed');
@@ -37,13 +37,14 @@ describe('SigninConfirmed', () => {
   });
 
   it('emits the expected metrics on render', () => {
-    render(<SigninConfirmed />);
+    render(<SigninConfirmed isSignedIn />);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
     render(
       <SigninConfirmed
+        isSignedIn
         continueHandler={() => {
           console.log('beepboop');
         }}

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
@@ -9,6 +9,7 @@ import { MozServices } from '../../../lib/types';
 
 type SigninConfirmedProps = {
   continueHandler?: Function;
+  isSignedIn: boolean;
   serviceName?: MozServices;
 };
 
@@ -16,9 +17,10 @@ export const viewName = 'signin-confirmed';
 
 const SigninConfirmed = ({
   continueHandler,
+  isSignedIn,
   serviceName,
 }: SigninConfirmedProps & RouteComponentProps) => (
-  <Ready {...{ continueHandler, viewName, serviceName }} />
+  <Ready {...{ continueHandler, isSignedIn, viewName, serviceName }} />
 );
 
 export default SigninConfirmed;

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
@@ -4,8 +4,6 @@
 
 import React from 'react';
 import PrimaryEmailVerified, { PrimaryEmailVerifiedProps } from '.';
-import AppLayout from '../../../components/AppLayout';
-import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_SERVICE } from './mocks';
 import { withLocalization } from '../../../../.storybook/decorators';
@@ -16,22 +14,16 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = (props?: PrimaryEmailVerifiedProps) => {
-  const story = () => (
-    <LocationProvider>
-      <AppLayout>
-        <PrimaryEmailVerified {...props} />
-      </AppLayout>
-    </LocationProvider>
-  );
+const storyWithProps = (props: PrimaryEmailVerifiedProps) => {
+  const story = () => <PrimaryEmailVerified {...props} />;
   return story;
 };
 
-export const NotSignedIn = storyWithProps();
+export const BasicSignedIn = storyWithProps({ isSignedIn: true });
 
-export const SignedIn = storyWithProps({ isSignedIn: true });
+export const BasicSignedOut = storyWithProps({ isSignedIn: false });
 
-export const SignedInWithServiceName = storyWithProps({
-  isSignedIn: true,
+export const BasicWithServiceName = storyWithProps({
   serviceName: MOCK_SERVICE,
+  isSignedIn: false,
 });

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
@@ -23,19 +23,20 @@ describe('PrimaryEmailVerified page', () => {
   // });
 
   it('renders the page as expected when the user is signed in', () => {
-    render(<PrimaryEmailVerified />);
+    render(<PrimaryEmailVerified isSignedIn />);
     // testAllL10n(screen, bundle);
 
     screen.getByText('Primary email confirmed');
-    screen.getByText('Your account is ready!');
+    screen.getByText('You’re now ready to use account settings');
     const signinContinueButton = screen.queryByText('Continue');
     expect(signinContinueButton).not.toBeInTheDocument();
   });
 
-  it('renders the page as expected when the user is not signed in', () => {
-    render(<PrimaryEmailVerified isSignedIn />);
+  it('renders the page as expected when the user is signed out', () => {
+    render(<PrimaryEmailVerified isSignedIn={false} />);
+    // testAllL10n(screen, bundle);
 
-    screen.getByText('You’re now ready to use account settings');
+    screen.getByText('Your account is ready!');
   });
 
   it('show the service name when it is passed in', () => {
@@ -45,7 +46,7 @@ describe('PrimaryEmailVerified page', () => {
   });
 
   it('emits the expected metrics on render', () => {
-    render(<PrimaryEmailVerified />);
+    render(<PrimaryEmailVerified isSignedIn />);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
@@ -6,19 +6,24 @@ import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
 import { MozServices } from '../../../lib/types';
+import AppLayout from '../../../components/AppLayout';
 
 export type PrimaryEmailVerifiedProps = {
   serviceName?: MozServices;
-  isSignedIn?: boolean;
+  isSignedIn: boolean;
 };
 
 export const viewName = 'primary-email-verified';
 
 const PrimaryEmailVerified = ({
   serviceName,
-  isSignedIn = false,
-}: PrimaryEmailVerifiedProps & RouteComponentProps) => (
-  <Ready {...{ viewName, serviceName, isSignedIn }} />
-);
+  isSignedIn,
+}: PrimaryEmailVerifiedProps & RouteComponentProps) => {
+  return (
+    <AppLayout>
+      <Ready {...{ viewName, serviceName, isSignedIn }} />
+    </AppLayout>
+  );
+};
 
 export default PrimaryEmailVerified;

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
@@ -15,10 +15,18 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
+export const DefaultSignedIn = () => (
   <LocationProvider>
     <AppLayout>
-      <SignupConfirmed />
+      <SignupConfirmed isSignedIn />
+    </AppLayout>
+  </LocationProvider>
+);
+
+export const DefaultSignedOut = () => (
+  <LocationProvider>
+    <AppLayout>
+      <SignupConfirmed isSignedIn={false} />
     </AppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
@@ -22,7 +22,7 @@ describe('SignupConfirmed', () => {
   //   bundle = await getFtlBundle('settings');
   // });
   it('renders Ready component as expected', () => {
-    render(<SignupConfirmed />);
+    render(<SignupConfirmed isSignedIn />);
     // testAllL10n(screen, bundle);
 
     const signupConfirmation = screen.getByText('Account confirmed');
@@ -38,13 +38,14 @@ describe('SignupConfirmed', () => {
   });
 
   it('emits the expected metrics on render', () => {
-    render(<SignupConfirmed />);
+    render(<SignupConfirmed isSignedIn />);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', () => {
     render(
       <SignupConfirmed
+        isSignedIn
         continueHandler={() => {
           console.log('beepboop');
         }}

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
@@ -9,6 +9,7 @@ import { MozServices } from '../../../lib/types';
 
 type SignupConfirmedProps = {
   continueHandler?: Function;
+  isSignedIn: boolean;
   serviceName?: MozServices;
 };
 
@@ -16,9 +17,10 @@ export const viewName = 'signup-confirmed';
 
 const SignupConfirmed = ({
   continueHandler,
+  isSignedIn,
   serviceName,
 }: SignupConfirmedProps & RouteComponentProps) => (
-  <Ready {...{ continueHandler, viewName, serviceName }} />
+  <Ready {...{ continueHandler, isSignedIn, viewName, serviceName }} />
 );
 
 export default SignupConfirmed;


### PR DESCRIPTION
## Because:

* We want to move the primary_email_verified React page into the React app behind a flag

## This commit:

* Allows us to check if a user is logged in without being redirected to the signin page if we are at a URL outside of the Settings app

* Makes the `primary_email_verified` page visible to both logged in and logged out users behind a feature flag

* Shows different copy in the Ready view based on a user's logged-in status

* Create a new wrapper component to check if the user is logged in or logged out, and keep the state handling out of presentation component

Closes #FXA-6494

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
<img width="597" alt="Screen Shot 2023-02-23 at 3 01 48 PM" src="https://user-images.githubusercontent.com/11150372/221050390-462a9723-80f5-4239-a3f1-060db879b6a8.png">

After:
<img width="648" alt="Screen Shot 2023-02-23 at 3 01 40 PM" src="https://user-images.githubusercontent.com/11150372/221050369-1ea44f82-a962-42ac-af24-536e548d7c20.png">


## Other information (Optional)

The way that the Settings app keeps track of whether or not a user is signed in is actually in the way we set up graphql. In `packages/fxa-settings/src/lib/gql.ts`, we listen to incoming responses from all GQL queries and run the following check:
```if (networkError && 'statusCode' in networkError) {
    if (networkError.statusCode === 401) {
      reauth = true;
    }
  }
  if (reauth) {
    window.location.replace(
      `/signin?redirect_to=${encodeURIComponent(window.location.pathname)}`
    );
```
Basically if you make a request to GQL and are not authenticated, we force you out to `/signin`. My understanding is that this has not been an issue for some of the new pages because they don't actually make any requests to GQL, so an unauthenticated user can see them without any trouble. But if we want to check if the user is authenticated the same way that the Settings app does....of course we get redirected back to the `signin` page. A conundrum! 
I resolved this (inelegantly but effectively) by creating an array of url snippets (such as settings) which require authentication, and checking if the current `window.location.href` contains any of those snippets before running `window.location.replace`.)

To test:
-- start up `localhost:3030`
-- create a user
-- go to `localhost:3030/settings` to verify that you are logged in and things are working
-- go to `localhost:3030/primary_email_verified?showReactApp=true` to verify that you are seeing the page 
-- the copy at the bottom of the card should read "You're now ready to use account settings"

-- go back to `locahost:3030/settings` and logout
-- verify that when you try to revisit `localhost:3030/settings` you are pushed back to the signin page. (this means that you are indeed logged out, and Settings is still operating as desired.)
-- now go to `localhost:3030/primary_email_verified?showReactApp=true`
-- You should not be redirected out to the signin page.
-- the copy at the bottom of the card should be the "signed out" copy: "Your account is ready!"
