### PR TITLE
fix(device commands): throw unknown device error if no device id

### DIFF
--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -252,6 +252,19 @@ module.exports = (
           throw new error.featureNotEnabled();
         }
 
+        if (!deviceId) {
+          log.error('device.command.deviceIdMissing', {
+            clientId: credentials.client?.id ? hex(credentials.client.id) : '',
+            clientName: credentials.client?.name ? credentials.client.name : '',
+            uaBrowser: credentials.uaBrowser,
+            uaBrowserVersion: credentials.uaBrowserVersion,
+            uaOS: credentials.uaOS,
+            uaOSVersion: credentials.uaOSVersion,
+          });
+
+          throw new error.unknownDevice();
+        }
+
         const response = await pushbox.retrieve(uid, deviceId, limit, index);
 
         // To measure command delivery, we emit a "retrieved" event for each retrieved

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -961,6 +961,44 @@ describe('/account/device/commands', () => {
     }
     assert.ok(mockPushbox.retrieve.notCalled);
   });
+
+  it('throws when a device id is not found', async () => {
+    const mockPushbox = mocks.mockPushbox();
+    const route = getRoute(
+      makeRoutes({
+        customs: mockCustoms,
+        log: mockLog,
+        pushbox: mockPushbox,
+      }),
+      '/account/device/commands'
+    );
+
+    mockRequest.auth.credentials.refreshTokenId = 'aaabbbccc';
+    mockRequest.auth.credentials.deviceId = undefined;
+    mockRequest.auth.credentials.client = { name: 'fx ios' };
+    mockRequest.auth.credentials.uaBrowser = 'Firefox iOS';
+
+    try {
+      await route.handler(mockRequest);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.output.statusCode, 400);
+      assert.equal(err.errno, error.ERRNO.DEVICE_UNKNOWN);
+      sinon.assert.calledOnceWithExactly(
+        mockLog.error,
+        'device.command.deviceIdMissing',
+        {
+          clientId: '',
+          clientName: 'fx ios',
+          uaBrowser: 'Firefox iOS',
+          uaBrowserVersion: undefined,
+          uaOS: undefined,
+          uaOSVersion: undefined,
+        }
+      );
+    }
+    assert.ok(mockPushbox.retrieve.notCalled);
+  });
 });
 
 describe('/account/devices/invoke_command', () => {


### PR DESCRIPTION
Because:
 - we've been seeing a trickle of errors on get device commands endpoint, and the error messages indicated that a value needed for the where clause of the db query is undefined
   - we suspect that the device id is undefined in some requests since it is possible for the device id to be undefined

This commit:
 - write some device/client info to the error log
 - throw the unknown device error as the response (http 400)
