### PR TITLE
feat(auth): customer mover script

### DIFF
--- a/packages/fxa-auth-server/scripts/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/move-customers-to-new-plan.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+
+import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+import { CustomerPlanMover } from './move-customers-to-new-plan/move-customers-to-new-plan';
+
+const pckg = require('../package.json');
+
+const parseBatchSize = (batchSize: string | number) => {
+  return parseInt(batchSize.toString(), 10);
+};
+
+const parseRateLimit = (rateLimit: string | number) => {
+  return parseInt(rateLimit.toString(), 10);
+};
+
+const parseExcludePlanIds = (planIds: string) => {
+  return planIds.split(',');
+};
+
+async function init() {
+  program
+    .version(pckg.version)
+    .option(
+      '-b, --batch-size [number]',
+      'Number of subscriptions to query from firestore at a time.  Defaults to 100.',
+      100
+    )
+    .option(
+      '-o, --output-file [string]',
+      'Output file to write report to. Will be output in CSV format.  Defaults to move-customers-to-new-plan-output.csv.',
+      'move-customers-to-new-plan-output.csv'
+    )
+    .option(
+      '-r, --rate-limit [number]',
+      'Rate limit for Stripe. Defaults to 70',
+      70
+    )
+    .option(
+      '-s, --source [string]',
+      'Source Stripe plan ID. All customers on this price ID will be moved off of this price ID'
+    )
+    .option(
+      '-d, --destination [string]',
+      'Destination Stripe plan ID. All customers on the source price ID will be moved to this price ID'
+    )
+    .option(
+      '-e, --exclude [string]',
+      'Do not sign customers up for the destination plan if they have a subscription to a price in this list',
+      ''
+    )
+    .parse(process.argv);
+
+  const { stripeHelper, database } = await setupProcessingTaskObjects(
+    'move-customers-to-new-plan'
+  );
+
+  const batchSize = parseBatchSize(program.batchSize);
+  const rateLimit = parseRateLimit(program.rateLimit);
+  const excludePlanIds = parseExcludePlanIds(program.exclude);
+
+  if (!program.source) throw new Error('--source must be provided');
+  if (!program.destination) throw new Error('--destination must be provided');
+
+  const customerPlanMover = new CustomerPlanMover(
+    program.source,
+    program.destination,
+    excludePlanIds,
+    batchSize,
+    program.outputFile,
+    stripeHelper,
+    database,
+    rateLimit
+  );
+
+  await customerPlanMover.convert();
+
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/scripts/move-customers-to-new-plan/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/move-customers-to-new-plan/move-customers-to-new-plan.ts
@@ -1,0 +1,273 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Stripe from 'stripe';
+import { Firestore } from '@google-cloud/firestore';
+import Container from 'typedi';
+import fs from 'fs';
+import PQueue from 'p-queue';
+
+import { AppConfig, AuthFirestore } from '../../lib/types';
+import { ConfigType } from '../../config';
+import { StripeHelper } from '../../lib/payments/stripe';
+
+/**
+ * Firestore subscriptions contain additional expanded information
+ * on top of the base Stripe.Subscription type
+ */
+export interface FirestoreSubscription extends Stripe.Subscription {
+  customer: string;
+  plan: Stripe.Plan;
+  price: Stripe.Price;
+}
+
+export class CustomerPlanMover {
+  private config: ConfigType;
+  private firestore: Firestore;
+  private stripeQueue: PQueue;
+  private stripe: Stripe;
+
+  /**
+   * A converter to move customers from one plan to another
+   * @param sourcePlanId A Stripe plan or price ID which customers will be moved off of
+   * @param destinationPlanId A Stripe plan or price ID which customers will be moved to
+   * @param excludePlanIds A list of Stripe plan or price ID which if customers have will not be subscribed to the destination plan
+   * @param batchSize Number of subscriptions to fetch from Firestore at a time
+   * @param outputFile A CSV file to output a report of affected subscriptions to
+   * @param stripeHelper An instance of StripeHelper
+   * @param rateLimit A limit for number of stripe requests within the period of 1 second
+   * @param database A reference to the FXA database
+   */
+  constructor(
+    private sourcePlanId: string,
+    private destinationPlanId: string,
+    private excludePlanIds: string[],
+    private batchSize: number,
+    private outputFile: string,
+    private stripeHelper: StripeHelper,
+    private database: any,
+    rateLimit: number
+  ) {
+    this.stripe = stripeHelper.stripe;
+
+    const config = Container.get<ConfigType>(AppConfig);
+    this.config = config;
+
+    const firestore = Container.get<Firestore>(AuthFirestore);
+    this.firestore = firestore;
+
+    this.stripeQueue = new PQueue({
+      intervalCap: rateLimit,
+      interval: 1000, // Stripe measures it's rate limit per second
+    });
+  }
+
+  /**
+   * Move all customers from the source plan to the destination plan in batches
+   */
+  async convert() {
+    let startAfter: string | null = null;
+    let hasMore = true;
+
+    while (hasMore) {
+      const subscriptions = await this.fetchSubsBatch(startAfter);
+
+      startAfter = subscriptions.at(-1)?.id as string;
+      if (!startAfter) hasMore = false;
+
+      await Promise.all(
+        subscriptions.map((sub) => this.convertSubscription(sub))
+      );
+    }
+  }
+
+  /**
+   * Fetches subscriptions from Firestore paginated by batchSize
+   * @param startAfter ID of the last element of the previous batch for pagination
+   * @returns A list of subscriptions from firestore
+   */
+  async fetchSubsBatch(startAfter: string | null) {
+    const collectionPrefix = `${this.config.authFirestore.prefix}stripe-`;
+    const subscriptionCollection = `${collectionPrefix}subscriptions`;
+
+    const subscriptionSnap = await this.firestore
+      .collectionGroup(subscriptionCollection)
+      .where('plan.id', '==', this.sourcePlanId)
+      .orderBy('id')
+      .startAfter(startAfter)
+      .limit(this.batchSize)
+      .get();
+
+    const subscriptions = subscriptionSnap.docs.map(
+      (doc) => doc.data() as FirestoreSubscription
+    );
+
+    return subscriptions;
+  }
+
+  /**
+   * Attempts to move a customer off of the source price ID
+   * and subscribing any customers who do not have an excluded price ID to the destination price ID
+   * @param firestoreSubscription The subscription to convert
+   */
+  async convertSubscription(firestoreSubscription: FirestoreSubscription) {
+    const { id: subscriptionId, customer: customerId } = firestoreSubscription;
+
+    try {
+      const customer = await this.fetchCustomer(customerId);
+      if (!customer?.subscriptions?.data) {
+        console.error(`Customer not found: ${customerId}`);
+        return;
+      }
+
+      const account = await this.database.account(customer.metadata.userid);
+      if (!account) {
+        console.error(`Account not found: ${customer.metadata.userid}`);
+        return;
+      }
+
+      await this.cancelSubscription(firestoreSubscription);
+
+      const isExcluded = this.isCustomerExcluded(customer.subscriptions.data);
+      if (!isExcluded) await this.createSubscription(customer.id);
+
+      const report = this.buildReport(customer, account, isExcluded);
+
+      await this.writeReport(report);
+
+      console.log(subscriptionId);
+    } catch (e) {
+      console.error(subscriptionId, e);
+    }
+  }
+
+  /**
+   * Retrieves a customer record directly from Stripe
+   * @param customerId The Stripe customer ID of the customer to fetch
+   * @returns The customer record for the customerId provided, or null if not found or deleted
+   */
+  async fetchCustomer(customerId: string) {
+    const customer = await this.enqueueRequest(() =>
+      this.stripe.customers.retrieve(customerId, {
+        expand: ['subscriptions'],
+      })
+    );
+
+    if (customer.deleted) return null;
+
+    return customer;
+  }
+
+  /**
+   * Cancel subscription and refund customer for latest bill
+   * @param subscription The subscription to cancel
+   */
+  async cancelSubscription(subscription: Stripe.Subscription) {
+    await this.enqueueRequest(() =>
+      this.stripe.subscriptions.cancel(subscription.id, {
+        prorate: false, // We are going to refund, so do not prorate
+      })
+    );
+
+    if (!subscription.latest_invoice) {
+      console.log(`No latest invoice for ${subscription.id}`);
+      return;
+    }
+
+    const latestInvoiceId =
+      typeof subscription.latest_invoice === 'string'
+        ? subscription.latest_invoice
+        : subscription.latest_invoice.id;
+
+    const invoice = await this.enqueueRequest(() =>
+      this.stripe.invoices.retrieve(latestInvoiceId)
+    );
+
+    const chargeId =
+      typeof invoice.charge === 'string' ? invoice.charge : invoice.charge?.id;
+    if (!chargeId) {
+      console.log(`No charge for ${invoice.id}`);
+      return;
+    }
+
+    console.log(`Refunding ${chargeId}`);
+    await this.enqueueRequest(() =>
+      this.stripe.refunds.create({
+        charge: chargeId,
+      })
+    );
+  }
+
+  /**
+   * Check if a customer's list of subscriptions contains an excluded price ID
+   * @param subscriptions List of subscriptions to check for an excluded price ID in
+   */
+  isCustomerExcluded(subscriptions: Stripe.Subscription[]) {
+    for (const subscription of subscriptions) {
+      for (const item of subscription.items.data) {
+        if (this.excludePlanIds.includes(item.plan.id)) return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Create a subscription to the destinationPlanId
+   * @param customerId The customer ID to create a subscription for
+   */
+  async createSubscription(customerId: string) {
+    await this.enqueueRequest(() =>
+      this.stripe.subscriptions.create({
+        customer: customerId,
+        items: [
+          {
+            price: this.destinationPlanId,
+          },
+        ],
+      })
+    );
+  }
+
+  /**
+   * Creates an ordered array of fields destined for CSV format
+   * @returns An array representing the fields to be output to CSV
+   */
+  buildReport(customer: Stripe.Customer, account: any, isExcluded: boolean) {
+    // We build a temporary object first for readability & maintainability purposes
+    const report = {
+      uid: customer.metadata.userid,
+      email: customer.email,
+      isExcluded: isExcluded.toString(),
+
+      locale: account.locale,
+    };
+
+    return [
+      report.uid,
+      `"${report.email}"`,
+      report.isExcluded,
+      `"${report.locale}"`,
+    ];
+  }
+
+  /**
+   * Appends the report to the output file
+   * @param report an array representing the report CSV
+   */
+  async writeReport(report: (string | number | null)[]) {
+    const reportCSV = report.join(',') + '\n';
+
+    await fs.promises.writeFile(this.outputFile, reportCSV, {
+      flag: 'a+',
+      encoding: 'utf-8',
+    });
+  }
+
+  async enqueueRequest<T>(callback: () => T): Promise<T> {
+    return this.stripeQueue.add(callback, {
+      throwOnTimeout: true,
+    });
+  }
+}

--- a/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
@@ -1,0 +1,376 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+import cp from 'child_process';
+import util from 'util';
+import path from 'path';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import Container from 'typedi';
+
+import { ConfigType } from '../../config';
+import { AppConfig, AuthFirestore } from '../../lib/types';
+
+import {
+  CustomerPlanMover,
+  FirestoreSubscription,
+} from '../../scripts/move-customers-to-new-plan/move-customers-to-new-plan';
+import Stripe from 'stripe';
+import { StripeHelper } from '../../lib/payments/stripe';
+
+import product1 from '../local/payments/fixtures/stripe/product1.json';
+import customer1 from '../local/payments/fixtures/stripe/customer1.json';
+import subscription1 from '../local/payments/fixtures/stripe/subscription1.json';
+
+const mockProduct = product1 as unknown as Stripe.Product;
+const mockCustomer = customer1 as unknown as Stripe.Customer;
+const mockSubscription = subscription1 as unknown as FirestoreSubscription;
+
+const mockAccount = {
+  locale: 'en-US',
+};
+
+const ROOT_DIR = '../..';
+const execAsync = util.promisify(cp.exec);
+const cwd = path.resolve(__dirname, ROOT_DIR);
+const execOptions = {
+  cwd,
+  env: {
+    ...process.env,
+    NODE_ENV: 'dev',
+    LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
+  },
+};
+
+describe('starting script', () => {
+  it('does not fail', function () {
+    this.timeout(20000);
+    return execAsync(
+      'node -r esbuild-register scripts/remove-unverified-accounts.ts',
+      execOptions
+    );
+  });
+});
+
+const mockConfig = {
+  authFirestore: {
+    prefix: 'mock-fxa-',
+  },
+  subscriptions: {
+    playApiServiceAccount: {
+      credentials: {
+        clientEmail: 'mock-client-email',
+      },
+      keyFile: 'mock-private-keyfile',
+    },
+    productConfigsFirestore: {
+      schemaValidation: {
+        cdnUrlRegex: '^http',
+      },
+    },
+  },
+} as unknown as ConfigType;
+
+describe('CustomerPlanMover', () => {
+  let customerPlanMover: CustomerPlanMover;
+  let stripeStub: Stripe;
+  let stripeHelperStub: StripeHelper;
+  let dbStub: any;
+  let firestoreGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    firestoreGetStub = sinon.stub();
+    Container.set(AuthFirestore, {
+      collectionGroup: sinon.stub().returns({
+        where: sinon.stub().returnsThis(),
+        orderBy: sinon.stub().returnsThis(),
+        startAfter: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        get: firestoreGetStub,
+      }),
+    });
+
+    Container.set(AppConfig, mockConfig);
+
+    stripeStub = {
+      on: sinon.stub(),
+      products: {},
+      customers: {},
+      subscriptions: {},
+      invoices: {},
+    } as unknown as Stripe;
+
+    stripeHelperStub = {
+      stripe: stripeStub,
+      currencyHelper: {
+        isCurrencyCompatibleWithCountry: sinon.stub(),
+      },
+    } as unknown as StripeHelper;
+
+    dbStub = {
+      account: sinon.stub(),
+    };
+
+    customerPlanMover = new CustomerPlanMover(
+      'source',
+      'destination',
+      ['exclude'],
+      100,
+      './move-customers-to-new-plan.tmp.csv',
+      stripeHelperStub,
+      dbStub,
+      20
+    );
+  });
+
+  describe('convert', () => {
+    let fetchSubsBatchStub: sinon.SinonStub;
+    let convertSubscriptionStub: sinon.SinonStub;
+    const mockSubs = [mockSubscription];
+
+    beforeEach(async () => {
+      fetchSubsBatchStub = sinon
+        .stub()
+        .onFirstCall()
+        .returns(mockSubs)
+        .onSecondCall()
+        .returns([]);
+      customerPlanMover.fetchSubsBatch = fetchSubsBatchStub;
+
+      convertSubscriptionStub = sinon.stub();
+      customerPlanMover.convertSubscription = convertSubscriptionStub;
+
+      await customerPlanMover.convert();
+    });
+
+    it('fetches subscriptions until no results', () => {
+      expect(fetchSubsBatchStub.callCount).eq(2);
+    });
+
+    it('generates a report for each applicable subscription', () => {
+      expect(convertSubscriptionStub.callCount).eq(1);
+    });
+  });
+
+  describe('fetchSubsBatch', () => {
+    const mockSubscriptionId = 'mock-id';
+    let result: FirestoreSubscription[];
+
+    beforeEach(async () => {
+      firestoreGetStub.resolves({
+        docs: [
+          {
+            data: sinon.stub().returns(mockSubscription),
+          },
+        ],
+      });
+
+      result = await customerPlanMover.fetchSubsBatch(mockSubscriptionId);
+    });
+
+    it('returns a list of subscriptions from Firestore', () => {
+      sinon.assert.match(result, [mockSubscription]);
+    });
+  });
+
+  describe('convertSubscription', () => {
+    const mockFirestoreSub = {
+      id: 'test',
+      customer: 'test',
+      plan: {
+        product: 'example-product',
+      },
+    } as FirestoreSubscription;
+    const mockReport = ['mock-report'];
+    let logStub: sinon.SinonStub;
+    let cancelSubscriptionStub: sinon.SinonStub;
+    let createSubscriptionStub: sinon.SinonStub;
+    let isCustomerExcludedStub: sinon.SinonStub;
+    let buildReport: sinon.SinonStub;
+    let writeReportStub: sinon.SinonStub;
+
+    beforeEach(async () => {
+      stripeStub.products.retrieve = sinon.stub().resolves(mockProduct);
+      customerPlanMover.fetchCustomer = sinon.stub().resolves(mockCustomer);
+      dbStub.account.resolves({
+        locale: 'en-US',
+      });
+      cancelSubscriptionStub = sinon.stub().resolves();
+      customerPlanMover.cancelSubscription = cancelSubscriptionStub;
+      createSubscriptionStub = sinon.stub().resolves();
+      customerPlanMover.createSubscription = createSubscriptionStub;
+      isCustomerExcludedStub = sinon.stub().returns(false);
+      customerPlanMover.isCustomerExcluded = isCustomerExcludedStub;
+      buildReport = sinon.stub().returns(mockReport);
+      customerPlanMover.buildReport = buildReport;
+      writeReportStub = sinon.stub().resolves();
+      customerPlanMover.writeReport = writeReportStub;
+      logStub = sinon.stub(console, 'log');
+    });
+
+    afterEach(() => {
+      logStub.restore();
+    });
+
+    describe('success', () => {
+      beforeEach(async () => {
+        await customerPlanMover.convertSubscription(mockFirestoreSub);
+      });
+
+      it('cancels old subscription', () => {
+        expect(cancelSubscriptionStub.calledWith(mockFirestoreSub)).true;
+      });
+
+      it('creates new subscription', () => {
+        expect(createSubscriptionStub.calledWith(mockCustomer.id)).true;
+      });
+
+      it('writes the report to disk', () => {
+        expect(writeReportStub.calledWith(mockReport)).true;
+      });
+    });
+
+    describe('invalid', () => {
+      it('aborts if customer does not exist', async () => {
+        customerPlanMover.fetchCustomer = sinon.stub().resolves(null);
+        await customerPlanMover.convertSubscription(mockFirestoreSub);
+
+        expect(writeReportStub.notCalled).true;
+      });
+
+      it('aborts if account for customer does not exist', async () => {
+        dbStub.account.resolves(null);
+        await customerPlanMover.convertSubscription(mockFirestoreSub);
+
+        expect(writeReportStub.notCalled).true;
+      });
+
+      it('does not create subscription if customer is excluded', async () => {
+        customerPlanMover.isCustomerExcluded = sinon.stub().resolves(true);
+        await customerPlanMover.convertSubscription(mockFirestoreSub);
+
+        expect(createSubscriptionStub.notCalled).true;
+      });
+    });
+  });
+
+  describe('fetchCustomer', () => {
+    let customerRetrieveStub: sinon.SinonStub;
+    let result: Stripe.Customer | Stripe.DeletedCustomer | null;
+
+    describe('customer exists', () => {
+      beforeEach(async () => {
+        customerRetrieveStub = sinon.stub().resolves(mockCustomer);
+        stripeStub.customers.retrieve = customerRetrieveStub;
+
+        result = await customerPlanMover.fetchCustomer(mockCustomer.id);
+      });
+
+      it('fetches customer from Stripe', () => {
+        expect(
+          customerRetrieveStub.calledWith(mockCustomer.id, {
+            expand: ['subscriptions'],
+          })
+        ).true;
+      });
+
+      it('returns customer', () => {
+        sinon.assert.match(result, mockCustomer);
+      });
+    });
+
+    describe('customer deleted', () => {
+      beforeEach(async () => {
+        const deletedCustomer = {
+          ...mockCustomer,
+          deleted: true,
+        };
+        customerRetrieveStub = sinon.stub().resolves(deletedCustomer);
+        stripeStub.customers.retrieve = customerRetrieveStub;
+
+        result = await customerPlanMover.fetchCustomer(mockCustomer.id);
+      });
+
+      it('returns null', () => {
+        sinon.assert.match(result, null);
+      });
+    });
+  });
+
+  describe('isCustomerExcluded', () => {
+    it("returns true if the customer has a price that's excluded", () => {
+      const result = customerPlanMover.isCustomerExcluded([
+        {
+          ...mockSubscription,
+          items: {
+            ...mockSubscription.items,
+            data: [
+              {
+                ...mockSubscription.items.data[0],
+                plan: {
+                  ...mockSubscription.items.data[0].plan,
+                  id: 'exclude',
+                },
+              },
+            ],
+          },
+        },
+      ]);
+      expect(result).true;
+    });
+
+    it("returns false if the customer does not have a price that's excluded", () => {
+      const result = customerPlanMover.isCustomerExcluded([
+        {
+          ...subscription1,
+        },
+      ]);
+      expect(result).false;
+    });
+  });
+
+  describe('createSubscription', () => {
+    let createStub: sinon.SinonStub;
+
+    beforeEach(async () => {
+      createStub = sinon.stub().resolves(mockSubscription);
+      stripeStub.subscriptions.create = createStub;
+
+      await customerPlanMover.createSubscription(mockCustomer.id);
+    });
+
+    it('creates a subscription', () => {
+      expect(
+        createStub.calledWith({
+          customer: mockCustomer.id,
+          items: [
+            {
+              price: 'destination',
+            },
+          ],
+        })
+      ).true;
+    });
+  });
+
+  describe('buildReport', () => {
+    it('returns a report', () => {
+      const result = customerPlanMover.buildReport(
+        mockCustomer,
+        mockAccount,
+        true
+      );
+
+      sinon.assert.match(result, [
+        mockCustomer.metadata.userid,
+        `"${mockCustomer.email}"`,
+        'true',
+        `"${mockAccount.locale}"`,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Because

* We need to be able to migrate customers off of a given plan.

## This pull request

* Adds a script to move customers from one plan to another.

## Issue that this pull request solves

Closes FXA-7125
Closes FXA-7122
