### PR TITLE
bug(shared): Fix issue with check on PerformanceObserver

### DIFF
--- a/packages/fxa-shared/metrics/navigation-timing.ts
+++ b/packages/fxa-shared/metrics/navigation-timing.ts
@@ -32,10 +32,12 @@ export const observeNavigationTiming = (
   url: string,
   send: ReturnType<typeof sendFn> = defaultSendFn
 ) => {
-  // TS4 wants to mark this as a bug saying it's always true
-  // but in the unit tests under jsdom it isn't
-  // @ts-ignore
-  if (performance.getEntriesByType && PerformanceObserver && !!send) {
+  if (
+    typeof performance === 'object' &&
+    typeof performance.getEntriesByType === 'function' &&
+    typeof PerformanceObserver === 'function' &&
+    !!send
+  ) {
     // By the time this is called, the event might've completed.  Use the
     // PerformanceObserver API if it hasn't, otherwise send the data.
     const navTiming = performance.getEntriesByType(


### PR DESCRIPTION
## Because

- There was an app error when about:config > dom.enable_performance_observer = false.
- In this case, any reference to PerformanceObserver would result in an unhandled error

## This pull request

- Uses `typeof PerformanceObserver` instead, which works around the is not defined error.

## Issue that this pull request solves

Closes: FXA-7382

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The fix here is a bit surprising, for some reason any ref to the PerformanceObserver results in a runtime error when it's been disabled in the Firefox config. As a result the check which ran `&& PerformanceObserver` wouldn't eval like a typical undefined variable, and instead threw an error. 

This can be replicated by going to about:config in the address bar, changing the dom.enable_performance_observer setting to false, opening a new tab and running a check like `!!PerformanceObserver` in the console.
