### PR TITLE
task(settings): Remove .only from PairingSupplicantRelier test

### DIFF
--- a/packages/fxa-graphql-api/src/backend/legal.service.spec.ts
+++ b/packages/fxa-graphql-api/src/backend/legal.service.spec.ts
@@ -45,9 +45,7 @@ async function mockFetch(url: RequestInfo | URL, _init?: RequestInit) {
   };
 }
 
-// jest.mock('node-fetch', () => fetch);
-
-describe.only('#unit - LegalService', () => {
+describe('#unit - LegalService', () => {
   let service: LegalService;
 
   beforeEach(async () => {

--- a/packages/fxa-settings/src/lib/reliers/relier-factory.test.ts
+++ b/packages/fxa-settings/src/lib/reliers/relier-factory.test.ts
@@ -138,10 +138,10 @@ describe('lib/reliers/relier-factory', () => {
       );
     });
 
-    it('has correct state`', function () {
+    it('has correct state`', async () => {
       expect(relier.name).toEqual('base');
       expect(relier.isOAuth()).toBeFalsy();
-      expect(relier.isSync()).toBeFalsy();
+      expect(await relier.isSync()).toBeFalsy();
       expect(relier.wantsKeys()).toBeFalsy();
       expect(relier.pickResumeTokenInfo()).toEqual({});
       expect(relier.isTrusted()).toBeTruthy();
@@ -175,10 +175,10 @@ describe('lib/reliers/relier-factory', () => {
       );
     });
 
-    it('has correct state', () => {
+    it('has correct state', async () => {
       expect(relier.name).toEqual('browser');
       expect(relier.isOAuth()).toBeFalsy();
-      expect(relier.isSync()).toBeTruthy();
+      expect(await relier.isSync()).toBeTruthy();
       expect(relier.wantsKeys()).toBeTruthy();
       expect(relier.pickResumeTokenInfo()).toEqual({});
       expect(relier.isTrusted()).toBeTruthy();
@@ -212,10 +212,10 @@ describe('lib/reliers/relier-factory', () => {
       );
     });
 
-    it('has correct state', () => {
+    it('has correct state', async () => {
       expect(relier.name).toEqual('oauth');
       expect(relier.isOAuth()).toBeTruthy();
-      expect(relier.isSync()).toBeFalsy();
+      expect(await relier.isSync()).toBeFalsy();
       expect(relier.wantsKeys()).toBeFalsy();
       expect(relier.pickResumeTokenInfo()).toEqual({});
       expect(relier.isTrusted()).toBeFalsy();
@@ -223,7 +223,7 @@ describe('lib/reliers/relier-factory', () => {
     // TODO: Port remaining tests from content-server
   });
 
-  describe.only('PairingSupplicantRelier creation', () => {
+  describe('PairingSupplicantRelier creation', () => {
     let relier: PairingSupplicantRelier;
 
     beforeAll(async () => {
@@ -258,13 +258,13 @@ describe('lib/reliers/relier-factory', () => {
       );
     });
 
-    it('has correct state', () => {
+    it('has correct state', async () => {
       mockSearchParams({
         redirect_uri: 'foo',
       });
       expect(relier.name).toEqual('pairing-authority');
       expect(relier.isOAuth()).toBeTruthy();
-      expect(relier.isSync()).toBeFalsy();
+      expect(await relier.isSync()).toBeFalsy();
       expect(relier.wantsKeys()).toBeFalsy();
       expect(relier.pickResumeTokenInfo()).toEqual({});
       expect(relier.isTrusted()).toBeFalsy();


### PR DESCRIPTION
## Because

- A .only was left in place accidentally and this was preventing all relier factory tests from running

## This pull request

- Removes .only
- Fixes a small issue surfaced where async call to isSync was not being awaited.

## Issue that this pull request solves

Closes: FXA-7103

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

