### PR TITLE
task(ci): Add jq to docker

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     build-essential \
     zip \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=app:app . /fxa

--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
 RUN apt-get update && apt-get install -y \
     netcat \
     openssl \
+    jq \
     iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Because

- The jq command line utility was missing from docker images based on node:18 slim

## This pull request

- Installs jq

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was discovered in the train-255 deploy.
