### PR TITLE
fix(fxa-settings): Reposition Banner below CardHeader in CompleteResetPassword

### DIFF
--- a/packages/fxa-settings/src/components/LinkDamaged/index.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.tsx
@@ -20,7 +20,7 @@ const getHeaderValues = (linkType: LinkType) => {
   switch (linkType) {
     case 'reset-password':
       headerValues.text = 'Reset password link damaged';
-      headerValues.headerId = 'password-reset-link-damaged-header';
+      headerValues.headerId = 'reset-pwd-link-damaged-header';
       break;
     case 'signin':
       headerValues.text = 'Confirmation link damaged';
@@ -42,7 +42,7 @@ const LinkDamaged = ({ linkType }: LinkDamagedProps) => {
         headingTextFtlId={headerValue.headerId}
       />
 
-      <FtlMsg id="link-damaged-message">
+      <FtlMsg id="reset-pwd-link-damaged-message">
         <p className="mt-4 text-sm">
           The link you clicked was missing characters, and may have been broken
           by your email client. Copy the address carefully, and try again.

--- a/packages/fxa-settings/src/components/LinkExpired/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.tsx
@@ -70,7 +70,7 @@ const LinkExpired = ({ linkType }: LinkExpiredProps) => {
       <FtlMsg id={templateValues.messageId}>
         <p className="mt-4 text-sm">{templateValues.messageText}</p>
       </FtlMsg>
-      <FtlMsg id="resend-link">
+      <FtlMsg id="reset-pwd-resend-link">
         <button onClick={resendLinkHandler} className="link-blue mt-4">
           Receive new link
         </button>

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -194,6 +194,7 @@ describe('CompleteResetPassword page', () => {
   describe('errors', () => {
     it('displays "problem setting your password" error', async () => {
       account = {
+        hasRecoveryKey: jest.fn().mockResolvedValue(false),
         resetPasswordStatus: jest.fn().mockResolvedValue(true),
         completeResetPassword: jest
           .fn()


### PR DESCRIPTION
## Because

- For consistency, all banners should be placed below CardHeader.

## This pull request

* Use an enum for error type in CompleteResetPassword to ensure only one banner can be displayed at a time
* Move Banner below CardHeader in CompleteResetPassword
* Fix test for Submit error in CompleteResetPassword (add function mock for hasRecoveryKey)
* Fix FTL ids for LinkDamaged, LinkExpired (ids in code did not match up with FTL ids)

## Issue that this pull request solves

Closes: #FXA-7019

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://user-images.githubusercontent.com/22231637/224832230-82f10ae6-9ffa-4352-a8d9-c5f896ed9105.png)

After:
![image](https://user-images.githubusercontent.com/22231637/224832100-5a0184a4-31c2-4ad8-8f1a-4e2dbebeade6.png)

## Other information (Optional)

Banner also needs to be moved in `ConfirmResetPassword` and `AccountRecovery` pages, but I've included those fixes with FXA-6891 (in progress)
