### PR TITLE
chore(style): Add prettier to fxa-auth-client

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1410,7 +1410,10 @@ export default class AuthClient {
   }
 
   async getProductInfo(productId: string) {
-    return this.request('GET', `/oauth/subscriptions/productname?productId=${productId}`)
+    return this.request(
+      'GET',
+      `/oauth/subscriptions/productname?productId=${productId}`
+    );
   }
 
   async sendPushLoginRequest(sessionToken: string) {

--- a/packages/fxa-auth-client/lib/crypto.ts
+++ b/packages/fxa-auth-client/lib/crypto.ts
@@ -1,7 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { hexToUint8, uint8ToBase64Url, base64UrlToUint8, uint8ToHex, xor } from './utils';
+import {
+  hexToUint8,
+  uint8ToBase64Url,
+  base64UrlToUint8,
+  uint8ToHex,
+  xor,
+} from './utils';
 
 const encoder = () => new TextEncoder();
 const NAMESPACE = 'identity.mozilla.com/picl/v1/';
@@ -211,8 +217,11 @@ export async function jweEncrypt(
  * @param keyMaterial Key material
  * @param jwe JWE token
  */
-export async function jweDecrypt(keyMaterial: Uint8Array, jwe: string) : Promise<string> {
- const encoder = new TextEncoder();
+export async function jweDecrypt(
+  keyMaterial: Uint8Array,
+  jwe: string
+): Promise<string> {
+  const encoder = new TextEncoder();
   const [header, empty, iv, ciphertext, authenticationTag] = jwe.split('.');
   const key = await crypto.subtle.importKey(
     'raw',
@@ -234,7 +243,7 @@ export async function jweDecrypt(keyMaterial: Uint8Array, jwe: string) : Promise
       tagLength: 128,
     },
     key,
-   dataBuf
+    dataBuf
   );
   const decoder = new TextDecoder();
   return decoder.decode(decrypted);

--- a/packages/fxa-auth-client/lib/recoveryKey.ts
+++ b/packages/fxa-auth-client/lib/recoveryKey.ts
@@ -7,8 +7,8 @@ import { hexToUint8, uint8ToHex } from './utils';
 
 export type DecryptedRecoveryKeyData = {
   kA: string;
-  kB: string; 
-}
+  kB: string;
+};
 export async function randomKey() {
   // The key is displayed in base32 'Crockford' so the length should be
   // divisible by (5 bits per character) and (8 bits per byte).
@@ -80,17 +80,22 @@ export async function generateRecoveryKey(
 }
 
 /**
- * Decrypts a user's recoveryKeyData. This data contains the user's encryption 
+ * Decrypts a user's recoveryKeyData. This data contains the user's encryption
  * keys (kA, kB) used in OnePW protocol.
- * 
+ *
  * @param recoveryKey
  * @param recoveryKeyId
  * @param recoveryData encrypted user recovery data
  */
-export async function decryptRecoveryKeyData(recoveryKey:Uint8Array, recoveryKeyId:string, recoveryData:string, uid:hexstring): Promise<DecryptedRecoveryKeyData> {
+export async function decryptRecoveryKeyData(
+  recoveryKey: Uint8Array,
+  recoveryKeyId: string,
+  recoveryData: string,
+  uid: hexstring
+): Promise<DecryptedRecoveryKeyData> {
   const encoder = new TextEncoder();
   const salt = hexToUint8(uid);
-  
+
   const encryptionKey = await hkdf(
     recoveryKey,
     salt,

--- a/packages/fxa-auth-client/lib/utils.ts
+++ b/packages/fxa-auth-client/lib/utils.ts
@@ -31,10 +31,10 @@ export function uint8ToBase64Url(array: Uint8Array) {
 
 export function base64UrlToUint8(value: string): Uint8Array {
   const m = value.length % 4;
-  return Uint8Array.from(atob(
-   value.replace(/-/g, '+')
-    .replace(/_/g, '/')
-  ), c => c.charCodeAt(0))
+  return Uint8Array.from(
+    atob(value.replace(/-/g, '+').replace(/_/g, '/')),
+    (c) => c.charCodeAt(0)
+  );
 }
 
 export function xor(array1: Uint8Array, array2: Uint8Array) {

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -18,6 +18,7 @@
     "compile": "tsc --noEmit",
     "ts-check": "tsc --noEmit",
     "test": "mocha -r esbuild-register test/*",
+    "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "test:unit": "MOCHA_FILE=../../artifacts/tests/$npm_package_name/mocha-unit.xml mocha -r esbuild-register test/*",
     "test:integration": "echo No integration tests present for $npm_package_name"
   },
@@ -35,11 +36,13 @@
     "@types/mocha": "^8",
     "@types/node": "^18.14.2",
     "@types/node-fetch": "^2.5.7",
+    "@types/prettier": "^2",
     "asmcrypto.js": "^0.22.0",
     "esbuild": "^0.14.2",
     "esbuild-register": "^3.2.0",
     "fast-text-encoding": "^1.0.4",
     "mocha": "^10.0.0",
+    "prettier": "^2.8.7",
     "typescript": "^4.9.3",
     "webcrypto-liner": "^1.4.0"
   },

--- a/packages/fxa-auth-client/test/crypto.ts
+++ b/packages/fxa-auth-client/test/crypto.ts
@@ -1,7 +1,16 @@
 import * as assert from 'assert';
 import '../server'; // must import this to run with nodejs
-import { getCredentials, hkdf, jweDecrypt, jweEncrypt, unbundleKeyFetchResponse } from 'fxa-auth-client/lib/crypto';
-import { randomKey, getRecoveryKeyIdByUid } from 'fxa-auth-client/lib/recoveryKey';
+import {
+  getCredentials,
+  hkdf,
+  jweDecrypt,
+  jweEncrypt,
+  unbundleKeyFetchResponse,
+} from 'fxa-auth-client/lib/crypto';
+import {
+  randomKey,
+  getRecoveryKeyIdByUid,
+} from 'fxa-auth-client/lib/recoveryKey';
 import { hexToUint8 } from 'fxa-auth-client/lib/utils';
 
 const uid = 'aaaaabbbbbcccccdddddeeeeefffff00';
@@ -40,28 +49,32 @@ describe('lib/crypto', () => {
       );
     });
   });
-  
+
   describe('jwe', () => {
-   it('should encrypt and decrypt',  async () => {
+    it('should encrypt and decrypt', async () => {
       const recoveryKey = await randomKey();
       const encoder = new TextEncoder();
       const salt = hexToUint8(uid);
       const data = {
-       kB: "aaaa"
+        kB: 'aaaa',
       };
-     const recoveryKeyId = await getRecoveryKeyIdByUid(recoveryKey, uid);
+      const recoveryKeyId = await getRecoveryKeyIdByUid(recoveryKey, uid);
 
-    const encryptionKey = await hkdf(
-     recoveryKey,
-     salt,
-     encoder.encode('fxa recovery encrypt key'),
-     32
-    );
-    
-    const encryptedData = await jweEncrypt(encryptionKey, recoveryKeyId, encoder.encode(JSON.stringify(data)));
-    const decryptedData = await jweDecrypt(encryptionKey, encryptedData);
+      const encryptionKey = await hkdf(
+        recoveryKey,
+        salt,
+        encoder.encode('fxa recovery encrypt key'),
+        32
+      );
 
-    assert.deepEqual(JSON.parse(decryptedData), data);
-   });
+      const encryptedData = await jweEncrypt(
+        encryptionKey,
+        recoveryKeyId,
+        encoder.encode(JSON.stringify(data))
+      );
+      const decryptedData = await jweDecrypt(encryptionKey, encryptedData);
+
+      assert.deepEqual(JSON.parse(decryptedData), data);
+    });
   });
 });

--- a/packages/fxa-auth-client/test/recoveryKey.ts
+++ b/packages/fxa-auth-client/test/recoveryKey.ts
@@ -53,12 +53,17 @@ describe('lib/recoveryKey', () => {
   describe('decryptRecoveryKeyData', () => {
     it('matches the test vector', async () => {
       const { recoveryKey, recoveryKeyId, recoveryData } =
-       await generateRecoveryKey(uid, keys, {
-         testRecoveryKey: expectedRecoveryKey,
-         testIV: iv,
-       });
-      
-      const result = await decryptRecoveryKeyData(recoveryKey, recoveryKeyId, recoveryData, uid);
+        await generateRecoveryKey(uid, keys, {
+          testRecoveryKey: expectedRecoveryKey,
+          testIV: iv,
+        });
+
+      const result = await decryptRecoveryKeyData(
+        recoveryKey,
+        recoveryKeyId,
+        recoveryData,
+        uid
+      );
       assert.deepStrictEqual(result, keys);
     });
   });

--- a/packages/fxa-auth-client/tsconfig.browser.json
+++ b/packages/fxa-auth-client/tsconfig.browser.json
@@ -6,5 +6,5 @@
     "types": ["mocha", "./lib/types"]
   },
   "include": ["./lib/**/*", "./browser.ts"],
-  "exclude": ["dist","node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/fxa-auth-client/tsconfig.json
+++ b/packages/fxa-auth-client/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["mocha", "./lib/types"]
   },
   "include": ["./lib/**/*", "./server.ts"],
-  "exclude": ["dist","node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12759,6 +12759,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prettier@npm:^2":
+  version: 2.7.2
+  resolution: "@types/prettier@npm:2.7.2"
+  checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
+  languageName: node
+  linkType: hard
+
 "@types/prettier@npm:^2.0.0, @types/prettier@npm:^2.1.5":
   version: 2.4.1
   resolution: "@types/prettier@npm:2.4.1"
@@ -25837,6 +25844,7 @@ fsevents@~2.1.1:
     "@types/mocha": ^8
     "@types/node": ^18.14.2
     "@types/node-fetch": ^2.5.7
+    "@types/prettier": ^2
     abab: ^2.0.6
     abort-controller: ^3.0.0
     asmcrypto.js: ^0.22.0
@@ -25845,6 +25853,7 @@ fsevents@~2.1.1:
     fast-text-encoding: ^1.0.4
     mocha: ^10.0.0
     node-fetch: ^2.6.7
+    prettier: ^2.8.7
     typescript: ^4.9.3
     webcrypto-liner: ^1.4.0
   languageName: unknown
@@ -41031,6 +41040,15 @@ fsevents@~2.1.1:
   bin:
     prettier: bin-prettier.js
   checksum: 3b37731ff7150feecf19736c77c790e7e276b404ac9af81cbaf87cfecefc48ef9a864f34c2a5caf5955378b8f2525984b8611703a0d9c1f052b4cfa6eb35899f
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.8.7":
+  version: 2.8.7
+  resolution: "prettier@npm:2.8.7"
+  bin:
+    prettier: bin-prettier.js
+  checksum: fdc8f2616f099f5f0d685907f4449a70595a0fc1d081a88919604375989e0d5e9168d6121d8cc6861f21990b31665828e00472544d785d5940ea08a17660c3a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- This was missing prettier formating

## This pull request

- Adds deps and runs script to format code

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7109

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

