### PR TITLE
fix(auth): include tax in renewal notice emails

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -763,39 +763,16 @@ export class StripeHelper extends StripeHelperBase {
    * Previews the subsequent invoice for a specific subscription
    */
   async previewInvoiceBySubscriptionId({
-    automaticTax,
     subscriptionId,
     includeCanceled,
   }: {
-    automaticTax: boolean;
     subscriptionId: string;
     includeCanceled?: boolean;
   }) {
-    const retrieveUpcomingParams = {
+    return this.stripe.invoices.retrieveUpcoming({
+      subscription: subscriptionId,
       ...(includeCanceled && { subscription_cancel_at_period_end: false }),
-      ...{ subscription: subscriptionId },
-    };
-
-    if (automaticTax) {
-      try {
-        return await this.stripe.invoices.retrieveUpcoming({
-          ...retrieveUpcomingParams,
-          automatic_tax: {
-            enabled: true,
-          },
-        });
-      } catch (e: any) {
-        this.log.warn('stripe.previewInvoice.automatic_tax', {
-          subscriptionId,
-        });
-
-        throw e;
-      }
-    } else {
-      return await this.stripe.invoices.retrieveUpcoming(
-        retrieveUpcomingParams
-      );
-    }
+    });
   }
 
   /** Fetch a coupon with `applies_to` expanded. */

--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -136,8 +136,12 @@ export class SubscriptionReminders {
       const { email } = account;
       const formattedSubscription =
         await this.stripeHelper.formatSubscriptionForEmail(subscription);
-      const { amount, currency, interval_count, interval } =
+      const { interval_count, interval } =
         await this.stripeHelper.findAbbrevPlanById(planId);
+      const invoicePreview =
+        await this.stripeHelper.previewInvoiceBySubscriptionId({
+          subscriptionId: subscription.id,
+        });
       await this.mailer.sendSubscriptionRenewalReminderEmail(
         account.emails,
         account,
@@ -150,8 +154,8 @@ export class SubscriptionReminders {
           planIntervalCount: interval_count,
           planInterval: interval,
           // Using invoice prefix instead of plan to accommodate `yarn write-emails`.
-          invoiceTotalInCents: amount,
-          invoiceTotalCurrency: currency,
+          invoiceTotalInCents: invoicePreview.total,
+          invoiceTotalCurrency: invoicePreview.currency,
           productMetadata: formattedSubscription.productMetadata,
           planConfig: formattedSubscription.planConfig,
         }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -481,7 +481,6 @@ export class StripeHandler {
     request: AuthRequest
   ): Promise<invoiceDTO.subsequentInvoicePreviewsSchema> {
     this.log.begin('subscriptions.subsequentInvoicePreview', request);
-    const automaticTax = this.automaticTax;
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'subsequentInvoicePreviews');
 
@@ -496,7 +495,6 @@ export class StripeHandler {
     const subsequentInvoicePreviews = await Promise.all(
       customer.subscriptions.data.map((sub) => {
         return this.stripeHelper.previewInvoiceBySubscriptionId({
-          automaticTax: automaticTax && sub.automatic_tax.enabled,
           subscriptionId: sub.id,
           includeCanceled: !!sub.canceled_at,
         });

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2224,14 +2224,12 @@ describe('#integration - StripeHelper', () => {
   });
 
   describe('previewInvoiceBySubscriptionId', () => {
-    it('uses country when automatic tax is not enabled', async () => {
+    it('fetches invoice preview', async () => {
       const stripeStub = sandbox
         .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
         .resolves();
-      sandbox.stub(stripeHelper, 'taxRateByCountryCode').resolves();
 
       await stripeHelper.previewInvoiceBySubscriptionId({
-        automaticTax: false,
         subscriptionId: 'sub123',
       });
 
@@ -2240,14 +2238,12 @@ describe('#integration - StripeHelper', () => {
       });
     });
 
-    it('uses country when automatic tax is not enabled', async () => {
+    it('fetches invoice preview for cancelled subscription', async () => {
       const stripeStub = sandbox
         .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
         .resolves();
-      sandbox.stub(stripeHelper, 'taxRateByCountryCode').resolves();
 
       await stripeHelper.previewInvoiceBySubscriptionId({
-        automaticTax: false,
         subscriptionId: 'sub123',
         includeCanceled: true,
       });
@@ -2256,39 +2252,6 @@ describe('#integration - StripeHelper', () => {
         subscription: 'sub123',
         subscription_cancel_at_period_end: false,
       });
-    });
-
-    it('uses shipping address when automatic tax is enabled', async () => {
-      const stripeStub = sandbox
-        .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
-        .resolves();
-
-      await stripeHelper.previewInvoiceBySubscriptionId({
-        automaticTax: true,
-        subscriptionId: 'sub123',
-      });
-
-      sinon.assert.calledOnceWithExactly(stripeStub, {
-        subscription: 'sub123',
-        automatic_tax: {
-          enabled: true,
-        },
-      });
-    });
-
-    it('logs when there is an error when automatic tax is enabled', async () => {
-      sandbox
-        .stub(stripeHelper.stripe.invoices, 'retrieveUpcoming')
-        .throws(new Error());
-
-      try {
-        await stripeHelper.previewInvoiceBySubscriptionId({
-          automaticTax: true,
-          subscriptionId: 'sub123',
-        });
-      } catch (e) {
-        sinon.assert.calledOnce(stripeHelper.log.warn);
-      }
     });
   });
 

--- a/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
+++ b/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
@@ -17,6 +17,7 @@ const {
   EMAIL_TYPE,
   SubscriptionReminders,
 } = require('../../../lib/payments/subscription-reminders');
+const invoicePreview = require('./fixtures/stripe/invoice_preview_tax.json');
 const longPlan1 = require('./fixtures/stripe/plan1.json');
 const longPlan2 = require('./fixtures/stripe/plan2.json');
 const shortPlan1 = require('./fixtures/stripe/plan3.json');
@@ -270,6 +271,10 @@ describe('SubscriptionReminders', () => {
         interval_count: longPlan1.interval_count,
         interval: longPlan1.interval,
       });
+      mockStripeHelper.previewInvoiceBySubscriptionId = sandbox.fake.resolves({
+        total: invoicePreview.total,
+        currency: invoicePreview.currency,
+      });
       const planConfig = {
         wibble: 'quux',
       };
@@ -312,6 +317,12 @@ describe('SubscriptionReminders', () => {
         longPlan1.id
       );
       sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.previewInvoiceBySubscriptionId,
+        {
+          subscriptionId: subscription.id,
+        }
+      );
+      sinon.assert.calledOnceWithExactly(
         mockLog.info,
         'sendSubscriptionRenewalReminderEmail',
         {
@@ -334,8 +345,8 @@ describe('SubscriptionReminders', () => {
           reminderLength: 14,
           planIntervalCount: 1,
           planInterval: 'month',
-          invoiceTotalInCents: 499,
-          invoiceTotalCurrency: 'usd',
+          invoiceTotalInCents: invoicePreview.total,
+          invoiceTotalCurrency: invoicePreview.currency,
           productMetadata: formattedSubscription.productMetadata,
           planConfig,
         }
@@ -365,6 +376,10 @@ describe('SubscriptionReminders', () => {
         interval_count: longPlan1.interval_count,
         interval: longPlan1.interval,
       });
+      mockStripeHelper.previewInvoiceBySubscriptionId = sandbox.fake.resolves({
+        total: invoicePreview.total,
+        currency: invoicePreview.currency,
+      });
       mockLog.info = sandbox.fake.returns({});
       mockLog.error = sandbox.fake.returns({});
       const errMessage = 'Something went wrong.';
@@ -387,6 +402,12 @@ describe('SubscriptionReminders', () => {
       sinon.assert.calledOnceWithExactly(
         mockStripeHelper.findAbbrevPlanById,
         longPlan1.id
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.previewInvoiceBySubscriptionId,
+        {
+          subscriptionId: subscription.id,
+        }
       );
       sinon.assert.calledOnceWithExactly(
         mockLog.error,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -909,12 +909,10 @@ describe('DirectStripeRoutes', () => {
         },
         [
           {
-            automaticTax: false,
             subscriptionId: 'sub_id1',
             includeCanceled: false,
           },
           {
-            automaticTax: false,
             subscriptionId: 'sub_id2',
             includeCanceled: false,
           },
@@ -929,12 +927,10 @@ describe('DirectStripeRoutes', () => {
         },
         [
           {
-            automaticTax: false,
             subscriptionId: 'sub_id1',
             includeCanceled: true,
           },
           {
-            automaticTax: false,
             subscriptionId: 'sub_id2',
             includeCanceled: false,
           },
@@ -986,30 +982,6 @@ describe('DirectStripeRoutes', () => {
         directStripeRoutesInstance.stripeHelper.previewInvoiceBySubscriptionId
       );
       assert.deepEqual(expected, actual);
-    });
-
-    it('uses stripe tax if enabled', async () => {
-      directStripeRoutesInstance.automaticTax = true;
-      await successInvoices(
-        {
-          data: [
-            { id: 'sub_id1', automatic_tax: { enabled: true } },
-            { id: 'sub_id2', automatic_tax: { enabled: true } },
-          ],
-        },
-        [
-          {
-            automaticTax: true,
-            subscriptionId: 'sub_id1',
-            includeCanceled: false,
-          },
-          {
-            automaticTax: true,
-            subscriptionId: 'sub_id2',
-            includeCanceled: false,
-          },
-        ]
-      );
     });
   });
 


### PR DESCRIPTION
## Because

* Our subscription renewal emails do not contain tax

## This pull request

* Includes tax in renewal email by fetching an invoice preview, rather than taking the base cost of the plan. This is done via the previewInvoiceBySubscriptionId, such that it gets the next billed amount direct to the customer.
* Removes the automaticTax flag from previewInvoiceBySubscriptionId. Having automaticTax as a flag isn't necessary here, since you're previewing a subscription by ID which already inherits the subscription's automaticTax status, and could also be misunderstood/misused since it actually behaves as an override.

## Issue that this pull request solves

Closes FXA-7082