### PR TITLE
fix(payments): sanitize legal-docs url query param

### DIFF
--- a/packages/fxa-payments-server/server/lib/routes/legal-docs.js
+++ b/packages/fxa-payments-server/server/lib/routes/legal-docs.js
@@ -91,6 +91,11 @@ module.exports = {
       return res.sendStatus(400).end();
     }
 
+    // Prevent implicit protocol in url path
+    if (docUrl.pathname.includes('//')) {
+      return res.sendStatus(400).end();
+    }
+
     // For backwards compatibility and future single-locale products(?)
     if (docUrl.pathname.endsWith('.pdf')) {
       return res.redirect(docUrl.href);


### PR DESCRIPTION
## Because

- legal-docs url query param needs more sanitization.

## This pull request

- Prevents implicit protocol absolute urls in legal docs url query param.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).