### PR TITLE
feat(auth): report All AJV Validation Errors

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -279,7 +279,7 @@ Lug.prototype.amplitudeEvent = function (data) {
           error: err.message,
         });
         Sentry.captureMessage(
-          `Amplitude event failed validation: ${err.message}.`,
+          'Amplitude event failed validation',
           Sentry.Severity.Error
         );
       });

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -856,7 +856,7 @@ function receiveEvent(event, request, data) {
             error: err.message,
           });
           Sentry.captureMessage(
-            `Amplitude event failed validation: ${err.message}.`,
+            'Amplitude event failed validation',
             Sentry.Severity.Error
           );
         });

--- a/packages/fxa-content-server/tests/server/amplitude-schema-validation.js
+++ b/packages/fxa-content-server/tests/server/amplitude-schema-validation.js
@@ -131,7 +131,7 @@ registerSuite('amplitude json schema validation', {
       );
       assert.isTrue(
         mockSentry.captureMessage.calledOnceWith(
-          'Amplitude event failed validation: QUUX IS NOT A VALID DEVICE ID.',
+          'Amplitude event failed validation',
           Sentry.Severity.Error
         )
       );

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -123,7 +123,7 @@ module.exports = (event, request, data) => {
             error: err.message,
           });
           Sentry.captureMessage(
-            `Amplitude event failed validation: ${err.message}.`,
+            'Amplitude event failed validation',
             Sentry.Severity.Error
           );
         });

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -206,7 +206,7 @@ describe('lib/amplitude', () => {
       );
       expect(mockSentry.captureMessage).toHaveBeenCalledTimes(1);
       expect(mockSentry.captureMessage).toHaveBeenCalledWith(
-        'Amplitude event failed validation: QUUX IS NOT A VALID DEVICE ID.',
+        'Amplitude event failed validation',
         Sentry.Severity.Error
       );
       expect(log.info).toHaveBeenCalledTimes(1);

--- a/packages/fxa-shared/metrics/amplitude.ts
+++ b/packages/fxa-shared/metrics/amplitude.ts
@@ -15,7 +15,7 @@ type AmplitudeEventFuzzyEventNameMapFn = (
 ) => string;
 type EventData = { [key: string]: any };
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true });
 const amplitudeSchema = require('./amplitude-event.1.schema.json');
 const validateAmplitudeEvent = ajv.compile(amplitudeSchema);
 


### PR DESCRIPTION
Because:

* ajv was configured to error on the first validation error, we were missing info if there were multiple ajv errors

This commit:

* configures ajv to report all validation errors, updates tests accordingly

Closes #FXA-6995

## Checklist

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
See below how to force multiple validation errors for testing.

<img width="711" alt="Screenshot 2023-03-12 at 10 05 07 PM" src="https://user-images.githubusercontent.com/1585040/224612922-ee80e6d4-6ea4-48fe-8b84-89d761dae85b.png">

And the validation errors should be visible in sentry and logs:

<img width="1103" alt="Screenshot 2023-03-12 at 10 23 25 PM" src="https://user-images.githubusercontent.com/1585040/224615304-8c4999ff-77d5-4f75-a39c-2edc54936537.png">

<img width="1652" alt="Screenshot 2023-03-12 at 10 25 15 PM" src="https://user-images.githubusercontent.com/1585040/224615324-fa0019ef-872c-4e3a-943c-6d8fd07e36a2.png">
