### PR TITLE
feat(auth): tax conv locale, logging, filter unchanged totals

### DIFF
--- a/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax.ts
@@ -45,7 +45,7 @@ async function init() {
     )
     .parse(process.argv);
 
-  const { stripeHelper } = await setupProcessingTaskObjects(
+  const { stripeHelper, database } = await setupProcessingTaskObjects(
     'existing-customers-stripe-tax'
   );
 
@@ -61,7 +61,8 @@ async function init() {
     program.outputFile,
     program.ipAddressMapFile,
     stripeHelper.stripe,
-    rateLimit
+    rateLimit,
+    database
   );
 
   await stripeAutomaticTaxConverter.convert();


### PR DESCRIPTION
## Because

* Marketing cannot pull locale via their contact database
* Marketing cannot filter out unchanged total sub amounts when looking at sub totals

## This pull request

* Adds locale to the CSV output
* Filters any subs who's totals are unchanged before/after the update

## Issue that this pull request solves

Closes FXA-7037
