### PR TITLE
fix(customs): refactor customs server export syntax

### DIFF
--- a/packages/fxa-customs-server/bin/customs_server.js
+++ b/packages/fxa-customs-server/bin/customs_server.js
@@ -56,4 +56,4 @@ process.on('unhandledRejection', (err) => {
 
 const initPromise = init();
 
-export default initPromise;
+module.exports = initPromise;


### PR DESCRIPTION
## Because

- Customs is failing to start up due to SyntaxError.

## This pull request

- Replace ESM export default with CommonJS syntax

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
