### PR TITLE
feat(webchannels): Add initial support for `fxa_status` webchannel event

### DIFF
--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -59,7 +59,7 @@ export class ResetPasswordPage extends BaseLayout {
   }
 
   async fillOutResetPassword(email) {
-    await this.page.fill(selectors.EMAIL, email);
+    await this.page.locator(selectors.EMAIL).fill(email);
     await this.submit();
   }
 
@@ -82,10 +82,8 @@ export class ResetPasswordPage extends BaseLayout {
   }
 
   async submit() {
-    return Promise.all([
-      this.page.locator(selectors.SUBMIT).click(),
-      this.page.waitForNavigation({ waitUntil: 'load' }),
-    ]);
+    await this.page.locator(selectors.SUBMIT).click();
+    await this.page.waitForURL(/confirm_reset_password/);
   }
 
   async addQueryParamsToLink(link: string, query: object) {

--- a/packages/fxa-settings/src/lib/firefox.ts
+++ b/packages/fxa-settings/src/lib/firefox.ts
@@ -2,6 +2,7 @@ export enum FirefoxCommand {
   AccountDeleted = 'fxaccounts:delete',
   ProfileChanged = 'profile:change',
   PasswordChanged = 'fxaccounts:change_password',
+  FxAStatus = 'fxaccounts:fxa_status',   
   Error = 'fxError',
 }
 
@@ -30,6 +31,28 @@ interface ProfileMetricsEnabled {
 
 type Profile = ProfileUid | ProfileMetricsEnabled;
 type FirefoxEvent = CustomEvent<FirefoxMessage | string>;
+
+// This is defined in the Firefox source code:
+// https://searchfox.org/mozilla-central/source/services/fxaccounts/tests/xpcshell/test_web_channel.js#348
+type FxAStatusRequest = {
+  service: 'sync', // ex. 'sync'
+  context: string // ex. 'fx_desktop_v3'
+}
+export type FxAStatusResponse = {
+  capabilities: {
+    engines: string[],
+    multiService: boolean,
+    pairing: boolean
+  },
+  clientId?: string,
+  signedInUser?: SignedInUser
+}
+type SignedInUser = {
+  email: string,
+  sessionToken: string,
+  uid: string,
+  verified: boolean,
+}
 
 export class Firefox extends EventTarget {
   private broadcastChannel?: BroadcastChannel;
@@ -154,6 +177,10 @@ export class Firefox extends EventTarget {
   profileChanged(profile: Profile) {
     this.send(FirefoxCommand.ProfileChanged, profile);
     this.broadcast(FirefoxCommand.ProfileChanged, profile);
+  }
+  
+  fxaStatus(options: FxAStatusRequest) {
+    this.send(FirefoxCommand.FxAStatus, options);
   }
 }
 

--- a/packages/fxa-settings/src/models/AppContext.ts
+++ b/packages/fxa-settings/src/models/AppContext.ts
@@ -11,7 +11,7 @@ import {
   UrlHashContext,
   UrlSearchContext,
 } from '../lib/context';
-import firefox, { FirefoxCommand } from '../lib/firefox';
+import firefox, { FirefoxCommand, FxAStatusResponse } from '../lib/firefox';
 import { createApolloClient } from '../lib/gql';
 import { OAuthClient } from '../lib/oauth/oauth-client';
 import { Account, ACCOUNT_FIELDS, GET_PROFILE_INFO } from './Account';
@@ -116,6 +116,11 @@ export function initializeAppContext() {
   });
   firefox.addEventListener(FirefoxCommand.Error, (event) => {
     console.error(event);
+  });
+  firefox.addEventListener(FirefoxCommand.FxAStatus, (event) => {
+    const response = (event as CustomEvent).detail as FxAStatusResponse;
+    // TODO: This event should be registered in the RelierFactory or Notifier
+    // since they would be doing different things based on the response.
   });
 
   const context: AppContextValue = {


### PR DESCRIPTION
## Because

- We need to be able to send and recieve the `fxa_status` webchannel event

## This pull request

- Adds support for this message

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-3362

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
