### PR TITLE
feat(metrics): report A Warning To Sentry If Flow Initialization Fails

### DIFF
--- a/packages/fxa-payments-server/src/lib/flow-event.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.ts
@@ -1,4 +1,5 @@
 import sentryMetrics from './sentry';
+import { Severity } from '@sentry/browser';
 
 interface FlowEventParams {
   device_id?: string;
@@ -15,6 +16,14 @@ let initialized = false;
 let optEventData: FlowEventData;
 
 function shouldSend() {
+  if (!initialized) {
+    sentryMetrics.captureMessage(
+      'Flow events not initialized - Metrics not captured for checkout flow',
+      'flowEvents.initializationError',
+      { referrer: document.referrer, url: document.URL },
+      Severity.Warning
+    );
+  }
   return initialized && window.navigator.sendBeacon;
 }
 

--- a/packages/fxa-payments-server/src/lib/sentry.js
+++ b/packages/fxa-payments-server/src/lib/sentry.js
@@ -166,6 +166,21 @@ SentryMetrics.prototype = {
     });
   },
 
+  /**
+   * Capture message to report to sentry.
+   *
+   * @param {*} message Passed to Sentry.captureMessage
+   * @param {*} contextKey Sentry.setContext key
+   * @param {*} context Sentry.setContext context object
+   * @param {*} severity Enum passed to Sentry.captureMessage to set severity level
+   */
+  captureMessage(message, contextKey, context, severity) {
+    Sentry.withScope(function(scope) {
+      scope.setContext(contextKey, context);
+      Sentry.captureMessage(message, severity);
+    });
+  },
+
   // Private functions, exposed for testing
   __beforeSend: beforeSend,
   __cleanUpQueryParam: cleanUpQueryParam,


### PR DESCRIPTION
Because:

* we want to report to sentry when we will not be able to capture flow events for a checkout flow

This commit:

* Adds a method to sentryMetrics and calls it from flow-events if initialized is false in shouldSend

Closes #FXA-6963

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Note about screenshots below: I've updated the message to include that flow metrics are not captured for the checkout flow and the referrer is blank because I entered the url into address bar (was not directed to the checkout page)

<img width="1103" alt="Screenshot 2023-04-07 at 12 28 09 PM" src="https://user-images.githubusercontent.com/1585040/230666141-fdd78686-cff3-4686-93ad-d89abf40744f.png">
<img width="1119" alt="Screenshot 2023-04-07 at 12 27 50 PM" src="https://user-images.githubusercontent.com/1585040/230666144-d3d6d995-25cf-41dd-88b7-93f70239c306.png">


## Other information (Optional)
To test this, remove one of the following from the query params:  `device_id`, `flow_begin_time`, `flow_id`
