### PR TITLE
feat(payments): Add name to card payment element

### DIFF
--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -22,6 +22,7 @@ export type PaymentError = undefined | StripeError;
 export type SubscriptionPaymentHandlerParam = {
   stripe: Pick<Stripe, 'createPaymentMethod' | 'confirmCardPayment'>;
   name: string;
+  email: string;
   card: StripeCardElement | null;
   idempotencyKey: string;
   selectedPlan: Plan;
@@ -69,6 +70,7 @@ export async function handlePasswordlessSubscription({
     return handleSubscriptionPayment({
       stripe,
       name,
+      email,
       card,
       idempotencyKey,
       selectedPlan,
@@ -92,6 +94,7 @@ export async function handleSubscriptionPayment({
   stripe,
   name,
   card,
+  email,
   idempotencyKey,
   selectedPlan,
   customer,
@@ -137,6 +140,10 @@ export async function handleSubscriptionPayment({
     await stripe.createPaymentMethod({
       type: 'card',
       card: card as StripeCardElement,
+      billing_details: {
+        name,
+        email,
+      },
     });
   if (paymentError) {
     return onFailure(paymentError);

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -144,6 +144,7 @@ export const SubscriptionCreate = ({
             stripe:
               stripeOverride /* istanbul ignore next - used for testing */ ||
               stripeFromParams,
+            email: profile.email,
             selectedPlan,
             customer,
             retryStatus,
@@ -166,6 +167,7 @@ export const SubscriptionCreate = ({
       },
       [
         selectedPlan,
+        profile,
         customer,
         retryStatus,
         apiClientOverrides,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -22,6 +22,7 @@ import {
   FILTERED_SETUP_INTENT,
   INACTIVE_PLAN,
   PLAN,
+  PROFILE,
 } from '../../lib/mock-data';
 
 import { PickPartial } from '../../lib/types';
@@ -39,6 +40,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     PaymentUpdateFormProps,
     | 'plan'
     | 'customer'
+    | 'profile'
     | 'refreshSubscriptions'
     | 'setUpdatePaymentIsSuccess'
     | 'resetUpdatePaymentIsSuccess'
@@ -47,6 +49,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   const Subject = ({
     plan = PLAN,
     customer = CUSTOMER,
+    profile = PROFILE,
     paymentErrorInitialState,
     apiClientOverrides = defaultApiClientOverrides(),
     stripeOverride = defaultStripeOverride(),
@@ -60,6 +63,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
         {...{
           plan,
           customer,
+          profile,
           refreshSubscriptions,
           setUpdatePaymentIsSuccess,
           resetUpdatePaymentIsSuccess,
@@ -78,6 +82,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   const DISPLAY_NAME = 'Foo Barson';
+  const PROFILE_EMAIL = 'foo@example.com';
 
   const CONFIRM_CARD_SETUP_RESULT = {
     setupIntent: {
@@ -329,7 +334,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     {
       payment_method: {
         card: { isMockElement: true, testid: 'cardElement' },
-        billing_details: { name: DISPLAY_NAME },
+        billing_details: { name: DISPLAY_NAME, email: PROFILE_EMAIL },
       },
     },
   ];
@@ -510,11 +515,9 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       await commonSubmitSetup({
         apiClientOverrides: {
           ...defaultApiClientOverrides(),
-          apiUpdateDefaultPaymentMethod: jest
-            .fn()
-            .mockRejectedValue({
-              message: 'barf apiUpdateDefaultPaymentMethod',
-            }),
+          apiUpdateDefaultPaymentMethod: jest.fn().mockRejectedValue({
+            message: 'barf apiUpdateDefaultPaymentMethod',
+          }),
         },
       });
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -12,7 +12,7 @@ import { useBooleanState } from 'fxa-react/lib/hooks';
 import { useNonce, usePaypalButtonSetup } from '../../lib/hooks';
 import { getFallbackTextByFluentId, getErrorMessageId } from '../../lib/errors';
 import { AppContext } from '../../lib/AppContext';
-import { Customer, Plan } from '../../store/types';
+import { Customer, Plan, Profile } from '../../store/types';
 
 import * as Amplitude from '../../lib/amplitude';
 import * as apiClient from '../../lib/apiClient';
@@ -48,6 +48,7 @@ export type PaymentUpdateAuthServerAPIs = Pick<
 export type PaymentUpdateFormProps = {
   plan: Plan | null;
   customer: Customer;
+  profile: Profile;
   refreshSubscriptions: () => void;
   setUpdatePaymentIsSuccess: () => void;
   resetUpdatePaymentIsSuccess: () => void;
@@ -60,6 +61,7 @@ export type PaymentUpdateFormProps = {
 export const PaymentUpdateForm = ({
   plan,
   customer,
+  profile,
   refreshSubscriptions,
   setUpdatePaymentIsSuccess,
   resetUpdatePaymentIsSuccess,
@@ -169,6 +171,7 @@ export const PaymentUpdateForm = ({
           ...params,
           ...apiClient,
           ...apiClientOverrides,
+          email: profile.email,
           stripe:
             stripeOverride /* istanbul ignore next - used for testing */ ||
             stripeFromParams,
@@ -187,6 +190,7 @@ export const PaymentUpdateForm = ({
       refreshSubmitNonce();
     },
     [
+      profile,
       stripeSubmitSetInProgress,
       resetUpdatePaymentIsSuccess,
       setPaymentError,
@@ -331,6 +335,7 @@ export const PaymentUpdateForm = ({
 async function handlePaymentUpdate({
   stripe,
   name,
+  email,
   card,
   apiCreateSetupIntent,
   apiUpdateDefaultPaymentMethod,
@@ -339,6 +344,7 @@ async function handlePaymentUpdate({
 }: {
   stripe: PaymentUpdateStripeAPIs;
   name: string;
+  email: string;
   card: StripeCardElement;
   onFailure: (error: PaymentUpdateError) => void;
   onSuccess: () => void;
@@ -353,7 +359,7 @@ async function handlePaymentUpdate({
     {
       payment_method: {
         card,
-        billing_details: { name },
+        billing_details: { name, email },
       },
     }
   );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -352,6 +352,7 @@ export const Subscriptions = ({
               {...{
                 plan: planForId(planId!, plans.result),
                 customer: customer.result,
+                profile: profile.result,
                 refreshSubscriptions: fetchSubscriptionsRouteResources,
                 setUpdatePaymentIsSuccess,
                 resetUpdatePaymentIsSuccess:


### PR DESCRIPTION
## Because

- Card holder name is not currently added to payment element on new subscriptions with a new card.

## This pull request

- Adds card holder name to card payment method.

## Issue that this pull request solves

Closes: # FXA-7440

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

![image](https://github.com/mozilla/fxa/assets/10620585/ee45c16e-ec5c-4863-bc91-74e52ff790e7)

