### PR TITLE
fix(reset_password): Update apollo cache after recovery key consumption

### DIFF
--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -115,5 +115,8 @@ test.describe('recovery key react', () => {
 
     // Cleanup requires setting this value to correct password
     credentials.password = NEW_PASSWORD;
+
+    await page.locator('text="Generate a new account recovery key"').click();
+    await page.waitForURL(/settings\/account_recovery/);
   });
 });

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1222,5 +1222,14 @@ export class Account implements AccountData {
       { kB: opts.kB }
     );
     currentAccount(data);
+    const cache = this.apolloClient.cache;
+    cache.modify({
+      id: cache.identify({ __typename: 'Account' }),
+      fields: {
+        recoveryKey() {
+          return false;
+        },
+      },
+    });
   }
 }


### PR DESCRIPTION
Because:
* Users were not taken to the generate new account recovery key flow after resetting with an account recovery key since apollo cache still had this value set to true

This commit:
* Updates the cache to reflect that the account no longer has a recovery key after a successful password reset with recovery key

Closes FXA-7163

---

We don't currently have tests for `Account.ts`, and it feels like this should be tested in an end-to-end test anyway.