### PR TITLE
remove stage runs from prod deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,29 +845,7 @@ workflows:
   production_smoke_tests:
     when: << pipeline.parameters.enable_production_smoke_tests >>
     jobs:
-    # Note that these target stage too! This might seem odd, but having tests pass on staging is currently
-      # a requirement for all production deploys.
-      - test-content-server-remote-part-0:
-          name: Smoke Stage - Content Server Part 1
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - test-content-server-remote-part-1:
-          name: Smoke Stage - Content Server Part 2
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - test-content-server-remote-part-2:
-          name: Smoke Stage - Content Server Part 3
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
+    # Note that we removed content server tests as it runs on Stage only
       - smoke-tests:
           name: Smoke Test Production - Playwright
           target: test-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,37 +845,6 @@ workflows:
   production_smoke_tests:
     when: << pipeline.parameters.enable_production_smoke_tests >>
     jobs:
-      # Note that these target stage too! This might seem odd, but having tests pass on staging is currently
-      # a requirement for all production deploys.
-      - test-content-server-remote-part-0:
-          name: Smoke Stage - Content Server Part 1
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - test-content-server-remote-part-1:
-          name: Smoke Stage - Content Server Part 2
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - test-content-server-remote-part-2:
-          name: Smoke Stage - Content Server Part 3
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - smoke-tests:
-          name: Smoke Test Stage - Playwright
-          target: test-stage
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
       - smoke-tests:
           name: Smoke Test Production - Playwright
           target: test-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,6 +845,29 @@ workflows:
   production_smoke_tests:
     when: << pipeline.parameters.enable_production_smoke_tests >>
     jobs:
+    # Note that these target stage too! This might seem odd, but having tests pass on staging is currently
+      # a requirement for all production deploys.
+      - test-content-server-remote-part-0:
+          name: Smoke Stage - Content Server Part 1
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - test-content-server-remote-part-1:
+          name: Smoke Stage - Content Server Part 2
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - test-content-server-remote-part-2:
+          name: Smoke Stage - Content Server Part 3
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - smoke-tests:
           name: Smoke Test Production - Playwright
           target: test-production


### PR DESCRIPTION
## Because

- Recently we saw that every time we do a prod deployment all the content-server and playwright tests are run on stage as well. There doesn’t seem to be a good reason why it is set up like that. We need to remove the stage runs from prod deployments.

## This pull request

- Is to remove all the stage runs from the prod deployments and to run only the Prod smoke test - playwright suite

## Issue that this pull request solves

Closes: #[FXA-7370](https://mozilla-hub.atlassian.net/browse/FXA-7370)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-7370]: https://mozilla-hub.atlassian.net/browse/FXA-7370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ