### PR TITLE
task(subscriptions): add invoice to billing subs api

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -77,3 +77,15 @@ export function stripeInvoicesToSubsequentInvoicePreviewsDTO(
     return invoicePreview;
   });
 }
+
+/**
+ * Formats an array of Stripe Invoice to the stripeInvoiceToLatestInvoiceItemsDTO DTO format.
+ *
+ * Currently this is the same as stripeInvoiceToFirstInvoicePreviewDTO, however could change
+ * in future.
+ */
+export function stripeInvoiceToLatestInvoiceItemsDTO(
+  invoice: Stripe.Invoice
+): invoiceDTO.LatestInvoiceItems {
+  return stripeInvoiceToFirstInvoicePreviewDTO(invoice);
+}

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -23,6 +23,9 @@ const {
   playStoreSubscriptionSchema,
 } = require('fxa-shared/dto/auth/payments/iap-subscription');
 const {
+  latestInvoiceItemsSchema,
+} = require('fxa-shared/dto/auth/payments/invoice');
+const {
   default: DESCRIPTIONS,
 } = require('../../docs/swagger/shared/descriptions');
 
@@ -406,6 +409,7 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
     .string()
     .required()
     .description(DESCRIPTIONS.latestInvoice),
+  latest_invoice_items: latestInvoiceItemsSchema.required(),
   plan_id: module.exports.subscriptionsPlanId
     .required()
     .description(DESCRIPTIONS.planId),

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_open.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_open.json
@@ -73,6 +73,35 @@
           "trial_period_days": null,
           "usage_type": "licensed"
         },
+        "price": {
+          "id": "plan_FxFGE9jvhYvCMe",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1570549157,
+          "currency": "usd",
+          "custom_unit_amount": null,
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {
+            "upgrades": "plan_FiII5wajzrxfrl"
+          },
+          "nickname": null,
+          "product": "prod_GvH2k78kKusAlV",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "exclusive",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 499,
+          "unit_amount_decimal": "499"
+        },
         "proration": false,
         "quantity": 1,
         "subscription": "sub_GY2uVWIDdywa3l",

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid.json
@@ -73,6 +73,35 @@
           "trial_period_days": null,
           "usage_type": "licensed"
         },
+        "price": {
+          "id": "plan_FxFGE9jvhYvCMe",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1570549157,
+          "currency": "usd",
+          "custom_unit_amount": null,
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {
+            "upgrades": "plan_FiII5wajzrxfrl"
+          },
+          "nickname": null,
+          "product": "prod_GvH2k78kKusAlV",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "exclusive",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 499,
+          "unit_amount_decimal": "499"
+        },
         "proration": false,
         "quantity": 1,
         "subscription": "sub_GY2uVWIDdywa3l",

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid_subscription_create.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid_subscription_create.json
@@ -72,6 +72,33 @@
           "trial_period_days": null,
           "usage_type": "licensed"
         },
+        "price": {
+          "id": "plan_GqM9N6qyhvxaVk",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1583259953,
+          "currency": "usd",
+          "custom_unit_amount": null,
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {},
+          "nickname": "123Done Pro Monthly",
+          "product": "prod_GqM9ToKK62qjkK",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "exclusive",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 500,
+          "unit_amount_decimal": "500"
+        },
         "proration": false,
         "quantity": 1,
         "subscription": "sub_GyHjvuW3xOeaZS",

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid_subscription_create_tax.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_paid_subscription_create_tax.json
@@ -90,6 +90,33 @@
           "trial_period_days": null,
           "usage_type": "licensed"
         },
+        "price": {
+          "id": "plan_GqM9N6qyhvxaVk",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1583259953,
+          "currency": "usd",
+          "custom_unit_amount": null,
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {},
+          "nickname": "123Done Pro Monthly",
+          "product": "prod_GqM9ToKK62qjkK",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "exclusive",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 500,
+          "unit_amount_decimal": "500"
+        },
         "proration": false,
         "quantity": 1,
         "subscription": "sub_GyHjvuW3xOeaZS",

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -9,6 +9,7 @@ const { assert } = require('chai');
 const {
   stripeInvoiceToFirstInvoicePreviewDTO,
   stripeInvoicesToSubsequentInvoicePreviewsDTO,
+  stripeInvoiceToLatestInvoiceItemsDTO,
 } = require('../../../lib/payments/stripe-formatter');
 const previewInvoiceWithTax = require('./fixtures/stripe/invoice_preview_tax.json');
 const previewInvoiceWithDiscountAndTax = require('./fixtures/stripe/invoice_preview_tax_discount.json');
@@ -88,5 +89,55 @@ describe('stripeInvoicesToSubsequentInvoicePreviewsDTO', () => {
       previewInvoiceWithDiscountAndTax.period_end
     );
     assert.equal(invoice[1].total, previewInvoiceWithDiscountAndTax.total);
+  });
+});
+
+describe('stripeInvoiceToLatestInvoiceItemsDTO', () => {
+  it('formats an invoice with tax', () => {
+    const invoice = stripeInvoiceToLatestInvoiceItemsDTO(
+      deepCopy(previewInvoiceWithTax)
+    );
+    assert.equal(invoice.total, previewInvoiceWithTax.total);
+    assert.equal(invoice.subtotal, previewInvoiceWithTax.subtotal);
+    assert.equal(
+      invoice.tax[0].amount,
+      previewInvoiceWithTax.total_tax_amounts[0].amount
+    );
+    assert.equal(
+      invoice.tax[0].display_name,
+      previewInvoiceWithTax.total_tax_amounts[0].tax_rate.display_name
+    );
+    assert.equal(invoice.tax[0].inclusive, true);
+    assert.isUndefined(invoice.discount);
+  });
+
+  it('formats an invoice with tax and discount', () => {
+    const invoice = stripeInvoiceToLatestInvoiceItemsDTO(
+      deepCopy(previewInvoiceWithDiscountAndTax)
+    );
+    assert.equal(invoice.total, previewInvoiceWithDiscountAndTax.total);
+    assert.equal(invoice.subtotal, previewInvoiceWithDiscountAndTax.subtotal);
+    assert.equal(
+      invoice.tax[0].amount,
+      previewInvoiceWithDiscountAndTax.total_tax_amounts[0].amount
+    );
+    assert.equal(
+      invoice.tax[0].display_name,
+      previewInvoiceWithDiscountAndTax.total_tax_amounts[0].tax_rate
+        .display_name
+    );
+    assert.equal(invoice.tax[0].inclusive, true);
+    assert.equal(
+      invoice.discount.amount,
+      previewInvoiceWithDiscountAndTax.total_discount_amounts[0].amount
+    );
+    assert.equal(
+      invoice.discount.amount_off,
+      previewInvoiceWithDiscountAndTax.discount.coupon.amount_off
+    );
+    assert.equal(
+      invoice.discount.percent_off,
+      previewInvoiceWithDiscountAndTax.discount.coupon.percent_off
+    );
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -791,6 +791,20 @@ describe('lib/routes/validators:', () => {
       current_period_start: 1573695337,
       end_at: null,
       latest_invoice: 'in_1FeXFGJNcmPzuWtR3EUd2zw7',
+      latest_invoice_items: {
+        line_items: [
+          {
+            amount: 599,
+            currency: 'usd',
+            id: 'plan_G93lTs8hfK7NNG',
+            name: 'testo',
+          },
+        ],
+        subtotal: 599,
+        subtotal_excluding_tax: null,
+        total: 599,
+        total_excluding_tax: null,
+      },
       plan_id: 'plan_G93lTs8hfK7NNG',
       product_id: 'prod_G93l8Yn7XJHYUs',
       product_name: 'testo',

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -257,6 +257,20 @@ describe('#integration - remote subscriptions:', function () {
             cancel_at_period_end: false,
             end_at: null,
             latest_invoice: '628031D-0002',
+            latest_invoice_items: {
+              line_items: [
+                {
+                  amount: 599,
+                  currency: 'usd',
+                  id: 'plan_G93lTs8hfK7NNG',
+                  name: 'testo',
+                },
+              ],
+              subtotal: 599,
+              subtotal_excluding_tax: null,
+              total: 599,
+              total_excluding_tax: null,
+            },
             status: 'active',
             failure_code: undefined,
             failure_message: undefined,

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -8,9 +8,8 @@ import { PaymentConfirmation, PaymentConfirmationProps } from './index';
 import { Customer, Profile, Plan } from '../../store/types';
 import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
-import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { Meta } from '@storybook/react';
-import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import { LatestInvoiceItems } from 'fxa-shared/dto/auth/payments/invoice';
 
 export default {
   title: 'components/PaymentConfirmation',
@@ -50,6 +49,14 @@ const selectedPlanWithMetadata: Plan = {
   },
 };
 
+const invoice: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
+
 const customer: Customer = {
   billing_name: 'Jane Doe',
   payment_provider: 'stripe',
@@ -62,6 +69,7 @@ const customer: Customer = {
     {
       _subscription_type: MozillaSubscriptionTypes.WEB,
       latest_invoice: '628031D-0002',
+      latest_invoice_items: invoice,
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
       product_id: 'prod_123',
@@ -79,14 +87,6 @@ const customer: Customer = {
 };
 
 const productUrl = 'https://mozilla.org';
-
-const invoice: FirstInvoicePreview = {
-  line_items: [],
-  subtotal: 735,
-  subtotal_excluding_tax: null,
-  total: 735,
-  total_excluding_tax: null,
-};
 
 const storyWithProps = (
   props: PaymentConfirmationProps,

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -12,7 +12,10 @@ import { FluentBundle } from '@fluent/bundle';
 import AppContext, { defaultAppContext } from '../../lib/AppContext';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import { updateConfig } from '../../lib/config';
-import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import {
+  FirstInvoicePreview,
+  LatestInvoiceItems,
+} from 'fxa-shared/dto/auth/payments/invoice';
 
 const userProfile = {
   avatar: './avatar.svg',
@@ -76,6 +79,14 @@ const selectedPlanWithConfiguration = {
   },
 };
 
+const latestInvoiceItems: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
+
 const customer: Customer = {
   billing_name: 'Jane Doe',
   payment_provider: 'stripe',
@@ -88,6 +99,7 @@ const customer: Customer = {
     {
       _subscription_type: MozillaSubscriptionTypes.WEB,
       latest_invoice: '628031D-0002',
+      latest_invoice_items: latestInvoiceItems,
       subscription_id: 'sub0.28964929339372136',
       plan_id: 'plan_123',
       product_id: 'prod_123',
@@ -116,6 +128,7 @@ const paypalCustomer: Customer = {
     {
       _subscription_type: MozillaSubscriptionTypes.WEB,
       latest_invoice: '628031D-0002',
+      latest_invoice_items: latestInvoiceItems,
       subscription_id: 'sub0.28964929339372136',
       plan_id: 'plan_123',
       product_id: 'prod_123',

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -8,6 +8,7 @@ import { Customer } from '../../store/types';
 import { useNonce } from '../../lib/hooks';
 import { SignInLayout } from '../AppLayout';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+import { LatestInvoiceItems } from 'fxa-shared/dto/auth/payments/invoice';
 
 export default {
   title: 'components/PaymentFormV2',
@@ -37,6 +38,15 @@ const PLAN = {
       'https://www.mozilla.org/fr/privacy/websites/',
   },
 };
+
+const invoice: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
+
 const CUSTOMER: Customer = {
   billing_name: 'Foo Barson',
   payment_provider: 'stripe',
@@ -53,6 +63,7 @@ const CUSTOMER: Customer = {
       product_id: 'prod_123',
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: invoice,
       status: 'active',
       cancel_at_period_end: false,
       created: Date.now(),

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,11 +1,22 @@
 import { PaymentIntent, PaymentMethod } from '@stripe/stripe-js';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { AppStoreSubscription } from 'fxa-shared/dto/auth/payments/iap-subscription';
-import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import {
+  FirstInvoicePreview,
+  LatestInvoiceItems,
+} from 'fxa-shared/dto/auth/payments/invoice';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 import { FilteredSetupIntent } from '../lib/apiClient';
 import { Customer, Plan, Profile } from '../store/types';
+
+const invoice: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -41,6 +52,7 @@ export const CUSTOMER: Customer = {
       product_id: 'prod_123',
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: invoice,
       status: 'active',
       created: Date.now(),
       cancel_at_period_end: false,
@@ -134,6 +146,7 @@ export const PAYPAL_CUSTOMER: Customer = {
       product_id: 'prod_123',
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: invoice,
       status: 'active',
       cancel_at_period_end: false,
       created: Date.now(),

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -22,6 +22,7 @@ import {
 import { MemoryRouter } from 'react-router-dom';
 import {
   FirstInvoicePreview,
+  LatestInvoiceItems,
   SubsequentInvoicePreview,
 } from 'fxa-shared/dto/auth/payments/invoice';
 
@@ -717,6 +718,14 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
   },
 ];
 
+export const MOCK_LATEST_INVOICE_ITEMS: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
+
 export const MOCK_CUSTOMER: Customer = {
   customerId: 'cus_123xyz',
   billing_name: 'Jane Doe',
@@ -734,6 +743,7 @@ export const MOCK_CUSTOMER: Customer = {
       product_id: 'prod_123',
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: MOCK_LATEST_INVOICE_ITEMS,
       status: 'active',
       cancel_at_period_end: false,
       created: 1565815388.815,

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -11,6 +11,15 @@ import { Product, ProductProps } from './index';
 import { Customer, Plan, Profile } from '../../store/types';
 import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+import { LatestInvoiceItems } from 'fxa-shared/dto/auth/payments/invoice';
+
+const invoice: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
 
 function init() {
   storiesOf('routes/Product', module)
@@ -59,6 +68,7 @@ function init() {
               product_name: 'Example Product',
               product_id: 'prod_123',
               latest_invoice: '628031D-0002',
+              latest_invoice_items: invoice,
               plan_id: 'plan_123',
               status: 'active',
               subscription_id: 'sk_78987',
@@ -246,6 +256,7 @@ const CUSTOMER: Customer = {
       product_id: 'prod_123',
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: invoice,
       status: 'active',
       cancel_at_period_end: false,
       current_period_end: Date.now() / 1000 + 86400 * 31,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -22,7 +22,10 @@ import {
   WebSubscription,
 } from 'fxa-shared/subscriptions/types';
 import withMock from 'storybook-addon-mock';
-import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import {
+  FirstInvoicePreview,
+  LatestInvoiceItems,
+} from 'fxa-shared/dto/auth/payments/invoice';
 
 function init() {
   setupVariantStories('routes/Subscriptions', {
@@ -445,6 +448,14 @@ const baseProps: SubscriptionsProps = {
   },
 };
 
+const invoice: LatestInvoiceItems = {
+  line_items: [],
+  subtotal: 735,
+  subtotal_excluding_tax: null,
+  total: 735,
+  total_excluding_tax: null,
+};
+
 const customerSubscriptions = [
   {
     _subscription_type: MozillaSubscriptionTypes.WEB,
@@ -454,6 +465,7 @@ const customerSubscriptions = [
     cancel_at_period_end: false,
     end_at: null,
     latest_invoice: '628031D-0002',
+    latest_invoice_items: invoice,
     plan_id: PLAN_ID,
     product_id: PRODUCT_ID,
     product_name: 'Example Product',

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -136,3 +136,9 @@ export type subsequentInvoicePreview = {
 };
 
 export type subsequentInvoicePreviewsSchema = Array<subsequentInvoicePreview>;
+
+export interface LatestInvoiceItems extends FirstInvoicePreview {}
+
+export const latestInvoiceItemsSchema = firstInvoicePreviewSchema;
+
+export type latestInvoiceItemsSchema = firstInvoicePreviewSchema;

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -4,6 +4,7 @@ import {
   AppStoreSubscription,
   PlayStoreSubscription,
 } from '../dto/auth/payments/iap-subscription';
+import { LatestInvoiceItems } from '../dto/auth/payments/invoice';
 import { PlanConfigurationDtoT } from '../dto/auth/payments/plan-configuration';
 
 export type PlanInterval = Stripe.Plan['interval'];
@@ -125,6 +126,7 @@ export type WebSubscription = Pick<
     _subscription_type: SubscriptionTypes[0];
     end_at: Stripe.Subscription['ended_at'];
     latest_invoice: string;
+    latest_invoice_items: LatestInvoiceItems;
     plan_id: Stripe.Plan['id'];
     product_name: Stripe.Product['name'];
     product_id: Stripe.Product['id'];

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -14,6 +14,7 @@ import {
   getProductSupportApps,
 } from '../../subscriptions/metadata';
 import { PlanConfigurationDtoT } from '../../dto/auth/payments/plan-configuration';
+import { LatestInvoiceItems } from '../../dto/auth/payments/invoice';
 
 const NULL_METADATA = {
   productSet: [],
@@ -40,6 +41,21 @@ const PLAN: Plan = {
   active: true,
   plan_metadata: null,
   product_metadata: null,
+};
+
+const LATEST_INVOICE_ITEMS: LatestInvoiceItems = {
+  line_items: [
+    {
+      amount: 599,
+      currency: 'usd',
+      id: 'plan_8675309',
+      name: 'Example product',
+    },
+  ],
+  subtotal: 599,
+  subtotal_excluding_tax: null,
+  total: 599,
+  total_excluding_tax: null,
 };
 
 const requiredProductMetadata = {
@@ -241,6 +257,7 @@ describe('#unit - subscriptions/metadata', () => {
         cancel_at_period_end: false,
         end_at: null,
         latest_invoice: 'DDCB9132-0002',
+        latest_invoice_items: LATEST_INVOICE_ITEMS,
         plan_id: 'price_1HJnNbBVqmGyQTMaoduxgunR',
         product_name: 'Cooking with Foxkeh',
         product_id: 'prod_GvH2k78kKusAlV',
@@ -257,6 +274,7 @@ describe('#unit - subscriptions/metadata', () => {
         cancel_at_period_end: false,
         end_at: null,
         latest_invoice: 'DDCB9132-0001',
+        latest_invoice_items: LATEST_INVOICE_ITEMS,
         plan_id: 'plan_GjeF1VyTFSnOkD',
         product_name: 'Firefox Guardian',
         product_id: 'prod_GjeBkx6iQFoVgg',


### PR DESCRIPTION
## Because

- Need to return certain fields from the latest invoice associated with the customers subscriptions.

## This pull request

- Adds latest_invoice_items which returns the same values as the invoice preview api.
- Does not change latest_invoice, which remains the latest_invoice.number

## Issue that this pull request solves

Closes: #FXA-6831

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
