### PR TITLE
task(CI): Make smoke test URLs configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,21 @@ parameters:
   force-deploy-fxa-ci-images:
     type: boolean
     default: false
+  accounts-domain:
+    type: string
+    default: ''
+  payments-domain:
+    type: string
+    default: ''
+  accounts-api-domain:
+    type: string
+    default: ''
+  relier-domain:
+    type: string
+    default: ''
+  untrusted-relier-domain:
+    type: string
+    default: ''
 
 orbs:
   browser-tools: circleci/browser-tools@1.2.3
@@ -278,6 +293,11 @@ commands:
           environment:
             CIRCLE_NODE_INDEX: << parameters.index >>
             CIRCLE_NODE_TOTAL: << parameters.total >>
+            ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
+            PAYMENTS_DOMAIN: << pipeline.parameters.payments-domain >>
+            ACCOUNTS_API_DOMAIN: << pipeline.parameters.accounts-api-domain >>
+            RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
+            UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
           command: ./packages/fxa-content-server/scripts/test-ci-remote.sh
       - store-artifacts
 
@@ -331,6 +351,11 @@ commands:
             NODE_OPTIONS: --dns-result-order=ipv4first
             JEST_JUNIT_OUTPUT_DIR: ./artifacts/tests
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: true
+            ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
+            PAYMENTS_DOMAIN: << pipeline.parameters.payments-domain >>
+            ACCOUNTS_API_DOMAIN: << pipeline.parameters.accounts-api-domain >>
+            RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
+            UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
 
   store-artifacts:
     steps:

--- a/packages/functional-tests/lib/targets/production.ts
+++ b/packages/functional-tests/lib/targets/production.ts
@@ -1,14 +1,23 @@
 import { TargetName } from '.';
 import { RemoteTarget } from './remote';
 
+const ACCOUNTS_DOMAIN = process.env.ACCOUNTS_DOMAIN || 'accounts.firefox.com';
+const ACCOUNTS_API_DOMAIN =
+  process.env.ACCOUNTS_API_DOMAIN || 'api.accounts.firefox.com';
+const PAYMENTS_DOMAIN =
+  process.env.PAYMENTS_DOMAIN || 'subscriptions.firefox.com';
+const RELIER_DOMAIN =
+  process.env.RELIER_DOMAIN || 'production-123done.herokuapp.com';
+
 export class ProductionTarget extends RemoteTarget {
   static readonly target = 'production';
   readonly name: TargetName = ProductionTarget.target;
-  readonly contentServerUrl = 'https://accounts.firefox.com';
-  readonly paymentsServerUrl = 'https://subscriptions.firefox.com';
-  readonly relierUrl = 'https://production-123done.herokuapp.com/';
+
+  readonly contentServerUrl = `https://${ACCOUNTS_DOMAIN}`;
+  readonly paymentsServerUrl = `https://${PAYMENTS_DOMAIN}`;
+  readonly relierUrl = `https://${RELIER_DOMAIN}`;
 
   constructor() {
-    super('https://api.accounts.firefox.com');
+    super(`https://${ACCOUNTS_API_DOMAIN}`);
   }
 }

--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -1,15 +1,23 @@
 import { TargetName } from '.';
 import { RemoteTarget } from './remote';
 
+const ACCOUNTS_DOMAIN =
+  process.env.ACCOUNTS_DOMAIN || 'accounts.stage.mozaws.net';
+const ACCOUNTS_API_DOMAIN =
+  process.env.ACCOUNTS_API_DOMAIN || 'api-accounts.stage.mozaws.net';
+const PAYMENTS_DOMAIN =
+  process.env.PAYMENTS_DOMAIN || 'payments.stage.mozaws.net';
+const RELIER_DOMAIN =
+  process.env.RELIER_DOMAIN || 'stage-123done.herokuapp.com';
+
 export class StageTarget extends RemoteTarget {
   static readonly target = 'stage';
   readonly name: TargetName = StageTarget.target;
-  readonly contentServerUrl = 'https://accounts.stage.mozaws.net';
-  readonly paymentsServerUrl =
-    'https://payments-stage.fxa.nonprod.cloudops.mozgcp.net';
-  readonly relierUrl = 'https://stage-123done.herokuapp.com';
+  readonly contentServerUrl = `https://${ACCOUNTS_DOMAIN}`;
+  readonly paymentsServerUrl = `https://${PAYMENTS_DOMAIN}`;
+  readonly relierUrl = `https://${RELIER_DOMAIN}`;
 
   constructor() {
-    super('https://api-accounts.stage.mozaws.net');
+    super(`https://${ACCOUNTS_API_DOMAIN}`);
   }
 }

--- a/packages/fxa-content-server/scripts/test-ci-remote.sh
+++ b/packages/fxa-content-server/scripts/test-ci-remote.sh
@@ -13,12 +13,17 @@ function test_suite() {
   local numGroups=$2
   local i=$3
 
+  local fxaAccountsApiDomain="${ACCOUNTS_API_DOMAIN:-api-accounts.stage.mozaws.net}"
+  local fxaAccountsDomain="${ACCOUNTS_DOMAIN:-accounts.stage.mozaws.net}"
+  local relierDomain="${RELIER_DOMAIN:-stage-123done.herokuapp.com}"
+  local untrustedRelierDomain="${UNTRUSTED_RELIER_DOMAIN:-stage-123done-untrusted.herokuapp.com}"
+
   node tests/intern.js \
     --suites="${suite}" \
-    --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
-    --fxaContentRoot=https://accounts.stage.mozaws.net/ \
-    --fxaOAuthApp=https://stage-123done.herokuapp.com/ \
-    --fxaUntrustedOauthApp=https://stage-123done-untrusted.herokuapp.com/ \
+    --fxaAuthRoot=https://${fxaAccountsApiDomain}/v1 \
+    --fxaContentRoot=https://${fxaAccountsDomain}/ \
+    --fxaOAuthApp=https://${relierDomain}/ \
+    --fxaUntrustedOauthApp=https://${untrustedRelierDomain}/ \
     --fxaEmailRoot=http://restmail.net \
     --fxaProduction=true \
     --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \
@@ -29,10 +34,10 @@ function test_suite() {
     || \
   node tests/intern.js \
     --suites="${suite}" \
-    --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
-    --fxaContentRoot=https://accounts.stage.mozaws.net/ \
-    --fxaOAuthApp=https://stage-123done.herokuapp.com/ \
-    --fxaUntrustedOauthApp=https://stage-123done-untrusted.herokuapp.com/ \
+    --fxaAuthRoot=https://${fxaAccountsApiDomain}/v1 \
+    --fxaContentRoot=https://${fxaAccountsDomain}/ \
+    --fxaOAuthApp=https://${relierDomain}/ \
+    --fxaUntrustedOauthApp=https://${untrustedRelierDomain}/ \
     --fxaEmailRoot=http://restmail.net \
     --fxaProduction=true \
     --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \


### PR DESCRIPTION
## Because

- We want to try running smoke tests against a new environment

## This pull request

- Adds pipeline parameters for configuring standard domains
- Transfers pipeline parameters to a set of standard envs
- Updates playwright tests to use these envs
- Updates functional content server tests to use these envs

## Issue that this pull request solves

Closes: FXA-7017

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

