### PR TITLE
fix (fxa-settings) : render localized {$retryAfter} variable

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -6,11 +6,9 @@ auth-error-105-2 = Invalid confirmation code
 auth-error-110 = Invalid token
 # This string is the amount of time required before a user can attempt another request.
 # Variables:
-#   $retryAfter (String) - Time required before retrying a request. This text is localized
-#                          by our server based on accept language in request. Our timestamp
-#                          formatting library (momentjs) will automatically add the word `in`
-#                          as part of the string.
-#                           (for example: "in 15 minutes")
+#   $retryAfter (String) - Time required before retrying a request. The variable is localized by our
+#                          formatting library (momentjs) as a "time from now" and automatically includes
+#                          the prefix as required by the current locale (for example, "in 15 minutes", "dans 15 minutes").
 auth-error-114 = You’ve tried too many times. Please try again { $retryAfter }.
 auth-error-138-2 = Unconfirmed session
 auth-error-139 = Secondary email must be different than your account email
@@ -19,4 +17,3 @@ auth-error-183-2 = Invalid or expired confirmation code
 auth-error-999 = Unexpected error
 auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different
-

--- a/packages/fxa-settings/src/pages/ResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/en.ftl
@@ -7,10 +7,8 @@ reset-password-heading-w-default-service = Reset password <span>to continue to a
 # If more appropriate in a locale, the string within the <span>, "to continue to { $serviceName }" can stand alone as "Continue to { $serviceName }"
 # { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable
 reset-password-heading-w-custom-service = Reset password <span>to continue to { $serviceName }</span>
-
 reset-password-warning-message-2 = <span>Note:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy. You’ll still keep any subscriptions you may have and { -product-pocket } data will not be affected.
-
+# Users type their email address in this field to start a password reset
+reset-password-password-input =
+  .label = Email
 reset-password-button = Begin reset
-reset-password-success-alert = Password reset
-reset-password-error-general = Sorry, there was a problem resetting your password
-reset-password-error-unknown-account = Unknown account

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import ResetPassword from '.';
+import ResetPassword, { ResetPasswordProps } from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../models/mocks';
@@ -16,7 +16,7 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = ({ ...props }) => {
+const storyWithProps = (props?: Partial<ResetPasswordProps>) => {
   const story = () => (
     <LocationProvider>
       <ResetPassword {...props} />
@@ -25,7 +25,7 @@ const storyWithProps = ({ ...props }) => {
   return story;
 };
 
-export const Default = storyWithProps({});
+export const Default = storyWithProps();
 
 export const WithServiceName = storyWithProps({
   serviceName: MozServices.MozillaVPN,

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -134,8 +134,6 @@ describe('PageResetPassword', () => {
       fireEvent.click(screen.getByText('Begin Reset'));
     });
 
-    await screen.findByText(
-      'Sorry, there was a problem resetting your password'
-    );
+    await screen.findByText('Unknown account');
   });
 });


### PR DESCRIPTION
## Because

* We want to show a localized time instead of {$retryAfter} variable in "You've tried too many times. Please try again {$retryAfter}" error message for the ResetPassword page.

## This pull request

* Adjust localized error message to include localized time.
* Fix test to reflect the actual auth errors that are now rendered instead of a generic error.

Edited to add:
* Adjust l10n comment for error string - some misunderstandings were identified in existing translations.
* Add missing FTL string for input label.

## Issue that this pull request solves

Closes: #FXA-6875

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
