### PR TITLE
chore(metrics): count RPs fetching scoped keys

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -11,7 +11,7 @@ module.exports = (log, config, db, mailer, devices, statsd) => {
     require('./introspect')({ oauthDB }),
     require('./jwks')(),
     require('./key_data')({ log, oauthDB, statsd }),
-    require('./token')({ log, oauthDB, db, mailer, devices }),
+    require('./token')({ log, oauthDB, db, mailer, devices, statsd }),
     require('./verify')({ log }),
   ].flat();
 

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -179,7 +179,7 @@ const PAYLOAD_SCHEMA = Joi.object({
   resource: validators.resourceUrl.optional().description(DESCRIPTION.resource),
 });
 
-module.exports = ({ log, oauthDB, db, mailer, devices }) => {
+module.exports = ({ log, oauthDB, db, mailer, devices, statsd }) => {
   async function validateGrantParameters(client, params) {
     let requestedGrant;
     switch (params.grant_type) {
@@ -377,6 +377,12 @@ module.exports = ({ log, oauthDB, db, mailer, devices }) => {
       service: hex(grant.clientId),
       uid: hex(grant.userId),
     });
+
+    // the client receiving keys at the end of the scoped keys flow
+    if (tokens.keys_jwe) {
+      statsd.increment('oauth.rp.keys-jwe', { clientId: hex(client.id) });
+    }
+
     return tokens;
   }
 


### PR DESCRIPTION
Because:
 - we want to quantify scoped keys usage

This commit:
 - add statsd metrics to count the RPs getting scoped keys
