### PR TITLE
feat(account): Allow user to delete account if no password set

### DIFF
--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -468,7 +468,7 @@ const conf = convict({
   googleAuthConfig: {
     clientId: {
       default:
-        '210899493109-gll5587a3bo8huare772alo08734o4kh.apps.googleusercontent.com',
+        '210899493109-u0erdakhegg6b572faenm3mn9hf4mdp8.apps.googleusercontent.com',
       env: 'GOOGLE_AUTH_CLIENT_ID',
       format: String,
       doc: 'Google auth client id',

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -198,7 +198,7 @@ const convictConf = convict({
   googleAuthConfig: {
     clientId: {
       default:
-        '210899493109-gll5587a3bo8huare772alo08734o4kh.apps.googleusercontent.com',
+        '210899493109-u0erdakhegg6b572faenm3mn9hf4mdp8.apps.googleusercontent.com',
       env: 'GOOGLE_AUTH_CLIENT_ID',
       format: String,
       doc: 'Google auth client id',

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3814,6 +3814,25 @@ describe('/account/destroy', () => {
     });
   });
 
+  it('should delete the password less account', () => {
+    mockDB = { ...mocks.mockDB({ email: email, uid: uid, verifierSetAt: 0 }) };
+    mockRequest = mocks.mockRequest({
+      log: mockLog,
+      payload: {
+        email: email,
+      },
+    });
+    const route = buildRoute();
+
+    return runTest(route, mockRequest, () => {
+      sinon.assert.calledOnceWithExactly(mockDB.accountRecord, email);
+      sinon.assert.calledWithMatch(mockDB.deleteAccount, {
+        uid,
+        email,
+      });
+    });
+  });
+
   it('does not fail if pushbox fails to delete', async () => {
     mockPushbox = { deleteAccount: sinon.fake.rejects() };
     try {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -336,6 +336,7 @@ function mockDB(data, errors) {
         },
         uid: data.uid,
         wrapWrapKb: crypto.randomBytes(32),
+        verifierSetAt: data.verifierSetAt ?? Date.now(),
       });
     }),
     consumeSigninCode: sinon.spy(() => {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -316,7 +316,7 @@ const conf = (module.exports = convict({
     },
     clientId: {
       default:
-        '210899493109-gll5587a3bo8huare772alo08734o4kh.apps.googleusercontent.com',
+        '210899493109-u0erdakhegg6b572faenm3mn9hf4mdp8.apps.googleusercontent.com',
       env: 'GOOGLE_AUTH_CLIENT_ID',
       format: String,
       doc: 'Google auth client id',

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
@@ -23,6 +23,7 @@ const account = {
   },
   uid: '0123456789abcdef',
   metricsEnabled: true,
+  hasPassword: true,
 } as unknown as Account;
 
 window.URL.createObjectURL = jest.fn();
@@ -142,5 +143,30 @@ describe('PageDeleteAccount', () => {
     expect(deleteAccountButton).toBeEnabled();
 
     expect(location.pathname).toContainEqual('/');
+  });
+
+  it('deletes account if no password set', async () => {
+    const pwdlessAccount = {
+      primaryEmail: {
+        email: 'rfeeley@mozilla.com',
+      },
+      uid: '0123456789abcdef',
+      metricsEnabled: true,
+      hasPassword: false,
+      destroy: jest.fn().mockResolvedValue({}),
+    } as unknown as Account;
+
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account: pwdlessAccount })}>
+        <PageDeleteAccount />
+      </AppContext.Provider>
+    );
+
+    await advanceStep();
+
+    expect(logViewEvent).toHaveBeenCalledWith(
+      'flow.settings.account-delete',
+      'confirm-password.success'
+    );
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -111,12 +111,17 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const account = useAccount();
 
   const advanceStep = () => {
-    setSubtitleText(
-      l10n.getString('delete-account-step-2-2', null, 'Step 2 of 2')
-    );
-    setConfirmed(true);
+    // Accounts that do not have a password set, will delete immediately
+    if (!account.hasPassword) {
+      deleteAccount('');
+    } else {
+      setSubtitleText(
+        l10n.getString('delete-account-step-2-2', null, 'Step 2 of 2')
+      );
+      setConfirmed(true);
 
-    logViewEvent('flow.settings.account-delete', 'terms-checked.success');
+      logViewEvent('flow.settings.account-delete', 'terms-checked.success');
+    }
   };
 
   const deleteAccount = useCallback(


### PR DESCRIPTION
## Because

- Users that create an account via third party auth (apple/google) might not have a password set and need to be able to delete their account

## This pull request

- Updates settings delete page to skip the confirm password screen if the account doesn't have a password
- Updates auth-server delete account route to handle case where password was not set

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7032

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
