### PR TITLE
chore(copyright): Add missing copyright headers to fxa-admin-panel

### DIFF
--- a/packages/fxa-admin-panel/postcss.config.js
+++ b/packages/fxa-admin-panel/postcss.config.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 module.exports = {
   plugins: {
     'postcss-import': {},

--- a/packages/fxa-admin-panel/server/jest.config.js
+++ b/packages/fxa-admin-panel/server/jest.config.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 module.exports = {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],

--- a/packages/fxa-admin-panel/src/lib/config.spec.ts
+++ b/packages/fxa-admin-panel/src/lib/config.spec.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { config } from './config';
 
 describe('config', () => {

--- a/packages/fxa-admin-panel/src/react-app-env.d.ts
+++ b/packages/fxa-admin-panel/src/react-app-env.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /// <reference types="react-scripts" />
 
 type Nullable<T> = T | null;


### PR DESCRIPTION
## Because

- Some files are missing copyright headers. Ref: FXA-6700

## This pull request

- Fixes the missing copyright headers in fxa-admin-panel package.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
