### PR TITLE
fix(many): Fix potential race condition when calling clone:l10n from post install.

### DIFF
--- a/_scripts/l10n/bundle.sh
+++ b/_scripts/l10n/bundle.sh
@@ -25,7 +25,7 @@ cd "$(dirname "$0")/../.."
 # Check path is valid
 target_folder="packages/$PACKAGE/$FOLDER"
 if [ ! -d "$target_folder" ]; then
-    echo "$PREFIX: Invalid location! The path $target_folder must exist."
+    echo "$PREFIX: Invalid location! The path $target_folder must exist. Did yarn l10n:prime get run?"
     exit 1
 fi
 

--- a/_scripts/l10n/clone.sh
+++ b/_scripts/l10n/clone.sh
@@ -46,6 +46,3 @@ elif [ -n "${FXA_L10N_BRANCH}" ]; then
     git pull --quiet origin "${FXA_L10N_BRANCH}"
     echo "$PREFIX: L10N now on branch: ${FXA_L10N_BRANCH}"
 fi
-
-# record the git verison
-git rev-parse HEAD > git-head.txt

--- a/_scripts/l10n/prime.sh
+++ b/_scripts/l10n/prime.sh
@@ -40,5 +40,7 @@ for d in */; do
     fi
     cd ..
 done
-cd ..
-cp git-head.txt "$ROOT_FOLDER/$TARGET_FOLDER"
+
+# Record the current git version
+cd "$ROOT_FOLDER/external/l10n"
+git rev-parse HEAD > "$ROOT_FOLDER/$TARGET_FOLDER/git-head.txt"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "firefox": "./packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs",
     "generate-lockfile": "docker build . -f _dev/docker/ci-lockfile-generator/Dockerfile -t generate-lockfile && docker run generate-lockfile > yarn.lock",
     "l10n:clone": "_scripts/l10n/clone.sh",
-    "l10n:prime": "yarn l10n:clone && _scripts/l10n/prime.sh",
+    "l10n:prime": "_scripts/l10n/prime.sh",
     "l10n:bundle": "_scripts/l10n/bundle.sh"
   },
   "homepage": "https://github.com/mozilla/fxa",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -53,7 +53,7 @@
     "./tracing/*": "./dist/tracing/*.js"
   },
   "scripts": {
-    "postinstall": "yarn build || true",
+    "postinstall": "yarn l10n:clone && yarn build || true",
     "build": "tsc --build && yarn copy-assets && yarn copy-sql",
     "compile": "tsc --noEmit && yarn copy-assets && yarn copy-sql",
     "copy-assets": "cp -r ./db/luaScripts ./dist/db/luaScripts",


### PR DESCRIPTION
## Because

- It seems as though we are hitting a race condition in l10n:clone

## This pull request

- Shifts the burden of cloning l10n to fxa-shared
  - This means only ONE repo inacts the clone
  - FXA-shared is dependency of almost all other workspaces so it is candidate for a low-level operation like this
- Is kind of a hack ;)


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
