### PR TITLE
feat(url): Add support to immediately redirect to a page after Sync signin

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -47,6 +47,14 @@ const ConnectAnotherDeviceView = FormView.extend({
     if (this.isEligibleForPairing()) {
       return this.replaceCurrentPageWithPairScreen();
     }
+
+    // Some RPs specify a `redirect_to` query param, check to see if this should
+    // be automatically navigated via the `redirect_immediately` param. Note that 
+    // the user is redirected to `settings` page because it performs extra validation 
+    // on whether the url is allowed to be redirected to.
+    if (this.getSearchParam('redirect_immediately') === 'true') {
+      this.navigate('/settings');
+    }
   },
 
   afterRender() {

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -463,6 +463,25 @@ describe('views/connect_another_device', () => {
     });
   });
 
+  describe('with `redirect_immediately`', () => {
+    beforeEach(() => {
+      relier.set('context', 'fx_desktop_v3');
+      windowMock.location.search = `?redirect_immediately=true&redirect_to=123`;
+      sinon.spy(view, 'navigate');
+    });
+
+    it('sends the user to /settings when `redirect_immediately` set to true', () => {
+      view.beforeRender();
+      assert.isTrue(view.navigate.calledWith('/settings'));
+    });
+
+    it(`doesn't send the user to /settings if unset`, () => {
+      windowMock.location.search = `?redirect_immediately=false&redirect_to=123`;
+      view.beforeRender();
+      assert.isFalse(view.navigate.calledWith('/settings'));
+    });
+  });
+
   describe('_isSignedIn', () => {
     it('returns `true` if the account is signed', () => {
       sinon.stub(user, 'isSignedInAccount').callsFake(() => true);


### PR DESCRIPTION
## Because

- To support device migration epic, they want to be able to immediately redirect to a page after a user signs into Sync

## This pull request

- Adds support for the `redirect_immedately` query param. If this param is set to `true` the user will be automatically redirected to the url specified in the `redirect_to` query param

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7336

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

I took a slightly different approach here that allows it this feature to be independent of the entrypoint value.
