### PR TITLE
fix(test): Playwright with large instance but less workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -809,7 +809,7 @@ workflows:
             - Build (PR)
       - playwright-functional-tests:
           name: Functional Tests - Playwright (PR)
-          resource_class: xlarge
+          resource_class: large
           requires:
             - Build (PR)
       - build-and-deploy-storybooks:

--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -97,6 +97,10 @@ export const test = base.extend<TestOptions, WorkerOptions>({
               value: JSON.stringify(credentials.uid),
             },
             {
+              name: '__fxa_storage.experiment.generalizedReactApp',
+              value: JSON.stringify({ enrolled: false }),
+            },
+            {
               name: '__fxa_storage.accounts',
               value: JSON.stringify({
                 [credentials.uid]: {
@@ -130,5 +134,8 @@ export async function newPagesForSync(target: BaseTarget) {
     firefoxUserPrefs: getFirefoxUserPrefs(target.name, DEBUG),
     headless: !DEBUG,
   });
-  return newPages(browser, target);
+  return {
+    ...(await newPages(browser, target)),
+    browser: browser,
+  };
 }

--- a/packages/functional-tests/lib/targets/firefoxUserPrefs.ts
+++ b/packages/functional-tests/lib/targets/firefoxUserPrefs.ts
@@ -22,6 +22,9 @@ const CONFIGS = {
   },
 } as const;
 
+const UA_OVERRIDE =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:71.0) Gecko/20100101 Firefox/71.0 FxATester/1.0';
+
 export function getFirefoxUserPrefs(
   target: 'local' | 'stage' | 'production',
   debug?: boolean
@@ -66,5 +69,7 @@ export function getFirefoxUserPrefs(
     // allow webchannel url, strips slash from content-server origin.
     'webchannel.allowObject.urlWhitelist': fxaEnv.content.slice(0, -1),
     ...(debug ? debugOptions : {}),
+    // Override the user agent so that feature flags and experiments are not set
+    'general.useragent.override': UA_OVERRIDE,
   };
 }

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -4,29 +4,30 @@ import { ConnectedService } from './connectedService';
 export class UnitRow {
   constructor(readonly page: Page, readonly id: string) {}
 
-  protected clickCta() {
-    return Promise.all([
-      this.page.locator(`[data-testid=${this.id}-unit-row-route]`).click(),
-      this.page.waitForNavigation(),
-    ]);
+  protected async clickCta() {
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page.locator(`[data-testid=${this.id}-unit-row-route]`).click();
+    return waitForNavigation;
   }
 
   protected clickShowModal() {
-    return this.page.click(`[data-testid=${this.id}-unit-row-modal]`);
+    return this.page.locator(`[data-testid=${this.id}-unit-row-modal]`).click();
   }
 
   protected clickShowSecondaryModal() {
-    return this.page.click(`[data-testid=${this.id}-secondary-unit-row-modal]`);
+    return this.page
+      .locator(`[data-testid=${this.id}-secondary-unit-row-modal]`)
+      .click();
   }
 
   statusText() {
-    return this.page.innerText(
-      `[data-testid=${this.id}-unit-row-header-value]`
-    );
+    return this.page
+      .locator(`[data-testid=${this.id}-unit-row-header-value]`)
+      .innerText();
   }
 
   clickRefresh() {
-    return this.page.click(`[data-testid=${this.id}-refresh]`);
+    return this.page.locator(`[data-testid=${this.id}-refresh]`).click();
   }
 
   async screenshot() {
@@ -75,10 +76,12 @@ export class SecondaryEmailRow extends UnitRow {
     return this.clickCta();
   }
   clickMakePrimary() {
-    return this.page.click('[data-testid=secondary-email-make-primary]');
+    return this.page
+      .locator('[data-testid=secondary-email-make-primary]')
+      .click();
   }
   clickDelete() {
-    return this.page.click('[data-testid=secondary-email-delete]');
+    return this.page.locator('[data-testid=secondary-email-delete]').click();
   }
 }
 
@@ -99,9 +102,9 @@ export class TotpRow extends UnitRow {
     return this.clickShowModal();
   }
   clickDisable() {
-    return this.page.click(
-      `[data-testid=two-step-disable-button-unit-row-modal]`
-    );
+    return this.page
+      .locator(`[data-testid=two-step-disable-button-unit-row-modal]`)
+      .click();
   }
 }
 

--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -5,18 +5,17 @@ export class SecondaryEmailPage extends SettingsLayout {
   readonly path = 'settings/emails';
 
   setEmail(email: string) {
-    return this.page.fill('input[type=email]', email);
+    return this.page.locator('input[type=email]').fill(email);
   }
 
   setVerificationCode(code: string) {
-    return this.page.fill('input[type=text]', code);
+    return this.page.locator('input[type=text]').fill(code);
   }
 
-  submit() {
-    return Promise.all([
-      this.page.locator('button[type=submit]').click(),
-      this.page.waitForNavigation(),
-    ]);
+  async submit() {
+    const waitForNavigation = this.page.waitForNavigation();
+    await this.page.locator('button[type=submit]').click();
+    return waitForNavigation;
   }
 
   async addAndVerify(email: string) {

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -12,12 +12,12 @@ const DEBUG = !!process.env.DEBUG;
 const SLOWMO = parseInt(process.env.PLAYWRIGHT_SLOWMO || '0');
 
 let retries = 0,
-  workers = undefined,
+  workers = 2,
   maxFailures = 0;
 if (CI) {
   // Overall maxFailures is now dependent on the number of retries, workers
   retries = 3;
-  workers = 2;
+  workers = 1;
   maxFailures = retries * workers * 2;
 }
 

--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -7,6 +7,7 @@ test.describe('severity-1', () => {
     await page.goto(`${target.contentServerUrl}/tests/index.html`, {
       waitUntil: 'networkidle',
     });
+    await page.waitForTimeout(2000); // wait for mocha to load
     await page.evaluate(() =>
       globalThis.runner.on('end', () => (globalThis.done = true))
     );

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -30,7 +30,7 @@ test.describe('OAuth signin', () => {
     await relier.clickEmailFirst();
 
     // Email is prefilled
-    await expect(await login.getPrefilledEmail()).toMatch(credentials.email);
+    await expect(await login.getPrefilledEmail()).toContain(credentials.email);
     expect(await login.isCachedLogin()).toBe(true);
     await login.submit();
 

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -5,8 +5,12 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
-function getReactFeatureFlagUrl(target: BaseTarget, path: string) {
-  return `${target.contentServerUrl}${path}?showReactApp=true`;
+function getReactFeatureFlagUrl(
+  target: BaseTarget,
+  path: string,
+  showReactApp: boolean = true
+) {
+  return `${target.contentServerUrl}${path}?showReactApp=${showReactApp}`;
 }
 
 test.describe('legal', () => {

--- a/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
@@ -12,7 +12,9 @@ test.describe('Reset password current', () => {
     page,
     pages: { resetPassword },
   }) => {
-    await page.goto(`${target.contentServerUrl}/confirm_reset_password`);
+    await page.goto(
+      `${target.contentServerUrl}/confirm_reset_password?showReactApp=false`
+    );
 
     // Verify its redirected to reset password page
     expect(await resetPassword.resetPasswordHeader()).toBe(true);
@@ -29,7 +31,7 @@ test.describe('Reset password current', () => {
   });
 
   test('enter an email with leading/trailing whitespace', async ({
-   credentials,
+    credentials,
     target,
     page,
     pages: { login, resetPassword },
@@ -44,7 +46,7 @@ test.describe('Reset password current', () => {
   });
 
   test('open confirm_reset_password page, click resend', async ({
-   credentials,
+    credentials,
     target,
     page,
     pages: { resetPassword },
@@ -65,11 +67,13 @@ test.describe('Reset password current', () => {
     await page.goto(`${target.contentServerUrl}/reset_password`);
     await login.setEmail('email@restmail.com');
     await resetPassword.clickBeginReset();
-    expect(await resetPassword.unknownAccountError()).toContain('Unknown account.');
+    expect(await resetPassword.unknownAccountError()).toContain(
+      'Unknown account.'
+    );
   });
 
   test('browse directly to page with email on query params', async ({
-   credentials,
+    credentials,
     target,
     page,
     pages: { resetPassword },

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -18,7 +18,7 @@ test.describe('change password tests', () => {
       newPassword
     );
     await changePassword.clickSignIn();
-    expect(await changePassword.changePasswordTooltip()).toMatch(
+    expect(await changePassword.changePasswordTooltip()).toContain(
       'Incorrect password'
     );
   });

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { BaseTarget } from '../../lib/targets/base';
 
 test.describe('severity-1 #smoke', () => {
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293389
@@ -44,11 +45,12 @@ test.describe('severity-1 #smoke', () => {
     });
     await login.setEmail(credentials.email);
     await login.submit();
-    const link = await target.email.waitForEmail(
+    let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
       EmailHeader.link
     );
+    link = `${link}&showReactApp=false`;
     await page.goto(link, { waitUntil: 'networkidle' });
     await login.clickDontHaveRecoveryKey();
     await login.setNewPassword(credentials.password);

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -64,11 +64,12 @@ test.describe('recovery key test', () => {
     await login.clickForgotPassword();
     await login.setEmail(credentials.email);
     await login.submit();
-    const link = await target.email.waitForEmail(
+    let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
       EmailHeader.link
     );
+    link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
     await page.goto(link, { waitUntil: 'load' });
     await login.setRecoveryKey(key);
     await recoveryKey.confirmRecoveryKey();
@@ -109,11 +110,12 @@ test.describe('recovery key test', () => {
     await login.clickForgotPassword();
     await login.setEmail(credentials.email);
     await login.submit();
-    const link = await target.email.waitForEmail(
+    let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
       EmailHeader.link
     );
+    link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
     await page.goto(link, { waitUntil: 'networkidle' });
     await recoveryKey.clickLostRecoveryKey();
 
@@ -144,11 +146,12 @@ test.describe('recovery key test', () => {
     await login.clickForgotPassword();
     await login.setEmail(credentials.email);
     await login.submit();
-    const link = await target.email.waitForEmail(
+    let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
       EmailHeader.link
     );
+    link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
     await page.goto(link);
     await login.setRecoveryKey(key);
     await recoveryKey.confirmRecoveryKey();
@@ -163,11 +166,12 @@ test.describe('recovery key test', () => {
     await login.login(credentials.email, credentials.password);
 
     // Attempt to reuse reset link,
-    const link2 = await target.email.waitForEmail(
+    let link2 = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
       EmailHeader.link
     );
+    link2 = `${link2}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
     await page.goto(link2, { waitUntil: 'load' });
 
     // Verify reset link expired
@@ -186,11 +190,12 @@ test.describe('recovery key test', () => {
     await login.clickForgotPassword();
     await login.setEmail(credentials.email);
     await login.submit();
-    const link = await target.email.waitForEmail(
+    let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
       EmailHeader.link
     );
+    link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
     await page.goto(link, { waitUntil: 'networkidle' });
     await login.setRecoveryKey(key);
     await login.submit();

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
 test.describe('two step auth', () => {
@@ -61,24 +61,6 @@ test.describe('two step auth', () => {
     await login.setTotp(credentials.secret);
     const status = await settings.totp.statusText();
     expect(status).toEqual('Enabled');
-  });
-
-  test('add TOTP and confirm sync signin', async ({ credentials, target }) => {
-    const { login, settings, totp, page, connectAnotherDevice } =
-      await newPagesForSync(target);
-    await settings.goto();
-    await settings.totp.clickAdd();
-    await totp.enable(credentials);
-    await settings.signOut();
-
-    // Sync sign in
-    await page.goto(
-      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`,
-      { waitUntil: 'networkidle' }
-    );
-    await login.login(credentials.email, credentials.password);
-    await login.setTotp(credentials.secret);
-    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293450

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -5,7 +5,8 @@ test.describe('connect_another_device', () => {
     credentials,
     target,
   }) => {
-    const { page, login, connectAnotherDevice } = await newPagesForSync(target);
+    const { browser, page, login, connectAnotherDevice } =
+      await newPagesForSync(target);
     await target.auth.accountDestroy(credentials.email, credentials.password);
 
     await page.goto(
@@ -20,5 +21,7 @@ test.describe('connect_another_device', () => {
     await expect(connectAnotherDevice.signInButton).toHaveCount(0);
     await expect(connectAnotherDevice.installFxDesktop).toHaveCount(1);
     await expect(connectAnotherDevice.success).toHaveCount(0);
+
+    await browser?.close();
   });
 });

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -6,7 +6,7 @@ test.describe('severity-1 #smoke', () => {
     target,
     credentials,
   }) => {
-    const { page, login, settings } = await newPagesForSync(target);
+    const { browser, page, login, settings } = await newPagesForSync(target);
 
     await page.goto(
       target.contentServerUrl +
@@ -27,6 +27,8 @@ test.describe('severity-1 #smoke', () => {
     await settings.disconnectSync(credentials);
 
     expect(page.url()).toContain(login.url);
+
+    await browser.close();
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293475

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -9,9 +9,16 @@ const makeUid = () =>
     .map(() => Math.floor(Math.random() * 16).toString(16))
     .join('');
 
+let syncBrowserPages;
+
 test.describe('Desktop Sync V3 force auth', () => {
-  test.beforeEach(async ({}) => {
+  test.beforeEach(async ({ target }) => {
     test.slow();
+    syncBrowserPages = await newPagesForSync(target);
+  });
+
+  test.afterEach(async () => {
+    await syncBrowserPages.browser?.close();
   });
 
   test('sync v3 with a registered email, no uid', async ({
@@ -21,9 +28,10 @@ test.describe('Desktop Sync V3 force auth', () => {
     const {
       fxDesktopV3ForceAuth,
       login,
-      signinTokenCode,
       connectAnotherDevice,
-    } = await newPagesForSync(target);
+      signinTokenCode,
+    } = syncBrowserPages;
+
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       uid: undefined,
     });
@@ -45,9 +53,10 @@ test.describe('Desktop Sync V3 force auth', () => {
     const {
       fxDesktopV3ForceAuth,
       login,
-      signinTokenCode,
       connectAnotherDevice,
-    } = await newPagesForSync(target);
+      signinTokenCode,
+    } = syncBrowserPages;
+
     await fxDesktopV3ForceAuth.open(credentials);
     await login.setPassword(credentials.password);
     await login.submit();
@@ -67,9 +76,10 @@ test.describe('Desktop Sync V3 force auth', () => {
     const {
       fxDesktopV3ForceAuth,
       login,
-      signinTokenCode,
       connectAnotherDevice,
-    } = await newPagesForSync(target);
+      signinTokenCode,
+    } = syncBrowserPages;
+
     const uid = makeUid();
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, { uid });
     await fxDesktopV3ForceAuth.noSuchWebChannelMessage('fxaccounts:logout');
@@ -88,7 +98,8 @@ test.describe('Desktop Sync V3 force auth', () => {
     credentials,
     target,
   }) => {
-    const { fxDesktopV3ForceAuth, login } = await newPagesForSync(target);
+    const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
+
     const email = `sync${Math.random()}@restmail.net`;
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       email,
@@ -114,7 +125,8 @@ test.describe('Desktop Sync V3 force auth', () => {
     credentials,
     target,
   }) => {
-    const { fxDesktopV3ForceAuth, login } = await newPagesForSync(target);
+    const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
+
     const email = `sync${Math.random()}@restmail.net`;
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       email,
@@ -134,7 +146,8 @@ test.describe('Desktop Sync V3 force auth', () => {
     credentials,
     target,
   }) => {
-    const { fxDesktopV3ForceAuth, login } = await newPagesForSync(target);
+    const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
+
     const email = `sync${Math.random()}@restmail.net`;
     const uid = makeUid();
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
@@ -157,7 +170,8 @@ test.describe('Desktop Sync V3 force auth', () => {
     target,
   }) => {
     const { fxDesktopV3ForceAuth, login, connectAnotherDevice } =
-      await newPagesForSync(target);
+      syncBrowserPages;
+
     const uid = makeUid();
     await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
       uid,

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -14,9 +14,11 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
     credentials,
     target,
   }) => {
-    const { page, login, resetPassword } = await newPagesForSync(target);
+    const { browser, page, login, resetPassword } = await newPagesForSync(
+      target
+    );
     await page.goto(
-      `${target.contentServerUrl}/reset_password?context=fx_desktop_v3&service=sync`
+      `${target.contentServerUrl}/reset_password?context=fx_desktop_v3&service=sync&forceExperiment=generalizedReactApp&forceExperimentGroup=control`
     );
     await resetPassword.fillOutResetPassword(credentials.email);
 
@@ -57,8 +59,6 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
     // Update credentials file so that account can be deleted as part of test cleanup
     credentials.password = 'Newpassword@';
 
-    await login.page.close();
-    await page.close();
-    await resetPassword.page.close();
+    await browser?.close();
   });
 });

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -2,7 +2,7 @@
   "contentServer": {
     "url": "http://localhost:3030"
   },
-  "customsUrl": "http://localhost:7000",
+  "customsUrl": "none",
   "lockoutEnabled": true,
   "log": {
     "fmt": "pretty",

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -90,10 +90,11 @@ const ResetPassword = ({
   const onSubmit = async () => {
     try {
       setErrorMessage('');
-      const result = await account.resetPassword(email);
+      const sanitizedEmail = email.trim();
+      const result = await account.resetPassword(sanitizedEmail);
       navigateToConfirmPwReset({
         passwordForgotToken: result.passwordForgotToken,
-        email,
+        email: sanitizedEmail,
       });
     } catch (err) {
       let localizedError;


### PR DESCRIPTION
## Because

- We want to use a smaller instance size to run our playwright test 

## This pull request

- Updates our `newPagesForSync` to return the browser instance as well. When we use this function, we need to ensure that we call, `browser.close()` to ensure that the browser gets closed properly.
- Adds logic so that experiments are not loaded when running playwright tests, this makes them indetermistic
- Updates a few tests to use the now prefered way to use `.waitForNavigation`
- Updates a few selectors to use the recommended `.locator` and then `.click`
- Updates CI workers to 1
- Adds a delay before running playwright mocha tests since this would fail before the tests run
- Appends `showReactApp=false` to links from emails, not sure why this was bypassing the experiment logic
- Moved `add TOTP and confrim sync signin` to Sync V3 signin tests
- Fixes an issue in React password reset test that was perma failing when there was whitespace before/after email

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7273

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Ram usage seems stable now 

<img width="1108" alt="Screenshot 2023-04-13 at 10 18 34 PM" src="https://user-images.githubusercontent.com/1295288/231925110-5bb31792-826d-4d10-829f-3b9784d501a1.png">

## Notes

Oddly, despite the smaller instance and running 1 worker, the tests are completing in the same amount of time maybe even faster than before (~10mins)