### PR TITLE
task(admin-server): Audit oauth and profile DB tables

### DIFF
--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -16,7 +16,7 @@
     "restart": "pm2 restart pm2.config.js",
     "delete": "pm2 delete pm2.config.js",
     "test": "yarn gen-keys && yarn test-default && yarn test-e2e ",
-    "gen-keys": "node -r esbuild-register ./scripts/gen_keys.ts;",
+    "gen-keys": "node -r esbuild-register ./src/scripts/gen_keys.ts;",
     "test-unit": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --runInBand --coverage --forceExit --logHeapUsage -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
     "test-integration": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml jest --runInBand --coverage --forceExit --logHeapUsage -t '#integration' --ci --reporters=default --reporters=jest-junit",
     "test-default": "jest --runInBand --forceExit -t=\"scripts/audit-tokens\"",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -18,7 +18,7 @@
     "test": "yarn gen-keys && yarn test-default && yarn test-e2e ",
     "gen-keys": "node -r esbuild-register ./scripts/gen_keys.ts;",
     "test-unit": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --runInBand --coverage --forceExit --logHeapUsage -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
-    "test-integration-disabled": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml jest --runInBand --coverage --forceExit --logHeapUsage -t '#integration' --ci --reporters=default --reporters=jest-junit",
+    "test-integration": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml jest --runInBand --coverage --forceExit --logHeapUsage -t '#integration' --ci --reporters=default --reporters=jest-junit",
     "test-default": "jest --runInBand --forceExit -t=\"scripts/audit-tokens\"",
     "test-watch": "jest --watch",
     "test-cov": "jest --coverage",

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -42,6 +42,7 @@ const conf = convict({
   },
   database: {
     fxa: makeMySQLConfig('AUTH', 'fxa'),
+    profile: makeMySQLConfig('PROFILE', 'fxa_profile'),
     fxa_oauth: makeMySQLConfig('OAUTH', 'fxa_oauth'),
   },
   redis: makeRedisConfig(),

--- a/packages/fxa-admin-server/src/scripts/audit-tokens.spec.ts
+++ b/packages/fxa-admin-server/src/scripts/audit-tokens.spec.ts
@@ -7,23 +7,51 @@ import util from 'node:util';
 import path from 'node:path';
 import { auditRowCounts, auditAge, auditOrphanedRows } from './audit-tokens';
 import Config from '../config';
-import { clearDb, bindKnex, scaffoldDb } from './db-helpers';
+import { clearDb, bindKnex, scaffoldDb, TargetDB } from './db-helpers';
 
 import { Account } from 'fxa-shared/db/models/auth';
+import { Knex } from 'knex';
+import { Profile } from 'fxa-shared/db/models/profile';
+import { uuidTransformer } from 'fxa-shared/db/transformers';
+import { randomBytes } from 'node:crypto';
 
 const config = Config.getProperties();
 const exec = util.promisify(require('node:child_process').exec);
 const cwd = path.resolve(__dirname, '..');
 
 describe('#integration - scripts/audit-tokens', () => {
+  let fxaDb: Knex;
+  let fxaOauthDb: Knex;
+  let fxaProfileDb: Knex;
   const uid = 'f9916686c226415abd06ae550f073cea';
   const email = 'user1@test.com';
   const createdAt = new Date('2022-10').getTime();
   const lastAccessTime = new Date('2022-11').getTime();
 
   beforeAll(async () => {
-    bindKnex(config.database.fxa);
+    // Create DB connections. Note that in the real world, these would be
+    // separate databases instances. During local testing, we use the same
+    // instance for all databases.
+    fxaDb = bindKnex(config.database.fxa);
+    fxaProfileDb = bindKnex(config.database.profile, TargetDB.profile);
+    fxaOauthDb = bindKnex(config.database.fxa_oauth, TargetDB.oauth);
+
     await scaffoldDb(uid, email, createdAt, lastAccessTime);
+
+    // Add a dummy profile
+    await Profile.knexQuery().insert({
+      userId: uuidTransformer.to(uid),
+      displayName: 'test',
+    });
+
+    // Add a dummy auth token. Note, there are no DTOs for oauth db tables currently.
+    await fxaOauthDb('tokens').insert({
+      token: randomBytes(32),
+      clientId: randomBytes(8),
+      userId: uuidTransformer.to(uid),
+      type: 'refresh',
+      scope: '',
+    });
 
     // Manually delete the account to simulate orphaned record situation.
     await Account.knexQuery().del();
@@ -32,10 +60,22 @@ describe('#integration - scripts/audit-tokens', () => {
   describe('query checks)', () => {
     afterAll(async () => {
       await clearDb();
+      await fxaProfileDb('profile').del();
+      await fxaOauthDb('tokens').del();
     });
 
-    it('counts rows', async () => {
+    it('counts rows in fxa db table', async () => {
       const result = await auditRowCounts('fxa.devices');
+      assert.equal(result.table_size, 1);
+    });
+
+    it('counts rows in oauth db table', async () => {
+      const result = await auditRowCounts('fxa_oauth.tokens');
+      assert.equal(result.table_size, 1);
+    });
+
+    it('counts rows in profile db table', async () => {
+      const result = await auditRowCounts('fxa_profile.profile');
       assert.equal(result.table_size, 1);
     });
 

--- a/packages/fxa-admin-server/src/scripts/audit-tokens.ts
+++ b/packages/fxa-admin-server/src/scripts/audit-tokens.ts
@@ -4,7 +4,11 @@
 
 import program from 'commander';
 import { StatsD } from 'hot-shots';
-import { setupDatabase } from 'fxa-shared/db';
+import {
+  setupAuthDatabase,
+  setupDatabase,
+  setupProfileDatabase,
+} from 'fxa-shared/db';
 import packageJson from '../../package.json';
 import Config from '../config';
 import mozlog from 'mozlog';
@@ -13,9 +17,29 @@ import { ILogger } from 'fxa-shared/log';
 const config = Config.getProperties();
 
 const statsd = new StatsD(config.metrics);
-const knex = setupDatabase({
+const knexForFxa = setupAuthDatabase({
   ...config.database.fxa,
 });
+
+const knexForProfile = setupProfileDatabase({
+  ...config.database.fxa_oauth,
+});
+
+const knexForOAuth = setupDatabase({
+  ...config.database.profile,
+});
+
+function getKnex(table: string) {
+  if (table.startsWith('fxa.')) {
+    return knexForFxa;
+  } else if (table.startsWith('fxa_oauth.')) {
+    return knexForOAuth;
+  } else if (table.startsWith('fxa_profile.')) {
+    return knexForProfile;
+  } else {
+    throw new Error(`Unsupported table! ${table}.`);
+  }
+}
 
 const logFactory = mozlog(config.log);
 let log: ILogger = logFactory('default');
@@ -38,6 +62,7 @@ const tables = {
   devices: toTable('devices'),
   deviceCommands: toTable('deviceCommands'),
   emails: toTable('emails'),
+  emailBounces: toTable('emailBounces'),
   keyFetchTokens: toTable('keyFetchTokens'),
   linkedAccounts: toTable('linkedAccounts'),
   passwordChangeTokens: toTable('passwordChangeTokens'),
@@ -53,6 +78,15 @@ const tables = {
   unblockCodes: toTable('unblockCodes'),
   unverifiedTokens: toTable('unverifiedTokens'),
   verificationReminders: toTable('verificationReminders'),
+
+  // OAuth tables
+  oauthCodes: toTable('codes', 'fxa_oauth'),
+  oauthRefreshTokens: toTable('refreshTokens', 'fxa_oauth'),
+  oauthTokens: toTable('tokens', 'fxa_oauth'),
+
+  // Profile tables
+  profile: toTable('profile', 'fxa_profile'),
+  avatars: toTable('avatars', 'fxa_profile'),
 };
 
 //#endregion
@@ -182,6 +216,7 @@ async function audit(name: string, raw: string) {
   }
 
   try {
+    const knex = getKnex(name);
     const isolationLevel = 'read uncommitted';
     const trx = await knex.transaction({ isolationLevel });
     const rawResult = await trx.raw(raw);
@@ -315,6 +350,9 @@ async function auditAll() {
       [tables.unblockCodes, 'createdAt', 'unblockCodeHash'],
       [tables.unverifiedTokens, 'tokenVerificationCodeExpiresAt', 'tokenId'],
       [tables.verificationReminders, 'createdAt', 'uid'],
+      [tables.oauthCodes, 'createdAt', 'token'],
+      [tables.oauthRefreshTokens, 'createdAt', 'token'],
+      [tables.oauthTokens, 'createdAt', 'token'],
     ];
     for (const [table, colName, colSort] of set) {
       await auditAge(table, colName, colSort);
@@ -322,7 +360,9 @@ async function auditAll() {
   }
 
   // If requested look for potentially orphaned rows. These are rows
-  // were an implied parent key is missing.
+  // where an implied parent key is missing. Note that we cannot audit
+  // across databases... So oauth and profile tables can't be audited
+  // against fxa tables.
   if (program.auditOrphanedRows) {
     let set = [
       tables.accountCustomers,

--- a/packages/fxa-admin-server/src/scripts/db-helpers.ts
+++ b/packages/fxa-admin-server/src/scripts/db-helpers.ts
@@ -11,7 +11,13 @@ import {
   SignInCodes,
 } from 'fxa-shared/db/models/auth';
 import crypto from 'crypto';
-import { setupAuthDatabase } from 'fxa-shared/db';
+import {
+  setupAuthDatabase,
+  setupDatabase,
+  setupOAuthDatabase,
+  setupProfileDatabase,
+} from 'fxa-shared/db';
+import { Profile } from 'fxa-shared/db/models/profile';
 
 const toRandomBuff = (size: number) =>
   uuidTransformer.to(crypto.randomBytes(size).toString('hex'));
@@ -120,6 +126,20 @@ export async function clearDb() {
   await SignInCodes.knexQuery().del();
 }
 
-export function bindKnex(dbConfig: any) {
-  return setupAuthDatabase(dbConfig);
+export enum TargetDB {
+  auth,
+  oauth,
+  profile,
+}
+
+export function bindKnex(dbConfig: any, db: TargetDB = TargetDB.auth) {
+  switch (db) {
+    case TargetDB.oauth:
+      return setupDatabase(dbConfig);
+    case TargetDB.profile:
+      return setupProfileDatabase(dbConfig);
+    case TargetDB.auth:
+    default:
+      return setupAuthDatabase(dbConfig);
+  }
 }

--- a/packages/fxa-content-server/server/lib/sentry.js
+++ b/packages/fxa-content-server/server/lib/sentry.js
@@ -72,15 +72,13 @@ if (config.get('sentry.dsn')) {
       event = tagFxaName(event, opts.serverName);
       return event;
     },
-    integrations: [
-      new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' }),
-    ],
+    integrations: [new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' })],
   });
 }
 
 /**
  * Attempts to capture an error and report it to sentry. If the error is a
- * validation error special steps are taking to capture the reasons validation failed.
+ * validation error special steps are taken to capture the reasons validation failed.
  * @param {*} err
  * @returns true if error was reported, false otherwise
  */

--- a/packages/fxa-shared/db/index.ts
+++ b/packages/fxa-shared/db/index.ts
@@ -112,6 +112,15 @@ export function setupAuthDatabase(
   return knex;
 }
 
+export function setupOAuthDatabase(
+  opts: MySQLConfig,
+  log?: ILogger,
+  metrics?: StatsD
+) {
+  const knex = setupDatabase(opts, log, metrics);
+  return knex;
+}
+
 export function setupProfileDatabase(
   opts: MySQLConfig,
   log?: ILogger,


### PR DESCRIPTION
## Because

- We want to audit table row counts in oauth DB
- We want to audit table row counts in profile DB

## This pull request

- Audits a couple more tables in oauth DB
- Audits a couple more tables in profile DB
- Configures oauth connection independently
- Configures profile db connection independently
- Fixes bad reference to gen_keys.ts file in package.json


## Issue that this pull request solves

Closes: FXA-7153

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The logic for auditing more tables was essentially already supported; however, the code wasn't configured in a way that would connect to multiple database instances. During local development all database instances live on the same instance, but in staging/prod we have dedicated database instances for oauth data, which was the impetus for these changes.
