### PR TITLE
task(ci): Build all packages but don't fail fast

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ commands:
     steps:
       - run:
           name: Compiling TypeScript
-          command: yarn workspaces foreach --exclude fxa-payments-server --exclude fxa-content-server --topological-dev --verbose run compile
+          command: yarn workspaces foreach --topological-dev --verbose run compile
 
   report-coverage:
     # Not currently used. But should be soon once coverage reports are fixed up.
@@ -720,8 +720,6 @@ workflows:
           name: Compile (PR)
           requires:
             - Build (PR)
-          post-steps:
-            - fail-fast
       - unit-test:
           name: Unit Test (PR)
           requires:
@@ -998,8 +996,6 @@ workflows:
               only: /.*/
           requires:
             - Build
-          post-steps:
-            - fail-fast
       - unit-test:
           name: Unit Test
           filters:
@@ -1152,8 +1148,6 @@ workflows:
           name: Compile (nightly)
           requires:
             - Build (nightly)
-          post-steps:
-            - fail-fast
       - unit-test:
           name: Unit Test (nightly)
           requires:

--- a/packages/fxa-content-server/app/scripts/models/subscription.ts
+++ b/packages/fxa-content-server/app/scripts/models/subscription.ts
@@ -27,7 +27,11 @@ interface IResumeTokenMixin {
 }
 
 const RESUME_TOKEN_FIELDS = ['planId', 'productId'];
-class SubscriptionModel extends Backbone.Model {
+class SubscriptionModel extends Backbone.Model<
+  Record<string, unknown>,
+  Record<string, unknown>,
+  { window?: Window }
+> {
   window?: Window;
   resumeTokenFields?: string[];
 
@@ -42,7 +46,7 @@ class SubscriptionModel extends Backbone.Model {
     );
   }
 
-  initialize(attrs = {}, options: { window?: Window } = {}) {
+  initialize(_attrs = {}, options: { window?: Window } = {}) {
     if (this.get('planId') && this.get('productId')) {
       // already set, no need to look anywhere else for the values.
       return;

--- a/packages/fxa-content-server/tsconfig.json
+++ b/packages/fxa-content-server/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": ["node_modules", "**/*.spec.ts"],
   "compilerOptions": {
     "outDir": "./.tscompiled/",
-    "rootDir": "./app/scripts/",
+    "rootDirs": ["./app/scripts/", "./server/lib/routes/react-app"],
     "baseUrl": "./app/scripts",
     "noImplicitAny": false
   },

--- a/packages/fxa-payments-server/tsconfig.json
+++ b/packages/fxa-payments-server/tsconfig.json
@@ -20,6 +20,10 @@
   "include": [
     "src"
   ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
   "references": [
     {
       "path": "../fxa-react"


### PR DESCRIPTION
## Because

- We want to start tracking build errors on all packages
- We should create urgency around fixing typescript build errors

## This pull request

- Removes any typescript compile exclusions
- Disabled the 'fail-fast' step for compile jobs

## Issue that this pull request solves

Closes: FXA-7133, FXA-7194

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This will result in failures, but it won't block the pipeline or merging. Hopefully we can be proactive about fixing these typescript errors.
