### PR TITLE
fix(cookies_disabled): Pass the disable_local_storage param to React if present

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -187,6 +187,16 @@ Router = Router.extend({
           // further if being redirected from content-server. Flow params are not always
           // available to check against, so we explicitly send in an additional param.
           contentRedirect: true,
+          // We pass along `disable_local_storage` for functional-tests that hit another page
+          // with this param (synthetically disabling local storage). Without this, tests will
+          // be redirected to this page, but local storage will appear enabled.
+          /* eslint-disable camelcase */
+          ...(Url.searchParam(
+            'disable_local_storage',
+            this.window.location.search
+          ) === '1' && {
+            disable_local_storage: 1,
+          }),
         }
       );
     },


### PR DESCRIPTION
Because:
* The `disable_local_storage=1` param synthetically disables local storage in unit tests and functional tests. In our functional tests, if we hit any page with this param, we're redirected to `cookies_disabled`, however, if this param is not passed with the redirect we can't test the page itself (try again button) with local storage still disabled

This commit:
* Includes this parameter in the redirect to React if it's present

Fixes FXA-7375

---

You can try this locally by going to `about:config` and flipping `dom.storage.enabled` to `false`. Hit any page (like `/`) with the `simpleRoutes` flag set to true and you'll be taken to `cookies_disabled`. Before this patch the param is not present after the redirect, and after it is.

this should help #15251