### PR TITLE
fix(ci): Don't clone on postinstall & create lists after base install.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,8 +213,8 @@ commands:
           name: Base Install
           command: |
             ./_scripts/l10n/clone.sh
-            ./.circleci/create-lists.sh
             ./.circleci/base-install.sh
+            ./.circleci/create-lists.sh
             ./_scripts/create-version-json.sh
       - store_artifacts:
           path: ./packages/version.json

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "firefox": "./packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs",
     "generate-lockfile": "docker build . -f _dev/docker/ci-lockfile-generator/Dockerfile -t generate-lockfile && docker run generate-lockfile > yarn.lock",
     "l10n:clone": "_scripts/l10n/clone.sh",
-    "l10n:prime": "yarn l10n:clone && _scripts/l10n/prime.sh",
+    "l10n:prime": "_scripts/l10n/prime.sh",
     "l10n:bundle": "_scripts/l10n/bundle.sh"
   },
   "homepage": "https://github.com/mozilla/fxa",


### PR DESCRIPTION
## Because

- Deploy was failing

## This pull request

- Runs the create lists command after base-install, so diffparser module should be present.
- Only run the clone l10n operation once and remove the operation from the post install step.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

