### PR TITLE
refactor(settings): change Pocket link. Fix FXA-4912

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
@@ -45,7 +45,7 @@ export function Service({
       Icon = <AddonIcon data-testid="addon-icon" />;
       break;
     case 'Pocket':
-      serviceLink = 'https://www.mozilla.org/en-US/firefox/pocket/';
+      serviceLink = 'https://getpocket.com/';
       Icon = <PocketIcon data-testid="pocket-icon" />;
       break;
     case 'Firefox Monitor':

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -125,10 +125,7 @@ describe('Connected Services', () => {
   it('should show the pocket icon and link', async () => {
     await getIconAndServiceLink('Pocket', 'pocket-icon').then((result) => {
       expect(result.icon).toBeTruthy();
-      expect(result.link).toHaveAttribute(
-        'href',
-        'https://www.mozilla.org/en-US/firefox/pocket/'
-      );
+      expect(result.link).toHaveAttribute('href', 'https://getpocket.com/');
     });
   });
 


### PR DESCRIPTION
Because:

* This link is out of date

This commit:

* Updates the link

Closes FXA-4912
