### PR TITLE
fix(payments): Fix Typescript errors

### DIFF
--- a/packages/fxa-payments-server/.eslintrc.json
+++ b/packages/fxa-payments-server/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "react-app",
+    "react-app/jest"
+  ],
+  "ignorePatterns": [
+    "build",
+    "storybook-static"
+  ],
+  "rules": {
+    "jest/no-jest-import": "off",
+    "jest/valid-describe": "off"
+  },
+  "root": true
+}

--- a/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
@@ -7,6 +7,7 @@ import { AppContext, defaultAppContext } from '../../lib/AppContext';
 import AppLayout, { SignInLayout, SettingsLayout } from './index';
 import TermsAndPrivacy from '../TermsAndPrivacy';
 import { SELECTED_PLAN } from '../../lib/mock-data';
+import { RawMetadata } from 'fxa-shared/subscriptions/types';
 
 afterEach(cleanup);
 
@@ -15,7 +16,7 @@ const {
     'product:termsOfServiceURL': termsOfServiceURL,
     'product:privacyNoticeURL': privacyNoticeURL,
   },
-} = SELECTED_PLAN;
+}: RawMetadata = SELECTED_PLAN;
 
 describe('AppLayout', () => {
   const subject = () => {

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -62,6 +62,7 @@ const WrapNewUserEmailForm = ({
             invalidDomain,
           })
         }
+        onToggleNewsletterCheckbox={() => {}}
         selectedPlan={selectedPlan}
       />
     </div>

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -10,12 +10,9 @@ import { MOCK_PLANS, getLocalizedMessage } from '../../lib/test-utils';
 import { getFtlBundle } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import AppContext, { defaultAppContext } from '../../lib/AppContext';
-import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import { updateConfig } from '../../lib/config';
-import {
-  FirstInvoicePreview,
-  LatestInvoiceItems,
-} from 'fxa-shared/dto/auth/payments/invoice';
+import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
+import { CUSTOMER, PAYPAL_CUSTOMER } from '../../lib/mock-data';
 
 const userProfile = {
   avatar: './avatar.svg',
@@ -59,9 +56,10 @@ const selectedPlanWithMetadata = {
   },
 };
 
-const selectedPlanWithConfiguration = {
+const selectedPlanWithConfiguration: Plan = {
   ...selectedPlan,
   configuration: {
+    productSet: ['testSet'],
     uiContent: {
       successActionButtonLabel: 'Do something else, with configuration',
     },
@@ -72,79 +70,21 @@ const selectedPlanWithConfiguration = {
         },
       },
     },
+    styles: {},
+    support: {},
     urls: {
       termsOfService: 'https://test',
       termsOfServiceDownload: 'https://test2',
       privacyNotice: 'https://test3',
+      successActionButton: 'https://test/4',
+      webIcon: 'https://webicon',
     },
   },
 };
 
-const latestInvoiceItems: LatestInvoiceItems = {
-  line_items: [],
-  subtotal: 735,
-  subtotal_excluding_tax: null,
-  total: 735,
-  total_excluding_tax: null,
-};
+const customer: Customer = CUSTOMER;
 
-const customer: Customer = {
-  billing_name: 'Jane Doe',
-  payment_provider: 'stripe',
-  payment_type: 'credit',
-  last4: '5309',
-  exp_month: '02',
-  exp_year: '2099',
-  brand: 'Visa',
-  subscriptions: [
-    {
-      _subscription_type: MozillaSubscriptionTypes.WEB,
-      latest_invoice: '628031D-0002',
-      latest_invoice_items: latestInvoiceItems,
-      subscription_id: 'sub0.28964929339372136',
-      plan_id: 'plan_123',
-      product_id: 'prod_123',
-      product_name: '123 Done Pro',
-      status: 'active',
-      cancel_at_period_end: false,
-      current_period_end: Date.now() / 1000 + 86400 * 31,
-      current_period_start: Date.now() / 1000 - 86400 * 31,
-      end_at: null,
-      promotion_duration: null,
-      promotion_end: null,
-      created: Date.now() / 1000 - 86400 * 31,
-    },
-  ],
-};
-
-const paypalCustomer: Customer = {
-  billing_name: 'Pay Pal Doe',
-  payment_provider: 'paypal',
-  payment_type: 'credit',
-  last4: '7777',
-  exp_month: '03',
-  exp_year: '3000',
-  brand: 'Visa',
-  subscriptions: [
-    {
-      _subscription_type: MozillaSubscriptionTypes.WEB,
-      latest_invoice: '628031D-0002',
-      latest_invoice_items: latestInvoiceItems,
-      subscription_id: 'sub0.28964929339372136',
-      plan_id: 'plan_123',
-      product_id: 'prod_123',
-      product_name: '123 Done Pro',
-      status: 'active',
-      cancel_at_period_end: false,
-      current_period_end: Date.now() / 1000 + 86400 * 31,
-      current_period_start: Date.now() / 1000 - 86400 * 31,
-      end_at: null,
-      promotion_duration: null,
-      promotion_end: null,
-      created: Date.now() / 1000 - 86400 * 31,
-    },
-  ],
-};
+const paypalCustomer: Customer = PAYPAL_CUSTOMER;
 
 const invoice: FirstInvoicePreview = {
   line_items: [],
@@ -297,8 +237,8 @@ describe('PaymentConfirmation', () => {
     expect(footer).toBeVisible();
     expect(
       queryByText(
-        selectedPlanWithConfiguration.configuration.uiContent
-          .successActionButtonLabel
+        selectedPlanWithConfiguration.configuration?.uiContent
+          .successActionButtonLabel!
       )
     ).toBeInTheDocument();
     expect(queryByText(defaultButtonLabel)).not.toBeInTheDocument();
@@ -334,8 +274,8 @@ describe('PaymentConfirmation', () => {
     expect(footer).toBeVisible();
     expect(
       queryByText(
-        selectedPlanWithConfiguration.configuration.locales['fy-NL'].uiContent
-          .successActionButtonLabel
+        selectedPlanWithConfiguration.configuration?.locales['fy-NL'].uiContent!
+          .successActionButtonLabel!
       )
     ).toBeInTheDocument();
     expect(queryByText(defaultButtonLabel)).not.toBeInTheDocument();

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -4,77 +4,14 @@ import { action } from '@storybook/addon-actions';
 import MockApp from '../../../.storybook/components/MockApp';
 import PaymentForm, { PaymentFormProps } from './index';
 import { State as ValidatorState } from '../../lib/validator';
-import { Customer } from '../../store/types';
 import { useNonce } from '../../lib/hooks';
 import { SignInLayout } from '../AppLayout';
-import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
-import { LatestInvoiceItems } from 'fxa-shared/dto/auth/payments/invoice';
+import { CUSTOMER, SELECTED_PLAN } from '../../lib/mock-data';
 
 export default {
   title: 'components/PaymentFormV2',
   component: PaymentForm,
 } as Meta;
-
-const PRODUCT_ID = 'product_8675309';
-const PLAN_ID = 'plan_123';
-const PLAN = {
-  plan_id: PLAN_ID,
-  product_id: PRODUCT_ID,
-  product_name: 'Example Product',
-  currency: 'USD',
-  amount: 1099,
-  interval: 'month' as const,
-  interval_count: 1,
-  active: true,
-  plan_metadata: null,
-  product_metadata: {
-    'product:termsOfServiceURL':
-      'https://www.mozilla.org/en-US/about/legal/terms/services/',
-    'product:termsOfServiceURL:fr':
-      'https://www.mozilla.org/fr/about/legal/terms/services/',
-    'product:privacyNoticeURL':
-      'https://www.mozilla.org/en-US/privacy/websites/',
-    'product:privacyNoticeURL:fr':
-      'https://www.mozilla.org/fr/privacy/websites/',
-  },
-};
-
-const invoice: LatestInvoiceItems = {
-  line_items: [],
-  subtotal: 735,
-  subtotal_excluding_tax: null,
-  total: 735,
-  total_excluding_tax: null,
-};
-
-const CUSTOMER: Customer = {
-  billing_name: 'Foo Barson',
-  payment_provider: 'stripe',
-  payment_type: 'credit',
-  last4: '5309',
-  exp_month: '02',
-  exp_year: '2099',
-  brand: 'Visa',
-  subscriptions: [
-    {
-      _subscription_type: MozillaSubscriptionTypes.WEB,
-      subscription_id: 'sub0.28964929339372136',
-      plan_id: '123doneProMonthly',
-      product_id: 'prod_123',
-      product_name: '123done Pro',
-      latest_invoice: '628031D-0002',
-      latest_invoice_items: invoice,
-      status: 'active',
-      cancel_at_period_end: false,
-      created: Date.now(),
-      current_period_end: Date.now() / 1000 + 86400 * 31,
-      current_period_start: Date.now() / 1000 - 86400 * 31,
-      end_at: null,
-      promotion_duration: null,
-      promotion_end: null,
-    },
-  ],
-};
 
 const mockValidatorState = (): ValidatorState => ({
   error: null,
@@ -117,7 +54,7 @@ const defaultPaymentFormProps: MostPaymentFormProps = {
   inProgress: false,
   confirm: false,
   customer: undefined,
-  plan: PLAN,
+  plan: SELECTED_PLAN,
   onSubmit: action('onSubmit'),
   onChange: () => {},
   onMounted: () => {},

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -19,18 +19,9 @@ import {
 } from '../../lib/test-utils';
 
 import PaymentForm, { PaymentFormProps } from './index';
+import { SELECTED_PLAN } from '../../lib/mock-data';
 
 jest.mock('../../lib/sentry');
-
-const MOCK_PLAN = {
-  plan_id: 'plan_123',
-  product_id: '123doneProProduct',
-  product_name: 'Example Product',
-  currency: 'USD',
-  amount: 1050,
-  interval: 'month' as const,
-  interval_count: 1,
-};
 
 afterEach(cleanup);
 
@@ -38,13 +29,19 @@ afterEach(cleanup);
 // functions by default in Subject.
 type SubjectProps = Omit<
   PaymentFormProps,
-  'onSubmit' | 'onMounted' | 'onEngaged' | 'onChange' | 'submitNonce'
+  | 'onSubmit'
+  | 'onMounted'
+  | 'onEngaged'
+  | 'onChange'
+  | 'submitNonce'
+  | 'getString'
 > & {
   onSubmit?: PaymentFormProps['onSubmit'];
   onMounted?: PaymentFormProps['onMounted'];
   onEngaged?: PaymentFormProps['onEngaged'];
   onChange?: PaymentFormProps['onChange'];
   submitNonce?: string;
+  getString?: PaymentFormProps['getString'];
 };
 const Subject = ({
   onSubmit = jest.fn(),
@@ -52,6 +49,7 @@ const Subject = ({
   onEngaged = jest.fn(),
   onChange = jest.fn(),
   submitNonce = 'test-nonce',
+  getString,
   ...props
 }: SubjectProps) => {
   return (
@@ -62,7 +60,7 @@ const Subject = ({
         onEngaged,
         onChange,
         submitNonce,
-        getString: null,
+        getString,
         ...props,
       }}
     />
@@ -149,7 +147,7 @@ it('calls onMounted and onEngaged', () => {
 it('when confirm = true, enables submit button when all fields are valid and checkbox checked', () => {
   let { getByTestId } = renderWithValidFields({
     confirm: true,
-    plan: MOCK_PLAN,
+    plan: SELECTED_PLAN,
   });
   expect(getByTestId('submit')).toHaveClass('payment-button-disabled');
   fireEvent.click(getByTestId('confirm'));
@@ -163,7 +161,7 @@ it('omits the confirmation checkbox when confirm = false', () => {
 
 it('includes the confirmation checkbox when confirm = true and plan supplied', () => {
   const { queryByTestId } = render(
-    <Subject {...{ confirm: true, plan: MOCK_PLAN }} />
+    <Subject {...{ confirm: true, plan: SELECTED_PLAN }} />
   );
   expect(queryByTestId('confirm')).toBeInTheDocument();
 });
@@ -240,7 +238,7 @@ it('does not call onSubmit if somehow submitted without confirm checked', async 
   // renderWithValidFields does not check the confirm box
   let { getByTestId } = renderWithValidFields({
     confirm: true,
-    plan: MOCK_PLAN,
+    plan: SELECTED_PLAN,
     onSubmit,
     onChange: () => {},
   });
@@ -272,7 +270,7 @@ it('does not call onSubmit if somehow submitted while in progress', async () => 
 describe('with existing card', () => {
   it('renders correctly', () => {
     const { queryByTestId, queryByText } = render(
-      <Subject customer={MOCK_CUSTOMER} plan={MOCK_PLAN} />
+      <Subject customer={MOCK_CUSTOMER} plan={SELECTED_PLAN} />
     );
     expect(queryByTestId('card-logo-and-last-four')).toBeInTheDocument();
     expect(queryByTestId('name')).not.toBeInTheDocument();
@@ -293,7 +291,7 @@ describe('with existing card', () => {
     const { getByTestId } = render(
       <Subject
         customer={MOCK_CUSTOMER}
-        plan={MOCK_PLAN}
+        plan={SELECTED_PLAN}
         confirm={false}
         onSubmit={onSubmit}
       />
@@ -309,7 +307,7 @@ describe('with existing PayPal billing agreement', () => {
     const { queryByTestId } = render(
       <Subject
         customer={{ ...MOCK_CUSTOMER, payment_provider: 'paypal' }}
-        plan={MOCK_PLAN}
+        plan={SELECTED_PLAN}
       />
     );
     expect(queryByTestId('card-logo-and-last-four')).not.toBeInTheDocument();
@@ -321,7 +319,7 @@ describe('with existing PayPal billing agreement', () => {
     const { getByTestId } = render(
       <Subject
         customer={{ ...MOCK_CUSTOMER, payment_provider: 'paypal' }}
-        plan={MOCK_PLAN}
+        plan={SELECTED_PLAN}
         confirm={false}
         onSubmit={onSubmit}
       />

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
@@ -7,6 +7,7 @@ import { TermsAndPrivacy } from './index';
 import { defaultAppContext, AppContext } from '../../lib/AppContext';
 import { DEFAULT_PRODUCT_DETAILS } from 'fxa-shared/subscriptions/metadata';
 import { updateConfig } from '../../lib/config';
+import { Plan } from 'fxa-shared/subscriptions/types';
 
 const enTermsOfServiceURL =
   'https://www.mozilla.org/en-US/about/legal/terms/services/';
@@ -19,7 +20,7 @@ const frTermsOfServiceDownloadURL =
   'https://www.mozilla.org/fr/about/legal/terms/services/download.pdf';
 const frPrivacyNoticeURL = 'https://www.mozilla.org/fr/privacy/websites/';
 
-const plan = {
+const plan: Plan = {
   ...MOCK_PLANS[0],
   plan_metadata: {
     'product:termsOfServiceURL': enTermsOfServiceURL,
@@ -35,13 +36,15 @@ const planWithNoLegalLinks = {
   ...MOCK_PLANS[0],
 };
 
-const planWithConfiguration = {
+const planWithConfiguration: Plan = {
   ...MOCK_PLANS[0],
   configuration: {
     urls: {
       termsOfService: `${enTermsOfServiceURL}/config`,
       termsOfServiceDownload: `${enTermsOfServiceDownloadURL}/config`,
       privacyNotice: `${enPrivacyNoticeURL}/config`,
+      successActionButton: 'https://test/1',
+      webIcon: 'https://webicon',
     },
     locales: {
       fr: {
@@ -52,6 +55,10 @@ const planWithConfiguration = {
         },
       },
     },
+    productSet: ['testSet'],
+    styles: {},
+    support: {},
+    uiContent: {},
   },
 };
 

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -546,7 +546,10 @@ describe('API requests', () => {
       const invoicePreview: SubsequentInvoicePreview = {
         subscriptionId: 'test',
         period_start: 0,
+        subtotal: 100,
+        subtotal_excluding_tax: null,
         total: 100,
+        total_excluding_tax: null,
       };
       const expected = [invoicePreview];
       const requestMock = nock(AUTH_BASE_URL).get(path).reply(200, expected);
@@ -685,6 +688,7 @@ describe('API requests', () => {
   describe('apiCapturePaypalPayment', () => {
     const path = '/v1/oauth/subscriptions/active/new-paypal';
     const params = {
+      idempotencyKey: '',
       priceId: 'price_12345',
       productId: 'product_2a',
       ...MOCK_CHECKOUT_TOKEN,

--- a/packages/fxa-payments-server/src/lib/flow-event.test.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.test.ts
@@ -77,7 +77,9 @@ it('initializes when given all flow params', () => {
     flow_begin_time: 9001,
     flow_id: 'ipsoandfacto',
   });
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, mockNow - 9001, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {
+    flowBeginTime: mockNow - 9001,
+  });
 
   expect(window.navigator.sendBeacon).toHaveBeenCalled();
 });

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -6,6 +6,7 @@ import {
   LatestInvoiceItems,
 } from 'fxa-shared/dto/auth/payments/invoice';
 import {
+  IapSubscription,
   MozillaSubscriptionTypes,
   WebSubscription,
 } from 'fxa-shared/subscriptions/types';
@@ -172,7 +173,7 @@ export const PAYPAL_CUSTOMER: Customer = {
   ],
 };
 
-export const PLAN = {
+export const PLAN: Plan = {
   plan_id: 'plan_456',
   product_id: PRODUCT_ID,
   product_name: 'Example Product',
@@ -282,7 +283,7 @@ export const MOCK_CURRENCY_ERROR = {
   country: 'RO',
 };
 
-export const IAP_GOOGLE_SUBSCRIPTION = {
+export const IAP_GOOGLE_SUBSCRIPTION: IapSubscription = {
   _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
   product_id: 'prod_123',
   auto_renewing: true,

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -153,9 +153,12 @@ describe('SubscriptionSuccess', () => {
             customer: MOCK_CUSTOMER,
             isMobile: true,
             coupon: {
+              expired: false,
               promotionCode: 'Test',
               type: 'repeating',
               discountAmount: 10,
+              durationInMonths: 1,
+              maximallyRedeemed: false,
               valid: true,
             },
           }}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -158,11 +158,22 @@ describe('CancelSubscriptionPanel', () => {
           },
         });
         const plan = findMockPlan('plan_daily');
-        const upgradeablePlan = {
+        const upgradeablePlan: Plan = {
           ...plan,
           configuration: {
+            locales: {},
+            productSet: ['testSet'],
+            styles: {},
+            support: {},
             uiContent: {
               upgradeCTA: 'Upgrade to config store premium plus plan!',
+            },
+            urls: {
+              termsOfService: 'https://test',
+              termsOfServiceDownload: 'https://test2',
+              privacyNotice: 'https://test3',
+              successActionButton: 'https://test/4',
+              webIcon: 'https://webicon',
             },
           },
         };
@@ -170,9 +181,8 @@ describe('CancelSubscriptionPanel', () => {
           <CancelSubscriptionPanel {...baseProps} plan={upgradeablePlan} />
         );
         expect(queryByTestId('upgrade-cta')).toBeInTheDocument();
-        expect(
-          queryByText(upgradeablePlan.configuration.uiContent.upgradeCTA)
-        ).toBeInTheDocument();
+        const upgradeCTA = upgradeablePlan.configuration?.uiContent.upgradeCTA!;
+        expect(queryByText(upgradeCTA)).toBeInTheDocument();
       });
 
       it('should be displayed when upgradeCTA is in the plan configuration locale', () => {
@@ -182,7 +192,7 @@ describe('CancelSubscriptionPanel', () => {
           },
         });
         const plan = findMockPlan('plan_daily');
-        const upgradeablePlan = {
+        const upgradeablePlan: Plan = {
           ...plan,
           configuration: {
             uiContent: {
@@ -196,6 +206,16 @@ describe('CancelSubscriptionPanel', () => {
                 },
               },
             },
+            productSet: ['testSet'],
+            styles: {},
+            support: {},
+            urls: {
+              termsOfService: 'https://test',
+              termsOfServiceDownload: 'https://test2',
+              privacyNotice: 'https://test3',
+              successActionButton: 'https://test/4',
+              webIcon: 'https://webicon',
+            },
           },
         };
         render(
@@ -208,7 +228,7 @@ describe('CancelSubscriptionPanel', () => {
         expect(queryByTestId('upgrade-cta')).toBeInTheDocument();
         expect(
           queryByText(
-            upgradeablePlan.configuration.locales.fr.uiContent.upgradeCTA
+            upgradeablePlan.configuration?.locales.fr.uiContent?.upgradeCTA!
           )
         ).toBeInTheDocument();
       });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -95,6 +95,17 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     confirmCardSetup: jest.fn().mockResolvedValue(CONFIRM_CARD_SETUP_RESULT),
   });
 
+  const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
+    return (
+      <button
+        data-testid="paypal-button"
+        onClick={async () => {
+          onApprove!({ orderID: 'new-sub' });
+        }}
+      />
+    );
+  };
+
   let consoleSpy: jest.SpyInstance<void, [any?, ...any[]]>;
 
   beforeEach(() => {
@@ -161,11 +172,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     };
 
     const refreshSubscriptions = jest.fn();
-
-    const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
-      return <button data-testid="paypal-button" onClick={onApprove} />;
-    };
-
     await act(async () => {
       render(
         <Subject
@@ -220,10 +226,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     };
 
     const refreshSubscriptions = jest.fn();
-
-    const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
-      return <button data-testid="paypal-button" onClick={onApprove} />;
-    };
 
     await act(async () => {
       render(

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/index.test.tsx
@@ -2,15 +2,14 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { MockApp } from '../../../lib/test-utils';
-import { SELECTED_PLAN } from '../../../lib/mock-data';
+import {
+  IAP_APPLE_SUBSCRIPTION,
+  IAP_GOOGLE_SUBSCRIPTION,
+  SELECTED_PLAN,
+} from '../../../lib/mock-data';
 import { SignInLayout } from '../../../components/AppLayout';
 
-import {
-  AppleSubscription,
-  GooglePlaySubscription,
-  IapSubscription,
-  MozillaSubscriptionTypes,
-} from 'fxa-shared/subscriptions/types';
+import { IapSubscription } from 'fxa-shared/subscriptions/types';
 
 import SubscriptionIapItem, {
   SubscriptionIapItemProps,
@@ -19,20 +18,6 @@ import { PickPartial } from '../../../lib/types';
 
 const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
 
-const appleSubscription: IapSubscription = {
-  _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
-  product_id: SELECTED_PLAN.product_id,
-};
-
-const googleSubscription: IapSubscription = {
-  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-  product_id: SELECTED_PLAN.product_id,
-  auto_renewing: true,
-  expiry_time_millis: Date.now(),
-  package_name: 'mozilla.cooking.with.foxkeh.monthly',
-  sku: 'mozilla.foxkeh',
-};
-
 type SubjectProps = PickPartial<
   SubscriptionIapItemProps,
   'productName' | 'customerSubscription'
@@ -40,7 +25,7 @@ type SubjectProps = PickPartial<
 
 const Subject = ({
   productName = SELECTED_PLAN.product_name,
-  customerSubscription = googleSubscription,
+  customerSubscription = IAP_GOOGLE_SUBSCRIPTION,
 }: SubjectProps) => {
   return (
     <MockApp>
@@ -73,9 +58,9 @@ describe('routes/Subscriptions/SubscriptionIapItem', () => {
       <Subject
         customerSubscription={
           {
-            ...googleSubscription,
+            ...IAP_GOOGLE_SUBSCRIPTION,
             auto_renewing: false,
-          } as GooglePlaySubscription
+          } as IapSubscription
         }
       />
     );
@@ -86,7 +71,9 @@ describe('routes/Subscriptions/SubscriptionIapItem', () => {
   });
   it('renders as expected for an App Store subscription', async () => {
     const { findByTestId, queryByTestId } = render(
-      <Subject customerSubscription={appleSubscription as AppleSubscription} />
+      <Subject
+        customerSubscription={IAP_APPLE_SUBSCRIPTION as IapSubscription}
+      />
     );
     const subscriptionItemEle = await findByTestId('subscription-item');
     expect(subscriptionItemEle).toBeInTheDocument();
@@ -98,10 +85,10 @@ describe('routes/Subscriptions/SubscriptionIapItem', () => {
   });
 
   it('renders an App store subscription with no expiration data', async () => {
-    const subscription = deepCopy(appleSubscription);
+    const subscription = deepCopy(IAP_APPLE_SUBSCRIPTION);
 
     const { findByTestId } = render(
-      <Subject customerSubscription={subscription as AppleSubscription} />
+      <Subject customerSubscription={subscription as IapSubscription} />
     );
     const subscriptionItemEle = await findByTestId('subscription-item');
     expect(subscriptionItemEle).toBeInTheDocument();
@@ -112,12 +99,12 @@ describe('routes/Subscriptions/SubscriptionIapItem', () => {
   });
 
   it('renders an App store subscription with expiration data and auto renew', async () => {
-    const subscription = deepCopy(appleSubscription);
+    const subscription = deepCopy(IAP_APPLE_SUBSCRIPTION);
     subscription.expiry_time_millis = 1656759852811;
     subscription.auto_renewing = true;
 
     const { findByTestId } = render(
-      <Subject customerSubscription={subscription as AppleSubscription} />
+      <Subject customerSubscription={subscription as IapSubscription} />
     );
     const subscriptionItemEle = await findByTestId('subscription-item');
     expect(subscriptionItemEle).toBeInTheDocument();
@@ -129,12 +116,12 @@ describe('routes/Subscriptions/SubscriptionIapItem', () => {
   });
 
   it('renders an App store subscription with expiration data and no auto renew', async () => {
-    const subscription = deepCopy(appleSubscription);
+    const subscription = deepCopy(IAP_APPLE_SUBSCRIPTION);
     subscription.expiry_time_millis = 1656759852811;
     subscription.auto_renewing = false;
 
     const { findByTestId } = render(
-      <Subject customerSubscription={subscription as AppleSubscription} />
+      <Subject customerSubscription={subscription as IapSubscription} />
     );
     const subscriptionItemEle = await findByTestId('subscription-item');
     expect(subscriptionItemEle).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -19,6 +19,7 @@ import { CUSTOMER, FILTERED_SETUP_INTENT } from '../../lib/mock-data';
 import {
   IapSubscription,
   MozillaSubscriptionTypes,
+  Plan,
   WebSubscription,
 } from 'fxa-shared/subscriptions/types';
 import { LatestInvoiceItems } from 'fxa-shared/dto/auth/payments/invoice';
@@ -111,7 +112,7 @@ const PROFILE: Profile = {
   metricsEnabled: true,
 };
 
-const PLANS = [
+const PLANS: Plan[] = [
   {
     plan_id: PLAN_ID,
     product_id: PRODUCT_ID,

--- a/packages/fxa-payments-server/tsconfig.json
+++ b/packages/fxa-payments-server/tsconfig.json
@@ -20,10 +20,6 @@
   "include": [
     "src"
   ],
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.test.tsx"
-  ],
   "references": [
     {
       "path": "../fxa-react"


### PR DESCRIPTION
## Because

- Typescript compilation on test files in payments were temporarily disabled

## This pull request

- fixes TypeScript errors from [https://app.circleci.com/pipelines/github/mozilla/fxa/39710/workflows/aadf68b4-2667-41a6-bb51-8fcced647d20/jobs/419847](https://app.circleci.com/pipelines/github/mozilla/fxa/39710/workflows/aadf68b4-2667-41a6-bb51-8fcced647d20/jobs/419847)
- removes the ‘exclude’ config in payment’s tsconfig file

## Issue that this pull request solves

Closes: [FXA-7144](https://mozilla-hub.atlassian.net/browse/FXA-7144)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

[FXA-7144]: https://mozilla-hub.atlassian.net/browse/FXA-7144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ