### PR TITLE
feat(metrics): Add `fxa_subscribe - subscription_ended` auth server event

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -112,6 +112,10 @@ const EVENTS = {
     group: GROUPS.activity,
     event: 'oauth_access_token_created',
   },
+  'subscription.ended': {
+    group: GROUPS.sub,
+    event: 'subscription_ended',
+  },
   'token.created': {
     group: GROUPS.activity,
     event: 'access_token_created',

--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -533,6 +533,22 @@ describe('metrics/amplitude', () => {
       });
     });
 
+    describe('subscription.ended', () => {
+      beforeEach(() => {
+        return amplitude('subscription.ended', mocks.mockRequest({}));
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+
+      it('called log.amplitudeEvent correctly', () => {
+        assert.equal(log.amplitudeEvent.callCount, 1);
+        const args = log.amplitudeEvent.args[0];
+        assert.equal(args[0].event_type, 'fxa_subscribe - subscription_ended');
+      });
+    });
+
     describe('flow.complete (sign-up)', () => {
       beforeEach(() => {
         return amplitude(

--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -93,6 +93,16 @@
           "description": "The OAuth client ID for a RP integrated with FxA.",
           "type": "string"
         },
+        "country_code_source": {
+          "description": "The 2 character country ISO code. This value represents the payment method country for the user.",
+          "type": "string",
+          "pattern": "^[A-Z]{2}$"
+        },
+        "payment_provider": {
+          "description": "The third party service ultimately processing a user’s payments (i.e. one of: Stripe, PayPal, Google or Apple at the time of writing).",
+          "type": "string",
+          "maxLength": 128
+        },
         "plan_id": {
           "description": "Plan ID of a subscription.",
           "type": "string",
@@ -102,6 +112,20 @@
           "description": "Product ID of a subscription.",
           "type": "string",
           "maxLength": 128
+        },
+        "provider_event_id": {
+          "description": "A unique identifier for the subscription notification from a payment provider. For Stripe and Stripe-managed providers like PayPal, this is the Stripe webhook event id.",
+          "type": "string",
+          "maxLength": 128
+        },
+        "subscription_id": {
+          "description": "ID of a subscription being canceled.",
+          "type": "string",
+          "maxLength": 128
+        },
+        "voluntary_cancellation": {
+          "description": "True if the cancellation was a Voluntary Cancellation else false for an Involuntary Cancellation.",
+          "type": "boolean"
         }
       }
     },
@@ -198,6 +222,34 @@
       },
       "then": {
         "required": ["language"]
+      }
+    },
+    {
+      "if": {
+        "$comment": "For event_type's matching the pattern below, the required fields are as follows: event_type, language, payment_provider, plan_id, product_id, provider_event_id, subscription_id, time, voluntary_cancellation",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "pattern": "fxa_subscribe - subscription_ended"
+          }
+        },
+        "required": ["event_type"]
+      },
+      "then": {
+        "required": ["event_type", "language", "time", "event_properties"],
+        "properties": {
+          "event_properties": {
+            "type": "object",
+            "required": [
+              "payment_provider",
+              "plan_id",
+              "product_id",
+              "provider_event_id",
+              "subscription_id",
+              "voluntary_cancellation"
+            ]
+          }
+        }
       }
     }
   ]

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -585,6 +585,7 @@ describe('metrics/amplitude:', () => {
         );
       }
     });
+
     it('errors - event_properties required', () => {
       const event = {
         ...minimumEvent,
@@ -703,6 +704,125 @@ describe('metrics/amplitude:', () => {
           `Invalid data: event must have required property 'language', event must match "then" schema, event must have required property 'op'`
         );
       }
+    });
+
+    describe('fxa_subscribe - subscription_ended', () => {
+      const subscriptionEndedEvent = {
+        device_id: '9ce8626e11ab4238981287fb95c8545e',
+        event_type: 'fxa_subscribe - subscription_ended',
+        language: 'piglatin',
+        op: 'amplitudeEvent',
+        time: 1680884839890,
+        user_id: '9ce8626e11ab4238981287fb95c8545e',
+        user_properties: {},
+        event_properties: {
+          country_code_source: 'BC',
+          payment_provider: 'abc',
+          plan_id: 'def',
+          product_id: 'ghi',
+          provider_event_id: 'jkl',
+          subscription_id: 'mno',
+          voluntary_cancellation: true,
+        },
+      };
+
+      it('success - valid with all required and all optional properties', () => {
+        const event = {
+          ...subscriptionEndedEvent,
+        };
+        const result = amplitude.validate(event);
+        assert.isTrue(result);
+      });
+
+      it('success - valid with only required and none of the optional properties', () => {
+        const event = {
+          ...subscriptionEndedEvent,
+        };
+        delete event.user_id;
+        delete event.event_properties.country_code_source;
+
+        const result = amplitude.validate(event);
+        assert.isTrue(result);
+      });
+
+      it('error - all fields (required or optional) are missing', () => {
+        const event = {
+          ...subscriptionEndedEvent,
+        };
+        delete event.event_properties;
+        delete event.event_type;
+        delete event.language;
+        delete event.time;
+        delete event.user_id;
+
+        try {
+          amplitude.validate(event);
+          assert.fail('Validate is expected to fail');
+        } catch (err) {
+          assert.isTrue(err instanceof Error);
+          assert.equal(
+            err.message,
+            `Invalid data: event must have required property 'language', event must match "then" schema, event must have required property 'event_type', event must have required property 'time', event must have required property 'event_properties'`
+          );
+        }
+      });
+
+      it('error - all required fields are missing', () => {
+        const event = {
+          ...subscriptionEndedEvent,
+        };
+        delete event.event_type;
+        delete event.language;
+        delete event.time;
+        delete event.event_properties;
+
+        try {
+          amplitude.validate(event);
+          assert.fail('Validate is expected to fail');
+        } catch (err) {
+          assert.isTrue(err instanceof Error);
+          assert.equal(
+            err.message,
+            `Invalid data: event must have required property 'language', event must match "then" schema, event must have required property 'event_type', event must have required property 'time', event must have required property 'event_properties'`
+          );
+        }
+      });
+
+      it('error - one required field is missing', () => {
+        const event = {
+          ...subscriptionEndedEvent,
+        };
+        delete event.time;
+
+        try {
+          amplitude.validate(event);
+          assert.fail('Validate is expected to fail');
+        } catch (err) {
+          assert.isTrue(err instanceof Error);
+          assert.equal(
+            err.message,
+            `Invalid data: event must have required property 'time', event must match "then" schema, event must have required property 'time'`
+          );
+        }
+      });
+
+      it('error - one required event properties field is missing', () => {
+        const event = {
+          ...subscriptionEndedEvent,
+        };
+        delete event.event_properties.plan_id;
+
+        try {
+          amplitude.validate(event);
+          assert.fail('Validate is expected to fail');
+        } catch (err) {
+          assert.isTrue(err instanceof Error);
+          assert.equal(
+            err.message,
+            `Invalid data: event/event_properties must have required property 'plan_id', event must match "then" schema`
+          );
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## Because

- we should log when a user’s subscription is Canceled

## This pull request

- this adds `fxa_subscribe - subscription_ended` event in auth-server

## Issue that this pull request solves

Closes: [FXA-6955](https://mozilla-hub.atlassian.net/browse/FXA-6955)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

[FXA-6955]: https://mozilla-hub.atlassian.net/browse/FXA-6955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ