### PR TITLE
bug(fxa-content-server): fix password balloon and eye toggle

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/password-strength-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-strength-mixin.js
@@ -28,7 +28,7 @@ export default function (config = {}) {
     afterRender() {
       return Promise.resolve().then(() => {
         if (!this.$(passwordEl).length) {
-          // Only attach the balloon iff there is a password element. This avoids
+          // Only attach the balloon if there is a password element. This avoids
           // problems in the reset-password screen when using the account recovery key
           return;
         }

--- a/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
@@ -115,7 +115,7 @@ Cocktail.mixin(
   SetPassword,
   PasswordMixin,
   PasswordStrengthMixin({
-    balloonEl: '#password-strength-balloon',
+    balloonEl: '#password-strength-balloon-container',
     passwordEl: '#password',
   }),
   FlowEventsMixin

--- a/packages/fxa-content-server/app/styles/tailwind/inputs.css
+++ b/packages/fxa-content-server/app/styles/tailwind/inputs.css
@@ -48,7 +48,8 @@
   }
 }
 
-.input-password-toggle {
+/* doubling up this selector lets us override some tricky checkbox styles showing up in password inputs and hiding the toggle */
+.input-password-toggle, #main-content input[type="checkbox"] ~ label.input-password-toggle {
   @apply opacity-0 absolute w-1;
 
   &-label {
@@ -67,6 +68,7 @@
     }
   }
 }
+
 
 @media (hover: hover) {
   .input-checkbox {


### PR DESCRIPTION
## Because:

* The password balloon and eye toggle weren't showing up on password input for the post_verify/finish_account_setup/set_password view in fxa-content-server.

## This commit:

* Supplies the correct element ID for the password balloon so that it will be applied correctly, and fixes an accidental CSS override in the cascade.

Closes #FXA-7083

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


<img width="823" alt="Screen Shot 2023-05-02 at 9 44 47 AM" src="https://user-images.githubusercontent.com/11150372/235731007-3bbeb88f-9dbb-48b8-aa4a-b8a2626b1ea2.png">
