### PR TITLE
fix(many): Don't write git-head.txt to the l10n repo

### DIFF
--- a/_scripts/l10n/clone.sh
+++ b/_scripts/l10n/clone.sh
@@ -46,6 +46,3 @@ elif [ -n "${FXA_L10N_BRANCH}" ]; then
     git pull --quiet origin "${FXA_L10N_BRANCH}"
     echo "$PREFIX: L10N now on branch: ${FXA_L10N_BRANCH}"
 fi
-
-# record the git verison
-git rev-parse HEAD > git-head.txt

--- a/_scripts/l10n/prime.sh
+++ b/_scripts/l10n/prime.sh
@@ -40,5 +40,7 @@ for d in */; do
     fi
     cd ..
 done
-cd ..
-cp git-head.txt "$ROOT_FOLDER/$TARGET_FOLDER"
+
+# Record the current git version
+cd "$ROOT_FOLDER/external/l10n"
+git rev-parse HEAD > "$ROOT_FOLDER/$TARGET_FOLDER/git-head.txt"


### PR DESCRIPTION
## Because

- Writing git-head.txt to the l10n repo resulted in changes being up by git

## This pull request

- Moves the creation of the git-head.txt to prime.sh
- Writes the file on the fly

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


