### PR TITLE
fix(content-server): Revise Contact Support confirmation modal

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/support-form-success.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/support-form-success.mustache
@@ -3,5 +3,5 @@
   <div class="message">
     <p>{{{message}}}</p>
   </div>
-  <button class="settings-button primary-button cta-primary cta-base-p">{{#t}}Back to Subscriptions{{/t}}</button>
+  <button class="settings-button primary-button center-text cta-primary cta-base-p">{{#t}}Back to Subscriptions{{/t}}</button>
 </div>

--- a/packages/fxa-content-server/app/styles/modules/support.scss
+++ b/packages/fxa-content-server/app/styles/modules/support.scss
@@ -77,11 +77,17 @@
   .message {
     font-size: 16px;
     line-height: 1.5;
-    margin-bottom: 30px;
+    margin-top: 10px;
+    margin-bottom: 20px;
 
     p {
       margin-bottom: 0;
     }
+  }
+
+  .center-text {
+    display: inline-grid;
+    align-content: center;
   }
 
   &.dialog-error,


### PR DESCRIPTION
## Because

- The "Back to Subscriptions" text is not centered within the button
- There should be more space between the title and message of the confirmation modal

## This pull request

- Centers the text within the button
- Increases the margin above the message of the confirmation modal
- Decreases the margin below the message of the confirmation modal

## Issue that this pull request solves

Closes: [FXA-6678](https://mozilla-hub.atlassian.net/browse/FXA-6678)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Before
<img width="424" alt="Screenshot 2023-03-03 at 4 40 00 PM" src="https://user-images.githubusercontent.com/28129806/222834419-e750beaf-1164-4d59-856a-64230f1da3a1.png">

After
<img width="425" alt="Screenshot 2023-03-03 at 4 38 56 PM" src="https://user-images.githubusercontent.com/28129806/222834285-4ca5b34d-1ee1-42a9-aad6-6734319cd967.png">


[FXA-6678]: https://mozilla-hub.atlassian.net/browse/FXA-6678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ