### PR TITLE
task(subscriptions): in sub manage use invoice from customer

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -170,51 +170,6 @@ export function useInfoBoxMessage(
   return infoBoxMessage;
 }
 
-export function useHandleConfirmationDialog(
-  customerSubscription: WebSubscription
-) {
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<boolean>(false);
-  const [amount, setAmount] = useState<number>(0);
-
-  useEffect(() => {
-    const getSubscriptionPrice = async () => {
-      const {
-        promotion_code: promotionCode,
-        plan_id: priceId,
-        promotion_end,
-        current_period_end,
-        promotion_duration,
-      } = customerSubscription;
-
-      const includeCoupon =
-        promotionCode &&
-        couponOnSubsequentInvoice(
-          current_period_end,
-          promotion_end,
-          promotion_duration
-        );
-
-      try {
-        setLoading(true);
-        const preview = await apiInvoicePreview({
-          priceId,
-          promotionCode: includeCoupon ? promotionCode : undefined,
-        });
-        setAmount(preview.total);
-      } catch (err) {
-        setError(true);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getSubscriptionPrice();
-  }, [customerSubscription]);
-
-  return { loading, error, amount };
-}
-
 /**
  * Type guard function to check if a MozillaSubscription is a WebSubscription
  */

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -756,7 +756,7 @@ export const MOCK_CUSTOMER: Customer = {
   ],
 };
 
-export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION = {
+export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION: Customer = {
   ...MOCK_CUSTOMER,
   subscriptions: [
     ...MOCK_CUSTOMER.subscriptions,
@@ -765,11 +765,17 @@ export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION = {
       subscription_id: 'sub0.21234123424',
       plan_id: PLAN_ID,
       product_id: PRODUCT_ID,
+      product_name: '',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: MOCK_LATEST_INVOICE_ITEMS,
       status: 'active',
       cancel_at_period_end: false,
+      created: 1565816388.815,
       current_period_start: 1565816388.815,
       current_period_end: 1568408388.815,
+      end_at: null,
+      promotion_duration: null,
+      promotion_end: null,
     },
   ],
 };
@@ -907,6 +913,23 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT: FirstInvoicePrevi
       percent_off: null,
     },
   };
+
+export const INVOICE_NO_TAX: LatestInvoiceItems = MOCK_PREVIEW_INVOICE_NO_TAX;
+
+export const INVOICE_AFTER_SUBSCRIPTION: LatestInvoiceItems =
+  MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION;
+
+export const INVOICE_WITH_TAX_EXCLUSIVE: LatestInvoiceItems =
+  MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE;
+
+export const INVOICE_WITH_TAX_INCLUSIVE: LatestInvoiceItems =
+  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE;
+
+export const INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT: LatestInvoiceItems =
+  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT;
+
+export const INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT: LatestInvoiceItems =
+  MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT;
 
 export function getLocalizedMessage(
   bundle: FluentBundle,

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
-import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { APIError } from '../../../lib/apiClient';
@@ -17,6 +17,7 @@ import {
   MOCK_PLANS,
   getLocalizedMessage,
   MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE,
+  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE,
   MOCK_PREVIEW_INVOICE_NO_TAX,
 } from '../../../lib/test-utils';
 import { getFtlBundle } from 'fxa-react/lib/test-utils';
@@ -34,7 +35,6 @@ import { SignInLayout } from '../../../components/AppLayout';
 import SubscriptionUpgrade, { SubscriptionUpgradeProps } from './index';
 import { getLocalizedCurrency } from '../../../lib/formats';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
-import { MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE } from '../../Subscriptions/index.stories';
 import { updateConfig } from '../../../lib/config';
 
 jest.mock('../../../lib/sentry');

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -15,11 +15,11 @@ import {
   MOCK_PLANS,
   MOCK_CUSTOMER,
   MOCK_SUBSEQUENT_INVOICES,
-  MOCK_PREVIEW_INVOICE_NO_TAX,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT,
-  MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT,
+  INVOICE_NO_TAX,
+  INVOICE_WITH_TAX_EXCLUSIVE,
+  INVOICE_WITH_TAX_INCLUSIVE,
+  INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT,
+  INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT,
 } from '../../../lib/test-utils';
 import { Plan } from 'fxa-payments-server/src/store/types';
 import {
@@ -52,7 +52,7 @@ describe('CancelSubscriptionPanel', () => {
     cancelSubscription: jest.fn().mockResolvedValue(null),
     cancelSubscriptionStatus: defaultState.cancelSubscription,
     subsequentInvoice: MOCK_SUBSEQUENT_INVOICES[0],
-    invoicePreview: MOCK_PREVIEW_INVOICE_NO_TAX,
+    invoice: INVOICE_NO_TAX,
     promotionCode: undefined,
     paymentProvider: undefined,
   };
@@ -73,7 +73,7 @@ describe('CancelSubscriptionPanel', () => {
           render(<CancelSubscriptionPanel {...props} />);
 
           const planPrice = formatPlanPricing(
-            props.invoicePreview.total,
+            props.invoice.total,
             props.plan.currency,
             props.plan.interval,
             props.plan.interval_count
@@ -276,7 +276,7 @@ describe('CancelSubscriptionPanel', () => {
                 ...MOCK_SUBSEQUENT_INVOICES[2],
                 period_start: 1568408388.815,
               }}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE}
+              invoice={INVOICE_WITH_TAX_EXCLUSIVE}
             />
           </LocalizationProvider>
         );
@@ -307,7 +307,7 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[2]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE}
+              invoice={INVOICE_WITH_TAX_EXCLUSIVE}
             />
           </LocalizationProvider>
         );
@@ -336,7 +336,7 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[4]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT}
+              invoice={INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT}
             />
           </LocalizationProvider>
         );
@@ -368,7 +368,7 @@ describe('CancelSubscriptionPanel', () => {
                 ...MOCK_SUBSEQUENT_INVOICES[3],
                 period_start: 1568408388.815,
               }}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE}
+              invoice={INVOICE_WITH_TAX_INCLUSIVE}
             />
           </LocalizationProvider>
         );
@@ -398,7 +398,7 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[3]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE}
+              invoice={INVOICE_WITH_TAX_INCLUSIVE}
             />
           </LocalizationProvider>
         );
@@ -427,7 +427,7 @@ describe('CancelSubscriptionPanel', () => {
               {...baseProps}
               plan={plan}
               subsequentInvoice={MOCK_SUBSEQUENT_INVOICES[5]}
-              invoicePreview={MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT}
+              invoice={INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT}
             />
           </LocalizationProvider>
         );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -16,10 +16,7 @@ import CancelSubscriptionPanel from './Cancel/CancelSubscriptionPanel';
 import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 import { PaymentProvider } from 'fxa-payments-server/src/lib/PaymentProvider';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
-import {
-  FirstInvoicePreview,
-  SubsequentInvoicePreview,
-} from 'fxa-shared/dto/auth/payments/invoice';
+import { SubsequentInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type SubscriptionItemProps = {
   customerSubscription: WebSubscription;
@@ -29,7 +26,6 @@ export type SubscriptionItemProps = {
   customer: Customer;
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
   subsequentInvoice: SubsequentInvoicePreview | undefined;
-  invoicePreview: FirstInvoicePreview | undefined;
 };
 
 export const SubscriptionItem = ({
@@ -40,7 +36,6 @@ export const SubscriptionItem = ({
   plan,
   customerSubscription,
   subsequentInvoice,
-  invoicePreview,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
   const total = subsequentInvoice?.total;
@@ -109,33 +104,6 @@ export const SubscriptionItem = ({
     );
   }
 
-  if (!invoicePreview) {
-    const ariaLabelledBy = 'invoice-preview-not-found-header';
-    const ariaDescribedBy = 'invoice-preview-not-found-description';
-    return (
-      <DialogMessage
-        className="dialog-error"
-        onDismiss={locationReload}
-        headerId={ariaLabelledBy}
-        descId={ariaDescribedBy}
-      >
-        <Localized id="sub-invoice-preview-error-title">
-          <h4
-            id={ariaLabelledBy}
-            data-testid="error-subhub-missing-invoice-preview"
-          >
-            Invoice preview not found
-          </h4>
-        </Localized>
-        <Localized id="sub-invoice-preview-error-text">
-          <p id={ariaDescribedBy}>
-            Invoice preview not found for this subscription
-          </p>
-        </Localized>
-      </DialogMessage>
-    );
-  }
-
   return (
     <section className="settings-unit" aria-labelledby={labelId}>
       <div className="subscription" data-testid="subscription-item">
@@ -155,7 +123,7 @@ export const SubscriptionItem = ({
               paymentProvider,
               promotionCode,
               subsequentInvoice,
-              invoicePreview,
+              invoice: customerSubscription.latest_invoice_items,
             }}
           />
         ) : (

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -41,8 +41,7 @@ import {
   PLAN_ID,
   PRODUCT_ID,
   MOCK_SUBSEQUENT_INVOICES,
-  MOCK_PREVIEW_INVOICE_NO_TAX,
-  MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION,
+  MOCK_LATEST_INVOICE_ITEMS,
 } from '../../lib/test-utils';
 
 import { SettingsLayout } from '../../components/AppLayout';
@@ -140,14 +139,12 @@ describe('routes/Subscriptions', () => {
     mockActiveSubscriptions = MOCK_ACTIVE_SUBSCRIPTIONS,
     mockPlans = MOCK_PLANS,
     mockSubsequentInvoices = MOCK_SUBSEQUENT_INVOICES,
-    mockPreviewInvoice = MOCK_PREVIEW_INVOICE_NO_TAX,
   }: {
     displayName?: string | undefined;
     mockCustomer?: typeof MOCK_CUSTOMER;
     mockActiveSubscriptions?: typeof MOCK_ACTIVE_SUBSCRIPTIONS;
     mockPlans?: typeof MOCK_PLANS;
     mockSubsequentInvoices?: typeof MOCK_SUBSEQUENT_INVOICES;
-    mockPreviewInvoice?: typeof MOCK_PREVIEW_INVOICE_NO_TAX;
   } = {}) => [
     nock(profileServer)
       .get('/v1/profile')
@@ -162,20 +159,13 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, mockSubsequentInvoices),
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, mockPreviewInvoice),
   ];
 
   it('uses PaymentUpdateForm', async () => {
     initApiMocks({
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
       mockActiveSubscriptions: MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION,
-      mockPreviewInvoice: MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     render(<Subject />);
     await screen.findByTestId('subscription-management-loaded');
     await waitForExpect(() => {
@@ -192,9 +182,6 @@ describe('routes/Subscriptions', () => {
       mockSubsequentInvoices: MOCK_SUBSEQUENT_INVOICES,
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
 
     const { findByTestId, queryAllByTestId, queryByTestId } = render(
       <Subject />
@@ -214,9 +201,6 @@ describe('routes/Subscriptions', () => {
     initApiMocks({
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { findByTestId } = render(<Subject />);
     await findByTestId('manage-pocket-title');
     await findByTestId('manage-pocket-link');
@@ -238,9 +222,6 @@ describe('routes/Subscriptions', () => {
         },
       })),
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { findByTestId, queryAllByTestId } = render(<Subject />);
     await findByTestId('subscription-management-loaded');
     expect(queryAllByTestId('upgrade-cta').length).toBe(2);
@@ -265,9 +246,6 @@ describe('routes/Subscriptions', () => {
       mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
       mockActiveSubscriptions: MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION,
     });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { getAllByTestId, findByTestId } = render(<Subject />);
     await findByTestId('subscription-management-loaded');
     fireEvent.click(getAllByTestId('reveal-cancel-subscription-button')[0]);
@@ -308,9 +286,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-profile');
   });
@@ -329,9 +304,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-plans');
   });
@@ -350,9 +322,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-customer');
   });
@@ -371,32 +340,8 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(500, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-invoice');
-  });
-
-  it('displays an error if preview invoice fetch fails', async () => {
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/active')
-      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
-    nock(authServer)
-      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
-      .reply(200, MOCK_CUSTOMER);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-      .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(500, MOCK_PREVIEW_INVOICE_NO_TAX);
-    const { findByTestId } = render(<Subject />);
-    await findByTestId('error-loading-invoice-previews');
   });
 
   it('displays an error if subsequent invoice response is an empty array', async () => {
@@ -413,32 +358,8 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, []);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-subhub-missing-subsequent-invoice');
-  });
-
-  it('displays an error if invoice preview doesnt match any subscription', async () => {
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/active')
-      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
-    nock(authServer)
-      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
-      .reply(200, MOCK_CUSTOMER);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-      .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
-    const { findByTestId } = render(<Subject />);
-    await findByTestId('error-subhub-missing-invoice-preview');
   });
 
   it('redirects to settings if customer fetch fails with 404', async () => {
@@ -457,9 +378,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
 
     const navigateToUrl = jest.fn();
     render(<Subject navigateToUrl={navigateToUrl} />);
@@ -517,26 +435,7 @@ describe('routes/Subscriptions', () => {
       ]);
     nock(authServer)
       .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
-      .reply(200, {
-        ...MOCK_CUSTOMER,
-        subscriptions: [
-          {
-            _subscription_type: MozillaSubscriptionTypes.WEB,
-            subscription_id: 'sub0.28964929339372136',
-            plan_id: '123doneProMonthly',
-            product_id: 'prod_123',
-            product_name: '123done Pro',
-            latest_invoice: '628031D-0002',
-            status: 'active',
-            cancel_at_period_end: true,
-            current_period_start: 1565816388.815,
-            current_period_end: 1568408388.815,
-          },
-        ],
-      });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
+      .reply(200, MOCK_CUSTOMER_AFTER_SUBSCRIPTION);
 
     const {
       findByTestId,
@@ -600,9 +499,6 @@ describe('routes/Subscriptions', () => {
     });
 
     nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
-    nock(authServer)
       .delete('/v1/oauth/subscriptions/active/sub0.28964929339372136')
       .reply(200, {});
     nock(authServer)
@@ -627,6 +523,7 @@ describe('routes/Subscriptions', () => {
             plan_id: PLAN_ID,
             product_id: PRODUCT_ID,
             latest_invoice: '628031D-0002',
+            latest_invoice_items: MOCK_LATEST_INVOICE_ITEMS,
             status: 'active',
             cancel_at_period_end: false,
             current_period_start: 1565816388.815,
@@ -639,6 +536,7 @@ describe('routes/Subscriptions', () => {
             product_id: 'prod_123',
             product_name: '123done Pro',
             latest_invoice: '628031D-0002',
+            latest_invoice_items: MOCK_LATEST_INVOICE_ITEMS,
             status: 'active',
             cancel_at_period_end: true,
             current_period_start: 1565816388.815,
@@ -646,12 +544,6 @@ describe('routes/Subscriptions', () => {
           },
         ],
       });
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_NO_TAX);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
 
     const { findByTestId, queryAllByTestId, queryByTestId, getAllByTestId } =
       render(<Subject />);
@@ -716,6 +608,11 @@ describe('routes/Subscriptions', () => {
   async function commonReactivationSetup({
     useDefaultIcon = false,
     cancelledAtIsUnavailable = false,
+    discount = 'NONE',
+  }: {
+    useDefaultIcon?: boolean;
+    cancelledAtIsUnavailable?: boolean;
+    discount?: 'NONE' | 'ENDS_NEXT_INTERVAL' | 'ONGOING';
   }) {
     // To exercise the default icon fallback, delete webIconURL from the second plan.
     const plans = !useDefaultIcon
@@ -732,6 +629,42 @@ describe('routes/Subscriptions', () => {
           },
           ...MOCK_PLANS.slice(2),
         ];
+
+    let latest_invoice_items;
+    let otherPromotionItems;
+    switch (discount) {
+      case 'ENDS_NEXT_INTERVAL':
+        latest_invoice_items = {
+          ...MOCK_LATEST_INVOICE_ITEMS,
+          total: 685,
+        };
+        otherPromotionItems = {
+          promotion_code: 'PROMO50',
+          promotion_end: 1568408388.815,
+          promotion_duration: 'repeating',
+        };
+        break;
+      case 'ONGOING':
+        latest_invoice_items = {
+          ...MOCK_LATEST_INVOICE_ITEMS,
+          total: 685,
+        };
+        otherPromotionItems = {
+          promotion_code: 'PROMO50',
+          promotion_end: 1677273263.815,
+          promotion_duration: 'repeating',
+        };
+        break;
+      case 'NONE':
+      default:
+        latest_invoice_items = MOCK_LATEST_INVOICE_ITEMS;
+        otherPromotionItems = {
+          promotion_code: undefined,
+          promotion_end: null,
+          promotion_duration: null,
+        };
+        break;
+    }
 
     nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
     nock(authServer).get('/v1/oauth/subscriptions/plans').reply(200, plans);
@@ -752,12 +685,14 @@ describe('routes/Subscriptions', () => {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
+            ...otherPromotionItems,
             _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
             product_id: 'prod_123',
             product_name: '123done Pro',
             latest_invoice: '628031D-0002',
+            latest_invoice_items,
             status: 'active',
             cancel_at_period_end: true,
             current_period_start: 1565816388.815,
@@ -782,12 +717,14 @@ describe('routes/Subscriptions', () => {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
+            ...otherPromotionItems,
             _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
             product_id: 'prod_123',
             product_name: '123done Pro',
             latest_invoice: '628031D-0002',
+            latest_invoice_items,
             status: 'active',
             cancel_at_period_end: false,
             current_period_start: 1565816388.815,
@@ -820,76 +757,91 @@ describe('routes/Subscriptions', () => {
     }
   };
 
-  const reactivationTests =
-    (useDefaultIcon = true) =>
-    () => {
-      it('supports reactivating a subscription through the confirmation flow', async () => {
-        commonReactivationSetup({ useDefaultIcon });
-        nock(authServer)
-          .post('/v1/oauth/subscriptions/reactivate')
-          .reply(200, {});
-        nock(authServer)
-          .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-          .reply(200, MOCK_SUBSEQUENT_INVOICES);
-        const { findByTestId, getByTestId, getByAltText, queryByTestId } =
-          render(<Subject />);
+  const reactivationTests = (
+    useDefaultIcon = true,
+    discount: 'NONE' | 'ENDS_NEXT_INTERVAL' | 'ONGOING' = 'NONE'
+  ) => {
+    let amountString: string = '';
+    switch (discount) {
+      case 'ONGOING':
+        amountString = '$6.85';
+        break;
+      case 'ENDS_NEXT_INTERVAL':
+      case 'NONE':
+      default:
+        amountString = '$7.35';
+    }
+    it('supports reactivating a subscription through the confirmation flow', async () => {
+      commonReactivationSetup({ useDefaultIcon, discount });
+      nock(authServer)
+        .post('/v1/oauth/subscriptions/reactivate')
+        .reply(200, {});
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
+        .reply(200, MOCK_SUBSEQUENT_INVOICES);
+      const { findByTestId, getByTestId, getByAltText, queryByTestId } = render(
+        <Subject />
+      );
 
-        // Wait for the page to load with one subscription
-        await findByTestId('subscription-management-loaded');
+      // Wait for the page to load with one subscription
+      await findByTestId('subscription-management-loaded');
 
-        const reactivateButton = getByTestId('reactivate-subscription-button');
-        fireEvent.click(reactivateButton);
+      const reactivateButton = getByTestId('reactivate-subscription-button');
+      fireEvent.click(reactivateButton);
 
-        // Product image should appear in the reactivation confirm dialog.
-        expectProductImage({ getByAltText, useDefaultIcon });
+      // Product image should appear in the reactivation confirm dialog.
+      expectProductImage({ getByAltText, useDefaultIcon });
 
-        const reactivateConfirmButton = getByTestId(
-          'reactivate-subscription-confirm-button'
-        );
-        fireEvent.click(reactivateConfirmButton);
+      const reactivateModalCopy = getByTestId('reactivate-modal-copy');
+      expect(reactivateModalCopy.textContent).toContain(amountString);
 
-        await findByTestId('reactivate-subscription-success-dialog');
+      const reactivateConfirmButton = getByTestId(
+        'reactivate-subscription-confirm-button'
+      );
+      fireEvent.click(reactivateConfirmButton);
 
-        await waitForExpect(() =>
-          expect(queryByTestId('loading-overlay')).not.toBeInTheDocument()
-        );
+      await findByTestId('reactivate-subscription-success-dialog');
 
-        // Product image should appear in the reactivation success dialog.
-        expectProductImage({ getByAltText, useDefaultIcon });
+      await waitForExpect(() =>
+        expect(queryByTestId('loading-overlay')).not.toBeInTheDocument()
+      );
 
-        const successButton = getByTestId(
-          'reactivate-subscription-success-button'
-        );
-        fireEvent.click(successButton);
+      // Product image should appear in the reactivation success dialog.
+      expectProductImage({ getByAltText, useDefaultIcon });
 
-        await findByTestId('reveal-cancel-subscription-button');
-      });
+      const successButton = getByTestId(
+        'reactivate-subscription-success-button'
+      );
+      fireEvent.click(successButton);
 
-      it('should display an error message if reactivation fails', async () => {
-        commonReactivationSetup({ useDefaultIcon });
-        nock(authServer)
-          .post('/v1/oauth/subscriptions/reactivate')
-          .reply(500, {});
-        nock(authServer)
-          .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-          .reply(200, MOCK_SUBSEQUENT_INVOICES);
+      await findByTestId('reveal-cancel-subscription-button');
+    });
 
-        const { findByTestId, getByTestId } = render(<Subject />);
+    it('should display an error message if reactivation fails', async () => {
+      commonReactivationSetup({ useDefaultIcon });
+      nock(authServer)
+        .post('/v1/oauth/subscriptions/reactivate')
+        .reply(500, {});
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
+        .reply(200, MOCK_SUBSEQUENT_INVOICES);
 
-        // Wait for the page to load with one subscription
-        await findByTestId('subscription-management-loaded');
+      const { findByTestId, getByTestId } = render(<Subject />);
 
-        const reactivateButton = getByTestId('reactivate-subscription-button');
-        fireEvent.click(reactivateButton);
+      // Wait for the page to load with one subscription
+      await findByTestId('subscription-management-loaded');
 
-        const reactivateConfirmButton = getByTestId(
-          'reactivate-subscription-confirm-button'
-        );
-        fireEvent.click(reactivateConfirmButton);
+      const reactivateButton = getByTestId('reactivate-subscription-button');
+      fireEvent.click(reactivateButton);
 
-        await findByTestId('error-reactivation');
-      });
-    };
+      const reactivateConfirmButton = getByTestId(
+        'reactivate-subscription-confirm-button'
+      );
+      fireEvent.click(reactivateConfirmButton);
+
+      await findByTestId('error-reactivation');
+    });
+  };
 
   describe('reactivation with defined webIconURL', () => {
     reactivationTests(false);
@@ -897,6 +849,14 @@ describe('routes/Subscriptions', () => {
 
   describe('reactivation with default icon', () => {
     reactivationTests(true);
+  });
+
+  describe('reactivation with ongoing discount', () => {
+    reactivationTests(true, 'ONGOING');
+  });
+
+  describe('reactivation with discount ending next interval', () => {
+    reactivationTests(true, 'ENDS_NEXT_INTERVAL');
   });
 
   it('should display an error message for a plan found in auth-server but not subhub', async () => {
@@ -911,9 +871,6 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
       .reply(200, MOCK_SUBSEQUENT_INVOICES);
-    nock(authServer)
-      .post('/v1/oauth/subscriptions/invoice/preview')
-      .reply(200, MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-subhub-missing-plan');
   });
@@ -944,6 +901,7 @@ describe('routes/Subscriptions', () => {
       product_id: PRODUCT_ID,
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
+      latest_invoice_items: MOCK_LATEST_INVOICE_ITEMS,
       status: 'active',
       cancel_at_period_end: false,
       current_period_start: 1565816388.815,
@@ -1004,7 +962,6 @@ describe('routes/Subscriptions', () => {
         },
         mockPlans: MOCK_PLANS,
         mockSubsequentInvoices: MOCK_SUBSEQUENT_INVOICES,
-        mockPreviewInvoice: MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION,
       });
 
       const { findByTestId, queryAllByTestId } = render(<Subject />);


### PR DESCRIPTION
## Because

- To support archived prices, the subscription management pages currently using the invoice preview api need to be refactored to use the invoice on the customer instead.

## This pull request

- In Subscription Management use invoice_latest_items instead of the invoice preview.
- Remove invoice preview logic from Subscription Management where its no longer used.

## Issue that this pull request solves

Closes: #FXA-6832

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional Information
To test this locally you can use the following product and price.
- Product: prod_GqM9ToKK62qjkK
- Price: price_1MYuLZBVqmGyQTMa4pIWatVi
- URL: [link](http://localhost:3031/products/prod_GqM9ToKK62qjkK?plan=price_1MYuLZBVqmGyQTMa4pIWatVi)

## Screenshots (Optional)

#### No discount archived plan
![image](https://user-images.githubusercontent.com/10620585/221315381-df5b350a-e992-49f8-9752-53eeaf171be7.png)

#### Recurring 50cent discount
![image](https://user-images.githubusercontent.com/10620585/221314641-409a6b28-c23c-4158-b7e7-51d50448b0f7.png)

#### One-time 100% discount
![image](https://user-images.githubusercontent.com/10620585/221314260-8845c4f5-7338-4f0c-8424-f8f194ed8ec5.png)

#### No discount resubscribe
![image](https://user-images.githubusercontent.com/10620585/221315313-bb50349b-fbc0-464a-b082-1d9614b6dadf.png)

#### Recurring 50cent discount resubscribe
![image](https://user-images.githubusercontent.com/10620585/221316280-7938837a-95e1-41f2-9960-13d3ab12368d.png)

#### One-time 100% discount resubscribe
![image](https://user-images.githubusercontent.com/10620585/221315896-bb413e71-5618-4476-b14b-634b6bf73699.png)

