### PR TITLE
task(subscriptions): subsequent invoice for canceled sub

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -765,14 +765,21 @@ export class StripeHelper extends StripeHelperBase {
   async previewInvoiceBySubscriptionId({
     automaticTax,
     subscriptionId,
+    includeCanceled,
   }: {
     automaticTax: boolean;
     subscriptionId: string;
+    includeCanceled?: boolean;
   }) {
+    const retrieveUpcomingParams = {
+      ...(includeCanceled && { subscription_cancel_at_period_end: false }),
+      ...{ subscription: subscriptionId },
+    };
+
     if (automaticTax) {
       try {
         return await this.stripe.invoices.retrieveUpcoming({
-          subscription: subscriptionId,
+          ...retrieveUpcomingParams,
           automatic_tax: {
             enabled: true,
           },
@@ -785,9 +792,9 @@ export class StripeHelper extends StripeHelperBase {
         throw e;
       }
     } else {
-      return await this.stripe.invoices.retrieveUpcoming({
-        subscription: subscriptionId,
-      });
+      return await this.stripe.invoices.retrieveUpcoming(
+        retrieveUpcomingParams
+      );
     }
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -494,14 +494,13 @@ export class StripeHandler {
     }
 
     const subsequentInvoicePreviews = await Promise.all(
-      customer.subscriptions.data
-        .filter((sub) => !sub.canceled_at)
-        .map((sub) => {
-          return this.stripeHelper.previewInvoiceBySubscriptionId({
-            automaticTax: automaticTax && sub.automatic_tax.enabled,
-            subscriptionId: sub.id,
-          });
-        })
+      customer.subscriptions.data.map((sub) => {
+        return this.stripeHelper.previewInvoiceBySubscriptionId({
+          automaticTax: automaticTax && sub.automatic_tax.enabled,
+          subscriptionId: sub.id,
+          includeCanceled: !!sub.canceled_at,
+        });
+      })
     );
 
     return stripeInvoicesToSubsequentInvoicePreviewsDTO(

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2240,6 +2240,24 @@ describe('#integration - StripeHelper', () => {
       });
     });
 
+    it('uses country when automatic tax is not enabled', async () => {
+      const stripeStub = sandbox
+        .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
+        .resolves();
+      sandbox.stub(stripeHelper, 'taxRateByCountryCode').resolves();
+
+      await stripeHelper.previewInvoiceBySubscriptionId({
+        automaticTax: false,
+        subscriptionId: 'sub123',
+        includeCanceled: true,
+      });
+
+      sinon.assert.calledOnceWithExactly(stripeStub, {
+        subscription: 'sub123',
+        subscription_cancel_at_period_end: false,
+      });
+    });
+
     it('uses shipping address when automatic tax is enabled', async () => {
       const stripeStub = sandbox
         .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -10,9 +10,8 @@ import DialogMessage from '../../../components/DialogMessage';
 import fpnImage from '../../../images/fpn';
 import { Plan, Customer } from '../../../store/types';
 import { webIconConfigFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
-import { WebSubscription } from 'fxa-shared/subscriptions/types';
 import AppContext from '../../../lib/AppContext';
-import { couponOnSubsequentInvoice } from '../../../lib/coupon';
+import { SubsequentInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 const ConfirmationDialogContent = ({
   onConfirm,
@@ -114,14 +113,14 @@ const ConfirmationDialog = ({
   onConfirm,
   plan,
   customer,
-  customerSubscription,
+  subsequentInvoice,
   periodEndDate,
 }: {
   onDismiss: Function;
   onConfirm: () => void;
   plan: Plan;
   customer: Customer;
-  customerSubscription: WebSubscription;
+  subsequentInvoice: SubsequentInvoicePreview;
   periodEndDate: number;
 }) => {
   const { navigatorLanguages, config } = useContext(AppContext);
@@ -132,26 +131,7 @@ const ConfirmationDialog = ({
   );
   const { last4 } = customer;
 
-  const {
-    promotion_code: promotionCode,
-    promotion_end,
-    current_period_end,
-    promotion_duration,
-  } = customerSubscription;
-
-  const includeCoupon =
-    promotionCode &&
-    couponOnSubsequentInvoice(
-      current_period_end,
-      promotion_end,
-      promotion_duration
-    );
-
-  // Depending on whether or not the coupon should be applied to the next invoice
-  // use total or subtotal.
-  const amount = includeCoupon
-    ? customerSubscription.latest_invoice_items.total
-    : customerSubscription.latest_invoice_items.subtotal;
+  const amount = subsequentInvoice.total;
 
   const ariaLabelledBy = 'confirmation-content-header';
   const ariaDescribedBy = 'confirmation-content-description';

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -11,17 +11,20 @@ import { getLocalizedDateString, getLocalizedDate } from '../../../lib/formats';
 import { ActionFunctions } from '../../../store/actions';
 import ReactivationConfirmationDialog from './ConfirmationDialog';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
+import { SubsequentInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 const ReactivateSubscriptionPanel = ({
   plan,
   customerSubscription,
   customer,
   reactivateSubscription,
+  subsequentInvoice,
 }: {
   plan: Plan;
   customerSubscription: WebSubscription;
   customer: Customer;
   reactivateSubscription: ActionFunctions['reactivateSubscription'];
+  subsequentInvoice: SubsequentInvoicePreview;
 }) => {
   const { subscription_id } = customerSubscription;
   const [
@@ -51,6 +54,7 @@ const ReactivateSubscriptionPanel = ({
             customer,
             periodEndDate: periodEndTimeStamp,
             customerSubscription,
+            subsequentInvoice,
           }}
           onDismiss={hideReactivateConfirmation}
           onConfirm={onReactivateClick}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -74,10 +74,7 @@ export const SubscriptionItem = ({
     );
   }
 
-  if (
-    customerSubscription.cancel_at_period_end === false &&
-    !((total || total === 0) && period_start)
-  ) {
+  if (!subsequentInvoice) {
     const ariaLabelledBy = 'invoice-not-found-header';
     const ariaDescribedBy = 'invoice-not-found-description';
     return (
@@ -134,6 +131,7 @@ export const SubscriptionItem = ({
                 customer,
                 customerSubscription,
                 reactivateSubscription,
+                subsequentInvoice,
               }}
             />
           </>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -631,38 +631,32 @@ describe('routes/Subscriptions', () => {
         ];
 
     let latest_invoice_items;
-    let otherPromotionItems;
+    let mockSubsequentInvoices;
     switch (discount) {
       case 'ENDS_NEXT_INTERVAL':
         latest_invoice_items = {
           ...MOCK_LATEST_INVOICE_ITEMS,
-          total: 685,
+          total: 735,
         };
-        otherPromotionItems = {
-          promotion_code: 'PROMO50',
-          promotion_end: 1568408388.815,
-          promotion_duration: 'repeating',
-        };
+        mockSubsequentInvoices = [
+          { ...MOCK_SUBSEQUENT_INVOICES[0], total: 735 },
+        ];
         break;
       case 'ONGOING':
         latest_invoice_items = {
           ...MOCK_LATEST_INVOICE_ITEMS,
           total: 685,
         };
-        otherPromotionItems = {
-          promotion_code: 'PROMO50',
-          promotion_end: 1677273263.815,
-          promotion_duration: 'repeating',
-        };
+        mockSubsequentInvoices = [
+          { ...MOCK_SUBSEQUENT_INVOICES[0], total: 685 },
+        ];
         break;
       case 'NONE':
       default:
         latest_invoice_items = MOCK_LATEST_INVOICE_ITEMS;
-        otherPromotionItems = {
-          promotion_code: undefined,
-          promotion_end: null,
-          promotion_duration: null,
-        };
+        mockSubsequentInvoices = [
+          { ...MOCK_SUBSEQUENT_INVOICES[0], total: 735 },
+        ];
         break;
     }
 
@@ -685,7 +679,6 @@ describe('routes/Subscriptions', () => {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
-            ...otherPromotionItems,
             _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
@@ -717,7 +710,6 @@ describe('routes/Subscriptions', () => {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
-            ...otherPromotionItems,
             _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
@@ -734,7 +726,7 @@ describe('routes/Subscriptions', () => {
       });
     nock(authServer)
       .get('/v1/oauth/subscriptions/invoice/preview-subsequent')
-      .reply(200, MOCK_SUBSEQUENT_INVOICES);
+      .reply(200, mockSubsequentInvoices);
   }
 
   const expectProductImage = ({


### PR DESCRIPTION
## Because

- The total amount does not include tax.

## This pull request

- Fetch subsequent invoice for canceled subscription.
- Updates Reactivate subscription model to use subsequent invoice.

## Issue that this pull request solves

Closes: #FXA-6996

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).