### PR TITLE
fix(fxa-settings): Reduce form-related re-renders in new React flows

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -25,8 +25,6 @@ export type FormPasswordWithBalloonsProps = {
   getValues: UseFormMethods['getValues'];
   email: string;
   onFocusMetricsEvent?: string;
-  passwordMatchErrorText: string;
-  setPasswordMatchErrorText: React.Dispatch<React.SetStateAction<string>>;
   loading: boolean;
   children?: React.ReactNode;
 };
@@ -74,12 +72,12 @@ export const FormPasswordWithBalloons = ({
   register,
   getValues,
   onFocusMetricsEvent,
-  passwordMatchErrorText,
-  setPasswordMatchErrorText,
   loading,
   children,
 }: FormPasswordWithBalloonsProps) => {
   const passwordValidator = new PasswordValidator(email);
+  const [passwordMatchErrorText, setPasswordMatchErrorText] =
+    useState<string>('');
   const [hasNewPwdFocused, setHasNewPwdFocused] = useState<boolean>(false);
   const [hasUserTakenAction, setHasUserTakenAction] = useState<boolean>(false);
   const [isNewPwdBalloonVisible, setIsNewPwdBalloonVisible] =
@@ -155,14 +153,21 @@ export const FormPasswordWithBalloons = ({
     }
   };
 
-  const onBlurConfirmPassword = () => {
+  const onBlurConfirmPassword = useCallback(() => {
     passwordFormType === 'signup' &&
       isConfirmPwdBalloonVisible &&
       hideConfirmPwdBalloon();
 
     getValues('confirmPassword') !== getValues('newPassword') &&
       setPasswordMatchErrorText(localizedPasswordMatchError);
-  };
+  }, [
+    getValues,
+    hideConfirmPwdBalloon,
+    isConfirmPwdBalloonVisible,
+    localizedPasswordMatchError,
+    passwordFormType,
+    setPasswordMatchErrorText,
+  ]);
 
   return (
     <>
@@ -181,7 +186,6 @@ export const FormPasswordWithBalloons = ({
               onFocusCb={onFocusMetricsEvent ? onNewPwdFocus : undefined}
               onBlurCb={onNewPwdBlur}
               onChange={() => {
-                trigger(['newPassword', 'confirmPassword']);
                 getValues('confirmPassword') === getValues('newPassword') &&
                   setPasswordMatchErrorText('');
               }}
@@ -242,10 +246,8 @@ export const FormPasswordWithBalloons = ({
               }
               onBlurCb={() => onBlurConfirmPassword()}
               onChange={() => {
-                if (passwordMatchErrorText) {
+                getValues('confirmPassword') === getValues('newPassword') &&
                   setPasswordMatchErrorText('');
-                }
-                trigger(['newPassword', 'confirmPassword']);
               }}
               hasErrors={errors.confirmPassword && passwordMatchErrorText}
               errorText={passwordMatchErrorText}

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/mocks.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useForm } from 'react-hook-form';
 import FormPasswordWithBalloons, { PasswordFormType } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
@@ -21,9 +21,6 @@ export const Subject = ({ passwordFormType }: SubjectProps) => {
     // this alert is for Storybook
     alert('Form submitted! (onFormSubmit called)');
   };
-
-  const [passwordMatchErrorText, setPasswordMatchErrorText] =
-    useState<string>('');
 
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<FormData>({
@@ -44,8 +41,6 @@ export const Subject = ({ passwordFormType }: SubjectProps) => {
         register,
         getValues,
         passwordFormType,
-        passwordMatchErrorText,
-        setPasswordMatchErrorText,
       }}
       onSubmit={handleSubmit(onFormSubmit)}
       email={MOCK_ACCOUNT.primaryEmail.email}

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -95,8 +95,6 @@ const AccountRecoveryResetPassword = ({
 
   const [bannerState, setBannerState] = useState<BannerState>(BannerState.None);
   const [linkStatus, setLinkStatus] = useState<LinkStatus>(state.linkStatus);
-  const [passwordMatchErrorText, setPasswordMatchErrorText] =
-    useState<string>('');
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<FormData>({
       mode: 'onTouched',
@@ -183,8 +181,6 @@ const AccountRecoveryResetPassword = ({
             trigger,
             register,
             getValues,
-            passwordMatchErrorText,
-            setPasswordMatchErrorText,
           }}
           passwordFormType="reset"
           onSubmit={handleSubmit(

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -11,7 +11,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { Account } from '../../../models';
-import { logPageViewEvent } from '../../../lib/metrics';
+import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT, SHOW_BALLOON_TIMEOUT } from '../../../constants';
 import {
   mockCompleteResetPasswordParams,
@@ -37,7 +37,7 @@ const PASSWORD = 'passwordzxcv';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
 }));
 
 let account: Account;
@@ -174,7 +174,7 @@ describe('CompleteResetPassword page', () => {
   it('emits the expected metrics on render', () => {
     renderSubject(account);
 
-    expect(logPageViewEvent).toHaveBeenCalledWith(
+    expect(usePageViewEvent).toHaveBeenCalledWith(
       'complete-reset-password',
       REACT_ENTRYPOINT
     );
@@ -288,7 +288,6 @@ describe('CompleteResetPassword page', () => {
       fireEvent.input(screen.getByTestId('new-password-input-field'), {
         target: { value: PASSWORD },
       });
-
       fireEvent.input(screen.getByTestId('verify-password-input-field'), {
         target: { value: PASSWORD },
       });

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from '@reach/router';
 import { useForm } from 'react-hook-form';
-import { logPageViewEvent } from '../../../lib/metrics';
+import { usePageViewEvent } from '../../../lib/metrics';
 import {
   CreateIntegration,
   IntegrationType,
@@ -71,10 +71,8 @@ const CompleteResetPassword = ({
   params: CompleteResetPasswordLink;
   setLinkStatus: React.Dispatch<React.SetStateAction<LinkStatus>>;
 }) => {
-  logPageViewEvent(viewName, REACT_ENTRYPOINT);
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  const [passwordMatchErrorText, setPasswordMatchErrorText] =
-    useState<string>('');
   const [errorType, setErrorType] = useState(ErrorType.none);
   /* Show a loading spinner until all checks complete. Without this, users with a
    * recovery key set or with an expired or damaged link will experience some jank due
@@ -87,6 +85,16 @@ const CompleteResetPassword = ({
     state: LocationState;
   };
   const integration = CreateIntegration();
+
+  const { handleSubmit, register, getValues, errors, formState, trigger } =
+    useForm<FormData>({
+      mode: 'onTouched',
+      criteriaMode: 'all',
+      defaultValues: {
+        newPassword: '',
+        confirmPassword: '',
+      },
+    });
 
   /* When the user clicks the confirm password reset link from their email, we check
    * to see if they have an account recovery key set. If they do, we navigate to the
@@ -137,16 +145,6 @@ const CompleteResetPassword = ({
 
     setShowLoadingSpinner(false);
   }, [params.token, account, setLinkStatus]);
-
-  const { handleSubmit, register, getValues, errors, formState, trigger } =
-    useForm<FormData>({
-      mode: 'onTouched',
-      criteriaMode: 'all',
-      defaultValues: {
-        newPassword: '',
-        confirmPassword: '',
-      },
-    });
 
   const alertSuccessAndNavigate = useCallback(() => {
     setErrorType(ErrorType.none);
@@ -299,8 +297,6 @@ const CompleteResetPassword = ({
             trigger,
             register,
             getValues,
-            passwordMatchErrorText,
-            setPasswordMatchErrorText,
           }}
           email={params.email}
           passwordFormType="reset"

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
@@ -12,11 +12,11 @@ import { REACT_ENTRYPOINT } from '../../../constants';
 import { LocationProvider } from '@reach/router';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext, MOCK_ACCOUNT } from '../../../models/mocks';
-import { logPageViewEvent, logViewEvent } from '../../../lib/metrics';
+import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
-  logPageViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
 }));
 
 const account = MOCK_ACCOUNT as unknown as Account;
@@ -91,7 +91,7 @@ describe('ConfirmResetPassword page', () => {
 
   it('emits the expected metrics on render', async () => {
     render(<ConfirmResetPassword />);
-    expect(logPageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 
   it('renders a "Remember your password?" link', () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useState } from 'react';
 import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import { POLLING_INTERVAL_MS, REACT_ENTRYPOINT } from '../../../constants';
-import { logPageViewEvent, logViewEvent } from '../../../lib/metrics';
+import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ResendStatus } from '../../../lib/types';
 import { useAccount, useInterval } from '../../../models';
 import AppLayout from '../../../components/AppLayout';
@@ -23,7 +23,7 @@ export type ConfirmResetPasswordLocationState = {
 };
 
 const ConfirmResetPassword = (_: RouteComponentProps) => {
-  logPageViewEvent(viewName, REACT_ENTRYPOINT);
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const navigate = useNavigate();
   let { state } = useLocation();

--- a/packages/fxa-settings/src/pages/ResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/en.ftl
@@ -12,3 +12,5 @@ reset-password-warning-message-2 = <span>Note:</span> When you reset your passwo
 reset-password-password-input =
   .label = Email
 reset-password-button = Begin reset
+# Error message displayed in a tooltip when a user attempts to submit a password reset form without entering an email address
+reset-password-email-required-error = Email required

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -68,8 +68,6 @@ const Signup = ({
 
   const [ageCheckErrorText, setAgeCheckErrorText] = useState<string>('');
   const [isFocused, setIsFocused] = useState<boolean>(false);
-  const [passwordMatchErrorText, setPasswordMatchErrorText] =
-    useState<string>('');
   const [
     isAccountSuggestionBannerVisible,
     setIsAccountSuggestionBannerVisible,
@@ -206,8 +204,6 @@ const Signup = ({
           onFocus,
           email,
           onFocusMetricsEvent,
-          passwordMatchErrorText,
-          setPasswordMatchErrorText,
         }}
         passwordFormType="signup"
         onSubmit={handleSubmit(onSubmit)}


### PR DESCRIPTION
## Because

- We want to reduce form-related re-rendering to a minimum in the new react flows and only emit screen events once on initial load.

## This pull request

* Reduce form-related re-renders to a minimum (previously re-rendered on every input change, now re-renders if inputs have errors that are displayed in adjacent components - there is no `useWatch` equivalent for `formState errors`)
* Update ResetPassword form to use the `useWatch` hook to isolate re-rendering, remove `trigger`
* Replace `logPageViewEvent` with `usePageViewEvent` hook
* Move some state from pages to the `FormPasswordWithBalloons` component
* Update tests for submit error on `ResetPassword`
* Displays a tooltip error if the ResetPassword form is submitted without an email

## Issue that this pull request solves

Closes: # FXA-7100, #FXA-7160

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Separate issue filed for `usePageViewEvent` hook initializing metrics instead of emitting metrics event: https://mozilla-hub.atlassian.net/browse/FXA-7201
