### PR TITLE
feat(webchannels): Add initial support for login / logout web channel…

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -39,6 +39,7 @@ describe('lib/router', () => {
     postVerifyAddRecoveryKeyRoutes: true,
     postVerifyCADViaQRRoutes: true,
     signInVerificationViaPushRoutes: true,
+    webChannelExampleRoutes: true,
   };
 
   beforeEach(() => {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -264,6 +264,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH_ROUTES',
     },
+    webChannelExampleRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of "web channel example" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_WEB_CHANNEL_EXAMPLE_ROUTES',
+    },
   },
   flow_id_expiry: {
     default: '2 hours',

--- a/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
@@ -85,6 +85,7 @@ const FRONTEND_ROUTES = [
   'verify_primary_email',
   'verify_secondary_email',
   'would_you_like_to_sync',
+  'web_channel_example',
 ];
 
 // The array is converted into a RegExp

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -87,6 +87,11 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       featureFlagOn: showReactApp.signInVerificationViaPushRoutes,
       routes: [],
     },
+
+    webChannelExampleRoutes: {
+      featureFlagOn: showReactApp.webChannelExampleRoutes,
+      routes: reactRoute.getRoutes(['web_channel_example']),
+    },
   };
 };
 

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -55,6 +55,7 @@ type ShowReactApp = {
   postVerifyAddRecoveryKeyRoutes: boolean;
   postVerifyCADViaQRRoutes: boolean;
   signInVerificationViaPushRoutes: boolean;
+  webChannelExampleRoutes: boolean;
 };
 
 export interface ReactRouteGroups {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -40,6 +40,7 @@ import LinkValidator from '../LinkValidator';
 import { UrlQueryData } from '../../lib/model-data';
 import { CompleteResetPasswordLink } from '../../models/reset-password/verification';
 import { LinkType } from 'fxa-settings/src/lib/types';
+import WebChannelExample from '../../pages/WebChannelExample';
 
 export const App = ({
   flowQueryParams,
@@ -106,6 +107,8 @@ export const App = ({
 
               <ResetPassword path="/reset_password/*" />
               <ConfirmResetPassword path="/confirm_reset_password/*" />
+
+              <WebChannelExample path="/web_channel_example/*" />
 
               <LinkValidator
                 path="/complete_reset_password/*"

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
@@ -8,7 +8,7 @@ import { useAccount, useAlertBar, useSession } from '../../../models';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import { useEscKeydownEffect } from '../../../lib/hooks';
 import { ReactComponent as SignOut } from './sign-out.svg';
-import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
+import { logViewEvent, settingsViewName } from '../../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
 
 export const DropDownAvatarMenu = () => {

--- a/packages/fxa-settings/src/pages/WebChannelExample/index.tsx
+++ b/packages/fxa-settings/src/pages/WebChannelExample/index.tsx
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import AppLayout from '../../components/AppLayout';
+import { RouteComponentProps } from '@reach/router';
+import { usePageViewEvent } from '../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../constants';
+import firefox, { FirefoxCommand, FxAStatusResponse } from '../../lib/firefox';
+import CardHeader from '../../components/CardHeader';
+import { useConfig } from '../../models';
+
+export const viewName = 'web_channel_example';
+
+const WebChannelExample = (_: RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  const config = useConfig();
+  const [fxaStatusResult, setFxaStatusResult] = useState('');
+  const [signedInUser, setSignedInUser] = useState({
+    authAt: Date.now(),
+    email: 'unknown',
+    sessionToken: 'unknown',
+    uid: 'unknown',
+    verified: true,
+
+    // Fake data for example. In user flows, these would exist.
+    keyFetchToken: '123',
+    unwrapBKey: '123',
+  });
+
+  // Handles the relayed FxA Status event
+  firefox.addEventListener(FirefoxCommand.FxAStatus, (event) => {
+    const status = (event as any).detail as FxAStatusResponse;
+
+    signedInUser.authAt = Date.now();
+    signedInUser.email = status.signedInUser?.email || 'unknown';
+    signedInUser.sessionToken = status.signedInUser?.sessionToken || 'unknown';
+    signedInUser.uid = status.signedInUser?.uid || 'unknown';
+    signedInUser.verified = status.signedInUser?.verified || false;
+
+    setSignedInUser(signedInUser);
+
+    setFxaStatusResult(JSON.stringify(status, null, 1));
+  });
+
+  if (config.env !== 'development') {
+    return <></>;
+  }
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingTextFtlId="web-channel-examples"
+        headingText="Web Channel Examples"
+      />
+      <div className="flex mobile:justify-between gap-x-10">
+        <div>
+          <div>
+            <b>FxA Status</b>
+            <p>Request status of the currently signed in user.</p>
+            <button
+              className="cta-neutral cta-base"
+              onClick={() => {
+                firefox.fxaStatus({
+                  service: 'sync',
+                  context: 'fx_desktop_v3',
+                });
+              }}
+            >
+              Get FxA Status
+            </button>
+            <br />
+            <br />
+            <pre style={{ fontSize: 8, textAlign: 'left' }}>
+              {fxaStatusResult}
+            </pre>
+          </div>
+          <br />
+          <div>
+            <b>FxA Logout</b>
+            <p>Request the current user be signed out of firefox.</p>
+            <button
+              className="cta-neutral cta-base"
+              onClick={() => firefox.fxaLogout({ uid: signedInUser?.uid })}
+            >
+              Logout Web Channel Event
+            </button>
+          </div>
+          <br />
+          <div>
+            <b>FxA Login</b>
+            <p>
+              Requests a user be signed into firefox.{' '}
+              <i>(Use the last known state returned by FxaStatus above.)</i>
+            </p>
+            <button
+              className="cta-neutral cta-base"
+              onClick={() => {
+                firefox.fxaLogin({
+                  ...signedInUser,
+                });
+              }}
+            >
+              Login Web Channel Event
+            </button>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default WebChannelExample;


### PR DESCRIPTION
## Because

- We need to support web channel events for logged in
- We need to support web channel events for logged out

## This pull request

- Specifies the message payloads for login / logout web channel events
- Creates a test page so we can see them in action
- Wires up logout web channel event

## Issue that this pull request solves

Closes: FXA-6613, FXA-6615

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![image](https://user-images.githubusercontent.com/94418270/228334076-00888bad-74e6-4e12-af2f-991e6edac428.png)


## Other information (Optional)
These tickets specified that the events should not be wired up, however, the logout event was trivial. I didn't wire up the signin/signup event cause I couldn't find a single place to do this in the new react flows.

A special test page was added to test the web channels work as expected. I think we might be able to extend this page to get some test coverage and guard against a future regression relating to a web channel message with playwright.

