### PR TITLE
task(CI): Resolve linter OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,7 @@ jobs:
   # Runs linter on packages that have changes.
   lint:
     executor: default-executor
-    resource_class: small
+    resource_class: medium
     steps:
       - git-checkout
       - restore-workspace


### PR DESCRIPTION
## Because

- We were running out of memory.
- We recently increased the scope of linter coverage, which is likely related.

## This pull request

- Bumps the resource class for lint jobs.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This only addresses the OOM. There's a follow up for the fact that an OOM can result in an exit code of 0.
