### PR TITLE
fix(fxa-settings): Replace bullet used in recovery key download

### DIFF
--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
@@ -19,14 +19,14 @@ recovery-key-file-instructions = Store this file containing your account recover
 recovery-key-file-key-value = 🔑 Key:  { $recoveryKeyValue }
 
 # { $email }  - The primary email associated with the account
-recovery-key-file-user-email = ➤ { -product-firefox-account }: { $email }
+recovery-key-file-user-email = • { -product-firefox-account }: { $email }
 
 # Date when the recovery key was created and this file was downloaded
 # { $downloadDate } is a formatted date in the user's preferred locale
 # e.g., "12/11/2012" if run in en-US locale with time zone America/Los_Angeles
-recovery-key-file-download-date = ➤ Key generated: { $downloadDate }
+recovery-key-file-download-date = • Key generated: { $downloadDate }
 
 # Link to get more information and support
 # { $supportUrl } will be a URL such as https://mzl.la/3bNrM1I
 # The URL will not be hyperlinked and will be presented as plain text in the downloaded file
-recovery-key-file-support = ➤ Learn more about your account recovery key: { $supportURL }
+recovery-key-file-support = • Learn more about your account recovery key: { $supportURL }

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -42,13 +42,13 @@ export const ButtonDownloadRecoveryKey = ({
 
   const fileUserEmail = ftlMsgResolver.getMsg(
     'recovery-key-file-user-email',
-    `➤ Firefox account: ${primaryEmail.email}`,
+    `• Firefox account: ${primaryEmail.email}`,
     { email: primaryEmail.email }
   );
 
   const fileDate = ftlMsgResolver.getMsg(
     'recovery-key-file-download-date',
-    `➤ Key generated: ${downloadDateInLocale}`,
+    `• Key generated: ${downloadDateInLocale}`,
     { downloadDate: downloadDateInLocale }
   );
 
@@ -56,7 +56,7 @@ export const ButtonDownloadRecoveryKey = ({
 
   const fileSupport = ftlMsgResolver.getMsg(
     'recovery-key-file-support',
-    `➤ Learn more about your account recovery key: ${supportURL}`,
+    `• Learn more about your account recovery key: ${supportURL}`,
     { supportURL }
   );
 


### PR DESCRIPTION
## Because

- The arrow bullet that was previously used may not be well supported for RTL languages

## This pull request

- Replace arrow bullet with unidirectional circle bullet

## Issue that this pull request solves

Closes: #FXA-7331

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).