### PR TITLE
[wip]feat(payments): update keyboard a11y on disabled form

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -99,7 +99,6 @@ export type BasePaymentFormProps = {
   submitNonce: string;
   promotionCode?: string;
   invoicePreview?: FirstInvoicePreview;
-  disabled?: boolean;
 } & WithLocalizationProps;
 
 export const PaymentForm = ({
@@ -121,7 +120,6 @@ export const PaymentForm = ({
   submitNonce,
   promotionCode,
   invoicePreview,
-  disabled = false,
 }: BasePaymentFormProps) => {
   const isStripeCustomer = isExistingStripeCustomer(customer);
 
@@ -278,7 +276,6 @@ export const PaymentForm = ({
             onValidate={(value, focused, props) =>
               validateName(value, focused, props, getString)
             }
-            disabled={disabled}
           />
         </Localized>
 
@@ -291,7 +288,6 @@ export const PaymentForm = ({
             options={STRIPE_ELEMENT_STYLES}
             getString={getString}
             required
-            disabled={disabled}
           />
         </Localized>
       </>

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -167,7 +167,6 @@ const UnwrappedInput = (props: InputProps) => {
     required = false,
     className,
     getString,
-    disabled = false,
     ...childProps
   } = props;
 
@@ -251,7 +250,6 @@ const UnwrappedInput = (props: InputProps) => {
           value: validator.getValue(name, ''),
           onBlur,
           onChange,
-          disabled,
         }}
       />
     </Field>
@@ -298,7 +296,6 @@ type StripeElementWrapperProps = FieldProps & {
   onValidate?: OnValidateFunction;
   component: any;
   getString?: Function;
-  disabled?: boolean;
 };
 
 type WrappedStripeElementProps = StripeElementWrapperProps & CardElementProps;
@@ -314,7 +311,6 @@ export const StripeElement = (props: WrappedStripeElementProps) => {
     className,
     autoFocus,
     getString,
-    disabled = false,
     ...childProps
   } = props;
   const { validator } = useContext(FormContext) as FormContextValue;
@@ -361,7 +357,6 @@ export const StripeElement = (props: WrappedStripeElementProps) => {
             ...childProps,
             onChange,
             onBlur,
-            disabled,
           }}
         />
       </div>


### PR DESCRIPTION
## Because

- Elements are still tabbable while form is disabled.

## This pull request

- Adds `tabindex="-1"` to interactive form elements when disabled and removes attribute to return to DOM sequence for keyboard navigation when enabled.

## Issue that this pull request solves

Closes: FXA-7340

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).