### PR TITLE
feat(fxa-settings): setup signin_reported route in React app

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -356,7 +356,12 @@ Router = Router.extend({
       type: VerificationReasons.SIGN_IN,
     }),
     'signin_recovery_code(/)': createViewHandler(SignInRecoveryCodeView),
-    'signin_reported(/)': createViewHandler(SignInReportedView),
+    'signin_reported(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'signin_reported',
+        SignInReportedView
+      );
+    },
     'signin_token_code(/)': createViewHandler(SignInTokenCodeView, {
       type: VerificationReasons.SIGN_IN,
     }),

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -50,7 +50,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
 
     signInRoutes: {
       featureFlagOn: showReactApp.signInRoutes,
-      routes: [],
+      routes: reactRoute.getRoutes(['signin_reported']),
     },
 
     signUpRoutes: {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -27,6 +27,8 @@ import AccountRecoveryConfirmKey from '../../pages/ResetPassword/AccountRecovery
 import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
 import ConfirmSignupCode from '../../pages/Signup/ConfirmSignupCode';
 
+import SigninReported from '../../pages/Signin/SigninReported';
+
 export const App = ({
   flowQueryParams,
 }: { flowQueryParams: QueryParams } & RouteComponentProps) => {
@@ -55,6 +57,8 @@ export const App = ({
               <ConfirmResetPassword path="/confirm_reset_password/*" />
               <CompleteResetPassword path="/complete_reset_password/*" />
               <AccountRecoveryConfirmKey path="/account_recovery_confirm_key/*" />
+
+              <SigninReported path="/signin_reported/*" />
               {/* Pages using the Ready view need to be accessible to logged out viewers,
                * but need to be able to check if the user is logged in or logged out,
                * so they are wrapped in this component.

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.stories.tsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import SigninReported from '.';
-import AppLayout from '../../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from '../../../../.storybook/decorators';
@@ -17,8 +16,6 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
-      <SigninReported />
-    </AppLayout>
+    <SigninReported />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.tsx
@@ -8,6 +8,7 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { RouteComponentProps } from '@reach/router';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import CardHeader from '../../../components/CardHeader';
+import AppLayout from '../../../components/AppLayout';
 
 export const viewName = 'signin-reported';
 
@@ -15,7 +16,7 @@ const SigninReported = (props: RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   return (
-    <>
+    <AppLayout>
       <CardHeader
         headingText="Thank you for your vigilance"
         headingTextFtlId="signin-reported-header"
@@ -26,7 +27,7 @@ const SigninReported = (props: RouteComponentProps) => {
           intruders.
         </p>
       </FtlMsg>
-    </>
+    </AppLayout>
   );
 };
 


### PR DESCRIPTION
## Because:

* We're moving the `/signin` routes into the React app behind a feature flag

## This commit:

* Moves the `/signin_reported` route into the React app behind a feature flag, with metrics, tests and localization

Closes #FXA-6486

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before: 
<img width="559" alt="Screen Shot 2023-03-03 at 8 46 01 AM" src="https://user-images.githubusercontent.com/11150372/222778296-5ff83b78-d58e-40eb-bb1a-974cc51d51f3.png">


After:
<img width="570" alt="Screen Shot 2023-03-03 at 8 46 11 AM" src="https://user-images.githubusercontent.com/11150372/222778217-7cd6d60b-ce78-41c9-aac8-9e7b5eb7930b.png">

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Still need to add metrics to the excel doc
