### PR TITLE
fix(payments): on upgrade correct next invoice

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -21,6 +21,10 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       id: line.price!.id,
       name: line.description || '',
+      period: {
+        end: line.period.end,
+        start: line.period.start,
+      },
     })),
   };
 

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -15,11 +15,27 @@ const previewInvoiceWithTax = require('./fixtures/stripe/invoice_preview_tax.jso
 const previewInvoiceWithDiscountAndTax = require('./fixtures/stripe/invoice_preview_tax_discount.json');
 const { deepCopy } = require('./util');
 
+function buildExpectedLineItems(invoice) {
+  return invoice.line_items.map((item) => ({
+    amount: item.amount,
+    currency: item.currency,
+    id: item.id,
+    name: item.name,
+    period: {
+      end: item.period.end,
+      start: item.period.start,
+    },
+  }));
+}
+
 describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
   it('formats an invoice with tax', () => {
     const invoice = stripeInvoiceToFirstInvoicePreviewDTO(
       deepCopy(previewInvoiceWithTax)
     );
+    const expectedLineItems = buildExpectedLineItems(invoice);
+
+    assert.deepEqual(invoice.line_items, expectedLineItems);
     assert.equal(invoice.total, previewInvoiceWithTax.total);
     assert.equal(invoice.subtotal, previewInvoiceWithTax.subtotal);
     assert.equal(
@@ -97,6 +113,9 @@ describe('stripeInvoiceToLatestInvoiceItemsDTO', () => {
     const invoice = stripeInvoiceToLatestInvoiceItemsDTO(
       deepCopy(previewInvoiceWithTax)
     );
+    const expectedLineItems = buildExpectedLineItems(invoice);
+
+    assert.deepEqual(invoice.line_items, expectedLineItems);
     assert.equal(invoice.total, previewInvoiceWithTax.total);
     assert.equal(invoice.subtotal, previewInvoiceWithTax.subtotal);
     assert.equal(

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -798,6 +798,10 @@ describe('lib/routes/validators:', () => {
             currency: 'usd',
             id: 'plan_G93lTs8hfK7NNG',
             name: 'testo',
+            period: {
+              end: 1576287337,
+              start: 1576287337,
+            },
           },
         ],
         subtotal: 599,

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -263,6 +263,10 @@ describe('#integration - remote subscriptions:', function () {
                   currency: 'usd',
                   id: 'plan_G93lTs8hfK7NNG',
                   name: 'testo',
+                  period: {
+                    end: date,
+                    start: date,
+                  },
                 },
               ],
               subtotal: 599,

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -37,7 +37,8 @@ const userProfileNoDisplayName = {
 const productUrl = 'https://www.example.com';
 const defaultButtonLabel = 'Continue to download';
 
-const selectedPlan = {
+const selectedPlan: Plan = {
+  active: true,
   plan_id: 'planId',
   plan_name: 'Pro level',
   product_id: 'fpnID',

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -505,13 +505,19 @@ describe('API requests', () => {
       const promotionCode = 'VALID';
       const expected: FirstInvoicePreview = {
         subtotal: 200,
+        subtotal_excluding_tax: 200,
         total: 170,
+        total_excluding_tax: 170,
         line_items: [
           {
             amount: 200,
             currency: 'usd',
             id: priceId,
             name: 'Plan name',
+            period: {
+              end: 1715457345,
+              start: 1715457345,
+            },
           },
         ],
         discount: {

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -5,7 +5,10 @@ import {
   FirstInvoicePreview,
   LatestInvoiceItems,
 } from 'fxa-shared/dto/auth/payments/invoice';
-import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+import {
+  MozillaSubscriptionTypes,
+  WebSubscription,
+} from 'fxa-shared/subscriptions/types';
 
 import { FilteredSetupIntent } from '../lib/apiClient';
 import { Customer, Plan, Profile } from '../store/types';
@@ -304,6 +307,11 @@ export const IAP_CUSTOMER: Customer = {
   subscriptions: [IAP_GOOGLE_SUBSCRIPTION],
 };
 
+const invoicePreviewLinePeriod = {
+  end: (CUSTOMER.subscriptions[0] as WebSubscription).current_period_end,
+  start: (CUSTOMER.subscriptions[0] as WebSubscription).current_period_start,
+};
+
 export const INVOICE_PREVIEW_WITHOUT_DISCOUNT: FirstInvoicePreview = {
   line_items: [
     {
@@ -311,6 +319,7 @@ export const INVOICE_PREVIEW_WITHOUT_DISCOUNT: FirstInvoicePreview = {
       currency: 'usd',
       id: 'plan_GqM9N64ksvxaVk',
       name: '1 x 123Done Pro (at $5.00 / month)',
+      period: invoicePreviewLinePeriod,
     },
   ],
   subtotal: 500,
@@ -326,6 +335,7 @@ export const INVOICE_PREVIEW_WITH_VALID_DISCOUNT: FirstInvoicePreview = {
       currency: 'usd',
       id: 'plan_GqM9N64ksvxaVk',
       name: '1 x 123Done Pro (at $5.00 / month)',
+      period: invoicePreviewLinePeriod,
     },
   ],
   subtotal: 500,
@@ -383,6 +393,7 @@ export const INVOICE_PREVIEW_WITH_100_VALID_DISCOUNT: FirstInvoicePreview = {
       currency: 'usd',
       id: 'plan_GqM9N64ksvxaVk',
       name: '1 x 123Done Pro (at $5.00 / month)',
+      period: invoicePreviewLinePeriod,
     },
   ],
   subtotal: 500,
@@ -403,6 +414,7 @@ export const INVOICE_PREVIEW_WITH_INVALID_DISCOUNT: FirstInvoicePreview = {
       currency: 'usd',
       id: 'plan_GqM9N64ksvxaVk',
       name: '1 x 123Done Pro (at $5.00 / month)',
+      period: invoicePreviewLinePeriod,
     },
   ],
   subtotal: 500,
@@ -423,6 +435,7 @@ export const INVOICE_PREVIEW_INCLUSIVE_TAX: FirstInvoicePreview = {
       currency: 'usd',
       id: 'plan_GqM9N64ksvxaVk',
       name: '1 x 123Done Pro (at $5.00 / month)',
+      period: invoicePreviewLinePeriod,
     },
   ],
   subtotal: 500,
@@ -445,6 +458,7 @@ export const INVOICE_PREVIEW_EXCLUSIVE_TAX: FirstInvoicePreview = {
       currency: 'usd',
       id: 'plan_GqM9N64ksvxaVk',
       name: '1 x 123Done Pro (at $5.00 / month)',
+      period: invoicePreviewLinePeriod,
     },
   ],
   subtotal: 500,

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -880,6 +880,10 @@ export const MOCK_PREVIEW_INVOICE_NO_TAX: FirstInvoicePreview = {
       currency: 'USD',
       id: customerWebSubscriptionPlanId,
       name: 'first invoice',
+      period: {
+        end: 1565816388,
+        start: 1565816388,
+      },
     },
   ],
 };
@@ -895,6 +899,10 @@ export const MOCK_PREVIEW_INVOICE_AFTER_SUBSCRIPTION: FirstInvoicePreview = {
       currency: 'USD',
       id: PLAN_ID,
       name: 'first invoice',
+      period: {
+        end: 1565816388,
+        start: 1565816388,
+      },
     },
   ],
 };
@@ -910,6 +918,10 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE: FirstInvoicePreview = {
       currency: 'USD',
       id: customerWebSubscriptionPlanId,
       name: 'first invoice',
+      period: {
+        end: 1565816388,
+        start: 1565816388,
+      },
     },
   ],
   tax: [
@@ -932,6 +944,10 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE: FirstInvoicePreview = {
       currency: 'USD',
       id: customerWebSubscriptionPlanId,
       name: 'first invoice',
+      period: {
+        end: 1565816388,
+        start: 1565816388,
+      },
     },
   ],
   tax: [
@@ -955,6 +971,10 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_INCLUSIVE_DISCOUNT: FirstInvoicePrevi
         currency: 'USD',
         id: customerWebSubscriptionPlanId,
         name: 'first invoice',
+        period: {
+          end: 1565816388,
+          start: 1565816388,
+        },
       },
     ],
     tax: [
@@ -983,6 +1003,10 @@ export const MOCK_PREVIEW_INVOICE_WITH_TAX_EXCLUSIVE_DISCOUNT: FirstInvoicePrevi
         currency: 'USD',
         id: customerWebSubscriptionPlanId,
         name: 'first invoice',
+        period: {
+          end: 1565816388,
+          start: 1565816388,
+        },
       },
     ],
     tax: [

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -43,6 +43,11 @@ const invoicePreviewNoTax: FirstInvoicePreview = {
       currency: 'USD',
       id: SELECTED_PLAN.plan_id,
       name: 'first invoice',
+      period: {
+        end: (CUSTOMER.subscriptions[0] as WebSubscription).current_period_end,
+        start: (CUSTOMER.subscriptions[0] as WebSubscription)
+          .current_period_start,
+      },
     },
   ],
 };

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -115,6 +115,10 @@ export const SubscriptionUpgrade = ({
     </div>
   ) : null;
 
+  const nextInvoiceDate =
+    invoicePreview.line_items.find((item) => item.id === selectedPlan.plan_id)
+      ?.period.end || upgradeFromSubscription.current_period_end;
+
   return (
     <>
       {updateSubscriptionPlanStatus.error && (
@@ -167,18 +171,14 @@ export const SubscriptionUpgrade = ({
             <Localized
               id="sub-update-copy"
               vars={{
-                startingDate: getLocalizedDate(
-                  upgradeFromSubscription.current_period_end
-                ),
+                startingDate: getLocalizedDate(nextInvoiceDate),
               }}
             >
               <p>
                 Your plan will change immediately, and you’ll be charged an
                 adjusted amount for the rest of your billing cycle. Starting
-                {getLocalizedDateString(
-                  upgradeFromSubscription.current_period_end
-                )}{' '}
-                you’ll be charged the full amount.
+                {getLocalizedDateString(nextInvoiceDate)} you’ll be charged the
+                full amount.
               </p>
             </Localized>
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -174,6 +174,11 @@ const baseProps: SubscriptionsProps = {
   },
 };
 
+const latestInvoiceLineItemPeriod = {
+  end: (Date.now() + 86400) / 1000,
+  start: (Date.now() + 86400) / 1000,
+};
+
 const INVOICE_NO_TAX: LatestInvoiceItems = {
   total: 2000,
   total_excluding_tax: null,
@@ -185,6 +190,7 @@ const INVOICE_NO_TAX: LatestInvoiceItems = {
       currency: 'USD',
       id: PLAN_ID,
       name: 'first invoice',
+      period: latestInvoiceLineItemPeriod,
     },
   ],
 };
@@ -200,6 +206,7 @@ const INVOICE_WITH_TAX_EXCLUSIVE: LatestInvoiceItems = {
       currency: 'USD',
       id: PLAN_ID,
       name: 'first invoice',
+      period: latestInvoiceLineItemPeriod,
     },
   ],
   tax: [
@@ -222,6 +229,7 @@ const INVOICE_WITH_TAX_INCLUSIVE: LatestInvoiceItems = {
       currency: 'USD',
       id: PLAN_ID,
       name: 'first invoice',
+      period: latestInvoiceLineItemPeriod,
     },
   ],
   tax: [

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -8,6 +8,10 @@ export interface InvoiceLineItem {
   currency: string;
   id: string;
   name: string;
+  period: {
+    end: number;
+    start: number;
+  };
 }
 
 export interface InvoiceTax {
@@ -46,6 +50,12 @@ export const firstInvoicePreviewSchema = joi.object({
           currency: joi.string().required(),
           id: joi.string().required(),
           name: joi.string().required(),
+          period: joi
+            .object({
+              end: joi.number().required(),
+              start: joi.number().required(),
+            })
+            .required(),
         })
         .required()
     )
@@ -71,6 +81,10 @@ type line_item = {
   currency: string;
   id: string;
   name: string;
+  period: {
+    end: number;
+    start: number;
+  };
 };
 
 export type firstInvoicePreviewSchema = {

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -50,6 +50,7 @@ const LATEST_INVOICE_ITEMS: LatestInvoiceItems = {
       currency: 'usd',
       id: 'plan_8675309',
       name: 'Example product',
+      period: { end: 1600208907, start: 1600208907 },
     },
   ],
   subtotal: 599,


### PR DESCRIPTION
## Because

- On an upgrade where the interval or interval_count of the new price differs from the current price, the incorrect next invoice date is shown.

## This pull request

- Updates the invoice preview API to return the period
- Updates invoice preview and latest invoice DTO entities.
- Updates all tests and storybooks where invoice preview and latest invoice are used.

## Issue that this pull request solves

Closes: # FXA-7060

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Monthly -> Yearly
![image](https://github.com/mozilla/fxa/assets/10620585/0aabf782-19e2-4488-98c4-3d964f941bfa)

Monthly -> Monthly
![image](https://github.com/mozilla/fxa/assets/10620585/3f3f01c9-919e-45ea-80bd-c826d0a1966e)

