### PR TITLE
fix(CI): install deps before requiring in script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,8 +213,8 @@ commands:
           name: Base Install
           command: |
             ./_scripts/l10n/clone.sh
-            ./.circleci/create-lists.sh
             ./.circleci/base-install.sh
+            ./.circleci/create-lists.sh
             ./_scripts/create-version-json.sh
       - store_artifacts:
           path: ./packages/version.json


### PR DESCRIPTION
Because:
 - we should install packages before requiring them in scripts

This commit:
 - run base install first
 - originally part of commit 0d82821
