### PR TITLE
feat(fxa-settings): Add Change Recovery Key capability

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -397,18 +397,6 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'account_recovery_view',
   },
-  'screen.settings.account-recovery.info': {
-    group: GROUPS.settings,
-    event: 'account_recovery_info_view',
-  },
-  'flow.settings.account-recovery.info.navigate-backward': {
-    group: GROUPS.settings,
-    event: 'account_recovery_info_navigate_backward',
-  },
-  'flow.settings.account-recovery.info.navigate-forward': {
-    group: GROUPS.settings,
-    event: 'account_recovery_info_navigate_forward',
-  },
   // Revoke
   'flow.settings.account-recovery.confirm-revoke.submit': {
     group: GROUPS.settings,
@@ -422,7 +410,33 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'account_recovery_confirm_revoke_fail',
   },
-  // Add
+  // Create/Change Key
+  // Info page
+  'flow.settings.account-recovery.create-key.info': {
+    group: GROUPS.settings,
+    event: 'account_recovery_create_key_info',
+  },
+  'flow.settings.account-recovery.change-key.info': {
+    group: GROUPS.settings,
+    event: 'account_recovery_change_key_info',
+  },
+  'flow.settings.account-recovery.create-key.start': {
+    group: GROUPS.settings,
+    event: 'account_recovery_create_key_start',
+  },
+  'flow.settings.account-recovery.change-key.start': {
+    group: GROUPS.settings,
+    event: 'account_recovery_change_key_start',
+  },
+  'flow.settings.account-recovery.create-key.cancel': {
+    group: GROUPS.settings,
+    event: 'account_recovery_create_key_cancel',
+  },
+  'flow.settings.account-recovery.change-key.cancel': {
+    group: GROUPS.settings,
+    event: 'account_recovery_change_key_cancel',
+  },
+  // Confirm password page
   'flow.settings.account-recovery.confirm-password.submit': {
     group: GROUPS.settings,
     event: 'account_recovery_confirm_password_submit',
@@ -435,6 +449,7 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'account_recovery_confirm_password_fail',
   },
+  // Key download page
   'flow.settings.account-recovery.recovery-key.download-option': {
     group: GROUPS.settings,
     event: 'account_recovery_option_download',
@@ -443,14 +458,16 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'account_recovery_option_copy',
   },
+  'flow.settings.account-recovery.recovery-key.skip-download': {
+    group: GROUPS.settings,
+    event: 'account_recovery_skip_download',
+  },
+  // TODO remove in FXA-7419, print option not available in new UI
   'flow.settings.account-recovery.recovery-key.print-option': {
     group: GROUPS.settings,
     event: 'account_recovery_option_print',
   },
-  'flow.settings.account-recovery.hint-step-view': {
-    group: GROUPS.settings,
-    event: 'account_recovery_hint_view',
-  },
+  // Save hint page
   'flow.settings.account-recovery.hint-submit': {
     group: GROUPS.settings,
     event: 'account_recovery_hint_submit',

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -59,9 +59,9 @@ const settingsConfig = {
     count: config.get('recovery_codes.count'),
     length: config.get('recovery_codes.length'),
   },
-  showRecoveryKeyV2: config.get('showRecoveryKeyV2'),
+  showRecoveryKeyV2: config.get('featureFlags.showRecoveryKeyV2'),
   googleAuthConfig: config.get('googleAuthConfig'),
-  appleAuthConfig: config.get('appleAuthConfig')
+  appleAuthConfig: config.get('appleAuthConfig'),
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -215,6 +215,12 @@ const conf = (module.exports = convict({
         format: 'int',
       },
     },
+    showRecoveryKeyV2: {
+      default: false,
+      doc: 'Enable users to see the new recovery key flow in settings',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_SHOW_RECOVERY_KEY_V2',
+    },
   },
   showReactApp: {
     simpleRoutes: {
@@ -628,12 +634,6 @@ const conf = (module.exports = convict({
       env: 'RECOVERY_CODE_LENGTH',
       format: 'nat',
     },
-  },
-  showRecoveryKeyV2: {
-    default: false,
-    doc: 'Enable users to see the new recovery key flow in settings',
-    format: Boolean,
-    env: 'SHOW_RECOVERY_KEY_V2',
   },
   redirect_port: {
     default: 80,

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
@@ -104,7 +104,7 @@ describe('ButtonDownloadRecoveryKey', () => {
 
     expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
-      'download-option'
+      'recovery-key.download-option'
     );
   });
 });

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -107,7 +107,7 @@ export const ButtonDownloadRecoveryKey = ({
         data-testid="recovery-key-download"
         className="cta-primary cta-xl w-full"
         onClick={() => {
-          logViewEvent(`flow.${viewName}`, `download-option`);
+          logViewEvent(`flow.${viewName}`, `recovery-key.download-option`);
           navigateForward && navigateForward();
         }}
       >

--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -49,7 +49,8 @@ export const DataBlock = ({
   const actionCb: actionFn = (action) => {
     onAction(action);
 
-    if (actionTypeToNotification[action]) {
+    // No feedback tooltip displayed for inline copy button
+    if (actionTypeToNotification[action] && !isInline) {
       setPerformedAction(action);
     }
   };
@@ -58,9 +59,9 @@ export const DataBlock = ({
     <div className="flex flex-col items-center">
       <div
         className={classNames(
-          'relative flex rounded-lg px-6 font-mono text-center text-sm font-bold text-black bg-gradient-to-tr from-blue-600/10 to-purple-500/10 mb-2',
+          'relative flex rounded-lg px-6 font-mono text-center text-sm font-bold text-black bg-gradient-to-tr from-blue-600/10 to-purple-500/10',
           valueIsArray ? 'max-w-sm py-4' : 'max-w-lg py-5',
-          isInline ? 'flex-nowrap w-full mb-4' : 'flex-wrap mb-8'
+          isInline ? 'flex-nowrap w-full my-2' : 'flex-wrap mb-8'
         )}
         data-testid={dataTestId}
         {...{ onCopy }}

--- a/packages/fxa-settings/src/components/IconListItem/index.tsx
+++ b/packages/fxa-settings/src/components/IconListItem/index.tsx
@@ -97,7 +97,9 @@ export const ShieldIconListItem = ({
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
     <IconListItem
-      icon={<IconShield className="w-5 h-5 items-center justify-center" />}
+      icon={
+        <IconShield className="w-5 h-5 translate-y-0.5 px-[1.75px] items-center justify-center" />
+      }
     >
       {children}
     </IconListItem>

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -67,7 +67,7 @@ export const InputPassword = ({
       <button
         type="button"
         data-testid={formatDataTestId('visibility-toggle')}
-        className={`px-3 py-2 text-grey-900 box-content ${
+        className={`px-3 py-2 text-grey-500 box-content ${
           !hasContent && 'hidden'
         }`}
         tabIndex={-1}

--- a/packages/fxa-settings/src/components/Settings/ButtonIcon/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ButtonIcon/index.test.tsx
@@ -11,7 +11,7 @@ it('can render with props', () => {
   render(
     <ButtonIcon
       testId="test-button"
-      title="Hello"
+      title="Test Icon"
       classNames="ml-2"
       disabled={true}
       icon={[TrashIcon, 10, 15]}
@@ -22,9 +22,9 @@ it('can render with props', () => {
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('ml-2');
   expect(button).toBeDisabled();
-  expect(button).toHaveProperty('title', 'Hello');
+  expect(button).toHaveProperty('title', 'Test Icon');
   expect(button.innerHTML).toEqual(
-    '<svg width="10" height="15" class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 fill-current">trash-icon.svg</svg>'
+    '<svg width="10" height="15" class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 fill-current" aria-label="Test Icon">trash-icon.svg</svg>'
   );
 });
 

--- a/packages/fxa-settings/src/components/Settings/ButtonIcon/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ButtonIcon/index.tsx
@@ -27,7 +27,7 @@ export const ButtonIcon = ({
 
   return (
     <button
-      className={`relative w-8 h-8 disabled:text-grey-300 disabled:cursor-wait ${classNames}`}
+      className={`relative w-8 h-8 rounded disabled:text-grey-300  hover:bg-grey-50 active:bg-grey-100 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 focus:bg-grey-10 disabled:cursor-wait ${classNames}`}
       data-testid={testId}
       {...{ title, onClick, disabled }}
     >
@@ -35,6 +35,7 @@ export const ButtonIcon = ({
         width={icon[1]}
         height={icon[2]}
         className="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 fill-current"
+        aria-label={title}
       />
     </button>
   );
@@ -48,7 +49,7 @@ export const ButtonIconTrash = ({
   title,
 }: Omit<ButtonIconProps, 'icon'>) => (
   <ButtonIcon
-    classNames={`text-red-500 active:text-red-800 focus:text-red-800 ${classNames}`}
+    classNames={`text-grey-500 active:text-grey-800 focus:text-grey-800 ${classNames}`}
     icon={[TrashIcon, 11, 14]}
     {...{ title, disabled, onClick, testId }}
   />

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
@@ -7,6 +7,7 @@ import { FlowRecoveryKeyConfirmPwd } from '.';
 import { Meta } from '@storybook/react';
 import { useFtlMsgResolver } from '../../../models';
 import { withLocalization } from '../../../../.storybook/decorators';
+import { RecoveryKeyAction } from '../PageRecoveryKeyCreate';
 
 export default {
   title: 'Components/Settings/FlowRecoveryKeyConfirmPwd',
@@ -16,7 +17,15 @@ export default {
 
 const viewName = 'example-view-name';
 
-export const Default = () => {
+const navigateBackward = () => {
+  alert('navigating to previous page');
+};
+
+const navigateForward = () => {
+  alert('navigating to next view within wizard');
+};
+
+export const CreateKey = () => {
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>('');
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedBackButtonTitle = ftlMsgResolver.getMsg(
@@ -28,16 +37,35 @@ export const Default = () => {
     'Account Recovery Key'
   );
 
-  const navigateBackward = () => {
-    alert('navigating to previous page');
-  };
+  return (
+    <FlowRecoveryKeyConfirmPwd
+      {...{
+        localizedBackButtonTitle,
+        localizedPageTitle,
+        navigateBackward,
+        navigateForward,
+        setFormattedRecoveryKey,
+        viewName,
+      }}
+    />
+  );
+};
 
-  const navigateForward = () => {
-    alert('navigating to next view within wizard');
-  };
+export const ChangeKey = () => {
+  const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>('');
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedBackButtonTitle = ftlMsgResolver.getMsg(
+    'recovery-key-create-back-button',
+    'Back to settings'
+  );
+  const localizedPageTitle = ftlMsgResolver.getMsg(
+    'recovery-key-create-page-title',
+    'Account Recovery Key'
+  );
 
   return (
     <FlowRecoveryKeyConfirmPwd
+      action={RecoveryKeyAction.Change}
       {...{
         localizedBackButtonTitle,
         localizedPageTitle,

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -79,7 +79,10 @@ describe('FlowRecoveryKeyDownload', () => {
     );
     fireEvent.click(downloadButton);
     expect(navigateForward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'download-option');
+    expect(logViewEvent).toBeCalledWith(
+      `flow.${viewName}`,
+      'recovery-key.download-option'
+    );
   });
 
   it('emits the expected metrics when user navigates forward without downloading the key', () => {
@@ -87,7 +90,10 @@ describe('FlowRecoveryKeyDownload', () => {
     const nextPageLink = screen.getByRole('link', { name: 'Next' });
     fireEvent.click(nextPageLink);
     expect(navigateForward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'skip-download');
+    expect(logViewEvent).toBeCalledWith(
+      `flow.${viewName}`,
+      'recovery-key.skip-download'
+    );
   });
 
   // TODO expect metric event when back arrow clicked

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
@@ -38,7 +38,10 @@ export const FlowRecoveryKeyDownload = ({
   return (
     <FlowContainer
       title={localizedPageTitle}
-      onBackButtonClick={navigateBackward}
+      onBackButtonClick={() => {
+        navigateBackward();
+        logViewEvent(`flow.${viewName}`, 'recovery-key.skip-download');
+      }}
       {...{ localizedBackButtonTitle }}
     >
       <div className="w-full flex flex-col gap-4">
@@ -56,8 +59,16 @@ export const FlowRecoveryKeyDownload = ({
             This key will help recover your data if you forget your password.
           </p>
         </FtlMsg>
-        {/* TODO Add copy metric flow.settings.account-recovery.copy-option */}
-        <DataBlock value={recoveryKeyValue} isInline />
+        <DataBlock
+          value={recoveryKeyValue}
+          onCopy={() =>
+            logViewEvent(
+              'flow.settings.account-recovery',
+              `recovery-key.copy-option`
+            )
+          }
+          isInline
+        />
         <FtlMsg id="flow-recovery-key-download-storage-ideas-heading">
           <h3 id="key-storage-ideas" className="font-semibold -mb-4">
             Some ideas for storing your account recovery key:
@@ -93,7 +104,7 @@ export const FlowRecoveryKeyDownload = ({
             to=""
             className="text-sm link-blue text-center py-2 mx-auto"
             onClick={() => {
-              logViewEvent(`flow.${viewName}`, 'skip-download');
+              logViewEvent(`flow.${viewName}`, 'recovery-key.skip-download');
               navigateForward();
             }}
           >

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/en.ftl
@@ -2,9 +2,15 @@
 
 # The header of the first view in the Recovery Key Create flow
 flow-recovery-key-info-header = Create an account recovery key in case you forget your password
+# The header of the first view in the Recovery Key Create flow when replacing an existing recovery key
+flow-recovery-key-info-header-change-key = Change your account recovery key
 # In the first view of the PageRecoveryKeyCreate flow, this is the first of two bullet points explaining why the user should create an account recovery key
 flow-recovery-key-info-shield-bullet-point = We encrypt browsing data –– passwords, bookmarks, and more. It’s great for privacy, but it means we can’t recover your data if you forget your password.
 # In the first view of the PageRecoveryKeyCreate flow, this is the second of two bullet points explaining why the user should create an account recovery key
 flow-recovery-key-info-key-bullet-point = That’s why creating an account recovery key is so important –– you can use your key to get your data back.
 # The text of the "submit" button in the first view of the PageRecoveryKeyCreate flow
 flow-recovery-key-info-cta-text-v2 = Start creating your account recovery key
+# The text of the "submit" button in the first view of the Account Recovery Key Create flow
+flow-recovery-key-info-cta-text-change-key = Change account recovery key
+# Link to cancel account recovery key change and return to settings
+flow-recovery-key-info-cancel-link = Cancel

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.stories.tsx
@@ -7,6 +7,7 @@ import FlowRecoveryKeyInfo from '.';
 import { Meta } from '@storybook/react';
 import { useFtlMsgResolver } from '../../../models';
 import { withLocalization } from '../../../../.storybook/decorators';
+import { RecoveryKeyAction } from '../PageRecoveryKeyCreate';
 
 export default {
   title: 'Components/Settings/FlowRecoveryKeyInfo',
@@ -14,9 +15,17 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+const navigateBackward = () => {
+  alert('navigating to previous page');
+};
+
+const navigateForward = () => {
+  alert('navigating to next view within wizard');
+};
+
 const viewName = 'viewname';
 
-export const Default = () => {
+export const CreateKey = () => {
   const ftlMsgResolver = useFtlMsgResolver();
 
   const localizedBackButtonTitle = ftlMsgResolver.getMsg(
@@ -28,16 +37,34 @@ export const Default = () => {
     'Account Recovery Key'
   );
 
-  const navigateBackward = () => {
-    alert('navigating to previous page');
-  };
+  return (
+    <FlowRecoveryKeyInfo
+      {...{
+        localizedBackButtonTitle,
+        localizedPageTitle,
+        navigateBackward,
+        navigateForward,
+        viewName,
+      }}
+    />
+  );
+};
 
-  const navigateForward = () => {
-    alert('navigating to next view within wizard');
-  };
+export const ChangeKey = () => {
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const localizedBackButtonTitle = ftlMsgResolver.getMsg(
+    'recovery-key-create-back-button',
+    'Back to settings'
+  );
+  const localizedPageTitle = ftlMsgResolver.getMsg(
+    'recovery-key-create-page-title',
+    'Account Recovery Key'
+  );
 
   return (
     <FlowRecoveryKeyInfo
+      action={RecoveryKeyAction.Change}
       {...{
         localizedBackButtonTitle,
         localizedPageTitle,

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.tsx
@@ -2,15 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FlowContainer } from '../FlowContainer';
 import { ProgressBar } from '../ProgressBar';
 import { SecurityShieldImage } from '../../images';
 import { ShieldIconListItem, KeyIconListItem } from '../../IconListItem';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../../lib/metrics';
+import { RecoveryKeyAction } from '../PageRecoveryKeyCreate';
+import { Link } from '@reach/router';
+import { HomePath } from '../../../constants';
 
 export type FlowRecoveryKeyInfoProps = {
+  action?: RecoveryKeyAction;
   localizedBackButtonTitle: string;
   localizedPageTitle: string;
   navigateForward: () => void;
@@ -18,32 +22,47 @@ export type FlowRecoveryKeyInfoProps = {
   viewName: string;
 };
 
-export const backwardNavigationEventName = 'info.navigate-forward';
-export const forwardNavigationEventName = 'info.navigate-backward';
-
 export const FlowRecoveryKeyInfo = ({
+  action = RecoveryKeyAction.Create,
   localizedBackButtonTitle,
   localizedPageTitle,
   navigateForward,
   navigateBackward,
   viewName,
 }: FlowRecoveryKeyInfoProps) => {
+  useEffect(() => {
+    action === RecoveryKeyAction.Create
+      ? logViewEvent(`flow.${viewName}`, 'create-key.info')
+      : logViewEvent(`flow.${viewName}`, 'change-key.info');
+  }, [action, viewName]);
+
   return (
     <FlowContainer
       {...{ localizedBackButtonTitle }}
       title={localizedPageTitle}
       onBackButtonClick={() => {
-        logViewEvent(`flow.${viewName}`, backwardNavigationEventName);
+        action === RecoveryKeyAction.Create
+          ? logViewEvent(`flow.${viewName}`, 'create-key.cancel')
+          : logViewEvent(`flow.${viewName}`, 'change-key.cancel');
         navigateBackward();
       }}
     >
       <ProgressBar currentStep={1} numberOfSteps={4} />
       <SecurityShieldImage className="mx-auto my-6" />
-      <FtlMsg id="flow-recovery-key-info-header">
-        <h2 className="font-bold text-xl mb-4">
-          Create an account recovery key in case you forget your password
-        </h2>
-      </FtlMsg>
+      {action === RecoveryKeyAction.Create ? (
+        <FtlMsg id="flow-recovery-key-info-header">
+          <h2 className="font-bold text-xl mb-4">
+            Create an account recovery key in case you forget your password
+          </h2>
+        </FtlMsg>
+      ) : (
+        <FtlMsg id="flow-recovery-key-info-header-change-key">
+          <h2 className="font-bold text-xl mb-4">
+            Change your account recovery key
+          </h2>
+        </FtlMsg>
+      )}
+
       <ul>
         <ShieldIconListItem>
           <FtlMsg id="flow-recovery-key-info-shield-bullet-point">
@@ -63,18 +82,49 @@ export const FlowRecoveryKeyInfo = ({
           </FtlMsg>
         </KeyIconListItem>
       </ul>
-      <FtlMsg id="flow-recovery-key-info-cta-text-v2">
-        <button
-          className="cta-primary cta-xl mt-4"
-          type="button"
-          onClick={() => {
-            logViewEvent(`flow.${viewName}`, forwardNavigationEventName);
-            navigateForward();
-          }}
-        >
-          Start creating your account recovery key
-        </button>
-      </FtlMsg>
+      {action === RecoveryKeyAction.Create && (
+        <FtlMsg id="flow-recovery-key-info-cta-text-v2">
+          <button
+            className="cta-primary cta-xl mt-4"
+            type="button"
+            onClick={() => {
+              logViewEvent(`flow.${viewName}`, 'create-key.start');
+              navigateForward();
+            }}
+          >
+            Start creating your account recovery key
+          </button>
+        </FtlMsg>
+      )}
+      {action === RecoveryKeyAction.Change && (
+        <FtlMsg id="flow-recovery-key-info-cta-text-change-key">
+          <button
+            className="cta-primary cta-xl mt-4"
+            type="button"
+            onClick={() => {
+              logViewEvent(`flow.${viewName}`, 'change-key.start');
+              navigateForward();
+            }}
+          >
+            Change account recovery key
+          </button>
+        </FtlMsg>
+      )}
+
+      {action === RecoveryKeyAction.Change && (
+        <FtlMsg id="flow-recovery-key-info-cancel-link">
+          {/* TODO: Remove feature flag param in FXA-7419 */}
+          <Link
+            className="link-blue text-sm mx-auto mt-4"
+            to={HomePath}
+            onClick={() =>
+              logViewEvent(`flow.${viewName}`, 'change-key.cancel')
+            }
+          >
+            Cancel
+          </Link>
+        </FtlMsg>
+      )}
     </FlowContainer>
   );
 };

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -72,13 +72,13 @@ export const Modal = ({
             data-testid="modal-tab-fence"
             className="outline-none"
           />
-          <div className="flex justify-end pr-2 pt-2">
+          <div className="flex justify-end pe-2 py-2">
             <button
               data-testid="modal-dismiss"
               onClick={(event) => onDismiss()}
               title={ftlMsgResolver.getMsg('modal-close-title', 'Close')}
             >
-              <CloseIcon className="w-2 h-2 m-3" role="img" />
+              <CloseIcon className="w-4 h-4 m-3" role="img" />
             </button>
           </div>
 

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
@@ -21,6 +21,7 @@ const recoveryKeyRaw = new Uint8Array(20);
 
 const accountWithSuccess = {
   ...MOCK_ACCOUNT,
+  recoveryKey: false,
   createRecoveryKey: () => recoveryKeyRaw,
 } as unknown as Account;
 
@@ -45,6 +46,13 @@ const accountWithUnexpectedError = {
   },
 } as unknown as Account;
 
+const accountWithKeyEnabled = {
+  ...MOCK_ACCOUNT,
+  recoveryKey: true,
+  createRecoveryKey: () => recoveryKeyRaw,
+  deleteRecoveryKey: () => true,
+} as unknown as Account;
+
 const storyWithContext = (account: Account) => {
   const story = () => (
     <LocationProvider>
@@ -56,10 +64,12 @@ const storyWithContext = (account: Account) => {
   return story;
 };
 
-export const WithSuccess = storyWithContext(accountWithSuccess);
+export const CreateKeyWithSuccess = storyWithContext(accountWithSuccess);
 
 export const WithPasswordError = storyWithContext(accountWithPasswordError);
 
 export const WithThrottledError = storyWithContext(accountWithThrottledError);
 
 export const WithUnexpectedError = storyWithContext(accountWithUnexpectedError);
+
+export const ChangeKeyWithSuccess = storyWithContext(accountWithKeyEnabled);

--- a/packages/fxa-settings/src/components/Settings/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.tsx
@@ -57,7 +57,6 @@ export const Security = () => {
                 : '/settings/create_password'
             }
             prefixDataTestId="password"
-            isLevelWithRefreshButton={true}
           >
             {hasPassword ? (
               <PwdDate {...{ passwordCreated }} />

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
@@ -16,7 +16,6 @@ type ModalButtonProps = {
   revealModal: () => void;
   modalRevealed?: boolean;
   alertBarRevealed?: boolean;
-  leftSpaced?: boolean;
   prefixDataTestId?: string;
 };
 
@@ -26,7 +25,6 @@ export const ModalButton = ({
   revealModal,
   modalRevealed,
   alertBarRevealed,
-  leftSpaced,
   prefixDataTestId = '',
 }: ModalButtonProps) => {
   const modalTriggerElement = useRef<HTMLButtonElement>(null);
@@ -47,7 +45,6 @@ export const ModalButton = ({
     <button
       className={classNames(
         'cta-base transition-standard',
-        leftSpaced && 'ml-2',
         className || 'cta-neutral cta-base-p'
       )}
       data-testid={formatDataTestId('unit-row-modal')}
@@ -80,7 +77,6 @@ type UnitRowProps = {
   alertBarRevealed?: boolean;
   hideCtaText?: boolean;
   prefixDataTestId?: string;
-  isLevelWithRefreshButton?: boolean;
   disabled?: boolean;
   disabledReason?: string;
 };
@@ -106,7 +102,6 @@ export const UnitRow = ({
   alertBarRevealed,
   hideCtaText,
   prefixDataTestId = '',
-  isLevelWithRefreshButton = false,
   disabled = false,
   disabledReason = '',
 }: UnitRowProps & RouteComponentProps) => {
@@ -130,7 +125,6 @@ export const UnitRow = ({
   ctaText = ctaText || (headerValue ? localizedCtaChange : localizedCtaAdd);
 
   const location = useLocation();
-  const multiButton = !!(route || secondaryCtaRoute);
 
   function formatDataTestId(id: string) {
     return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;
@@ -138,7 +132,7 @@ export const UnitRow = ({
 
   return (
     <div className="unit-row">
-      <div className="font-header w-full mb-1 mobileLandscape:flex-none mobileLandscape:mb-0 mobileLandscape:mr-2 mobileLandscape:w-40">
+      <div className="font-header w-full mb-1 mobileLandscape:flex-none mobileLandscape:mb-0 mobileLandscape:me-2 mobileLandscape:w-40">
         <span className="flex justify-between items-center">
           <h3
             data-testid={formatDataTestId('unit-row-header')}
@@ -165,13 +159,10 @@ export const UnitRow = ({
       </div>
 
       <div className="unit-row-actions">
-        <div className="flex items-center">
+        <div className="flex items-center h-8 gap-2">
           {disabled ? (
             <button
-              className={classNames(
-                'cta-neutral cta-base cta-base-p transition-standard rtl:ml-1',
-                isLevelWithRefreshButton && 'mobileLandscape:mr-9'
-              )}
+              className="cta-neutral cta-base cta-base-p transition-standard me-1"
               data-testid={formatDataTestId('unit-row-route')}
               title={disabledReason}
               disabled={disabled}
@@ -182,10 +173,7 @@ export const UnitRow = ({
             <>
               {!hideCtaText && route && (
                 <Link
-                  className={classNames(
-                    'cta-neutral cta-base cta-base-p transition-standard rtl:ml-1',
-                    isLevelWithRefreshButton && 'mobileLandscape:mr-9'
-                  )}
+                  className="cta-neutral cta-base cta-base-p transition-standard me-1"
                   data-testid={formatDataTestId('unit-row-route')}
                   to={`${route}${location.search}`}
                 >
@@ -206,7 +194,7 @@ export const UnitRow = ({
 
               {secondaryCtaRoute && (
                 <Link
-                  className="cta-neutral cta-base cta-base-p transition-standard ltr:mr-1 rtl:ml-1"
+                  className="cta-neutral cta-base cta-base-p transition-standard me-1"
                   data-testid={formatDataTestId('unit-row-route')}
                   to={`${secondaryCtaRoute}${location.search}`}
                 >
@@ -216,7 +204,6 @@ export const UnitRow = ({
 
               {revealSecondaryModal && (
                 <ModalButton
-                  leftSpaced={multiButton}
                   revealModal={revealSecondaryModal}
                   ctaText={secondaryCtaText}
                   className={secondaryButtonClassName}

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/en.ftl
@@ -4,6 +4,8 @@ rk-header-1 = Account recovery key
 rk-enabled = Enabled
 rk-not-set = Not Set
 rk-action-create = Create
+# Button to delete the existing account recovery key and create a new one
+rk-action-change-button = Change
 rk-action-remove = Remove
 rk-cannot-refresh-1 = Sorry, there was a problem refreshing the account recovery key.
 rk-key-removed-2 = Account recovery key removed
@@ -16,3 +18,5 @@ rk-remove-modal-content-1 = In the event you reset your password, you won’t be
   able to use your account recovery key to access your data. You can’t undo this action.
 rk-refresh-error-1 = Sorry, there was a problem refreshing the account recovery key.
 rk-remove-error-2 = Your account recovery key could not be removed
+# Icon button to delete user's account recovery key. Text appears in tooltip on hover and as alt text for screen readers.
+unit-row-recovery-key-delete-icon-button-title = Delete account recovery key

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.stories.tsx
@@ -9,6 +9,7 @@ import { LocationProvider } from '@reach/router';
 import UnitRowRecoveryKey from '.';
 import { Account, AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
+import { Config, getDefault } from '../../../lib/config';
 
 export default {
   title: 'Components/Settings/UnitRowRecoveryKey',
@@ -31,8 +32,17 @@ const accountWithoutPassword = {
   recoveryKey: false,
 } as unknown as Account;
 
-const storyWithContext = (account: Partial<Account>) => {
-  const context = { account: account as Account };
+// Remove featureFlagConfig in FXA-7419
+const featureFlagConfig = {
+  ...getDefault(),
+  showRecoveryKeyV2: true,
+} as unknown as Config;
+
+const storyWithContext = (
+  account: Partial<Account>,
+  config?: Partial<Config>
+) => {
+  const context = { account: account as Account, config: config as Config };
 
   const story = () => (
     <LocationProvider>
@@ -43,9 +53,24 @@ const storyWithContext = (account: Partial<Account>) => {
   );
   return story;
 };
-
+// Remove first three stories in FXA-7419
 export const HasAccountRecoveryKey = storyWithContext(accountHasRecoveryKey);
 
 export const NoAccountRecoveryKey = storyWithContext(accountWithoutRecoveryKey);
 
 export const DisabledStateNoPassword = storyWithContext(accountWithoutPassword);
+
+export const HasAccountRecoveryKeyVersion2 = storyWithContext(
+  accountHasRecoveryKey,
+  featureFlagConfig
+);
+
+export const NoAccountRecoveryKeyVersion2 = storyWithContext(
+  accountWithoutRecoveryKey,
+  featureFlagConfig
+);
+
+export const DisabledStateNoPasswordVersion2 = storyWithContext(
+  accountWithoutPassword,
+  featureFlagConfig
+);

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -28,6 +28,7 @@ import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
 
 export const Settings = (props: RouteComponentProps) => {
   const config = useConfig();
+  // TODO Remove in FXA-7419
   const { showRecoveryKeyV2 } = config;
   const { metricsEnabled, hasPassword } = useAccount();
 
@@ -65,9 +66,11 @@ export const Settings = (props: RouteComponentProps) => {
           <PageDisplayName path="/display_name" />
           <PageAvatar path="/avatar" />
           {hasPassword ? (
+            // TODO remove feature flag condition in FXA-7419 and only keep PageRecoveryKeyCreate
             showRecoveryKeyV2 ? (
               <PageRecoveryKeyCreate path="/account_recovery" />
             ) : (
+              // TODO Remove in FXA-7419
               <PageRecoveryKeyAdd path="/account_recovery" />
             )
           ) : (

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -47,6 +47,7 @@ export interface Config {
     count: number;
     length: number;
   };
+  // TODO Remove feature flag from config in FXA-7419
   showRecoveryKeyV2: boolean;
   version: string;
   googleAuthConfig: {
@@ -101,6 +102,7 @@ export function getDefault() {
       count: 8,
       length: 10,
     },
+    // TODO Remove feature flag in FXA-7419
     showRecoveryKeyV2: false,
     googleAuthConfig: {
       enabled: false,
@@ -113,7 +115,7 @@ export function getDefault() {
       clientId: '',
       redirectUri: '',
       authorizationEndpoint: '',
-    }
+    },
   } as Config;
 }
 


### PR DESCRIPTION
## Because

- As part of the redesign of the Recovery Key creation flow, we want to add capability to replace an enabled recovery key.

## This pull request

- Update `UnitRowRecoveryKey` with `Create`/`Change` buttons and delete icon
- Update `PageRecoveryKeyCreate` with option to change the key
- Update metrics, tests and l10n
- Update `showRecoveryKeyV2` feature flag to be nested under `featureFlags`

## Issue that this pull request solves

Closes: #FXA-7239, #FXA-7240

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

No key: "Create" button, no trash can/delete icon
![image](https://github.com/mozilla/fxa/assets/22231637/e5b80d60-6d2e-42c8-958b-d729e74f0352)

Changed trash can icon colour from red to grey, and added icon state indicators on hover/active/focus
![image](https://github.com/mozilla/fxa/assets/22231637/16cfb488-a912-4656-b553-88ead2397e8a)

**Additional UI changes in response to Product/Product Design feedback:**

Reduced shield icon size:
![image](https://github.com/mozilla/fxa/assets/22231637/8212091d-6423-4867-ac66-eba2b42f9116)

Adjusted eye icon colour from black to grey
![image](https://github.com/mozilla/fxa/assets/22231637/4d31a3ca-a978-41d3-9936-566c2fb0cf3f)

Adjusted spacing and removed "Copied" feedback tooltip

![image](https://github.com/mozilla/fxa/assets/22231637/95ffff93-1d2d-416b-a481-4d8ee4c258c7)


## Other information (Optional)

To view the new flow, update `local.json` to add:
```
  "featureFlags": {
    "showRecoveryKeyV2": true
  }
  ```
