### PR TITLE
feat(fxa-settings): Functional ConfirmSignupCode in React

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -160,7 +160,12 @@ Router = Router.extend({
     'confirm_signin(/)': createViewHandler(ConfirmView, {
       type: VerificationReasons.SIGN_IN,
     }),
-    'confirm_signup_code(/)': createViewHandler(ConfirmSignupCodeView),
+    'confirm_signup_code(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'confirm_signup_code',
+        ConfirmSignupCodeView
+      );
+    },
     'connect_another_device(/)': createViewHandler(ConnectAnotherDeviceView),
     'cookies_disabled(/)': function () {
       this.createReactOrBackboneViewHandler(

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -56,6 +56,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
     signUpRoutes: {
       featureFlagOn: showReactApp.signUpRoutes,
       routes: reactRoute.getRoutes([
+        'confirm_signup_code',
         'primary_email_verified',
         'signup_confirmed',
         'signup_verified',

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -25,6 +25,7 @@ import CompleteResetPassword from '../../pages/ResetPassword/CompleteResetPasswo
 import ResetPasswordConfirmed from '../../pages/ResetPassword/ResetPasswordConfirmed';
 import AccountRecoveryConfirmKey from '../../pages/ResetPassword/AccountRecoveryConfirmKey';
 import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
+import ConfirmSignupCode from '../../pages/Signup/ConfirmSignupCode';
 
 export const App = ({
   flowQueryParams,
@@ -78,6 +79,8 @@ export const App = ({
                 Page={SignupConfirmed}
                 path="/signup_confirmed/*"
               />
+
+              <ConfirmSignupCode path="/confirm_signup_code/*" />
             </>
           )}
           <Settings path="/settings/*" {...{ flowQueryParams }} />

--- a/packages/fxa-settings/src/components/FormVerifyCode/en.ftl
+++ b/packages/fxa-settings/src/components/FormVerifyCode/en.ftl
@@ -1,0 +1,4 @@
+## FormVerifyCode
+
+# Fallback default localized error message for empty input field
+form-verify-code-default-error = This field is required

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.stories.tsx
@@ -20,3 +20,9 @@ export const Default = () => (
     <Subject />
   </AppLayout>
 );
+
+export const WithCustomErrorMessage = () => (
+  <AppLayout>
+    <Subject localizedCustomCodeRequiredMessage="This is a spoofed custom error" />
+  </AppLayout>
+);

--- a/packages/fxa-settings/src/components/FormVerifyCode/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/mocks.tsx
@@ -3,19 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import FormVerifyCode, { FormAttributes } from '.';
-import { useFtlMsgResolver } from '../../models';
-import { MOCK_ACCOUNT } from '../../models/mocks';
+import FormVerifyCode, { FormAttributes, FormVerifyCodeProps } from '.';
 
-export const Subject = () => {
-  type FormData = {
-    code?: string;
-  };
-
-  const [code, setCode] = useState<string>('');
+export const Subject = ({
+  localizedCustomCodeRequiredMessage = '',
+}: Partial<FormVerifyCodeProps>) => {
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
-  const ftlMsgResolver = useFtlMsgResolver();
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'demo-input-label-id',
@@ -27,32 +20,16 @@ export const Subject = () => {
   };
 
   const onFormSubmit = () => {
-    if (!code) {
-      const codeRequiredError = ftlMsgResolver.getMsg(
-        'confirm-signup-code-required-error',
-        'Confirmation code required'
-      );
-      setCodeErrorMessage(codeRequiredError);
-    }
+    alert('Trying to submit');
   };
-
-  const { handleSubmit } = useForm<FormData>({
-    mode: 'onBlur',
-    criteriaMode: 'all',
-    defaultValues: {
-      code: '',
-    },
-  });
 
   return (
     <FormVerifyCode
-      email={MOCK_ACCOUNT.primaryEmail.email}
-      onSubmit={handleSubmit(onFormSubmit)}
+      verifyCode={onFormSubmit}
       viewName="default-view"
       {...{
         formAttributes,
-        code,
-        setCode,
+        localizedCustomCodeRequiredMessage,
         codeErrorMessage,
         setCodeErrorMessage,
       }}

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/en.ftl
@@ -31,9 +31,9 @@ tfa-button-cant-scan-qr = Can’t scan code?
 # When the user cannot use a QR code.
 tfa-enter-secret-key = Enter this secret key into your authenticator app:
 
-tfa-enter-totp = Now enter the security code from the authentication app.
-tfa-input-enter-totp =
- .label = Enter security code
+tfa-enter-totp-v2 = Now enter the authentication code from the authentication app.
+tfa-input-enter-totp-v2 =
+ .label = Enter authentication code
 tfa-save-these-codes-1 = Save these one-time use backup authentication codes in a safe place for when
   you don’t have your mobile device.
 

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -257,15 +257,15 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               </p>
             </div>
           )}
-          <Localized id="tfa-enter-totp">
-            <p>Now enter the security code from the authentication app.</p>
+          <Localized id="tfa-enter-totp-v2">
+            <p>Now enter the authentication code from the authentication app.</p>
           </Localized>
 
           <div className="mt-4 mb-6" data-testid="recovery-key-input">
-            <Localized id="tfa-input-enter-totp" attrs={{ label: true }}>
+            <Localized id="tfa-input-enter-totp-v2" attrs={{ label: true }}>
               <InputText
                 name="totp"
-                label="Enter security code"
+                label="Enter authentication code"
                 prefixDataTestId="totp"
                 maxLength={6}
                 autoFocus

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -14,6 +14,8 @@ export const MDNLink = 'https://developer.mozilla.org/';
 export const HubsLink = 'https://hubs.mozilla.com/';
 export const SHOW_BALLOON_TIMEOUT = 500;
 export const HIDE_BALLOON_TIMEOUT = 400;
+export const CLEAR_MESSAGES_TIMEOUT = 750;
+export const RESEND_CODE_TIMEOUT = 5000;
 export const REACT_ENTRYPOINT = { entrypoint_variation: 'react' };
 
 export enum ENTRYPOINTS {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
 import classNames from 'classnames';
 import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
@@ -45,34 +44,23 @@ export const InlineTotpSetup = ({
     `Use the code ${code} to set up two-step authentication in supported applications.`,
     { code }
   );
+  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
+    'inline-totp-setup-code-required-error',
+    'Authentication code required'
+  );
   const [secret, setSecret] = useState<string>();
   const [qrCodeSrc, setQRCodeSrc] = useState<string>();
   const [showIntro, setShowIntro] = useState(true);
-  const [totpCodeValue, setTotpCodeValue] = useState('');
   const [showQR, setShowQR] = useState(true);
   const [totpErrorMessage, setTotpErrorMessage] = useState('');
 
-  type FormData = {
-    confirmationCode: string;
-  };
-
-  const { handleSubmit } = useForm<FormData>({
-    mode: 'onBlur',
-    criteriaMode: 'all',
-    defaultValues: {
-      confirmationCode: '',
-    },
-  });
-
   const onSubmit = () => {
-    if (!totpCodeValue) {
-      // TODO: Add l10n for this string
-      // Holding on l10n pending product decision
-      // See FXA-6422, and discussion on PR-14744
-      setTotpErrorMessage('Backup authentication code required');
-    }
+    // TODO: Error message for empty field here or in FormVerifyCode?
+    // Holding on l10n pending product decision
+    // See FXA-6422, and discussion on PR-14744
+    // setTotpErrorMessage('Backup authentication code required');
     try {
-      // Check security code
+      // Check authentication code
       // logViewEvent('flow', `${viewName}.submit`, REACT_ENTRYPOINT);
     } catch (e) {
       // TODO: error handling, error message confirmation
@@ -176,7 +164,7 @@ export const InlineTotpSetup = ({
                       ),
                     }}
                   >
-                    <p className="text-sm mb-4">
+                    <p className="text-sm my-4">
                       Scan the QR code in your authentication app and then enter
                       the authentication code it provides.{' '}
                       <button
@@ -248,8 +236,7 @@ export const InlineTotpSetup = ({
               )}
               <FormVerifyCode
                 viewName="inline_totp_setup"
-                email={email}
-                onSubmit={handleSubmit(onSubmit)}
+                verifyCode={onSubmit}
                 formAttributes={{
                   inputLabelText: 'Authentication code',
                   inputFtlId: 'inline-totp-setup-security-code-placeholder',
@@ -258,10 +245,9 @@ export const InlineTotpSetup = ({
                   submitButtonText: 'Ready',
                   submitButtonFtlId: 'inline-totp-setup-ready-button',
                 }}
-                code={totpCodeValue}
-                setCode={setTotpCodeValue}
                 codeErrorMessage={totpErrorMessage}
                 setCodeErrorMessage={setTotpErrorMessage}
+                {...{ localizedCustomCodeRequiredMessage }}
               />
               <button className="link-blue text-sm mt-4">
                 <FtlMsg id="inline-totp-setup-cancel-setup-button">

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/en.ftl
@@ -1,19 +1,17 @@
-## SigninTOTPCode page
+## AuthTotp page
 ## TOTP (time-based one-time password) is a form of two-factor authentication (2FA).
-## Users that have set up two-factor authentication land on this page during sign-in.
+## Users that have set up two-factor authentication land on this page during device pairing.
 
 # String within the <span> element appears on a separate line
 # If more appropriate in a locale, the string within the <span>, "to continue to account settings" can stand alone as "Continue to account settings"
-signin-totp-code-heading-w-default-service-v2 = Enter authentication code <span>to continue to account settings</span>
+auth-totp-heading-w-default-service = Enter authentication code <span>to continue to account settings</span>
 # String within the <span> element appears on a separate line
 # If more appropriate in a locale, the string within the <span>, "to continue to { $serviceName }" can stand alone as "Continue to { $serviceName }"
 # { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable
-signin-totp-code-heading-w-custom-service-v2 = Enter authentication code <span>to continue to { $serviceName }</span>
-signin-totp-code-instruction-v2 = Open your authentication app and enter the authentication code it provides.
-signin-totp-code-input-label-v2 = Enter 6-digit code
+auth-totp-heading-w-custom-service = Enter authentication code <span>to continue to { $serviceName }</span>
+auth-totp-instruction = Open your authentication app and enter the authentication code it provides.
+auth-totp-input-label = Enter 6-digit code
 # Form button to confirm if the authentication code entered by the user is valid
-signin-totp-code-confirm-button = Confirm
-signin-totp-code-other-account-link = Use a different account
-signin-totp-code-recovery-code-link = Trouble entering code?
+auth-totp-confirm-button = Confirm
 # Error displayed in a tooltip when the form is submitted without a code
-signin-totp-code-required-error = Authentication code required
+auth-totp-code-required-error = Authentication code required

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.test.tsx
@@ -32,7 +32,7 @@ describe('Sign in with TOTP code page', () => {
 
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      'Enter security code to continue to account settings'
+      'Enter authentication code to continue to account settings'
     );
     screen.getByLabelText('Enter 6-digit code');
 
@@ -55,7 +55,7 @@ describe('Sign in with TOTP code page', () => {
     );
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      'Enter security code to continue to Mozilla VPN'
+      'Enter authentication code to continue to Mozilla VPN'
     );
   });
 

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-// import { useFtlMsgResolver } from '../../../models/hooks';
+import { useFtlMsgResolver } from '../../../models';
 import { usePageViewEvent } from '../../../lib/metrics';
 // import { useAlertBar } from '../../models';
 import { TwoFactorAuthImage } from '../../../components/images';
@@ -31,51 +31,43 @@ const AuthTotp = ({
 }: AuthTotpProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
   // const ftlMsgResolver = useFtlMsgResolver();
 
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
+    'auth-totp-code-required-error',
+    'Authentication code required'
+  );
+
   // These ftlids match those in `SigninTotpCode`
   const formAttributes: FormAttributes = {
-    inputFtlId: 'signin-totp-code-input-label-v2',
+    inputFtlId: 'auth-totp-input-label',
     inputLabelText: 'Enter 6-digit code',
     pattern: '[0-9]{6}',
     maxLength: 6,
-    submitButtonFtlId: 'signin-totp-code-confirm-button',
+    submitButtonFtlId: 'auth-totp-confirm-button',
     submitButtonText: 'Confirm',
   };
 
   const onSubmit = () => {
-    if (!code) {
-      // TODO: Add l10n for this string
-      // Holding on l10n pending product decision
-      // Current string vs "Security code required" vs other
-      // See FXA-6422, and discussion on PR-14744
-      setCodeErrorMessage('Two-step authentication code required');
-    }
     try {
-      // Check security code
+      // Check authentication code
       // logViewEvent('flow', `${viewName}.submit`, ENTRYPOINT_REACT);
       // redirect to /pair/auth/allow
     } catch (e) {
       // TODO: error handling, error message confirmation
-      //
-      // const errorAuthTotp = ftlMsgResolver.getMsg(
-      //   'signin-totp-code-error-general',
-      //   'Invalid confirmation code'
-      // );
-      // put the error into a <Banner /> element
+      // this should use auth-errors and place the errors in a tooltip or banner
     }
   };
 
   return (
     // TODO: redirect to force_auth or signin if user has not initiated sign in
     <>
-      {/* Ftl ids match those in signin-totp-code because it uses those strings. */}
       <CardHeader
-        headingWithDefaultServiceFtlId="signin-totp-code-heading-w-default-service"
-        headingWithCustomServiceFtlId="signin-totp-code-heading-w-custom-service"
-        headingText="Enter security code"
+        headingWithDefaultServiceFtlId="auth-totp-heading-w-default-service"
+        headingWithCustomServiceFtlId="auth-totp-heading-w-custom-service"
+        headingText="Enter authentication code"
         {...{ serviceName }}
       />
 
@@ -84,9 +76,9 @@ const AuthTotp = ({
           <TwoFactorAuthImage className="w-3/5" />
         </div>
 
-        <FtlMsg id="signin-totp-code-instruction">
+        <FtlMsg id="auth-totp-instruction">
           <p id="totp-code-instruction" className="my-5 text-sm">
-            Open your authentication app and enter the security code it
+            Open your authentication app and enter the authentication code it
             provides.
           </p>
         </FtlMsg>
@@ -95,10 +87,8 @@ const AuthTotp = ({
           {...{
             formAttributes,
             viewName,
-            email,
-            onSubmit,
-            code,
-            setCode,
+            verifyCode: onSubmit,
+            localizedCustomCodeRequiredMessage,
             codeErrorMessage,
             setCodeErrorMessage,
           }}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/en.ftl
@@ -14,8 +14,10 @@ signin-recovery-code-instruction = Please enter a backup authentication code tha
 signin-recovery-code-input-label = Enter 10-digit backup authentication code
 # Form button to confirm if the backup authentication code entered by the user is valid
 signin-recovery-code-confirm-button = Confirm
-# Link to return to signin with two-step authentication code (security code)
+# Link to return to signin with two-step authentication code
 signin-recovery-code-back-link = Back
 # External link for support if the user can't use two-step autentication or a backup authentication code
 # https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication
 signin-recovery-code-support-link = Are you locked out?
+# Error displayed in a tooltip when form is submitted witout a code
+signin-recovery-code-required-error = Backup authentication code required

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver } from '../../../models/hooks';
+import { useFtlMsgResolver } from '../../../models';
 import { usePageViewEvent } from '../../../lib/metrics';
 // import { useAlertBar } from '../../models';
 import { RecoveryCodesImage } from '../../../components/images';
@@ -30,10 +30,12 @@ const SigninRecoveryCode = ({
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
-  // const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
+  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
+    'signin-recovery-code-required-error',
+    'Backup authentication code required'
+  );
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-recovery-code-input-label',
@@ -45,24 +47,13 @@ const SigninRecoveryCode = ({
   };
 
   const onSubmit = () => {
-    if (!code) {
-      const codeRequiredError = ftlMsgResolver.getMsg(
-        'signin-recovery-code-required-error',
-        'Backup authentication code required'
-      );
-      setCodeErrorMessage(codeRequiredError);
-    }
     try {
       // Check recovery code
       // Log success event
       // Check if isForcePasswordChange
     } catch (e) {
       // TODO: error handling, error message confirmation
-      // const errorSigninRecoveryCode = ftlMsgResolver.getMsg(
-      //   'signin-recovery-code-error-general',
-      //   'Incorrect backup authentication code'
-      // );
-      // alertBar.error(errorSigninRecoveryCode);
+      // This will likely use auth-errors, and errors should be displayed in a tooltip or banner
     }
   };
 
@@ -93,10 +84,8 @@ const SigninRecoveryCode = ({
           {...{
             formAttributes,
             viewName,
-            email,
-            onSubmit,
-            code,
-            setCode,
+            verifyCode: onSubmit,
+            localizedCustomCodeRequiredMessage,
             codeErrorMessage,
             setCodeErrorMessage,
           }}

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
@@ -14,4 +14,5 @@ signin-token-code-confirm-button = Confirm
 signin-token-code-code-expired = Code expired?
 # Link to resend a new code to the user's email.
 signin-token-code-resend-code-link = Email new code.
+# Error displayed in a tooltip when the form is submitted without a code
 signin-token-code-required-error = Confirmation code required

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver } from '../../../models/hooks';
+import { useFtlMsgResolver } from '../../../models';
 import { usePageViewEvent } from '../../../lib/metrics';
 // import { useAlertBar } from '../../models';
 import { MailImage } from '../../../components/images';
@@ -25,11 +25,13 @@ const SigninTokenCode = ({
 }: SigninTokenCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
 
-  // const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
+  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
+    'signin-token-code-required-error',
+    'Confirmation code required'
+  );
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-token-code-input-label-v2',
@@ -43,29 +45,18 @@ const SigninTokenCode = ({
   const handleResendCode = () => {
     // TODO: add resend code action
     // account.verifySessionResendCode()
-    // if success, display alert bar message
+    // if success, display message in banner
     // 'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
   };
 
   const onSubmit = () => {
-    if (!code) {
-      const codeRequiredError = ftlMsgResolver.getMsg(
-        'signin-token-code-required-error',
-        'Confirmation code required'
-      );
-      setCodeErrorMessage(codeRequiredError);
-    }
     try {
       // Check confirmation code
       // Log success event
       // Check if isForcePasswordChange
     } catch (e) {
       // TODO: error handling, error message confirmation
-      // const errorSigninTokenCode = ftlMsgResolver.getMsg(
-      //   'signin-token-code-error',
-      //   'Incorrect confirmation code'
-      // );
-      // alertBar.error(errorSigninTokenCode);
+      // this should likely use auth-errors and display in a tooltip or banner
     }
   };
 
@@ -86,7 +77,7 @@ const SigninTokenCode = ({
         <MailImage className="w-3/5" />
       </div>
 
-      <FtlMsg id="signin-token-code-instruction" vars={{email}}>
+      <FtlMsg id="signin-token-code-instruction" vars={{ email }}>
         <p id="verification-email-message" className="m-5 text-sm">
           Enter the code that was sent to {email} within 5 minutes.
         </p>
@@ -96,10 +87,8 @@ const SigninTokenCode = ({
         {...{
           formAttributes,
           viewName,
-          email,
-          onSubmit,
-          code,
-          setCode,
+          verifyCode: onSubmit,
+          localizedCustomCodeRequiredMessage,
           codeErrorMessage,
           setCodeErrorMessage,
         }}

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -32,7 +32,7 @@ describe('Sign in with TOTP code page', () => {
 
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      'Enter security code to continue to account settings'
+      'Enter authentication code to continue to account settings'
     );
     screen.getByLabelText('Enter 6-digit code');
 
@@ -50,7 +50,7 @@ describe('Sign in with TOTP code page', () => {
     );
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      'Enter security code to continue to Mozilla VPN'
+      'Enter authentication code to continue to Mozilla VPN'
     );
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -5,9 +5,8 @@
 import React, { useState } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-// import { useFtlMsgResolver } from '../../../models/hooks';
+import { useFtlMsgResolver } from '../../../models';
 import { usePageViewEvent } from '../../../lib/metrics';
-// import { useAlertBar } from '../../models';
 import { TwoFactorAuthImage } from '../../../components/images';
 import CardHeader from '../../../components/CardHeader';
 import FormVerifyCode, {
@@ -31,12 +30,14 @@ const SigninTotpCode = ({
 }: SigninTotpCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const [code, setCode] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
-  // const alertBar = useAlertBar();
-  // const ftlMsgResolver = useFtlMsgResolver();
+  const ftlMsgResolver = useFtlMsgResolver();
 
-  // FTL strings in this view are reused in `Pair/AuthTotp` -- if we change them here but not there, we need to split those strings out.
+  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
+    'signin-totp-code-required-error',
+    'Authentication code required'
+  );
+
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-totp-code-input-label-v2',
     inputLabelText: 'Enter 6-digit code',
@@ -47,25 +48,13 @@ const SigninTotpCode = ({
   };
 
   const onSubmit = () => {
-    if (!code) {
-      // TODO: Add l10n for this string
-      // Holding on l10n pending product decision
-      // Current string vs "Security code required" vs other
-      // See FXA-6422, and discussion on PR-14744
-      setCodeErrorMessage('Two-step authentication code required');
-    }
     try {
-      // Check security code
+      // Check authentication code
       // logViewEvent('flow', `${viewName}.submit`, ENTRYPOINT_REACT);
       // Check if isForcePasswordChange
     } catch (e) {
       // TODO: error handling, error message confirmation
-      //       - decide if alertBar or error div
-      // const errorSigninTotpCode = ftlMsgResolver.getMsg(
-      //   'signin-totp-code-error-general',
-      //   'Invalid confirmation code'
-      // );
-      // alertBar.error(errorSigninTotpCode);
+      // this should probably use auth-errors and message should be displayed in tooltip or banner
     }
   };
 
@@ -73,9 +62,9 @@ const SigninTotpCode = ({
     // TODO: redirect to force_auth or signin if user has not initiated sign in
     <>
       <CardHeader
-        headingWithDefaultServiceFtlId="signin-totp-code-heading-w-default-service"
-        headingWithCustomServiceFtlId="signin-totp-code-heading-w-custom-service"
-        headingText="Enter security code"
+        headingWithDefaultServiceFtlId="signin-totp-code-heading-w-default-service-v2"
+        headingWithCustomServiceFtlId="signin-totp-code-heading-w-custom-service-v2"
+        headingText="Enter authentication code"
         {...{ serviceName }}
       />
 
@@ -84,9 +73,9 @@ const SigninTotpCode = ({
           <TwoFactorAuthImage className="w-3/5" />
         </div>
 
-        <FtlMsg id="signin-totp-code-instruction">
+        <FtlMsg id="signin-totp-code-instruction-v2">
           <p id="totp-code-instruction" className="my-5 text-sm">
-            Open your authentication app and enter the security code it
+            Open your authentication app and enter the authentication code it
             provides.
           </p>
         </FtlMsg>
@@ -95,10 +84,8 @@ const SigninTotpCode = ({
           {...{
             formAttributes,
             viewName,
-            email,
-            onSubmit,
-            code,
-            setCode,
+            verifyCode: onSubmit,
+            localizedCustomCodeRequiredMessage,
             codeErrorMessage,
             setCodeErrorMessage,
           }}

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
@@ -2,6 +2,9 @@
 ## Users see this page after they have initiated account sign up,
 # and a confirmation code has been sent to their email address.
 
+# Page title show in browser title bar or page tab
+confirm-signup-code-page-title = Enter confirmation code
+
 # String within the <span> element appears on a separate line
 # If more appropriate in a locale, the string within the <span>, "for your { -product-firefox-account }"
 # can stand alone as "{ -product-firefox-account }"
@@ -14,4 +17,11 @@ confirm-signup-code-confirm-button = Confirm
 confirm-signup-code-code-expired = Code expired?
 # Link to resend a new code to the user's email.
 confirm-signup-code-resend-code-link = Email new code.
-confirm-signup-code-required-error = Please enter confirmation code
+confirm-signup-code-success-alert = Account confirmed successfully
+# Message displayed in a banner after the user requested to receive a new confirmation code.
+# Variable $accountsEmail is the email addressed used to send accounts related emails to users.
+confirm-signup-code-resend-code-success-message = Email resent. Add { $accountsEmail } to your contacts to ensure a smooth delivery.
+# Error message displayed in an error banner. This is a general message when the cause of the error is unclear.
+confirm-signup-code-error-message = Something went wrong. A new code could not be sent.
+# Error displayed in tooltip.
+confirm-signup-code-is-required-error = Confirmation code is required

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
@@ -4,10 +4,9 @@
 
 import React from 'react';
 import ConfirmSignupCode from '.';
-import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { withLocalization } from '../../../../.storybook/decorators';
+import { LocationProvider } from '@reach/router';
 
 export default {
   title: 'Pages/Signup/ConfirmSignupCode',
@@ -16,7 +15,7 @@ export default {
 } as Meta;
 
 export const Default = () => (
-  <AppLayout>
-    <ConfirmSignupCode email={MOCK_ACCOUNT.primaryEmail.email} />
-  </AppLayout>
+  <LocationProvider>
+    <ConfirmSignupCode />
+  </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -136,7 +136,7 @@ const Signup = ({
   const onSubmit = useCallback(async ({ newPassword, userAge }: FormData) => {
     try {
       // await something
-      // go somwehere
+      // go somwehere, pass email as location state
     } catch (e) {
       // do something with the error
     }


### PR DESCRIPTION
## Because

* We want to make the page created in Storybook fully functional to match parity with the content-server page.

## This pull request

* Activate React route for ConfirmSignupCode.
* Add functionality to verify confirmation code
* Add functionality to resend a new code
* Clean up FormVerifyCode to remove unnecessary props
* Update FormVerifyCode and pages that use it to display an error tooltip when the form is submitted without a code
* Replaces instances of 'security code' with 'authentication code'

## Issue that this pull request solves

Closes #FXA-6493, FXA-6799

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/22231637/221296068-3ff82f59-bb45-44ed-9c24-01803d036344.png)

![image](https://user-images.githubusercontent.com/22231637/221296112-cac32a4e-af65-4b38-ac17-2c45c994bfc0.png)

## Other information (Optional)

### How to test locally

1. Modify `fxa-content-server/server/config/local.json` to enable the showReactApp feature flag for the signUpRoutes (see this doc: https://docs.google.com/document/d/1VZLh7vnUfKsAHNoZla-p7SfYwmwPdmjPUjAeiYe0qfw/edit?usp=sharing).
2. Create a new account on `localhost:3030`
3. At the `/confirm_signup_code` page, add the flag `?showReactApp=true` to view the React page (a quick check to see if you are on the right version - check the dev tools inspector for a `div id='root'`
4. Submitting the form without a code or with a random code should result in error messages.
5. Test a correct code by obtaining it from the CLI with `yarn pm2 logs inbox` - entering that code should redirect to the /settings page with a success alert bar

### Some follow-ups that aren't (yet) handled:

- Handling bounced emails and redirecting
- Using a broker (not yet available in Settings) to redirect based on entrypoint/relying parties
- Using a notifier (not yet available in Settings) to handle newsletter subscription
