### PR TITLE
task(ci): Allow smoke tests on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -840,16 +840,41 @@ workflows:
       # a requirement for all production deploys.
       - test-content-server-remote-part-0:
           name: Smoke Stage - Content Server Part 1
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - test-content-server-remote-part-1:
           name: Smoke Stage - Content Server Part 2
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - test-content-server-remote-part-2:
           name: Smoke Stage - Content Server Part 3
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - smoke-tests:
           name: Smoke Test Stage - Playwright
           target: test-stage
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - smoke-tests:
           name: Smoke Test Production - Playwright
           target: test-production
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
 
   # Triggered remotely. See .circleci/README.md
   stage_smoke_tests:
@@ -857,13 +882,33 @@ workflows:
     jobs:
       - test-content-server-remote-part-0:
           name: Smoke Test Stage - Content Server Part 1
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - test-content-server-remote-part-1:
           name: Smoke Test Stage - Content Server Part 2
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - test-content-server-remote-part-2:
           name: Smoke Test Stage - Content Server Part 3
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - smoke-tests:
           name: Smoke Test Stage - Playwright
           target: test-stage
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
 
   deploy_packages:
     # This workflow can be triggered after a PR lands on main. It requires approval.


### PR DESCRIPTION
## Because
- Smoke tests could be triggered on branches but not on tags
- Generally we only run smoke tests on tags

## This pull request

- Applies filters such that smoke tests can be run on tags.
- Applies filters such that smoke tests cannot be run on branches.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

