### PR TITLE
fix(test): Use `newPagesForSync` in flaky tests and disable coppa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,7 +598,7 @@ jobs:
         default: large
       parallelism:
         type: integer
-        default: 5
+        default: 6
     executor: functional-test-executor
     resource_class: << parameters.resource_class >>
     parallelism: << parameters.parallelism >>

--- a/packages/functional-tests/scripts/test-ci.sh
+++ b/packages/functional-tests/scripts/test-ci.sh
@@ -4,5 +4,5 @@ DIR=$(dirname "$0")
 
 cd "$DIR/../../../"
 
-circleci tests glob "packages/functional-tests/tests/**/*.spec.ts" | circleci tests split > tests-to-run.txt
+circleci tests glob "packages/functional-tests/tests/**/*.spec.ts" | circleci tests split --split-by=timings > tests-to-run.txt
 yarn workspace functional-tests test $(cat tests-to-run.txt|awk -F"/" '{ print $NF }')

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
+let email = '';
 const PASSWORD = 'passwordzxcv';
 
 test.describe('OAuth signin', () => {
@@ -70,7 +71,7 @@ test.describe('OAuth signin', () => {
     pages: { login, relier },
   }) => {
     // Create unverified account via backend
-    const email = login.createEmail();
+    email = login.createEmail();
     await target.auth.signUp(email, PASSWORD, {
       lang: 'en',
       preVerified: 'false',
@@ -90,7 +91,7 @@ test.describe('OAuth signin', () => {
     pages: { login, relier },
   }) => {
     // Create unverified account
-    const email = login.createEmail();
+    email = login.createEmail();
     const password = 'passwordzxcv';
 
     await relier.goto();
@@ -122,7 +123,7 @@ test.describe('OAuth signin', () => {
     test.slow(project.name !== 'local', 'email delivery can be slow');
 
     // Create unverified account
-    const email = login.createEmail();
+    email = login.createEmail();
 
     await relier.goto();
     await relier.clickChooseFlow();

--- a/packages/functional-tests/tests/signin/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/signin/resetPassword.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '../../lib/fixtures/standard';
-import { EmailHeader, EmailType } from '../../lib/email';
 
 const PASSWORD = 'passwordzxcv';
 let email;

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -5,7 +5,8 @@ test.describe('ui functionality', () => {
     test.slow();
   });
 
-  test('verify discount textbox display', async ({
+  test('verify coupon feature not available when changing plans', async ({
+    page,
     pages: { relier, subscribe },
   }) => {
     await relier.goto();
@@ -13,14 +14,6 @@ test.describe('ui functionality', () => {
 
     // Verify discount section is displayed
     expect(await subscribe.discountTextbox()).toBe(true);
-  });
-
-  test('verify coupon feature not available when changing plans', async ({
-    page,
-    pages: { relier, subscribe },
-  }) => {
-    await relier.goto();
-    await relier.clickSubscribe6Month();
 
     // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
     await subscribe.addCouponCode('auto10pforever');

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 
 const makeUid = () =>
   [...Array(32)]
@@ -10,15 +10,20 @@ const makeUid = () =>
     .join('');
 
 test.describe('Desktop Sync V3 force auth', () => {
+  test.beforeEach(async ({}) => {
+    test.slow();
+  });
+
   test('sync v3 with a registered email, no uid', async ({
     credentials,
-    pages: {
+    target,
+  }) => {
+    const {
       fxDesktopV3ForceAuth,
       login,
       signinTokenCode,
       connectAnotherDevice,
-    },
-  }) => {
+    } = await newPagesForSync(target);
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       uid: undefined,
     });
@@ -35,13 +40,14 @@ test.describe('Desktop Sync V3 force auth', () => {
 
   test('sync v3 with a registered email, registered uid', async ({
     credentials,
-    pages: {
+    target,
+  }) => {
+    const {
       fxDesktopV3ForceAuth,
       login,
       signinTokenCode,
       connectAnotherDevice,
-    },
-  }) => {
+    } = await newPagesForSync(target);
     await fxDesktopV3ForceAuth.open(credentials);
     await login.setPassword(credentials.password);
     await login.submit();
@@ -56,13 +62,14 @@ test.describe('Desktop Sync V3 force auth', () => {
 
   test('sync v3 with a registered email, unregistered uid', async ({
     credentials,
-    pages: {
+    target,
+  }) => {
+    const {
       fxDesktopV3ForceAuth,
       login,
       signinTokenCode,
       connectAnotherDevice,
-    },
-  }) => {
+    } = await newPagesForSync(target);
     const uid = makeUid();
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, { uid });
     await fxDesktopV3ForceAuth.noSuchWebChannelMessage('fxaccounts:logout');
@@ -79,8 +86,9 @@ test.describe('Desktop Sync V3 force auth', () => {
 
   test('sync v3 with an unregistered email, no uid', async ({
     credentials,
-    pages: { fxDesktopV3ForceAuth, login },
+    target,
   }) => {
+    const { fxDesktopV3ForceAuth, login } = await newPagesForSync(target);
     const email = `sync${Math.random()}@restmail.net`;
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       email,
@@ -104,8 +112,9 @@ test.describe('Desktop Sync V3 force auth', () => {
 
   test('sync v3 with an unregistered email, registered uid', async ({
     credentials,
-    pages: { fxDesktopV3ForceAuth, login },
+    target,
   }) => {
+    const { fxDesktopV3ForceAuth, login } = await newPagesForSync(target);
     const email = `sync${Math.random()}@restmail.net`;
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       email,
@@ -123,8 +132,9 @@ test.describe('Desktop Sync V3 force auth', () => {
 
   test('sync v3 with an unregistered email, unregistered uid', async ({
     credentials,
-    pages: { fxDesktopV3ForceAuth, login },
+    target,
   }) => {
+    const { fxDesktopV3ForceAuth, login } = await newPagesForSync(target);
     const email = `sync${Math.random()}@restmail.net`;
     const uid = makeUid();
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
@@ -144,8 +154,10 @@ test.describe('Desktop Sync V3 force auth', () => {
 
   test('blocked with an registered email, unregistered uid', async ({
     credentials,
-    pages: { fxDesktopV3ForceAuth, login, connectAnotherDevice },
+    target,
   }) => {
+    const { fxDesktopV3ForceAuth, login, connectAnotherDevice } =
+      await newPagesForSync(target);
     const uid = makeUid();
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       uid,

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -9,7 +9,7 @@ const password = 'passwordzxcv';
 let email;
 
 test.describe('Firefox Desktop Sync v3 sign in', () => {
-  test.beforeEach(async ({ page, pages: { login } }) => {
+  test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     email = login.createEmail('sync{id}');
   });

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 
 const password = 'passwordzxcv';
 const incorrectPassword = 'password123';
@@ -12,14 +12,11 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
   test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     email = login.createEmail('sync{id}');
-    await login.clearCache();
   });
 
-  test('sign up', async ({
-    target,
-    page,
-    pages: { login, signinTokenCode, connectAnotherDevice },
-  }) => {
+  test('sign up', async ({ target }) => {
+    const { login, signinTokenCode, page, connectAnotherDevice } =
+      await newPagesForSync(target);
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'networkidle' }
@@ -46,11 +43,8 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
     expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
   });
 
-  test('coppa disabled', async ({
-    target,
-    page,
-    pages: { login, connectAnotherDevice },
-  }) => {
+  test.skip('coppa disabled', async ({ target }) => {
+    const { login, page, connectAnotherDevice } = await newPagesForSync(target);
     const query = { coppa: 'false' };
     const queryParam = new URLSearchParams(query);
     await page.goto(
@@ -70,11 +64,8 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
     expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
   });
 
-  test('email specified by relier, invalid', async ({
-    target,
-    page,
-    pages: { login },
-  }) => {
+  test('email specified by relier, invalid', async ({ target }) => {
+    const { page, login } = await newPagesForSync(target);
     const invalidEmail = 'invalid@@';
     const query = { email: invalidEmail };
     const queryParam = new URLSearchParams(query);
@@ -86,11 +77,8 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
     expect(await login.getTooltipError()).toMatch('Valid email required');
   });
 
-  test('email specified by relier, empty string', async ({
-    target,
-    page,
-    pages: { login },
-  }) => {
+  test('email specified by relier, empty string', async ({ target }) => {
+    const { page, login } = await newPagesForSync(target);
     const emptyEmail = '';
     const query = { email: emptyEmail };
     const queryParam = new URLSearchParams(query);
@@ -102,11 +90,8 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
     expect(await login.getTooltipError()).toMatch('Valid email required');
   });
 
-  test('email specified by relier, not registered', async ({
-    target,
-    page,
-    pages: { login },
-  }) => {
+  test('email specified by relier, not registered', async ({ target }) => {
+    const { page, login } = await newPagesForSync(target);
     const query = { email };
     const queryParam = new URLSearchParams(query);
     await page.goto(
@@ -122,11 +107,8 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
     expect(await login.getPrefilledEmail()).toMatch(email);
   });
 
-  test('email specified by relier, registered', async ({
-    target,
-    page,
-    pages: { login },
-  }) => {
+  test('email specified by relier, registered', async ({ target }) => {
+    const { page, login } = await newPagesForSync(target);
     await target.auth.signUp(email, password, {
       lang: 'en',
       preVerified: 'true',

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 
 const PASSWORD = 'passwordzxcv';
 let email;
 
 test.describe('Firefox Desktop Sync v3 email first', () => {
-  test.beforeEach(async ({ target, credentials, pages: { login } }) => {
+  test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     email = login.createEmail('sync{id}');
-    await login.clearCache();
   });
 
   test('open directly to /signup page, refresh on the /signup page', async ({
     target,
-    page,
-    pages: { login },
   }) => {
+    const { page, login } = await newPagesForSync(target);
     await page.goto(
       `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'networkidle' }
@@ -39,9 +37,8 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
 
   test('open directly to /signin page, refresh on the /signin page', async ({
     target,
-    page,
-    pages: { login },
   }) => {
+    const { page, login } = await newPagesForSync(target);
     await target.auth.signUp(email, PASSWORD, {
       lang: 'en',
       preVerified: 'true',
@@ -64,11 +61,8 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     expect(await login.isEmailHeader()).toBe(true);
   });
 
-  test('enter a firefox.com address', async ({
-    target,
-    page,
-    pages: { login, signinTokenCode },
-  }) => {
+  test('enter a firefox.com address', async ({ target }) => {
+    const { page, login, signinTokenCode } = await newPagesForSync(target);
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'networkidle' }

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -2,28 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
 const PASSWORD = 'passwordzxcv';
+let email = '';
 
 test.describe('Firefox Desktop Sync v3 reset password', () => {
-  test.beforeEach(({}, testInfo) => {
-    test.slow(testInfo.project.name !== 'local', 'email delivery can be slow');
+  test.beforeEach(() => {
+    test.slow();
   });
 
-  test('reset password, verify same browser', async ({
-    target,
-    page,
-    pages: { login, resetPassword },
-  }) => {
+  test('reset password, verify same browser', async ({ target }) => {
+    const { page, login, resetPassword } = await newPagesForSync(target);
     const uaStrings = {
       desktop_firefox_58:
         'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:58.0) Gecko/20100101 Firefox/58.0',
     };
     const query = { forceUA: uaStrings['desktop_firefox_58'] };
     const queryParam = new URLSearchParams(query);
-    const email = login.createEmail();
+    email = login.createEmail();
     await target.auth.signUp(email, PASSWORD, {
       lang: 'en',
       preVerified: 'true',
@@ -48,14 +46,13 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
 
   test('reset password, verify same browser, password validation', async ({
     target,
-    page,
-    pages: { login, resetPassword },
   }) => {
+    const { page, login, resetPassword } = await newPagesForSync(target);
     const query = {
       forceExperiment: 'passwordStrength',
       forceExperimentGroup: 'designF',
     };
-    const email = login.createEmail();
+    email = login.createEmail();
     await target.auth.signUp(email, PASSWORD, {
       lang: 'en',
       preVerified: 'true',


### PR DESCRIPTION
## Because

- See this [comment](https://github.com/mozilla/fxa/blob/2fcfd881cb130eff6b1ee2228ad161aa408b8dd9/packages/functional-tests/lib/fixtures/standard.ts#L121) why we could potentially run into flaky tests that utilize Sync

## This pull request

- Use `newPagesForSync` that guaranttes the test is isolated

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6936

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

