### PR TITLE
fix(tests): Add some tweaks to reduce flaky playwright tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
         default: large
       parallelism:
         type: integer
-        default: 8
+        default: 4
     executor: functional-test-executor
     resource_class: << parameters.resource_class >>
     parallelism: << parameters.parallelism >>

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -282,7 +282,7 @@ export class LoginPage extends BaseLayout {
   }
 
   async getTooltipError() {
-    return this.page.innerText(selectors.TOOLTIP);
+    return this.page.locator(selectors.TOOLTIP).innerText();
   }
 
   async unblock(email: string) {
@@ -296,17 +296,14 @@ export class LoginPage extends BaseLayout {
   }
 
   async submit() {
-    return Promise.all([
-      this.page.locator(selectors.SUBMIT).click(),
-      this.page.waitForNavigation({ waitUntil: 'load' }),
-    ]);
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page.locator(selectors.SUBMIT).click();
+    return waitForNavigation;
   }
 
   async clickForgotPassword() {
-    return Promise.all([
-      this.page.locator(selectors.LINK_RESET_PASSWORD).click(),
-      this.page.waitForNavigation({ waitUntil: 'networkidle' }),
-    ]);
+    await this.page.locator(selectors.LINK_RESET_PASSWORD).click();
+    await this.page.waitForURL(/reset_password/);
   }
 
   async isSigninHeader() {
@@ -360,10 +357,8 @@ export class LoginPage extends BaseLayout {
   }
 
   async clickDontHaveRecoveryKey() {
-    return Promise.all([
-      this.page.locator(selectors.LINK_LOST_RECOVERY_KEY).click(),
-      this.page.waitForNavigation(),
-    ]);
+    await this.page.locator(selectors.LINK_LOST_RECOVERY_KEY).click();
+    await this.page.waitForURL(/complete_reset_password/);
   }
 
   setRecoveryKey(key: string) {
@@ -375,19 +370,19 @@ export class LoginPage extends BaseLayout {
   }
 
   async setNewPassword(password: string) {
-    await this.page.fill(selectors.PASSWORD, password);
-    await this.page.fill(selectors.VPASSWORD, password);
+    await this.page.locator(selectors.PASSWORD).fill(password);
+    await this.page.locator(selectors.VPASSWORD).fill(password);
     await this.submit();
   }
 
   async setTotp(secret: string) {
     const code = await getCode(secret);
-    await this.page.fill(selectors.NUMBER_INPUT, code);
+    await this.page.locator(selectors.NUMBER_INPUT).fill(code);
     await this.submit();
   }
 
   async getPrefilledEmail() {
-    return this.page.innerText(selectors.EMAIL_PREFILLED);
+    return this.page.locator(selectors.EMAIL_PREFILLED).innerText();
   }
 
   async getEmailInputElement() {
@@ -395,11 +390,11 @@ export class LoginPage extends BaseLayout {
   }
 
   async getEmailInput() {
-    return this.page.inputValue(selectors.EMAIL);
+    return this.page.locator(selectors.EMAIL).inputValue();
   }
 
   async getPasswordInput() {
-    return this.page.inputValue(selectors.PASSWORD);
+    return this.page.locator(selectors.PASSWORD).inputValue();
   }
 
   async isCachedLogin() {
@@ -416,7 +411,7 @@ export class LoginPage extends BaseLayout {
   }
 
   async getErrorMessage() {
-    return this.page.innerText(selectors.ERROR);
+    return this.page.locator(selectors.ERROR).innerText();
   }
 
   createEmail(template?: string) {

--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -38,10 +38,11 @@ export class SubscribePage extends BaseLayout {
       '[data-testid="paypal-button-container"]'
     );
     await paypalButton.waitFor({ state: 'visible' });
-    const [paypalWindow] = await Promise.all([
-      this.page.waitForEvent('popup'),
-      this.page.locator('[data-testid="paypal-button-container"]').click(),
-    ]);
+
+    const paypalWindowPromise = this.page.waitForEvent('popup');
+    await this.page.locator('[data-testid="paypal-button-container"]').click();
+    const paypalWindow = await paypalWindowPromise;
+
     await paypalWindow.waitForLoadState('load');
     await paypalWindow.waitForNavigation({
       url: /checkoutnow/,

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -1,4 +1,5 @@
 import { BaseLayout } from './layout';
+import { selectors } from './login';
 
 export class RelierPage extends BaseLayout {
   goto(query?: string) {
@@ -27,25 +28,22 @@ export class RelierPage extends BaseLayout {
     ]);
   }
 
-  clickEmailFirst() {
-    return Promise.all([
-      this.page.locator('button.email-first-button').click(),
-      this.page.waitForNavigation(),
-    ]);
+  async clickEmailFirst() {
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page.locator('button.email-first-button').click();
+    return waitForNavigation;
   }
 
-  clickSignIn() {
-    return Promise.all([
-      this.page.locator('button.sign-in-button.signin').click(),
-      this.page.waitForNavigation(),
-    ]);
+  async clickSignIn() {
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page.locator('button.sign-in-button.signin').click();
+    return waitForNavigation;
   }
 
-  clickForceAuth() {
-    return Promise.all([
-      this.page.locator('button.force-auth').click(),
-      this.page.waitForNavigation(),
-    ]);
+  async clickForceAuth() {
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page.locator('button.force-auth').click();
+    return waitForNavigation;
   }
 
   clickChooseFlow() {
@@ -53,27 +51,26 @@ export class RelierPage extends BaseLayout {
   }
 
   async clickSubscribe() {
-    await Promise.all([
-      this.page.getByRole('link', { name: 'Subscribe to Pro (USD)' }).click(),
-      this.page.waitForNavigation({ waitUntil: 'load' }),
-    ]);
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page
+      .getByRole('link', { name: 'Subscribe to Pro (USD)' })
+      .click();
+    return waitForNavigation;
   }
 
   async clickSubscribe6Month() {
-    await Promise.all([
-      this.page
-        .getByRole('link', { name: 'Subscribe to Pro 6m (USD)' })
-        .click(),
-      this.page.waitForNavigation({ waitUntil: 'load' }),
-    ]);
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page
+      .getByRole('link', { name: 'Subscribe to Pro 6m (USD)' })
+      .click();
+    return waitForNavigation;
   }
 
   async clickSubscribe12Month() {
-    await Promise.all([
-      this.page
-        .getByRole('link', { name: 'Subscribe to Pro 12m (USD)' })
-        .click(),
-      this.page.waitForNavigation({ waitUntil: 'load' }),
-    ]);
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page
+      .getByRole('link', { name: 'Subscribe to Pro 12m (USD)' })
+      .click();
+    return waitForNavigation;
   }
 }

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -53,8 +53,8 @@ export class ResetPasswordPage extends BaseLayout {
   }
 
   async resetNewPassword(password: string) {
-    await this.page.fill(selectors.PASSWORD, password);
-    await this.page.fill(selectors.VPASSWORD, password);
+    await this.page.locator(selectors.PASSWORD).fill(password);
+    await this.page.locator(selectors.VPASSWORD).fill(password);
     await this.page.locator(selectors.SUBMIT).click();
   }
 

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -62,9 +62,8 @@ export abstract class SettingsLayout extends BaseLayout {
 
   async signOut() {
     await this.clickAvatarIcon();
-    await Promise.all([
-      this.clickSignOut(),
-      this.page.waitForURL(this.target.baseUrl, { waitUntil: 'load' }),
-    ]);
+    const waitForURL = this.page.waitForURL(this.target.baseUrl);
+    await this.clickSignOut();
+    return waitForURL;
   }
 }

--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -13,19 +13,19 @@ export class RecoveryKeyPage extends SettingsLayout {
   }
 
   async invalidRecoveryKeyError() {
-    return this.page.innerText('#error-tooltip-159');
+    return this.page.locator('#error-tooltip-159').innerText();
   }
 
   setPassword(password: string) {
-    return this.page.fill('input[type=password]', password);
+    return this.page.locator('input[type=password]').fill(password);
   }
 
   async confirmRecoveryKey() {
-    return this.page.click('button[type=submit]');
+    return this.page.locator('button[type=submit]').click();
   }
 
   async clickLostRecoveryKey() {
-    return this.page.click('.lost-recovery-key');
+    return this.page.locator('.lost-recovery-key').click();
   }
 
   submit() {

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -1,5 +1,5 @@
 import { PlaywrightTestConfig, Project } from '@playwright/test';
-import path from 'path';
+import * as path from 'path';
 import { TargetNames } from './lib/targets';
 import { TestOptions, WorkerOptions } from './lib/fixtures/standard';
 import { getFirefoxUserPrefs } from './lib/targets/firefoxUserPrefs';
@@ -11,10 +11,20 @@ const CI = !!process.env.CI;
 const DEBUG = !!process.env.DEBUG;
 const SLOWMO = parseInt(process.env.PLAYWRIGHT_SLOWMO || '0');
 
+let retries = 0,
+  workers = undefined,
+  maxFailures = 0;
+if (CI) {
+  // Overall maxFailures is now dependent on the number of retries, workers
+  retries = 3;
+  workers = 2;
+  maxFailures = retries * workers * 2;
+}
+
 const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
   outputDir: path.resolve(__dirname, '../../artifacts/functional'),
   forbidOnly: CI,
-  retries: CI ? 2 : 0,
+  retries,
   testDir: 'tests',
   use: {
     viewport: { width: 1280, height: 720 },
@@ -66,8 +76,8 @@ const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
         ],
       ]
     : 'list',
-  workers: CI ? 2 : undefined,
-  maxFailures: CI ? 3 : 0,
+  workers,
+  maxFailures,
 };
 
 export default config;

--- a/packages/functional-tests/scripts/test-ci.sh
+++ b/packages/functional-tests/scripts/test-ci.sh
@@ -4,5 +4,5 @@ DIR=$(dirname "$0")
 
 cd "$DIR/../../../"
 
-circleci tests glob "packages/functional-tests/tests/**/*.spec.ts" | circleci tests split --split-by=timings > tests-to-run.txt
+circleci tests glob "packages/functional-tests/tests/**/*.spec.ts" | circleci tests split > tests-to-run.txt
 yarn workspace functional-tests test $(cat tests-to-run.txt|awk -F"/" '{ print $NF }')

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -9,7 +9,7 @@ test.describe('OAuth force auth', () => {
     await relier.clickForceAuth();
 
     // Email is prefilled
-    await expect(await login.page.innerText('#prefillEmail')).toMatch(
+    await expect(await login.page.innerText('#prefillEmail')).toContain(
       credentials.email
     );
     await login.setPassword(credentials.password);

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('OAuth totp', () => {
+  test.beforeEach(async ({}, { project }) => {
+    test.slow();
+  });
+
   test('can add TOTP to account and confirm oauth signin', async ({
     credentials,
     pages: { login, relier, settings, totp },

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -22,7 +22,7 @@ test.describe('severity-1 #smoke', () => {
     );
     await page.goto(link, { waitUntil: 'networkidle' });
     await login.setNewPassword(credentials.password);
-    expect(page.url()).toMatch(settings.url);
+    expect(page.url()).toContain(settings.url);
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293431

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -9,7 +9,7 @@ test.describe('recovery key test', () => {
     async ({ credentials, page, pages: { settings, recoveryKey } }) => {
       // Generating and consuming recovery keys is a slow process
       test.slow();
-      
+
       await settings.goto();
       let status = await settings.recoveryKey.statusText();
       expect(status).toEqual('Not Set');
@@ -43,8 +43,6 @@ test.describe('recovery key test', () => {
     page,
     pages: { settings, recoveryKey, login },
   }) => {
-    // Generating and consuming recovery keys is a slow process
-    test.slow();
     let secondKey;
 
     // Create new recovery key
@@ -76,7 +74,9 @@ test.describe('recovery key test', () => {
     await recoveryKey.confirmRecoveryKey();
 
     // Verify the error
-    expect(await recoveryKey.invalidRecoveryKeyError()).toContain('Invalid account recovery key');
+    expect(await recoveryKey.invalidRecoveryKeyError()).toContain(
+      'Invalid account recovery key'
+    );
 
     // Enter new recovery key
     await login.setRecoveryKey(secondKey);
@@ -149,7 +149,7 @@ test.describe('recovery key test', () => {
       EmailType.recovery,
       EmailHeader.link
     );
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link);
     await login.setRecoveryKey(key);
     await recoveryKey.confirmRecoveryKey();
 

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -50,7 +50,7 @@ test.describe('Sign up with code ', () => {
     await login.fillOutFirstSignUp(email, PASSWORD, false);
     await login.setCode('1234');
     await signinTokenCode.clickSubmitButton();
-    expect(await login.getTooltipError()).toMatch(
+    expect(await login.getTooltipError()).toContain(
       'Invalid or expired confirmation code'
     );
   });

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -13,10 +13,7 @@ test.describe('redirect_to', () => {
 
   async function engageRedirect(page, target, redirectTo) {
     await page.goto(
-      `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`,
-      {
-        waitUntil: 'networkidle',
-      }
+      `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`
     );
     await page.click('button[type=submit]');
   }
@@ -51,8 +48,13 @@ test.describe('redirect_to', () => {
     pages: { page },
   }) => {
     const redirectTo = `${target.contentServerUrl}/settings`;
-    await engageRedirect(page, target, redirectTo);
-    await page.waitForNavigation();
+    await page.goto(
+      `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`
+    );
+    await page.click('button[type=submit]');
+
+    await page.waitForURL(/settings\?/);
+
     expect(page.url().startsWith(redirectTo)).toBeTruthy();
   });
 });

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -13,7 +13,7 @@ test.describe('coupon test', () => {
     await subscribe.addCouponCode('autoexpired');
 
     // Verifying the correct error message
-    expect(await subscribe.couponErrorMessageText()).toMatch(
+    expect(await subscribe.couponErrorMessageText()).toContain(
       'The code you entered has expired'
     );
   });
@@ -27,7 +27,7 @@ test.describe('coupon test', () => {
     await subscribe.addCouponCode('autoinvalid');
 
     // Asserting that the code is invalid for a 6mo plan
-    expect(await subscribe.couponErrorMessageText()).toMatch(
+    expect(await subscribe.couponErrorMessageText()).toContain(
       'The code you entered is invalid'
     );
 
@@ -53,7 +53,7 @@ test.describe('coupon test', () => {
     await subscribe.addCouponCode('autoinvalid');
 
     // Asserting that the code is invalid for a 6m plan
-    expect(await subscribe.couponErrorMessageText()).toMatch(
+    expect(await subscribe.couponErrorMessageText()).toContain(
       'The code you entered is invalid'
     );
 

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -8,7 +8,7 @@ const password = 'passwordzxcv';
 const incorrectPassword = 'password123';
 let email;
 
-test.describe.skip('Firefox Desktop Sync v3 sign up', () => {
+test.describe('Firefox Desktop Sync v3 sign up', () => {
   test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     email = login.createEmail('sync{id}');

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -25,7 +25,7 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
       EmailType.recovery,
       EmailHeader.link
     );
-    await page.goto(link, { waitUntil: 'load' });
+    await page.goto(link);
 
     // Enter a short password
     await resetPassword.resetNewPassword('pass');

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.js
@@ -76,7 +76,7 @@ const execOptions = {
   },
 };
 
-describe.skip('#integration - scripts/bulk-mailer', function () {
+describe('#integration - scripts/bulk-mailer', function () {
   this.timeout(10000);
 
   let db, server;

--- a/packages/fxa-auth-server/test/scripts/dump-users.js
+++ b/packages/fxa-auth-server/test/scripts/dump-users.js
@@ -68,7 +68,7 @@ const execOptions = {
   },
 };
 
-describe.skip('#integration - scripts/dump-users', function () {
+describe('#integration - scripts/dump-users', function () {
   this.timeout(10000);
 
   let db, server;

--- a/packages/fxa-auth-server/test/scripts/must-reset.js
+++ b/packages/fxa-auth-server/test/scripts/must-reset.js
@@ -58,7 +58,7 @@ const account2Mock = createAccount(
 
 const DB = require('../../lib/db')(config, log, Token, UnblockCode);
 
-describe.skip('#integration - scripts/must-reset', async function () {
+describe('#integration - scripts/must-reset', async function () {
   this.timeout(30000);
 
   let db, server;


### PR DESCRIPTION
## Because

- Playwright tests are still flaky

## This pull request

- Uses new function `.waitForUrl` instead of deprecated `.waitForNavigation` in several places
- Increases flaky test retry to 3

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
