### PR TITLE
task(settings): Use reach router location instead of window.location.

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -37,10 +37,9 @@ import ConfirmSignupCode from '../../pages/Signup/ConfirmSignupCode';
 import SigninReported from '../../pages/Signin/SigninReported';
 import AccountRecoveryResetPassword from '../../pages/ResetPassword/AccountRecoveryResetPassword';
 import LinkValidator from '../LinkValidator';
-import { UrlQueryData } from '../../lib/model-data';
-import { CompleteResetPasswordLink } from '../../models/reset-password/verification';
 import { LinkType } from 'fxa-settings/src/lib/types';
 import WebChannelExample from '../../pages/WebChannelExample';
+import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
 
 export const App = ({
   flowQueryParams,
@@ -115,9 +114,7 @@ export const App = ({
                 linkType={LinkType['reset-password']}
                 viewName={'complete-reset-password'}
                 getParamsFromModel={() => {
-                  return new CompleteResetPasswordLink(
-                    new UrlQueryData(window)
-                  );
+                  return CreateCompleteResetPasswordLink();
                 }}
               >
                 {({ setLinkStatus, params }) => (

--- a/packages/fxa-settings/src/components/PageWithLoggedInStatusState/index.tsx
+++ b/packages/fxa-settings/src/components/PageWithLoggedInStatusState/index.tsx
@@ -1,5 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { useState, useEffect } from 'react';
-import { useInitialState, useRelier } from '../../models';
+import { CreateRelier, useInitialState } from '../../models';
 import { RouteComponentProps } from '@reach/router';
 
 export const PageWithLoggedInStatusState = (
@@ -14,7 +18,7 @@ export const PageWithLoggedInStatusState = (
   const [isSignedIn, setIsSignedIn] = useState<boolean>();
   const [isSync, setIsSync] = useState<boolean>();
   const [serviceName, setServiceName] = useState<string>();
-  const relier = useRelier();
+  const relier = CreateRelier();
 
   // TODO: Get the broker `continue` action once https://mozilla-hub.atlassian.net/browse/FXA-6989 is merged
   let continueHandler: Function | undefined;

--- a/packages/fxa-settings/src/lib/model-data/bind-decorator.spec.ts
+++ b/packages/fxa-settings/src/lib/model-data/bind-decorator.spec.ts
@@ -24,6 +24,7 @@ class TestModel extends ModelDataProvider {
 }
 
 describe('bind-decorator', function () {
+
   it('creates with empty state', () => {
     const data = new GenericData({});
     const model1 = new TestModel(data);

--- a/packages/fxa-settings/src/lib/model-data/data-stores/index.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/index.ts
@@ -6,3 +6,4 @@ export * from './generic-data';
 export * from './storage-data';
 export * from './url-hash-data';
 export * from './url-query-data';
+export * from './location-state-data';

--- a/packages/fxa-settings/src/lib/model-data/data-stores/location-state-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/location-state-data.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReachRouterWindow } from '../../window';
+import { ModelDataStore } from '../model-data-store';
+
+/**
+ * A data store that wraps Reach Router's `window.location.state`.
+ */
+export class LocationStateData extends ModelDataStore {
+  constructor(protected readonly window: ReachRouterWindow) {
+    super();
+
+    if (window.location.state == null) {
+      window.location.state = {};
+    }
+  }
+
+  get state() {
+    return this.window.location.state;
+  }
+
+  public getKeys() {
+    return Object.keys(this.state);
+  }
+
+  public get(key: string) {
+    return this.state[key];
+  }
+
+  public set(key: string, value: unknown) {
+    this.state[key] = value;
+  }
+}

--- a/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.test.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.test.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReachRouterWindow } from '../../window';
 import { StorageData } from './storage-data';
 
 describe('storage-data', () => {
+  const window = new ReachRouterWindow();
+
   it('creates', () => {
     const data = new StorageData(window);
     expect(data).toBeDefined();

--- a/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReachRouterWindow } from '../../window';
 import { ModelDataStore } from '../model-data-store';
 
 // TODO: Adapt to using ../../storage implementation. We need a way to migrate / deal with the namespace issue though.
@@ -15,7 +16,7 @@ export class StorageData extends ModelDataStore {
 
   private state: Record<string, unknown>;
 
-  constructor(private window: Window) {
+  constructor(private window: ReachRouterWindow) {
     super();
     this.state = {};
     this.load();

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-data.ts
@@ -2,18 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReachRouterWindow } from '../../window';
 import { ModelDataStore } from '../model-data-store';
-import { WindowLocation, HistorySource } from '@reach/router';
-
-export type Location = Pick<
-  WindowLocation,
-  'href' | 'pathname' | 'search' | 'hash'
->;
-export type History = Pick<HistorySource, 'history'>;
-
-export type WindowWrapper = History & {
-  location: Location;
-};
 
 /**
  * An abstract base class for persisting state in the URL.
@@ -30,7 +20,7 @@ export abstract class UrlData extends ModelDataStore {
    * @param window Current window
    * @param mode Whether or not to store state in the search query or the hash.
    */
-  constructor(public readonly window: WindowWrapper) {
+  constructor(public readonly window: ReachRouterWindow) {
     super();
   }
 

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-hash-data.test.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-hash-data.test.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReachRouterWindow } from '../../window';
 import { UrlHashData } from './url-hash-data';
 
 describe('url-hash-data', () => {
+  const window = new ReachRouterWindow();
+
   it('creates', () => {
     const data = new UrlHashData(window);
     expect(data).toBeDefined();

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-hash-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-hash-data.ts
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UrlData, WindowWrapper } from './url-data';
+import { UrlData } from './url-data';
+import { ReachRouterWindow } from '../../window';
 
 /**
  * Creates a data store from the current URL state.
  * Uses window.location.hash to hold state.
  */
 export class UrlHashData extends UrlData {
-  constructor(public readonly window: WindowWrapper) {
+  constructor(public readonly window: ReachRouterWindow) {
     super(window);
   }
 

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-query-data.test.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-query-data.test.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReachRouterWindow } from '../../window';
 import { UrlQueryData } from './url-query-data';
 
 describe('url-search-data', () => {
+  const window = new ReachRouterWindow();
+
   it('creates', () => {
     const data = new UrlQueryData(window);
     expect(data).toBeDefined();
@@ -19,5 +22,12 @@ describe('url-search-data', () => {
   it('does not require sync', () => {
     const data = new UrlQueryData(window);
     expect(data.requiresSync()).toBeFalsy();
+  });
+
+  it('gets query params', () => {
+    const data = new UrlQueryData(window);
+    data.set('foo', 'bar');
+    expect(data.toSearchQuery()).toContain('foo=bar');
+    expect(window.location.href).toContain('foo=bar');
   });
 });

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-query-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-query-data.ts
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UrlData, WindowWrapper } from './url-data';
+import { ReachRouterWindow } from '../../window';
+import { UrlData } from './url-data';
 
 /**
  * Creates a data store from the current URL state.
  * Uses window.location.search (ie the query params) to hold state.
  */
 export class UrlQueryData extends UrlData {
-  constructor(public readonly window: WindowWrapper) {
+  constructor(public readonly window: ReachRouterWindow) {
     super(window);
   }
 
@@ -20,11 +21,15 @@ export class UrlQueryData extends UrlData {
   protected setParams(params: URLSearchParams) {
     const url = new URL(this.window.location.href);
     url.search = params.toString();
-    // Use replaceState URL, but prevent page loads or history changes
-    this.window.history.replaceState({}, '', url.toString());
+
+    // Use replace false stops a page refresh
+    this.window.navigate(url.toString(), {
+      state: this.window.location.state,
+      replace: true,
+    });
   }
 
   public toSearchQuery() {
-    return this.getParams().toString();
+    return this.window.location.search;
   }
 }

--- a/packages/fxa-settings/src/lib/model-data/model-data-store.ts
+++ b/packages/fxa-settings/src/lib/model-data/model-data-store.ts
@@ -25,7 +25,6 @@ export abstract class ModelDataStore {
   toJSON() {
     const temp: Record<string, unknown> = {};
     for (const key of this.getKeys()) {
-      console.log('!!! key', key);
       temp[key] = this.get(key);
     }
     return JSON.stringify(temp);

--- a/packages/fxa-settings/src/lib/reliers/relier-factory-flags.test.ts
+++ b/packages/fxa-settings/src/lib/reliers/relier-factory-flags.test.ts
@@ -6,8 +6,10 @@ import { createSandbox, SinonSandbox } from 'sinon';
 import { Constants } from '../constants';
 import { StorageData, UrlQueryData } from '../model-data';
 import { DefaultRelierFlags } from './relier-factory-flags';
+import { ReachRouterWindow } from '../window';
 
 describe('lib/reliers/relier-factory-flags', function () {
+  const window = new ReachRouterWindow();
   let relierFlags: DefaultRelierFlags;
   let queryData: UrlQueryData;
   let storageData: StorageData;

--- a/packages/fxa-settings/src/lib/reliers/relier-factory.test.ts
+++ b/packages/fxa-settings/src/lib/reliers/relier-factory.test.ts
@@ -15,6 +15,7 @@ import { StorageData, UrlHashData, UrlQueryData } from '../model-data';
 import { RelierDelegates } from './interfaces';
 import { RelierFactory } from './relier-factory';
 import { DefaultRelierFlags } from './relier-factory-flags';
+import { ReachRouterWindow } from '../window';
 
 type RelierFlagOverrides = {
   isDevicePairingAsAuthority?: boolean;
@@ -32,6 +33,7 @@ type FactoryCallCounts = {
 };
 
 describe('lib/reliers/relier-factory', () => {
+  const window = new ReachRouterWindow();
   let sandbox: sinon.SinonSandbox;
   let flags: DefaultRelierFlags;
   let urlQueryData: UrlQueryData;
@@ -65,6 +67,7 @@ describe('lib/reliers/relier-factory', () => {
 
     // Create a factory with current state
     const factory = new RelierFactory({
+      window,
       data: urlQueryData,
       channelData: urlHashData,
       flags,

--- a/packages/fxa-settings/src/lib/reliers/relier-factory.ts
+++ b/packages/fxa-settings/src/lib/reliers/relier-factory.ts
@@ -22,6 +22,7 @@ import {
   UrlQueryData,
 } from '../model-data';
 import { OAuthError } from '../oauth';
+import { ReachRouterWindow } from '../window';
 import { RelierFlags } from './interfaces';
 import { RelierDelegates } from './interfaces/relier-delegates';
 import { DefaultRelierFlags } from './relier-factory-flags';
@@ -70,11 +71,13 @@ export class RelierFactory {
   protected readonly delegates: RelierDelegates;
 
   constructor(opts: {
+    window: ReachRouterWindow;
     delegates: RelierDelegates;
     data?: ModelDataStore;
     channelData?: ModelDataStore;
     flags?: RelierFlags;
   }) {
+    const { window } = opts;
     this.data = opts.data || new UrlQueryData(window);
     this.channelData = opts.channelData || new UrlHashData(window);
     this.flags =

--- a/packages/fxa-settings/src/lib/window.test.ts
+++ b/packages/fxa-settings/src/lib/window.test.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { NavigateFn, WindowLocation } from '@reach/router';
+import { ReachRouterWindow } from './window';
+
+describe('window', () => {
+  describe('ReachRouterWindow', () => {
+    it('creates', () => {
+      const window = new ReachRouterWindow();
+      expect(window).toBeDefined();
+      expect(window.location).toBeDefined();
+      expect(window.navigate).toBeDefined();
+      expect(window.history).toBeDefined();
+      expect(window.localStorage).toBeDefined();
+      expect(window.sessionStorage).toBeDefined();
+    });
+
+    it('allows overrides', () => {
+      const fakeOverride: any = {
+        fake: 'yup',
+      };
+
+      const window = new ReachRouterWindow({
+        location: fakeOverride as WindowLocation<any>,
+        navigate: fakeOverride as NavigateFn,
+        history: fakeOverride as History,
+        localStorage: fakeOverride as Storage,
+        sessionStorage: fakeOverride as Storage,
+      });
+      expect(window).toBeDefined();
+      expect(window.location).toStrictEqual(fakeOverride);
+      expect(window.navigate).toStrictEqual(fakeOverride);
+      expect(window.history).toStrictEqual(fakeOverride);
+      expect(window.localStorage).toStrictEqual(fakeOverride);
+      expect(window.sessionStorage).toStrictEqual(fakeOverride);
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/window.ts
+++ b/packages/fxa-settings/src/lib/window.ts
@@ -2,8 +2,63 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { NavigateFn, WindowLocation, globalHistory } from '@reach/router';
+
 // Export window so it's possible to jest.mock the import of it in tests.
 
 const theRealWindow = window;
-
 export { theRealWindow as window };
+
+/**
+ * Combines reach router and browser window apis, preferring Reach Router apis if available.
+ */
+export class ReachRouterWindow {
+  /**
+   * Provides access to the current reach router's location API, or the window location API if the reach router isn't available.
+   */
+  public get location() {
+    return this.opts?.location || globalHistory.location;
+  }
+
+  /**
+   * Provides access to the reach router's navigate API.
+   */
+  public get navigate() {
+    return this.opts?.navigate || globalHistory.navigate;
+  }
+
+  /**
+   * Provides access to the windows history API.
+   */
+  public get history() {
+    return this.opts?.history || window.history;
+  }
+
+  /**
+   * Provides access to the window's localStorage API.
+   */
+  public get localStorage() {
+    return this.opts?.localStorage || window.localStorage;
+  }
+
+  /**
+   * Provides access to the window's sessionStorage API.
+   */
+  public get sessionStorage() {
+    return this.opts?.sessionStorage || window.sessionStorage;
+  }
+
+  /**
+   * Creates a new window wrapper instance
+   * @param opts - A set of options to override the default behaviors of window API and reach router API.
+   */
+  public constructor(
+    private readonly opts?: {
+      location?: WindowLocation<any>;
+      navigate?: NavigateFn;
+      history?: History;
+      localStorage?: Storage;
+      sessionStorage?: Storage;
+    }
+  ) {}
+}

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -10,8 +10,6 @@ import { gql, useQuery } from '@apollo/client';
 import { useLocalization } from '@fluent/react';
 import { FtlMsgResolver } from 'fxa-react/lib/utils';
 import { getDefault } from '../lib/config';
-import { GenericData } from '../lib/model-data';
-import { useLocation } from '@reach/router';
 
 export function useAccount() {
   const { account } = useContext(AppContext);
@@ -83,35 +81,18 @@ export function useAlertBar() {
   return alertBarInfo;
 }
 
+export function useWindowWrapper() {
+  const { windowWrapper } = useContext(AppContext);
+  if (windowWrapper == null) {
+    throw new Error('windowWrapper never initialized!');
+  }
+  return windowWrapper;
+}
+
 export function useFtlMsgResolver() {
   const config = useConfig();
   const { l10n } = useLocalization();
   return new FtlMsgResolver(l10n, config.l10n.strict);
-}
-
-export function useRelier() {
-  const { relierFactory } = useContext(AppContext);
-  if (relierFactory == null) {
-    throw new Error('Relier factory never initialized!');
-  }
-  return relierFactory.getRelier();
-}
-
-export function useUrlQueryDataStore() {
-  let { urlQueryData } = useContext(AppContext);
-  if (urlQueryData == null) {
-    throw new Error('urlQueryData never initialized!');
-  }
-  return urlQueryData;
-}
-
-export function useLocationStateData() {
-  const location = useLocation();
-  if (location == null) {
-    throw new Error('Location missing!');
-  }
-
-  return new GenericData((location.state || {}) as Record<string, unknown>);
 }
 
 export function useNotifier() {

--- a/packages/fxa-settings/src/models/reliers/base-relier.test.ts
+++ b/packages/fxa-settings/src/models/reliers/base-relier.test.ts
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { UrlQueryData } from '../../lib/model-data';
+import { ReachRouterWindow } from '../../lib/window';
 import { BaseRelier } from './base-relier';
 
 describe('BaseRelier Model', function () {
+  const window = new ReachRouterWindow();
   let model: BaseRelier;
   beforeEach(function () {
     model = new BaseRelier(new UrlQueryData(window));

--- a/packages/fxa-settings/src/models/reliers/factory.ts
+++ b/packages/fxa-settings/src/models/reliers/factory.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useContext } from 'react';
+import { DefaultRelierFlags, RelierFactory } from '../../lib/reliers';
+import { AppContext } from '../AppContext';
+
+export function CreateRelierDelegates() {
+  const { oauthClient, authClient, windowWrapper } = useContext(AppContext);
+
+  if (!oauthClient || !authClient || !windowWrapper) {
+    throw new Error('Are you forgetting an AppContext.Provider?');
+  }
+
+  const delegates = {
+    getClientInfo: (id: string) => oauthClient.getClientInfo(id),
+    getProductInfo: (id: string) => authClient.getProductInfo(id),
+    getProductIdFromRoute: () => {
+      const re = new RegExp('/subscriptions/products/(.*)');
+      return re.exec(windowWrapper.location.pathname)?.[1] || '';
+    },
+  };
+
+  return delegates;
+}
+
+export function CreateRelierFlags() {
+  const { urlQueryData, storageData } = useContext(AppContext);
+
+  if (!urlQueryData || !storageData) {
+    throw new Error('Are you forgetting an AppContext.Provider?');
+  }
+
+  return new DefaultRelierFlags(urlQueryData, storageData);
+}
+
+export function CreateRelierFactory() {
+  const {
+    windowWrapper: window,
+    urlQueryData,
+    urlHashData,
+  } = useContext(AppContext);
+
+  if (!window || !urlHashData || !urlQueryData) {
+    throw new Error('Are you forgetting an AppContext.Provider?');
+  }
+
+  const delegates = CreateRelierDelegates();
+  const flags = CreateRelierFlags();
+  const relierFactory = new RelierFactory({
+    window,
+    delegates,
+    data: urlQueryData,
+    channelData: urlHashData,
+    flags,
+  });
+  return relierFactory;
+}
+
+export function CreateRelier() {
+  return CreateRelierFactory().getRelier();
+}

--- a/packages/fxa-settings/src/models/reliers/index.ts
+++ b/packages/fxa-settings/src/models/reliers/index.ts
@@ -12,3 +12,4 @@ export * from './pairing-supplicant-relier';
 export * from './resume-obj';
 export * from './signin-signup-info';
 export * from './supplicant-info';
+export * from './factory';

--- a/packages/fxa-settings/src/models/reset-password/verification/factory.ts
+++ b/packages/fxa-settings/src/models/reset-password/verification/factory.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useContext } from 'react';
+import { AppContext } from '../../AppContext';
+import { CompleteResetPasswordLink } from './complete-reset-password-link';
+
+export function CreateCompleteResetPasswordLink() {
+  const { urlQueryData } = useContext(AppContext);
+
+  if (urlQueryData == null) {
+    throw new Error('Are you forgetting an AppContext.Provider?');
+  }
+
+  return new CompleteResetPasswordLink(urlQueryData);
+}

--- a/packages/fxa-settings/src/models/verification/factory.ts
+++ b/packages/fxa-settings/src/models/verification/factory.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useContext } from 'react';
+import { VerificationInfo } from './verification-info';
+import { AppContext } from '../AppContext';
+import { AccountRecoveryKeyInfo } from './account-recovery-key-info';
+
+export function CreateVerificationInfo() {
+  const { urlQueryData } = useContext(AppContext);
+
+  if (urlQueryData == null) {
+    throw new Error('Are you forgetting an AppContext.Provider?');
+  }
+
+  return new VerificationInfo(urlQueryData);
+}
+
+export function CreateAccountRecoveryKeyInfo() {
+  const { locationStateData } = useContext(AppContext);
+
+  if (locationStateData == null) {
+    throw new Error('Are you forgetting an AppContext.Provider?');
+  }
+
+  return new AccountRecoveryKeyInfo(locationStateData);
+}

--- a/packages/fxa-settings/src/models/verification/index.ts
+++ b/packages/fxa-settings/src/models/verification/index.ts
@@ -4,3 +4,4 @@
 
 export * from './verification-info';
 export * from './account-recovery-key-info';
+export * from './factory';

--- a/packages/fxa-settings/src/models/verification/verification-info.ts
+++ b/packages/fxa-settings/src/models/verification/verification-info.ts
@@ -18,19 +18,19 @@ const { isEmail, isRequired, isVerificationCode, isHex, isString, isBoolean } =
 const { snakeCase } = KeyTransforms;
 
 export class VerificationInfo extends ModelDataProvider {
-  @bind([isEmail, isRequired])
+  @bind([isRequired, isEmail])
   email: string = '';
 
-  @bind([isEmail, isRequired])
+  @bind([isRequired, isEmail])
   emailToHashWith: string = '';
 
-  @bind([isVerificationCode, isRequired])
+  @bind([isRequired, isVerificationCode])
   code: string = '';
 
-  @bind([isHex, isRequired])
+  @bind([isRequired, isHex])
   token: string = '';
 
-  @bind([isString, isRequired])
+  @bind([isRequired, isString])
   uid: string = '';
 
   @bind([isBoolean], snakeCase)

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -3,7 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useState } from 'react';
-import { NavigateFn, RouteComponentProps, useNavigate } from '@reach/router';
+import {
+  NavigateFn,
+  RouteComponentProps,
+  useLocation,
+  useNavigate,
+} from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useForm } from 'react-hook-form';
 
@@ -27,18 +32,12 @@ import {
   setUserPreference,
   usePageViewEvent,
 } from '../../../lib/metrics';
+import { useNotifier, useBroker, useAccount } from '../../../models/hooks';
 import { LinkStatus } from '../../../lib/types';
 import {
-  useNotifier,
-  useBroker,
-  useAccount,
-  useRelier,
-  useUrlQueryDataStore,
-} from '../../../models/hooks';
-import {
-  AccountRecoveryKeyInfo,
-  VerificationInfo,
-  useLocationStateData,
+  CreateAccountRecoveryKeyInfo,
+  CreateRelier,
+  CreateVerificationInfo,
 } from '../../../models';
 
 // This page is based on complete_reset_password but has been separated to align with the routes.
@@ -81,19 +80,13 @@ const AccountRecoveryResetPassword = ({
   const notifier = useNotifier();
   const broker = useBroker();
   const account = useAccount();
-  const relier = useRelier();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  let navigate = useNavigate();
-  navigate = overrides?.navigate || navigate;
+  const relier = CreateRelier();
+  const verificationInfo = CreateVerificationInfo();
+  const accountRecoveryKeyInfo = CreateAccountRecoveryKeyInfo();
 
-  let urlQueryData = useUrlQueryDataStore();
-  urlQueryData = overrides?.urlQueryData || urlQueryData;
-
-  let locationData = useLocationStateData();
-  locationData = overrides?.locationData || locationData;
-
-  const verificationInfo = new VerificationInfo(urlQueryData);
-  const accountRecoveryKeyInfo = new AccountRecoveryKeyInfo(locationData);
   const state = getInitialState();
 
   const [bannerState, setBannerState] = useState<BannerState>(BannerState.None);
@@ -115,9 +108,14 @@ const AccountRecoveryResetPassword = ({
       alertValidationError(state.validationError);
     } else if (!state.supportsRecovery) {
       setBannerState(BannerState.Redirecting);
-      navigate(`/complete_reset_password?${urlQueryData.toSearchQuery()}`);
+      navigate(`/complete_reset_password?${location.search}`);
     }
-  }, [state, navigate, urlQueryData]);
+  }, [
+    state.validationError,
+    state.supportsRecovery,
+    navigate,
+    location.search,
+  ]);
 
   if (linkStatus === 'damaged') {
     return <ResetPasswordLinkDamaged />;
@@ -292,15 +290,11 @@ const AccountRecoveryResetPassword = ({
     setUserPreference('account-recovery', account.recoveryKey);
     logViewEvent(viewName, 'recovery-key-consume.success');
 
-    const queryString = urlQueryData.toSearchQuery();
-    navigate(`/reset_password_with_recovery_key_verified?${queryString}`);
+    navigate(`/reset_password_with_recovery_key_verified?${location.search}`);
   }
 
   function alertValidationError(err: ModelValidationErrors) {
     setBannerState(BannerState.UnexpectedError);
-    console.error(
-      `Invalid keys detected: ${err.errors.map((x) => x.key).join(',')}`
-    );
   }
 };
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -69,7 +69,6 @@ enum BannerState {
   UnexpectedError,
   PasswordResetSuccess,
   Redirecting,
-  InvalidContext,
   PasswordResendError,
   ValidationError,
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -10,6 +10,7 @@ import { UrlQueryData } from '../../../lib/model-data';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext, MOCK_ACCOUNT } from '../../../models/mocks';
 import { CompleteResetPasswordLink } from '../../../models/reset-password/verification';
+import { ReachRouterWindow } from '../../../lib/window';
 
 export const mockCompleteResetPasswordParams = {
   email: MOCK_ACCOUNT.primaryEmail.email,
@@ -41,11 +42,12 @@ export const paramsWithMissingToken = {
 export function mockUrlQueryData(
   params: Record<string, string> = mockCompleteResetPasswordParams
 ) {
-  const ctx = new UrlQueryData(window);
+  const window = new ReachRouterWindow();
+  const data = new UrlQueryData(window);
   for (const param of Object.keys(params)) {
-    ctx.set(param, params[param]);
+    data.set(param, params[param]);
   }
-  return ctx;
+  return data;
 }
 
 export const Subject = ({


### PR DESCRIPTION
## Because

- We predominantly use reach router
- We want to be consistent

## This pull request

- Uses reach router for window API access where possible.
- Creates a WindowWrapper to decouple direct dependence on either window or reach router apis.
- Makes model creation more react like, by making factory functions that create models from app context.
- Cleans up tests, now that we can rely on a mocked reach router location.

## Issue that this pull request solves

Closes: FXA-7048

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This change set ended up being bigger than initially anticipated. Using reach router location as the underlying data store for models had some nice side effects, particularly when it came to mocking state for storybook, so this PR was used as an opportunity to also do some clean up.