### PR TITLE
fix(fxa-settings): enable Sentry for new React pages

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { ReactNode } from 'react';
+import { render, act } from '@testing-library/react';
+import App from '.';
+import * as Metrics from '../../lib/metrics';
+import { useInitialState } from '../../models';
+
+jest.mock('../../models', () => ({
+  ...jest.requireActual('../../models'),
+  useInitialState: jest.fn(),
+}));
+
+jest.mock('react-markdown', () => {});
+jest.mock('rehype-raw', () => {});
+
+jest.mock('fxa-react/lib/AppLocalizationProvider', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => (
+    <section data-testid="AppLocalizationProvider">{children}</section>
+  ),
+}));
+
+jest.mock('../Settings/ScrollToTop', () => ({
+  __esModule: true,
+  ScrollToTop: ({ children }: { children: ReactNode }) => (
+    <span data-testid="ScrollTop">{children}</span>
+  ),
+}));
+
+describe('metrics', () => {
+  beforeEach(() => {
+    //@ts-ignore
+    delete window.location;
+    window.location = {
+      ...window.location,
+      replace: jest.fn(),
+    };
+  });
+
+  it('Initializes metrics flow data when present', async () => {
+    (useInitialState as jest.Mock).mockReturnValueOnce({ loading: true });
+    const DEVICE_ID = 'yoyo';
+    const BEGIN_TIME = 123456;
+    const FLOW_ID = 'abc123';
+    const flowInit = jest.spyOn(Metrics, 'init');
+    const updatedFlowQueryParams = {
+      deviceId: DEVICE_ID,
+      flowBeginTime: BEGIN_TIME,
+      flowId: FLOW_ID,
+    };
+
+    await act(async () => {
+      render(<App flowQueryParams={updatedFlowQueryParams} />);
+    });
+
+    expect(flowInit).toHaveBeenCalledWith(true, {
+      deviceId: DEVICE_ID,
+      flowId: FLOW_ID,
+      flowBeginTime: BEGIN_TIME,
+    });
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ReactNode } from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { History } from '@reach/router';
 import App from '.';
-import * as Metrics from '../../lib/metrics';
 import { Account, AppContext, useInitialState } from '../../models';
 import {
   mockAppContext,
@@ -41,41 +40,6 @@ const flowQueryParams = {
   flowBeginTime: 1,
   flowId: 'x',
 };
-
-describe('metrics', () => {
-  beforeEach(() => {
-    //@ts-ignore
-    delete window.location;
-    window.location = {
-      ...window.location,
-      replace: jest.fn(),
-    };
-  });
-
-  it('Initializes metrics flow data when present', async () => {
-    (useInitialState as jest.Mock).mockReturnValueOnce({ loading: true });
-    const DEVICE_ID = 'yoyo';
-    const BEGIN_TIME = 123456;
-    const FLOW_ID = 'abc123';
-    const flowInit = jest.spyOn(Metrics, 'init');
-    const updatedFlowQueryParams = {
-      deviceId: DEVICE_ID,
-      flowBeginTime: BEGIN_TIME,
-      flowId: FLOW_ID,
-    };
-
-    await act(async () => {
-      render(<App flowQueryParams={updatedFlowQueryParams} />);
-    });
-
-    expect(flowInit).toHaveBeenCalledWith(true, {
-      deviceId: DEVICE_ID,
-      flowId: FLOW_ID,
-      flowBeginTime: BEGIN_TIME,
-    });
-    expect(window.location.replace).not.toHaveBeenCalled();
-  });
-});
 
 describe('performance metrics', () => {
   beforeEach(() => {

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -6,7 +6,6 @@ import React, { useEffect } from 'react';
 import AppLayout from './AppLayout';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import AppErrorDialog from 'fxa-react/components/AppErrorDialog';
-import * as Metrics from '../../lib/metrics';
 import { useAccount, useConfig, useInitialState } from '../../models';
 import { Redirect, Router, RouteComponentProps } from '@reach/router';
 import Head from 'fxa-react/components/Head';
@@ -23,14 +22,10 @@ import { PageDeleteAccount } from './PageDeleteAccount';
 import { ScrollToTop } from './ScrollToTop';
 import { HomePath } from '../../constants';
 import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
-import sentryMetrics from 'fxa-shared/lib/sentry';
 import PageAvatar from './PageAvatar';
-import { QueryParams } from '../..';
 import PageRecentActivity from './PageRecentActivity';
 
-export const Settings = ({
-  flowQueryParams,
-}: { flowQueryParams: QueryParams } & RouteComponentProps) => {
+export const Settings = (props: RouteComponentProps) => {
   const config = useConfig();
   const { metricsEnabled, hasPassword } = useAccount();
 
@@ -45,27 +40,6 @@ export const Settings = ({
   ]);
 
   const { loading, error } = useInitialState();
-  useEffect(() => {
-    Metrics.init(metricsEnabled, flowQueryParams);
-  }, [metricsEnabled, flowQueryParams]);
-
-  useEffect(() => {
-    if (!loading) {
-      // For settings app, we only enable Sentry once we know the user's metrics
-      // preferences. A bit of chicken and egg but it could be possible that we
-      // miss some errors while the page is loading and user is being fetched.
-      if (metricsEnabled) {
-        sentryMetrics.configure({
-          release: config.version,
-          sentry: {
-            ...config.sentry,
-          },
-        });
-      } else {
-        sentryMetrics.disable();
-      }
-    }
-  }, [metricsEnabled, config.sentry, config.version, loading]);
 
   // In case of an invalid token the page will redirect,
   // but to prevent a flash of the error message we show


### PR DESCRIPTION
## Because:

* Currently, Sentry is only enabled for Settings pages

## This commit:

* Wraps the other pages in Sentry as well

Closes #FXA-6933

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
(Shows errors still coming in over local from Settings page, and also from new React conversion pages)
<img width="665" alt="Screen Shot 2023-03-14 at 4 14 35 PM" src="https://user-images.githubusercontent.com/11150372/225162812-436dd72d-df7b-41dc-b843-641353f95ae6.png">

## Other information (Optional)

Previously, since only logged in users could interact with the Settings app, we would only enable sentry for users who had opted in to enabling their metrics. Since we are now sharing a Sentry configuration between signed in and signed out pages, we instead enable Sentry conditionally, requiring a user to be EITHER logged out, OR logged in with metrics enabled.
