### PR TITLE
task(auth): include metricsUid if artifacts not set

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -104,8 +104,11 @@ module.exports = (log, config) => {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const request = this;
 
-      if (data && data.uid && request.auth && request.auth.artifacts) {
-        request.auth.artifacts.metricsUid = data.uid;
+      if (data && data.uid && request.auth) {
+        request.auth.artifacts = {
+          ...request.auth.artifacts,
+          metricsUid: data.uid,
+        };
       }
 
       const isMetricsEnabled = await request.app.isMetricsEnabled;


### PR DESCRIPTION
## Because

- If events.emit data includes uid it should be included on request.auth.artifacts, as metricsUid, even if the artifacts property was initial null.

## This pull request

- Sets metricsUid on request.auth.artifacts, even if the artifacts property was initially null.

## Issue that this pull request solves

Closes: #FXA-6967

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
