### PR TITLE
feat(fxa-settings): add a simple progress bar for the recovery flow

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ProgressBar/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/en.ftl
@@ -1,0 +1,7 @@
+## Progress bar
+
+# This is the aria-label text for the progress bar. The progress bar is meant to visually show the user how much progress they have made through the steps of a given flow.
+# Variables:
+#   $currentStep (number) - the step which the user is currently on
+#   $numberOfSteps (number) - the total number of steps in a given flow
+progress-bar-aria-label = A progress bar showing that the user is on step { $currentStep } of { $numberOfSteps }.

--- a/packages/fxa-settings/src/components/Settings/ProgressBar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/index.stories.tsx
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
+import { LocationProvider } from '@reach/router';
+import ProgressBar from '.';
+
+export default {
+  title: 'Components/Settings/ProgressBar',
+  component: ProgressBar,
+  decorators: [
+    withLocalization,
+    (Story) => (
+      <LocationProvider>
+        <Story />
+      </LocationProvider>
+    ),
+  ],
+} as Meta;
+
+export const FirstOfFiveSteps = () => (
+  <ProgressBar currentStep={1} numberOfSteps={5} />
+);
+
+export const SecondOfFiveSteps = () => (
+  <ProgressBar currentStep={2} numberOfSteps={5} />
+);
+
+export const FinalStep = () => (
+  <ProgressBar currentStep={5} numberOfSteps={5} />
+);

--- a/packages/fxa-settings/src/components/Settings/ProgressBar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/index.test.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProgressBar from '.';
+
+describe('ProgressBar', () => {
+  it('is accessible to the user', async () => {
+    const currentStep = 1;
+    const numberOfSteps = 4;
+    render(<ProgressBar {...{ currentStep, numberOfSteps }} />);
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute(
+      'aria-valuemin',
+      currentStep.toString()
+    );
+    expect(progressBar).toHaveAttribute(
+      'aria-valuemax',
+      numberOfSteps.toString()
+    );
+    expect(progressBar).toHaveAttribute(
+      'aria-valuetext',
+      currentStep.toString()
+    );
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/ProgressBar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/index.tsx
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { useFtlMsgResolver } from '../../../models';
+
+export type ProgressBarProps = {
+  numberOfSteps: number;
+  currentStep: number;
+};
+
+export const ProgressBar = ({
+  numberOfSteps,
+  currentStep,
+}: ProgressBarProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedProgressBarAriaLabel = ftlMsgResolver.getMsg(
+    'progress-bar-aria-label',
+    `A progress bar showing that the user is on step ${currentStep} of ${numberOfSteps}.`,
+    { currentStep, numberOfSteps }
+  );
+  if (currentStep > numberOfSteps) {
+    throw new Error(
+      'Current step submitted to the progress bar cannot be a greater number than the total number of steps in a flow. You may have reversed your inputs'
+    );
+  }
+
+  return (
+    <progress
+      aria-label={localizedProgressBarAriaLabel}
+      aria-valuemin={1}
+      aria-valuemax={numberOfSteps}
+      aria-valuetext={currentStep.toString()}
+      value={currentStep}
+      max={numberOfSteps}
+      className="h-2 w-full bg-grey-100 rounded flex ltr:flex-row rtl:flex-row-reverse"
+    />
+  );
+};
+
+export default ProgressBar;

--- a/packages/fxa-settings/src/styles/tailwind.css
+++ b/packages/fxa-settings/src/styles/tailwind.css
@@ -22,6 +22,36 @@ body {
   @apply absolute -top-20;
 }
 
+progress {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  border-radius: 10px;
+  /* for IE10 and up */
+  @apply text-blue-400;
+  @apply bg-grey-100
+}
+
+progress::-webkit-progress-bar {
+  border-radius: 10px;
+  @apply bg-grey-100;
+}
+progress::-webkit-progress-inner-element {
+  border-radius: 10px;
+}
+
+progress::-webkit-progress-value {
+   border-radius: 10px;
+  @apply bg-blue-400;
+}
+
+progress[value]::-moz-progress-bar {
+  border-radius: 10px;
+  border-radius: 10px;
+  @apply bg-blue-400;
+}
+
 @layer utilities {
   .break-word {
     word-break: break-word;


### PR DESCRIPTION
## Because:

* We need a simple progress bar to track the user's progress through the account recovery flow

## This commit:

* Adds in a simple progress bar

Closes #FXA-7229

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Firefox:
<img width="1318" alt="Screen Shot 2023-04-19 at 4 12 56 PM" src="https://user-images.githubusercontent.com/11150372/233431835-66c6656d-f29b-4d18-abdc-af1b8e26d75c.png">
Safari:
<img width="1077" alt="Screen Shot 2023-04-19 at 4 13 04 PM" src="https://user-images.githubusercontent.com/11150372/233431849-b0bfe825-3dd3-4c73-9820-834fbef64d01.png">
Chrome:
![Uploading Screen Shot 2023-04-20 at 9.44.03 AM.png…]()

