### PR TITLE
chore(auth/shared): add `transactionId` to Apple subscriptions in Firestore

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/subscription-purchase.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/subscription-purchase.js
@@ -24,6 +24,7 @@ const transactionInfo = require('../../fixtures/apple-app-store/decoded_transact
 
 describe('SubscriptionPurchase', () => {
   const autoRenewStatus = 1;
+  const transactionId = '2000000000000000';
   const originalTransactionId = '1000000000000000';
   const bundleId = 'org.mozilla.ios.SkydivingWithFoxkeh';
   const productId = 'skydiving.with.foxkeh';
@@ -46,6 +47,7 @@ describe('SubscriptionPurchase', () => {
       autoRenewStatus,
       bundleId,
       originalTransactionId,
+      transactionId,
       productId,
       status,
       type,

--- a/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
@@ -93,6 +93,7 @@ export class AppStoreSubscriptionPurchase {
   originalTransactionId!: string; // unique identifier for the subscription; analogous to a Stripe subscription id
   productId!: string; // unique identifier for the plan; analogous to the Stripe plan id
   private status!: SubscriptionStatus;
+  transactionId!: string;
   private type!: TransactionType;
   private expirationIntent?: number;
   expiresDate?: number;
@@ -132,6 +133,7 @@ export class AppStoreSubscriptionPurchase {
     purchase.originalTransactionId = originalTransactionId;
     purchase.productId = transactionInfo.productId;
     purchase.status = subscriptionStatus;
+    purchase.transactionId = transactionInfo.transactionId;
     purchase.type = transactionInfo.type;
     purchase.verifiedAt = verifiedAt;
 


### PR DESCRIPTION
## Because

- Currently for Apple subscriptions the `originalTransactionId` is included, but not the `transactionId`.
- Including `transactionId` would provide an important indicator whether it's the initial transaction or a restore/renewal.

## This pull request

- Adds `transactionId` to Apple subscriptions in Firestore.

## Issue that this pull request solves

Closes: FXA-6987

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
