### PR TITLE
chore(content): Remove duplicate copyright header line

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/lib/cocktail.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/cocktail.js
@@ -1,5 +1,4 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 


### PR DESCRIPTION
## Because

- The copyright header was slightly duped.

```sh
git grep -c "* This Source Code Form is subject to the terms of the Mozilla Public" packages | grep -Ev ":1$"
```

Looks like we have roughly 360 [ *.ts | *.tsx | *.js | *.jsx ] files without any copyright headers, but that's an issue for some future PRs.
```sh
git grep -L "* This Source Code Form is subject to the terms of the Mozilla Public" -- ':*.tsx' ':*.ts' ':*.js' ':*.jsx' | wc -l # 362
```

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
