### PR TITLE
feat(metrics): send language on payments metrics

### DIFF
--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -95,6 +95,7 @@ const mocks = {
     headers: {
       'user-agent':
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
+      'accept-language': 'en-US,en;q=0.7,de-DE;q=0.3'
     },
   },
 };
@@ -145,13 +146,12 @@ describe('lib/amplitude', () => {
       flowBeginTime: 1570000000000,
       flowId:
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-      lang: 'gd',
+      lang: 'en-US',
     };
     mockAmplitudeConfig.rawEvents = true;
     amplitude(mocks.event, mocks.request, {
       ...mocks.data,
       useless: 'junk',
-      lang: 'gd',
     });
     expect(log.info).toHaveBeenCalledTimes(2);
     expect(log.info.mock.calls[0][0]).toMatch('rawAmplitudeData');
@@ -212,6 +212,7 @@ describe('lib/amplitude', () => {
         app_version: '148.8',
         os_name: 'Mac OS X',
         os_version: '10.14',
+        language: 'en-US',
         event_properties: {},
         user_properties: {
           flow_id:

--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -179,5 +179,17 @@
     "event_properties",
     "user_properties"
   ],
-  "anyOf": [{ "required": ["user_id"] }, { "required": ["device_id"] }]
+  "anyOf": [{ "required": ["user_id"] }, { "required": ["device_id"] }],
+  "if": {
+    "$comment": "For event_type's matching the pattern below, make language a required field",
+    "properties": {
+      "event_type": {
+        "type": "string",
+        "pattern": "^fxa_pay_setup -|fxa_pay_subscription_change -"
+      }
+    }
+  },
+  "then": {
+    "required": ["language"]
+  }
 }

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -467,4 +467,199 @@ describe('metrics/amplitude:', () => {
       });
     });
   });
+
+  describe('validate', () => {
+    const minimumEvent = {
+      device_id: '9ce8626e11ab4238981287fb95c8545e',
+      event_properties: {
+        service: 'qux',
+      },
+      event_type: 'fxa_connect_device - blee',
+      op: 'amplitudeEvent',
+      time: 1680884839890,
+      user_id: '9ce8626e11ab4238981287fb95c8545e',
+      user_properties: {
+        flow_id:
+          'aed8442f52e9af1694ff13bf1f4523815e651e0c0e7242c72fb46069fa9adaee',
+      },
+    };
+    it('success', () => {
+      const result = amplitude.validate(minimumEvent);
+      assert.isTrue(result);
+    });
+
+    it('success - if event_type is `fxa_pay_setup - *` and language is provided', () => {
+      const event = {
+        ...minimumEvent,
+        event_type: 'fxa_pay_setup - view',
+        language: 'en',
+      };
+      const result = amplitude.validate(event);
+      assert.isTrue(result);
+    });
+
+    it('success - if event_type is `fxa_pay_subscription_change - *` and language is provided', () => {
+      const event = {
+        ...minimumEvent,
+        event_type: 'fxa_pay_subscription_change - view',
+        language: 'en',
+      };
+      const result = amplitude.validate(event);
+      assert.isTrue(result);
+    });
+
+    it('errors - op required', () => {
+      const event = {
+        ...minimumEvent,
+      };
+      delete event.op;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'op'`
+        );
+      }
+    });
+
+    it('errors - event_type required', () => {
+      const event = {
+        ...minimumEvent,
+      };
+      delete event.event_type;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'language', event must match "then" schema, event must have required property 'event_type'`
+        );
+      }
+    });
+
+    it('errors - event_type required and language is provided', () => {
+      const event = {
+        ...minimumEvent,
+        language: 'en-US',
+      };
+      delete event.event_type;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'event_type'`
+        );
+      }
+    });
+
+    it('errors - time required', () => {
+      const event = {
+        ...minimumEvent,
+      };
+      delete event.time;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'time'`
+        );
+      }
+    });
+    it('errors - event_properties required', () => {
+      const event = {
+        ...minimumEvent,
+      };
+      delete event.event_properties;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'event_properties'`
+        );
+      }
+    });
+
+    it('errors - user_properties required', () => {
+      const event = {
+        ...minimumEvent,
+      };
+      delete event.user_properties;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'user_properties'`
+        );
+      }
+    });
+
+    it('errors - if event_type is `fxa_pay_setup - *` and language is undefined', () => {
+      const event = {
+        ...minimumEvent,
+        event_type: 'fxa_pay_setup - view',
+      };
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'language', event must match "then" schema`
+        );
+      }
+    });
+
+    it('errors - if event_type is `fxa_pay_subscription_change - *` and language is undefined', () => {
+      const event = {
+        ...minimumEvent,
+        event_type: 'fxa_pay_subscription_change - view',
+      };
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'language', event must match "then" schema`
+        );
+      }
+    });
+
+    it('errors - if event_type is `fxa_pay_setup - *` and language and op are undefined', () => {
+      const event = {
+        ...minimumEvent,
+        event_type: 'fxa_pay_setup - view',
+      };
+      delete event.op;
+      try {
+        amplitude.validate(event);
+        assert.fail('Validate is expected to fail');
+      } catch (err) {
+        assert.isTrue(err instanceof Error);
+        assert.equal(
+          err.message,
+          `Invalid data: event must have required property 'language', event must match "then" schema, event must have required property 'op'`
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Because

- Payments metrics should include the users language

## This pull request

- Adds language field to events for event_type fxa_pay_setup - * and fxa_pay_subscription_change - *

## Issue that this pull request solves

Closes: #FXA-6951

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
