### PR TITLE
feat(pocket): update pocket delete account messaging

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
@@ -34,6 +34,8 @@ delete-account-continue-button = Continue
 
 delete-account-password-input =
  .label = Enter password
+ 
+pocket-delete-notice = If you subscribe to Pocket Premium, please make sure that you <a>cancel your subscription</a> before deleting your account.
 
 delete-account-cancel-button = Cancel
 delete-account-delete-button-2 = Delete

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
@@ -71,6 +71,7 @@ describe('PageDeleteAccount', () => {
         "Firefox Monitor",
         "MDN Plus",
         "Mozilla Hubs",
+        "Pocket",
       ]
     `);
   });

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -30,6 +30,7 @@ import {
   composeAuthUiErrorTranslationId,
 } from '../../../lib/auth-errors/auth-errors';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
 
 type FormData = {
   password: string;
@@ -201,6 +202,24 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                 </li>
               ))}
             </ul>
+
+            <Localized id="pocket-delete-notice"
+                       elems={{
+                         a: (
+                          <LinkExternal
+                           href="https://help.getpocket.com/article/986-canceling-your-pocket-premium-subscription"
+                           data-testid="link-pocket-delete-notice"
+                           className="link-blue"
+                          >
+                            cancel your subscription
+                          </LinkExternal>
+                         ),
+                       }}
+            >
+            <p className="mb-4">
+                If you subscribe to Pocket Premium, please make sure that you <a>cancel your subscription</a> before deleting your account.
+              </p>
+            </Localized>
             <Localized id="delete-account-acknowledge">
               <p className="mb-4">
                 Please acknowledge that by deleting your account:

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -15,6 +15,7 @@ import {
   HubsLink,
   MDNLink,
   MonitorLink,
+  PocketLink,
   RelayLink,
   ROOTPATH,
   SyncLink,
@@ -80,6 +81,11 @@ const deleteProducts = [
     localizationId: 'delete-account-product-mozilla-hubs',
     productName: 'Mozilla Hubs',
     href: HubsLink,
+  },
+  {
+    localizationId: 'delete-account-product-pocket',
+    productName: 'Pocket',
+    href: PocketLink,
   },
 ];
 

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -12,6 +12,7 @@ export const RelayLink = 'https://relay.firefox.com/';
 export const AddonsLink = 'https://addons.mozilla.org/';
 export const MDNLink = 'https://developer.mozilla.org/';
 export const HubsLink = 'https://hubs.mozilla.com/';
+export const PocketLink = 'https://getpocket.com/';
 export const SHOW_BALLOON_TIMEOUT = 500;
 export const HIDE_BALLOON_TIMEOUT = 400;
 export const CLEAR_MESSAGES_TIMEOUT = 750;


### PR DESCRIPTION
## Because

- We need updated messaging

## This pull request

- Adds Pocket to the deleted accounts list

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7086

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="615" alt="Screenshot 2023-05-10 at 1 32 31 PM" src="https://github.com/mozilla/fxa/assets/1295288/8fce3184-798b-44cc-b016-dd015791acb3">

## Notes

This PR is blocked on https://getpocket.atlassian.net/browse/INFRA-1201, Pocket needs to listen to the FxA delete account even and process it accordingly. 
