### PR TITLE
task(ci): Add jq to docker

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     build-essential \
     zip \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=app:app . /fxa

--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
 RUN apt-get update && apt-get install -y \
     netcat \
     openssl \
+    jq \
     iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Because:
- jq util was missing from docker images based on node:18

This Commit:
- Installs jq
