### PR TITLE
fix(auth): tax conversion script does not escape CSV commas

### DIFF
--- a/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax/convert-customers-to-stripe-automatic-tax.ts
@@ -313,11 +313,11 @@ export class StripeAutomaticTaxConverter {
 
     return [
       report.uid,
-      report.email,
+      `"${report.email}"`,
       report.productId,
-      report.productName,
+      `"${report.productName}"`,
       report.planId,
-      report.planName,
+      `"${report.planName}"`,
       report.planInterval,
       report.planIntervalUnit,
       report.baseAmount,

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.ts
@@ -562,11 +562,11 @@ describe('StripeAutomaticTaxConverter', () => {
 
       sinon.assert.match(result, [
         mockCustomer.metadata.userid,
-        mockCustomer.email,
+        `"${mockCustomer.email}"`,
         mockProduct.id,
-        mockProduct.name,
+        `"${mockProduct.name}"`,
         mockPlan.id,
-        mockPlan.nickname,
+        `"${mockPlan.nickname}"`,
         mockPlan.interval_count,
         mockPlan.interval,
         _mockInvoicePreview.total_excluding_tax,


### PR DESCRIPTION
## Because

* Stripe tax conversion script does not currently escape CSV commas present in the nickname field.

## This pull request

* Escapes commas in the nickname field, as well as the email and product name fields just in case.

## Issue that this pull request solves

Closes FXA-7034
