### PR TITLE
feat(metrics): update Event Properties

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -484,7 +484,7 @@ export class StripeHelper extends StripeHelperBase {
     const createParams: Stripe.SubscriptionCreateParams = {
       customer: customerId,
       items: [{ price: priceId }],
-      expand: ['latest_invoice.payment_intent'],
+      expand: ['latest_invoice.payment_intent.latest_charge'],
       promotion_code: promotionCode?.id,
       automatic_tax: {
         enabled: automaticTax,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -919,7 +919,7 @@ describe('#integration - StripeHelper', () => {
         {
           customer: 'customerId',
           items: [{ price: 'priceId' }],
-          expand: ['latest_invoice.payment_intent'],
+          expand: ['latest_invoice.payment_intent.latest_charge'],
           promotion_code: undefined,
           automatic_tax: {
             enabled: true,
@@ -990,7 +990,7 @@ describe('#integration - StripeHelper', () => {
         {
           customer: 'customerId',
           items: [{ price: 'priceId' }],
-          expand: ['latest_invoice.payment_intent'],
+          expand: ['latest_invoice.payment_intent.latest_charge'],
           promotion_code: promotionCode.id,
           automatic_tax: {
             enabled: false,
@@ -1065,7 +1065,7 @@ describe('#integration - StripeHelper', () => {
         {
           customer: 'customerId',
           items: [{ price: 'priceId' }],
-          expand: ['latest_invoice.payment_intent'],
+          expand: ['latest_invoice.payment_intent.latest_charge'],
           promotion_code: undefined,
           automatic_tax: {
             enabled: true,

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -210,7 +210,7 @@ describe('lib/amplitude', () => {
         device_id: 'QUUX',
         session_id: 1570000000000,
         app_version: '148.8',
-        countryCode: "DE",
+        country_code: "DE",
         os_name: 'Mac OS X',
         os_version: '10.14',
         language: 'en-US',

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -8,6 +8,7 @@ import {
   checkAccountExists,
 } from './index';
 import { Localized } from '@fluent/react';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 jest.mock('../../lib/apiClient', () => ({
   apiFetchAccountStatus: jest.fn(),
@@ -27,7 +28,7 @@ const selectedPlan = {
     'product:details:2': 'Detail 2',
     'product:details:3': 'Detail 3',
   },
-  checkout_type: 'without-account',
+  checkout_type: CheckoutType.WITHOUT_ACCOUNT,
 };
 
 const WrapNewUserEmailForm = ({

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -14,6 +14,7 @@ import './index.scss';
 import * as Amplitude from '../../lib/amplitude';
 import { useCallbackOnce } from '../../lib/hooks';
 import { apiFetchAccountStatus } from '../../lib/apiClient';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 export type NewUserEmailFormProps = {
   getString?: (id: string) => string;
@@ -51,10 +52,14 @@ export const NewUserEmailForm = ({
 
   const [emailInputState, setEmailInputState] = useState<string>();
 
-  selectedPlan.checkoutType = 'without-account';
+  const checkoutType = CheckoutType.WITHOUT_ACCOUNT;
 
   const onFormMounted = useCallback(
-    () => Amplitude.createAccountMounted(selectedPlan),
+    () =>
+      Amplitude.createAccountMounted({
+        ...selectedPlan,
+        checkoutType: checkoutType,
+      }),
     [selectedPlan]
   );
   useEffect(() => {
@@ -62,7 +67,11 @@ export const NewUserEmailForm = ({
   }, [onFormMounted, selectedPlan]);
 
   const onFormEngaged = useCallbackOnce(
-    () => Amplitude.createAccountEngaged(selectedPlan),
+    () =>
+      Amplitude.createAccountEngaged({
+        ...selectedPlan,
+        checkoutType: checkoutType,
+      }),
     [selectedPlan]
   );
   const onChange = useCallback(() => {
@@ -71,7 +80,10 @@ export const NewUserEmailForm = ({
 
   const onClickSignInButton = () => {
     selectedPlan.other = 'click-signnin';
-    Amplitude.createAccountSignIn(selectedPlan);
+    Amplitude.createAccountSignIn({
+      ...selectedPlan,
+      checkoutType: checkoutType,
+    });
   };
 
   return (

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.stories.tsx
@@ -5,6 +5,7 @@ import { linkTo } from '@storybook/addon-links';
 import { CUSTOMER, PLAN } from '../../lib/mock-data';
 import { PickPartial } from '../../lib/types';
 import { Meta } from '@storybook/react';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 export default {
   title: 'Routes/Product/PaypalButton',
@@ -58,22 +59,14 @@ const Subject = ({
   );
 };
 
-const storyWithContext = (
-  storyName?: string,
-  disabled?: boolean,
-) => {
+const storyWithContext = (storyName?: string, disabled?: boolean) => {
   const story = () => (
-    <Subject disabled={disabled} />
+    <Subject disabled={disabled} checkoutType={CheckoutType.WITHOUT_ACCOUNT} />
   );
   if (storyName) story.storyName = storyName;
   return story;
-}
+};
 
-export const Default = storyWithContext(
-  'default'
-)
+export const Default = storyWithContext('default');
 
-export const Disabled = storyWithContext(
-  'disabled',
-  true
-)
+export const Disabled = storyWithContext('disabled', true);

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.test.tsx
@@ -5,6 +5,7 @@ import { PaypalButton, PaypalButtonProps } from './index';
 
 import { PickPartial } from '../../lib/types';
 import { CUSTOMER, PLAN } from '../../lib/mock-data';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 const Subject = ({
   disabled = false,
@@ -51,7 +52,7 @@ describe('PaypalButton', () => {
   it("Doesn't render the PayPal button if the PayPal script fails to load", async () => {
     // The script is loaded in this button's consumer (e.g. SubscriptionCreate), so we
     // can guarantee that it won't be loaded for the button in isolation
-    render(<Subject />);
+    render(<Subject checkoutType={CheckoutType.WITH_ACCOUNT} />);
     expect(screen.queryByTestId('paypal-button')).not.toBeInTheDocument();
   });
 });

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -5,11 +5,12 @@ import ReactDOM from 'react-dom';
 
 import { Localized } from '@fluent/react';
 import * as apiClient from '../../lib/apiClient';
-import { Customer, Plan } from '../../store/types';
+import { Customer, Plan, Profile } from '../../store/types';
 import { SubscriptionCreateAuthServerAPIs } from '../../routes/Product/SubscriptionCreate';
 import { PaymentUpdateAuthServerAPIs } from '../../routes/Subscriptions/PaymentUpdateForm';
 
 import { needsCustomer } from '../../lib/customer';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 declare var paypal: {
   Buttons: {
@@ -19,6 +20,7 @@ declare var paypal: {
 
 export type PaypalButtonProps = {
   customer: Customer | null;
+  checkoutType: CheckoutType;
   disabled: boolean;
   idempotencyKey: string;
   refreshSubmitNonce: () => void;
@@ -55,6 +57,7 @@ export const PaypalButtonBase =
 
 export const PaypalButton = ({
   customer,
+  checkoutType,
   disabled,
   idempotencyKey,
   refreshSubmitNonce,
@@ -129,6 +132,7 @@ export const PaypalButton = ({
             productId,
             token,
             promotionCode,
+            checkoutType,
           });
         } else {
           await apiUpdateBillingAgreement({

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -65,6 +65,7 @@ import {
   SubsequentInvoicePreview,
 } from 'fxa-shared/dto/auth/payments/invoice';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 function nock(it: any) {
   //@ts-ignore
@@ -266,6 +267,7 @@ describe('API requests', () => {
       paymentProvider: params.paymentProvider,
       previousPlanId: params.previousPlanId,
       previousProductId: params.previousProductId,
+      subscriptionId: params.subscriptionId,
     };
 
     it('PUT {auth-server}/v1/oauth/subscriptions/active', async () => {
@@ -400,8 +402,10 @@ describe('API requests', () => {
       priceId: 'price_12345',
       productId: 'prod_abdce',
       paymentMethodId: 'pm_test',
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
     };
     const metricsOptions: EventProperties = {
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
       planId: params.priceId,
       productId: params.productId,
       paymentProvider: 'stripe',
@@ -422,7 +426,7 @@ describe('API requests', () => {
         createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
-        sourceCountry: expected.sourceCountry,
+        country_code_source: expected.sourceCountry,
       });
       requestMock.done();
     });
@@ -472,7 +476,7 @@ describe('API requests', () => {
         createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
-        sourceCountry: expected.sourceCountry,
+        country_code_source: expected.sourceCountry,
         promotionCode,
       });
       requestMock.done();
@@ -691,12 +695,15 @@ describe('API requests', () => {
       idempotencyKey: '',
       priceId: 'price_12345',
       productId: 'product_2a',
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
       ...MOCK_CHECKOUT_TOKEN,
     };
     const metricsOptions = {
       planId: params.priceId,
       productId: params.productId,
       paymentProvider: 'paypal',
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
+      promotionCode: undefined,
     };
 
     it('POST {auth-server}/v1/oauth/subscriptions/active/new-paypal', async () => {
@@ -714,7 +721,7 @@ describe('API requests', () => {
         createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
-        sourceCountry: 'FR',
+        country_code_source: 'FR',
       });
 
       requestMock.done();
@@ -764,7 +771,7 @@ describe('API requests', () => {
         createSubscriptionWithPaymentMethod_FULFILLED as jest.Mock
       ).toBeCalledWith({
         ...metricsOptions,
-        sourceCountry: 'FR',
+        country_code_source: 'FR',
         promotionCode,
       });
 

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -16,6 +16,8 @@ import {
   SubsequentInvoicePreview,
 } from 'fxa-shared/dto/auth/payments/invoice';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import customer from './customer';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 // TODO: Use a better type here
 export interface APIFetchOptions {
@@ -187,6 +189,7 @@ export async function apiUpdateSubscriptionPlan(params: {
     paymentProvider,
     previousPlanId,
     previousProductId,
+    subscriptionId,
   };
   try {
     Amplitude.updateSubscriptionPlan_PENDING(metricsOptions);
@@ -295,6 +298,7 @@ export async function apiCapturePaypalPayment(params: {
   idempotencyKey: string;
   priceId: string;
   productId: string;
+  checkoutType: CheckoutType;
   token?: string;
   promotionCode?: string;
 }): Promise<{
@@ -306,6 +310,7 @@ export async function apiCapturePaypalPayment(params: {
     productId: params.productId,
     paymentProvider: 'paypal',
     promotionCode: params.promotionCode,
+    checkoutType: params.checkoutType,
   };
   Amplitude.createSubscriptionWithPaymentMethod_PENDING(metricsOptions);
   try {
@@ -320,7 +325,7 @@ export async function apiCapturePaypalPayment(params: {
     );
     Amplitude.createSubscriptionWithPaymentMethod_FULFILLED({
       ...metricsOptions,
-      sourceCountry: response.sourceCountry,
+      country_code_source: response.sourceCountry,
     });
 
     return response;
@@ -336,8 +341,10 @@ export async function apiCapturePaypalPayment(params: {
 export async function apiCreateSubscriptionWithPaymentMethod(params: {
   priceId: string;
   productId: string;
+  checkoutType: CheckoutType;
   paymentMethodId?: string;
   promotionCode?: string;
+  profile?: Profile;
 }): Promise<{
   id: string;
   latest_invoice: {
@@ -358,6 +365,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
     productId: params.productId,
     paymentProvider: 'stripe',
     promotionCode: params.promotionCode,
+    checkoutType: params.checkoutType,
   };
   try {
     Amplitude.createSubscriptionWithPaymentMethod_PENDING(metricsOptions);
@@ -375,7 +383,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
     );
     Amplitude.createSubscriptionWithPaymentMethod_FULFILLED({
       ...metricsOptions,
-      sourceCountry: result.sourceCountry,
+      country_code_source: result.sourceCountry,
     });
     return result.subscription;
   } catch (error) {

--- a/packages/fxa-payments-server/src/lib/stripe.test.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.test.ts
@@ -5,6 +5,7 @@
 import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
 import { handlePasswordlessSubscription, localeToStripeLocale } from './stripe';
 import { NEW_CUSTOMER, PLAN } from './mock-data';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 jest.mock('./account', () => ({
   handlePasswordlessSignUp: jest.fn(),
@@ -59,6 +60,7 @@ describe('handlePasswordlessSubscription', () => {
       name: 'BMO',
       card: null,
       idempotencyKey: 'dontrepeat',
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
       selectedPlan: PLAN,
       customer: null,
       retryStatus: undefined,
@@ -84,6 +86,7 @@ describe('handlePasswordlessSubscription', () => {
       name: 'BMO',
       card: null,
       idempotencyKey: 'dontrepeat',
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
       selectedPlan: PLAN,
       customer: null,
       retryStatus: undefined,

--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -8,8 +8,9 @@ import {
   StripeElementsOptions,
   StripeError,
 } from '@stripe/stripe-js';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 import { SubscriptionCreateAuthServerAPIs } from '../routes/Product/SubscriptionCreate';
-import { Customer, Plan } from '../store/types';
+import { Customer, Plan, Profile } from '../store/types';
 import {
   handlePasswordlessSignUp,
   PasswordlessSignupHandlerParam,
@@ -27,6 +28,7 @@ export type SubscriptionPaymentHandlerParam = {
   idempotencyKey: string;
   selectedPlan: Plan;
   customer: Customer | null;
+  checkoutType: CheckoutType;
   retryStatus: RetryStatus;
   promotionCode?: string;
   apiDetachFailedPaymentMethod: SubscriptionCreateAuthServerAPIs['apiDetachFailedPaymentMethod'];
@@ -49,6 +51,7 @@ export async function handlePasswordlessSubscription({
   idempotencyKey,
   selectedPlan,
   customer,
+  checkoutType,
   retryStatus,
   promotionCode,
   apiCreateCustomer,
@@ -75,6 +78,7 @@ export async function handlePasswordlessSubscription({
       idempotencyKey,
       selectedPlan,
       customer,
+      checkoutType,
       retryStatus,
       promotionCode,
       apiCreateCustomer,
@@ -98,6 +102,7 @@ export async function handleSubscriptionPayment({
   idempotencyKey,
   selectedPlan,
   customer,
+  checkoutType,
   retryStatus,
   promotionCode,
   apiCreateCustomer,
@@ -116,6 +121,7 @@ export async function handleSubscriptionPayment({
         priceId: selectedPlan.plan_id,
         productId: selectedPlan.product_id,
         promotionCode: promotionCode,
+        checkoutType: checkoutType,
       });
     return handlePaymentIntent({
       customer,
@@ -178,6 +184,7 @@ export async function handleSubscriptionPayment({
         productId: selectedPlan.product_id,
         paymentMethodId: paymentMethod.id,
         promotionCode: promotionCode,
+        checkoutType: checkoutType,
       });
     return handlePaymentIntent({
       customer,

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -64,6 +64,7 @@ import {
 import CouponForm from '../../components/CouponForm';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
 import { useParams } from 'react-router-dom';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 const PaypalButton = React.lazy(() => import('../../components/PayPalButton'));
 
@@ -146,15 +147,19 @@ export const Checkout = ({
     [productId, planId, plansByProductId]
   );
 
-  const onFormMounted = useCallback(
-    () => Amplitude.createSubscriptionMounted(selectedPlan),
-    [selectedPlan]
-  );
+  const onFormMounted = useCallback(() => {
+    Amplitude.createSubscriptionMounted({
+      ...selectedPlan,
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
+    });
+  }, [selectedPlan]);
 
-  const onFormEngaged = useCallback(
-    () => Amplitude.createSubscriptionEngaged(selectedPlan),
-    [selectedPlan]
-  );
+  const onFormEngaged = useCallback(() => {
+    Amplitude.createSubscriptionEngaged({
+      ...selectedPlan,
+      checkoutType: CheckoutType.WITHOUT_ACCOUNT,
+    });
+  }, [selectedPlan]);
 
   // clear any error rendered with `ErrorMessage` on form change
   const onChange = useCallback(() => {
@@ -176,6 +181,7 @@ export const Checkout = ({
           email: validEmail,
           clientId: config.servers.oauth.clientId,
           customer: null,
+          checkoutType: CheckoutType.WITHOUT_ACCOUNT,
           stripe: stripeOverride || stripeFormParams,
           selectedPlan,
           retryStatus,
@@ -455,6 +461,7 @@ export const Checkout = ({
                 setTransactionInProgress={setTransactionInProgress}
                 ButtonBase={paypalButtonBase}
                 promotionCode={coupon?.promotionCode}
+                checkoutType={CheckoutType.WITHOUT_ACCOUNT}
               />
             )}
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -47,6 +47,7 @@ import { GeneralError } from '../../../lib/errors';
 import { PaymentMethodHeader } from '../../../components/PaymentMethodHeader';
 import CouponForm from '../../../components/CouponForm';
 import { CouponDetails } from 'fxa-shared/dto/auth/payments/coupon';
+import { CheckoutType } from 'fxa-shared/subscriptions/types';
 
 const PaypalButton = React.lazy(
   () => import('../../../components/PayPalButton')
@@ -89,18 +90,28 @@ export const SubscriptionCreate = ({
   coupon,
   setCoupon,
 }: SubscriptionCreateProps) => {
+  const checkoutType = CheckoutType.WITH_ACCOUNT;
+
   const [submitNonce, refreshSubmitNonce] = useNonce();
   const [transactionInProgress, setTransactionInProgress] = useState(false);
   const [checkboxSet, setCheckboxSet] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
 
   const onFormMounted = useCallback(
-    () => Amplitude.createSubscriptionMounted(selectedPlan),
+    () =>
+      Amplitude.createSubscriptionMounted({
+        ...selectedPlan,
+        checkoutType: checkoutType,
+      }),
     [selectedPlan]
   );
 
   const onFormEngaged = useCallback(
-    () => Amplitude.createSubscriptionEngaged(selectedPlan),
+    () =>
+      Amplitude.createSubscriptionEngaged({
+        ...selectedPlan,
+        checkoutType: checkoutType,
+      }),
     [selectedPlan]
   );
 
@@ -147,6 +158,7 @@ export const SubscriptionCreate = ({
             email: profile.email,
             selectedPlan,
             customer,
+            checkoutType,
             retryStatus,
             onSuccess: refreshSubscriptions,
             onFailure: setSubscriptionError,
@@ -187,6 +199,7 @@ export const SubscriptionCreate = ({
         try {
           await apiCapturePaypalPayment({
             ...params,
+            checkoutType: checkoutType,
             productId: selectedPlan.product_id,
           });
           refreshSubscriptions();
@@ -312,6 +325,7 @@ export const SubscriptionCreate = ({
                     ButtonBase={paypalButtonBase}
                     setTransactionInProgress={setTransactionInProgress}
                     promotionCode={coupon?.promotionCode}
+                    checkoutType={checkoutType}
                   />
                 )}
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -65,12 +65,32 @@ export const SubscriptionUpgrade = ({
     customer?.payment_provider;
 
   useEffect(() => {
-    Amplitude.updateSubscriptionPlanMounted(selectedPlan);
-  }, [selectedPlan]);
+    const metrics = {
+      paymentProvider: paymentProvider,
+      previousPlanId: upgradeFromSubscription.plan_id,
+      previousProductId: upgradeFromSubscription.product_id,
+      subscriptionId: upgradeFromSubscription.subscription_id,
+      ...selectedPlan,
+    };
+    Amplitude.updateSubscriptionPlanMounted(metrics);
+  }, [
+    paymentProvider,
+    selectedPlan,
+    upgradeFromSubscription.plan_id,
+    upgradeFromSubscription.product_id,
+    upgradeFromSubscription.subscription_id,
+  ]);
 
   const engageOnce = useCallbackOnce(() => {
-    Amplitude.updateSubscriptionPlanEngaged(selectedPlan);
-  }, [selectedPlan]);
+    const metrics = {
+      paymentProvider: paymentProvider,
+      previousPlanId: upgradeFromSubscription.plan_id,
+      previousProductId: upgradeFromSubscription.product_id,
+      subscriptionId: upgradeFromSubscription.subscription_id,
+      ...selectedPlan,
+    };
+    Amplitude.updateSubscriptionPlanEngaged(metrics);
+  }, [selectedPlan, upgradeFromSubscription.subscription_id]);
 
   const handleClick = () => {
     engageOnce();

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -30,6 +30,7 @@ import PaymentProviderDetails from '../../components/PaymentProviderDetails';
 import { ActionButton } from './ActionButton';
 import { LoadingOverlay } from '../../components/LoadingOverlay';
 import {
+  CheckoutType,
   PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
   PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
 } from 'fxa-shared/subscriptions/types';
@@ -277,6 +278,7 @@ export const PaymentUpdateForm = ({
                   apiClientOverrides={apiClientOverrides}
                   setTransactionInProgress={setTransactionInProgress}
                   ButtonBase={paypalButtonBase}
+                  checkoutType={CheckoutType.WITH_ACCOUNT}
                 />
               </Suspense>
             )}

--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -56,7 +56,7 @@
       "type": "string",
       "pattern": "^[a-z]{1,}(-[a-zA-Z0-9]{1,})*$"
     },
-    "countryCode": {
+    "country_code": {
       "description": "The 2 character country ISO code",
       "type": "string",
       "pattern": "^[A-Z]{2}$"
@@ -85,26 +85,44 @@
       "description": "Properties associated with a particular event, which values are current for the moment at which the event was triggered.",
       "type": "object",
       "properties": {
-        "service": {
-          "description": "The name of the service.",
-          "type": "string"
-        },
-        "oauth_client_id": {
-          "description": "The OAuth client ID for a RP integrated with FxA.",
-          "type": "string"
+        "checkout_type": {
+          "description": "Whether the checkout flow is for new users or existing users. One of “with-account” or “without-account”",
+          "type": "string",
+          "enum": ["with-account", "without-account"]
         },
         "country_code_source": {
           "description": "The 2 character country ISO code. This value represents the payment method country for the user.",
           "type": "string",
           "pattern": "^[A-Z]{2}$"
         },
+        "error_id": {
+          "description": "The error id, if any, encountered for a fxa_pay_setup - fail event",
+          "type": "string"
+        },
+        "oauth_client_id": {
+          "description": "The OAuth client ID for a RP integrated with FxA.",
+          "type": "string"
+        },
         "payment_provider": {
-          "description": "The third party service ultimately processing a user’s payments (i.e. one of: Stripe, PayPal, Google or Apple at the time of writing).",
+          "description": "The third party service ultimately processing a user’s payments (e.g. 'stripe').",
           "type": "string",
-          "maxLength": 128
+          "enum": ["stripe", "paypal", "google", "apple"]
         },
         "plan_id": {
           "description": "Plan ID of a subscription.",
+          "type": "string",
+          "maxLength": 128
+        },
+        "previous_plan_id": {
+          "description": "The Stripe price_* or plan_* ID for the subscription the user currently has prior to the change",
+          "type": "string"
+        },
+        "previous_product_id": {
+          "description": "The Stripe product_* ID for the subscription the user currently has prior to the change",
+          "type": "string"
+        },
+        "provider_event_id": {
+          "description": "A unique identifier for the subscription notification from a payment provider. For Stripe and Stripe-managed providers like PayPal, this is the Stripe webhook event id.",
           "type": "string",
           "maxLength": 128
         },
@@ -113,10 +131,17 @@
           "type": "string",
           "maxLength": 128
         },
-        "provider_event_id": {
-          "description": "A unique identifier for the subscription notification from a payment provider. For Stripe and Stripe-managed providers like PayPal, this is the Stripe webhook event id.",
-          "type": "string",
-          "maxLength": 128
+        "promotion_code": {
+          "description": "The Stripe customer-facing promotion code applied, if any.",
+          "type": "string"
+        },
+        "service": {
+          "description": "The name of the service.",
+          "type": "string"
+        },
+        "subscribed_plan_ids": {
+          "description": "Comma-separated list of Stripe price/plan IDs the user is already subscribed to.",
+          "type": "string"
         },
         "subscription_id": {
           "description": "ID of a subscription being canceled.",
@@ -208,11 +233,19 @@
     "event_properties",
     "user_properties"
   ],
-  "anyOf": [{ "required": ["user_id"] }, { "required": ["device_id"] }],
+  "anyOf": [
+    {
+      "required": ["user_id"]
+    },
+    {
+      "required": ["device_id"]
+    }
+  ],
   "allOf": [
     {
       "if": {
-        "$comment": "For event_type's matching the pattern below, make language a required field",
+        "$comment": "Required fields for fxa_pay_setup* or fxa_pay_subscription_change* events",
+        "required": ["event_type"],
         "properties": {
           "event_type": {
             "type": "string",
@@ -221,12 +254,115 @@
         }
       },
       "then": {
-        "required": ["language"]
+        "required": ["language"],
+        "properties": {
+          "user_properties": {
+            "required": ["flow_id"]
+          },
+          "event_properties": {
+            "required": ["plan_id", "product_id"]
+          }
+        }
       }
     },
     {
       "if": {
-        "$comment": "For event_type's matching the pattern below, the required fields are as follows: event_type, language, payment_provider, plan_id, product_id, provider_event_id, subscription_id, time, voluntary_cancellation",
+        "$comment": "Additional required fields for fxa_pay_setup* events",
+        "required": ["event_type"],
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "pattern": "^fxa_pay_setup -"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "event_properties": {
+            "required": ["checkout_type"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "$comment": "Additional required fields for fxa_pay_subscription_change* events",
+        "required": ["event_type"],
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "pattern": "^fxa_pay_subscription_change -"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "event_properties": {
+            "required": ["previous_plan_id", "previous_product_id", "subscription_id", "payment_provider"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "$comment": "Additional required fields for fxa_pay_setup - <submit|success|fail> events",
+        "required": ["event_type"],
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "pattern": "^fxa_pay_setup - submit|fxa_pay_setup - success|fxa_pay_setup - fail"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "event_properties": {
+            "required": ["payment_provider"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "$comment": "Require error_id event property for fxa_pay_setup - fail and fxa_pay_subscription_change - fail events",
+        "required": ["event_type"],
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "pattern": "^fxa_pay_setup - fail$|fxa_pay_subscription_change - fail$"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "event_properties": {
+            "required": ["error_id"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "$comment": "Additional required fields for when a subscription is successfully created or ended",
+        "required": ["event_type"],
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "pattern": "^fxa_pay_setup - success|fxa_subscribe - subscription_ended"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "event_properties": {
+            "required": ["country_code_source"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "$comment": "Required fields for fxa_subscribe - subscription_ended events",
         "properties": {
           "event_type": {
             "type": "string",

--- a/packages/fxa-shared/metrics/amplitude.ts
+++ b/packages/fxa-shared/metrics/amplitude.ts
@@ -199,6 +199,22 @@ function mapSubscriptionChangeEventProperties(
       properties['previous_product_id'] = data.previousProductId;
     }
 
+    if (data.subscriptionId) {
+      properties['subscription_id'] = data.subscriptionId;
+    }
+
+    if (data.subscribed_plan_ids) {
+      properties['subscribed_plan_ids'] = data.subscribed_plan_ids;
+    }
+
+    if (data.country_code_source) {
+      properties['country_code_source'] = data.country_code_source;
+    }
+
+    if (data.error_id) {
+      properties['error_id'] = data.error_id;
+    }
+
     return properties;
   }
 
@@ -214,12 +230,20 @@ function mapSubscriptionPaymentEventProperties(
   if (data) {
     const properties: { [key: string]: string } = {};
 
-    if (data.sourceCountry) {
-      properties['source_country'] = data.sourceCountry;
+    if (data.country_code_source) {
+      properties['country_code_source'] = data.country_code_source;
     }
 
     if (data.checkoutType) {
       properties['checkout_type'] = data.checkoutType;
+    }
+
+    if (data.subscribed_plan_ids) {
+      properties['subscribed_plan_ids'] = data.subscribed_plan_ids;
+    }
+
+    if (data.error_id) {
+      properties['error_id'] = data.error_id;
     }
 
     if (data.other) {
@@ -383,7 +407,7 @@ export const amplitude = {
           session_id: data.flowBeginTime,
           app_version: version,
           language: data.lang,
-          countryCode: data.countryCode,
+          country_code: data.countryCode,
           country: data.country,
           region: data.region,
           os_name: data.os,
@@ -426,7 +450,7 @@ export const amplitude = {
           plan_id: data.planId || data.plan_id,
           product_id: data.productId || data.product_id,
           payment_provider: data.paymentProvider || data.payment_provider,
-          promotionCode: data.promotionCode,
+          promotion_code: data.promotionCode,
           provider_event_id: data.provider_event_id,
           subscription_id: data.subscription_id,
           voluntary_cancellation: data.voluntary_cancellation,

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -32,6 +32,11 @@ export interface Plan {
   configuration?: PlanConfigurationDtoT | null;
 }
 
+export enum CheckoutType {
+  WITH_ACCOUNT = 'with-account',
+  WITHOUT_ACCOUNT = 'without-account',
+}
+
 export type ConfiguredPlan = Stripe.Plan & {
   configuration: PlanConfigurationDtoT | null;
 };


### PR DESCRIPTION
Because:

* we wanted to have an expanded set of properties on certain metrics events and want to enforce the schema appropriately

This commit:

* adds the required and optional properties to the fxa_pay_setup* and fxa_subscription_change* events and updates the ajv schema such that errors will be reported for missing information

Closes FXA-6953, FXA-6954, FXA-7499

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).