### PR TITLE
fix(test): change restmail domain from com to net

### DIFF
--- a/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
@@ -65,7 +65,7 @@ test.describe('Reset password current', () => {
     pages: { login, resetPassword },
   }) => {
     await page.goto(`${target.contentServerUrl}/reset_password`);
-    await login.setEmail('email@restmail.com');
+    await login.setEmail('email@restmail.net');
     await resetPassword.clickBeginReset();
     expect(await resetPassword.unknownAccountError()).toContain(
       'Unknown account.'


### PR DESCRIPTION
## Because

A few reset password tests were failing on Stage with error “You've tried too many times. Try again in 30 minutes." 

Circle CI run : https://app.circleci.com/pipelines/github/mozilla/fxa/40580/workflows/5f63d299-f26a-48d5-b3b5-a419037d2702/jobs/429056

## This pull request

Fixes the restmail domain for the test from .com to .net 

## Issue that this pull request solves

Closes: FXA-7396

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
