### PR TITLE
feat(payments): move The Confirmation Checkbox

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/en.ftl
@@ -1,3 +1,5 @@
 ## Component - PaymentConsentCheckbox
 
-payment-confirm-with-legal-links-static = I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method for the amount shown, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+# Variables: $price (String) - The amount of the subscription being billed, including currency, e.g. $10.00. 
+# $productName (String) - The name of the subscribed product, e.g. Mozilla VPN.
+payment-confirm-with-legal-links = I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method { $price } for { $productName }, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
@@ -73,24 +73,32 @@ describe('components/PaymentConsentCheckbox', () => {
         const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
 
         expect(legalCheckbox.props.children.props.children[0]).toBe(
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to'
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method '
         );
-        expect(legalCheckbox.props.children.props.children[1]).toBe(' ');
-        expect(legalCheckbox.props.children.props.children[2].props.href).toBe(
+        expect(legalCheckbox.props.children.props.children[1]).toBe(
+          '$5.00 daily'
+        );
+        expect(legalCheckbox.props.children.props.children[2]).toBe(' for ');
+        expect(legalCheckbox.props.children.props.children[3]).toBe('FPN');
+        expect(legalCheckbox.props.children.props.children[4]).toBe(
+          ', according to'
+        );
+        expect(legalCheckbox.props.children.props.children[5]).toBe(' ');
+        expect(legalCheckbox.props.children.props.children[6].props.href).toBe(
           'https://www.mozilla.org/about/legal/terms/firefox-private-network'
         );
         expect(
-          legalCheckbox.props.children.props.children[2].props.children
+          legalCheckbox.props.children.props.children[6].props.children
         ).toBe('Terms of Service');
-        expect(legalCheckbox.props.children.props.children[3]).toBe(' and');
-        expect(legalCheckbox.props.children.props.children[4]).toBe(' ');
-        expect(legalCheckbox.props.children.props.children[5].props.href).toBe(
+        expect(legalCheckbox.props.children.props.children[7]).toBe(' and');
+        expect(legalCheckbox.props.children.props.children[8]).toBe(' ');
+        expect(legalCheckbox.props.children.props.children[9].props.href).toBe(
           'https://www.mozilla.org/privacy/firefox-private-network'
         );
         expect(
-          legalCheckbox.props.children.props.children[5].props.children
+          legalCheckbox.props.children.props.children[9].props.children
         ).toBe('Privacy Notice');
-        expect(legalCheckbox.props.children.props.children[6]).toBe(
+        expect(legalCheckbox.props.children.props.children[10]).toBe(
           ', until I cancel my subscription.'
         );
       }
@@ -98,7 +106,7 @@ describe('components/PaymentConsentCheckbox', () => {
       it('renders Localized for a plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_daily';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-static';
+        const expectedMsgId = 'payment-confirm-with-legal-links';
 
         runTests(plan, expectedMsgId);
       });

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
@@ -1,20 +1,24 @@
 import { Localized } from '@fluent/react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 import { urlsFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
 import React, { useContext } from 'react';
 
 import AppContext from '../../lib/AppContext';
+import { formatPlanPricing } from '../../lib/formats';
 import { Plan } from '../../store/types';
 import { Checkbox } from '../fields';
 
 export type PaymentConsentCheckboxProps = {
   plan: Plan;
   onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
+  invoice?: FirstInvoicePreview;
 };
 
 export const PaymentConsentCheckbox = ({
   plan,
   onClick,
+  invoice,
 }: PaymentConsentCheckboxProps) => {
   const { navigatorLanguages, config } = useContext(AppContext);
 
@@ -24,9 +28,19 @@ export const PaymentConsentCheckbox = ({
     config.featureFlags.useFirestoreProductConfigs
   );
 
+  const { amount, currency, interval, interval_count } = plan;
+  const displayedPrice = invoice ? invoice.total : amount;
+  const price = formatPlanPricing(
+    displayedPrice as unknown as number,
+    currency,
+    interval,
+    interval_count
+  );
+
   return (
     <Localized
-      id="payment-confirm-with-legal-links-static"
+      id="payment-confirm-with-legal-links"
+      vars={{ price: price, productName: plan.product_name }}
       elems={{
         termsOfServiceLink: (
           <LinkExternal href={termsOfService}>Terms of Service</LinkExternal>
@@ -38,7 +52,7 @@ export const PaymentConsentCheckbox = ({
     >
       <Checkbox name="confirm" data-testid="confirm" onClick={onClick} required>
         I authorize Mozilla, maker of Firefox products, to charge my payment
-        method for the amount shown, according to{' '}
+        method {price} for {plan.product_name}, according to{' '}
         <LinkExternal href={termsOfService}>Terms of Service</LinkExternal> and{' '}
         <LinkExternal href={privacyNotice}>Privacy Notice</LinkExternal>, until
         I cancel my subscription.

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/en.ftl
@@ -3,4 +3,4 @@
 payment-method-header = Choose your payment method
 # This message is used to indicate the second step in a multi step process.
 payment-method-header-second-step = 2. { payment-method-header }
-payment-method-required = Required
+payment-method-first-approve = First you'll need to approve your subscription

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -61,8 +61,8 @@ describe('components/PaymentMethodHeader', () => {
     });
 
     it('returns correct text for required text', async () => {
-      const msgId = 'payment-method-required';
-      const expected = 'Required';
+      const msgId = 'payment-method-first-approve';
+      const expected = "First you'll need to approve your subscription";
       const actual = getLocalizedMessage(bundle, msgId, {});
       expect(actual).toEqual(expected);
     });
@@ -97,7 +97,7 @@ describe('components/PaymentMethodHeader', () => {
         MOCK_PLANS.find((p) => p.plan_id === 'plan_daily') || MOCK_PLANS[0];
       const props = { plan, onClick: () => {} };
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to Terms of ServiceOpens in new window and Privacy NoticeOpens in new window, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method $5.00 daily for FPN, according to Terms of ServiceOpens in new window and Privacy NoticeOpens in new window, until I cancel my subscription.';
 
       const { findByTestId } = render(<PaymentMethodHeader {...props} />);
 

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -1,4 +1,5 @@
 import { Localized } from '@fluent/react';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 import { Plan } from 'fxa-shared/subscriptions/types';
 import React from 'react';
 import useValidatorState from '../../lib/validator';
@@ -36,22 +37,28 @@ export type PaymentMethodHeaderProps = {
   plan: Plan;
   onClick: (event: React.MouseEvent<HTMLInputElement>) => void;
   type?: PaymentMethodHeaderType;
+  invoice?: FirstInvoicePreview;
 };
 
 export const PaymentMethodHeader = ({
   plan,
   onClick,
   type,
+  invoice,
 }: PaymentMethodHeaderProps) => {
   const checkboxValidator = useValidatorState();
   return (
     <>
       {returnPaymentMethodHeader(type || PaymentMethodHeaderType.NoPrefix)}
-      <Localized id="payment-method-required">
-        <strong>Required</strong>
+      <Localized id="payment-method-first-approve">
+        <strong>First you'll need to approve your subscription</strong>
       </Localized>
       <Form validator={checkboxValidator}>
-        <PaymentConsentCheckbox plan={plan} onClick={onClick} />
+        <PaymentConsentCheckbox
+          plan={plan}
+          onClick={onClick}
+          invoice={invoice}
+        />
       </Form>
     </>
   );

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -65,6 +65,7 @@ import {
 import CouponForm from '../../components/CouponForm';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { useParams } from 'react-router-dom';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 const PaypalButton = React.lazy(() => import('../../components/PayPalButton'));
 
@@ -144,6 +145,7 @@ export const Checkout = ({
     () => getSelectedPlan(productId, planId, plansByProductId),
     [productId, planId, plansByProductId]
   );
+  const [invoice, setInvoice] = useState<FirstInvoicePreview>();
 
   const onFormMounted = useCallback(
     () => Amplitude.createSubscriptionMounted(selectedPlan),
@@ -356,6 +358,7 @@ export const Checkout = ({
                 isMobile,
                 showExpandButton: isMobile,
                 coupon,
+                setInvoice,
               }}
             />
 
@@ -404,11 +407,15 @@ export const Checkout = ({
             plan={selectedPlan}
             onClick={() => setCheckboxSet(!checkboxSet)}
             type={PaymentMethodHeaderType.SecondStep}
+            invoice={invoice}
           />
 
           <>
             {paypalScriptLoaded && (
               <>
+                <Localized id="pay-with-heading-paypal">
+                  <p className="pay-with-heading">Pay with PayPal</p>
+                </Localized>
                 <div data-testid="pay-with-other">
                   <Suspense fallback={<div>Loading...</div>}>
                     <PaypalButton

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -275,6 +275,9 @@ export const SubscriptionCreate = ({
                     className="subscription-create-pay-with-other"
                     data-testid="pay-with-other"
                   >
+                    <Localized id="pay-with-heading-paypal">
+                      <p className="pay-with-heading">Pay with PayPal</p>
+                    </Localized>
                     <Suspense fallback={<div>Loading...</div>}>
                       <div className="paypal-button">
                         <PaypalButton

--- a/packages/fxa-payments-server/src/routes/en.ftl
+++ b/packages/fxa-payments-server/src/routes/en.ftl
@@ -4,3 +4,4 @@ sub-update-payment-title = Payment information
 ## Routes - Checkout and Product/Subscription create
 pay-with-heading-card-or = Or pay with card
 pay-with-heading-card-only = Pay with card
+pay-with-heading-paypal = Pay with { -brand-name-paypal }


### PR DESCRIPTION
Because:

* the confirmation checkbox looks like it applies to just the paypal payment option and confuses users since the submit payment is disabled until checked

This Commit:

* moves the checkbox, adds info about the price and product the user is committing to

Closes: FXA-4260

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1044" alt="Screenshot 2023-03-27 at 11 29 07 PM" src="https://user-images.githubusercontent.com/1585040/228147853-4213c8dd-0dd1-4139-b772-014530667867.png">

## Other information (Optional)

Ticket assets are out of date, figma has current designs https://www.figma.com/file/XqeVmcXail0yJfWytiShkc/%5BProposed%5D-Subplat-Desktop-Payment-page-UI-updates?node-id=222-289&t=6XsPgE8XQCLm6rCr-0
