### PR TITLE
feat(react): Implement functionality for React /confirm page

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -151,9 +151,11 @@ Router = Router.extend({
     'complete_signin(/)': createViewHandler(CompleteSignUpView, {
       type: VerificationReasons.SIGN_IN,
     }),
-    'confirm(/)': createViewHandler(ConfirmView, {
-      type: VerificationReasons.SIGN_UP,
-    }),
+    'confirm(/)': function () {
+      this.createReactOrBackboneViewHandler('confirm', ConfirmView, null, {
+        type: VerificationReasons.SIGN_UP,
+      });
+    },
     'confirm_reset_password(/)': function () {
       this.createReactOrBackboneViewHandler(
         'confirm_reset_password',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -61,6 +61,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
     signUpRoutes: {
       featureFlagOn: showReactApp.signUpRoutes,
       routes: reactRoute.getRoutes([
+        'confirm',
         'confirm_signup_code',
         'primary_email_verified',
         'signup_confirmed',

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, Router } from '@reach/router';
 import { ScrollToTop } from '../Settings/ScrollToTop';
+import { sessionToken } from '../../lib/cache';
 import { useInitialState, useAccount, useConfig } from '../../models';
 import * as Metrics from '../../lib/metrics';
 
@@ -38,6 +39,7 @@ import SigninReported from '../../pages/Signin/SigninReported';
 import AccountRecoveryResetPassword from '../../pages/ResetPassword/AccountRecoveryResetPassword';
 import LinkValidator from '../LinkValidator';
 import { LinkType } from 'fxa-settings/src/lib/types';
+import Confirm from 'fxa-settings/src/pages/Signup/Confirm';
 import WebChannelExample from '../../pages/WebChannelExample';
 import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
 
@@ -50,6 +52,7 @@ export const App = ({
   const { loading, error } = useInitialState();
   const { metricsEnabled } = useAccount();
   const config = useConfig();
+  const sessionTokenId = sessionToken();
 
   useEffect(() => {
     Metrics.init(metricsEnabled || !isSignedIn, flowQueryParams);
@@ -164,6 +167,7 @@ export const App = ({
                 path="/signin_confirmed/*"
               />
 
+              <Confirm path="/confirm/*" {...{ sessionTokenId }} />
               <ConfirmSignupCode path="/confirm_signup_code/*" />
             </>
           )}

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
@@ -45,7 +45,6 @@ const account = {
   verifyTotp: jest.fn().mockResolvedValue(true),
   sendVerificationCode: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
-const session = mockSession();
 
 window.URL.createObjectURL = jest.fn();
 

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -16,6 +16,8 @@ export const SHOW_BALLOON_TIMEOUT = 500;
 export const HIDE_BALLOON_TIMEOUT = 400;
 export const CLEAR_MESSAGES_TIMEOUT = 750;
 export const RESEND_CODE_TIMEOUT = 5000;
+export const POLLING_INTERVAL_MS = 2000;
+export const NAVIGATION_TIMEOUT_MS = 2000;
 export const REACT_ENTRYPOINT = { entrypoint_variation: 'react' };
 
 export const FIREFOX_NOREPLY_EMAIL = 'accounts@firefox.com';

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { AccountData, Session } from '.';
+import { AccountData, ProfileInfo, Session } from '.';
 import { AppContextValue } from './AppContext';
 import {
   createHistory,
@@ -75,6 +75,17 @@ export const mockEmail = (
   isPrimary,
   verified,
 });
+
+export const MOCK_PROFILE_INFO: ProfileInfo = {
+  uid: MOCK_ACCOUNT.uid,
+  displayName: null,
+  avatar: {
+    id: null,
+    url: null,
+  },
+  primaryEmail: MOCK_ACCOUNT.primaryEmail,
+  emails: MOCK_ACCOUNT.emails,
+};
 
 export function mockAppContext(context?: AppContextValue) {
   return Object.assign(

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
@@ -7,11 +7,7 @@ import { Meta } from '@storybook/react';
 import CompleteResetPassword from '.';
 import { Account } from '../../../models';
 import { withLocalization } from '../../../../.storybook/decorators';
-import {
-  mockCompleteResetPasswordParams,
-  paramsWithMissingEmail,
-  Subject,
-} from './mocks';
+import { paramsWithMissingEmail, Subject } from './mocks';
 
 export default {
   title: 'Pages/ResetPassword/CompleteResetPassword',

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { LinkType } from 'fxa-settings/src/lib/types';
 import CompleteResetPassword from '.';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
-import { REACT_ENTRYPOINT } from '../../../constants';
+import { POLLING_INTERVAL_MS, REACT_ENTRYPOINT } from '../../../constants';
 import { logPageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ResendStatus } from '../../../lib/types';
 import { useAccount, useInterval } from '../../../models';
@@ -20,8 +20,6 @@ export type ConfirmResetPasswordLocationState = {
   email: string;
   passwordForgotToken: string;
 };
-
-const POLLING_INTERVAL_MS = 2000;
 
 const ConfirmResetPassword = (_: RouteComponentProps) => {
   logPageViewEvent(viewName, REACT_ENTRYPOINT);

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.stories.tsx
@@ -3,12 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import Confirm, { ConfirmProps } from '.';
-import AppLayout from '../../../components/AppLayout';
+import Confirm from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { mockAppContext } from '../../../models/mocks';
 import { withLocalization } from '../../../../.storybook/decorators';
+import { Account, AppContext } from 'fxa-settings/src/models';
+import {
+  MOCK_PROFILE_WITH_RESEND_ERROR,
+  MOCK_PROFILE_WITH_RESEND_SUCCESS,
+  MOCK_SESSION_TOKEN,
+  MOCK_UNVERIFIED_SESSION,
+} from './mocks';
 
 export default {
   title: 'Pages/Signup/Confirm',
@@ -16,21 +22,23 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = (props: ConfirmProps) => {
+const storyWithContext = (account: Account) => {
   const story = () => (
     <LocationProvider>
-      <AppLayout>
-        <Confirm {...props} />
-      </AppLayout>
+      <AppContext.Provider
+        value={mockAppContext({ account, session: MOCK_UNVERIFIED_SESSION })}
+      >
+        <Confirm sessionTokenId={MOCK_SESSION_TOKEN} />
+      </AppContext.Provider>
     </LocationProvider>
   );
   return story;
 };
 
-export const Default = storyWithProps({
-  email: MOCK_ACCOUNT.primaryEmail.email,
-});
+export const WithSuccessOnResend = storyWithContext(
+  MOCK_PROFILE_WITH_RESEND_SUCCESS
+);
 
-export const UserCanGoBack = storyWithProps({
-  email: MOCK_ACCOUNT.primaryEmail.email,
-});
+export const WithErrorOnResend = storyWithContext(
+  MOCK_PROFILE_WITH_RESEND_ERROR
+);

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
@@ -3,50 +3,141 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen } from '@testing-library/react';
-// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LocationProvider } from '@reach/router';
 // import { FluentBundle } from '@fluent/bundle';
+// import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+import { FIREFOX_NOREPLY_EMAIL, REACT_ENTRYPOINT } from '../../../constants';
 import { usePageViewEvent } from '../../../lib/metrics';
+import { Account, AppContext, Session } from '../../../models';
+import {
+  mockAppContext,
+  mockEmail,
+  MOCK_ACCOUNT,
+  MOCK_PROFILE_INFO,
+} from '../../../models/mocks';
 import Confirm, { viewName } from '.';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
-import { REACT_ENTRYPOINT } from '../../../constants';
+import { MOCK_SESSION_TOKEN, MOCK_UNVERIFIED_SESSION } from './mocks';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
 }));
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  navigate: jest.fn(),
+}));
+
+const MOCK_ACCOUNT_WITH_SUCCESS = {
+  getProfileInfo: jest.fn().mockResolvedValue(MOCK_PROFILE_INFO),
+  sendVerificationCode: jest.fn().mockResolvedValue(true),
+  primaryEmail: mockEmail(MOCK_ACCOUNT.primaryEmail.email, true, false),
+} as unknown as Account;
+
+const MOCK_ACCOUNT_WITH_ERROR = {
+  getProfileInfo: jest.fn().mockResolvedValue(MOCK_PROFILE_INFO),
+  sendVerificationCode: jest.fn().mockRejectedValue(Error),
+  primaryEmail: mockEmail(MOCK_ACCOUNT.primaryEmail.email, true, false),
+} as unknown as Account;
+
+function renderWithContext(
+  account: Account | undefined,
+  session: Session,
+  sessionTokenId: string | null
+) {
+  render(
+    <AppContext.Provider
+      value={mockAppContext({
+        account,
+        session,
+      })}
+    >
+      <LocationProvider>
+        <Confirm {...{ sessionTokenId }} />
+      </LocationProvider>
+    </AppContext.Provider>
+  );
+}
 
 describe('Confirm page', () => {
-  // TODO: Enable l10n tests when FXA-6461 is resolved.
+  // TODO : l10n test currently failing on image l10n
+  // - enabling these tests will require attributes handling
   // let bundle: FluentBundle;
   // beforeAll(async () => {
   //   bundle = await getFtlBundle('settings');
   // });
-  // TODO: add tests for all metrics as they are added
+  afterEach(() => jest.clearAllMocks());
 
-  it("renders default view as expected with user's email", () => {
-    render(<Confirm email={MOCK_ACCOUNT.primaryEmail.email} />);
-    // testAllL10n(screen, bundle, { email: MOCK_ACCOUNT.primaryEmail.email });
-
-    const headingEl = screen.getByRole('heading', { level: 1 });
-    expect(headingEl).toHaveTextContent('Confirm your account');
-    screen.getByText(
-      `Check your email for the confirmation link sent to ${MOCK_ACCOUNT.primaryEmail.email}`
+  it('renders a loading spinner until account data is available', async () => {
+    renderWithContext(
+      MOCK_ACCOUNT_WITH_SUCCESS,
+      MOCK_UNVERIFIED_SESSION,
+      MOCK_SESSION_TOKEN
     );
-    screen.getByRole('button', { name: 'Not in inbox or spam folder? Resend' });
+    expect(screen.getByRole('img', { name: 'Loading…' })).toBeInTheDocument();
+    await waitFor(() => {
+      const headingEl = screen.getByRole('heading', { level: 1 });
+      expect(headingEl).toHaveTextContent('Confirm your account');
+    });
   });
 
-  // TODO Enable testing when resend email function is added to the page
-  // it('resends the email when the user clicks the resend button', () => {
-  //   render(<Confirm email={MOCK_ACCOUNT.primaryEmail.email} />);
-  //   const resendEmailButton = screen.getByRole('button', {
-  //     name: 'Not in inbox or spam folder? Resend',
-  //   });
-  // });
+  it('renders as expected with unverified session, session token and profile info', async () => {
+    renderWithContext(
+      MOCK_ACCOUNT_WITH_SUCCESS,
+      MOCK_UNVERIFIED_SESSION,
+      MOCK_SESSION_TOKEN
+    );
+    // wait for setEmail to update with email from account model
+    await waitFor(() => {
+      const headingEl = screen.getByRole('heading', { level: 1 });
+      expect(headingEl).toHaveTextContent('Confirm your account');
+      screen.getByText(
+        `Check your email for the confirmation link sent to ${MOCK_ACCOUNT.primaryEmail.email}`
+      );
+      screen.getByRole('button', {
+        name: 'Not in inbox or spam folder? Resend',
+      });
+      // testAllL10n(screen, bundle, { email: MOCK_ACCOUNT.primaryEmail.email });
+    });
+  });
 
-  it('emits a metrics event on render', () => {
-    render(<Confirm email={MOCK_ACCOUNT.primaryEmail.email} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  it('resends the email when the user clicks the resend button', async () => {
+    const account: Account = MOCK_ACCOUNT_WITH_SUCCESS;
+    renderWithContext(account, MOCK_UNVERIFIED_SESSION, MOCK_SESSION_TOKEN);
+    await waitFor(() => {
+      const resendEmailButton = screen.getByRole('button', {
+        name: 'Not in inbox or spam folder? Resend',
+      });
+      fireEvent.click(resendEmailButton);
+      expect(account.sendVerificationCode).toBeCalled();
+      const successBannerText = `Email resent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a smooth delivery.`;
+      expect(screen.getByText(successBannerText)).toBeInTheDocument();
+    });
+  });
+
+  it('renders an error banner when resending an email fails', async () => {
+    const account: Account = MOCK_ACCOUNT_WITH_ERROR;
+    renderWithContext(account, MOCK_UNVERIFIED_SESSION, MOCK_SESSION_TOKEN);
+    await waitFor(() => {
+      const resendEmailButton = screen.getByRole('button', {
+        name: 'Not in inbox or spam folder? Resend',
+      });
+      fireEvent.click(resendEmailButton);
+      expect(account.sendVerificationCode).toBeCalled();
+      const successBannerText = `Something went wrong. A new link could not be sent.`;
+      expect(screen.getByText(successBannerText)).toBeInTheDocument();
+    });
+  });
+
+  // only page view event added, could not hit route on prod to test which other metrics should be emitted
+  it('emits a metrics event on render', async () => {
+    renderWithContext(
+      MOCK_ACCOUNT_WITH_SUCCESS,
+      MOCK_UNVERIFIED_SESSION,
+      MOCK_SESSION_TOKEN
+    );
+    await waitFor(() => {
+      expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+    });
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
@@ -2,28 +2,68 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
-import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
-import { RouteComponentProps } from '@reach/router';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  logErrorEvent,
+  logViewEvent,
+  usePageViewEvent,
+} from '../../../lib/metrics';
+import { RouteComponentProps, useNavigate } from '@reach/router';
 import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
 } from '../../../components/ConfirmWithLink';
-import { REACT_ENTRYPOINT } from '../../../constants';
+import {
+  NAVIGATION_TIMEOUT_MS,
+  POLLING_INTERVAL_MS,
+  REACT_ENTRYPOINT,
+} from '../../../constants';
 import { ResendStatus } from '../../../lib/types';
+import AppLayout from 'fxa-settings/src/components/AppLayout';
+import { useAccount, useInterval } from 'fxa-settings/src/models';
+import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
-export type ConfirmProps = {
-  email: string;
-};
+// This page is no longer part of the typical/expected signup flow, but has been preserverd during
+// the conversion from backbone to react as we were still seeing some traffic to this route.
+// TODO in FXA-7185: Check metrics once this React page is rolled out to determine if this page can be entirely replaced by ConfirmSignupCode.
 
 export const viewName = 'confirm';
 
-const Confirm = ({ email }: RouteComponentProps & ConfirmProps) => {
-  // TODO: Confirm event name  - could not hit this route
+export type ConfirmProps = {
+  sessionTokenId: string | null;
+};
+
+export const Confirm = ({
+  sessionTokenId,
+}: ConfirmProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
+  // Show a loading spinner until all checks complete. Without this,
+  // users without a session will experience some jank due to an
+  // immediate redirect or rerender of this page.
+  const [showLoadingSpinner, setShowLoadingSpinner] = useState(true);
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
   );
+  const [email, setEmail] = useState('');
+
+  const account = useAccount();
+  const navigate = useNavigate();
+  const [isPolling, setIsPolling] = useState<number | null>(
+    POLLING_INTERVAL_MS
+  );
+
+  const getEmail = useCallback(async () => {
+    const response = await account.getProfileInfo();
+    setEmail(response.primaryEmail.email);
+  }, [account]);
+
+  const redirectToSignup = useCallback(() => {
+    // TODO: Going from react page to non-react page will require a hard
+    // navigate. When signup flow has been fully converted we should be able
+    // to use `navigate`.
+    window.location.href = '/signup';
+  }, []);
 
   const confirmSignupPageText: ConfirmWithLinkPageStrings = {
     headingFtlId: 'confirm-signup-heading',
@@ -32,25 +72,119 @@ const Confirm = ({ email }: RouteComponentProps & ConfirmProps) => {
     instructionText: `Check your email for the confirmation link sent to ${email}`,
   };
 
-  const resendEmailHandler = async () => {
+  // Verifies if we have access to profile info and session token.
+  // If we do, set the email and render the page. If not, we don't know
+  // who the user is and can't confirm if we've sent a confirmation
+  // link, and we can't send a new one without an email address => redirect
+  // the user to retry signup.
+  useEffect(() => {
     try {
-      // TO-DO: signin confirmation email to user.
-      logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
-      setResendStatus(ResendStatus['sent']);
+      if (sessionTokenId) {
+        getEmail();
+      } else {
+        redirectToSignup();
+      }
     } catch (e) {
-      setResendStatus(ResendStatus['error']);
+      redirectToSignup();
     }
+  }, [getEmail, redirectToSignup, sessionTokenId]);
+
+  useEffect(() => {
+    if (email) {
+      setShowLoadingSpinner(false);
+    }
+  }, [email, setShowLoadingSpinner]);
+
+  const navigateToConfirmCode = useCallback(
+    () =>
+      navigate('/confirm_signup_code?showReactApp=true', {
+        state: { email },
+        replace: true,
+      }),
+    [email, navigate]
+  );
+
+  // TODO implement broker to determine the the next screen
+  const navigateToNextScreen = () => {
+    logViewEvent(viewName, 'verification.success');
+    // TODO check if isForcePasswordChange
+    // navigate('/post_verify/password/force_password_change', {account})
+
+    // default behaviour: '/signup_confirmed'
+    // if Sync: '/connect_another_device'
+    // if Web: '/settings'
+    navigate('/settings', { replace: true });
   };
 
+  // Adds a timeout before navigating to the /confirm_signup_code page
+  // when the user clicks on the resend email link.
+  useEffect(() => {
+    function onTimeout() {
+      navigateToConfirmCode();
+    }
+    let navigateTimeoutId: NodeJS.Timeout;
+    if (resendStatus === ResendStatus.sent) {
+      navigateTimeoutId = setTimeout(onTimeout, NAVIGATION_TIMEOUT_MS);
+    }
+
+    return () => {
+      clearTimeout(navigateTimeoutId);
+    };
+  }, [navigateToConfirmCode, resendStatus]);
+
+  // Subscribe to account updates to find out if the session becomes verified.
+  // Stay on this page until the session is verified, then automatically
+  // navigate to the next screen.
+  useInterval(async () => {
+    try {
+      const sessionStatus = await account.isSessionVerified();
+      if (sessionStatus === true) {
+        navigateToNextScreen();
+        setIsPolling(null);
+      }
+    } catch (e) {
+      setIsPolling(null);
+    }
+  }, isPolling);
+
+  const resendEmailHandler = async () => {
+    try {
+      // The logic here differs from content-server. Since we are moving away
+      // from confirmation link, this resend function sends a verification code
+      // instead of a verification link and navigates to /signup_confirm_code.
+      // This avoids adding a (to be discontinued) method to the React Account model.
+      await account.sendVerificationCode();
+    } catch (err) {
+      setResendStatus(ResendStatus['error']);
+      if (AuthUiErrors['INVALID_TOKEN'].errno === err.errno) {
+        logErrorEvent({ viewName, ...err });
+        // TODO: When redirectToSignup is changed to use navigate,
+        // pass in the error so it can be displayed in an banner
+        // on the /signup page
+        redirectToSignup();
+      }
+      return;
+    }
+    setResendStatus(ResendStatus['sent']);
+  };
+
+  if (showLoadingSpinner) {
+    return (
+      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
+    );
+  }
+
   return (
-    <ConfirmWithLink
-      confirmWithLinkPageStrings={confirmSignupPageText}
-      {...{
-        email,
-        resendEmailHandler,
-        resendStatus,
-      }}
-    />
+    <AppLayout>
+      <ConfirmWithLink
+        confirmWithLinkPageStrings={confirmSignupPageText}
+        {...{
+          email,
+          resendEmailHandler,
+          resendStatus,
+        }}
+      />
+    </AppLayout>
   );
 };
 

--- a/packages/fxa-settings/src/pages/Signup/Confirm/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/mocks.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Account } from 'fxa-settings/src/models';
+import {
+  mockEmail,
+  mockSession,
+  MOCK_PROFILE_INFO,
+} from 'fxa-settings/src/models/mocks';
+
+export const MOCK_PROFILE_WITH_RESEND_SUCCESS = {
+  getProfileInfo: () => Promise.resolve(MOCK_PROFILE_INFO),
+  sendVerificationCode: () => Promise.resolve({}),
+  primaryEmail: mockEmail('blabidi@blabidiboop.com', true, false),
+} as unknown as Account;
+
+export const MOCK_PROFILE_WITH_RESEND_ERROR = {
+  getProfileInfo: () => Promise.resolve(MOCK_PROFILE_INFO),
+  sendVerificationCode: () => Promise.reject(Error),
+  primaryEmail: mockEmail('blabidi@blabidiboop.com', true, false),
+} as unknown as Account;
+
+export const MOCK_UNVERIFIED_SESSION = mockSession(false);
+
+export const MOCK_VERIFIED_SESSION = mockSession(true);
+
+export const MOCK_SESSION_TOKEN = 'abc123';


### PR DESCRIPTION
## Because

* We're converting our views from backbone to React

## This pull request

* Serves the React version of the 'confirm' page if the feature flag is on
* Adds page functionality to Confirm, including adding needed methods to the Account model and a ProfileInfo mock
* Implements one functionality change to the React version of the Confirm page: asking to resend the email sends a confirmation code instead of a confirmation link, and redirects to the 'confirm_signup_code' page
* Adds React import to CompleteResetPassword mocks (missing import was breaking the stories for this page)

## Issue that this pull request solves

Closes: #[FXA-6492](https://mozilla-hub.atlassian.net/browse/FXA-6492)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information

### Challenge of recreating this page:
- We are keeping this page to preserve legacy functionality (some traffic is still hitting this route), but it is not part of our currently rendered flow.
- The method described below to test the functionality will NOT send a confirmation link (this would be handled by a previous step in the flow), so no confirmation link will be available from `yarn pm2 logs inbox`.

### One change to note from backbone version of the page:
- Clicking 'Not in inbox or spam folder? Resend' will send a code instead of a link, then redirect to `/confirm_signup_code?showReactApp=true`

### To test on local:
- Enable feature flag for React 'signup' routes
- Start creating a new account, then replace `confirm_signup_code` with `/confirm?showReactApp=true` 
- Trying to hit `/confirm?showReactApp=true` without a new unverified account will redirect to `/signup`
- This page does not handle sending the confirmation link (this would be done on a previous step), so to test automatic redirect once session is verified:
  - Duplicate the `/confirm?showReactApp=true` tab
  - In the new tab, click the 'Not in inbox or spam folder? Resend' link
  - Your will be redirected to `/confirm_signup_code?showReactApp=true`
  - Retrieve the confirmation code from `yarn pm2 logs inbox` and enter in the /confirm_signup_code page
  - /confirm_signup_code redirects to /settings
  - Return to initial /confirm tab - should also automatically redirect to `/settings`.


[FXA-6492]: https://mozilla-hub.atlassian.net/browse/FXA-6492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ