### PR TITLE
task(auth): move metricsUid to app.metricsEventUid

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -205,8 +205,8 @@ module.exports = (log, config) => {
     }
 
     const uid = data.uid || getFromToken(request, 'uid');
-    if (uid && request.auth.artifacts) {
-      request.auth.artifacts.metricsUid = uid;
+    if (uid) {
+      request.app.metricsEventUid = uid;
     }
 
     let devices;

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -104,8 +104,9 @@ module.exports = (log, config) => {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const request = this;
 
-      if (data && data.uid && request.auth && request.auth.artifacts) {
-        request.auth.artifacts.metricsUid = data.uid;
+      if (data && data.uid) {
+        // Used by request.app.isMetricsEnabled to determine Account.metricsEnabled
+        request.app.metricsEventUid = data.uid;
       }
 
       const isMetricsEnabled = await request.app.isMetricsEnabled;

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -272,13 +272,9 @@ async function create(log, error, config, routes, db, statsd) {
       } else if (request.payload && request.payload.uid) {
         // Some unauthenticated requests might set uid in payload, ex. `/account/status`
         uid = request.payload.uid;
-      } else if (
-        request.auth &&
-        request.auth.artifacts &&
-        request.auth.artifacts.metricsUid
-      ) {
-        // For access tokens, we stash the uid
-        uid = request.auth.artifacts.metricsUid;
+      } else if (request.app.metricsEventUid) {
+        // For access tokens, and webhooks, we stash the uid
+        uid = request.app.metricsEventUid;
       } else if (request.payload && request.payload.email) {
         // last resort is to check if an email is in the payload
         try {

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -21,6 +21,7 @@ export interface AuthApp extends RequestApplicationState {
   acceptLanguage: string;
   clientAddress: string;
   metricsContext: any;
+  metricsEventUid?: string;
   accountRecreated: boolean;
   ua: {
     browser: string;

--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -181,7 +181,7 @@ describe('metrics/amplitude', () => {
       });
     });
 
-    describe('sets metricsUid when uid specified', () => {
+    describe('sets metricsEventUid when uid specified', () => {
       it('credentials with metricsOptOutAt set do not log', async () => {
         const request = mocks.mockRequest({
           credentials: {
@@ -192,7 +192,7 @@ describe('metrics/amplitude', () => {
           },
         });
         await amplitude('account.confirmed', request);
-        assert.equal(request.auth.artifacts.metricsUid, 'blee');
+        assert.equal(request.app.metricsEventUid, 'blee');
       });
     });
 

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -1172,6 +1172,35 @@ describe('metrics/events', () => {
     });
   });
 
+  it('.emit does not log event if isMetricsEnabled is false', () => {
+    const request = mocks.mockRequest({
+      isMetricsEnabledValue: false,
+    });
+    const data = {
+      uid: 'baz',
+    };
+    assert.equal(request.app.metricsEventUid, undefined);
+    return events.emit.call(request, 'account.signed', data).then(() => {
+      assert.equal(request.app.metricsEventUid, data.uid);
+      assert.equal(
+        log.amplitudeEvent.callCount,
+        0,
+        'log.amplitudeEvent was not called'
+      );
+    });
+  });
+
+  it('.emit sets metricsEventUid if provided in data', () => {
+    const request = mocks.mockRequest({});
+    const data = {
+      uid: 'baz',
+    };
+    assert.equal(request.app.metricsEventUid, undefined);
+    return events.emit.call(request, 'account.signed', data).then(() => {
+      assert.equal(request.app.metricsEventUid, data.uid);
+    });
+  });
+
   it('.emitRouteFlowEvent with matching route and response.statusCode', () => {
     const time = Date.now();
     sinon.stub(Date, 'now').callsFake(() => time);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -763,6 +763,11 @@ function mockRequest(data, errors) {
     metricsContextData = {};
   }
   const app = data.app || {};
+  const isMetricsEnabledValue =
+    data.isMetricsEnabledValue === undefined ||
+    data.isMetricsEnabledValue === null
+      ? true
+      : false;
   return {
     app: {
       acceptLanguage: data.acceptLanguage || 'en-US',
@@ -780,7 +785,7 @@ function mockRequest(data, errors) {
         deviceType: data.uaDeviceType || null,
         formFactor: data.uaFormFactor || null,
       },
-      isMetricsEnabled: Promise.resolve(true),
+      isMetricsEnabled: Promise.resolve(isMetricsEnabledValue),
       ...app,
     },
     auth: {


### PR DESCRIPTION
## Because

- If events.emit data includes uid it should be included on request.app.metricsEventUid instead of request.auth.artifacts.metricsUid.

## This pull request

- Sets request.app.metricsEventUid and updates request.isMetricsEnabled to use metricsEventUid if necessary to determine Account.metricsEnabled.

## Issue that this pull request solves

Closes: #FXA-6967

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).