### PR TITLE
chore(copyright): Add missing copyright headers to fxa-admin-server

### DIFF
--- a/packages/fxa-admin-server/src/auth/auth-header.decorator.ts
+++ b/packages/fxa-admin-server/src/auth/auth-header.decorator.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 

--- a/packages/fxa-admin-server/src/auth/auth-header.guard.spec.ts
+++ b/packages/fxa-admin-server/src/auth/auth-header.guard.spec.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { GqlAuthHeaderGuard } from './auth-header.guard';
 
 describe('AuthHeaderGuard', () => {

--- a/packages/fxa-admin-server/src/auth/auth-header.guard.ts
+++ b/packages/fxa-admin-server/src/auth/auth-header.guard.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GqlExecutionContext } from '@nestjs/graphql';

--- a/packages/fxa-admin-server/src/database/database.module.ts
+++ b/packages/fxa-admin-server/src/database/database.module.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Module } from '@nestjs/common';
 import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { DatabaseService } from './database.service';

--- a/packages/fxa-admin-server/src/scripts/email-bounce.ts
+++ b/packages/fxa-admin-server/src/scripts/email-bounce.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { knex } from 'knex';
 import { Model } from 'objection';
 import yargs from 'yargs';


### PR DESCRIPTION
## Because

- Some files are missing copyright headers. Ref: FXA-6700

## This pull request

- Fixes the missing copyright headers in fxa-admin-server package.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
