### PR TITLE
task(content): Add another magic number to distinguish between L1 and…

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -145,7 +145,6 @@ function marshallEmailDomain(email) {
 }
 
 function Metrics(options = {}) {
-
   // Supplying a custom start time is a good way to create invalid metrics. We
   // are deprecating this option.
   if (options.startTime !== undefined) {
@@ -366,6 +365,11 @@ _.extend(Metrics.prototype, Backbone.Events, {
       isDeviceIdValid: Validate.isDeviceIdValid,
     });
 
+    // Short circuit if bad L1 navigation timing data is detected.
+    if (validator.hasInvalidL1TimingData(filteredData)) {
+      return;
+    }
+
     validator.sanitizeDeviceId(filteredData);
     validator.sanitizeDuration(filteredData);
     validator.sanitizeEvents(filteredData);
@@ -541,7 +545,7 @@ _.extend(Metrics.prototype, Backbone.Events, {
     // metrics generated are not reliable and should not be
     // reported.
     if (this._speedTrap.isInSuspectState()) {
-      return Promise.resolve()
+      return Promise.resolve();
     }
 
     const url = `${this._collector}/metrics`;

--- a/packages/fxa-shared/metrics/validate.ts
+++ b/packages/fxa-shared/metrics/validate.ts
@@ -7,6 +7,7 @@ import {
   InvalidNavigationTimingError,
 } from './metric-errors';
 import * as Sentry from '@sentry/browser';
+import { InvalidL1Val } from '../speed-trap/navigation-timing';
 
 export const UTM_REGEX = /^[\w\/.%-]{1,128}$/;
 export const DEVICE_ID_REGEX = /^[0-9a-f]{32}$|^none$/;
@@ -67,7 +68,7 @@ export class MetricErrorReporter {
   /**
    * Reports an error to sentry.
    * @param error - Error to report
-   * @param capture - Flag indication whether or not to count the error.
+   * @param capture - Flag indicating whether or not to count the error.
    *
    * Note: The error.critical and capture flags operate independently. There might be situations where
    * you want to report the error, but it is not critical... or vice versa.
@@ -173,6 +174,18 @@ export class MetricValidator {
       0,
       MAX_SAFE_INTEGER,
       0
+    );
+  }
+
+  /**
+   * Check for bad potentially bad L1 navigation timing values.
+   */
+  public hasInvalidL1TimingData(
+    data: Pick<CheckedMetrics, 'navigationTiming'>
+  ) {
+    // Check for magic numbers that indicate bad l1 navigation timing data.
+    return Object.values(data.navigationTiming || []).some(
+      (x) => x === InvalidL1Val
     );
   }
 


### PR DESCRIPTION
## Because

- We'd like to distinguish between erroneous values coming from L1 vs L2 navigation timing APIs.

## This pull request

- Uses a new magic number, -22222, for invalid values produced by the L2 navigation API.
- Don't report L1 navigation timing errors to sentry anymore.

## Issue that this pull request solves

Closes: FXA-7005

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

