### PR TITLE
fix(fxa-settings): resending reset password link redirects to signin

### DIFF
--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -548,6 +548,7 @@ export class Account implements AccountData {
       const errno = (err as ApolloError).graphQLErrors[0].extensions?.errno;
 
       // Invalid token means the user has completed reset password
+      // or that the provided token is stale (expired or replaced with new token)
       if (errno === AuthUiErrors.INVALID_TOKEN.errno) {
         return false;
       }

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
@@ -26,13 +26,8 @@ history.location.state = {
   passwordForgotToken: MOCK_PASSWORD_FORGOT_TOKEN,
 };
 
-const storyWithProps = ({ ...props }) => {
-  const story = () => (
-    <LocationProvider history={history}>
-      <ConfirmResetPassword {...props} />
-    </LocationProvider>
-  );
-  return story;
-};
-
-export const Default = storyWithProps({});
+export const Default = () => (
+  <LocationProvider history={history}>
+    <ConfirmResetPassword />
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -21,7 +21,7 @@ import { REACT_ENTRYPOINT } from '../../constants';
 import AppLayout from '../../components/AppLayout';
 import { composeAuthUiErrorTranslationId } from '../../lib/auth-errors/auth-errors';
 import Banner, { BannerType } from '../../components/Banner';
-import { ConfirmResetPasswordProps } from './ConfirmResetPassword';
+import { ConfirmResetPasswordLocationState } from './ConfirmResetPassword';
 
 export const viewName = 'reset-password';
 
@@ -73,7 +73,7 @@ const ResetPassword = ({
   };
 
   const navigateToConfirmPwReset = useCallback(
-    (stateData: ConfirmResetPasswordProps) => {
+    (stateData: ConfirmResetPasswordLocationState) => {
       navigate('confirm_reset_password', { state: stateData, replace: true });
     },
     [navigate]


### PR DESCRIPTION
## Because

* Requesting a new link from /confirm_reset_password in the React app should send a new link and stay on the same page. (Should not redirect to signin)

## This pull request

* Stores the currentPasswordForgotToken in React state so it can be updated when requesting a new link.
* Corrects issue where polling would check against the previous (replaced) token.

## Issue that this pull request solves

Closes: #FXA-6893

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
