### PR TITLE
task(settings): Implement AccountRecoveryResetPassword in settings

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -125,9 +125,12 @@ Router = Router.extend({
         AccountRecoveryConfirmKey
       );
     },
-    'account_recovery_reset_password(/)': createViewHandler(
-      CompleteResetPasswordView
-    ),
+    'account_recovery_reset_password(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'account_recovery_reset_password',
+        CompleteResetPasswordView
+      );
+    },
     'authorization(/)': createViewHandler(RedirectAuthView),
     'cannot_create_account(/)': function () {
       this.createReactOrBackboneViewHandler(

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -40,6 +40,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'reset_password_verified',
         'reset_password_with_recovery_key_verified',
         'account_recovery_confirm_key',
+        'account_recovery_reset_password',
       ]),
     },
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -29,14 +29,13 @@ import SigninConfirmed from '../../pages/Signin/SigninConfirmed';
 
 import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
 import ConfirmSignupCode from '../../pages/Signup/ConfirmSignupCode';
-
 import SigninReported from '../../pages/Signin/SigninReported';
+import AccountRecoveryResetPassword from '../../pages/ResetPassword/AccountRecoveryResetPassword';
 
 export const App = ({
   flowQueryParams,
 }: { flowQueryParams: QueryParams } & RouteComponentProps) => {
   const { showReactApp } = flowQueryParams;
-
   return (
     <>
       <Router basepath={'/'}>
@@ -60,6 +59,7 @@ export const App = ({
               <ConfirmResetPassword path="/confirm_reset_password/*" />
               <CompleteResetPassword path="/complete_reset_password/*" />
               <AccountRecoveryConfirmKey path="/account_recovery_confirm_key/*" />
+              <AccountRecoveryResetPassword path="/account_recovery_reset_password/*" />
 
               <SigninReported path="/signin_reported/*" />
               {/* Pages using the Ready view need to be accessible to logged out viewers,

--- a/packages/fxa-settings/src/components/LinkExpired/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.test.tsx
@@ -7,8 +7,16 @@ import { render, screen } from '@testing-library/react';
 import LinkExpired from '.';
 
 describe('LinkExpired', () => {
+  let handler: () => Promise<void>;
+
+  beforeAll(() => {
+    handler = jest.fn();
+  });
+
   it('renders the component as expected for an expired Reset Password link', () => {
-    render(<LinkExpired linkType="reset-password" />);
+    render(
+      <LinkExpired linkType="reset-password" resendLinkHandler={handler} />
+    );
 
     screen.getByRole('heading', {
       name: 'Reset password link expired',
@@ -20,7 +28,7 @@ describe('LinkExpired', () => {
   });
 
   it('renders the component as expected for an expired Signin link', () => {
-    render(<LinkExpired linkType="signin" />);
+    render(<LinkExpired linkType="signin" resendLinkHandler={handler} />);
 
     screen.getByRole('heading', {
       name: 'Confirmation link expired',
@@ -29,5 +37,15 @@ describe('LinkExpired', () => {
     screen.getByRole('button', {
       name: 'Receive new link',
     });
+  });
+
+  it('fires the handler', () => {
+    render(<LinkExpired linkType="signin" resendLinkHandler={handler} />);
+    screen
+      .getByRole('button', {
+        name: 'Receive new link',
+      })
+      .click();
+    expect(handler).toBeCalled();
   });
 });

--- a/packages/fxa-settings/src/components/LinkExpired/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.tsx
@@ -10,20 +10,11 @@ import AppLayout from '../AppLayout';
 
 type LinkExpiredProps = {
   linkType: LinkType;
+  // FOLLOW-UP: Make link handler mandatory
+  resendLinkHandler?: (linkType: LinkType) => Promise<void>;
 };
 
-const getResendLinkHandler = (linkType: LinkType) => {
-  if (linkType === 'reset-password') {
-    return function () {
-      //   TODO: add resend link action
-    };
-  }
-  return function () {
-    //   TODO: add resend link action
-  };
-};
-
-const getTemplateValues = (linkType: LinkType) => {
+function getTemplateValues(linkType: LinkType) {
   let templateValues = {
     headerText: '',
     headerId: '',
@@ -51,14 +42,19 @@ const getTemplateValues = (linkType: LinkType) => {
       throw new Error('Invalid link type passed into LinkExpired component');
   }
   return templateValues;
-};
+}
 
-const LinkExpired = ({ linkType }: LinkExpiredProps) => {
+const LinkExpired = ({ linkType, resendLinkHandler }: LinkExpiredProps) => {
   // TODO : Metric event(s) for expired link
 
-  const resendLinkHandler = getResendLinkHandler(linkType);
   const templateValues = getTemplateValues(linkType);
-
+  const onClickReceiveNewLink = () => {
+    if (resendLinkHandler == null) {
+      console.error('resendLinkHandler missing!');
+    } else {
+      resendLinkHandler(linkType);
+    }
+  };
   return (
     <AppLayout>
       {/* TODO: Add alertBar for success/failure status of resendLinkHandler */}
@@ -70,8 +66,8 @@ const LinkExpired = ({ linkType }: LinkExpiredProps) => {
       <FtlMsg id={templateValues.messageId}>
         <p className="mt-4 text-sm">{templateValues.messageText}</p>
       </FtlMsg>
-      <FtlMsg id="reset-pwd-resend-link">
-        <button onClick={resendLinkHandler} className="link-blue mt-4">
+      <FtlMsg id="resend-link">
+        <button onClick={onClickReceiveNewLink} className="link-blue mt-4">
           Receive new link
         </button>
       </FtlMsg>

--- a/packages/fxa-settings/src/lib/context/implementations/base-context.ts
+++ b/packages/fxa-settings/src/lib/context/implementations/base-context.ts
@@ -23,4 +23,19 @@ export abstract class BaseContext implements ModelContext {
   persist() {
     // no-op
   }
+
+  toJSON() {
+    const temp: Record<string, unknown> = {};
+    for (const key in this.getKeys()) {
+      temp[key] = this.get(key);
+    }
+    return JSON.stringify(temp);
+  }
+
+  fromJSON(json: string) {
+    const parsed = JSON.parse(json);
+    Object.keys(parsed).forEach((key) => {
+      this.set(key, parsed[key]);
+    });
+  }
 }

--- a/packages/fxa-settings/src/lib/context/implementations/url-context.ts
+++ b/packages/fxa-settings/src/lib/context/implementations/url-context.ts
@@ -4,6 +4,14 @@
 
 import { BaseContext } from './base-context';
 
+export type UrlContextWindow = {
+  location: Pick<
+    typeof window.location,
+    'href' | 'pathname' | 'search' | 'hash'
+  >;
+  history: Pick<typeof window.history, 'replaceState'>;
+};
+
 /**
  * Creates a context from the current URL state
  */
@@ -19,7 +27,7 @@ export abstract class UrlContext extends BaseContext {
    * @param window Current window
    * @param mode Whether or not to store state in the search query or the hash.
    */
-  constructor(public readonly window: Window) {
+  constructor(public readonly window: UrlContextWindow) {
     super();
   }
 

--- a/packages/fxa-settings/src/lib/context/implementations/url-hash-context.ts
+++ b/packages/fxa-settings/src/lib/context/implementations/url-hash-context.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UrlContext } from './url-context';
+import { UrlContext, UrlContextWindow } from './url-context';
 
 /**
  * Uses window.location.hash to store state in set of url search parameter like strings.
  */
 export class UrlHashContext extends UrlContext {
-  constructor(public readonly window: Window) {
+  constructor(public readonly window: UrlContextWindow) {
     super(window);
   }
 

--- a/packages/fxa-settings/src/lib/context/implementations/url-search-context.ts
+++ b/packages/fxa-settings/src/lib/context/implementations/url-search-context.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UrlContext } from './url-context';
+import { UrlContext, UrlContextWindow } from './url-context';
 
 /**
  * Uses window.location.search to store state in set of url search parameter like strings.
  */
 export class UrlSearchContext extends UrlContext {
-  constructor(public readonly window: Window) {
+  constructor(public readonly window: UrlContextWindow) {
     super(window);
   }
 
@@ -21,5 +21,9 @@ export class UrlSearchContext extends UrlContext {
     url.search = params.toString();
     // Use replaceState URL, but prevent page loads or history changes
     this.window.history.replaceState({}, '', url);
+  }
+
+  public toSearchQuery() {
+    return this.getParams().toString();
   }
 }

--- a/packages/fxa-settings/src/lib/context/model-validation.ts
+++ b/packages/fxa-settings/src/lib/context/model-validation.ts
@@ -4,6 +4,7 @@
 
 // TODO: Figure out how to port Vat. Here's a simplistic implementation for POC.
 
+import { isEmailValid } from 'fxa-shared/email/helpers';
 import { Constants } from '../constants';
 
 /**
@@ -132,6 +133,11 @@ export const ContextValidation = {
     return v;
   },
 
+  isVerificationCode: (k: string, v: any) => {
+    // TODO: Add validation
+    return ContextValidation.isString(k, v);
+  },
+
   isAction: (k: string, v: any) => {
     // TODO: Add validation
     return ContextValidation.isString(k, v);
@@ -149,7 +155,11 @@ export const ContextValidation = {
 
   isEmail: (k: string, v: any) => {
     // TODO: Add validation
-    return ContextValidation.isString(k, v);
+    v = ContextValidation.isString(k, v);
+    if (!isEmailValid(v)) {
+      throw new ContextValidationError(k, v, 'Is not a valid email');
+    }
+    return v;
   },
 
   isGreaterThanZero: (k: string, v: any) => {

--- a/packages/fxa-settings/src/lib/metrics.test.ts
+++ b/packages/fxa-settings/src/lib/metrics.test.ts
@@ -16,6 +16,7 @@ import {
   useUserPreferences,
   useViewEvent,
   usePageViewEvent,
+  logErrorEvent,
 } from './metrics';
 
 import { window } from './window';
@@ -425,5 +426,38 @@ describe('setNewsletters', () => {
     expectPayloadProperties({
       newsletters,
     });
+  });
+});
+
+describe('logError', () => {
+  it('logs an fxa-ish error with view name and context', () => {
+    initFlow();
+
+    logErrorEvent({
+      viewName: 'foo',
+      context: 'bar',
+      namespace: 'baz',
+      errno: 77,
+    });
+
+    expectPayloadEvents(['error.bar.baz.77']);
+  });
+
+  it('logs an fxa-ish error with view name', () => {
+    initFlow();
+
+    logErrorEvent({
+      viewName: 'foo',
+      namespace: 'baz',
+      errno: 77,
+    });
+
+    expectPayloadEvents(['error.foo.baz.77']);
+  });
+
+  it('logs empty error', () => {
+    initFlow();
+    logErrorEvent({});
+    expectPayloadEvents(['error.unknown context.unknown namespace.-1']);
   });
 });

--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -314,6 +314,49 @@ export function logEvents(
 }
 
 /**
+ * Logs an error event
+ * @param error - An error object to log. Based loosely on AuthUiError state. This drives a unique the event identifier.
+ * @param eventProperties - Extra event properties.
+ */
+export function logErrorEvent(
+  error: {
+    viewName?: string;
+    errno?: number;
+    context?: string;
+    namespace?: string;
+  },
+  eventProperties: Hash<any> = {}
+) {
+  logEvents([errorToId()], eventProperties);
+
+  function errorToId() {
+    let context = error.context;
+    if (!context) {
+      if (error.viewName) {
+        context = addViewNamePrefix(error.viewName);
+      } else {
+        context = 'unknown context';
+      }
+    }
+
+    const id =
+      'error.' +
+      [context, error.namespace || 'unknown namespace', error.errno || -1].join(
+        '.'
+      );
+
+    return id;
+  }
+
+  function addViewNamePrefix(viewName: string) {
+    if (viewNamePrefix) {
+      return `${viewNamePrefix}.${viewName}`;
+    }
+    return viewName;
+  }
+}
+
+/**
  * Log an event with the view name as a prefix
  *
  * @param viewName

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -700,6 +700,10 @@ export class Account implements AccountData {
     firefox.profileChanged({ uid: this.uid });
   }
 
+  setLastLogin(date: number) {
+    // FOLLOW-UP: Not yet implemented.
+  }
+
   async deleteAvatar() {
     await this.withLoadingStatus(
       this.apolloClient.mutate({
@@ -1104,5 +1108,22 @@ export class Account implements AccountData {
     );
     firefox.accountDeleted(this.uid);
     Storage.factory('localStorage').clear();
+  }
+
+  async resetPasswordWithRecoveryKey(opts: {
+    accountResetToken: string;
+    emailToHashWith: string;
+    password: string;
+    recoveryKeyId: string;
+    kB: string;
+  }) {
+    const data = await this.authClient.resetPasswordWithRecoveryKey(
+      opts.accountResetToken,
+      opts.emailToHashWith,
+      opts.password,
+      opts.recoveryKeyId,
+      { kB: opts.kB }
+    );
+    currentAccount(data);
   }
 }

--- a/packages/fxa-settings/src/models/AppContext.ts
+++ b/packages/fxa-settings/src/models/AppContext.ts
@@ -6,14 +6,19 @@ import { ApolloClient, gql } from '@apollo/client';
 import AuthClient from 'fxa-auth-client/browser';
 import React from 'react';
 import config, { Config, readConfigMeta } from '../lib/config';
+import {
+  StorageContext,
+  UrlHashContext,
+  UrlSearchContext,
+} from '../lib/context';
 import firefox, { FirefoxCommand } from '../lib/firefox';
 import { createApolloClient } from '../lib/gql';
 import { OAuthClient } from '../lib/oauth/oauth-client';
-import { RelierFactory } from '../lib/reliers';
 import { Account, ACCOUNT_FIELDS, GET_PROFILE_INFO } from './Account';
 import { AlertBarInfo } from './AlertBarInfo';
 import { mockAppContext } from './mocks';
 import { Session } from './Session';
+import { RelierFactory } from '../lib/reliers';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -26,12 +31,16 @@ export const GET_INITIAL_STATE = gql`
 
 export interface AppContextValue {
   authClient?: AuthClient;
+  oauthClient?: OAuthClient;
   apolloClient?: ApolloClient<object>;
   config?: Config;
   account?: Account;
   alertBarInfo?: AlertBarInfo;
   session?: Session; // used exclusively for test mocking
   navigatorLanguages?: readonly string[];
+  urlSearchContext?: UrlSearchContext;
+  urlHashContext?: UrlHashContext;
+  storageContext?: StorageContext;
   relierFactory?: RelierFactory;
 }
 
@@ -45,6 +54,10 @@ export function initializeAppContext() {
   const apolloClient = createApolloClient(config.servers.gql.url);
   const account = new Account(authClient, apolloClient);
   const alertBarInfo = new AlertBarInfo();
+  const storageContext = new StorageContext(window);
+  const urlSearchContext = new UrlSearchContext(window);
+  const urlHashContext = new UrlHashContext(window);
+
   const relierFactory = new RelierFactory({
     delegates: {
       getClientInfo: (id: string) => oauthClient.getClientInfo(id),
@@ -104,15 +117,22 @@ export function initializeAppContext() {
   firefox.addEventListener(FirefoxCommand.Error, (event) => {
     console.error(event);
   });
-  return {
+
+  const context: AppContextValue = {
     authClient,
+    oauthClient,
     apolloClient,
     config,
     account,
     alertBarInfo,
-    navigatorLanguages: navigator.languages || ['en'],
+    urlSearchContext,
+    urlHashContext,
+    storageContext,
     relierFactory,
-  } as AppContextValue;
+    navigatorLanguages: navigator.languages || ['en'],
+  };
+
+  return context;
 }
 
 export const AppContext = React.createContext<AppContextValue>(

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -10,6 +10,8 @@ import { gql, useQuery } from '@apollo/client';
 import { useLocalization } from '@fluent/react';
 import { FtlMsgResolver } from 'fxa-react/lib/utils';
 import { getDefault } from '../lib/config';
+import { GenericContext } from '../lib/context';
+import { useLocation } from '@reach/router';
 
 export function useAccount() {
   const { account } = useContext(AppContext);
@@ -93,6 +95,39 @@ export function useRelier() {
     throw new Error('Relier factory never initialized!');
   }
   return relierFactory.getRelier();
+}
+
+export function useUrlSearchContext() {
+  let { urlSearchContext } = useContext(AppContext);
+  if (urlSearchContext == null) {
+    throw new Error('urlSearchContext never initialized!');
+  }
+  return urlSearchContext;
+}
+
+export function useLocationStateContext() {
+  const location = useLocation();
+  if (location == null) {
+    throw new Error('Location missing!');
+  }
+
+  return new GenericContext((location.state || {}) as Record<string, unknown>);
+}
+
+export function useNotifier() {
+  return {
+    onAccountSignIn(_account: unknown) {
+      // FOLLOW-UP: Not yet implemented.
+    },
+  };
+}
+
+export function useBroker() {
+  return {
+    async invokeBrokerMethod(_name: string, _account: unknown) {
+      // FOLLOW-UP: Not yet implemented.
+    },
+  };
 }
 
 /**

--- a/packages/fxa-settings/src/models/index.ts
+++ b/packages/fxa-settings/src/models/index.ts
@@ -3,3 +3,5 @@ export * from './AlertBarInfo';
 export * from './Account';
 export * from './Session';
 export * from './hooks';
+export * from './verification';
+export * from './reliers';

--- a/packages/fxa-settings/src/models/reliers/base-relier.ts
+++ b/packages/fxa-settings/src/models/reliers/base-relier.ts
@@ -92,7 +92,7 @@ export class BaseRelier implements ModelContextProvider, Relier {
   /** Lazy loaded subscription info. */
   subscriptionInfo: Promise<RelierSubscriptionInfo> | undefined;
 
-  @bind([V.isString, V.isRequired])
+  @bind([V.isString])
   context: string | undefined;
 
   @bind([V.isString])
@@ -107,7 +107,7 @@ export class BaseRelier implements ModelContextProvider, Relier {
   @bind([V.isString], T.snakeCase)
   entrypointVariation: string | undefined;
 
-  @bind([V.isString], T.snakeCase)
+  @bind([V.isBoolean], T.snakeCase)
   resetPasswordConfirm: boolean | undefined;
 
   @bind([V.isString])

--- a/packages/fxa-settings/src/models/verification/account-recovery-key-info.ts
+++ b/packages/fxa-settings/src/models/verification/account-recovery-key-info.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  bind,
+  ContextValidation,
+  ModelContextProvider,
+  ModelContext,
+  validateContext,
+  ContextValidationErrors,
+} from '../../lib/context';
+
+const { isNonEmptyString, isRequired } = ContextValidation;
+
+export class AccountRecoveryKeyInfo implements ModelContextProvider {
+  @bind([isNonEmptyString, isRequired])
+  accountResetToken: string = '';
+
+  @bind([isNonEmptyString, isRequired])
+  kB: string = '';
+
+  @bind([isNonEmptyString, isRequired])
+  recoveryKeyId: string = '';
+
+  constructor(public readonly context: ModelContext) {}
+
+  isValid() {
+    try {
+      this.validate();
+      return true;
+    } catch (err) {
+      if (err instanceof ContextValidationErrors) {
+        console.error(
+          err.errors.map((x) => `${x.key}-${x.value}-${x.message}`)
+        );
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  getModelContext() {
+    return this.context;
+  }
+
+  validate(): void {
+    validateContext(this);
+  }
+}

--- a/packages/fxa-settings/src/models/verification/index.ts
+++ b/packages/fxa-settings/src/models/verification/index.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './verification-info';
+export * from './account-recovery-key-info';

--- a/packages/fxa-settings/src/models/verification/verification-info.ts
+++ b/packages/fxa-settings/src/models/verification/verification-info.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  ContextKeyTransforms,
+  ContextValidation,
+  ContextValidationErrors,
+  ModelContext,
+  ModelContextProvider,
+  bind,
+  validateContext,
+} from '../../lib/context';
+
+export * from './verification-info';
+
+export type VerificationInfoLinkStatus = 'expired' | 'damaged' | 'valid';
+
+const { isEmail, isRequired, isVerificationCode, isHex, isString, isBoolean } =
+  ContextValidation;
+const { snakeCase } = ContextKeyTransforms;
+
+export class VerificationInfo implements ModelContextProvider {
+  @bind([isEmail, isRequired])
+  email: string = '';
+
+  @bind([isEmail, isRequired])
+  emailToHashWith: string = '';
+
+  @bind([isVerificationCode, isRequired])
+  code: string = '';
+
+  @bind([isHex, isRequired])
+  token: string = '';
+
+  @bind([isString, isRequired])
+  uid: string = '';
+
+  @bind([isBoolean], snakeCase)
+  forceAuth: boolean = false;
+
+  @bind([isBoolean])
+  lostRecoveryKey: boolean | undefined;
+
+  constructor(public readonly context: ModelContext) {}
+  [x: string]: any;
+  getModelContext(): ModelContext {
+    return this.context;
+  }
+
+  isValid() {
+    try {
+      this.validate();
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+    return true;
+  }
+
+  validate(): void {
+    validateContext(this);
+  }
+
+  tryValidate(): { isValid: boolean; error?: ContextValidationErrors } {
+    let error: ContextValidationErrors | undefined;
+    let isValid = true;
+    try {
+      this.validate();
+    } catch (err) {
+      console.error(err);
+      isValid = false;
+      if (err instanceof ContextValidationErrors) {
+        error = err;
+      } else {
+        throw err;
+      }
+    }
+
+    return {
+      isValid,
+      error,
+    };
+  }
+}

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../../lib/hooks/useLinkStatus';
 import AppLayout from '../../../components/AppLayout';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { randomBytes } from 'crypto';
 
 type FormData = {
   recoveryKey: string;
@@ -84,8 +85,19 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
         await account.getRecoveryKeyBundle(accountResetToken, recoveryKey, uid);
 
       logViewEvent('flow', `${viewName}.success`, REACT_ENTRYPOINT);
-      navigate('/account_recovery_reset_password', {
-        state: { accountResetToken, email, recoveryData, recoveryKeyId },
+
+      // FOLLOW-UP: Get values by decoding recovery data.
+      const decode = (_data: string) => ({
+        kB: randomBytes(64).toString('hex'),
+      });
+      const { kB } = decode(recoveryData);
+
+      navigate(`/account_recovery_reset_password${window.location.search}`, {
+        state: {
+          accountResetToken,
+          recoveryKeyId,
+          kB,
+        },
       });
     },
     [account]

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/en.ftl
@@ -5,3 +5,9 @@ create-new-password-header = Create new password
 account-restored-success-message = You have successfully restored your account using your account recovery key. Create a new password to secure your data, and store it in a safe location.
 # Feedback displayed in alert bar when password reset is successful
 account-recovery-reset-password-success-alert = Password set
+# An error case was hit that we cannot account for.
+account-recovery-reset-password-unexpected-error = Unexpected error encountered
+# $accountsEmail is the email address the resent password reset confirmation is sent from. (e.g. accounts@firefox.com)
+account-recovery-reset-password-email-resent = Email resent. Add { $accountsEmail } to your contacts to ensure a smooth delivery.
+account-recovery-reset-password-email-resend-error = Sorry, there was a problem resending a reset password link to your email.
+account-recovery-reset-password-redirecting = Redirecting

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
@@ -6,12 +6,20 @@ import React from 'react';
 import AccountRecoveryResetPassword, {
   AccountRecoveryResetPasswordProps,
 } from '.';
-import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { withLocalization } from '../../../../.storybook/decorators';
-import { LinkStatus } from '../../../lib/types';
+import { AppContext, AppContextValue } from '../../../models';
+import {
+  mockUrlSearchContext,
+  mockUrlHashContext,
+  mockStorageContext,
+  mockAccount,
+  mockRelierFactory,
+  mockLocationContext,
+} from './mocks';
+import { mockAppContext } from '../../../models/mocks';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 
 export default {
   title: 'Pages/ResetPassword/AccountRecoveryResetPassword',
@@ -19,26 +27,80 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = (props?: Partial<AccountRecoveryResetPasswordProps>) => {
-  const story = () => (
-    <LocationProvider>
-      <AppLayout>
-        <AccountRecoveryResetPassword
-          email={MOCK_ACCOUNT.primaryEmail.email}
-          linkStatus="valid"
-        />
-      </AppLayout>
-    </LocationProvider>
+const storyWithProps = (
+  ctx: AppContextValue,
+  props: AccountRecoveryResetPasswordProps
+) => {
+  return (
+    <AppContext.Provider value={ctx}>
+      <LocationProvider>
+        <AccountRecoveryResetPassword {...props} />
+      </LocationProvider>
+    </AppContext.Provider>
   );
-  return story;
 };
 
-export const WithValidLink = storyWithProps();
+function setup() {
+  const account = mockAccount();
+  const navigate = async (to: string | number, opts?: {}) => {
+    console.log('Would navigate to', to, opts);
+  };
+  const urlSearchContext = mockUrlSearchContext();
+  const urlHashContext = mockUrlHashContext();
+  const storageContext = mockStorageContext();
+  const locationContext = mockLocationContext();
+  const relierFactory = mockRelierFactory(
+    urlSearchContext,
+    urlHashContext,
+    storageContext
+  );
 
-export const WithBrokenLink = storyWithProps({
-  linkStatus: LinkStatus.damaged,
-});
+  const ctx = mockAppContext({
+    urlSearchContext,
+    urlHashContext,
+    storageContext,
+    account,
+    relierFactory,
+  });
 
-export const WithExpiredLink = storyWithProps({
-  linkStatus: LinkStatus.expired,
-});
+  return {
+    ctx,
+    props: {
+      overrides: {
+        navigate,
+        urlSearchContext,
+        locationContext,
+      },
+    },
+    account,
+    urlSearchContext,
+    locationContext,
+  };
+}
+
+export const WithValidLink = () => {
+  const { props, ctx } = setup();
+  return storyWithProps(ctx, props);
+};
+
+export const WithExpiredLink = () => {
+  const { props, ctx, account } = setup();
+  // Mock the response. An INVALID_TOKEN means the link expired.
+  account.resetPasswordWithRecoveryKey = async () => {
+    const err = AuthUiErrors['INVALID_TOKEN'];
+    throw err;
+  };
+  return storyWithProps(ctx, props);
+};
+
+export const WithBrokenLink = () => {
+  const { props, urlSearchContext, ctx } = setup();
+  urlSearchContext.set('email', 'foobar.com');
+  return storyWithProps(ctx, props);
+};
+
+export const WithBrokenRecoveryKeyState = () => {
+  const { props, locationContext, ctx } = setup();
+  locationContext.set('kB', '');
+  return storyWithProps(ctx, props);
+};

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -2,104 +2,313 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import { LocationProvider, NavigateFn } from '@reach/router';
 import '@testing-library/jest-dom/extend-expect';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
-// import { FluentBundle } from '@fluent/bundle';
-import { usePageViewEvent } from '../../../lib/metrics';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import AccountRecoveryResetPassword, { viewName } from '.';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { REACT_ENTRYPOINT, SHOW_BALLOON_TIMEOUT } from '../../../constants';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import {
+  GenericContext,
+  StorageContext,
+  UrlHashContext,
+  UrlSearchContext,
+} from '../../../lib/context';
+import {
+  logErrorEvent,
+  logViewEvent,
+  usePageViewEvent,
+} from '../../../lib/metrics';
+import { Account, AppContext, AppContextValue, Relier } from '../../../models';
+import {
+  mockAccount,
+  mockLocationContext,
+  mockRelierFactory,
+  mockStorageContext,
+  mockUrlHashContext,
+  mockUrlSearchContext,
+  resetContextMock,
+} from './mocks';
+import { RelierFactory } from '../../../lib/reliers';
+import { mockAppContext } from '../../../models/mocks';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
+  logErrorEvent: jest.fn(),
+  setUserPreference: jest.fn(),
 }));
 
-const mockNavigate = jest.fn();
-jest.mock('@reach/router', () => ({
-  ...jest.requireActual('@reach/router'),
-  useNavigate: () => mockNavigate,
+const mockOnAccountSignIn = jest.fn();
+const mockInvokeBrokerMethod = jest.fn();
+jest.mock('../../../models/hooks', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../models/hooks'),
+  useNotifier: () => ({
+    onAccountSignIn: mockOnAccountSignIn,
+  }),
+  useBroker: () => ({
+    invokeBrokerMethod: mockInvokeBrokerMethod,
+  }),
 }));
 
 describe('AccountRecoveryResetPassword page', () => {
-  // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
-  // TODO: in FXA-6461
-  // let bundle: FluentBundle;
-  // beforeAll(async () => {
-  //   bundle = await getFtlBundle('settings');
-  // });
+  let urlSearchContext: UrlSearchContext;
+  let urlHashContext: UrlHashContext;
+  let storageContext: StorageContext;
+  let account: Account;
+  let locationContext: GenericContext;
+  let navigate: NavigateFn;
+  let relierFactory: RelierFactory;
+  let relier: Relier;
+  let ctx: AppContextValue;
 
-  it('renders as expected with valid link', () => {
+  async function renderPage() {
+    const overrides = {
+      navigate,
+      locationContext,
+    };
     render(
-      <AccountRecoveryResetPassword
-        email={MOCK_ACCOUNT.primaryEmail.email}
-        linkStatus="valid"
-      />
+      <AppContext.Provider value={ctx}>
+        <LocationProvider>
+          <AccountRecoveryResetPassword {...{ overrides }} />
+        </LocationProvider>
+      </AppContext.Provider>
     );
-    // testAllL10n(screen, bundle);
+  }
 
-    screen.getByRole('heading', { name: 'Create new password' });
-    screen.getByLabelText('New password');
-    screen.getByLabelText('Re-enter password');
+  function clickResetPassword() {
+    screen.getByRole('button', { name: 'Reset password' }).click();
+  }
 
-    screen.getByRole('button', { name: 'Reset password' });
-    screen.getByRole('link', {
-      name: 'Remember your password? Sign in',
+  function clickReceiveNewLink() {
+    screen
+      .getByRole('button', {
+        name: 'Receive new link',
+      })
+      .click();
+  }
+
+  function enterPassword(password: string, password2?: string) {
+    const newPassword = screen.getByLabelText('New password');
+    const newPassword2 = screen.getByLabelText('Re-enter password');
+    fireEvent.change(newPassword, { target: { value: password } });
+    fireEvent.change(newPassword2, {
+      target: { value: password2 || password },
+    });
+  }
+
+  function resetContext() {
+    resetContextMock(mockUrlSearchContext(), urlSearchContext);
+    resetContextMock(mockUrlHashContext(), urlHashContext);
+    resetContextMock(mockStorageContext(), storageContext);
+    resetContextMock(mockLocationContext(), locationContext);
+  }
+
+  beforeAll(() => {
+    account = mockAccount();
+    navigate = jest.fn();
+    urlSearchContext = mockUrlSearchContext();
+    urlHashContext = mockUrlHashContext();
+    storageContext = mockStorageContext();
+    locationContext = mockLocationContext();
+    relierFactory = mockRelierFactory(
+      urlSearchContext,
+      urlHashContext,
+      storageContext
+    );
+    relier = relierFactory.getRelier();
+
+    ctx = mockAppContext({
+      urlSearchContext,
+      urlHashContext,
+      storageContext,
+      account,
+      relierFactory,
     });
   });
 
-  it('displays password requirements when the new password field is in focus', async () => {
-    render(
-      <AccountRecoveryResetPassword
-        email={MOCK_ACCOUNT.primaryEmail.email}
-        linkStatus="valid"
-      />
-    );
-
-    const newPasswordField = screen.getByTestId('new-password-input-field');
-    expect(screen.queryByText('Password requirements')).not.toBeInTheDocument();
-
-    fireEvent.focus(newPasswordField);
-    await waitFor(
-      () => {
-        expect(screen.getByText('Password requirements')).toBeVisible();
-      },
-      {
-        timeout: SHOW_BALLOON_TIMEOUT,
-      }
-    );
+  afterEach(() => {
+    resetContext();
+    jest.restoreAllMocks();
   });
 
-  it('shows a different message when given a damaged link', () => {
-    render(
-      <AccountRecoveryResetPassword
-        email={MOCK_ACCOUNT.primaryEmail.email}
-        linkStatus="damaged"
-      />
-    );
-    screen.getByRole('heading', { name: 'Reset password link damaged' });
+  describe('required recovery key info', () => {
+    async function setState(key: string) {
+      locationContext.set(key, '');
+      await renderPage();
+    }
+
+    it(`requires kB`, function () {
+      setState('kB');
+      expect(navigate).toBeCalledWith(
+        `/complete_reset_password?${urlSearchContext.toSearchQuery()}`
+      );
+    });
+
+    it(`requires recoveryKeyId`, function () {
+      setState('recoveryKeyId');
+      expect(navigate).toBeCalledWith(
+        `/complete_reset_password?${urlSearchContext.toSearchQuery()}`
+      );
+    });
+
+    it(`requires accountResetToken`, function () {
+      setState('accountResetToken');
+      expect(navigate).toBeCalledWith(
+        `/complete_reset_password?${urlSearchContext.toSearchQuery()}`
+      );
+    });
   });
 
-  it('shows a different message for an expired link, with a button for getting a new link', () => {
-    render(
-      <AccountRecoveryResetPassword
-        email={MOCK_ACCOUNT.primaryEmail.email}
-        linkStatus="expired"
-      />
-    );
-    screen.getByRole('heading', { name: 'Reset password link expired' });
-    screen.getByRole('button', { name: 'Receive new link' });
+  describe('damaged link', () => {
+    beforeEach(async () => {
+      // By setting an invalid email state, we trigger a damaged link state.
+      urlSearchContext.set('email', 'foo');
+      await renderPage();
+    });
+
+    it('shows damaged link message', () => {
+      screen.getByRole('heading', { name: 'Reset password link damaged' });
+    });
   });
 
-  it('emits a metrics event on render', () => {
-    render(
-      <AccountRecoveryResetPassword
-        email={MOCK_ACCOUNT.primaryEmail.email}
-        linkStatus="valid"
-      />
-    );
-    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  describe('valid link', () => {
+    beforeEach(async () => {
+      await renderPage();
+    });
+
+    it('has valid l10n', () => {
+      // TODO
+      // testAllL10n(screen, bundle);
+    });
+
+    it('renders with valid link', () => {
+      const heading = screen.getByRole('heading', {
+        name: 'Create new password',
+      });
+      screen.getByLabelText('New password');
+      screen.getByLabelText('Re-enter password');
+
+      screen.getByRole('button', { name: 'Reset password' });
+      screen.getByRole('link', {
+        name: 'Remember your password? Sign in',
+      });
+
+      expect(heading).toBeDefined();
+    });
+
+    it('emits event', () => {
+      expect(usePageViewEvent).toHaveBeenCalled();
+      expect(usePageViewEvent).toHaveBeenCalledWith(
+        'account-recovery-reset-password',
+        REACT_ENTRYPOINT
+      );
+    });
+
+    it('displays password requirements when the new password field is in focus', async () => {
+      const newPasswordField = screen.getByTestId('new-password-input-field');
+      expect(
+        screen.queryByText('Password requirements')
+      ).not.toBeInTheDocument();
+
+      fireEvent.focus(newPasswordField);
+      await waitFor(
+        () => {
+          expect(screen.getByText('Password requirements')).toBeVisible();
+        },
+        {
+          timeout: SHOW_BALLOON_TIMEOUT,
+        }
+      );
+    });
+
+    describe('successful reset', () => {
+      beforeAll(() => {
+        account.setLastLogin = jest.fn();
+        account.resetPasswordWithRecoveryKey = jest.fn();
+      });
+
+      beforeEach(async () => {
+        await act(async () => {
+          enterPassword('foo12356789!');
+          clickResetPassword();
+        });
+      });
+
+      it('emits a metric on successful reset', async () => {
+        expect(logViewEvent).toHaveBeenCalledWith(
+          viewName,
+          'verification.success'
+        );
+      });
+
+      it('calls resetPasswordWithRecoveryKey', () => {
+        expect(account.resetPasswordWithRecoveryKey).toHaveBeenCalled();
+      });
+
+      it('sets relier state', () => {
+        expect(logViewEvent).toHaveBeenCalledWith(
+          viewName,
+          'verification.success'
+        );
+      });
+
+      it('invokes broker', () => {
+        expect(mockInvokeBrokerMethod).toHaveBeenCalled();
+      });
+
+      it('invokes webchannel', () => {
+        expect(mockOnAccountSignIn).toHaveBeenCalled();
+      });
+
+      it('sets last login data', () => {
+        expect(account.setLastLogin).toHaveBeenCalled();
+      });
+
+      it('sets relier resetPasswordConfirm state', () => {
+        expect(relier.resetPasswordConfirm).toBeTruthy();
+      });
+    });
+  });
+
+  describe('expired link', () => {
+    beforeAll(() => {
+      // A link is deemed expired if the server returns an invalid token error.
+      account.resetPasswordWithRecoveryKey = jest
+        .fn()
+        .mockRejectedValue(AuthUiErrors['INVALID_TOKEN']);
+      account.resetPassword = jest.fn();
+    });
+
+    beforeEach(async () => {
+      await renderPage();
+      await act(async () => {
+        enterPassword('foo12356789!');
+        clickResetPassword();
+      });
+    });
+
+    it('logs error event', async () => {
+      expect(logErrorEvent).toBeCalled();
+    });
+
+    it('triggers resend', async () => {
+      await act(async () => {
+        clickReceiveNewLink();
+      });
+
+      expect(logViewEvent).toHaveBeenCalledWith(
+        viewName,
+        'account-recovery-reset-password.resend'
+      );
+      expect(account.resetPassword).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -2,21 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps } from '@reach/router';
-import React, { useCallback, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useNavigate } from '@reach/router';
-import { usePageViewEvent } from '../../../lib/metrics';
-import { useAlertBar } from '../../../models';
+import React, { useEffect, useState } from 'react';
+import { NavigateFn, RouteComponentProps, useNavigate } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver } from '../../../models/hooks';
-
-import LinkRememberPassword from '../../../components/LinkRememberPassword';
-import LinkExpired from '../../../components/LinkExpired';
-import LinkDamaged from '../../../components/LinkDamaged';
-import FormPasswordWithBalloons from '../../../components/FormPasswordWithBalloons';
-import { REACT_ENTRYPOINT } from '../../../constants';
+import { useForm } from 'react-hook-form';
+import AppLayout from '../../../components/AppLayout';
 import CardHeader from '../../../components/CardHeader';
+import FormPasswordWithBalloons from '../../../components/FormPasswordWithBalloons';
+import LinkDamaged from '../../../components/LinkDamaged';
+import LinkExpired from '../../../components/LinkExpired';
+import LinkRememberPassword from '../../../components/LinkRememberPassword';
+import { REACT_ENTRYPOINT } from '../../../constants';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import {
+  ContextValidationErrors,
+  GenericContext,
+  UrlSearchContext,
+} from '../../../lib/context';
+import {
+  logErrorEvent,
+  logViewEvent,
+  setUserPreference,
+  usePageViewEvent,
+} from '../../../lib/metrics';
+import {
+  useNotifier,
+  useBroker,
+  useAccount,
+  useRelier,
+  useUrlSearchContext,
+} from '../../../models/hooks';
+import { LinkStatus } from '../../../lib/types';
+import {
+  AccountRecoveryKeyInfo,
+  VerificationInfo,
+  useLocationStateContext as useLocationContext,
+} from '../../../models';
+import Banner, { BannerType } from '../../../components/Banner';
 
 // This page is based on complete_reset_password but has been separated to align with the routes.
 
@@ -28,32 +50,58 @@ import CardHeader from '../../../components/CardHeader';
 
 export const viewName = 'account-recovery-reset-password';
 
+const accountsEmail = 'accounts@firefox.com';
+
 export type AccountRecoveryResetPasswordProps = {
-  email: string;
-  linkStatus: LinkStatus;
-  forceAuth?: boolean;
-};
+  overrides?: {
+    navigate?: NavigateFn;
+    locationContext?: GenericContext;
+    urlSearchContext?: UrlSearchContext;
+  };
+} & RouteComponentProps;
 
 type FormData = {
   newPassword: string;
   confirmPassword: string;
 };
 
-type LinkStatus = 'expired' | 'damaged' | 'valid';
+enum BannerState {
+  None,
+  UnexpectedError,
+  PasswordResendSuccess,
+  PasswordResetSuccess,
+  Redirecting,
+  PasswordResendError,
+  InvalidContext,
+}
 
 const AccountRecoveryResetPassword = ({
-  email,
-  linkStatus,
-  forceAuth = false,
-}: AccountRecoveryResetPasswordProps & RouteComponentProps) => {
+  overrides,
+}: AccountRecoveryResetPasswordProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
+  const notifier = useNotifier();
+  const broker = useBroker();
+  const account = useAccount();
+  const relier = useRelier();
+
+  let navigate = useNavigate();
+  navigate = overrides?.navigate || navigate;
+
+  let urlSearchContext = useUrlSearchContext();
+  urlSearchContext = overrides?.urlSearchContext || urlSearchContext;
+
+  let locationContext = useLocationContext();
+  locationContext = overrides?.locationContext || locationContext;
+
+  const verificationInfo = new VerificationInfo(urlSearchContext);
+  const accountRecoveryKeyInfo = new AccountRecoveryKeyInfo(locationContext);
+  const state = getInitialState();
+
+  const [bannerState, setBannerState] = useState<BannerState>(BannerState.None);
+  const [linkStatus, setLinkStatus] = useState<LinkStatus>(state.linkStatus);
   const [passwordMatchErrorText, setPasswordMatchErrorText] =
     useState<string>('');
-  const alertBar = useAlertBar();
-  const navigate = useNavigate();
-  const ftlMsgResolver = useFtlMsgResolver();
-
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<FormData>({
       mode: 'onTouched',
@@ -64,82 +112,231 @@ const AccountRecoveryResetPassword = ({
       },
     });
 
-  const alertSuccessAndNavigate = useCallback(() => {
-    const successCompletePwdReset = ftlMsgResolver.getMsg(
-      `${viewName}-success-alert`,
-      'Password set'
-    );
-    alertBar.success(successCompletePwdReset);
-    navigate('/reset_password_with_recovery_key_verified', { replace: true });
-  }, [alertBar, ftlMsgResolver, navigate]);
-
-  const sendNewLinkEmail = () => {
-    // TODO: Hook up functionality to send a new verification link
-  };
-
-  const onSubmit = () => {
-    try {
-      // TODO: - completeAccountPasswordResetWithRecoveryKey
-      //       - logViewEvent('verification.success');
-      //       - metrics.logUserPreferences('account-recovery', false)
-      //       - logFlowEventOnce('recovery-key-consume.success', viewName);
-      alertSuccessAndNavigate();
-    } catch (e) {
-      // TODO: - if token expired, re-render and show LinkExpired
-      //       - metrics event for error
-      //       - error feedback in alertBar
+  useEffect(() => {
+    if (state.contextError) {
+      alertInvalidContext(state.contextError);
+    } else if (!state.supportsRecovery) {
+      setBannerState(BannerState.Redirecting);
+      navigate(`/complete_reset_password?${urlSearchContext.toSearchQuery()}`);
     }
-  };
+  }, [state, navigate, urlSearchContext]);
+
+  if (linkStatus === 'damaged') {
+    return <LinkDamaged {...{ linkType: 'reset-password' }} />;
+  }
+
+  if (linkStatus === 'expired') {
+    return (
+      <LinkExpired {...{ linkType: 'reset-password', resendLinkHandler }} />
+    );
+  }
 
   return (
-    <>
-      {linkStatus === 'valid' && (
-        <>
-          <CardHeader
-            headingText="Create new password"
-            headingTextFtlId="create-new-password-header"
-          />
-          <FtlMsg id="account-restored-success-message">
-            <p className="text-sm mb-4">
-              You have successfully restored your account using your account
-              recovery key. Create a new password to secure your data, and store
-              it in a safe location.
+    <AppLayout>
+      <CardHeader
+        headingText="Create new password"
+        headingTextFtlId="create-new-password-header"
+      />
+
+      {BannerState.Redirecting === bannerState && (
+        <Banner type={BannerType.info}>
+          <FtlMsg id="account-recovery-reset-password-redirecting">
+            <p>Redirecting</p>
+          </FtlMsg>
+        </Banner>
+      )}
+      {BannerState.UnexpectedError === bannerState && (
+        <Banner type={BannerType.error}>
+          <FtlMsg id="account-recovery-reset-password-unexpected-error">
+            <p>Unexpected error encountered</p>
+          </FtlMsg>
+        </Banner>
+      )}
+      {BannerState.PasswordResendSuccess === bannerState && (
+        <Banner type={BannerType.success}>
+          <FtlMsg
+            id="account-recovery-reset-password-email-resent"
+            vars={{ accountsEmail }}
+          >
+            <p>
+              Email resent. Add {accountsEmail} to your contacts to ensure a
+              smooth delivery.
             </p>
           </FtlMsg>
-
-          {/* Hidden email field is to allow Fx password manager
-           to correctly save the updated password. Without it,
-           the password manager tries to save the old password
-           as the username. */}
-          <input type="email" value={email} className="hidden" readOnly />
-          <section className="text-start mt-4">
-            <FormPasswordWithBalloons
-              {...{
-                formState,
-                errors,
-                trigger,
-                register,
-                getValues,
-                passwordMatchErrorText,
-                setPasswordMatchErrorText,
-              }}
-              passwordFormType="reset"
-              onSubmit={handleSubmit(onSubmit)}
-              email={email}
-              loading={false}
-              onFocusMetricsEvent={`${viewName}.engage`}
-            />
-          </section>
-
-          {/* TODO: Verify if the "Remember password?" should always direct to /signin (current state) */}
-          <LinkRememberPassword {...{ email, forceAuth }} />
-        </>
+        </Banner>
       )}
-      {linkStatus === 'damaged' && <LinkDamaged linkType="reset-password" />}
-      {/* TODO update ResetPasswordLinkExpired to receive sendNewLinkEmail() */}
-      {linkStatus === 'expired' && <LinkExpired linkType="reset-password" />}
-    </>
+      {BannerState.PasswordResendError === bannerState && (
+        <Banner type={BannerType.error}>
+          <FtlMsg id="account-recovery-reset-password-email-resend-error">
+            <p>
+              Sorry, there was a problem resending a reset password link to your
+              email.
+            </p>
+          </FtlMsg>
+        </Banner>
+      )}
+      {BannerState.PasswordResetSuccess === bannerState && (
+        <Banner type={BannerType.success}>
+          <FtlMsg id="account-recovery-reset-password-success-alert">
+            <p>Password set</p>
+          </FtlMsg>
+        </Banner>
+      )}
+
+      <FtlMsg id="account-restored-success-message">
+        <p className="text-sm mb-4">
+          You have successfully restored your account using your account
+          recovery key. Create a new password to secure your data, and store it
+          in a safe location.
+        </p>
+      </FtlMsg>
+
+      {/* Hidden email field is to allow Fx password manager
+        to correctly save the updated password. Without it,
+        the password manager tries to save the old password
+        as the username. */}
+      <input type="email" value={state.email} className="hidden" readOnly />
+      <section className="text-start mt-4">
+        <FormPasswordWithBalloons
+          {...{
+            formState,
+            errors,
+            trigger,
+            register,
+            getValues,
+            passwordMatchErrorText,
+            setPasswordMatchErrorText,
+          }}
+          passwordFormType="reset"
+          onSubmit={handleSubmit(
+            (data: FormData) => {
+              onSubmit(data);
+            },
+            (err) => {
+              console.error(err);
+            }
+          )}
+          email={state.email}
+          loading={false}
+          onFocusMetricsEvent={`${viewName}.engage`}
+        />
+      </section>
+
+      <LinkRememberPassword {...state} />
+    </AppLayout>
   );
+
+  /**
+   * Determines starting state for component
+   */
+  function getInitialState() {
+    let email = '';
+    let linkStatus: LinkStatus = LinkStatus.valid;
+    let forceAuth = false;
+    let supportsRecovery = true;
+    let contextError: ContextValidationErrors | null = null;
+
+    try {
+      email = verificationInfo.email || '';
+
+      forceAuth = !!verificationInfo.forceAuth;
+
+      if (!verificationInfo.isValid()) {
+        supportsRecovery = false;
+        linkStatus = LinkStatus.damaged;
+      } else if (!accountRecoveryKeyInfo.isValid()) {
+        supportsRecovery = false;
+      } else if (verificationInfo.lostRecoveryKey === true) {
+        supportsRecovery = false;
+      }
+    } catch (err) {
+      if (err instanceof ContextValidationErrors) {
+        contextError = err;
+        linkStatus = LinkStatus.damaged;
+      }
+    }
+
+    return {
+      email,
+      linkStatus,
+      forceAuth,
+      supportsRecovery,
+      contextError,
+    };
+  }
+
+  async function onSubmit(data: FormData) {
+    const password = data.newPassword;
+
+    try {
+      await account.resetPasswordWithRecoveryKey({
+        password,
+        ...verificationInfo,
+        ...accountRecoveryKeyInfo,
+      });
+
+      // FOLLOW-UP: Functionality not yet available.
+      await account.setLastLogin(Date.now());
+
+      // FOLLOW-UP: Functionality not yet available.
+      notifier.onAccountSignIn(account);
+
+      relier.resetPasswordConfirm = true;
+      logViewEvent(viewName, 'verification.success');
+
+      // FOLLOW-UP: Functionality not yet available.
+      await broker.invokeBrokerMethod('afterCompleteResetPassword', account);
+
+      alertSuccess();
+      navigateAway();
+    } catch (err) {
+      if (AuthUiErrors['INVALID_TOKEN'].errno === err.errno) {
+        logErrorEvent({ viewName, ...err });
+        setLinkStatus(LinkStatus.expired);
+      } else {
+        // Context validation errors indicate a bad state in either the url query or
+        // maybe storage. In these cases show an alert bar and let the error keep bubbling
+        // up.
+        if (err instanceof ContextValidationErrors) {
+          alertInvalidContext(err);
+        } else {
+          logErrorEvent(err);
+          setBannerState(BannerState.UnexpectedError);
+        }
+        throw err;
+      }
+    }
+  }
+
+  async function resendLinkHandler() {
+    logViewEvent(viewName, 'account-recovery-reset-password.resend');
+
+    try {
+      await account.resetPassword(state.email);
+      setBannerState(BannerState.PasswordResendSuccess);
+    } catch (err) {
+      setBannerState(BannerState.PasswordResendError);
+    }
+  }
+
+  function alertSuccess() {
+    setBannerState(BannerState.PasswordResetSuccess);
+  }
+
+  function navigateAway() {
+    setUserPreference('account-recovery', account.recoveryKey);
+    logViewEvent(viewName, 'recovery-key-consume.success');
+    navigate(
+      `/reset_password_with_recovery_key_verified?${urlSearchContext.toSearchQuery()}`
+    );
+  }
+
+  function alertInvalidContext(err: ContextValidationErrors) {
+    setBannerState(BannerState.UnexpectedError);
+    console.error(
+      `Invalid keys detected: ${err.errors.map((x) => x.key).join(',')}`
+    );
+  }
 };
 
 export default AccountRecoveryResetPassword;

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { NavigateFn, NavigateOptions } from '@reach/router';
+import {
+  ModelContext,
+  StorageContext,
+  UrlHashContext,
+  UrlSearchContext,
+  GenericContext,
+} from '../../../lib/context';
+import { MozServices } from '../../../lib/types';
+import { Account } from '../../../models';
+import { mockAppContext, MOCK_ACCOUNT } from '../../../models/mocks';
+import { UrlContextWindow } from '../../../lib/context/implementations/url-context';
+import { DefaultRelierFlags, RelierFactory } from '../../../lib/reliers';
+
+export class UrlSearchContextMock extends UrlSearchContext {
+  // Holds an internal search state that is different than window.location.search
+  // this works around the fact that the defacto implementations essentially act
+  // as a singleton since they write and read from window.location.search
+  private searchState: string;
+
+  public debug() {
+    return this.searchState;
+  }
+
+  protected override getParams(): URLSearchParams {
+    return new URLSearchParams(this.searchState);
+  }
+
+  protected override setParams(params: URLSearchParams): void {
+    this.searchState = params.toString();
+  }
+
+  constructor(window: UrlContextWindow) {
+    super(window);
+    this.searchState = window.location.search.toString();
+  }
+}
+
+export class UrlHashContextMock extends UrlHashContext {
+  // Holds an internal search state that is different than window.location.search
+  // this works around the fact that the defacto implementations essentially act
+  // as a singleton since they write and read from window.location.search
+  private state: string;
+
+  public debug() {
+    return this.state;
+  }
+
+  protected override getParams(): URLSearchParams {
+    return new URLSearchParams(this.state);
+  }
+
+  protected override setParams(params: URLSearchParams): void {
+    this.state = params.toString();
+  }
+
+  constructor(window: UrlContextWindow) {
+    super(window);
+    this.state = window.location.hash.replace(/^#/, '');
+  }
+}
+
+export class StorageContextMock extends StorageContext {
+  public override persist(): void {
+    // no op
+  }
+  public override load(): void {
+    // no op
+  }
+}
+
+export class RelierFactoryMock extends RelierFactory {}
+
+export function mockUrlSearchContext() {
+  const ctx = new UrlSearchContextMock(window);
+  const params: Record<string, string> = {
+    uid: MOCK_ACCOUNT.uid,
+    email: MOCK_ACCOUNT.primaryEmail.email,
+    emailToHashWith: MOCK_ACCOUNT.primaryEmail.email,
+    token: '1111111111111111111111111111111111111111111111111111111111111111',
+    code: '11111111111111111111111111111111',
+    subscriptionProductName: '',
+    subscriptionProductId: '',
+    context: 'fx_desktop_v3',
+  };
+
+  for (const p of Object.keys(params)) {
+    ctx.set(p, params[p]);
+  }
+
+  return ctx;
+}
+
+export function mockLocationContext() {
+  return new GenericContext({
+    kB: '123',
+    accountResetToken: '123',
+    recoveryKeyId: '123',
+  });
+}
+
+export function mockUrlHashContext() {
+  const ctx = new UrlHashContextMock(window);
+  const params: Record<string, string> = {};
+  for (const p of Object.keys(params)) {
+    ctx.set(p, params[p]);
+  }
+  return ctx;
+}
+
+export function mockStorageContext() {
+  return new StorageContextMock(window);
+}
+
+export function mockRelier(
+  urlSearchContext: UrlSearchContext,
+  urlHashContext: UrlHashContext,
+  storageContext: StorageContext
+) {
+  const factory = mockRelierFactory(
+    urlSearchContext,
+    urlHashContext,
+    storageContext
+  );
+  return factory.getRelier();
+}
+
+export function mockRelierFactory(
+  urlSearchContext: UrlSearchContext,
+  urlHashContext: UrlHashContext,
+  storageContext: StorageContext
+) {
+  const factory = new RelierFactoryMock({
+    delegates: {
+      async getClientInfo(clientId: any) {
+        return {};
+      },
+      async getProductInfo(subscriptionId: string) {
+        return { productName: 'foo' };
+      },
+      getProductIdFromRoute() {
+        return 'bar';
+      },
+    },
+    context: urlSearchContext,
+    channelContext: urlHashContext,
+    flags: new DefaultRelierFlags(urlSearchContext, storageContext),
+  });
+  return factory;
+}
+
+export function mockAccount() {
+  return {
+    ...MOCK_ACCOUNT,
+    setLastLogin: () => {},
+    resetPasswordWithRecoveryKey: () => {},
+    resetPassword: () => {},
+  } as unknown as Account;
+}
+
+export type NavOpts = {};
+export const mockNavigate: NavigateFn = async (
+  to: string | number,
+  options?: NavigateOptions<NavOpts>
+) => {
+  console.log('Would have called navigate with', { to, options });
+};
+
+export function resetContextMock(source: ModelContext, target: ModelContext) {
+  for (const k of source.getKeys()) {
+    const val = source.get(k);
+    target.set(k, val);
+  }
+}
+
+export function mockContext() {
+  return mockAppContext({});
+}
+
+export const MOCK_SERVICE_NAME = MozServices.FirefoxSync;


### PR DESCRIPTION
## Because

- We are migrating content server to react

## This pull request

- Supports account_recovery_reset_password route in settings.
- Ports logic from complete_password_reset for account recovery key in AccountRecoveryResetPassword
- Adds more test coverage
- Gets storybooks working with new logic
- Adds missing metrics function logErrorEvent
- Adds verification-info model
- Adds account-recovery-key-info-model
- Uses AppContext.Provider in storybook so that hooks function properly.
- Fixes warning in CompleteResetPassword about act
- Extracts AccountRecoveryResetPassword mocks into a separate mocks.ts file
- Provides a UrlContextWindow for UrlContext classes in order to narrow access to the window object
- Hooks up the the resend link action.
- Provides empty dummy methods for Notifier.onAccountSignIn
- Provides empty dummy method for Broker.invokeBrokerMethod

## Issue that this pull request solves

Closes: FXA-6127

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

It was sort of tricky to test this flow manually. The test offer decent assurance, but the `AccountRecoveryConfirmKey` really needs to be hooked up to fully test in a flow. Depending on how data is passed between components, it may or may not work in the wild.

