### PR TITLE
chore(robots.txt): block the archive.org bot from indexing

### DIFF
--- a/packages/fxa-content-server/app/robots.txt
+++ b/packages/fxa-content-server/app/robots.txt
@@ -3,5 +3,9 @@
 # any site contents in their index.
 #
 # [1] https://support.google.com/webmasters/answer/93710
+
+User-agent: archive.org_bot
+Disallow: /
+
 User-agent: *
 Allow:


### PR DESCRIPTION
Because:
 - FxA is just a login page for someone who's not authenticated

This commit:
 - stops archive.org from indexing FxA into the wayback machine
