### PR TITLE
feat(auth): geoip, parallelization for automatic tax

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint-staged": "^13.0.3",
     "node-fetch": "^2.6.7",
     "nps": "^5.10.0",
+    "p-queue": "^7.3.4",
     "pm2": "^5.2.2",
     "prettier": "^2.3.1",
     "replace-in-file": "^6.3.5",

--- a/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax.ts
@@ -2,32 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import program from 'commander';
+import { ConfigType } from '../config';
+import { AppConfig } from '../lib/types';
+import GeoDB from 'fxa-geodb';
+import Container from 'typedi';
 
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
 import { StripeAutomaticTaxConverter } from './convert-customers-to-stripe-automatic-tax/convert-customers-to-stripe-automatic-tax';
 
 const pckg = require('../package.json');
 
-const parseDryRun = (dryRun: boolean | string) => {
-  return `${dryRun}`.toLowerCase() !== 'false';
-};
-
 const parseBatchSize = (batchSize: string | number) => {
   return parseInt(batchSize.toString(), 10);
 };
 
-const parseOutputFile = (outputFile: string) => {
-  return outputFile;
+const parseRateLimit = (rateLimit: string | number) => {
+  return parseInt(rateLimit.toString(), 10);
 };
 
 async function init() {
   program
     .version(pckg.version)
-    .option(
-      '-n, --dry-run [true|false]',
-      'Print what the script would do instead of performing the action.  Defaults to true.',
-      true
-    )
     .option(
       '-b, --batch-size [number]',
       'Number of subscriptions to query from firestore at a time.  Defaults to 100.',
@@ -38,22 +33,37 @@ async function init() {
       'Output file to write report to. Will be output in CSV format.  Defaults to stripe-tax-existing-customers-output.csv.',
       'stripe-tax-existing-customers-output.csv'
     )
+    .option(
+      '-i, --ip-address-map-file [string]',
+      'IP address mapping file. Must be in [{ uid: "", remote_address_chain: "" }] format.',
+      'ip-address-map-file.json'
+    )
+    .option(
+      '-r, --rate-limit [number]',
+      'Rate limit for Stripe. Defaults to 70',
+      70
+    )
     .parse(process.argv);
 
   const { stripeHelper } = await setupProcessingTaskObjects(
     'existing-customers-stripe-tax'
   );
 
-  const isDryRun = parseDryRun(program.dryRun);
   const batchSize = parseBatchSize(program.batchSize);
-  const outputFile = parseOutputFile(program.outputFile);
+  const rateLimit = parseRateLimit(program.rateLimit);
+
+  const config = Container.get<ConfigType>(AppConfig);
+  const geodb = GeoDB(config.geodb);
 
   const stripeAutomaticTaxConverter = new StripeAutomaticTaxConverter(
-    isDryRun,
+    geodb,
     batchSize,
-    outputFile,
-    stripeHelper.stripe
+    program.outputFile,
+    program.ipAddressMapFile,
+    stripeHelper.stripe,
+    rateLimit
   );
+
   await stripeAutomaticTaxConverter.convert();
 
   return 0;

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax-helpers.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax-helpers.ts
@@ -26,6 +26,73 @@ describe('StripeAutomaticTaxConverterHelpers', () => {
     helpers = new StripeAutomaticTaxConverterHelpers();
   });
 
+  describe('processIPAddressList', () => {
+    it('converts IP address mapping to internal mapping', () => {
+      const result = helpers.processIPAddressList([
+        {
+          uid: 'example-uid',
+          remote_address_chain: '["1.1.1.1"]',
+        },
+        {
+          uid: 'example-uid-2',
+          remote_address_chain: '["8.8.8.8"]',
+        },
+        {
+          uid: 'example-uid-3',
+          remote_address_chain: '["10.0.0.1", "1.1.1.1"]',
+        },
+      ]);
+
+      const expected = {
+        'example-uid': '1.1.1.1',
+        'example-uid-2': '8.8.8.8',
+      };
+
+      sinon.assert.match(result, expected);
+    });
+  });
+
+  describe('getClientIPFromRemoteAddressChain', () => {
+    it('returns the first IP address when it is non-local', () => {
+      sinon.assert.match(
+        helpers.getClientIPFromRemoteAddressChain('["1.1.1.1","8.8.8.8"]'),
+        '1.1.1.1'
+      );
+    });
+
+    it('returns undefined if first IP address is local', () => {
+      sinon.assert.match(
+        helpers.getClientIPFromRemoteAddressChain('["192.168.1.1", "1.1.1.1"]'),
+        undefined
+      );
+    });
+
+    it('returns undefined if address chain is empty', () => {
+      sinon.assert.match(
+        helpers.getClientIPFromRemoteAddressChain('[]'),
+        undefined
+      );
+    });
+  });
+
+  describe('isLocalIP', () => {
+    it('returns true for class A', () => {
+      expect(helpers.isLocalIP('10.0.0.1')).true;
+    });
+
+    it('returns true for class B', () => {
+      expect(helpers.isLocalIP('172.16.0.1')).true;
+    });
+
+    it('returns true for class C', () => {
+      expect(helpers.isLocalIP('192.168.0.1')).true;
+    });
+
+    it('returns false for non-local IP', () => {
+      expect(helpers.isLocalIP('1.1.1.1')).false;
+    });
+  });
+
   describe('isTaxEligible', () => {
     it('returns true for supported customer', () => {
       const customer = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23700,6 +23700,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "eventemitter3@npm:4.0.7"
+  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
+  languageName: node
+  linkType: hard
+
 "events-to-array@npm:^1.0.1":
   version: 1.1.2
   resolution: "events-to-array@npm:1.1.2"
@@ -26712,6 +26719,7 @@ fsevents@~2.1.1:
     mocha-multi: ^1.1.7
     node-fetch: ^2.6.7
     nps: ^5.10.0
+    p-queue: ^7.3.4
     pm2: ^5.2.2
     postcss: ^8.4.14
     prettier: ^2.3.1
@@ -38488,6 +38496,16 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"p-queue@npm:^7.3.4":
+  version: 7.3.4
+  resolution: "p-queue@npm:7.3.4"
+  dependencies:
+    eventemitter3: ^4.0.7
+    p-timeout: ^5.0.2
+  checksum: a21b8a4dd75f64a4988e4468cc344d1b45132506ddd2c771932d3de446d108ee68713b629e0d3f0809c227bc10eafc613edde6ae741d9f60db89b6031e40921c
+  languageName: node
+  linkType: hard
+
 "p-retry@npm:^3.0.1":
   version: 3.0.1
   resolution: "p-retry@npm:3.0.1"
@@ -38513,6 +38531,13 @@ fsevents@~2.1.1:
   dependencies:
     p-finally: ^1.0.0
   checksum: 3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^5.0.2":
+  version: 5.1.0
+  resolution: "p-timeout@npm:5.1.0"
+  checksum: f5cd4e17301ff1ff1d8dbf2817df0ad88c6bba99349fc24d8d181827176ad4f8aca649190b8a5b1a428dfd6ddc091af4606835d3e0cb0656e04045da5c9e270c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

* We need to geoip before saving the customer rather than using their IP address with Stripe directly.
* Parallelization speeds up the conversion process significantly

## This pull request

* Geocodes IP addresses prior to saving using fxa-geodb.
* Adds parallelization with rate limiting.
* Writes results to output CSV.

## Issue that this pull request solves

Closes FXA-6581
Closes FXA-6810

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).