### PR TITLE
fix(admin): filter plans by plan id rather than product id

### DIFF
--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.spec.ts
@@ -196,7 +196,9 @@ describe('Subscription Service', () => {
     mockPlayStoreGetSubscriptions.mockImplementation(
       async (_uid: string) => []
     );
-    mockAllAbbrevPlans.mockImplementation(async () => [plan]);
+    // Ensure we match on plan ID rather than product ID
+    const planOther = { ...plan, plan_id: 'plan_456' };
+    mockAllAbbrevPlans.mockImplementation(async () => [planOther, plan]);
     mockCreateManageSubscriptionLink.mockImplementation(
       async () => manageSubscriptionLink
     );

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
@@ -112,9 +112,9 @@ export class SubscriptionsService {
 
     for (const subscription of customer?.subscriptions?.data || []) {
       // Inspired by code in auth-server payments ;]
-      const plan = await plans.find(
+      const plan = plans.find(
         // @ts-ignore
-        (p) => p.product_id === subscription.plan.product
+        (p) => p.plan_id === subscription.plan.id
       );
 
       let invoice = subscription.latest_invoice;


### PR DESCRIPTION
Because:

* Support was seeing FxA users' subscriptions list the wrong plan ID in the FxA Admin Panel relative to Stripe.
* We were picking the first cached plan whose product ID matched the subscription product ID rather than matching the plan ID.

This commit:

* Matches by the plan ID instead.

Closes #FXA-7039

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
