### PR TITLE
fix(react): Add react experiment to as a startup experiment

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -13,7 +13,9 @@ const UA_OVERRIDE = 'FxATester';
 /**
  * Experiments that are created on startup in `chooseExperiments`.
  */
-const STARTUP_EXPERIMENTS = {};
+const STARTUP_EXPERIMENTS = {
+  generalizeReactApp: BaseExperiment,
+};
 
 /**
  * Experiments created manually by calling `getAndReportExperimentGroup`
@@ -24,7 +26,6 @@ const MANUAL_EXPERIMENTS = {
   qrCodeCad: BaseExperiment,
   pushLogin: BaseExperiment,
   pocketMigration: BaseExperiment,
-  generalizeReactApp: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);


### PR DESCRIPTION
## Because

- This experiment needs to be a start experiment to automatically enroll the user in the experiment, ref https://mozilla.github.io/ecosystem-platform/reference/experiments-ab-testing

## This pull request

- Adds as startup experiment

## Issue that this pull request solves

Closes: #

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We will need a point release for this.
