### PR TITLE
task(CI): Patch package.json version fields to reflect the git tag

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:18.14-slim
 
+ARG VERSION
+
 RUN set -x \
     && addgroup --gid 10001 app \
     && adduser --disabled-password \
@@ -21,4 +23,4 @@ RUN apt-get update && apt-get install -y \
 COPY --chown=app:app . /fxa
 USER app
 WORKDIR /fxa
-RUN _scripts/base-docker.sh
+RUN _scripts/base-docker.sh $VERSION

--- a/_scripts/base-docker.sh
+++ b/_scripts/base-docker.sh
@@ -3,8 +3,33 @@
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
+VERSION=$1
+
+if [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Updating version in package.json to ${VERSION}"
+else
+  echo "Invalid version or no version specified, ${VERSION}. Defaulting to v0.0.0"
+  VERSION="v0.0.0"
+fi
+
+# Trim the prefix "v" from the version
+VERSION=$(echo "${VERSION}" | sed 's/^v//')
+
+function patchVersion() {
+  if [ -f "package.json" ]; then
+    echo "Updating version in $(pwd)/package.json to ${VERSION}"
+    jq ".version = \"$VERSION\"" package.json > tmp && mv tmp package.json
+  else
+    echo "$(pwd)/package.json not found!"
+  fi
+}
+
+# Update the root package.json file.
+patchVersion
+
+# Create version files and update the version field in package.json files.
 for d in ./packages/*/ ; do
-  (cd "$d" && mkdir -p config && cp ../version.json . && cp ../version.json config)
+  (cd "$d" && mkdir -p config && cp ../version.json . && cp ../version.json config && patchVersion)
 done
 
 if [ -f _dev/local-build-env.sh ]; then

--- a/_scripts/build-builder.sh
+++ b/_scripts/build-builder.sh
@@ -3,9 +3,16 @@
 DIR=$(dirname "$0")
 cd "$DIR"
 
+# The circle tag often represents a version number. If the tag is present and
+# its format looks like a semver, ie v1.2.3, then this version will be applied
+# across all package.json files.
+if [ -n "${CIRCLE_TAG}" ]; then
+  VERSION="$CIRCLE_TAG"
+fi
+
 ./create-version-json.sh
 
 mkdir -p ../artifacts
 
 echo "Building fxa-builder image..."
-time (cd .. && docker build -f _dev/docker/builder/Dockerfile -t fxa-builder:latest . &> "artifacts/fxa-builder.log")
+time (cd .. && docker build -f _dev/docker/builder/Dockerfile --build-arg VERSION=$VERSION -t fxa-builder:latest . &> "artifacts/fxa-builder.log")


### PR DESCRIPTION
## Because

- We want the package.json version to match the git tag being deployed.
- We don't want to commit a change on the package.json file to accomplish this.

## This pull request

- If there is a git tag, the code will send the tag into the docker build as a VERSION build arg.
- This build arg is then used to update the version field in all package.json files.

## Issue that this pull request solves

Closes: FXA-7359

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Testing this is a bit tricky. I was able to validate most of the changeset locally by running the docker build command directly, ie `docker build --build-arg VERSION=v1.2.3 -f _dev/docker/builder/Dockerfile . -t test`, and then bash into the container and validate the package.json files had been updated, ie `docker run -it test bash` and then `cat package.json | grep version`.
