### PR TITLE
fix(CI): clone l10n repo

### DIFF
--- a/_dev/docker/ci/Dockerfile
+++ b/_dev/docker/ci/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /home/circleci/project
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV YARN_CHECKSUM_BEHAVIOR=throw
 ENV FXA_AUTO_INSTALL=0
+RUN yarn l10n:clone
 RUN yarn install --immutable; \
     yarn workspaces foreach \
         -pv \


### PR DESCRIPTION
Because:
 - we need to clone l10n repo so that packages can be built

This commit:
 - explicitly call `l10n:clone` in the Dockerfile for CI images
