### PR TITLE
test(subplat): disable tests related to payments in prod

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -47,7 +47,11 @@ test.describe('coupon test', () => {
 
   test('subscribe successfully with an invalid coupon', async ({
     pages: { relier, subscribe, login },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 
@@ -73,7 +77,11 @@ test.describe('coupon test', () => {
 
   test('subscribe successfully with a forever discount coupon', async ({
     pages: { relier, subscribe, login },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 
@@ -101,7 +109,11 @@ test.describe('coupon test', () => {
 
   test('subscribe with a one time discount coupon', async ({
     pages: { relier, subscribe, login },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe12Month();
 
@@ -130,7 +142,11 @@ test.describe('coupon test', () => {
 
   test('subscribe with credit card and use coupon', async ({
     pages: { relier, login, subscribe },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 
@@ -149,7 +165,11 @@ test.describe('coupon test', () => {
 
   test('subscribe with paypal and use coupon', async ({
     pages: { relier, login, subscribe },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe12Month();
 

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -10,7 +10,11 @@ test.describe('resubscription test', () => {
   test('resubscribe successfully with the same coupon after canceling for stripe', async ({
     page,
     pages: { relier, subscribe, login, settings, subscriptionManagement },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 
@@ -58,7 +62,11 @@ test.describe('resubscription test', () => {
   test('resubscribe successfully with the same coupon after canceling for paypal', async ({
     page,
     pages: { relier, subscribe, login, settings, subscriptionManagement },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 
@@ -104,7 +112,11 @@ test.describe('resubscription test', () => {
   test('update mode of payment for stripe', async ({
     page,
     pages: { relier, subscribe, login, settings, subscriptionManagement },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 
@@ -134,7 +146,11 @@ test.describe('resubscription test', () => {
   test('update mode of payment for paypal', async ({
     page,
     pages: { relier, subscribe, login, settings, subscriptionManagement },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe();
 

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -8,7 +8,11 @@ test.describe('ui functionality', () => {
   test('verify coupon feature not available when changing plans', async ({
     page,
     pages: { relier, subscribe },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe6Month();
 

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -9,7 +9,11 @@ test.describe('subscription test with cc and paypal', () => {
 
   test('subscribe with credit card and login to product', async ({
     pages: { relier, login, subscribe },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe();
     await subscribe.setConfirmPaymentCheckbox();
@@ -25,7 +29,11 @@ test.describe('subscription test with cc and paypal', () => {
 
   test('subscribe with credit card after initial failed subscription', async ({
     pages: { relier, login, subscribe },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe();
     await subscribe.setConfirmPaymentCheckbox();
@@ -44,7 +52,11 @@ test.describe('subscription test with cc and paypal', () => {
 
   test('subscribe with paypal and login to product', async ({
     pages: { relier, login, subscribe },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe();
     await subscribe.setConfirmPaymentCheckbox();

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -36,7 +36,11 @@ test.describe('support form with active subscriptions', () => {
 
   test('go to support form, submits the form', async ({
     pages: { login, relier, subscribe, settings, subscriptionManagement },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe();
     await subscribe.setConfirmPaymentCheckbox();
@@ -60,7 +64,11 @@ test.describe('support form with active subscriptions', () => {
   test('go to support form, cancel, redirects to subscription management', async ({
     page,
     pages: { login, relier, subscribe, settings, subscriptionManagement },
-  }) => {
+  }, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'no real payment method available in prod'
+    );
     await relier.goto();
     await relier.clickSubscribe();
     await subscribe.setConfirmPaymentCheckbox();


### PR DESCRIPTION
## Because

- Currently we have no real payment method in Prod for subscriptions, hence disabling tests related to CC or paypal payments in Prod only. They will still run in local and on Stage.

## This pull request

- Disables CC or paypal payment related tests in Prod only

## Issue that this pull request solves

Closes: #[FXA-7371](https://mozilla-hub.atlassian.net/browse/FXA-7371)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-7371]: https://mozilla-hub.atlassian.net/browse/FXA-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ