### PR TITLE
feat(fxa-settings): Conditionally render new RecoveryKey flow

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -59,6 +59,7 @@ const settingsConfig = {
     count: config.get('recovery_codes.count'),
     length: config.get('recovery_codes.length'),
   },
+  showRecoveryKeyV2: config.get('showRecoveryKeyV2'),
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -601,6 +601,12 @@ const conf = (module.exports = convict({
       format: 'nat',
     },
   },
+  showRecoveryKeyV2: {
+    default: false,
+    doc: 'Enable users to see the new recovery key flow in settings',
+    format: Boolean,
+    env: 'SHOW_RECOVERY_KEY_V2',
+  },
   redirect_port: {
     default: 80,
     doc: 'Redirect port for HTTPS',

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import base32encode from 'base32-encode';
@@ -22,6 +26,7 @@ type FormData = {
 
 export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
   usePageViewEvent('settings.account-recovery');
+
   const { handleSubmit, register, formState, setValue } = useForm<FormData>({
     mode: 'all',
     defaultValues: {

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps, useNavigate } from '@reach/router';
+import VerifiedSessionGuard from '../VerifiedSessionGuard';
+import { HomePath } from '../../../constants';
+
+export const PageRecoveryKeyCreate = (_: RouteComponentProps) => {
+  const navigate = useNavigate();
+  const goHome = () => navigate(HomePath + '#recovery-key', { replace: true });
+  return (
+    <>
+      <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
+      {/* TODO New content for recovery key flow will go here */}
+      Hello I'm the new Recovery Key Create Page
+    </>
+  );
+};
+
+export default PageRecoveryKeyCreate;

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -24,9 +24,11 @@ import { HomePath } from '../../constants';
 import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
 import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
+import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
 
 export const Settings = (props: RouteComponentProps) => {
   const config = useConfig();
+  const { showRecoveryKeyV2 } = config;
   const { metricsEnabled, hasPassword } = useAccount();
 
   useEffect(() => {
@@ -63,6 +65,15 @@ export const Settings = (props: RouteComponentProps) => {
           <PageDisplayName path="/display_name" />
           <PageAvatar path="/avatar" />
           {hasPassword ? (
+            showRecoveryKeyV2 ? (
+              <PageRecoveryKeyCreate path="/account_recovery" />
+            ) : (
+              <PageRecoveryKeyAdd path="/account_recovery" />
+            )
+          ) : (
+            <Redirect from="/account_recovery" to="/settings" noThrow />
+          )}
+          {hasPassword ? (
             <>
               <PageChangePassword path="/change_password" />
               <Redirect
@@ -70,7 +81,6 @@ export const Settings = (props: RouteComponentProps) => {
                 to="/settings/change_password"
                 noThrow
               />
-              <PageRecoveryKeyAdd path="/account_recovery" />
               <PageTwoStepAuthentication path="/two_step_authentication" />
               <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
             </>

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -47,6 +47,7 @@ export interface Config {
     count: number;
     length: number;
   };
+  showRecoveryKeyV2: boolean;
   version: string;
 }
 
@@ -88,6 +89,7 @@ export function getDefault() {
       count: 8,
       length: 10,
     },
+    showRecoveryKeyV2: false,
   } as Config;
 }
 


### PR DESCRIPTION
## Because

* We want to wait until the entire flow is finalized before shipping, but want to enable testing on stage.

## This pull request

* Creates a copy of the current `UnitRowRecoveryKey`, and add a new `PageRecoveryKeyCreate` to house the changes to `PageRecoveryKeyAdd`
* Adds an environment variable (`showRecoveryKeyV2`) to conditionally display the new flow

## Issue that this pull request solves

Closes: #FXA-7287

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Currently, it's necessary to complete stop/start the stack to change the env variable. Not sure if this is an issue with my local install.

Here's what currently works to activate the new flow locally:
- `yarn stop`
- Set `"showRecoveryKeyV2":true` in `local.json` OR add `SHOW_RECOVERY_KEY_V2=true` to `.env`
- `yarn start`
- Go to `localhost:3030/settings` after creating an account, and see that text background is red in the Security/Account Recovery Key section (color changed for quick visual confirmation that new flow is active)