### PR TITLE
chore(lint): move eslint-plugin-fxa into the monorepo

### DIFF
--- a/_dev/eslint-plugin-fxa/README.md
+++ b/_dev/eslint-plugin-fxa/README.md
@@ -1,0 +1,5 @@
+# eslint-plugin-fxa
+
+License MPL-2.0
+
+A continuation of https://github.com/mozilla/eslint-plugin-fxa

--- a/_dev/eslint-plugin-fxa/lib/configs/client.js
+++ b/_dev/eslint-plugin-fxa/lib/configs/client.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+module.exports = {
+  extends: 'plugin:fxa/recommended',
+
+  env: {
+    amd: true, // defines require() and define() as global variables as per the amd spec
+    browser: true, // browser global variables
+    mocha: true // adds all of the Mocha testing global variables
+  },
+
+  rules: {
+    'camelcase': 2,
+    'id-blacklist': [2, 'self'],
+    'strict': [2, 'function']
+  }
+}

--- a/_dev/eslint-plugin-fxa/lib/configs/default.js
+++ b/_dev/eslint-plugin-fxa/lib/configs/default.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+module.exports = {
+  extends: ['eslint:recommended'],
+  parserOptions: {
+    ecmaVersion: 2018
+  },
+  env: {
+    es6: true, // enable all ECMAScript 6 features except for modules
+    node: true // Node.js global variables and Node.js-specific rules
+  },
+  rules: {
+    'camelcase': 0,
+    'comma-dangle': 0,
+    'comma-style': [2, 'last'],
+    'consistent-return': 0,
+    'curly': [2, 'all'],
+    'dot-notation': 0,
+    'eol-last': 2,
+    'eqeqeq': [2, 'allow-null'],
+    'global-strict': 0,
+    'handle-callback-err': 1,
+    'indent': [2, 2, { 'SwitchCase': 1 }],
+    'key-spacing': 0,
+    'keyword-spacing': 2,
+    'new-cap': 0,
+    'no-cond-assign': [2, 'except-parens'],
+    'no-debugger': 2,
+    'no-empty': 0,
+    'no-eval': 2,
+    'fxa/no-exclusive-tests': 2,
+    'no-irregular-whitespace': 2,
+    'no-loop-func': 0,
+    'no-multi-spaces': 0,
+    'no-multiple-empty-lines': [2, {'max': 2}],
+    'no-new': 2,
+    'no-process-exit': 0,
+    'no-script-url': 2,
+    'no-sequences': 2,
+    'no-shadow': 0,
+    'no-spaced-func': 0,
+    'no-trailing-spaces': 2,
+    'no-undef': 2,
+    'no-underscore-dangle': 0,
+    'no-unused-vars': [2, {'vars': 'all', 'args': 'none'}],
+    'no-use-before-define': [2, 'nofunc'],
+    'no-with': 2,
+    'prefer-const': [2, {'destructuring': 'any', 'ignoreReadBeforeAssign': false}],
+    'quotes': [2, 'single', 'avoid-escape'],
+    'semi': [2, 'always'],
+    'space-unary-ops': [2, {'words': false}],
+    'strict': 0,
+    'valid-typeof': 2,
+    'wrap-iife': 0,
+    'yoda': 0
+  }
+};

--- a/_dev/eslint-plugin-fxa/lib/configs/index.js
+++ b/_dev/eslint-plugin-fxa/lib/configs/index.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+// All rules are auto-loaded into this module.
+
+const fs = require('fs')
+const path = require('path')
+
+fs.readdirSync(__dirname).forEach(name => {
+  if (name !== 'index.js') {
+    exports[name.substr(0, name.length - 3)] = require(path.join(__dirname, name))
+  }
+})

--- a/_dev/eslint-plugin-fxa/lib/configs/recommended.js
+++ b/_dev/eslint-plugin-fxa/lib/configs/recommended.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = {
+  extends: ['plugin:fxa/default', 'prettier']
+};

--- a/_dev/eslint-plugin-fxa/lib/configs/server.js
+++ b/_dev/eslint-plugin-fxa/lib/configs/server.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+module.exports = {
+  extends: 'plugin:fxa/recommended',
+
+  rules: {
+    'no-console': 'off',
+    'fxa/async-crypto-random': 'error',
+    'fxa/no-new-buffer': 'error'
+  }
+}

--- a/_dev/eslint-plugin-fxa/lib/index.js
+++ b/_dev/eslint-plugin-fxa/lib/index.js
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+module.exports = {
+  configs: require('./configs'),
+  rules: require('./rules')
+}

--- a/_dev/eslint-plugin-fxa/lib/rules/async-crypto-random.js
+++ b/_dev/eslint-plugin-fxa/lib/rules/async-crypto-random.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee
+        if (callee.object &&
+            callee.object.name === 'crypto' &&
+            callee.property &&
+            callee.property.name === 'randomBytes' &&
+            node.arguments.length === 1) {
+          context.report({
+            node: node,
+            message: 'Pass a callback to crypto.randomBytes().'
+          })
+        }
+      }
+    }
+  }
+}

--- a/_dev/eslint-plugin-fxa/lib/rules/index.js
+++ b/_dev/eslint-plugin-fxa/lib/rules/index.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+// All rules are auto-loaded into this module.
+
+const fs = require('fs')
+const path = require('path')
+
+fs.readdirSync(__dirname).forEach(name => {
+  if (name !== 'index.js') {
+    exports[name.substr(0, name.length - 3)] = require(path.join(__dirname, name))
+  }
+})

--- a/_dev/eslint-plugin-fxa/lib/rules/no-exclusive-tests.js
+++ b/_dev/eslint-plugin-fxa/lib/rules/no-exclusive-tests.js
@@ -1,0 +1,68 @@
+/*
+Borrowed from https://github.com/lo1tuma/eslint-plugin-mocha/tree/master/lib
+We cannot directly depend on that package due to lack of support for that in ESLint: https://github.com/eslint/rfcs/pull/5
+*/
+'use strict';
+
+const { getAdditionalTestFunctions } = require('../util/settings');
+const astUtils = require('../util/ast');
+
+module.exports = function (context) {
+  let mochaTestFunctions = [
+    'it',
+    'describe',
+    'suite',
+    'test',
+    'context',
+    'specify'
+  ];
+  const settings = context.settings;
+  const additionalTestFunctions = getAdditionalTestFunctions(settings);
+
+  mochaTestFunctions = mochaTestFunctions.concat(additionalTestFunctions);
+
+  function matchesMochaTestFunction(object) {
+    const name = astUtils.getNodeName(object);
+
+    return mochaTestFunctions.indexOf(name) !== -1;
+  }
+
+  function isPropertyNamedOnly(property) {
+    return property && astUtils.getPropertyName(property) === 'only';
+  }
+
+  function isCallToMochasOnlyFunction(callee) {
+    return callee.type === 'MemberExpression' &&
+      matchesMochaTestFunction(callee.object) &&
+      isPropertyNamedOnly(callee.property);
+  }
+
+  return {
+    CallExpression(node) {
+      const callee = node.callee;
+
+      if (callee && isCallToMochasOnlyFunction(callee)) {
+        context.report({
+          node: callee.property,
+          message: 'Unexpected exclusive mocha test.'
+        });
+      }
+    }
+  };
+};
+
+module.exports.schema = [
+  {
+    type: 'object',
+    properties: {
+      additionalTestFunctions: {
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        minItems: 1,
+        uniqueItems: true
+      }
+    }
+  }
+];

--- a/_dev/eslint-plugin-fxa/lib/rules/no-new-buffer.js
+++ b/_dev/eslint-plugin-fxa/lib/rules/no-new-buffer.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+function inferMethod(args) {
+  return (args.length > 0 && typeof args[0].value === 'number') ? 'alloc' : 'from';
+};
+
+module.exports = {
+  create(context) {
+    return {
+      NewExpression(node) {
+        const callee = node.callee
+        const method = inferMethod(node.arguments)
+        if (callee && callee.name === 'Buffer') {
+          context.report({
+            node: node,
+            message: `\`new Buffer()\` is deprecated, use \`Buffer.${method}()\` instead.`,
+          })
+        }
+      }
+    }
+  }
+}

--- a/_dev/eslint-plugin-fxa/lib/util/ast.js
+++ b/_dev/eslint-plugin-fxa/lib/util/ast.js
@@ -1,0 +1,126 @@
+/**
+ * Borrowed from https://github.com/lo1tuma/eslint-plugin-mocha/tree/master/lib
+ *
+ * We cannot directly depend on that package due to lack of support for that in
+  ESLint: https://github.com/eslint/rfcs/pull/5
+ */
+
+'use strict';
+
+const R = require('ramda');
+
+const isDefined = R.complement(R.isNil);
+const isCallExpression = R.both(isDefined, R.propEq('type', 'CallExpression'));
+
+const describeAliases = [
+  'describe',
+  'xdescribe',
+  'describe.only',
+  'describe.skip',
+  'context',
+  'xcontext',
+  'context.only',
+  'context.skip',
+  'suite',
+  'xsuite',
+  'suite.only',
+  'suite.skip',
+];
+const hooks = [
+  'before',
+  'after',
+  'beforeEach',
+  'afterEach',
+  'beforeAll',
+  'afterAll',
+];
+const testCaseNames = [
+  'it',
+  'it.only',
+  'it.skip',
+  'xit',
+  'test',
+  'test.only',
+  'test.skip',
+  'specify',
+  'specify.only',
+  'specify.skip',
+  'xspecify',
+];
+
+function getPropertyName(property) {
+  return property.name || property.value;
+}
+
+function getNodeName(node) {
+  if (node.type === 'MemberExpression') {
+    return `${getNodeName(node.object)}.${getPropertyName(node.property)}`;
+  }
+  return node.name;
+}
+
+function isDescribe(node, additionalSuiteNames) {
+  return (
+    isCallExpression(node) &&
+    describeAliases
+      .concat(additionalSuiteNames)
+      .indexOf(getNodeName(node.callee)) > -1
+  );
+}
+
+function isHookIdentifier(node) {
+  return node && node.type === 'Identifier' && hooks.indexOf(node.name) !== -1;
+}
+
+function isHookCall(node) {
+  return isCallExpression(node) && isHookIdentifier(node.callee);
+}
+
+function isTestCase(node) {
+  return (
+    isCallExpression(node) &&
+    testCaseNames.indexOf(getNodeName(node.callee)) > -1
+  );
+}
+
+function findReference(scope, node) {
+  const hasSameRangeAsNode = R.pathEq(['identifier', 'range'], node.range);
+
+  return R.find(hasSameRangeAsNode, scope.references);
+}
+
+function isShadowed(scope, identifier) {
+  const reference = findReference(scope, identifier);
+
+  return reference && reference.resolved && reference.resolved.defs.length > 0;
+}
+
+function isCallToShadowedReference(node, scope) {
+  const identifier =
+    node.callee.type === 'MemberExpression' ? node.callee.object : node.callee;
+
+  return isShadowed(scope, identifier);
+}
+
+function isMochaFunctionCall(node, scope) {
+  if (isCallToShadowedReference(node, scope)) {
+    return false;
+  }
+
+  return isTestCase(node) || isDescribe(node) || isHookCall(node);
+}
+
+function isStringLiteral(node) {
+  return node && node.type === 'Literal' && typeof node.value === 'string';
+}
+
+module.exports = {
+  isDescribe,
+  isHookIdentifier,
+  isTestCase,
+  getPropertyName,
+  getNodeName,
+  isMochaFunctionCall,
+  isHookCall,
+  isStringLiteral,
+};

--- a/_dev/eslint-plugin-fxa/lib/util/settings.js
+++ b/_dev/eslint-plugin-fxa/lib/util/settings.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* eslint-env node*/
+
+'use strict';
+
+function settingFor(propertyName) {
+  return function (settings) {
+    const value = settings[`mocha/${ propertyName}`];
+    const mochaSettings = settings.mocha || {};
+
+    return value || mochaSettings[propertyName] || [];
+  };
+}
+
+module.exports = {
+  getAdditionalTestFunctions: settingFor('additionalTestFunctions'),
+  additionalSuiteNames: settingFor('additionalSuiteNames'),
+  getAdditionalXFunctions: settingFor('additionalXFunctions')
+};

--- a/_dev/eslint-plugin-fxa/package.json
+++ b/_dev/eslint-plugin-fxa/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "eslint-plugin-fxa",
+  "version": "2.0.2",
+  "description": "eslint plugin for Firefox Accounts",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "dependencies": {
+    "eslint": "6.6.0",
+    "eslint-config-prettier": "6.5.0",
+    "ramda": "^0.26.1"
+  },
+  "devDependencies": {
+    "mocha": "6.2.2"
+  },
+  "peerDependencies": {
+    "eslint": ">=6.6.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozilla/fxa.git"
+  },
+  "author": "Mozilla (https://mozilla.org)",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/mozilla/fxa/issues"
+  },
+  "homepage": "https://github.com/mozilla/fxa"
+}

--- a/_dev/eslint-plugin-fxa/test/async-crypto-random.js
+++ b/_dev/eslint-plugin-fxa/test/async-crypto-random.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../lib/rules/async-crypto-random');
+
+const ruleTester = new RuleTester();
+ruleTester.run('async-crypto-random', rule, {
+  valid: ['crypto.randomBytes(32, cb)'],
+  invalid: [
+    {
+      code: 'crypto.randomBytes(32)',
+      errors: [{ message: 'Pass a callback to crypto.randomBytes().' }],
+    },
+  ],
+});

--- a/_dev/eslint-plugin-fxa/test/no-exclusive-tests.js
+++ b/_dev/eslint-plugin-fxa/test/no-exclusive-tests.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../lib/rules/no-exclusive-tests');
+
+const ruleTester = new RuleTester();
+
+const fromError = {
+  message: 'Unexpected exclusive mocha test.',
+};
+
+ruleTester.run('no-exclusive-tests', rule, {
+  valid: [`it('test', function() { });`],
+  invalid: [
+    {
+      code: `it.only('test', function() { });`,
+      errors: [fromError],
+    },
+  ],
+});

--- a/_dev/eslint-plugin-fxa/test/no-new-buffer.js
+++ b/_dev/eslint-plugin-fxa/test/no-new-buffer.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../lib/rules/no-new-buffer');
+
+const ruleTester = new RuleTester();
+
+const allocError = {
+  message: '`new Buffer()` is deprecated, use `Buffer.alloc()` instead.',
+};
+
+const fromError = {
+  message: '`new Buffer()` is deprecated, use `Buffer.from()` instead.',
+};
+
+ruleTester.run('no-new-buffer', rule, {
+  valid: [
+    `buf = Buffer.from('buf')`,
+    `buf = Buffer.from('7468697320697320612074c3a97374', 'hex')`,
+    'buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])',
+    'buf = Buffer.alloc(10)',
+  ],
+  invalid: [
+    {
+      code: 'buf = new Buffer()',
+      errors: [fromError],
+    },
+    {
+      code: `buf = new Buffer('buf')`,
+      errors: [fromError],
+    },
+    {
+      code: `buf = new Buffer('7468697320697320612074c3a97374', 'hex')`,
+      errors: [fromError],
+    },
+    {
+      code: 'buf = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])',
+      errors: [fromError],
+    },
+    {
+      code: 'buf = new Buffer(10)',
+      errors: [allocError],
+    },
+    {
+      code: `
+        ab = new ArrayBuffer(10);
+        buf = new Buffer(ab, 0, 2);
+      `,
+      errors: [fromError],
+    },
+    {
+      code: `
+        buf1 = new Buffer('buf');
+        buf2 = new Buffer(buf1);
+      `,
+      errors: [fromError, fromError],
+    },
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
+    "eslint-plugin-fxa": "file:_dev/eslint-plugin-fxa",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-react": "^7.32.2",
     "json": "^11.0.0",

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "audit-filter": "0.5.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "pm2": "^5.3.0",
     "prettier": "^2.3.1"
   },

--- a/packages/browserid-verifier/package.json
+++ b/packages/browserid-verifier/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "audit-filter": "0.5.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "fxa-shared": "workspace:*",
     "mocha": "^10.0.0",
     "pm2": "^5.3.0",

--- a/packages/fortress/package.json
+++ b/packages/fortress/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "audit-filter": "0.5.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "fxa-shared": "workspace:*",
     "npm-run-all": "4.1.5",
     "pm2": "^5.3.0",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -179,7 +179,6 @@
     "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "fxa-shared": "workspace:*",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.4.3",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -160,7 +160,6 @@
     "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "firefox-profile": "4.2.2",
     "got": "11.8.5",
     "grunt-ban-word": "0.1.1",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -50,7 +50,6 @@
     "audit-filter": "^0.5.0",
     "chai": "^4.3.6",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "fxa-shared": "workspace:*",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.4.3",

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -40,7 +40,6 @@
     "audit-filter": "^0.5.0",
     "chai": "^4.3.6",
     "eslint": "^8.19.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "fxa-shared": "workspace:*",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -92,7 +92,6 @@
     "browserslist": "^4.21.4",
     "eslint": "^7.32.0",
     "eslint-config-react-app": "^6.0.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-react": "^7.32.2",
     "express-http-proxy": "^1.6.3",

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -47,7 +47,6 @@
     "audit-filter": "^0.5.0",
     "commander": "9.3.0",
     "eslint": "^8.18.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "insist": "1.0.1",
     "mocha": "^10.0.0",
     "mocha-text-cov": "0.1.1",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -132,7 +132,6 @@
     "css-loader": "^3.6.0",
     "eslint": "^7.32.0",
     "eslint-config-react-app": "^6.0.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-react": "^7.32.2",
     "fxa-shared": "workspace:*",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -117,7 +117,6 @@
     "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "eslint": "^7.32.0",
-    "eslint-plugin-fxa": "^2.0.2",
     "jest": "27.5.1",
     "jest-junit": "^15.0.0",
     "jsdom": "20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,6 @@ __metadata:
     convict: ^6.2.4
     convict-format-with-validator: ^6.2.0
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.3
     fxa-jwtool: ^0.7.2
     ioredis: ^5.0.6
@@ -17782,7 +17781,6 @@ __metadata:
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.3
     fxa-shared: "workspace:*"
     intel: 1.2.0
@@ -23286,16 +23284,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-fxa@npm:^2.0.2":
+"eslint-plugin-fxa@file:_dev/eslint-plugin-fxa::locator=fxa%40workspace%3A.":
   version: 2.0.2
-  resolution: "eslint-plugin-fxa@npm:2.0.2"
+  resolution: "eslint-plugin-fxa@file:_dev/eslint-plugin-fxa#_dev/eslint-plugin-fxa::hash=f4864c&locator=fxa%40workspace%3A."
   dependencies:
     eslint: 6.6.0
     eslint-config-prettier: 6.5.0
     ramda: ^0.26.1
   peerDependencies:
     eslint: ">=6.6.0"
-  checksum: cb4c8ac7079d2c9d6940da381d92e041dc51706b89bc55e41f19ff7f680245348ce4fc41f6045ac6a64975b4564036df49415fa2e73dcb6e719b1c36fb650542
+  checksum: 6d10336b2dc4b0e1dfe013ad74d6ed5c8b05f9bbf2e86a18bb096605dea6cba779c5fb9721086aabef0d112110dab1fa52b9380e799b99d321ef47ca98a6fc07
   languageName: node
   linkType: hard
 
@@ -25299,7 +25297,6 @@ __metadata:
     client-sessions: 0.8.x
     ejs: ^3.1.6
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.3
     fxa-shared: "workspace:*"
     morgan: ^1.10.0
@@ -25911,7 +25908,6 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     fxa-customs-server: "workspace:*"
     fxa-geodb: "workspace:*"
     fxa-jwtool: ^0.7.2
@@ -26059,7 +26055,6 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     expose-loader: 1.0.3
     express: ^4.17.3
     extract-loader: 5.1.0
@@ -26201,7 +26196,6 @@ fsevents@~2.1.1:
     dedent: ^0.7.0
     deep-equal: 2.2.0
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     fxa-shared: "workspace:*"
     grunt: ^1.6.1
     grunt-cli: ^1.4.3
@@ -26325,7 +26319,6 @@ fsevents@~2.1.1:
     chai: ^4.3.6
     cron: 2.2.0
     eslint: ^8.19.0
-    eslint-plugin-fxa: ^2.0.2
     fxa-shared: "workspace:*"
     maxmind: ^4.3.6
     mocha: ^10.0.0
@@ -26498,7 +26491,6 @@ fsevents@~2.1.1:
     dayjs: ^1.11.5
     eslint: ^7.32.0
     eslint-config-react-app: ^6.0.0
-    eslint-plugin-fxa: ^2.0.2
     eslint-plugin-jest: ^27.2.1
     eslint-plugin-react: ^7.32.2
     express: ^4.17.3
@@ -26580,7 +26572,6 @@ fsevents@~2.1.1:
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
     eslint: ^8.18.0
-    eslint-plugin-fxa: ^2.0.2
     fxa-shared: "workspace:*"
     insist: 1.0.1
     joi: ^17.8.3
@@ -26717,7 +26708,6 @@ fsevents@~2.1.1:
     css-loader: ^3.6.0
     eslint: ^7.32.0
     eslint-config-react-app: ^6.0.0
-    eslint-plugin-fxa: ^2.0.2
     eslint-plugin-jest: ^27.2.1
     eslint-plugin-react: ^7.32.2
     fxa-auth-client: "workspace:*"
@@ -26826,7 +26816,6 @@ fsevents@~2.1.1:
     esbuild: ^0.14.2
     esbuild-register: ^3.2.0
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
     express: ^4.17.3
     find-up: ^5.0.0
     generic-pool: ^3.8.2
@@ -26874,7 +26863,7 @@ fsevents@~2.1.1:
   dependencies:
     diffparser: ^2.0.1
     eslint: ^7.32.0
-    eslint-plugin-fxa: ^2.0.2
+    eslint-plugin-fxa: "file:_dev/eslint-plugin-fxa"
     eslint-plugin-jest: ^27.2.1
     eslint-plugin-react: ^7.32.2
     husky: ^4.2.5


### PR DESCRIPTION
Because:
 - we don't want to maintain the fxa eslint plugin in another repo

This commit:
 - move the plugin into the monorepo
