### PR TITLE
task(many): Fix YN0068 warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,9 +8,6 @@ packageExtensions:
   fxa-pairing-channel@*:
     dependencies:
       webpack: ^4.43.0
-  react-document-title@*:
-    dependencies:
-      react: ^16.13.1
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs


### PR DESCRIPTION
## Because

- We are cleaning up yarn warnings.
- We want to address YN0068 errors

## This pull request
- Removes `react-document-title@*:` from the packageExtensions defined in `.yarnrc.yml`
- It appears this extension was no longer needed / referenced.

## Issue that this pull request solves

Closes: FXA-6536

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
