### PR TITLE
chore(auth): remove stripe automatic tax feature flag

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -901,14 +901,6 @@ const convictConf = convict({
       format: String,
       doc: 'Stripe API key for direct Stripe integration',
     },
-    stripeAutomaticTax: {
-      enabled: {
-        default: false,
-        doc: 'Whether to enable automatic tax for Stripe',
-        env: 'SUBSCRIPTIONS_STRIPE_AUTOMATIC_TAX',
-        format: Boolean,
-      },
-    },
     stripeWebhookPayloadLimit: {
       default: 1048576,
       env: 'STRIPE_WEBHOOK_PAYLOAD_LIMIT',

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -183,11 +183,6 @@ export class StripeWebhookHandler extends StripeHandler {
       case 'invoice.upcoming':
         await this.handleInvoiceUpcomingEvent(request, event);
         break;
-      case 'payment_method.automatically_updated':
-      case 'payment_method.updated':
-      case 'payment_method.attached':
-        await this.handlePaymentMethodUpdated(request, event);
-        break;
       case 'product.created':
       case 'product.updated':
       case 'product.deleted':
@@ -242,37 +237,6 @@ export class StripeWebhookHandler extends StripeHandler {
       this.log.error('subscriptions.handleWebhookEvent.failure', { error });
     }
     return {};
-  }
-
-  /**
-   * Handle `payment_method.automatically_updated` and `payment_method.updated`
-   * Stripe webhook events.
-   *
-   * This requires us to check their subscription, and if its in a European
-   * country, ensure the VAT still matches the card country.
-   *
-   * Other card checks are performed before the update is accepted
-   */
-  async handlePaymentMethodUpdated(request: AuthRequest, event: Stripe.Event) {
-    const paymentMethod = event.data.object as Stripe.PaymentMethod;
-
-    // If this payment method isn't attached to a user, ignore it.
-    if (!paymentMethod.customer) {
-      return;
-    }
-    const customer = await this.stripeHelper.expandResource(
-      paymentMethod.customer,
-      CUSTOMER_RESOURCE
-    );
-    if (customer.deleted) {
-      // If the customer was deleted, ignore it.
-      return;
-    }
-    await this.stripeHelper.updateCustomerPaymentMethodTaxRates(
-      customer,
-      paymentMethod
-    );
-    return;
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -50,7 +50,6 @@ describe('PaypalProcessor', () => {
       currenciesToCountries: { ZAR: ['AS', 'CA'] },
       subscriptions: {
         paypalNvpSigCredentials: { enabled: false },
-        stripeAutomaticTax: { enabled: false },
       },
     };
     mockStripeHelper = {};

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -61,7 +61,6 @@ describe('PayPalNotificationHandler', () => {
       subscriptions: {
         enabled: true,
         stripeApiKey: 'sk_test_1234',
-        stripeAutomaticTax: { enabled: false },
         paypalNvpSigCredentials: {
           enabled: false,
         },

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -25,7 +25,6 @@ describe('remote account create', function () {
     config.subscriptions = {
       enabled: true,
       stripeApiKey: 'fake_key',
-      stripeAutomaticTax: { enabled: false },
       paypalNvpSigCredentials: {
         enabled: false,
       },

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -40,7 +40,6 @@ describe('#integration - remote subscriptions:', function () {
     config.subscriptions = {
       sharedSecret: 'wibble',
       paymentsServer: config.subscriptions.paymentsServer,
-      stripeAutomaticTax: { enabled: false },
     };
   });
 


### PR DESCRIPTION
## Because

* Stripe automatic tax is now rolled out for all customers
* We want to remove all Stripe tax rate behavior

## This pull request

* Removes the Stripe automatic tax feature flag
* Removes Stripe tax rate code
* Restructures some internal utilities such as previewInvoice now that Stripe automatic tax is always on.

## Issue that this pull request solves

Closes FXA-6091