### PR TITLE
fix(auth): pin @types/convict to 5.2.2

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -71,6 +71,7 @@
     "@sentry/node": "^6.19.1",
     "@type-cacheable/core": "^11.0.0",
     "@type-cacheable/ioredis-adapter": "^10.0.4",
+    "@types/convict": "5.2.2",
     "@types/ejs": "^3.0.6",
     "@types/mjml": "^4.7.0",
     "ajv": "^6.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11684,7 +11684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/convict@npm:^5.2.2":
+"@types/convict@npm:5.2.2, @types/convict@npm:^5.2.2":
   version: 5.2.2
   resolution: "@types/convict@npm:5.2.2"
   dependencies:
@@ -25832,6 +25832,7 @@ fsevents@~2.1.1:
     "@types/babel__core": 7.1.14
     "@types/chai": ^4.2.18
     "@types/chai-as-promised": ^7
+    "@types/convict": 5.2.2
     "@types/dedent": ^0
     "@types/ejs": ^3.0.6
     "@types/hapi__hapi": ^20.0.10


### PR DESCRIPTION
## Because

* Failing builds due to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51408 and not pinned within auth-server

## This pull request

* Pins @types/convict to 5.2.2