### PR TITLE
fix(reset_password): Don't accept a recovery key with additional character

### DIFF
--- a/packages/fxa-settings/src/lib/utilities.test.ts
+++ b/packages/fxa-settings/src/lib/utilities.test.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { deepMerge, searchParam, searchParams } from './utilities';
+import {
+  deepMerge,
+  isBase32Crockford,
+  searchParam,
+  searchParams,
+} from './utilities';
 
 describe('deepMerge', () => {
   it('recursively merges multiple objects', () => {
@@ -91,5 +96,22 @@ describe('searchParams', () => {
 
     params = searchParams('', ['blue']);
     expect(Object.keys(params)).toHaveLength(0);
+  });
+});
+
+describe('isBase32Crockford', () => {
+  it('is case insensitive', () => {
+    expect(isBase32Crockford('ADF2EGK4HJJ4BTKF')).toBe(true);
+    expect(isBase32Crockford('adf2egk4hjj4btkf')).toBe(true);
+    expect(isBase32Crockford('Adf2eGk4hjJ4BtKF')).toBe(true);
+  });
+
+  it('rejects I, L, O, U', () => {
+    expect(isBase32Crockford('0123456789ABCDEFGHJKMNPQRSTVWXYZ')).toBe(true);
+
+    expect(isBase32Crockford('I')).toBe(false);
+    expect(isBase32Crockford('L')).toBe(false);
+    expect(isBase32Crockford('O')).toBe(false);
+    expect(isBase32Crockford('U')).toBe(false);
   });
 });

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -100,3 +100,9 @@ export function isMobileDevice(client?: AttachedClient) {
   }
   return /mobi/i.test(navigator.userAgent);
 }
+
+// Crockford base32 Regex. Case insensitive and excludes I, L, O, U
+const B32_STRING = /^[0-9A-HJ-KM-NP-TV-Z]+$/i;
+export function isBase32Crockford(value: string) {
+  return B32_STRING.test(value);
+}

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
@@ -10,6 +10,10 @@ import { mockAppContext } from '../../../models/mocks';
 import AccountRecoveryConfirmKey from '.';
 
 export const MOCK_SERVICE_NAME = MozServices.FirefoxSync;
+export const MOCK_RECOVERY_KEY = 'ARJDF300TFEPRJ7SFYB8QVNVYT60WWS2';
+export const MOCK_RESET_TOKEN = 'mockResetToken';
+export const MOCK_RECOVERY_KEY_ID = 'mockRecoveryKeyId';
+export const MOCK_KB = 'mockkB';
 
 export const Subject = ({
   account,

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -56,7 +56,6 @@ export function mockUrlQueryData(
   for (const param of Object.keys(params)) {
     data.set(param, params[param]);
   }
-  console.log('data!!!!', data);
   return data;
 }
 


### PR DESCRIPTION
Because:
* Recovery keys with an additional character were being accepted as valid due to how base32-decode works, wherein each character represents 5 bits of data which are ultimately split into 8-bit segments, and one extra character is not enough to change the resulting value

This commits:
* Disallows submission for recovery keys that are not 32 characters long, allowing for spaces in submission
* Clears errors onchange to better match parity
* Increases test coverage

Fixes FXA-7171

--

Mostly copied from my earlier Slack comment:

My understanding of the issue is when we decode the recovery key, the input string is 1) [processed one character at a time](https://github.com/LinusU/base32-decode/blob/a6601b2f57be2b2db954e939c66d09610256b5a4/index.js#L44), 2) each character is converted to the 5-bit value, and 3) the 5-bit values are combined and then split into 8-bit segments.

The difference between a 32-character recovery key and a 33-character recovery key is only 5 bits, which is not enough to produce a different byte in the output, meaning the buffers created are equal and therefore there’s no difference in the decoded output with one additional character. [See this](https://replit.com/@LZoog/Crockford-Base32-Experiments#index.js) demonstrating the problem.

While this feels kind of like a bandaid, I could be wrong here but it seems like we might need to change the encode/decode strategy to address the root of the problem, and I'm not sure that we can reject the value on the back-end since we decode on the front-end.

Note that this only fixes the React version.