### PR TITLE
test(functional): rewrite cookies disabled tests in playwright

### DIFF
--- a/packages/functional-tests/pages/cookiesDisabled.ts
+++ b/packages/functional-tests/pages/cookiesDisabled.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseLayout } from './layout';
+
+export class CookiesDisabledPage extends BaseLayout {
+  readonly path = 'cookies_disabled';
+
+  async isCookiesDisabledHeader() {
+    return this.page.locator('.card-header').isVisible();
+  }
+
+  async clickRetry() {
+    return this.page.getByRole('button', { name: 'Try again' }).click();
+  }
+
+  async isCookiesDiabledError() {
+    return this.page
+      .getByText('Local storage or cookies are still disabled')
+      .isVisible();
+  }
+}

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -19,6 +19,7 @@ import { TotpPage } from './settings/totp';
 import { SubscriptionManagementPage } from './products/subscriptionManagement';
 import { ResetPasswordPage } from './resetPassword';
 import { LegalPage } from './legal';
+import { CookiesDisabledPage } from './cookiesDisabled';
 
 export function create(page: Page, target: BaseTarget) {
   return {
@@ -42,5 +43,6 @@ export function create(page: Page, target: BaseTarget) {
     subscriptionManagement: new SubscriptionManagementPage(page, target),
     resetPassword: new ResetPasswordPage(page, target),
     legal: new LegalPage(page, target),
+    cookiesDisabled: new CookiesDisabledPage(page, target),
   };
 }

--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+//Add `disable_local_storage` to the URL to synthesize cookies being disabled.
+test.describe('cookies disabled', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    await login.clearCache();
+  });
+
+  test('visit signup page with localStorage disabled', async ({
+    target,
+    page,
+    pages: { cookiesDisabled },
+  }) => {
+    //Goto cookies disabled url
+    await page.goto(`${target.contentServerUrl}/?disable_local_storage=1`, {
+      waitUntil: 'networkidle',
+    });
+
+    //Verify the Cookies disabled header
+    expect(await cookiesDisabled.isCookiesDisabledHeader()).toBe(true);
+
+    //Click retry
+    await cookiesDisabled.clickRetry();
+
+    //Verify the error
+    expect(await cookiesDisabled.isCookiesDiabledError()).toBe(true);
+  });
+
+  test('synthesize enabling cookies by visiting the enter email page, then cookies_disabled, then clicking "try again', async ({
+    target,
+    page,
+    pages: { cookiesDisabled, login },
+  }) => {
+    //Goto cookies enabled url
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'networkidle',
+    });
+
+    //Verify Email header
+    expect(await login.isEmailHeader()).toBe(true);
+
+    //Goto cookies disabled url
+    await page.goto(`${target.contentServerUrl}/cookies_disabled`, {
+      waitUntil: 'networkidle',
+    });
+
+    //Verify the Cookies disabled header
+    expect(await cookiesDisabled.isCookiesDisabledHeader()).toBe(true);
+
+    //Click retry
+    await cookiesDisabled.clickRetry();
+    await page.waitForNavigation();
+
+    //Verify Email header
+    expect(await login.isEmailHeader()).toBe(true);
+  });
+
+  test('visit verify page with localStorage disabled', async ({
+    target,
+    page,
+    pages: { cookiesDisabled, login },
+  }) => {
+    //Goto cookies enabled url
+    await page.goto(
+      `${target.contentServerUrl}/verify_email?disable_local_storage=1&uid=240103bbecd645848103021e7d245bcb&code=fc46f44802b2a2ce979f39b2187aa1c0`,
+      {
+        waitUntil: 'networkidle',
+      }
+    );
+
+    //Verify the Cookies disabled header
+    expect(await cookiesDisabled.isCookiesDisabledHeader()).toBe(true);
+  });
+});

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -27,7 +27,7 @@ test.describe('OAuth force auth', () => {
     await relier.clickForceAuth();
 
     // Signup form is shown and email is prefilled
-    await expect(await login.getPrefilledEmail()).toMatch(newEmail);
+    await expect(await login.getPrefilledEmail()).toContain(newEmail);
     await login.setAge('21');
     await login.setNewPassword(credentials.password);
     await login.fillOutSignUpCode(newEmail);
@@ -44,7 +44,7 @@ test.describe('OAuth force auth', () => {
     await relier.goto(`email=${blockedEmail}`);
     await relier.clickForceAuth();
 
-    await expect(await login.getPrefilledEmail()).toMatch(blockedEmail);
+    await expect(await login.getPrefilledEmail()).toContain(blockedEmail);
     await login.setAge('21');
     await login.setNewPassword(credentials.password);
     await login.fillOutSignUpCode(blockedEmail);

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -10,7 +10,7 @@ test.describe('OAuth `login_hint` and `email` param', () => {
     await relier.goto(`email=${invalidEmail}`);
     await relier.clickEmailFirst();
     const error = await login.getTooltipError();
-    expect(error).toMatch('Valid email required');
+    expect(error).toContain('Valid email required');
   });
 
   test('login_hint specified by relier, not registered', async ({

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -51,7 +51,7 @@ test.describe('OAuth signin', () => {
     // Attempt to sign back in with cached user
     await relier.clickEmailFirst();
 
-    await expect(await login.getPrefilledEmail()).toMatch(credentials.email);
+    await expect(await login.getPrefilledEmail()).toContain(credentials.email);
     expect(await login.isCachedLogin()).toBe(true);
     await login.submit();
     await relier.signOut();
@@ -104,7 +104,7 @@ test.describe('OAuth signin', () => {
     await relier.clickEmailFirst();
 
     // Cached user detected
-    await expect(await login.getPrefilledEmail()).toMatch(email);
+    await expect(await login.getPrefilledEmail()).toContain(email);
     expect(await login.isCachedLogin()).toBe(true);
     await login.submit();
 

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -26,7 +26,7 @@ test.describe('change primary email tests', () => {
     await page.locator('button[type=submit]').click();
     await login.setPassword(credentials.password);
     await page.locator('button[type=submit]').click();
-    expect(await login.signInError()).toMatch(
+    expect(await login.signInError()).toContain(
       'Primary account email required for sign-in'
     );
 
@@ -55,7 +55,7 @@ test.describe('change primary email tests', () => {
     await page.locator('button[type=submit]').click();
     await login.setPassword(credentials.password);
     await page.locator('button[type=submit]').click();
-    expect(await login.getTooltipError()).toMatch('Incorrect password');
+    expect(await login.getTooltipError()).toContain('Incorrect password');
 
     // Sign in with new password
     credentials.password = newPassword;
@@ -107,7 +107,7 @@ test.describe('change primary email tests', () => {
 
     // // Try creating a new account with the same secondary email as previous account and new password
     await login.fillOutFirstSignUp(newEmail, credentials.password);
-    expect(await settings.alertBarText()).toMatch(
+    expect(await settings.alertBarText()).toContain(
       'Account confirmed successfully'
     );
     const primaryEmail = await settings.primaryEmail.statusText();
@@ -142,7 +142,7 @@ test.describe('change primary - unblock', () => {
     await login.unblock(credentials.email);
 
     // Verify the incorrect password error
-    expect(await login.signInError()).toMatch('Incorrect password');
+    expect(await login.signInError()).toContain('Incorrect password');
   });
 
   test('can change primary email, get blocked with valid password, redirect settings page', async ({

--- a/packages/functional-tests/tests/settings/deleteAccount.spec.ts
+++ b/packages/functional-tests/tests/settings/deleteAccount.spec.ts
@@ -24,7 +24,7 @@ test.describe('severity-1 #smoke', () => {
     await deleteAccount.submit();
 
     // Verifying that the tooltip throws error
-    expect(await deleteAccount.toolTipText()).toMatch('Incorrect password');
+    expect(await deleteAccount.toolTipText()).toContain('Incorrect password');
 
     // Enter correct password
     await deleteAccount.setPassword(credentials.password);

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -15,23 +15,23 @@ test.describe('severity-1 #smoke', () => {
     await settings.closeAlertBar();
     await settings.secondaryEmail.clickDelete();
     await settings.waitForAlertBar();
-    expect(await settings.alertBarText()).toMatch('successfully deleted');
+    expect(await settings.alertBarText()).toContain('successfully deleted');
     await settings.secondaryEmail.clickAdd();
     await secondaryEmail.setEmail(newEmail);
     await secondaryEmail.submit();
     // skip verification
     await settings.goto();
-    expect(await settings.secondaryEmail.statusText()).toMatch('UNCONFIRMED');
+    expect(await settings.secondaryEmail.statusText()).toContain('UNCONFIRMED');
     await settings.secondaryEmail.clickDelete();
     await settings.waitForAlertBar();
-    expect(await settings.alertBarText()).toMatch('successfully deleted');
+    expect(await settings.alertBarText()).toContain('successfully deleted');
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293504
   test('settings help link #1293504', async ({ pages: { settings } }) => {
     await settings.goto();
     const helpPage = await settings.clickHelp();
-    expect(helpPage.url()).toMatch('https://support.mozilla.org');
+    expect(helpPage.url()).toContain('https://support.mozilla.org');
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293480
@@ -46,7 +46,9 @@ test.describe('severity-1 #smoke', () => {
     login.page = emailPage;
     await login.setPassword(credentials.password);
     await login.submit();
-    expect(emailPage.url()).toMatch('https://www.mozilla.org/en-US/newsletter');
+    expect(emailPage.url()).toContain(
+      'https://www.mozilla.org/en-US/newsletter'
+    );
     // TODO change prefs and save
   });
 });


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [cookies disabled tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/cookies_disabled.js) have been rewritten in this PR.

## This pull request

contains [cookies disabled tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/cookies_disabled.js) modified to work with react pages.

## Issue that this pull request solves

Closes: #[FXA-5919](https://mozilla-hub.atlassian.net/browse/FXA-5919)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-5919]: https://mozilla-hub.atlassian.net/browse/FXA-5919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ