### PR TITLE
bug(CI): Add curl to docker images

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     zip \
     jq \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=app:app . /fxa

--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     openssl \
     jq \
+    curl \
     iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Because

- Builds were failing 

## This pull request

- Adds curl so that clone-legal-docs.sh doesn't error out.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
