### PR TITLE
chore(payments): set up fxa-geodb for metrics

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -98,6 +98,20 @@ const conf = convict({
     env: 'FLOW_ID_EXPIRY',
     format: 'duration',
   },
+  geodb: {
+    dbPath: {
+      default: path.resolve(__dirname, '../../../fxa-geodb/db/cities-db.mmdb'),
+      doc: 'Path to maxmind database file',
+      env: 'GEODB_DBPATH',
+      format: String,
+    },
+    enabled: {
+      default: true,
+      doc: 'Feature flag for geolocation',
+      env: 'GEODB_ENABLED',
+      format: Boolean,
+    },
+  },
   hstsEnabled: {
     default: true,
     doc: 'Send a Strict-Transport-Security header',

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -13,13 +13,24 @@ const {
   validate,
 } = require('fxa-shared/metrics/amplitude').amplitude;
 const config = require('../config');
-const amplitude = config.get('amplitude');
+const amplitudeConfig = config.get('amplitude');
 const log = require('./logging/log')();
 const ua = require('fxa-shared/metrics/user-agent');
 const { version: VERSION } = require('../../package.json');
 const Sentry = require('@sentry/node');
 const { Container } = require('typedi');
 const { StatsD } = require('hot-shots');
+
+const geodbConfig = config.get('geodb');
+const geodb = require('fxa-geodb')(geodbConfig);
+
+const remoteAddress =
+  require('fxa-shared/express/remote-address').remoteAddress(
+    config.get('clientAddressDepth')
+  );
+const geolocate = require('fxa-shared/express/geo-locate').geolocate(geodb)(
+  remoteAddress
+)(log);
 
 const FUZZY_EVENTS = new Map([
   [
@@ -38,13 +49,33 @@ const transform = initialize(
   FUZZY_EVENTS
 );
 
-module.exports = (event, request, data) => {
+// TODO: remove eslint ignore in FXA-6950
+// eslint-disable-next-line no-unused-vars
+function getLocation(request) {
+  if (!geodbConfig.enabled) {
+    return {};
+  }
+
+  return geolocate(request);
+}
+
+// TODO: remove eslint ignore in FXA-6950
+// eslint-disable-next-line no-unused-vars
+function getCountryCode(location) {
+  if (location && location.countryCode) {
+    return location.countryCode;
+  }
+
+  return null;
+}
+
+const amplitude = (event, request, data) => {
   const statsd = Container.get(StatsD);
-  if (!amplitude.enabled || !event || !request || !data) {
+  if (!amplitudeConfig.enabled || !event || !request || !data) {
     return;
   }
 
-  if (amplitude.rawEvents) {
+  if (amplitudeConfig.rawEvents) {
     const wanted = [
       'deviceId',
       'devices',
@@ -105,7 +136,7 @@ module.exports = (event, request, data) => {
   });
 
   if (amplitudeEvent) {
-    if (amplitude.schemaValidation) {
+    if (amplitudeConfig.schemaValidation) {
       try {
         validate(amplitudeEvent);
       } catch (err) {
@@ -136,4 +167,10 @@ module.exports = (event, request, data) => {
   } else {
     statsd.increment('amplitude.event.dropped');
   }
+};
+
+module.exports = {
+  amplitude,
+  getLocation,
+  getCountryCode,
 };

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const joi = require('joi');
-const amplitude = require('../amplitude');
+const { amplitude } = require('../amplitude');
 const logger = require('../logging/log')('server.post-metrics');
 
 const config = require('../../config');


### PR DESCRIPTION
Because:

* We want to record the country code for all payments server user events.

This commit:

* Includes the existing fxa-geodb package, config and some shared helpers in the payments server.
* Adds some new helpers to obtain the user's geolocation and country code for events.

Closes #FXA-6947

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
* We already had the `fxa-geodb` package as a dependency on the payments server; it just wasn't being used anywhere and didn't have any config.
* As discussed earlier with Julian, ideally, the `clientAddress` would be decorated on the request as part of Express' middleware, but that's not how it is implemented in its current usage in `fxa-shared` (and `fxa-content-server`). Since we will no longer be using Express in SubPlat 3.0 (we will be using NextJS), I am not going to make any changes to this at this time.
* The expected use of these two new helpers is in the function exported by this file, e.g.:
  * `const countryCode = getCountryCode(getLocation(request));`
