### PR TITLE
chore(l10n): fix linter issues around ftl placeables

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
@@ -10,7 +10,7 @@ subscriptionRenewalReminder-content-greeting = Dear { $productName } customer,
 #   $planIntervalCount (String) - The interval count of subscription plan, e.g. 2
 #   $planInterval (String) - The interval of time of the subscription plan, e.g. week
 #   $reminderLength (String) - The number of days until the current subscription is set to automatically renew, e.g. 14
-subscriptionRenewalReminder-content-current = Your current subscription is set to automatically renew in { $reminderLength } days. At that time, { -brand-mozilla } will renew your { $planIntervalCount} { $planInterval} subscription and a charge of { $invoiceTotal} will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-current = Your current subscription is set to automatically renew in { $reminderLength } days. At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
 subscriptionRenewalReminder-content-closing = Sincerely,
 # Variables
 #   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN

--- a/packages/fxa-payments-server/src/components/PaymentForm/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentForm/en.ftl
@@ -9,6 +9,6 @@ payment-cc =
 payment-cancel-btn = Cancel
 payment-update-btn = Update
 payment-pay-btn = Pay now
-payment-pay-with-paypal-btn = Pay with {-brand-name-paypal}
+payment-pay-with-paypal-btn = Pay with { -brand-name-paypal }
 
 payment-validate-name-error = Please enter your name


### PR DESCRIPTION
## Because:
- Updates to the l10n linter caught issues with ftl placeables (required spaces before and after placeable name missing)

## This pull request:
- Adds the missing spaces in the variables
- Does not require updating the string ID

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
