### PR TITLE
fix(auth): Fix multiple reset emails, location, add playwright test

### DIFF
--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+import { BaseTarget } from '../../lib/targets/base';
+import { EmailHeader, EmailType } from '../../lib/email';
+
+function getReactFeatureFlagUrl(target: BaseTarget, path: string) {
+  return `${target.contentServerUrl}${path}?showReactApp=true`;
+}
+
+const NEW_PASSWORD = 'notYourAveragePassW0Rd';
+
+test.describe('reset password', () => {
+  test.beforeEach(async ({}, { project }) => {
+    test.slow(project.name !== 'local', 'email delivery can be slow');
+  });
+
+  test('can reset password', async ({ page, target, credentials, context }) => {
+    await page.goto(getReactFeatureFlagUrl(target, '/reset_password'));
+
+    // Verify react page has been loaded
+    expect(await page.locator('#root').isVisible()).toBeTruthy();
+
+    await page.locator('input').fill(credentials.email);
+    await page.locator('text="Begin reset"').click();
+    await page.waitForNavigation();
+
+    // Verify confirm password reset page elements
+    expect(
+      await page.locator('text="Reset email sent"').isVisible()
+    ).toBeTruthy();
+    expect(
+      await page.locator('text="Remember your password? Sign in"').isVisible()
+    ).toBeTruthy();
+    expect(
+      await page
+        .locator('text="Not in inbox or spam folder? Resend"')
+        .isVisible()
+    ).toBeTruthy();
+
+    // We need to append `&showReactApp=true` to reset link inorder to enroll in reset password experiment
+    let link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    link = `${link}&showReactApp=true`;
+
+    // Open link in a new window
+    const diffPage = await context.newPage();
+    await diffPage.goto(link);
+
+    // Loads the React version
+    expect(await diffPage.locator('#root').isVisible()).toBeTruthy();
+    expect(
+      await diffPage.locator('text="Create new password"').isVisible()
+    ).toBeTruthy();
+    expect(
+      await diffPage
+        .locator('text="Remember your password? Sign in"')
+        .isVisible()
+    ).toBeTruthy();
+
+    await diffPage.locator('input[name="newPassword"]').fill(NEW_PASSWORD);
+    await diffPage.locator('input[name="confirmPassword"]').fill(NEW_PASSWORD);
+
+    await diffPage.locator('text="Reset password"').click();
+    await diffPage.waitForNavigation();
+
+    expect(
+      await diffPage.locator('text="Your password has been reset"').isVisible()
+    ).toBeTruthy();
+    await diffPage.close();
+
+    // Attempt to login
+    await page.waitForNavigation();
+    expect(
+      await page.locator('text="Enter your email"').isVisible()
+    ).toBeTruthy();
+
+    await page.locator('input[type=email]').fill(credentials.email);
+    await page.locator('text="Sign up or sign in"').click();
+    await page.waitForNavigation({ waitUntil: 'load' });
+    await page.locator('#password').fill(NEW_PASSWORD);
+
+    await page.locator('text="Sign in"').click();
+    await page.waitForNavigation({ waitUntil: 'load' });
+
+    const settingsHeader = await page.locator('text=Settings');
+    // A bit strange, not sure why I needed to add the `waitFor` here
+    await settingsHeader.waitFor();
+    expect(await settingsHeader.isVisible()).toBeTruthy();
+
+    // Cleanup requires setting this value to correct password
+    credentials.password = NEW_PASSWORD;
+  });
+});

--- a/packages/fxa-graphql-api/src/decorators.ts
+++ b/packages/fxa-graphql-api/src/decorators.ts
@@ -42,6 +42,9 @@ export const GqlXHeaders = createParamDecorator(
   (data: unknown, context: ExecutionContext): Headers => {
     const ctx = GqlExecutionContext.create(context).getContext();
     const headers = ctx.req?.headers;
+    // We don't need to propagate the authorization token because
+    // it needs to be updated to originate from gql server.
+    delete headers['authorization'];
     return new Headers(headers);
   }
 );

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -508,8 +508,8 @@ export class AccountResolver {
       input.email,
       input.newPassword,
       input.accountResetToken,
-      input.options
-      // headers, TODO: Not sure why this request fails when forwarding headers
+      input.options,
+      headers
     );
   }
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -82,8 +82,6 @@ const ResetPassword = ({
   const onSubmit = async () => {
     try {
       setErrorTranslationId('');
-      await account.resetPassword(email);
-
       const result = await account.resetPassword(email);
       navigateToConfirmPwReset({
         passwordForgotToken: result.passwordForgotToken,


### PR DESCRIPTION
## Because

- This fixes some critical bugs
- Fixes location in reset password email

## This pull request

- Fixes bugs
- Adds basic playwright test for react reset password

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6828
Closes: https://mozilla-hub.atlassian.net/browse/FXA-6858
Closes: https://mozilla-hub.atlassian.net/browse/FXA-6859

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

It was easier to write the playwright test than to manually go through the steps over and over to replicate the bug 😅
