### PR TITLE
task(CI): Enable rerun of only failed tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,23 @@ commands:
       - run:
           command: ./.circleci/report-coverage.sh << parameters.list >>
 
+  run-playwright-tests:
+    parameters:
+      project:
+        type: string
+    steps:
+      - run:
+          name: Running Playwright tests
+          # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
+          command: |
+            cd packages/functional-tests
+            TEST_FILES=$(circleci tests glob "tests/**/*.spec.ts")
+            echo $TEST_FILES | circleci tests run --command="xargs yarn playwright test --project=<< parameters.project >>" --verbose --split-by=timings
+          environment:
+            NODE_OPTIONS: --dns-result-order=ipv4first
+            JEST_JUNIT_OUTPUT_DIR: ./artifacts/tests
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: true
+
   store-artifacts:
     steps:
       - run:
@@ -624,26 +641,21 @@ jobs:
     steps:
       - git-checkout
       - provision
-      - run:
-          name: Running smoke tests
-          command: yarn workspace functional-tests test-production
+      - run-playwright-tests:
+          project: production
       - store-artifacts
-      # TODO: Is this actually needed?
-      - store_test_results:
-          path: artifacts/tests
 
   smoke-tests:
     parameters:
-      target:
+      project:
         type: string
-        default: test-production
+        default: production
     executor: smoke-test-executor
     steps:
       - git-checkout
       - provision
-      - run:
-          name: Running smoke tests
-          command: yarn workspace functional-tests << parameters.target >>
+      - run-playwright-tests:
+          project: << parameters.project >>
       - store-artifacts
 
   # Runs functional tests using playwright. These tests support splitting
@@ -671,9 +683,8 @@ jobs:
       - run:
           name: Start services for playwright tests
           command: ./packages/functional-tests/scripts/start-services.sh
-      - run:
-          name: Running playwright tests
-          command: ./packages/functional-tests/scripts/test-ci.sh
+      - run-playwright-tests:
+          project: local
       - store-artifacts
 
   build-and-deploy-storybooks:
@@ -839,7 +850,7 @@ workflows:
     # Note that we removed content server tests as it runs on Stage only
       - smoke-tests:
           name: Smoke Test Production - Playwright
-          target: test-production
+          project: production
           filters:
             branches:
               only: /.*/
@@ -873,7 +884,7 @@ workflows:
               only: /.*/
       - smoke-tests:
           name: Smoke Test Stage - Playwright
-          target: test-stage
+          project: stage
           filters:
             branches:
               only: /.*/

--- a/packages/functional-tests/scripts/start-services.sh
+++ b/packages/functional-tests/scripts/start-services.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -ex
 
-# This routine was formerly part of in test-ci.sh. It has been
-# split up so it can be run in separate steps in the CI,
-# resulting in more meaningful timing metrics.
+# This startup routine is seperate from the test command. This way it can be run in a
+# separate step in the CI, which results in more meaningful timing metrics.
 
 DIR=$(dirname "$0")
 

--- a/packages/functional-tests/scripts/test-ci.sh
+++ b/packages/functional-tests/scripts/test-ci.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -ex
-
-DIR=$(dirname "$0")
-
-cd "$DIR/../../../"
-
-circleci tests glob "packages/functional-tests/tests/**/*.spec.ts" | circleci tests split > tests-to-run.txt
-yarn workspace functional-tests test $(cat tests-to-run.txt|awk -F"/" '{ print $NF }')


### PR DESCRIPTION
## Because

- We'd like to only rerun failed tests

## This pull request

- Allows us to run run just the tests that have failed. See https://circleci.com/docs/rerun-failed-tests-only/
  - Uses`circleci tests run` to invoke playwright command
  - Adds required envs
- Removes functional-tests/test-ci.sh in favor of inline command in circleci config

## Issue that this pull request solves

Closes: FXA-7357

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This PR focuses on playwright tests because they are known to be flaky and there is good support for playwright. Since content-server functional tests are being phased out the rerun only failed feature will not be enabled for them. Since unit and integration tests aren't typically flaky, the rerun only failed feature will not be enabled at this time.

Also here's some screenshots showing this in action. Note that in the second run, the received test names changes to a single test that was purposely failed. The fabricated test failure has been removed in the final state of this PR. See the circle ci history[ here](https://app.circleci.com/pipelines/github/mozilla/fxa/40830).

First run:
![image](https://github.com/mozilla/fxa/assets/94418270/54eea214-b3ff-4236-bf10-7140d7b3584e)

Second run:
![image](https://github.com/mozilla/fxa/assets/94418270/6484a094-6b7d-4c73-8f5b-18954e584cfd)


