### PR TITLE
fix(fxa-settings): Receive new link button inactive

### DIFF
--- a/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
@@ -10,6 +10,7 @@ import { LinkExpired, LinkExpiredProps } from '.';
 import { LinkExpiredResetPassword } from '../LinkExpiredResetPassword';
 import { LinkExpiredSignin } from '../LinkExpiredSignin';
 import { ResendStatus } from 'fxa-settings/src/lib/types';
+import { MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
 
 export default {
   title: 'Components/LinkExpired',
@@ -26,6 +27,7 @@ export default {
 } as Meta;
 
 const viewName = 'example-view-name';
+const email = MOCK_ACCOUNT.primaryEmail.email;
 
 const mockResendHandler = async () => {
   try {
@@ -45,9 +47,9 @@ const mockedProps: LinkExpiredProps = {
 export const Default = () => <LinkExpired {...mockedProps} />;
 
 export const LinkExpiredForResetPassword = () => (
-  <LinkExpiredResetPassword {...{ viewName }} />
+  <LinkExpiredResetPassword {...{ email, viewName }} />
 );
 
 export const LinkExpiredForSignin = () => (
-  <LinkExpiredSignin {...{ viewName }} />
+  <LinkExpiredSignin {...{ email, viewName }} />
 );

--- a/packages/fxa-settings/src/components/LinkExpired/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.tsx
@@ -38,7 +38,7 @@ export const LinkExpired = ({
       </FtlMsg>
       {/* TODO Extract for reuse into ButtonResendResetPasswordLink */}
       <FtlMsg id="reset-pwd-resend-link">
-        <button onClick={() => resendLinkHandler} className="link-blue mt-4">
+        <button onClick={resendLinkHandler} className="link-blue mt-4">
           Receive new link
         </button>
       </FtlMsg>

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.test.tsx
@@ -4,36 +4,35 @@
 
 import React from 'react';
 import { LocationProvider } from '@reach/router';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { LinkExpiredResetPassword } from '.';
 import { mockAppContext, MOCK_ACCOUNT } from '../../models/mocks';
 import { Account, AppContext } from '../../models';
+import { FIREFOX_NOREPLY_EMAIL } from 'fxa-settings/src/constants';
 
 const viewName = 'example-view-name';
+const email = MOCK_ACCOUNT.primaryEmail.email;
+
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+}));
 
 function renderLinkExpiredResetPasswordWithAccount(account: Account) {
   render(
     <AppContext.Provider value={mockAppContext({ account })}>
       <LocationProvider>
-        <LinkExpiredResetPassword {...{ viewName }} />
+        <LinkExpiredResetPassword {...{ email, viewName }} />
       </LocationProvider>
     </AppContext.Provider>
   );
 }
 
-jest.mock('@reach/router', () => ({
-  ...jest.requireActual('@reach/router'),
-  useLocation: () => {
-    return {
-      state: {
-        email: MOCK_ACCOUNT.primaryEmail.email,
-      },
-    };
-  },
-}));
-
 describe('LinkExpiredResetPassword', () => {
   const account = {} as unknown as Account;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders the component as expected for an expired Reset Password link', () => {
     renderLinkExpiredResetPasswordWithAccount(account);
@@ -46,5 +45,38 @@ describe('LinkExpiredResetPassword', () => {
       name: 'Receive new link',
     });
   });
-  // TODO test CTA
+  it('displays a success banner when clicking on "receive a new link" is successful', async () => {
+    const account = {
+      resendResetPassword: jest.fn().mockResolvedValue(true),
+    } as unknown as Account;
+
+    renderLinkExpiredResetPasswordWithAccount(account);
+    const receiveNewLinkButton = screen.getByRole('button', {
+      name: 'Receive new link',
+    });
+    fireEvent.click(receiveNewLinkButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          `Email resent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a smooth delivery.`
+        )
+      ).toBeInTheDocument();
+    });
+  });
+  it('displays an error banner when clicking on "receive a new link" is unsuccessful', async () => {
+    const account = {
+      resendResetPassword: jest.fn().mockRejectedValue('error'),
+    } as unknown as Account;
+
+    renderLinkExpiredResetPasswordWithAccount(account);
+    const receiveNewLinkButton = screen.getByRole('button', {
+      name: 'Receive new link',
+    });
+    fireEvent.click(receiveNewLinkButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText(`Something went wrong. A new link could not be sent.`)
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
@@ -3,31 +3,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useLocation } from '@reach/router';
 import { useAccount } from '../../models';
 import { ResendStatus } from '../../lib/types';
 import { logViewEvent } from 'fxa-settings/src/lib/metrics';
 import { REACT_ENTRYPOINT } from 'fxa-settings/src/constants';
 import { LinkExpired } from '../LinkExpired';
 
-type LocationState = { email: string };
-
-type SubComponentProps = {
+type LinkExpiredResetPasswordProps = {
+  email: string;
   viewName: string;
 };
 
-export const LinkExpiredResetPassword = ({ viewName }: SubComponentProps) => {
+export const LinkExpiredResetPassword = ({
+  email,
+  viewName,
+}: LinkExpiredResetPasswordProps) => {
   const account = useAccount();
-  const location = useLocation() as ReturnType<typeof useLocation> & {
-    state: LocationState;
-  };
+
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
   );
 
   const resendResetPasswordLink = async () => {
     try {
-      await account.resendResetPassword(location.state.email);
+      await account.resendResetPassword(email);
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
       setResendStatus(ResendStatus['sent']);
     } catch (e) {

--- a/packages/fxa-settings/src/components/LinkExpiredSignin/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredSignin/index.test.tsx
@@ -10,27 +10,21 @@ import { mockAppContext, MOCK_ACCOUNT } from '../../models/mocks';
 import { Account, AppContext } from '../../models';
 
 const viewName = 'example-view-name';
+const email = MOCK_ACCOUNT.primaryEmail.email;
+
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+}));
 
 function renderLinkExpiredSigninWithAccount(account: Account) {
   render(
     <AppContext.Provider value={mockAppContext({ account })}>
       <LocationProvider>
-        <LinkExpiredSignin {...{ viewName }} />
+        <LinkExpiredSignin {...{ email, viewName }} />
       </LocationProvider>
     </AppContext.Provider>
   );
 }
-
-jest.mock('@reach/router', () => ({
-  ...jest.requireActual('@reach/router'),
-  useLocation: () => {
-    return {
-      state: {
-        email: MOCK_ACCOUNT.primaryEmail.email,
-      },
-    };
-  },
-}));
 
 describe('LinkExpiredSignin', () => {
   const account = {} as unknown as Account;

--- a/packages/fxa-settings/src/components/LinkExpiredSignin/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredSignin/index.tsx
@@ -3,22 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-// import { useLocation } from '@reach/router';
 // import { useAccount } from '../../models';
 import { ResendStatus } from '../../lib/types';
 import { LinkExpired } from '../LinkExpired';
 
-// type LocationState = { email: string };
-
-type SubComponentProps = {
+type LinkExpiredSigninProps = {
+  email: string;
   viewName: string;
 };
 
-export const LinkExpiredSignin = ({ viewName }: SubComponentProps) => {
+export const LinkExpiredSignin = ({
+  email,
+  viewName,
+}: LinkExpiredSigninProps) => {
   // const account = useAccount();
-  // const location = useLocation() as ReturnType<typeof useLocation> & {
-  //   state: LocationState;
-  // };
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
   );

--- a/packages/fxa-settings/src/components/LinkValidator/index.tsx
+++ b/packages/fxa-settings/src/components/LinkValidator/index.tsx
@@ -37,6 +37,16 @@ const LinkValidator = <TModel extends ModelDataProvider>({
 
   const params = getParamsFromModel();
   const isValid = params.isValid();
+  const email = getEmailFromParams();
+
+  function getEmailFromParams() {
+    const email = params.getModelData().get('email');
+    if (typeof email === 'string') {
+      return email;
+    } else {
+      return undefined;
+    }
+  }
 
   const [linkStatus, setLinkStatus] = useState<LinkStatus>(
     isValid ? LinkStatus.valid : LinkStatus.damaged
@@ -55,13 +65,18 @@ const LinkValidator = <TModel extends ModelDataProvider>({
 
   if (
     linkStatus === LinkStatus.expired &&
-    linkType === LinkType['reset-password']
+    linkType === LinkType['reset-password'] &&
+    email !== undefined
   ) {
-    return <LinkExpiredResetPassword {...{ viewName }} />;
+    return <LinkExpiredResetPassword {...{ email, viewName }} />;
   }
 
-  if (linkStatus === LinkStatus.expired && linkType === LinkType['signin']) {
-    return <LinkExpiredSignin {...{ viewName }} />;
+  if (
+    linkStatus === LinkStatus.expired &&
+    linkType === LinkType['signin'] &&
+    email !== undefined
+  ) {
+    return <LinkExpiredSignin {...{ email, viewName }} />;
   }
 
   return <>{child({ setLinkStatus, params })}</>;

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -39,8 +39,6 @@ type SubmitData = {
   recoveryKey: string;
 } & RequiredParamsAccountRecoveryConfirmKey;
 
-type LocationState = { email: string };
-
 export const viewName = 'account-recovery-confirm-key';
 
 const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
@@ -58,9 +56,7 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const { linkStatus, setLinkStatus, requiredParams } =
     useAccountRecoveryConfirmKeyLinkStatus();
-  const location = useLocation() as ReturnType<typeof useLocation> & {
-    state: LocationState;
-  };
+  const location = useLocation();
 
   const { handleSubmit, register } = useForm<FormData>({
     mode: 'onBlur',
@@ -94,12 +90,16 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
 
       logViewEvent('flow', `${viewName}.success`, REACT_ENTRYPOINT);
 
-
       const decodedRecoveryKey = base32Decode(recoveryKey, 'Crockford');
       const uint8RecoveryKey = new Uint8Array(decodedRecoveryKey);
 
-      const decryptedData = await decryptRecoveryKeyData(uint8RecoveryKey, recoveryKeyId, recoveryData, uid);
-      
+      const decryptedData = await decryptRecoveryKeyData(
+        uint8RecoveryKey,
+        recoveryKeyId,
+        recoveryData,
+        uid
+      );
+
       navigate(`/account_recovery_reset_password${window.location.search}`, {
         state: {
           accountResetToken,
@@ -179,7 +179,12 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
   }
 
   if (linkStatus === LinkStatus.expired) {
-    return <LinkExpiredResetPassword {...{ viewName }} />;
+    return (
+      <LinkExpiredResetPassword
+        email={requiredParams.email}
+        {...{ viewName }}
+      />
+    );
   }
 
   return (

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
@@ -89,7 +89,7 @@ export const WithValidLink = () => {
   return storyWithProps(ctx, history);
 };
 
-export const WithExpiredLink = () => {
+export const OnSubmitLinkExpired = () => {
   const { ctx, history } = setup();
   // Mock the response. An INVALID_TOKEN means the link expired.
   ctx.account!.resetPasswordWithRecoveryKey = async () => {
@@ -99,8 +99,8 @@ export const WithExpiredLink = () => {
   return storyWithProps(ctx, history);
 };
 
-// An invalid link should result in a broken link error.
-export const WithBrokenLink = () => {
+// An invalid link should result in a damaged link error.
+export const WithDamagedLink = () => {
   const { ctx, history } = setup();
   // An email must have an @ symbol.
   history.location.search = 'email=foo';

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -122,7 +122,7 @@ const AccountRecoveryResetPassword = ({
   }
 
   if (linkStatus === 'expired') {
-    return <LinkExpiredResetPassword {...{ viewName }} />;
+    return <LinkExpiredResetPassword email={state.email} {...{ viewName }} />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.stories.tsx
@@ -6,9 +6,9 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 import CompleteSignin, { CompleteSigninProps } from '.';
-import AppLayout from '../../../components/AppLayout';
 import { withLocalization } from '../../../../.storybook/decorators';
 import { LinkStatus } from '../../../lib/types';
+import { MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
 
 export default {
   title: 'Pages/Signin/CompleteSignin',
@@ -19,35 +19,38 @@ export default {
 const storyWithProps = (props: CompleteSigninProps) => {
   const story = () => (
     <LocationProvider>
-      <AppLayout>
-        <CompleteSignin {...props} />
-      </AppLayout>
+      <CompleteSignin {...props} />
     </LocationProvider>
   );
   return story;
 };
 
 export const WithValidLink = storyWithProps({
+  email: MOCK_ACCOUNT.primaryEmail.email,
   linkStatus: LinkStatus.valid,
   isForPrimaryEmail: true,
 });
 
 export const WithExpiredLink = storyWithProps({
+  email: MOCK_ACCOUNT.primaryEmail.email,
   linkStatus: LinkStatus.expired,
   isForPrimaryEmail: true,
 });
 
 export const WithDamagedLink = storyWithProps({
+  email: MOCK_ACCOUNT.primaryEmail.email,
   linkStatus: LinkStatus.damaged,
   isForPrimaryEmail: true,
 });
 
 export const WithUsedLinkDefault = storyWithProps({
+  email: MOCK_ACCOUNT.primaryEmail.email,
   linkStatus: LinkStatus.used,
   isForPrimaryEmail: false,
 });
 
 export const WithUsedLinkForPrimaryEmail = storyWithProps({
+  email: MOCK_ACCOUNT.primaryEmail.email,
   linkStatus: LinkStatus.used,
   isForPrimaryEmail: true,
 });

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import CompleteSignin, { viewName } from '.';
-import { renderWithRouter } from '../../../models/mocks';
+import { MOCK_ACCOUNT, renderWithRouter } from '../../../models/mocks';
 import { LinkStatus } from '../../../lib/types';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
@@ -24,7 +24,11 @@ jest.mock('@reach/router', () => ({
 describe('CompleteSignin', () => {
   it('redirects the user as expected after validation when the link is valid', async () => {
     renderWithRouter(
-      <CompleteSignin linkStatus={LinkStatus.valid} isForPrimaryEmail={true} />
+      <CompleteSignin
+        email={MOCK_ACCOUNT.primaryEmail.email}
+        linkStatus={LinkStatus.valid}
+        isForPrimaryEmail={true}
+      />
     );
     // TO-DO: Add in user signin validation and test for it.
     await waitFor(() => {
@@ -35,6 +39,7 @@ describe('CompleteSignin', () => {
   it('calls the custom broker method supplied if given a valid link', async () => {
     renderWithRouter(
       <CompleteSignin
+        email={MOCK_ACCOUNT.primaryEmail.email}
         linkStatus={LinkStatus.valid}
         isForPrimaryEmail={true}
         brokerNextAction={() => {
@@ -51,6 +56,7 @@ describe('CompleteSignin', () => {
   it('renders the component as expected when provided with an expired link', () => {
     renderWithRouter(
       <CompleteSignin
+        email={MOCK_ACCOUNT.primaryEmail.email}
         linkStatus={LinkStatus.expired}
         isForPrimaryEmail={true}
       />
@@ -75,6 +81,7 @@ describe('CompleteSignin', () => {
   it('renders the component as expected when provided with a damaged link', () => {
     renderWithRouter(
       <CompleteSignin
+        email={MOCK_ACCOUNT.primaryEmail.email}
         linkStatus={LinkStatus.damaged}
         isForPrimaryEmail={true}
       />
@@ -103,7 +110,11 @@ describe('CompleteSignin', () => {
 
   it('renders the component as expected when provided with a used link', () => {
     renderWithRouter(
-      <CompleteSignin linkStatus={LinkStatus.used} isForPrimaryEmail={true} />
+      <CompleteSignin
+        email={MOCK_ACCOUNT.primaryEmail.email}
+        linkStatus={LinkStatus.used}
+        isForPrimaryEmail={true}
+      />
     );
 
     screen.getByRole('heading', {
@@ -117,7 +128,11 @@ describe('CompleteSignin', () => {
   // TODO : check for metrics event when link is expired or damaged
   it('emits the expected metrics on render when the link is valid', () => {
     renderWithRouter(
-      <CompleteSignin linkStatus={LinkStatus.valid} isForPrimaryEmail={true} />
+      <CompleteSignin
+        email={MOCK_ACCOUNT.primaryEmail.email}
+        linkStatus={LinkStatus.valid}
+        isForPrimaryEmail={true}
+      />
     );
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
@@ -15,7 +15,9 @@ import { REACT_ENTRYPOINT } from '../../../constants';
 import AppLayout from '../../../components/AppLayout';
 
 // We will probably grab `isSignedIn` off of the Account model in the long run.
+// and email from validated query params
 export type CompleteSigninProps = {
+  email: string;
   brokerNextAction?: Function;
   isForPrimaryEmail: boolean;
   linkStatus: LinkStatus;
@@ -24,6 +26,7 @@ export type CompleteSigninProps = {
 export const viewName = 'complete-signin';
 
 const CompleteSignin = ({
+  email,
   brokerNextAction,
   isForPrimaryEmail,
   linkStatus,
@@ -51,7 +54,7 @@ const CompleteSignin = ({
     return <SigninLinkDamaged />;
   }
   if (linkStatus === LinkStatus.expired) {
-    return <LinkExpiredSignin {...{ viewName }} />;
+    return <LinkExpiredSignin {...{ email, viewName }} />;
   }
   if (linkStatus === LinkStatus.used) {
     return <LinkUsed {...{ isForPrimaryEmail }} />;


### PR DESCRIPTION
## Because

* 'Receive new link' button on Link Expired pages were not working on Stage

## This pull request

* Fix error with button click handler
* Pass in email from params to link expired page
* Add a few more tests to LinkExpired components

## Issue that this pull request solves

Closes: #FXA-6891

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Success banner should now be displayed when resending a link is successful (tested on localhost)
![image](https://user-images.githubusercontent.com/22231637/228957689-13ad1328-5f75-4bcb-9519-4853c459c330.png)

## Other information (Optional)

- On local, a new link is received with `yarn pm2 logs inbox` when clicking on the link.
- Link should now be enabled for all LinkExpired instances in the ResetPassword flow. 
- Link won't be active yet for Signin pages (functionality not enabled yet)
