### PR TITLE
test(functional): rewrite signin blocked tests using Playwright

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -31,6 +31,8 @@ export const selectors = {
   SIGN_IN_CODE_HEADER: '#fxa-signin-code-header',
   CONFIRM_EMAIL: '.email',
   SIGNIN_HEADER: '#fxa-signin-header',
+  SIGNIN_UNBLOCK_HEADER: '#fxa-signin-unblock-header',
+  SIGNIN_UNBLOCK_VERIFICATION: '.verification-email-message',
   COPPA_HEADER: '#fxa-cannot-create-account-header',
   SUBMIT: 'button[type=submit]',
   SUBMIT_USER_SIGNED_IN: '#use-logged-in',
@@ -71,6 +73,10 @@ export class LoginPage extends BaseLayout {
 
   get submitButton() {
     return this.page.locator(selectors.SUBMIT);
+  }
+
+  async getUnblockEmail() {
+    return this.page.locator(selectors.SIGNIN_UNBLOCK_VERIFICATION).innerText();
   }
 
   async fillOutEmailFirstSignIn(email, password) {
@@ -244,6 +250,12 @@ export class LoginPage extends BaseLayout {
     return header.isVisible();
   }
 
+  async signinUnblockHeader() {
+    const header = this.page.locator(selectors.SIGNIN_UNBLOCK_HEADER);
+    await header.waitFor();
+    return header.isVisible();
+  }
+
   async signInError() {
     const error = this.page.locator(selectors.ERROR);
     await error.waitFor();
@@ -327,6 +339,11 @@ export class LoginPage extends BaseLayout {
 
   async clickSignIn() {
     return this.page.locator(selectors.SUBMIT_USER_SIGNED_IN).click();
+  }
+
+  async enterUnblockCode(code: string) {
+    await this.setCode(code);
+    await this.clickSubmit();
   }
 
   async clickSubmit() {

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+const password = 'passwordzxcv';
+let blockedEmail;
+let email;
+let newEmail;
+let unverifiedEmail;
+
+test.describe('signin blocked', () => {
+  test.beforeEach(async ({ target, pages: { login } }) => {
+    blockedEmail = login.createEmail('blocked{id}');
+    await target.auth.signUp(blockedEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    email = await login.createEmail();
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    newEmail = login.createEmail('blocked{id}');
+    unverifiedEmail = login.createEmail('blocked{id}');
+    await target.auth.signUp(unverifiedEmail, password, {
+      lang: 'en',
+      preVerified: 'false',
+    });
+    await login.clearCache();
+  });
+
+  test.afterEach(async ({ target }) => {
+    const emails = [blockedEmail, email, newEmail, unverifiedEmail];
+    for (const email of emails) {
+      if (email) {
+        try {
+          await target.auth.accountDestroy(email, password);
+        } catch (e) {
+          // Handle any errors if needed
+        }
+      }
+    }
+  });
+
+  test('valid code entered', async ({ target, page, pages: { login } }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(blockedEmail, password);
+
+    //Verify sign in block header
+    expect(await login.signinUnblockHeader()).toBe(true);
+    expect(await login.getUnblockEmail()).toContain(blockedEmail);
+
+    //Unblock the email
+    await login.unblock(blockedEmail);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('incorrect code entered', async ({ target, page, pages: { login } }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(blockedEmail, password);
+
+    //Verify sign in block header
+    expect(await login.signinUnblockHeader()).toBe(true);
+    expect(await login.getUnblockEmail()).toContain(blockedEmail);
+    await login.enterUnblockCode('incorrect');
+
+    //Verify tooltip error
+    expect(await login.getTooltipError()).toContain(
+      'Invalid authorization code'
+    );
+
+    //Unblock the email
+    await login.unblock(blockedEmail);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('resend', async ({ target, page, pages: { login, resetPassword } }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(blockedEmail, password);
+
+    //Verify sign in block header
+    expect(await login.signinUnblockHeader()).toBe(true);
+    expect(await login.getUnblockEmail()).toContain(blockedEmail);
+
+    //Click resend link
+    await resetPassword.clickResend();
+
+    //Verify success message
+    expect(await resetPassword.resendSuccessMessage()).toContain(
+      'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+    );
+
+    //Unblock the email
+    await login.unblock(blockedEmail);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('with primary email changed', async ({
+    target,
+    page,
+    pages: { login, settings, secondaryEmail },
+  }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+
+    await settings.goto();
+    await settings.secondaryEmail.clickAdd();
+    await secondaryEmail.addAndVerify(newEmail);
+    await settings.secondaryEmail.clickMakePrimary();
+    await settings.signOut();
+
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(newEmail, password);
+
+    //Verify sign in block header
+    expect(await login.signinUnblockHeader()).toBe(true);
+    expect(await login.getUnblockEmail()).toContain(newEmail);
+
+    //Unblock the email
+    await login.unblock(newEmail);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('unverified', async ({ target, page, pages: { login } }) => {
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(unverifiedEmail, password);
+
+    //Verify sign in block header
+    expect(await login.signinUnblockHeader()).toBe(true);
+    expect(await login.getUnblockEmail()).toContain(unverifiedEmail);
+
+    //Unblock the email
+    await login.unblock(unverifiedEmail);
+
+    //Verify confirm code header
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+
+    await login.fillOutSignInCode(unverifiedEmail);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [signin blocked tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sign_in_blocked.js) have been rewritten in this PR. We decided to keep only 5 of the existing tests from the old file - `signin blocked - valid code entered`, `signin blocked - incorrect code entered`, `signin blocked - resend`, `signin blocked - unverified`, `signin blocked - with primary email changed`. The decision sheet could be found [here](https://docs.google.com/spreadsheets/d/11Wq-Y-ipeNFXqLHbr3GJCh_f_qEAG-CUuqBt5Dcnh5k/edit#gid=0)

## This pull request

contains the 5 [signin blocked tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sign_in_blocked.js)

## Issue that this pull request solves

Closes: FXA-5900

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
