### PR TITLE
Fxa 4924.2

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -301,7 +301,7 @@ module.exports = (log, db, mailer, customs, config) => {
           accountEventsManager.recordSecurityEvent(db, {
             name: 'account.two_factor_added',
             uid,
-            ip: request.app.clientAddress,
+            ipAddr: request.app.clientAddress,
             tokenId: sessionToken && sessionToken.id,
           });
 
@@ -322,7 +322,7 @@ module.exports = (log, db, mailer, customs, config) => {
           accountEventsManager.recordSecurityEvent(db, {
             name: 'account.two_factor_challenge_success',
             uid,
-            ip: request.app.clientAddress,
+            ipAddr: request.app.clientAddress,
             tokenId: sessionToken && sessionToken.id,
           });
         } else {
@@ -336,7 +336,7 @@ module.exports = (log, db, mailer, customs, config) => {
           accountEventsManager.recordSecurityEvent(db, {
             name: 'account.two_factor_challenge_failure',
             uid,
-            ip: request.app.clientAddress,
+            ipAddr: request.app.clientAddress,
             tokenId: sessionToken && sessionToken.id,
           });
         }

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.js
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { AccountEventsManager } = require  ('../../account-events');
+const { Container } = require('typedi');
+
+export function recordSecurityEvent(name, opts) {
+  const mgr = Container.get(AccountEventsManager);
+  if (mgr == null || typeof mgr.recordSecurityEvent !== 'function') {
+    return;
+  }
+
+  mgr.recordSecurityEvent(opts.db,  {
+    name,
+    uid: opts?.account?.uid || opts?.request?.auth?.credentials?.uid,
+    ipAddr: opts?.request?.app?.clientAddress,
+    tokenId:  opts?.request?.auth?.credentials?.id,
+  });
+}

--- a/packages/fxa-auth-server/test/local/account-events.js
+++ b/packages/fxa-auth-server/test/local/account-events.js
@@ -127,9 +127,9 @@ describe('Account Events', () => {
         tokenId: '123',
       };
       await accountEventsManager.recordSecurityEvent(mockDb, message);
-
+      
       assert.calledOnceWithExactly(mockDb.securityEvent, message);
-
+      
       assert.calledOnceWithExactly(
         statsd.increment,
         'accountEvents.recordSecurityEvent.write.account.login'

--- a/packages/fxa-auth-server/test/local/email/utils.js
+++ b/packages/fxa-auth-server/test/local/email/utils.js
@@ -345,6 +345,7 @@ describe('email utils helpers', () => {
     beforeEach(() => {
       mockAccountEventsManager = {
         recordEmailEvent: sinon.stub(),
+        recordSecurityEvent: sinon.stub().resolves({})
       };
       Container.set(AccountEventsManager, mockAccountEventsManager);
     });

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -280,14 +280,14 @@ describe('totp', () => {
         assert.calledWithExactly(accountEventsManager.recordSecurityEvent, db, {
           name: 'account.two_factor_added',
           uid: 'uid',
-          ip: '63.245.221.32',
+          ipAddr: '63.245.221.32',
           tokenId: 'id',
         });
 
         assert.calledWithExactly(accountEventsManager.recordSecurityEvent, db, {
           name: 'account.two_factor_challenge_success',
           uid: 'uid',
-          ip: '63.245.221.32',
+          ipAddr: '63.245.221.32',
           tokenId: 'id',
         });
       });
@@ -364,7 +364,7 @@ describe('totp', () => {
           {
             name: 'account.two_factor_challenge_success',
             uid: 'uid',
-            ip: '63.245.221.32',
+            ipAddr: '63.245.221.32',
             tokenId: 'id',
           }
         );
@@ -479,7 +479,7 @@ describe('totp', () => {
           {
             name: 'account.two_factor_challenge_failure',
             uid: 'uid',
-            ip: '63.245.221.32',
+            ipAddr: '63.245.221.32',
             tokenId: 'id',
           }
         );

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -15,6 +15,9 @@ const error = require('../lib/error');
 const knownIpLocation = require('./known-ip-location');
 const sinon = require('sinon');
 const { normalizeEmail } = require('fxa-shared').email.helpers;
+const { Container } = require('typedi');
+const { AccountEventsManager } = require('../lib/account-events');
+
 const proxyquire = require('proxyquire');
 const amplitudeModule = proxyquire('../lib/metrics/amplitude', {
   'fxa-shared/db/models/auth': {
@@ -226,6 +229,8 @@ module.exports = {
   mockPayPalHelper,
   mockPlaySubscriptions,
   mockAppStoreSubscriptions,
+  mockAccountEventsManager,
+  unMockAccountEventsManager
 };
 
 function mockCustoms(errors) {
@@ -867,4 +872,17 @@ function mockAppStoreSubscriptions(methods) {
     require('../lib/payments/iap/apple-app-store/subscriptions')
       .AppStoreSubscriptions
   );
+}
+
+function mockAccountEventsManager() {
+  const mgr = {
+    recordSecurityEvent: sinon.stub(),
+    recordEmailEvent: sinon.stub()
+  };
+  Container.set(AccountEventsManager, mgr)
+  return mgr;
+}
+
+function unMockAccountEventsManager() {
+  Container.remove(AccountEventsManager)
 }


### PR DESCRIPTION
## Because
- We are increasing the security events we record

## This pull request
- Adds a wrapper function to simplify security events being recorded from route handlers
- Fixes a couple issues with mocks in unit tests
- Adds:
- account.secondary_email_-ed
- account.secondary_email_removed
- account.primary_secondary_swapped
- account.recovery_key_-ed
- account.recovery_key_challenge_failure
- account.recovery_key_challenge_success
- account.recovery_key_removed
- account.password_reset_requested
- account.password_reset_success
- account.password_-ed
- account.password_changed

## Issue that this pull request solves

Closes: 
FXA-4923
FXA-4939
FXA-4940
FXA-4932
FXA-4933
FXA-4934
FXA-4935
FXA-4930
FXA-4931
FXA-4936
FXA-4937


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This commit is based on top of fxa-4924

Here's a mapping between event names and issues:
FXA-4923 - Add account.secondary_email_added
FXA-4939 - Add account.secondary_email_removed
FXA-4940 - Add account.primary_secondary_swapped
FXA-4932 - Add account.recovery_key_added
FXA-4933 - Add account.recovery_key_challenge_failure
FXA-4934 - Add account.recovery_key_challenge_success 
FXA-4935 - Add account.recovery_key_removed 
FXA-4930 - Add account.password_reset_requested
FXA-4931 - Add account.password_reset_success
FXA-4936 - Add account.password_added
FXA-4937 - Add account.password_changed
