### PR TITLE
bug(fxa-settings): fix bug enforcing authentication on new pages

### DIFF
--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { errorHandler } from './gql';
+import { errorHandler, pagesRequiringAuthentication } from './gql';
 import { ErrorResponse } from '@apollo/client/link/error';
 import { Operation, NextLink, ServerError } from '@apollo/client/core';
 import { GraphQLError } from 'graphql';
@@ -11,13 +11,15 @@ let errorResponse: ErrorResponse;
 let mockReplace: Mock;
 
 describe('errorHandler', () => {
+  const pageWhichRequiresAuthentication = pagesRequiringAuthentication[0];
+  const pageWhichDoesNotRequireAuthentication = 'foo';
   beforeAll(() => {
     mockReplace = jest.fn();
     Object.defineProperty(window, 'location', {
       value: {
         replace: mockReplace,
         search: '',
-        pathname: 'foo',
+        pathname: pageWhichRequiresAuthentication,
       },
     });
 
@@ -40,7 +42,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-      '/signin?redirect_to=foo'
+      `/signin?redirect_to=${pageWhichRequiresAuthentication}`
     );
   });
 
@@ -57,13 +59,40 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-      '/signin?redirect_to=foo'
+      `/signin?redirect_to=${pageWhichRequiresAuthentication}`
     );
   });
 
   it('does not redirect if called with a 500 NetworkError', () => {
     let networkError: any = new Error('Inscrutable and mysterious error');
     networkError.statusCode = 500;
+    errorResponse = {
+      networkError,
+      operation: null as any as Operation,
+      forward: null as any as NextLink,
+    };
+
+    errorHandler(errorResponse);
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect if the current page does not require the user to be authenticated', () => {
+    // This is not ideal but it is surprisingly tricky resetting the window location!
+    // @ts-ignore
+    delete window.location;
+    Object.defineProperty(window, 'location', {
+      value: {
+        replace: mockReplace,
+        search: '',
+        pathname: pageWhichDoesNotRequireAuthentication,
+      },
+    });
+    console.log(window.location);
+
+    let networkError: any;
+    networkError = new Error('Network error') as ServerError;
+    networkError.statusCode = 401;
     errorResponse = {
       networkError,
       operation: null as any as Operation,


### PR DESCRIPTION
Because:

* Setting up Sentry logging for the new React conversion pages meant that all pages are in a component tree which pings GQL. Previously, many of those pages did not ping GQL. This change meant that unauthenticated users on those pages were forcibly navigated out to the /signin page. While the behavior itself is not a bug, I failed to include all necessary pages into the `pageNotRequiringAuthentication` exclusion list, which would have addressed this issue.

This commit:

* Now, instead of having an exclusion list which listed off all pages excluded from the redirect rule (which navigated users out to the /signin page), I created an inclusion list (which currently only includes /settings.) This should make it easier to maintain.

Closes #FXA-7062

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
