### PR TITLE
fix(payments): update Single Quotation Marks

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/en.ftl
@@ -3,4 +3,4 @@
 payment-method-header = Choose your payment method
 # This message is used to indicate the second step in a multi step process.
 payment-method-header-second-step = 2. { payment-method-header }
-payment-method-first-approve = First you'll need to approve your subscription
+payment-method-first-approve = First you’ll need to approve your subscription

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -62,7 +62,7 @@ describe('components/PaymentMethodHeader', () => {
 
     it('returns correct text for required text', async () => {
       const msgId = 'payment-method-first-approve';
-      const expected = "First you'll need to approve your subscription";
+      const expected = 'First you’ll need to approve your subscription';
       const actual = getLocalizedMessage(bundle, msgId, {});
       expect(actual).toEqual(expected);
     });

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -51,7 +51,7 @@ export const PaymentMethodHeader = ({
     <>
       {returnPaymentMethodHeader(type || PaymentMethodHeaderType.NoPrefix)}
       <Localized id="payment-method-first-approve">
-        <strong>First you'll need to approve your subscription</strong>
+        <strong>First you’ll need to approve your subscription</strong>
       </Localized>
       <Form validator={checkboxValidator}>
         <PaymentConsentCheckbox


### PR DESCRIPTION
Because:

* this change accidentally got reverted and uses the wrong single quotation marks

This commit:

* Puts back the correct ones