### PR TITLE
feat(experiments): Turn on rollout rate (15%) for React pages

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/generalized-react-app.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/generalized-react-app.js
@@ -30,7 +30,7 @@ const GROUPS = [
  * in and either 2a) append `showReactApp=true` to the URL _or_ 2b) to see it in a flow, append
  * the following query params to the page that will navigate to the page you're interested in:
  * `?forceExperiment=generalizedReactApp&forceExperimentGroup=react` */
-const ROLLOUT_RATE = 0.0;
+const ROLLOUT_RATE = 0.15;
 
 module.exports = class GeneralizedReactApp extends BaseGroupingRule {
   constructor() {


### PR DESCRIPTION
Because:
* We want to turn on the React experiment for sets of pages that have their feature flag on in production, and we're now at the point where the 'simple routes' feature flag  will be turned on in prod

This commit:
* Hard-codes the rollout rate to 15% per discussions. When we're ready to rollout to 100% we'll remove the experiment logic around these routes.

Closes FXA-7053

--

We want to cherry-pick this into a release after #15029 is done and cherry-picked, which is the last PR left to unblock our first set of pages (simple routes) from going out.

After this is merged, we can get [this PR on the SRE side](https://github.com/mozilla-services/cloudops-deployment/pull/4802) merged.