### PR TITLE
fix(fxa-settings): Show localizedRetryAfter when resetPassword is throttled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ executors:
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
+      CUSTOMS_SERVER_URL: none
 
   # Contains minimal image for running common jobs like linting or unit tests.
   # This image requires a restored workspace state.
@@ -85,6 +86,7 @@ executors:
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
+      CUSTOMS_SERVER_URL: none
 
   # A minimal image for anything job needs infrastructure. Perfect for integration tests.
   # This image requires a restored workspace state.
@@ -104,6 +106,7 @@ executors:
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
+      CUSTOMS_SERVER_URL: none
 
   # For anything that needs a full stack to run and needs browsers available for
   # ui test automation. This image requires a restored workspace state.
@@ -141,6 +144,7 @@ executors:
       REACT_CONVERSION_POST_VERIFY_ADD_RECOVERY_KEY_ROUTES: true
       REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES: true
       REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH_ROUTES: true
+      CUSTOMS_SERVER_URL: none
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
   # automation. Perfect for running smoke tests against remote targets.
@@ -154,6 +158,7 @@ executors:
       - image: mozilla/fxa-circleci:ci-functional-test-runner
     environment:
       NODE_ENV: development
+      CUSTOMS_SERVER_URL: none
 
 
 commands:

--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -271,6 +271,12 @@ can be overridden in two ways:
    export CONFIG_FILES="~/fxa-content-server.json,~/fxa-db.json"
    ```
 
+### Rate-limiting config
+
+Rate-limiting and blocking is handled by fxa-customs-server. By default, these policies are _enabled_ in dev environment via `"customsUrl":"http://localhost:7000"` in `fxa-auth-server/config/dev.json`, but disabled for circleCI. Enabling the customs server allows error messages to be displayed when rate limiting occurs. Default rate-limiting values are found in `fxa-customs-server/lib/config/config.js` and can be modified with environment variables or by adding a `dev.json` file to `fxa-customs-server/config/`.
+
+The customs-server can be disabled for testing by changing the dev config to `"customsUrl":"none"`.
+
 ### Email config
 
 There is also some live config

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -2,7 +2,7 @@
   "contentServer": {
     "url": "http://localhost:3030"
   },
-  "customsUrl": "none",
+  "customsUrl": "http://localhost:7000",
   "lockoutEnabled": true,
   "log": {
     "fmt": "pretty",

--- a/packages/fxa-customs-server/pm2.config.js
+++ b/packages/fxa-customs-server/pm2.config.js
@@ -15,6 +15,8 @@ module.exports = {
       max_restarts: '1',
       env: {
         NODE_ENV: 'dev',
+        // By default, Node18 favours ipv6 for localhost
+        NODE_OPTIONS: '--dns-result-order=ipv4first',
         PORT: 7000,
         PATH,
         SENTRY_ENV: 'local',

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -9,6 +9,12 @@ import { Meta } from '@storybook/react';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { MozServices } from '../../lib/types';
 import { withLocalization } from '../../../.storybook/decorators';
+import { Account, AppContext } from '../../models';
+import {
+  mockAccountWithThrottledError,
+  mockAccountWithUnexpectedError,
+  mockDefaultAccount,
+} from './mocks';
 
 export default {
   title: 'Pages/ResetPassword',
@@ -16,22 +22,35 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = (props?: Partial<ResetPasswordProps>) => {
+const storyWithProps = (
+  account: Account,
+  props?: Partial<ResetPasswordProps>
+) => {
   const story = () => (
-    <LocationProvider>
-      <ResetPassword {...props} />
-    </LocationProvider>
+    <AppContext.Provider value={{ account }}>
+      <LocationProvider>
+        <ResetPassword {...props} />
+      </LocationProvider>
+    </AppContext.Provider>
   );
   return story;
 };
 
-export const Default = storyWithProps();
+export const Default = storyWithProps(mockDefaultAccount);
 
-export const WithServiceName = storyWithProps({
+export const WithServiceName = storyWithProps(mockDefaultAccount, {
   serviceName: MozServices.MozillaVPN,
 });
 
-export const WithForceAuth = storyWithProps({
+export const WithForceAuth = storyWithProps(mockDefaultAccount, {
   prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
   forceAuth: true,
 });
+
+export const WithThrottledErrorOnSubmit = storyWithProps(
+  mockAccountWithThrottledError
+);
+
+export const WithUnexpectedErrorOnSubmit = storyWithProps(
+  mockAccountWithUnexpectedError
+);

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -97,16 +97,27 @@ const ResetPassword = ({
       });
     } catch (err) {
       let localizedError;
-      if (err.errno === AuthUiErrors.THROTTLED.errno) {
-        localizedError = ftlMsgResolver.getMsg(
-          composeAuthUiErrorTranslationId(err),
-          AuthUiErrorNos[err.errno].message,
-          { retryAfter: err.retryAfterLocalized }
-        );
+      if (err.errno && AuthUiErrorNos[err.errno]) {
+        if (
+          err.errno === AuthUiErrors.THROTTLED.errno &&
+          err.retryAfterLocalized
+        ) {
+          localizedError = ftlMsgResolver.getMsg(
+            composeAuthUiErrorTranslationId(err),
+            AuthUiErrorNos[err.errno].message,
+            { retryAfter: err.retryAfterLocalized }
+          );
+        } else {
+          localizedError = ftlMsgResolver.getMsg(
+            composeAuthUiErrorTranslationId(err),
+            AuthUiErrorNos[err.errno].message
+          );
+        }
       } else {
+        const unexpectedError = AuthUiErrors.UNEXPECTED_ERROR;
         localizedError = ftlMsgResolver.getMsg(
-          composeAuthUiErrorTranslationId(err),
-          err.message
+          composeAuthUiErrorTranslationId(unexpectedError),
+          unexpectedError.message
         );
       }
       setErrorMessage(localizedError);

--- a/packages/fxa-settings/src/pages/ResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/mocks.tsx
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MOCK_ACCOUNT } from '../../models/mocks';
+import { Account } from '../../models';
+
+// No error message on submit
+export const mockDefaultAccount = { MOCK_ACCOUNT } as any as Account;
+
+mockDefaultAccount.resetPassword = () =>
+  Promise.resolve({ passwordForgotToken: 'mockPasswordForgotToken' });
+
+// Mocked localized throttled error (not localized in storybook)
+export const mockAccountWithThrottledError = {
+  MOCK_ACCOUNT,
+} as unknown as Account;
+
+const throttledErrorObj = {
+  errno: 114,
+  retryAfter: 500,
+  retryAfterLocalized: 'in 15 minutes',
+};
+
+mockAccountWithThrottledError.resetPassword = () =>
+  Promise.reject(throttledErrorObj);
+
+export const mockAccountWithUnexpectedError = {
+  MOCK_ACCOUNT,
+} as unknown as Account;
+
+mockAccountWithThrottledError.resetPassword = () =>
+  Promise.reject('some error');


### PR DESCRIPTION
## Because

* We want to show the retryAfterLocalized value in localized error messages when ResetPassword requests are throttled (maxEmails reached)

## This pull request

* Add retryAfter and retryAfterLocalized from Auth server errors to GraphQl errors
* Make this value available to the localized throttled error message for the ResetPassword page.
* Add ResetPassword stories to show error examples.
* Enable rate-limiting in dev environment by default to test rate-limiting errors.
* Use ipv4 for the customs-server localhost (prevent from using ipv6, favoured by Node18)

## Issue that this pull request solves

Closes: #FXA-6875

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2023-04-05 at 11 25 58 AM](https://user-images.githubusercontent.com/22231637/230170974-efe34cce-6838-4ecb-a3ba-fa98b22a33a6.png)

## Other information (Optional)

MAX_EMAILS is set to 3 by default - on 4 consecutive and incomplete attempts to reset the password (submitting the email 4 times at http://localhost:3030/reset_password?showReactApp=true without following next steps), the throttled error should be displayed in a banner.
