### PR TITLE
fix(reset_password): Don't allow submission with invalid email

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -17,3 +17,4 @@ auth-error-183-2 = Invalid or expired confirmation code
 auth-error-999 = Unexpected error
 auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different
+auth-error-1011 = Valid email required


### PR DESCRIPTION
Because:
* If an email isn't valid, we shouldn't bother sending up a request to the server

This commit:
* Adds a temporary Sentry log to help debug FXA-7347; we're hoping the issue resolves with a customs fix that will be pushed with the next tag, but this might help us glean a little more info in case it doesn't
* Does not allow form submission if the email is invalid, adds a couple tests

Closes FXA-7347

---

See [Slack thread 1](https://mozilla.slack.com/archives/CLV3KMZ8B/p1683656924296959) / [Slack thread 2](https://mozilla.slack.com/archives/CLV3KMZ8B/p1683657694032539).

FXA-7347 is not reproducible locally, what's mentioned locally in the ticket is a different error. We're hoping the issue is resolved with a customs push to staging that recently had a fix - our Account resolver for this uses `authAPI.passwordForgotSendCode`, which POSTs to `/password/forgot/send_code`, and we do a customs check [here](https://github.com/mozilla/fxa/blob/902119edce7b3e5a9029bae66d089d5f1e667f23/packages/fxa-auth-server/lib/routes/password.js#L488). Strangely the error is not in Sentry, and the POST request fails with this (404?):

<img width="419" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/334e88a6-c9aa-44a7-b2bb-c83ea6a2ad8c">


This code change addresses part of the ticket instead around disallowing submission for an invalid email. I've also added a temporary `sentryMetrics.captureException(err);` client-side in case this helps us glean any more info.

I'll either file a follow up PR to remove that error capture, or re-open the ticket, if it's not resolved with this tag.