### PR TITLE
task(ci): Allow docker build phase to happen in parallel

### DIFF
--- a/.circleci/build-all.sh
+++ b/.circleci/build-all.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+TAG=$1
+
+if [[ -z "${TAG}" ]]; then
+  echo "Usage: $1 <TAG>"
+  exit 1
+fi
+
 DIR=$(dirname "$0")
 cd "$DIR"
 
@@ -8,8 +15,8 @@ if [[ -n "${CIRCLECI}" ]]; then
 fi
 
 ../_scripts/build-builder.sh
-../_scripts/build-fxa-mono.sh
+../_scripts/build-fxa-mono.sh "${TAG}"
 
 for d in ../packages/*/ ; do
-  ./build.sh "$(basename "$d")"
+  ./build.sh "$(basename "$d")" "${TAG}"
 done

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 
 MODULE=$1
+TAG=$2
+
+# push temporary tag to docker hub
+DOCKER_USER=DOCKER_USER_${MODULE//-/_}
+DOCKER_PASS=DOCKER_PASS_${MODULE//-/_}
+DOCKERHUB_REPO=mozilla/${MODULE}
+
 DIR=$(dirname "$0")
 
 if grep -e "$MODULE" -e 'all' "$DIR/../packages/test.list" > /dev/null; then
@@ -11,14 +18,16 @@ if grep -e "$MODULE" -e 'all' "$DIR/../packages/test.list" > /dev/null; then
   echo "# building $MODULE"
   echo -e "################################\n"
 
-  mkdir -p ../../artifacts
-
-  if [[ -x scripts/build-ci.sh ]]; then
-    time ./scripts/build-ci.sh
-  elif [[ -r Dockerfile ]]; then
+  if [[ -r Dockerfile ]]; then
     # send Dockerfile over stdin to exclude local context
     # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#pipe-dockerfile-through-stdin
-    time (< Dockerfile docker build --progress=plain -t "${MODULE}:build" - &> "../../artifacts/${MODULE}.log")
+    time (< Dockerfile docker build --progress=plain -t "${DOCKERHUB_REPO}:${TAG}" - &> "../../artifacts/${MODULE}.log")
+
+
+
+    echo "${!DOCKER_PASS}" | docker login -u "${!DOCKER_USER}" --password-stdin
+    echo "Pushing temporary ${MODULE}:${TAG} to docker hub..."
+    docker push "${DOCKERHUB_REPO}:${TAG}"
   fi
 
   # for debugging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,22 +460,28 @@ commands:
 
 jobs:
 
-  # Does a production level build of FxA and produces docker images.
-  deploy-packages:
+  create-fxa-images:
     executor: docker-build-executor
     steps:
       - checkout
       - cache-restore-yarn
       - provision
       - setup_remote_docker:
-          docker_layer_caching: false
+          docker_layer_caching: true
       - run:
           name: Build docker images
-          command: ./.circleci/build-all.sh
+          command: ./.circleci/build-all.sh  << pipeline.id >>
           no_output_timeout: 1h
+
+  deploy-fxa-images:
+    executor: docker-build-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Push to docker hub
-          command: ./.circleci/deploy-all.sh
+          command: ./.circleci/deploy-all.sh << pipeline.id >>
       - store-artifacts
 
   # This deploys docker images that are useful for CI testing. Think of this image as
@@ -910,14 +916,14 @@ workflows:
             tags:
               only: /.*/
 
-  deploy_packages:
+  deploy_fxa_images:
     # This workflow can be triggered after a PR lands on main. It requires approval.
     # The same operation will eventually run nightly. The same operation will run nightly.
     when: << pipeline.parameters.enable_deploy_packages >>
     jobs:
       # Builds the monorepo for a production / stage deploy
-      - request-deploy-packages:
-          name: Request Deploy FxA Packages
+      - request-deploy-images:
+          name: Request Deploy FxA Images
           type: approval
           filters:
             branches:
@@ -927,10 +933,15 @@ workflows:
                 - /^dockerpush.*/
             tags:
               ignore: /.*/
-      - deploy-packages:
-          name: Deploy FxA Packages
+      - create-fxa-images:
+          name: Create FxA Images (requested)
           requires:
-            - Request Deploy FxA Packages
+            - Request Deploy FxA Images
+      - deploy-fxa-images:
+          name: Deploy FxA Images (requested)
+          requires:
+            - Create FxA Images (requested)
+
 
   deploy_ci_images:
     # This workflow is triggered after a PR lands on main. The workflow will
@@ -1106,8 +1117,17 @@ workflows:
               only: /.*/
           requires:
             - Build
-      - deploy-packages:
-          name: Deploy FXA
+      - create-fxa-images:
+          name: Create FxA Images
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+          requires:
+            - Build
+      - deploy-fxa-images:
+          name: Deploy Fxa Images
           filters:
             branches:
               ignore: /.*/
@@ -1126,6 +1146,7 @@ workflows:
             - Functional Test - Content 4
             - Functional Test - Content 5
             - Functional Tests - Playwright
+            - Create FxA Images
 
   nightly:
     # This work flow runs a full build, test suite, and deployment of docker images nightly
@@ -1204,10 +1225,14 @@ workflows:
           name: Deploy Storybooks (nightly)
           requires:
             - Tests Complete (nightly)
-      - deploy-packages:
-          name: Deploy FxA Packages (nightly)
+      - create-fxa-images:
+          name: Create FxA Images (nightly)
           requires:
             - Tests Complete (nightly)
+      - deploy-fxa-images:
+          name: Deploy FxA Images (nightly)
+          requires:
+            - Create FxA Images (nightly)
       - deploy-fxa-ci-images:
           name: Deploy CI Images (nightly)
           executor:

--- a/.circleci/deploy-all.sh
+++ b/.circleci/deploy-all.sh
@@ -1,12 +1,18 @@
 #!/bin/bash -e
 
+TAG=$1
+if [[ -z "${TAG}" ]]; then
+  echo "No tag specified! Exiting..."
+  exit 1
+fi
+
 DIR=$(dirname "$0")
 cd "$DIR"
 
 docker images
 
-./deploy.sh "fxa-mono"
+./deploy.sh "fxa-mono" "${TAG}"
 
 for d in ../packages/*/ ; do
-  ./deploy.sh "$(basename "$d")"
+  ./deploy.sh "$(basename "$d")" "${TAG}"
 done

--- a/_scripts/build-fxa-mono.sh
+++ b/_scripts/build-fxa-mono.sh
@@ -1,9 +1,25 @@
 #!/bin/bash -e
 
+TAG=$1
+
+MODULE="fxa-mono"
+DOCKER_USER=DOCKER_USER_${MODULE//-/_}
+DOCKER_PASS=DOCKER_PASS_${MODULE//-/_}
+DOCKERHUB_REPO=mozilla/${MODULE}
+
 DIR=$(dirname "$0")
 cd "$DIR"
 
+# Login to docker hub
+echo "${!DOCKER_PASS}" | docker login -u "${!DOCKER_USER}" --password-stdin
+
+# Ensure artifacts directory exists
 mkdir -p ../artifacts
 
-echo "Building fxa-mono image..."
-time (< ../_dev/docker/mono/Dockerfile docker build -t fxa-mono:build - &> "../artifacts/fxa-mono.log")
+# Build fxa-mono image
+echo "Building ${MODULE} image..."
+time (< ../_dev/docker/mono/Dockerfile docker build -t "${DOCKERHUB_REPO}:${TAG}" - &> "../artifacts/fxa-mono.log")
+
+# push temporary tag of fxa-mono to docker hub
+echo "Pushing temporary ${DOCKERHUB_REPO}:${TAG} to docker hub..."
+docker push "${DOCKERHUB_REPO}:${TAG}"


### PR DESCRIPTION
## Because

- We can build the docker image while tests are running
- This will cut down on deploy time


## This pull request

- Builds the deployed docker images in parallel to tests
- Pushes temporary image to docker up
- Once tests finish re-tags temporary image and pushes to docker hub
- Removes temporary build image from docker hub

## Issue that this pull request solves

Closes: FXA-7141

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

