### PR TITLE
bug(fxa-settings): fix 'link expired' error in reset password

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -52,6 +52,8 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
   // so we set its value after the first request for subsequent requests.
   const [fetchedResetToken, setFetchedResetToken] = useState('');
   const [isFocused, setIsFocused] = useState(false);
+  // We use this to debounce the submit button
+  const [isLoading, setIsLoading] = useState(false);
   const account = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
   const { linkStatus, setLinkStatus, requiredParams } =
@@ -149,6 +151,8 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
           );
           setRecoveryKeyErrorText(errorAccountRecoveryConfirmKey);
         }
+      } finally {
+        setIsLoading(false);
       }
     },
     [
@@ -161,6 +165,7 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
   );
 
   const onSubmit = ({ recoveryKey, token, code, email, uid }: SubmitData) => {
+    setIsLoading(true);
     logViewEvent('flow', `${viewName}.submit`, REACT_ENTRYPOINT);
     if (recoveryKey === '') {
       const errorEmptyRecoveryKeyInput = ftlMsgResolver.getMsg(
@@ -168,6 +173,7 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
         'Account recovery key required'
       );
       setRecoveryKeyErrorText(errorEmptyRecoveryKeyInput);
+      setIsLoading(false);
       return;
     }
 
@@ -251,7 +257,11 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
         </FtlMsg>
 
         <FtlMsg id="account-recovery-confirm-key-button">
-          <button type="submit" className="cta-primary cta-xl mb-6">
+          <button
+            type="submit"
+            className="cta-primary cta-xl mb-6"
+            disabled={isLoading}
+          >
             Confirm account recovery key
           </button>
         </FtlMsg>


### PR DESCRIPTION
## Because:

* Currently in the new React version of the account_recovery_confirm_key view, if the user hammers the `submit` button with an incorrect key typed into the input (or, basically with anything other than an empty input or a value that isn't the correct key) the user will eventually see a "link expired" message. This is not how the page currently behaves in Backbone and it is not desired behavior.

## This commit:

* Debounces the submit button

Closes #FXA-7152

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I would SUPER appreciate people going through this and seeing if they see the error on main, and then don't see the error with these changes in place -- I think this is a simple throttling issue but my understanding of what was causing this specific error is very surface level, so having other eyes on it would be a huge help!

Step to replicate are in the bug ticket (https://mozilla-hub.atlassian.net/browse/FXA-7152)
