### PR TITLE
task(subscriptions): update tests for archived plans

### DIFF
--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -130,6 +130,16 @@ export const UPGRADE_FROM_PLAN: Plan = {
   },
 };
 
+export const UPGRADE_FROM_PLAN_ARCHIVED: Plan = {
+  ...UPGRADE_FROM_PLAN,
+  product_metadata: {
+    ...UPGRADE_FROM_PLAN.product_metadata,
+  },
+  plan_id: 'plan_cba_archived',
+  product_name: 'Example archived product',
+  active: false,
+};
+
 export const PAYPAL_CUSTOMER: Customer = {
   billing_name: 'Foo Barson - Pays with PayPal',
   payment_provider: 'paypal',

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -450,6 +450,20 @@ export const MOCK_PLANS: Plan[] = [
     active: true,
   },
   {
+    plan_id: 'plan_archiveddaily',
+    product_id: 'prod_fpn',
+    product_name: 'FPN',
+    interval: 'day' as const,
+    interval_count: 1,
+    amount: 500,
+    currency: 'usd',
+    plan_metadata: null,
+    product_metadata: {
+      productSet: ['fpn'],
+    },
+    active: false,
+  },
+  {
     plan_id: 'plan_6days',
     product_id: 'prod_fpn',
     product_name: 'FPN',
@@ -476,6 +490,20 @@ export const MOCK_PLANS: Plan[] = [
       productSet: ['fpn'],
     },
     active: true,
+  },
+  {
+    plan_id: 'plan_archivedweekly',
+    product_id: 'prod_fpn',
+    product_name: 'FPN',
+    interval: 'week' as const,
+    interval_count: 1,
+    amount: 500,
+    currency: 'usd',
+    plan_metadata: null,
+    product_metadata: {
+      productSet: ['fpn'],
+    },
+    active: false,
   },
   {
     plan_id: 'plan_6weeks',
@@ -506,6 +534,20 @@ export const MOCK_PLANS: Plan[] = [
     active: true,
   },
   {
+    plan_id: 'plan_archivedmonthly',
+    product_id: 'prod_fpn',
+    product_name: 'FPN',
+    interval: 'month' as const,
+    interval_count: 1,
+    amount: 500,
+    currency: 'usd',
+    plan_metadata: null,
+    product_metadata: {
+      productSet: ['fpn'],
+    },
+    active: false,
+  },
+  {
     plan_id: 'plan_6months',
     product_id: 'prod_fpn',
     product_name: 'FPN',
@@ -532,6 +574,20 @@ export const MOCK_PLANS: Plan[] = [
       productSet: ['fpn'],
     },
     active: true,
+  },
+  {
+    plan_id: 'plan_archivedyearly',
+    product_id: 'prod_fpn',
+    product_name: 'FPN',
+    interval: 'year' as const,
+    interval_count: 1,
+    amount: 500,
+    currency: 'usd',
+    plan_metadata: null,
+    product_metadata: {
+      productSet: ['fpn'],
+    },
+    active: false,
   },
   {
     plan_id: 'plan_6years',
@@ -618,6 +674,16 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS = [
   },
 ];
 
+export const MOCK_ACTIVE_SUBSCRIPTIONS_TO_ARCHIVED = [
+  {
+    uid: 'a90fef48240b49b2b6a33d333aee9b13',
+    subscriptionId: 'sub0.28964929339372137',
+    productId: PRODUCT_ID,
+    createdAt: 1565816388815,
+    cancelledAt: null,
+  },
+];
+
 export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
   {
     subscriptionId: 'sub0.28964929339372136',
@@ -699,6 +765,14 @@ export const MOCK_SUBSEQUENT_INVOICES: SubsequentInvoicePreview[] = [
       },
     ],
   },
+  {
+    subscriptionId: MOCK_ACTIVE_SUBSCRIPTIONS_TO_ARCHIVED[0].subscriptionId,
+    period_start: 1565816388.815,
+    subtotal: 500,
+    subtotal_excluding_tax: null,
+    total: 500,
+    total_excluding_tax: null,
+  },
 ];
 
 export const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
@@ -777,6 +851,17 @@ export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION: Customer = {
       promotion_duration: null,
       promotion_end: null,
     },
+  ],
+};
+
+export const MOCK_CUSTOMER_ARCHIVED_PLAN: Customer = {
+  ...MOCK_CUSTOMER,
+  subscriptions: [
+    {
+      ...MOCK_CUSTOMER.subscriptions[0],
+      subscription_id: MOCK_ACTIVE_SUBSCRIPTIONS_TO_ARCHIVED[0].subscriptionId,
+      plan_id: INACTIVE_PLAN_ID,
+    } as WebSubscription,
   ],
 };
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -28,6 +28,7 @@ import {
   SELECTED_PLAN,
   UPGRADE_FROM_PLAN,
   PROFILE,
+  UPGRADE_FROM_PLAN_ARCHIVED,
 } from '../../../lib/mock-data';
 
 import { SignInLayout } from '../../../components/AppLayout';
@@ -42,6 +43,36 @@ jest.mock('../../../lib/amplitude');
 
 const customerWebSubscription = CUSTOMER.subscriptions[0] as WebSubscription;
 
+async function rendersAsExpected(upgradeFromPlan = UPGRADE_FROM_PLAN) {
+  const { findByTestId, queryByTestId, container } = render(
+    <Subject props={{ upgradeFromPlan }} />
+  );
+  await findByTestId('subscription-upgrade');
+
+  // Could do some more content-based tests here, but basically just a
+  // sanity test to assert that the products are in the correct slots
+  const fromName = container.querySelector(
+    '.from-plan .product-name'
+  ) as Element;
+  expect(fromName.textContent).toEqual(upgradeFromPlan.product_name);
+  const fromDesc = container.querySelector(
+    '.from-plan #product-description'
+  ) as Element;
+  expect(fromDesc.textContent).toContain(
+    upgradeFromPlan.product_metadata?.['product:subtitle']
+  );
+  const toName = container.querySelector('.to-plan .product-name') as Element;
+  expect(toName.textContent).toEqual(SELECTED_PLAN.product_name);
+  const toDesc = container.querySelector(
+    '.to-plan #product-description'
+  ) as Element;
+  expect(toDesc.textContent).toContain(
+    SELECTED_PLAN.product_metadata?.['product:subtitle']
+  );
+  expect(queryByTestId('plan-upgrade-subtotal')).not.toBeInTheDocument();
+  expect(queryByTestId('plan-upgrade-tax-amount')).not.toBeInTheDocument();
+}
+
 describe('routes/Product/SubscriptionUpgrade', () => {
   afterEach(() => {
     updateConfig({
@@ -54,31 +85,11 @@ describe('routes/Product/SubscriptionUpgrade', () => {
   });
 
   it('renders as expected', async () => {
-    const { findByTestId, queryByTestId, container } = render(<Subject />);
-    await findByTestId('subscription-upgrade');
+    await rendersAsExpected();
+  });
 
-    // Could do some more content-based tests here, but basically just a
-    // sanity test to assert that the products are in the correct slots
-    const fromName = container.querySelector(
-      '.from-plan .product-name'
-    ) as Element;
-    expect(fromName.textContent).toEqual(UPGRADE_FROM_PLAN.product_name);
-    const fromDesc = container.querySelector(
-      '.from-plan #product-description'
-    ) as Element;
-    expect(fromDesc.textContent).toContain(
-      UPGRADE_FROM_PLAN.product_metadata?.['product:subtitle']
-    );
-    const toName = container.querySelector('.to-plan .product-name') as Element;
-    expect(toName.textContent).toEqual(SELECTED_PLAN.product_name);
-    const toDesc = container.querySelector(
-      '.to-plan #product-description'
-    ) as Element;
-    expect(toDesc.textContent).toContain(
-      SELECTED_PLAN.product_metadata?.['product:subtitle']
-    );
-    expect(queryByTestId('plan-upgrade-subtotal')).not.toBeInTheDocument();
-    expect(queryByTestId('plan-upgrade-tax-amount')).not.toBeInTheDocument();
+  it('renders as expected when upgrade from plan is archived', async () => {
+    await rendersAsExpected(UPGRADE_FROM_PLAN_ARCHIVED);
   });
 
   it('renders as expected for inclusive tax', async () => {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -110,6 +110,12 @@ describe('CancelSubscriptionPanel', () => {
           const plan = findMockPlan(plan_id);
           runTests({ plan, ...baseProps });
         });
+
+        it('handles archived plans', () => {
+          const plan_id = `plan_archived${v}`;
+          const plan = findMockPlan(plan_id);
+          runTests({ plan, ...baseProps });
+        });
       });
     }
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -17,7 +17,12 @@ import {
   elementChangeResponse,
   MOCK_PAYPAL_CUSTOMER_RESULT,
 } from '../../lib/test-utils';
-import { CUSTOMER, FILTERED_SETUP_INTENT, PLAN } from '../../lib/mock-data';
+import {
+  CUSTOMER,
+  FILTERED_SETUP_INTENT,
+  INACTIVE_PLAN,
+  PLAN,
+} from '../../lib/mock-data';
 
 import { PickPartial } from '../../lib/types';
 import { defaultConfig } from '../../lib/config';
@@ -125,6 +130,18 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
 
   it('renders correctly for paypal', async () => {
     render(<Subject customer={{ ...CUSTOMER, payment_provider: 'paypal' }} />);
+    expect(
+      screen.getByTestId('change-payment-update-button')?.getAttribute('href')
+    ).toEqual(`${apiUrl}/myaccount/autopay/connect/ba-131243`);
+  });
+
+  it('renders correctly for paypal with archived plan', async () => {
+    render(
+      <Subject
+        customer={{ ...CUSTOMER, payment_provider: 'paypal' }}
+        plan={INACTIVE_PLAN}
+      />
+    );
     expect(
       screen.getByTestId('change-payment-update-button')?.getAttribute('href')
     ).toEqual(`${apiUrl}/myaccount/autopay/connect/ba-131243`);


### PR DESCRIPTION
## Because

- Some pages and components do not have tests for archived plans.

## This pull request

- Updates pages and components, where necessary, to include a test with an archived plan.

## Issue that this pull request solves

Closes: #FXA-6835

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).