### PR TITLE
feat(payments): vscode Launch Config For Debugging Payments Server Tests

### DIFF
--- a/packages/fxa-payments-server/.vscode/launch.json
+++ b/packages/fxa-payments-server/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug FxA-Payments Tests",
+            "name": "Debug FxA-Payments Frontend Tests",
             "type": "node",
             "protocol": "inspector",
             "env": {
@@ -15,6 +15,15 @@
             },
             "program": "${workspaceFolder}/../../node_modules/@rescripts/cli/bin/rescripts.js",
             "args": ["--inspect", "test", "--runInBand", "--no-cache"],
+            "autoAttachChildProcesses": true,
+            "cwd":"${workspaceFolder}",
+            "request": "launch",
+          },
+          {
+            "name": "Debug FxA-Payments Server Tests",
+            "type": "node",
+            "program": "${workspaceFolder}/../../node_modules/jest/bin/jest.js",
+            "args": ["--runInBand", "--config", "server/jest.config.js"],
             "autoAttachChildProcesses": true,
             "cwd":"${workspaceFolder}",
             "request": "launch",

--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -74,15 +74,13 @@ Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more adva
 
 ### Debugging Tests
 
-A launch config for Visual Studio Code is provided to help debug tests. In order to use the launch config, open the `fxa-payments-server` folder in Visual Studio Code, then add a `debugger` statement in the body of the test you plan to debug. In the Visual Studio Code sidebar navigate to the Run and Debug tab, and select the "Debug FxA-Payments Tests." Click the run button and the tests will begin to run and a debugger will be attached to the process. You can now add further breakpoints to the test source code by clicking near the line number.
+Launch configs for Visual Studio Code are provided to help debug tests. In order to use the launch config, open the `fxa-payments-server` folder in Visual Studio Code, then add a `debugger` statement in the body of the test you plan to debug. In the Visual Studio Code sidebar navigate to the Run and Debug tab, and select the "Debug FxA-Payments Frontend Tests" or "Debug FxA-Payments Server Tests." Click the run button and the tests will begin to run and a debugger will be attached to the process. You can now add further breakpoints to the test source code by clicking near the line number.
 
 #### Current Debugging Limitations
 
 As the launch config is currently offered, a `debugger` statement is needed to cause the debugger to properly attach; on initial run, simply selecting breakpoints on the side of the editor window will not work. Furthermore, the launch config currently runs all tests in a single process so it may take a moment before the test you are trying to debug is reached.
 
 We use rescripts and yarn workspaces to manage our node packages. If you are encountering any error with packages not being found, please make sure to run `yarn install` from the FxA root directory.
-
-This launch config currently only works for the tests under the `/src` directory in the `fxa-payments-server` package, not the `/server` directory.
 
 ### L10N
 


### PR DESCRIPTION
Because:

* we do not have an easy way to debug payments server tests through vs code

This commit:

* adds a launch config for vscode to debug the payments server tests

Closes #FXA-7049

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).