### PR TITLE
fix(payments): correct total amount displayed in PaymentForm

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -254,11 +254,13 @@ export function useFetchInvoicePreview(
           });
         }
       } catch (err) {
-        setInvoicePreview({
-          loading: false,
-          error: true,
-          result: undefined,
-        });
+        if (isMounted.current) {
+          setInvoicePreview({
+            loading: false,
+            error: true,
+            result: undefined,
+          });
+        }
       }
     };
 

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -223,6 +223,11 @@ describe('routes/Product', () => {
           '/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions'
         )
         .reply(200, MOCK_CUSTOMER, { 'Access-Control-Allow-Origin': '*' }),
+      nock(authServer)
+        .post('/v1/oauth/subscriptions/invoice/preview')
+        .reply(400, mockPreviewInvoiceResponse, {
+          'Access-Control-Allow-Origin': '*',
+        }),
     ];
     const { findByTestId, queryByTestId } = render(
       <Subject productId="bad_product" />


### PR DESCRIPTION
## Because

- The total amount displayed for existing customer subscribing to new plan omitted applied promo code and/or tax

## This pull request

- Updates the total to include promo code and/or tax if applied
- Fixes a failing test that returns an error for invalid product (and therefore no invoice preview)

## Issue that this pull request solves

Closes: FXA-7007

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
