### PR TITLE
chore: create release github action

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,76 @@
+name: Tag Release
+on:
+  workflow_dispatch:
+    inputs:
+      versionName:
+        description: 'What train is this?  eg. 275'
+        required: true
+permissions: {}
+jobs:
+  tagrelease:
+    permissions:
+      contents: write      # To make changes to files
+      pull-requests: write # To make PR
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Show GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+      shell: bash
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Create release branch
+      run: git checkout -b train-${{ github.event.inputs.versionName }}
+    - name: Initialize mandatory git config
+      run: |
+        git config user.name "${{ github.triggering_actor }}"
+        git config user.email "noreply@github.com"
+    - name: Update package versions
+      run: |
+        IFS=$'\n'
+        TARGETS="packages/fxa-auth-server
+        packages/fxa-admin-server
+        packages/fxa-admin-panel
+        packages/fxa-content-server
+        packages/fxa-customs-server
+        packages/fxa-event-broker
+        packages/fxa-geodb
+        packages/fxa-graphql-api
+        packages/fxa-payments-server
+        packages/fxa-profile-server
+        packages/fxa-react
+        packages/fxa-settings
+        packages/fxa-shared
+        packages/fxa-support-panel"
+
+        for TARGET in $TARGETS; do
+          if [ -f "$TARGET/package.json" ]; then
+            jq '.version="1.${{ github.event.inputs.versionName }}.0"' $TARGET/package.json > $TARGET/pacakage.json.new
+            mv $TARGET/pacakage.json.new $TARGET/package.json
+            git add $TARGET/package.json
+          fi
+        done
+
+    - name: Update AUTHORS
+      run: |
+        # git shortlog won't output by default with no terminal...
+        git log | git shortlog -s | cut -c8- | sort -f > AUTHORS
+        git add AUTHORS
+
+    - name: Commit update to branch
+      run: |
+        git commit --message "Release ${{ github.event.inputs.versionName }}"
+        git push origin train-${{ github.event.inputs.versionName }}
+
+    - name: Make a new tag
+      run: |
+        git tag -a "v1.${{ github.event.inputs.versionName }}.0" -m "Train release ${{ github.event.inputs.versionName }}"
+        git push origin v1.${{ github.event.inputs.versionName }}.0
+
+    - name: Create pull request into main
+      run: gh pr create -B main -H train-${{ github.event.inputs.versionName }} --fill
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because:

* We could encourage more consistent builds by using an environment built in an action instead of on developer machines

This commit:

* Creates a github action that tags our releases

This script is compatible with our current release script (as far as names of trains and tags and such).  This script does not file any bugs or have that big chunk of output to copy/paste at the end.

This script cannot handle patch releases because it wouldn't know what you wanted to patch but we could add good documentation for how to handle that.  

This will only fire if someone pushes the button on github so it's safe to land if it's something we want.