### PR TITLE
fix(subscriptions): show total for zero price

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -68,6 +68,7 @@ const selectedPlan: Plan = {
 const selectedPlanWithConfig: Plan = {
   ...selectedPlan,
   configuration: {
+    productSet: ['testSet'],
     urls: {
       webIcon: 'https://webicon',
       successActionButton: '',
@@ -604,6 +605,28 @@ describe('PlanDetails', () => {
       const { queryByTestId } = subject();
       expect(queryByTestId('coupon-success')).not.toBeInTheDocument();
       expect(queryByTestId('coupon-success-with-date')).not.toBeInTheDocument();
+    });
+
+    it('show total for 100% coupon', () => {
+      const subject = () => {
+        return render(
+          <PlanDetails
+            {...{
+              profile: userProfile,
+              showExpandButton: false,
+              isMobile: false,
+              selectedPlan,
+              coupon: {
+                ...coupon,
+                discountAmount: selectedPlan.amount || 935,
+              },
+            }}
+          />
+        );
+      };
+
+      const { queryByTestId } = subject();
+      expect(queryByTestId('total-price')).toBeInTheDocument();
     });
   });
 

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -347,35 +347,33 @@ export const PlanDetails = ({
               </div>
 
               <div className="pt-4 pb-6">
-                {!!priceAmounts.totalAmount && (
-                  <div className="plan-details-item font-semibold">
-                    <Localized id="plan-details-total-label">
-                      <div className="total-label">Total</div>
-                    </Localized>
+                <div className="plan-details-item font-semibold">
+                  <Localized id="plan-details-total-label">
+                    <div className="total-label">Total</div>
+                  </Localized>
 
-                    <Localized
-                      id={`plan-price-interval-${interval}`}
-                      data-testid="plan-price-total"
-                      attrs={{ title: true }}
-                      vars={{
-                        amount: getLocalizedCurrency(
-                          priceAmounts.totalAmount,
-                          currency
-                        ),
-                        intervalCount: interval_count,
-                      }}
+                  <Localized
+                    id={`plan-price-interval-${interval}`}
+                    data-testid="plan-price-total"
+                    attrs={{ title: true }}
+                    vars={{
+                      amount: getLocalizedCurrency(
+                        priceAmounts.totalAmount,
+                        currency
+                      ),
+                      intervalCount: interval_count,
+                    }}
+                  >
+                    <div
+                      className="total-price"
+                      title={priceAmounts.totalPrice}
+                      data-testid="total-price"
+                      id="total-price"
                     >
-                      <div
-                        className="total-price"
-                        title={priceAmounts.totalPrice}
-                        data-testid="total-price"
-                        id="total-price"
-                      >
-                        {priceAmounts.totalPrice}
-                      </div>
-                    </Localized>
-                  </div>
-                )}
+                      {priceAmounts.totalPrice}
+                    </div>
+                  </Localized>
+                </div>
 
                 {infoBoxMessage &&
                   (infoBoxMessage.couponDurationDate ? (

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -60,7 +60,7 @@ export const PlanUpgradeDetails = ({
       <PlanDetailsCard className="to-plan" plan={selectedPlan} />
 
       <div className="py-6 border-t-0">
-        {showTax && !!subTotal && exclusiveTaxRates.length && (
+        {showTax && !!subTotal && !!exclusiveTaxRates.length && (
           <>
             <div className="plan-details-item">
               <Localized id="plan-details-list-price">


### PR DESCRIPTION
## Because

- Total price should still be displayed when total price is zero.
- This could happen when a 100% promotion is applied.

## This pull request

- Show total for zero price.

## Issue that this pull request solves

Closes: #FXA-6871

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional information
Local testing:
- Price: Any price from Product `123Done Pro` (e.g. [plan_GqM9N6qyhvxaVk](localhost:3031/checkout/prod_GqM9ToKK62qjkK?plan=plan_GqM9N6qyhvxaVk))
- Promotion code: `EVERYTHING`

## Screenshots (Optional)
Checkout
![image](https://user-images.githubusercontent.com/10620585/221632540-bf825eb7-fb2c-4fd6-99d1-18b1ee847470.png)

Success screen
![image](https://user-images.githubusercontent.com/10620585/221632370-7037f1ce-d82b-4d00-a401-c562e7cbc908.png)
