### PR TITLE
feat(auth): change exclude behavior for mover script

### DIFF
--- a/packages/fxa-auth-server/scripts/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/move-customers-to-new-plan.ts
@@ -48,7 +48,7 @@ async function init() {
     )
     .option(
       '-e, --exclude [string]',
-      'Do not sign customers up for the destination plan if they have a subscription to a price in this list',
+      'Do not touch customers if they have a subscription to a price in this list',
       ''
     )
     .option(

--- a/packages/fxa-auth-server/scripts/move-customers-to-new-plan/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/move-customers-to-new-plan/move-customers-to-new-plan.ts
@@ -140,10 +140,10 @@ export class CustomerPlanMover {
 
       const isExcluded = this.isCustomerExcluded(customer.subscriptions.data);
 
-      if (!this.dryRun) {
+      if (!this.dryRun && !isExcluded) {
         await this.cancelSubscription(firestoreSubscription);
 
-        if (!isExcluded) await this.createSubscription(customer.id);
+        await this.createSubscription(customer.id);
       }
 
       const report = this.buildReport(customer, account, isExcluded);

--- a/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
@@ -277,6 +277,13 @@ describe('CustomerPlanMover', () => {
         expect(createSubscriptionStub.notCalled).true;
       });
 
+      it('does not cancel subscription if customer is excluded', async () => {
+        customerPlanMover.isCustomerExcluded = sinon.stub().resolves(true);
+        await customerPlanMover.convertSubscription(mockFirestoreSub);
+
+        expect(cancelSubscriptionStub.notCalled).true;
+      });
+
       it('does not move subscription if subscription is not in active state', async () => {
         await customerPlanMover.convertSubscription({
           ...mockFirestoreSub,


### PR DESCRIPTION
## Because

* The product requirements changed regarding excluding customers.
* We no longer want to cancel-only for excluded customers, but now want to exclude completely.

## This pull request

* Excludes customers in the excluded list completely, rather than just excluding them from the cancellation behavior.

## Issue that this pull request solves

Closes FXA-7448