### PR TITLE
fix(auth): automatic tax check IP addr before converting customers

### DIFF
--- a/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax.ts
@@ -60,7 +60,7 @@ async function init() {
     batchSize,
     program.outputFile,
     program.ipAddressMapFile,
-    stripeHelper.stripe,
+    stripeHelper,
     rateLimit,
     database
   );

--- a/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax/helpers.ts
+++ b/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax/helpers.ts
@@ -101,10 +101,13 @@ export class StripeAutomaticTaxConverterHelpers {
 
   /**
    * Checks if Stripe customer is in a taxable location
-   * @returns True if the user is currently taxable
+   * @returns True if the user is currently taxable, including customers in a not_collecting tax location
    */
   isTaxEligible(customer: Stripe.Customer) {
-    return customer.tax?.automatic_tax === 'supported';
+    return (
+      customer.tax?.automatic_tax === 'supported' ||
+      customer.tax?.automatic_tax === 'not_collecting'
+    );
   }
 
   /**

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax-helpers.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax-helpers.ts
@@ -109,7 +109,22 @@ describe('StripeAutomaticTaxConverterHelpers', () => {
       expect(result).true;
     });
 
-    it('returns false for unsupported customer', () => {
+    it('returns true for not_collecting customer', () => {
+      const customer = {
+        ...mockCustomer,
+        tax: {
+          ip_address: null,
+          location: null,
+          automatic_tax: 'not_collecting' as Stripe.Customer.Tax.AutomaticTax,
+        },
+      };
+
+      const result = helpers.isTaxEligible(customer);
+
+      expect(result).true;
+    });
+
+    it('returns false for unrecognized_location customer', () => {
       const customer = {
         ...mockCustomer,
         tax: {
@@ -117,6 +132,21 @@ describe('StripeAutomaticTaxConverterHelpers', () => {
           location: null,
           automatic_tax:
             'unrecognized_location' as Stripe.Customer.Tax.AutomaticTax,
+        },
+      };
+
+      const result = helpers.isTaxEligible(customer);
+
+      expect(result).false;
+    });
+
+    it('returns false for failed customer', () => {
+      const customer = {
+        ...mockCustomer,
+        tax: {
+          ip_address: null,
+          location: null,
+          automatic_tax: 'failed' as Stripe.Customer.Tax.AutomaticTax,
         },
       };
 


### PR DESCRIPTION
## Because

* The script could move customers between tax exclusive/inclusive regions.

## This pull request

* Checks customer's currency against mapped IP address country.
* Considers not_collecting as an eligible stripe autotax status.

## Issue that this pull request solves

Closes FXA-7061
