### PR TITLE
task(all): Turn on editor.formatOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
   },
   "python.pythonPath": "usr/bin/python3",
   "prettier.configPath": "_dev/.prettierrc",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
## Because

- Commits were sneaking through that weren't formatted.
- Improves formatting going forwards. Note that pre-commit hook only format lines change not entire files.

## This pull request

- Turns on format on save by default

## Issue that this pull request solves



## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This might be a bit contentious. We should get buy in from the team around whether or not having auto formatting on save on is typical.
