### PR TITLE
fix(auth): add p-queue to auth server workspace

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -119,6 +119,7 @@
     "node-zendesk": "^2.2.0",
     "nodemailer": "^6.7.3",
     "otplib": "^11.0.1",
+    "p-queue": "^7.3.4",
     "p-retry": "^4.2.0",
     "pem-jwk": "^2.0.0",
     "poolee": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25860,6 +25860,7 @@ fsevents@~2.1.1:
     npm-run-all: ^4.1.5
     nyc: ^15.1.0
     otplib: ^11.0.1
+    p-queue: ^7.3.4
     p-retry: ^4.2.0
     pem-jwk: ^2.0.0
     pm2: ^5.2.2


### PR DESCRIPTION
## Because

* The Stripe automatic tax conversion script depends on p-queue, which was added globally but does not appear to be present in auth-server builds. I believe this is due to the package not being added to the auth-server workspace specifically.

## This pull request

* Adds p-queue as a direct dependency to the auth-server workspace.
