### PR TITLE
fix(metrics): Add statsd metric for events with no service

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -340,6 +340,12 @@ module.exports = (log, config) => {
           time: amplitudeEvent.time + 1,
         });
       }
+
+      if (!service) {
+        // This is to help debug https://mozilla-hub.atlassian.net/browse/FXA-6619
+        const { browser } = getBrowser(request);
+        statsd.increment('amplitude.event.no_service', { browser });
+      }
     } else {
       statsd.increment('amplitude.event.dropped');
     }


### PR DESCRIPTION
## Because

- We are having a hard time tracking down why some metric events have non service

## This pull request

- Adds a statsd metric and browser when non service metric is emitted

## Issue that this pull request solves

Connected: https://mozilla-hub.atlassian.net/browse/FXA-6016

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

