### PR TITLE
bug(fxa-settings): unlink password input visibility toggle

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -86,8 +86,6 @@ export const FormPasswordWithBalloons = ({
     useState<boolean>(false);
   const [isConfirmPwdBalloonVisible, setIsConfirmPwdBalloonVisible] =
     useState<boolean>(false);
-  const [areBothPasswordsVisible, setAreBothPasswordsVisible] =
-    useState<boolean>(false);
 
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedPasswordMatchError = ftlMsgResolver.getMsg(
@@ -210,7 +208,6 @@ export const FormPasswordWithBalloons = ({
                 },
               })}
               prefixDataTestId="new-password"
-              {...{ areBothPasswordsVisible, setAreBothPasswordsVisible }}
             />
           </FtlMsg>
           {isNewPwdBalloonVisible && (
@@ -259,7 +256,6 @@ export const FormPasswordWithBalloons = ({
               anchorStart
               tooltipPosition="bottom"
               prefixDataTestId="verify-password"
-              {...{ areBothPasswordsVisible, setAreBothPasswordsVisible }}
             />
           </FtlMsg>
 

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -8,17 +8,7 @@ import { ReactComponent as OpenEye } from './eye-open.svg';
 import { ReactComponent as ClosedEye } from './eye-closed.svg';
 import { useLocalization } from '@fluent/react';
 
-type OptionalSyncedVisibilityProps =
-  | {
-      areBothPasswordsVisible?: boolean;
-      setAreBothPasswordsVisible?: React.Dispatch<
-        React.SetStateAction<boolean>
-      >;
-    }
-  | { areBothPasswordsVisible?: never; setAreBothPasswordsVisible?: never };
-
-export type InputPasswordProps = Omit<InputTextProps, 'type'> &
-  OptionalSyncedVisibilityProps;
+export type InputPasswordProps = Omit<InputTextProps, 'type'>;
 
 export const InputPassword = ({
   defaultValue,
@@ -36,8 +26,6 @@ export const InputPassword = ({
   prefixDataTestId = '',
   tooltipPosition,
   anchorStart,
-  areBothPasswordsVisible,
-  setAreBothPasswordsVisible,
 }: InputPasswordProps) => {
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
   const [visible, setVisible] = useState<boolean>(false);
@@ -57,11 +45,7 @@ export const InputPassword = ({
 
   return (
     <InputText
-      type={
-        (areBothPasswordsVisible ? areBothPasswordsVisible : visible)
-          ? 'text'
-          : 'password'
-      }
+      type={visible ? 'text' : 'password'}
       {...{
         defaultValue,
         disabled,
@@ -89,17 +73,14 @@ export const InputPassword = ({
         tabIndex={-1}
         onClick={() => {
           setVisible(!visible);
-          if (setAreBothPasswordsVisible) {
-            setAreBothPasswordsVisible(!visible);
-          }
         }}
         title={
-          (areBothPasswordsVisible ? areBothPasswordsVisible : visible)
+          visible
             ? l10n.getString('input-password-hide', null, 'Hide password')
             : l10n.getString('input-password-show', null, 'Show password')
         }
         aria-label={
-          (areBothPasswordsVisible ? areBothPasswordsVisible : visible)
+          visible
             ? l10n.getString(
                 'input-password-hide-aria',
                 null,
@@ -112,7 +93,7 @@ export const InputPassword = ({
               )
         }
       >
-        {(areBothPasswordsVisible ? areBothPasswordsVisible : visible) ? (
+        {visible ? (
           <ClosedEye
             width="24"
             height="24"

--- a/packages/fxa-settings/src/components/InputPassword/mocks.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/mocks.tsx
@@ -2,23 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React from 'react';
 import InputPassword from '.';
 
 export const SubjectWithPairedInputs = () => {
-  const [areBothPasswordsVisible, setAreBothPasswordsVisible] =
-    useState<boolean>(false);
-
   return (
     <>
-      <InputPassword
-        {...{ areBothPasswordsVisible, setAreBothPasswordsVisible }}
-        label="Make me visible..."
-      />
-      <InputPassword
-        {...{ areBothPasswordsVisible, setAreBothPasswordsVisible }}
-        label="...and I'll be visible too."
-      />
+      <InputPassword label="Make me visible..." />
+      <InputPassword label="...and I'll be visible too." />
       <p className="text-sm italic mt-10">
         <strong>Tip:</strong> Toggling visibility in one field controls
         visibility in both.


### PR DESCRIPTION
## Because:

* We want the password inputs to toggle visibility independent of each other. In other words, if you click on the "eye" icon next to either input, we want to change the visibility of only that input, and not the neighboring input.

## This commit:

* Removes the logic which linked the visibility status for the two inputs.

Closes #FXA-7150

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Separated visibility toggle functionality:
<img width="873" alt="Screen Shot 2023-04-06 at 11 27 09 AM" src="https://user-images.githubusercontent.com/11150372/230464154-f3960d12-f54d-46a6-9295-968694ea1491.png">
