### PR TITLE
fix(newsletters): Update newsletter input selector

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
@@ -22,7 +22,7 @@
             <div class="graphic graphic-add-newsletters"></div>
 
             {{#newsletters}}
-                <div class="input-row marketing-email-optin-row">
+                <div class="input-row marketing-email-optin-row" id="newsletters-optin">
                     <input id="{{slug}}" type="checkbox" class="marketing-email-optin" value="{{slug}}"><label for="{{slug}}">{{label}}</label>
                 </div>
             {{/newsletters}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -47,7 +47,7 @@
       {{/isAnyNewsletterEnabled}}
 
       {{#newsletters}}
-          <div class="text-start my-4 flex items-center">
+          <div class="text-start my-4 flex items-center" id="newsletters-optin">
               <input id="{{slug}}" type="checkbox" class="input-checkbox" value="{{slug}}"><label for="{{slug}}" class="input-checkbox-label">{{label}}</label>
           </div>
       {{/newsletters}}

--- a/packages/fxa-content-server/app/scripts/views/mixins/email-opt-in-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/email-opt-in-mixin.js
@@ -8,7 +8,7 @@
 
 import Newsletters from '../../lib/newsletters';
 
-const MARKETING_EMAIL_CHECKBOX_SELECTOR = 'input.marketing-email-optin';
+const MARKETING_EMAIL_CHECKBOX_SELECTOR = '#newsletters-optin input';
 
 /**
  * Newsletters to their slugs

--- a/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
@@ -21,7 +21,7 @@ class AddNewsletters extends FormView {
 
   events = assign(this.events, {
     'click #maybe-later-btn': preventDefaultThen('clickMaybeLater'),
-    'click input.marketing-email-optin': 'toggleSubscribeButton',
+    'click #newsletters-optin input': 'toggleSubscribeButton',
   });
 
   beforeRender() {
@@ -76,10 +76,6 @@ class AddNewsletters extends FormView {
   }
 }
 
-Cocktail.mixin(
-  AddNewsletters,
-  EmailOptInMixin,
-  FlowEventsMixin
-);
+Cocktail.mixin(AddNewsletters, EmailOptInMixin, FlowEventsMixin);
 
 export default AddNewsletters;

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/email-opt-in-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/email-opt-in-mixin.js
@@ -13,7 +13,7 @@ class View extends BaseView {
   template(context) {
     const newsletters = context.newsletters.map((newsletter) => {
       //eslint-disable-next-line max-len
-      return `<input type="checkbox" id="${newsletter.slug}" class="marketing-email-optin" value="${newsletter.slug}" /><label for="${newsletter.slug}" >${newsletter.label}</label>`;
+      return `<div id="newsletters-optin"><input type="checkbox" id="${newsletter.slug}" class="marketing-email-optin" value="${newsletter.slug}" /><label for="${newsletter.slug}" >${newsletter.label}</label></div>`;
     });
     return `<div>${newsletters.join('\n')}</div>`;
   }


### PR DESCRIPTION
Because:
* Newsletters aren't being passed to Basket

This commit:
* Updates the selector used to grab the inputs

Fixes FXA-7306

---

We removed this class when converting some flows to Tailwind classes and didn't update the selector. The changes in `add_newsletter` aren't necessary to fix the bug but were updated for consistency.

You can test this by logging `options` in [sessionVerifyCode](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-client/lib/client.ts#L747) before the patch and seeing `newsletters` is not present in the object after verifying an account with newsletters selected, vs it being present in that object with this patch. (you can probably alternatively check the network tab)