### PR TITLE
feat(subs): Fix issue where user would not be redirected back to product after 3rd party auth

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -349,18 +349,23 @@ Router = Router.extend({
         service,
         uniqueUserId,
       } = this.metrics.getFilteredData();
-      // Our GQL client sets the `redirect_to` param if a user attempts
-      // to navigate directly to a section in settings
+      
+      // Some flows can specify a redirect url after a client has logged in. This is
+      // useful when you want to ensure the user has authenticated. Our GQL client 
+      // also sets the `redirect_to` param if a user attempts to navigate directly 
+      // to a section in settings
       const searchParams = new URLSearchParams(this.window.location.search);
-      let endpoint = searchParams.get('redirect_to');
-      if (!endpoint) {
-        endpoint = `/settings`;
-      } else if (
-        !this.isValidRedirect(endpoint, this.config.redirectAllowlist)
-      ) {
-        throw new Error('Invalid redirect!');
-      }
-      const settingsLink = `${endpoint}${Url.objToSearchString({
+      const redirectUrl = searchParams.get('redirect_to');
+      if (redirectUrl) {
+        if (!this.isValidRedirect(redirectUrl, this.config.redirectAllowlist)) {
+          throw new Error('Invalid redirect!');
+        }
+        return this.navigateAway(redirectUrl);
+      } 
+      
+      // All other flows should redirect to the settings page
+      const settingsEndpoint = '/settings';
+      const settingsLink = `${settingsEndpoint}${Url.objToSearchString({
         deviceId,
         flowBeginTime,
         flowId,

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -195,7 +195,7 @@ describe('routes/Checkout', () => {
     const signInLink = getByTestId('sign-in-link');
     expect(signInLink).toHaveAttribute(
       'href',
-      `${mockConfig.servers.content.url}/subscriptions/products/${PRODUCT_ID}?plan=testo&extra=goodstuff&signin=yes`
+      `${mockConfig.servers.content.url}/subscriptions/products/${PRODUCT_ID}?plan=testo&extra=goodstuff&signin=yes&redirect_to=http%3A%2F%2Flocalhost%2F`
     );
 
     const formEl = await findByTestId('new-user-email-form');

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -133,8 +133,9 @@ export const Checkout = ({
   }, [fetchCheckoutRouteResources]);
 
   usePaypalButtonSetup(config, setPaypalScriptLoaded, paypalButtonBase);
-
-  const signInQueryParams = { ...queryParams, signin: 'yes' };
+  
+  const redirectUrl = encodeURIComponent(window.location.href.replace('/checkout/', '/products/'));
+  const signInQueryParams = { ...queryParams, signin: 'yes', redirect_to: redirectUrl };
   const signInQueryParamString = Object.entries(signInQueryParams)
     .map(([k, v]) => `${k}=${v}`)
     .join('&');


### PR DESCRIPTION
## Because

- This would break the user flow and they would have to open the product page again after signin

## This pull request

- Updates how our `/settings` redirect works to redirect without appending additional flow params (not needed since it is external)
- Updates the product signin url to include a `redirect_to` query param which is the product page
- 
## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6783

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

