### PR TITLE
fix(subscriptions): allow for missing tax fields on invoice

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -849,6 +849,20 @@ describe('lib/routes/validators:', () => {
       assert.ok(!res.error);
     });
 
+    it('accepts a Stripe subscription with missing or undefined optional parameters', () => {
+      const stripeSubMissing = deepCopy(stripeSub);
+      const stripeSubUndefined = deepCopy(stripeSub);
+      delete stripeSubMissing.latest_invoice_items.subtotal_excluding_tax;
+      stripeSubUndefined.latest_invoice_items.subtotal_excluding_tax =
+        undefined;
+
+      const res =
+        validators.subscriptionsMozillaSubscriptionsValidator.validate({
+          subscriptions: [stripeSubMissing, stripeSubUndefined],
+        });
+      assert.ok(!res.error);
+    });
+
     it('accepts a list with only Google Play subscriptions', () => {
       const res =
         validators.subscriptionsMozillaSubscriptionsValidator.validate({

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -9,7 +9,7 @@ import { Customer, Profile, Plan } from '../../store/types';
 import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import { Meta } from '@storybook/react';
-import { LatestInvoiceItems } from 'fxa-shared/dto/auth/payments/invoice';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export default {
   title: 'components/PaymentConfirmation',
@@ -49,7 +49,7 @@ const selectedPlanWithMetadata: Plan = {
   },
 };
 
-const invoice: LatestInvoiceItems = {
+const invoice: FirstInvoicePreview = {
   line_items: [],
   subtotal: 735,
   subtotal_excluding_tax: null,

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -137,8 +137,21 @@ export type subsequentInvoicePreview = {
 
 export type subsequentInvoicePreviewsSchema = Array<subsequentInvoicePreview>;
 
-export interface LatestInvoiceItems extends FirstInvoicePreview {}
+export interface LatestInvoiceItems
+  extends Omit<
+    FirstInvoicePreview,
+    'subtotal_excluding_tax' | 'total_excluding_tax'
+  > {
+  subtotal_excluding_tax?: number | null;
+  total_excluding_tax?: number | null;
+}
 
-export const latestInvoiceItemsSchema = firstInvoicePreviewSchema;
+export const latestInvoiceItemsSchema = firstInvoicePreviewSchema.fork(
+  ['subtotal_excluding_tax', 'total_excluding_tax'],
+  (schema) => schema.optional().allow(null)
+);
 
-export type latestInvoiceItemsSchema = firstInvoicePreviewSchema;
+export type latestInvoiceItemsSchema = firstInvoicePreviewSchema & {
+  subtotal_excluding_tax?: number | null;
+  total_excluding_tax?: number | null;
+};


### PR DESCRIPTION
## Because

- The invoice in Firestore is not guarenteed to have properties `total_excluding_tax` and `subtotal_excluding_tax`

## This pull request

- Updates the types and joi schemas for latestInvoiceItems to allow for undefined values for `total_excluding_tax` and `subtotal_excluding_tax`.

## Issue that this pull request solves

Closes: #FXA-7040

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
