### PR TITLE
feat(fxa-settings): Recovery key download file with localization

### DIFF
--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
@@ -1,0 +1,32 @@
+## DownloadRecoveryKeyAsFile
+## These strings are used in an unformatted plain text file that users can download to save their recovery key
+## The account recovery key can be used to recover data when users forget their account password
+
+# Button to download recovery key as a plain text file
+# .title will displayed as a tooltip on the button
+recovery-key-download-button = Download your recovery key
+  .title = Download
+
+# Heading in the text file. No formatting will be applied to the text. All caps is used in English to show this is a header.
+recovery-key-file-header = SAVE YOUR ACCOUNT RECOVERY KEY
+
+# Instructions in the text file to prompt the user to keep this information in a secure, easy to remember location.
+# Password resets without this key can result in data loss.
+recovery-key-file-instructions = Store this file containing your account recovery key in a place you’ll remember. Or print it and keep a physical copy. Your account recovery key can help you recover { -brand-firefox } data if you forget your password.
+
+# { $recoveryKeyValue } is the recovery key, a randomly generated code in latin characters
+# 🔑 is included for visual interest and to draw attention to the key
+recovery-key-file-key-value = 🔑 Key:  { $recoveryKeyValue }
+
+# { $email }  - The primary email associated with the account
+recovery-key-file-user-email = ➤ { -product-firefox-account }: { $email }
+
+# Date when the recovery key was created and this file was downloaded
+# { $downloadDate } is a formatted date in the user's preferred locale
+# e.g., "12/11/2012" if run in en-US locale with time zone America/Los_Angeles
+recovery-key-file-download-date = ➤ Key generated: { $downloadDate }
+
+# Link to get more information and support
+# { $supportUrl } will be a URL such as https://mzl.la/3bNrM1I
+# The URL will not be hyperlinked and will be presented as plain text in the downloaded file
+recovery-key-file-support = ➤ Learn more about your account recovery key: { $supportURL }

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.stories.tsx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import AppLayout from '../AppLayout';
+import ButtonDownloadRecoveryKey from '.';
+import { withLocalization } from '../../../.storybook/decorators';
+import { Account, AppContext } from '../../models';
+import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
+
+export default {
+  title: 'Components/ButtonDownloadRecoveryKey',
+  component: ButtonDownloadRecoveryKey,
+  decorators: [withLocalization],
+} as Meta;
+
+const recoveryKeyValue = 'RANDOM CODE RANDOM CODE RANDOM CODE';
+const viewName = 'settings.recovery-key';
+
+const account = MOCK_ACCOUNT as unknown as Account;
+
+const accountWithLongEmail = {
+  ...MOCK_ACCOUNT,
+  primaryEmail: {
+    email:
+      'supercalifragilisticexpialidocious@marypoppins.superfan.conference.com',
+  },
+} as unknown as Account;
+
+const storyWithContext = (account: Account) => {
+  const story = () => (
+    <AppContext.Provider value={mockAppContext({ account })}>
+      <AppLayout>
+        {' '}
+        <ButtonDownloadRecoveryKey {...{ recoveryKeyValue, viewName }} />
+      </AppLayout>
+    </AppContext.Provider>
+  );
+  return story;
+};
+
+export const Default = storyWithContext(account);
+
+export const WithVeryLongEmail = storyWithContext(accountWithLongEmail);

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Account, AppContext } from '../../models';
+import { ButtonDownloadRecoveryKey } from '.';
+import { MOCK_ACCOUNT } from '../../models/mocks';
+import { logViewEvent } from '../../lib/metrics';
+
+const recoveryKeyValue = 'WXYZ WXYZ WXYZ WXYZ WXYZ WXYZ';
+const viewName = 'settings.account-recovery';
+
+const account = {
+  ...MOCK_ACCOUNT,
+} as unknown as Account;
+
+jest.mock('../../lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+}));
+
+it('renders button as expected', () => {
+  window.URL.createObjectURL = jest.fn();
+  render(
+    <AppContext.Provider value={{ account }}>
+      <ButtonDownloadRecoveryKey {...{ recoveryKeyValue, viewName }} />
+    </AppContext.Provider>
+  );
+  expect(screen.getByText('Download your recovery key')).toBeInTheDocument();
+});
+
+it('emits a metrics event when the link is clicked', async () => {
+  window.URL.createObjectURL = jest.fn();
+  render(
+    <AppContext.Provider value={{ account }}>
+      <ButtonDownloadRecoveryKey {...{ recoveryKeyValue, viewName }} />
+    </AppContext.Provider>
+  );
+  const downloadButton = screen.getByText('Download your recovery key');
+  fireEvent.click(downloadButton);
+
+  expect(logViewEvent).toHaveBeenCalledWith(
+    `flow.${viewName}`,
+    'recovery-key.download-option'
+  );
+});

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { useAccount, useFtlMsgResolver } from '../../models';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { logViewEvent } from '../../lib/metrics';
+
+interface ButtonDownloadRecoveryKeyProps {
+  recoveryKeyValue: string;
+  viewName: string;
+}
+
+export const ButtonDownloadRecoveryKey = ({
+  recoveryKeyValue,
+  viewName,
+}: ButtonDownloadRecoveryKeyProps) => {
+  // TODO: format by locale
+  const { primaryEmail } = useAccount();
+  const currentDate = new Date();
+  const downloadDateInLocale = currentDate.toLocaleDateString(
+    navigator.language
+  );
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const fileHeading = ftlMsgResolver.getMsg(
+    'recovery-key-file-header',
+    'SAVE YOUR ACCOUNT RECOVERY KEY'
+  );
+
+  const fileInstructions = ftlMsgResolver.getMsg(
+    'recovery-key-file-instructions',
+    'Store this file containing your account recovery key in a place you’ll remember. Or print it and keep a physical copy. Your account recovery key can help you recover Firefox data if you forget your password.'
+  );
+
+  const fileKey = ftlMsgResolver.getMsg(
+    'recovery-key-file-key-value',
+    `🔑 Key:  ${recoveryKeyValue}`,
+    { recoveryKeyValue }
+  );
+
+  const fileUserEmail = ftlMsgResolver.getMsg(
+    'recovery-key-file-user-email',
+    `➤ Firefox account: ${primaryEmail.email}`,
+    { email: primaryEmail.email }
+  );
+
+  const fileDate = ftlMsgResolver.getMsg(
+    'recovery-key-file-download-date',
+    `➤ Key generated: ${downloadDateInLocale}`,
+    { downloadDate: downloadDateInLocale }
+  );
+
+  const supportURL = 'https://mzl.la/3bNrM1I';
+
+  const fileSupport = ftlMsgResolver.getMsg(
+    'recovery-key-file-support',
+    `➤ Learn more about your account recovery key: ${supportURL}`,
+    { supportURL }
+  );
+
+  const fileContent = new Blob(
+    [
+      fileHeading,
+      '\r\n\r\n',
+      fileInstructions,
+      '\r\n\r\n',
+      fileKey,
+      '\r\n\r\n',
+      fileUserEmail,
+      '\r\n',
+      fileDate,
+      '\r\n',
+      fileSupport,
+    ],
+    {
+      type: 'text/plain',
+    }
+  );
+
+  const getFilename = () => {
+    const date = currentDate.toISOString().split('T')[0];
+    // Windows has a max directory length of 260 characters (including path)
+    // filename should be kept much shorter (maxLength is arbitrary).
+    const maxLength = 70;
+    const prefix = 'Firefox-Recovery-Key';
+    let email = primaryEmail.email;
+    let filename = `${prefix}_${date}_${email}`;
+
+    if (filename.length > maxLength) {
+      const lengthWithoutEmail = filename.length - email.length;
+      email = email.slice(0, maxLength - lengthWithoutEmail);
+      filename = `${prefix}_${date}_${email}`;
+    }
+    return filename;
+  };
+
+  const onClickLogMetrics = () => {
+    logViewEvent(`flow.${viewName}`, `recovery-key.download-option`);
+  };
+
+  return (
+    <FtlMsg id="recovery-key-download-button" attrs={{ title: true }}>
+      <a
+        title="Download"
+        href={URL.createObjectURL(fileContent)}
+        download={getFilename()}
+        data-testid="recovery-key-download"
+        className="cta-primary cta-xl w-full"
+        onClick={onClickLogMetrics}
+      >
+        Download your recovery key
+      </a>
+    </FtlMsg>
+  );
+};
+
+export default ButtonDownloadRecoveryKey;


### PR DESCRIPTION
## Because

* We want to treat the key as a precious artifact that should be handled with care

## This pull request

* Create a ButtonDownloadRecoveryKey component with initial storybook and tests
* Adds new copy for the textfile
* Adds localization for the text file

## Issue that this pull request solves

Closes: #FXA-7266

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Screenshot of generated text file with additional localized string for testing:
![image](https://user-images.githubusercontent.com/22231637/232622865-d2e54e90-d1fe-4b00-bd72-3a15779b85f2.png)

## Other information (Optional)

Localization of text in generated text file was tested with an existing localized string in:

- Traditional Chinese zh-TW (extended character set/ double byte language)
- Hebrew (right-to-left)
- Icelandic (extended latin)
- Belarusian (Cyrillic)
