### PR TITLE
chore(deps): use mainline webcrypto-liner

### DIFF
--- a/packages/fxa-auth-client/lib/crypto.ts
+++ b/packages/fxa-auth-client/lib/crypto.ts
@@ -255,7 +255,7 @@ export async function checkWebCrypto() {
       window.asmCrypto = await import(/* webpackChunkName: "asmcrypto.js" */ 'asmcrypto.js');
       // prettier-ignore
       // @ts-ignore
-      await import(/* webpackChunkName: "webcrypto-liner" */ 'webcrypto-liner/build/shim');
+      await import(/* webpackChunkName: "webcrypto-liner" */ 'webcrypto-liner/build/webcrypto-liner.shim.min');
       return true;
     } catch (e) {
       return false;

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -36,7 +36,7 @@
     "fast-text-encoding": "^1.0.4",
     "mocha": "^10.0.0",
     "typescript": "^4.9.3",
-    "webcrypto-liner": "https://github.com/mozilla-fxa/webcrypto-liner.git#30d4ecdfbbe33535ad43f31bf3f0407edce543a3"
+    "webcrypto-liner": "^1.4.0"
   },
   "mocha": {
     "reporter": "mocha-multi",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -136,7 +136,7 @@
     "ua-parser-js": "1.0.33",
     "underscore": "^1.13.1",
     "verror": "1.10.1",
-    "webcrypto-liner": "https://github.com/mozilla-fxa/webcrypto-liner.git#30d4ecdfbbe33535ad43f31bf3f0407edce543a3",
+    "webcrypto-liner": "1.4.0",
     "webpack": "^4.41.2",
     "webpack-cli": "^4.10.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,21 +3938,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dannycoates/elliptic@npm:^6.4.2":
-  version: 6.4.2
-  resolution: "@dannycoates/elliptic@npm:6.4.2"
-  dependencies:
-    bn.js: ^4.4.0
-    brorand: ^1.0.1
-    hash.js: ^1.0.0
-    hmac-drbg: ^1.0.0
-    inherits: ^2.0.1
-    minimalistic-assert: ^1.0.0
-    minimalistic-crypto-utils: ^1.0.0
-  checksum: 55d5635fceb3560da05682acda5085ce8b5f4f633e669d0ce077229b70492aa6600d506eb4cb26ede7d6e171dceada3a4dc6340dbe70faeb5a411e5afe18cdf5
-  languageName: node
-  linkType: hard
-
 "@discoveryjs/json-ext@npm:^0.5.0, @discoveryjs/json-ext@npm:^0.5.3":
   version: 0.5.3
   resolution: "@discoveryjs/json-ext@npm:0.5.3"
@@ -8465,6 +8450,47 @@ __metadata:
   version: 0.7.1
   resolution: "@sinonjs/text-encoding@npm:0.7.1"
   checksum: 130de0bb568c5f8a611ec21d1a4e3f80ab0c5ec333010f49cfc1adc5cba6d8808699c8a587a46b0f0b016a1f4c1389bc96141e773e8460fcbb441875b2e91ba7
+  languageName: node
+  linkType: hard
+
+"@stablelib/binary@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/binary@npm:1.0.1"
+  dependencies:
+    "@stablelib/int": ^1.0.1
+  checksum: dca9b98eb1f56a4002b5b9e7351fbc49f3d8616af87007c01e833bd763ac89214eb5f3b7e18673c91ce59d4a0e4856a2eb661ace33d39f17fb1ad267271fccd8
+  languageName: node
+  linkType: hard
+
+"@stablelib/hash@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/hash@npm:1.0.1"
+  checksum: 3ff1f12d1a4082aaf4b6cdf40c2010aabe5c4209d3b40b97b5bbb0d9abc0ee94abdc545e57de0614afaea807ca0212ac870e247ec8f66cdce91ec39ce82948cf
+  languageName: node
+  linkType: hard
+
+"@stablelib/int@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/int@npm:1.0.1"
+  checksum: 65bfbf50a382eea70c68e05366bf379cfceff8fbc076f1c267ef2f2411d7aed64fd140c415cb6c29f19a3910d3b8b7805d4b32ad5721a5007a8e744a808c7ae3
+  languageName: node
+  linkType: hard
+
+"@stablelib/sha3@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/sha3@npm:1.0.1"
+  dependencies:
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/hash": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 301a33a91d515ca135ce923bb3b775f4707241444bebad39614a5a0e5bf2bb3277979a625cf0c91417f75c97793ab4493a7e65cd092333959ff08463433fa2e3
+  languageName: node
+  linkType: hard
+
+"@stablelib/wipe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/wipe@npm:1.0.1"
+  checksum: 287802eb146810a46ba72af70b82022caf83a8aeebde23605f5ee0decf64fe2b97a60c856e43b6617b5801287c30cfa863cfb0469e7fcde6f02d143cf0c6cbf4
   languageName: node
   linkType: hard
 
@@ -15435,6 +15461,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asmcrypto.js@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "asmcrypto.js@npm:2.3.2"
+  checksum: d61722be99d51c9a09093166412354845fb6ba278374b0cccfb33b18ad9edd26019ced171ae286b1d55c57edd8702fe87d2eec096f20fb2080ee52f8ba4b995e
+  languageName: node
+  linkType: hard
+
 "asn1.js@npm:1.0.3":
   version: 1.0.3
   resolution: "asn1.js@npm:1.0.3"
@@ -15481,7 +15514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1js@npm:^3.0.1, asn1js@npm:^3.0.4":
+"asn1js@npm:^3.0.1, asn1js@npm:^3.0.2, asn1js@npm:^3.0.4":
   version: 3.0.5
   resolution: "asn1js@npm:3.0.5"
   dependencies:
@@ -17385,7 +17418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.4.0":
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0":
   version: 4.11.8
   resolution: "bn.js@npm:4.11.8"
   checksum: 80d4709cd58a21f0be8201e9e5859fea5ef133318e9800c8454cd334625c6e1caea593ca21f9b9a085fb560fbc12fb2fb3514363f8604258db924237fd039139
@@ -20168,6 +20201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.22.5":
+  version: 3.29.0
+  resolution: "core-js@npm:3.29.0"
+  checksum: 2bd69d783efcd2ef9197ce892a8b91d7b2fd86dddce805a3be0ff721013a2342eeab0f7d0b4b5548c1377b9846a8fb81485054efd39618b9d1a1fca04af81ccf
+  languageName: node
+  linkType: hard
+
 "core-js@npm:^3.26.0":
   version: 3.26.0
   resolution: "core-js@npm:3.26.0"
@@ -21535,7 +21575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"des.js@npm:^1.0.0":
+"des.js@npm:^1.0.0, des.js@npm:^1.0.1":
   version: 1.0.1
   resolution: "des.js@npm:1.0.1"
   dependencies:
@@ -25727,7 +25767,7 @@ fsevents@~2.1.1:
     mocha: ^10.0.0
     node-fetch: ^2.6.7
     typescript: ^4.9.3
-    webcrypto-liner: "https://github.com/mozilla-fxa/webcrypto-liner.git#30d4ecdfbbe33535ad43f31bf3f0407edce543a3"
+    webcrypto-liner: ^1.4.0
   languageName: unknown
   linkType: soft
 
@@ -26054,7 +26094,7 @@ fsevents@~2.1.1:
     upng-js: 2.1.0
     url-loader: 4.1.1
     verror: 1.10.1
-    webcrypto-liner: "https://github.com/mozilla-fxa/webcrypto-liner.git#30d4ecdfbbe33535ad43f31bf3f0407edce543a3"
+    webcrypto-liner: 1.4.0
     webpack: ^4.41.2
     webpack-cli: ^4.10.0
     webpack-dev-middleware: ^5.3.3
@@ -28870,7 +28910,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"hmac-drbg@npm:^1.0.0, hmac-drbg@npm:^1.0.1":
+"hmac-drbg@npm:^1.0.1":
   version: 1.0.1
   resolution: "hmac-drbg@npm:1.0.1"
   dependencies:
@@ -35886,7 +35926,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"minimalistic-crypto-utils@npm:^1.0.0, minimalistic-crypto-utils@npm:^1.0.1":
+"minimalistic-crypto-utils@npm:^1.0.1":
   version: 1.0.1
   resolution: "minimalistic-crypto-utils@npm:1.0.1"
   checksum: 6e8a0422b30039406efd4c440829ea8f988845db02a3299f372fceba56ffa94994a9c0f2fd70c17f9969eedfbd72f34b5070ead9656a34d3f71c0bd72583a0ed
@@ -48135,7 +48175,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.7.1, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -49682,15 +49722,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"webcrypto-core@https://github.com/mozilla-fxa/webcrypto-core.git#e0bb9e60e7df2abc6d13caf4a15cf22188e2981a":
-  version: 0.1.19
-  resolution: "webcrypto-core@https://github.com/mozilla-fxa/webcrypto-core.git#commit=e0bb9e60e7df2abc6d13caf4a15cf22188e2981a"
-  dependencies:
-    tslib: ^1.7.1
-  checksum: f4517671da54620b5ac643749313c63b479427e8ffd59e4dc52b0c2b255555fec5d02b9aa4c55fe1d3d582a2bf3800313a20164ff9fbe2c284694994605660d7
-  languageName: node
-  linkType: hard
-
 "webcrypto-core@npm:^1.7.4":
   version: 1.7.5
   resolution: "webcrypto-core@npm:1.7.5"
@@ -49704,14 +49735,35 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"webcrypto-liner@https://github.com/mozilla-fxa/webcrypto-liner.git#30d4ecdfbbe33535ad43f31bf3f0407edce543a3":
-  version: 0.1.36
-  resolution: "webcrypto-liner@https://github.com/mozilla-fxa/webcrypto-liner.git#commit=30d4ecdfbbe33535ad43f31bf3f0407edce543a3"
+"webcrypto-core@npm:^1.7.5":
+  version: 1.7.6
+  resolution: "webcrypto-core@npm:1.7.6"
   dependencies:
-    "@dannycoates/elliptic": ^6.4.2
-    asmcrypto.js: ^0.22.0
-    webcrypto-core: "https://github.com/mozilla-fxa/webcrypto-core.git#e0bb9e60e7df2abc6d13caf4a15cf22188e2981a"
-  checksum: 52544d9ad86b4cfd78c79634a0a996604aeffdb125655601b9f043e8240db4440b67c62fc611f5077e1552a6a24f62bb4b3aa9d6c39ab022e20dc415b51a4a0b
+    "@peculiar/asn1-schema": ^2.1.6
+    "@peculiar/json-schema": ^1.1.12
+    asn1js: ^3.0.1
+    pvtsutils: ^1.3.2
+    tslib: ^2.4.0
+  checksum: 0503c92cd1fc8861383872774963104bf3d7ddf0a35cadd841862f0488e4613bdf23499d06b31938a4f2cf333bfde8dacc24e349c5e943e44246f3fcb623c7d0
+  languageName: node
+  linkType: hard
+
+"webcrypto-liner@npm:1.4.0, webcrypto-liner@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "webcrypto-liner@npm:1.4.0"
+  dependencies:
+    "@peculiar/asn1-schema": ^2.1.6
+    "@peculiar/json-schema": ^1.1.12
+    "@stablelib/sha3": ^1.0.1
+    asmcrypto.js: ^2.3.2
+    asn1js: ^3.0.2
+    core-js: ^3.22.5
+    des.js: ^1.0.1
+    elliptic: "git+https://github.com/mahrud/elliptic.git"
+    pvtsutils: ^1.3.2
+    tslib: ^2.4.0
+    webcrypto-core: ^1.7.5
+  checksum: ebb395e07abf63e58a6fe52a567f16b7d162b8cba078d3b13b29cae9b3c9e16c94557f4affbbb9fb6b60ac1954f10b0584b232a5d4fefd335dd1baf37a5fdb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
 - we don't need to use our own fork and branch of webcrypto-liner now that it implements hkdf
   - we will continue to polyfill since node's webcrypto module is still experimental as of v18

This commit:
 - uses mainline webcrypto-liner
