### PR TITLE
bug(content): MetricsEnabled not set properly by default in local storage

### DIFF
--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -158,6 +158,27 @@ test.describe('signup here', () => {
     // The original tab should transition to the settings page w/ success
     // message.
     expect(await login.loginHeader()).toBe(true);
+
+    // Verify the account is in local storage and has a correct state
+    const currentAccountUid = await page.evaluate(() => {
+      return JSON.parse(
+        localStorage.getItem('__fxa_storage.currentAccountUid') || ''
+      );
+    });
+    const accounts = await page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('__fxa_storage.accounts') || '{}');
+    });
+    const account = accounts[currentAccountUid];
+    expect(currentAccountUid).toBeDefined();
+    expect(accounts).toBeDefined();
+    expect(accounts[currentAccountUid]).toBeDefined();
+    expect(account.email).toBe(email);
+    expect(account.lastLogin).toBeDefined();
+    expect(account.metricsEnabled).toBe(true);
+    expect(account.sessionToken).toBeDefined();
+    expect(account.uid).toBeDefined();
+    expect(account.verified).toBe(true);
+
     await settings.signOut();
 
     await login.fillOutFirstSignUp(secondEmail, password, true);

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -111,8 +111,8 @@ function getUpdatedSessionData(email, relier, accountData, options = {}) {
     uid: accountData.uid,
     verificationMethod: accountData.verificationMethod,
     verificationReason: accountData.verificationReason,
-    verified: accountData.verified || false,
-    metricsEnabled: accountData.metricsEnabled || false,
+    verified: accountData.verified ?? false,
+    metricsEnabled: accountData.metricsEnabled ?? true,
     providerUid: accountData.providerUid,
   };
 


### PR DESCRIPTION
## Because

- The local storage stage for `metricsEnabled` was not aligned with the server side state.

## This pull request

- Ensures that default value for `metricsEnabled` in local storage is true.

## Issue that this pull request solves

Closes: FXA-7296

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

