### PR TITLE
feat(fxa-settings): create new flow container for account recovery

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.stories.tsx
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from '../../../../.storybook/decorators';
 import { FlowContainer } from '.';
+import { ProgressBar } from '../ProgressBar';
 import { LocationProvider } from '@reach/router';
 import { MOCK_CONTENT, MOCK_SUBTITLE, MOCK_TITLE } from './mocks';
 
@@ -27,3 +28,89 @@ export const Default = () => (
     {MOCK_CONTENT}
   </FlowContainer>
 );
+
+export const WizardExample = () => {
+  const [currentStep, setCurrentStep] = useState(1);
+  return (
+    <>
+      {currentStep === 1 && (
+        <FlowContainer
+          title="Example wizard flow"
+          {...{ currentStep, setCurrentStep }}
+          customBackButtonTitle="Previous page title"
+          customBackButtonLocalizationId="wizard-flow-back-button-title-first-step"
+          onBackButtonClick={() => {
+            window.history.back();
+          }}
+        >
+          <ProgressBar currentStep={1} numberOfSteps={3} />
+          <h2 className="font-bold text-xl mb-2">This is your first step.</h2>
+          <p>You should click the button below to proceed to the next step.</p>
+          <button
+            className="cta-primary cta-base-p m-2 flex-1"
+            type="button"
+            onClick={() => {
+              setCurrentStep(currentStep + 1);
+            }}
+          >
+            Next view
+          </button>
+        </FlowContainer>
+      )}
+      {currentStep === 2 && (
+        <FlowContainer
+          title="Example wizard flow"
+          {...{ currentStep, setCurrentStep }}
+          customBackButtonTitle="Example wizard flow"
+          customBackButtonLocalizationId="wizard-flow-back-button-title-wizard-step"
+          onBackButtonClick={() => {
+            setCurrentStep(currentStep - 1);
+          }}
+        >
+          <ProgressBar currentStep={2} numberOfSteps={3} />
+          <h2 className="font-bold text-xl mb-2">This is the second step.</h2>
+          <p>Click the button to proceed to the final step.</p>
+          <button
+            className="cta-primary cta-base-p m-2 flex-1"
+            type="button"
+            onClick={() => {
+              setCurrentStep(currentStep + 1);
+            }}
+          >
+            Next view
+          </button>
+        </FlowContainer>
+      )}
+      {
+        // Example wizard flow generated
+        currentStep === 3 && (
+          <FlowContainer
+            title="Example wizard flow"
+            {...{ currentStep, setCurrentStep }}
+            onBackButtonClick={() => {
+              setCurrentStep(currentStep - 1);
+            }}
+            customBackButtonTitle="Example wizard flow"
+            customBackButtonLocalizationId="wizard-flow-back-button-title-wizard-step"
+          >
+            <ProgressBar currentStep={3} numberOfSteps={3} />
+            <h2 className="font-bold text-xl mb-2">This is the end! </h2>
+            <p>
+              Take an arbitrary action by clicking the button, or navigate back
+              to a prior step.
+            </p>
+            <button
+              className="cta-primary cta-base-p m-2 flex-1"
+              type="button"
+              onClick={() => {
+                alert('You did it!');
+              }}
+            >
+              Finish flow
+            </button>
+          </FlowContainer>
+        )
+      }
+    </>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.tsx
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import { useFtlMsgResolver } from '../../../models';
 import { RouteComponentProps } from '@reach/router';
 import { ReactComponent as BackArrow } from './back-arrow.svg';
 import Head from 'fxa-react/components/Head';
-import { useLocalization } from '@fluent/react';
 
 type FlowContainerProps = {
   title?: string;
@@ -14,6 +14,8 @@ type FlowContainerProps = {
   onBackButtonClick?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => void;
+  customBackButtonTitle?: string;
+  customBackButtonLocalizationId?: string;
   children?: React.ReactNode;
 };
 
@@ -21,9 +23,18 @@ export const FlowContainer = ({
   title,
   subtitle,
   onBackButtonClick = () => window.history.back(),
+  customBackButtonTitle,
+  customBackButtonLocalizationId,
   children,
 }: FlowContainerProps & RouteComponentProps) => {
-  const { l10n } = useLocalization();
+  const ftlMsgResolver = useFtlMsgResolver();
+  const backButtonTitle =
+    customBackButtonTitle && customBackButtonLocalizationId
+      ? ftlMsgResolver.getMsg(
+          customBackButtonLocalizationId,
+          customBackButtonTitle
+        )
+      : ftlMsgResolver.getMsg('flow-container-back', 'Back');
   return (
     <div
       className={`max-w-lg mx-auto mt-6 p-6 pb-7 tablet:my-10 flex flex-col items-start bg-white shadow tablet:rounded-xl`}
@@ -35,7 +46,7 @@ export const FlowContainer = ({
         <button
           onClick={onBackButtonClick}
           data-testid="flow-container-back-btn"
-          title={l10n.getString('flow-container-back', null, 'Back')}
+          title={backButtonTitle}
           className="relative w-8 h-8 ltr:-ml-2 rtl:-mr-2 ltr:mr-2 rtl:ml-2 tablet:ltr:mr-10 tablet:rtl:ml-10 tablet:ltr:-ml-18 tablet:rtl:-mr-18"
         >
           <BackArrow

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from '../../../../.storybook/decorators';
+import { LocationProvider } from '@reach/router';
+import PageRecoveryKeyCreate from '.';
+
+export default {
+  title: 'Pages/Settings/PageRecoveryKeyCreate',
+  component: PageRecoveryKeyCreate,
+  decorators: [
+    withLocalization,
+    (Story) => (
+      <LocationProvider>
+        <Story />
+      </LocationProvider>
+    ),
+  ],
+} as Meta;
+
+export const Default = () => <PageRecoveryKeyCreate />;

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { usePageViewEvent } from '../../../lib/metrics';
+import PageRecoveryKeyCreate from '.';
+
+jest.mock('../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('PageRecoveryKeyCreate', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('renders as expected', () => {
+    // Content will be updated as views are completed.
+    render(<PageRecoveryKeyCreate />);
+    expect(screen.getByText('first step')).toBeInTheDocument();
+  });
+  it('shifts views when the user clicks through the flow steps', () => {
+    render(<PageRecoveryKeyCreate />);
+    expect(screen.getByText('first step')).toBeInTheDocument();
+    // TODO: We'll have to update this as the views are completed.
+    const nextButton = screen.getByText('click to move to next view');
+    fireEvent.click(nextButton);
+    expect(screen.getByText('second step')).toBeInTheDocument();
+  });
+  it('emits expected page view metrics on load', async () => {
+    render(<PageRecoveryKeyCreate />);
+    await waitFor(() => {
+      expect(usePageViewEvent).toHaveBeenCalledWith(
+        'settings.account-recovery'
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -2,18 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import React, { useState } from 'react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
+import { usePageViewEvent } from '../../../lib/metrics';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { HomePath } from '../../../constants';
 
-export const PageRecoveryKeyCreate = (_: RouteComponentProps) => {
+export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   const navigate = useNavigate();
   const goHome = () => navigate(HomePath + '#recovery-key', { replace: true });
+  const [currentStep, setCurrentStep] = useState(1);
+  usePageViewEvent('settings.account-recovery');
+
+  /*
+    The content here will obviously be replaced as we complete the separate views for this flow. This page will use the same pattern as the example wizard in storybook for `FlowContainer`. All steps will be separate components which use the `FlowContainer` and accept `currentStep` and `setCurrentStep` as the props necessary to move the user through the flow.
+  */
   return (
     <>
       <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
-      {/* TODO New content for recovery key flow will go here */}
-      Hello I'm the new Recovery Key Create Page
+      {
+        // Create an account recovery key
+        currentStep === 1 && (
+          <>
+            <p>first step</p>
+            <button
+              className="cta-primary cta-base-p mx-2 flex-1"
+              type="button"
+              onClick={() => {
+                setCurrentStep(currentStep + 1);
+              }}
+            >
+              click to move to next view
+            </button>
+          </>
+        )
+      }
+      {
+        // Enter your password again to get started
+        currentStep === 2 && <p>second step</p>
+      }
     </>
   );
 };


### PR DESCRIPTION
## Because:

* We want to manage the longer flow of views using a wizard component

## This commit:

* While this ticket originally asked for us to create a new flow container, revisions to the designs made a new Flow Container unnecessary. Instead, this PR builds out a simple Wizard to contain all of the UI for the PageRecoveryKeyAdd wizard, allowing us to somewhat separate the logic of the individual steps (views) of the wizard, and also separate the UI from the page logic.

Closes #FXA-7228

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1051" alt="Screen Shot 2023-04-20 at 2 08 55 PM" src="https://user-images.githubusercontent.com/11150372/233488204-0e8c1d98-916a-49b7-9530-a680b75e35f5.png">

<img width="1055" alt="Screen Shot 2023-04-20 at 2 09 03 PM" src="https://user-images.githubusercontent.com/11150372/233488216-0e8da473-8918-416b-86a4-afc85a03c505.png">
