### PR TITLE
fix: update adr status

### DIFF
--- a/docs/adr/0034-use-structurizr-diagrams.md
+++ b/docs/adr/0034-use-structurizr-diagrams.md
@@ -1,6 +1,6 @@
 # Use Structurizr for Software Diagrams
 
-- Status: proposed
+- Status: accepted
 - Deciders: Ben Bangert, Wil Clouser, Dan Schomburg
 - Date: 2023-01-26
 


### PR DESCRIPTION
Because:

* The ADR was accepted, but status was not updated.

This commit:

* Updates the ADR status to accepted.

