### PR TITLE
test(functional): fix timeout error

### DIFF
--- a/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
+++ b/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
@@ -30,13 +30,18 @@ test.describe('OAuth signin token code', () => {
   /* eslint-enable camelcase */
 
   test.beforeEach(async ({ target }, { project }) => {
-    test.skip(project.name === 'production', 'doesnt work in prod currently');
     // The `sync` prefix is needed to force confirmation.
     email = `sync${Math.random()}@restmail.net`;
-    await target.createAccount(email, password, {
-      // Important, must set this to be directed to /sign_in_token_code page
-      verificationMethod: 'email-otp',
-    });
+    await target.createAccount(email, password);
+  });
+
+  test.afterEach(async ({ target }) => {
+    if (email) {
+      // Cleanup any accounts created during the test
+      try {
+        await target.auth.accountDestroy(email, password);
+      } catch (e) {}
+    }
   });
 
   test('verified - invalid token', async ({


### PR DESCRIPTION
## Because

- The two tests for `Oauth Sign in token code` were failing in Stage and Prod with `Timeout error`

## This pull request

- Fixes the Stage and prod timeout errors and also adds steps for email cleanups after the tests.
- Below screenshot shows stage and prod runs for the tests
<img width="1354" alt="Screen Shot 2023-04-25 at 4 27 31 PM" src="https://user-images.githubusercontent.com/62558650/234396176-d30b954c-c579-42ff-9f2f-0d1ea446bc63.png">



## Issue that this pull request solves
Closes: #[FXA-7145](https://mozilla-hub.atlassian.net/browse/FXA-7145)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-7145]: https://mozilla-hub.atlassian.net/browse/FXA-7145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ