### PR TITLE
task(react): Update feature flag names, modify local.json-dist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,9 @@ parameters:
     type: boolean
     default: false
 
-
 orbs:
   browser-tools: circleci/browser-tools@1.2.3
   jira: circleci/jira@1.3.1
-
 
 executors:
   # Default node executor with low resources. Useful for running quick / small tasks
@@ -141,9 +139,8 @@ executors:
       REACT_CONVERSION_SIGNIN_ROUTES: true
       REACT_CONVERSION_SIGNUP_ROUTES: true
       REACT_CONVERSION_PAIR_ROUTES: true
-      REACT_CONVERSION_POST_VERIFY_ADD_RECOVERY_KEY_ROUTES: true
+      REACT_CONVERSION_POST_VERIFY_OTHER_ROUTES: true
       REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES: true
-      REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH_ROUTES: true
       CUSTOMS_SERVER_URL: none
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
@@ -160,9 +157,7 @@ executors:
       NODE_ENV: development
       CUSTOMS_SERVER_URL: none
 
-
 commands:
-
   git-clone:
     # Note: Cloning this way allows us to run a git fetch & checkout later on download the road. This type of
     # clone operation will result in a .git/config with no user attached that is using
@@ -364,7 +359,7 @@ commands:
       #   https://www.gnu.org/software/parallel/parallel_tutorial.html#number-of-simultaneous-jobs
       max_jobs:
         type: string
-        default: "NONE"
+        default: 'NONE'
       index:
         type: integer
         default: 0
@@ -462,9 +457,7 @@ commands:
             docker push mozilla/fxa-circleci:ci-builder
             wait
 
-
 jobs:
-
   create-fxa-images:
     executor: docker-build-executor
     steps:
@@ -571,7 +564,7 @@ jobs:
       - run-tests:
           test_name: Integration Test (many)
           list: integration-test.list
-          max_jobs: "1"
+          max_jobs: '1'
           index: << parameters.index >>
           total: << parameters.total >>
 
@@ -703,14 +696,12 @@ jobs:
     executor: tiny-executor
     steps:
       - run:
-          name: "Stage completed"
+          name: 'Stage completed'
           command: echo "<< parameters.stage >> completed!"
       - jira/notify:
           job_type: << parameters.job_type >>
 
-
 workflows:
-
   test_pull_request:
     # This workflow is executed whenever a pull request is issued. It will also
     # run on PR drafts.
@@ -945,7 +936,6 @@ workflows:
           requires:
             - Create FxA Images (requested)
 
-
   deploy_ci_images:
     # This workflow is triggered after a PR lands on main. The workflow will
     # short circuit if incoming PR doesn't modify any npm packages. The same
@@ -1155,7 +1145,7 @@ workflows:
     when: << pipeline.parameters.enable_nightly >>
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: '0 0 * * *'
           filters:
             branches:
               only: main

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -36,9 +36,8 @@ describe('lib/router', () => {
     signInRoutes: true,
     signUpRoutes: true,
     pairRoutes: true,
-    postVerifyAddRecoveryKeyRoutes: true,
+    postVerifyOtherRoutes: true,
     postVerifyCADViaQRRoutes: true,
-    signInVerificationViaPushRoutes: true,
     webChannelExampleRoutes: true,
   };
 

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -48,5 +48,8 @@
   },
   "recovery_codes": {
     "count": 3
+  },
+  "showReactApp": {
+    "simpleRoutes": true
   }
 }

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -246,23 +246,17 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'REACT_CONVERSION_PAIR_ROUTES',
     },
-    postVerifyAddRecoveryKeyRoutes: {
+    postVerifyOtherRoutes: {
       default: false,
-      doc: 'Enable users to visit the React version of "post-verify add recovery key" routes',
+      doc: 'Enable users to visit the React version of any other "post verify" routes',
       format: Boolean,
-      env: 'REACT_CONVERSION_POST_VERIFY_ADD_RECOVERY_KEY_ROUTES',
+      env: 'REACT_CONVERSION_POST_VERIFY_OTHER_ROUTES',
     },
     postVerifyCADViaQRRoutes: {
       default: false,
       doc: 'Enable users to visit the React version of "post verify CAD via QR code" routes',
       format: Boolean,
       env: 'REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES',
-    },
-    signInVerificationViaPushRoutes: {
-      default: false,
-      doc: 'Enable users to visit the React version of "signin verification via push" routes',
-      format: Boolean,
-      env: 'REACT_CONVERSION_SIGNIN_VERIFICATION_VIA_PUSH_ROUTES',
     },
     webChannelExampleRoutes: {
       default: false,

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -75,8 +75,8 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       routes: [],
     },
 
-    postVerifyAddRecoveryKeyRoutes: {
-      featureFlagOn: showReactApp.postVerifyAddRecoveryKeyRoutes,
+    postVerifyOtherRoutes: {
+      featureFlagOn: showReactApp.postVerifyOtherRoutes,
       routes: [],
     },
 
@@ -88,11 +88,6 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
     postVerifyThirdPartyAuthRoutes: {
       featureFlagOn: showReactApp.postVerifyThirdPartyAuthRoutes,
       routes: reactRoute.getRoutes(['post_verify/third_party_auth/callback']),
-    },
-
-    signInVerificationViaPushRoutes: {
-      featureFlagOn: showReactApp.signInVerificationViaPushRoutes,
-      routes: [],
     },
 
     webChannelExampleRoutes: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -52,9 +52,8 @@ type ShowReactApp = {
   signInRoutes: boolean;
   signUpRoutes: boolean;
   pairRoutes: boolean;
-  postVerifyAddRecoveryKeyRoutes: boolean;
+  postVerifyOtherRoutes: boolean;
   postVerifyCADViaQRRoutes: boolean;
-  signInVerificationViaPushRoutes: boolean;
   postVerifyThirdPartyAuthRoutes: boolean;
   webChannelExampleRoutes: boolean;
 };

--- a/packages/fxa-content-server/tests/server/routes/react-app.js
+++ b/packages/fxa-content-server/tests/server/routes/react-app.js
@@ -38,9 +38,8 @@ const showReactAppAll = {
   signInRoutes: true,
   signUpRoutes: true,
   pairRoutes: true,
-  postVerifyAddRecoveryKeyRoutes: true,
+  postVerifyOtherRoutes: true,
   postVerifyCADViaQRRoutes: true,
-  signInVerificationViaPushRoutes: true,
 };
 
 function getEmptyClientReactRouteGroups(showReactApp = showReactAppAll) {


### PR DESCRIPTION
Because:
* We cancelled the React port of post_verify add recovery key routes and post_verify add secondary email routes and deemed 'push' routes out of scope (see tickets for details), so our feature flags needed some tweaking
* simpleRoutes are rolled out to 100% in production and updating local.json-dist to match keeps local dev in sync

closes FXA-6647

---

corresponding cloudops PR: https://github.com/mozilla-services/cloudops-deployment/pull/4831
- removes postVerifyAddRecoveryKeyRoutes
- removes signInVerificationViaPushRoutes
- adds postVerifyOtherRoutes