### PR TITLE
Port over third party auth logic to react

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -18,7 +18,7 @@ enum tokenType {
   passwordChangeToken = 'passwordChangeToken',
 }
 
-enum AUTH_PROVIDER {
+export enum AUTH_PROVIDER {
   GOOGLE = 'google',
   APPLE = 'apple',
 }

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -35,6 +35,7 @@ import SignInTokenCodeView from '../views/sign_in_token_code';
 import SignInTotpCodeView from '../views/sign_in_totp_code';
 import SignInUnblockView from '../views/sign_in_unblock';
 import SignUpPasswordView from '../views/sign_up_password';
+import ThirdPartyAuthCallbackView from '../views/post_verify/third_party_auth/callback';
 import Storage from './storage';
 import SubscriptionsProductRedirectView from '../views/subscriptions_product_redirect';
 import SubscriptionsManagementRedirectView from '../views/subscriptions_management_redirect';
@@ -263,9 +264,13 @@ Router = Router.extend({
         type: VerificationReasons.SECONDARY_EMAIL_VERIFIED,
       }
     ),
-    'post_verify/third_party_auth/callback': createViewHandler(
-      'post_verify/third_party_auth/callback'
-    ),
+    'post_verify/third_party_auth/callback(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'post_verify/third_party_auth/callback',
+        ThirdPartyAuthCallbackView
+      );
+    },
+
     'push/confirm_login(/)': createViewHandler('push/confirm_login'),
     'push/send_login(/)': createViewHandler('push/send_login'),
     'push/completed(/)': createViewHandler('push/completed'),

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -60,6 +60,8 @@ const settingsConfig = {
     length: config.get('recovery_codes.length'),
   },
   showRecoveryKeyV2: config.get('showRecoveryKeyV2'),
+  googleAuthConfig: config.get('googleAuthConfig'),
+  appleAuthConfig: config.get('appleAuthConfig')
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
@@ -5,7 +5,7 @@
 const { getServerReactRouteGroups } = require('./route-groups-server');
 const config = require('../../configuration');
 
-/** Add all routes routes from all route objects for fxa-settings or fxa-content-server to serve.
+/** Add all routes from all route objects for fxa-settings or fxa-content-server to serve.
  * @type {import("./types").AddRoutes}
  */
 function addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n) {

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -85,6 +85,11 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       routes: [],
     },
 
+    postVerifyThirdPartyAuthRoutes: {
+      featureFlagOn: showReactApp.postVerifyThirdPartyAuthRoutes,
+      routes: reactRoute.getRoutes(['post_verify/third_party_auth/callback']),
+    },
+
     signInVerificationViaPushRoutes: {
       featureFlagOn: showReactApp.signInVerificationViaPushRoutes,
       routes: [],

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -55,6 +55,7 @@ type ShowReactApp = {
   postVerifyAddRecoveryKeyRoutes: boolean;
   postVerifyCADViaQRRoutes: boolean;
   signInVerificationViaPushRoutes: boolean;
+  postVerifyThirdPartyAuthRoutes: boolean;
   webChannelExampleRoutes: boolean;
 };
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -44,6 +44,7 @@ import { LinkType } from 'fxa-settings/src/lib/types';
 import Confirm from 'fxa-settings/src/pages/Signup/Confirm';
 import WebChannelExample from '../../pages/WebChannelExample';
 import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
+import ThirdPartyAuthCallback from '../../pages/PostVerify/ThirdPartyAuthCallback';
 
 export const App = ({
   flowQueryParams,
@@ -200,6 +201,8 @@ export const App = ({
 
               <Confirm path="/confirm/*" {...{ sessionTokenId }} />
               <ConfirmSignupCode path="/confirm_signup_code/*" />
+
+              <ThirdPartyAuthCallback path="/post_verify/third_party_auth/callback/*" />
             </>
           )}
           <Settings path="/settings/*" />

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -5,9 +5,13 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+import { getFtlBundle } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import { Subject } from './mocks';
+
+function renderWith(props?: any) {
+  return render(<Subject {...props} />);
+}
 
 describe('ThirdPartyAuth component', () => {
   let bundle: FluentBundle;
@@ -15,7 +19,7 @@ describe('ThirdPartyAuth component', () => {
     bundle = await getFtlBundle('settings');
   });
   it('renders as expected', async () => {
-    render(<Subject enabled />);
+    renderWith({ enabled: true });
     expect(screen.getByText('Continue with Google')).toBeInTheDocument();
     expect(screen.getByText('Continue with Apple')).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -2,18 +2,137 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
+
 import { ReactComponent as GoogleLogo } from './google-logo.svg';
 import { ReactComponent as AppleLogo } from './apple-logo.svg';
+
+import { useAccount, useConfig } from '../../models';
+import Storage from '../../lib/storage';
+import { AUTH_PROVIDER } from 'fxa-auth-client/browser';
 
 export type ThirdPartyAuthProps = {
   enabled?: boolean;
 };
 
+type ThirdPartyAuthSigninParams = {
+  authorizationEndpoint: string;
+  clientId: string;
+  scope: string;
+  redirectUri: string;
+  responseType: string;
+  responseMode?: string;
+};
+
+const GOOGLE_SCOPES = 'openid email profile';
+const APPLE_SCOPES = 'email';
+
+/**
+ * ThirdPartyAuth component
+ * A React component that renders Google and Apple third-party authentication buttons.
+ * It handles user sign-in with the respective provider when the buttons are clicked.
+ */
 const ThirdPartyAuth = ({ enabled = false }: ThirdPartyAuthProps) => {
+  const config = useConfig();
+  const account = useAccount();
+
+  useEffect(() => {
+    // TODO: Figure out why `storageData` is not available
+    const authParams = Storage.factory('localStorage', window).get(
+      'fxa_third_party_params'
+    );
+    if (authParams) {
+      completeSignIn();
+    }
+  }, []);
+
   if (!enabled) {
     return null;
+  }
+
+  /**
+   * signIn - Handles the sign-in process for third-party authentication providers.
+   * Creates a form, sets necessary parameters, and submits it to the provider's
+   * authorization endpoint.
+   *
+   * @param {ThirdPartyAuthSigninParams} config - Configuration parameters for the signIn process.
+   */
+  function signIn(config: ThirdPartyAuthSigninParams) {
+    clearStoredParams();
+
+    // We stash originating location in the state oauth param
+    // because we will need it to use it to log the user into FxA
+    const currentParams = new URLSearchParams(window.location.search);
+    currentParams.delete('deeplink');
+    currentParams.set('showReactApp', 'true');
+
+    const state = encodeURIComponent(
+      `${window.location.origin}${
+        window.location.pathname
+      }?${currentParams.toString()}`
+    );
+
+    // TODO: We should this in a more React way. The form and hidden inputs should
+    // be in their own component. Ref: https://mozilla-hub.atlassian.net/browse/FXA-7319
+    const form = window.document.createElement('form');
+
+    form.setAttribute('method', 'GET');
+    form.setAttribute('action', config.authorizationEndpoint);
+
+    const params: Record<string, string | undefined> = {
+      client_id: config.clientId,
+      scope: config.scope,
+      redirect_uri: config.redirectUri,
+      state,
+      access_type: 'offline',
+      prompt: 'consent',
+      response_type: config.responseType,
+      response_mode: config.responseMode,
+    };
+
+    for (const [key, value] of Object.entries(params)) {
+      if (!value) {
+        continue;
+      }
+      const input = window.document.createElement('input');
+      input.setAttribute('type', 'hidden');
+      input.setAttribute('name', key);
+      input.setAttribute('value', value);
+      form.appendChild(input);
+    }
+
+    // To avoid any CORs issues we append the form to the body and submit it.
+    window.document.body.appendChild(form);
+
+    form.submit();
+  }
+
+  async function completeSignIn() {
+    try {
+      const authParams = Storage.factory('localStorage', window).get(
+        'fxa_third_party_params'
+      );
+      const code = authParams.code;
+      const provider = authParams.provider || AUTH_PROVIDER.GOOGLE;
+
+      // Verify and link the third party account to FxA. Note, this
+      // will create a new FxA account if one does not exist.
+      await account.verifyAccountThirdParty(code, provider);
+
+      // TODO: The response from above contains a session token
+      // which can be used to sign the user in to FxA or used
+      // to complete an Oauth flow.
+    } catch (error) {
+      // Fail silently on errors, this could be some leftover
+      // state from a previous attempt.
+    }
+
+    clearStoredParams();
+  }
+  function clearStoredParams() {
+    // TODO: Use the correct storage mechanism
+    Storage.factory('localStorage', window).remove('fxa_third_party_params');
   }
 
   return (
@@ -31,6 +150,16 @@ const ThirdPartyAuth = ({ enabled = false }: ThirdPartyAuthProps) => {
           <button
             type="button"
             className="w-full mt-2 justify-center text-black bg-transparent border-black border hover:border-grey-300 font-medium rounded-lg text-sm text-center inline-flex items-center"
+            onClick={() => {
+              signIn({
+                authorizationEndpoint:
+                  config.googleAuthConfig.authorizationEndpoint,
+                clientId: config.googleAuthConfig.clientId,
+                scope: GOOGLE_SCOPES,
+                redirectUri: config.googleAuthConfig.redirectUri,
+                responseType: 'code',
+              });
+            }}
           >
             <GoogleLogo />
             <FtlMsg id="continue-with-google-button">
@@ -41,6 +170,17 @@ const ThirdPartyAuth = ({ enabled = false }: ThirdPartyAuthProps) => {
           <button
             type="button"
             className="w-full mt-2 justify-center text-black bg-transparent border-black border hover:border-grey-300 font-medium rounded-lg text-sm text-center inline-flex items-center"
+            onClick={() => {
+              signIn({
+                authorizationEndpoint:
+                  config.appleAuthConfig.authorizationEndpoint,
+                clientId: config.appleAuthConfig.clientId,
+                scope: APPLE_SCOPES,
+                redirectUri: config.appleAuthConfig.redirectUri,
+                responseType: 'code id_token',
+                responseMode: 'form_post',
+              });
+            }}
           >
             <AppleLogo />
             <FtlMsg id="continue-with-apple-button">Continue with Apple</FtlMsg>

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/mocks.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/mocks.tsx
@@ -4,7 +4,16 @@
 
 import React from 'react';
 import ThirdPartyAuth, { ThirdPartyAuthProps } from '.';
+import { AppContext } from '../../models';
+import { mockAppContext } from '../../models/mocks';
+import { LocationProvider } from '@reach/router';
 
 export const Subject = (props: ThirdPartyAuthProps) => {
-  return <ThirdPartyAuth {...props} />;
+  return (
+    <AppContext.Provider value={mockAppContext()}>
+      <LocationProvider>
+        <ThirdPartyAuth {...props} />;
+      </LocationProvider>
+    </AppContext.Provider>
+  );
 };

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -49,6 +49,18 @@ export interface Config {
   };
   showRecoveryKeyV2: boolean;
   version: string;
+  googleAuthConfig: {
+    enabled: boolean;
+    clientId: string;
+    redirectUri: string;
+    authorizationEndpoint: string;
+  };
+  appleAuthConfig: {
+    enabled: boolean;
+    clientId: string;
+    redirectUri: string;
+    authorizationEndpoint: string;
+  };
 }
 
 export function getDefault() {
@@ -90,6 +102,18 @@ export function getDefault() {
       length: 10,
     },
     showRecoveryKeyV2: false,
+    googleAuthConfig: {
+      enabled: false,
+      clientId: '',
+      redirectUri: '',
+      authorizationEndpoint: '',
+    },
+    appleAuthConfig: {
+      enabled: false,
+      clientId: '',
+      redirectUri: '',
+      authorizationEndpoint: '',
+    }
   } as Config;
 }
 
@@ -103,6 +127,7 @@ export function readConfigMeta(
   }
 
   const metaConfig = decode(metaEl.getAttribute('content'));
+
   update(metaConfig);
 }
 

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -7,6 +7,7 @@ import { gql, ApolloClient, Reference, ApolloError } from '@apollo/client';
 import { ThrottledError } from 'fxa-graphql-api/src/gql/lib/error';
 import config from '../lib/config';
 import AuthClient, {
+  AUTH_PROVIDER,
   generateRecoveryKey,
   getRecoveryKeyIdByUid,
 } from 'fxa-auth-client/browser';
@@ -861,6 +862,19 @@ export class Account implements AccountData {
         },
       },
     });
+  }
+
+  async verifyAccountThirdParty(
+    code: string,
+    provider: AUTH_PROVIDER
+  ): Promise<{
+    uid: hexstring;
+    sessionToken: hexstring;
+    verified: boolean;
+  }> {
+    return this.withLoadingStatus(
+      this.authClient.verifyAccountThirdParty(code, provider)
+    );
   }
 
   // TODO: Move this method to the Session model - this method was temporarily added to the Account model

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -66,6 +66,15 @@ export function mockSession(verified: boolean = true) {
   } as Session;
 }
 
+export function mockStorage() {
+  return {
+    get: () => 'deadc0de',
+    setItem(key: string, value: string) {
+      return;
+    },
+  };
+}
+
 export const mockEmail = (
   email = 'johndope@example.com',
   isPrimary = true,
@@ -94,6 +103,7 @@ export function mockAppContext(context?: AppContextValue) {
       session: mockSession(),
       config: getDefault(),
       alertBarInfo: new AlertBarInfo(),
+      storageData: mockStorage(),
     },
     context
   ) as AppContextValue;

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/en.ftl
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/en.ftl
@@ -1,0 +1,4 @@
+## ThirdPartyAuthCallback Page
+## This page is called after a user completes the third party authentication flow from Google or Apple.
+
+third-party-auth-callback-message = Please wait, you are being redirected to the authorized application.

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.stories.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import ThirdPartyAuthCallback from '.';
+import AppLayout from '../../../components/AppLayout';
+import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
+import { LocationProvider } from '@reach/router';
+import { Account, AppContext } from '../../../models';
+import CompleteSignin, {
+  CompleteSigninProps,
+} from '../../Signin/CompleteSignin';
+import DataBlock from '../../../components/DataBlock';
+import { StorageData } from '../../../lib/model-data';
+
+export default {
+  title: 'Pages/ThirdPartyAuthCallback',
+  component: ThirdPartyAuthCallback,
+  decorators: [withLocalization],
+} as Meta;
+
+const storageData = {
+  get: () => {},
+  set: () => {},
+} as unknown as StorageData;
+
+export const Default = () => (
+  <AppContext.Provider value={{ storageData }}>
+    <LocationProvider>
+      <ThirdPartyAuthCallback />
+    </LocationProvider>
+  </AppContext.Provider>
+);

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+import { FluentBundle } from '@fluent/bundle';
+import ThirdPartyAuthCallback from '.';
+import { AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
+import { LocationProvider } from '@reach/router';
+import { ThirdPartyAuthProps } from '../../../components/ThirdPartyAuth';
+
+function renderWith(props?: ThirdPartyAuthProps) {
+  return render(
+    <AppContext.Provider value={mockAppContext()}>
+      <LocationProvider>
+        <ThirdPartyAuthCallback {...props} />;
+      </LocationProvider>
+    </AppContext.Provider>
+  );
+}
+
+describe('ThirdPartyAuth component', () => {
+  let bundle: FluentBundle;
+  beforeAll(async () => {
+    bundle = await getFtlBundle('settings');
+  });
+  it('renders as expected', () => {
+    renderWith();
+    screen.getByText(
+      'Please wait, you are being redirected to the authorized application.'
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect } from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { RouteComponentProps, useNavigate } from '@reach/router';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../../../components/AppLayout';
+import Storage from '../../../lib/storage';
+
+const ThirdPartyAuthCallback = (_: RouteComponentProps) => {
+  const navigate = useNavigate();
+
+  function handleOauthResponse() {
+    try {
+      // To finish the oauth flow, we will need to stash away the response from
+      // 3rd party auth provider (contains state and code) and redirect back to the original FxA login page.
+      const searchParams = new URLSearchParams(window.location.search);
+      const redirectUrl = decodeURIComponent(searchParams.get('state') || '');
+      const url = new URL(redirectUrl);
+
+      if (url.origin === window.location.origin) {
+        Storage.factory('localStorage', window).set('fxa_third_party_params', searchParams);
+
+        navigate(redirectUrl, { replace: true });
+      }
+    } catch (e) {
+      // noop. navigate to home below.
+    }
+
+    navigate('/', { replace: true });
+  }
+
+  useEffect(() => {
+    handleOauthResponse();
+  }, []);
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col">
+        <FtlMsg id="third-party-auth-callback-message">
+          Please wait, you are being redirected to the authorized application.
+        </FtlMsg>
+        <LoadingSpinner className="flex items-center flex-col justify-center mt-4 select-none" />
+      </div>
+    </AppLayout>
+  );
+};
+
+export default ThirdPartyAuthCallback;


### PR DESCRIPTION
## Because

- To have feature parity with content-server, we need to port over this logic

## This pull request

- Adds the logic to sign-in with Apple/Google
- Adds Apple/Google config to settings-server
- Adds form submission logic to Third party auth component
- Adds the loading screen after a successful third party auth is completed

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7127

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2023-04-11 at 4 32 56 PM](https://user-images.githubusercontent.com/1295288/231281688-4d81c21a-ef7a-43c4-9ddb-acd58b6a804b.png)

## Other information (Optional)

This PR is dependent on https://github.com/mozilla/fxa/pull/15149
