### PR TITLE
feat(auth): add GeoDB Location Override

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -86,6 +86,64 @@ Use the following as a template, and fill in your own values:
 
 The sandbox PayPal business account API credentials above can be found in the PayPal developer dashboard under ["Sandbox" > "Accounts"](https://developer.paypal.com/developer/accounts/). You may need to create a business account if one doesn't exist.
 
+## Stripe Tax
+
+### Enabling Stripe Tax
+
+To enable Stripe Tax in the Auth server you can: enable `stripeAutomaticTax` in your secrets.json or through your environment variables with `SUBSCRIPTIONS_STRIPE_AUTOMATIC_TAX`
+
+Example using secrets.json:
+
+```json
+{
+  "subscriptions": {
+    "stripeAutomaticTax": {
+      "enabled": true
+    }
+  }
+}
+```
+
+or with a `.env` file and `dotenv`
+
+```
+SUBSCRIPTIONS_STRIPE_AUTOMATIC_TAX=true
+```
+
+### Testing With Stripe Tax
+
+When running the FxA stack locally, our geodb service needs an override to resolve a location. This override object takes the form of:
+
+```json
+{
+  "location": {
+    "countryCode": <2 letter country code string>,
+    "postalCode": <corresponding postal code string>
+  }
+}
+```
+
+and can be passed in either through your `secrets.json` or through your environment variables.
+
+Example using `secrets.json`:
+
+```json
+  "geodb": {
+    "locationOverride": {
+      "location": {
+        "countryCode": "US",
+        "postalCode": "98332"
+      }
+    }
+  },
+```
+
+or with a `.env` file using `dotenv`
+
+```
+GEODB_LOCATION_OVERRIDE= { "location": { "countryCode": "US", "postalCode": "85001"} }
+```
+
 ## Linting
 
 Run lint with:

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -143,6 +143,12 @@ const convictConf = convict({
       env: 'GEODB_LOG_ACCURACY',
       format: Boolean,
     },
+    locationOverride: {
+      doc: 'override for forcing location',
+      format: Object,
+      default: {},
+      env: 'GEODB_LOCATION_OVERRIDE',
+    },
   },
   appleAuthConfig: {
     clientId: {

--- a/packages/fxa-auth-server/lib/geodb.js
+++ b/packages/fxa-auth-server/lib/geodb.js
@@ -28,6 +28,15 @@ module.exports = (log) => {
     }
 
     try {
+      const locationOverride = config.locationOverride.location;
+      if (
+        !!locationOverride &&
+        locationOverride.countryCode &&
+        locationOverride.postalCode
+      ) {
+        return config.locationOverride;
+      }
+
       const location = geodb(ip);
       const accuracy = location.accuracy;
       let confidence = 'fxa.location.accuracy.';

--- a/packages/fxa-auth-server/test/local/geodb.js
+++ b/packages/fxa-auth-server/test/local/geodb.js
@@ -18,6 +18,7 @@ describe('geodb', () => {
           if (item === 'geodb') {
             return {
               enabled: true,
+              locationOverride: {}
             };
           }
         },


### PR DESCRIPTION
Because:

* we moved away from having stripe resolve IPs to geolocations, and need a way to override our own geodb service during local testing

This commit:

* adds a config/environment variable that foces the geodb to resolve the geolocation of the request to the configured value

Closes #FXA-6883

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).