### PR TITLE
fix(storybook): subplat email templates not loading

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.stories.ts
@@ -20,6 +20,8 @@ const createStory = subplatStoryWithProps(
     serviceLastActiveDateOnly: '12/13/2021',
     cancellationSurveryUrl:
       'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+    showOutstandingBalance: true,
+    cancelAtEnd: false,
   }
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
@@ -30,6 +30,7 @@ const createStory = subplatStoryWithProps(
     paymentProrated: null,
     showPaymentMethod: true,
     showProratedAmount: false,
+    showTaxAmount: false,
   }
 );
 
@@ -103,6 +104,7 @@ export const SubscriptionFirstInvoiceWithStripeTaxAndForeverCoupon =
       invoiceTaxAmount: '$2.00',
       discountType: 'forever',
       discountDuration: null,
+      showTaxAmount: true,
     },
     'Stripe - With Tax and Forever Coupon'
   );
@@ -115,6 +117,7 @@ export const SubscriptionFirstInvoiceWithStripeTax = createStory(
     invoiceTaxAmount: '$3.00',
     discountType: null,
     discountDuration: null,
+    showTaxAmount: true,
   },
   'Stripe - With Tax'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionSubsequentInvoice/index.stories.ts
@@ -30,6 +30,7 @@ const createStory = subplatStoryWithProps(
     paymentProrated: null,
     showPaymentMethod: true,
     showProratedAmount: false,
+    showTaxAmount: false,
   }
 );
 
@@ -128,6 +129,7 @@ export const SubscriptionSubsequentInvoiceStripeNoProratedOneTimeWithTax =
       invoiceTaxAmount: '$2.00',
       discountType: 'once',
       discountDuration: null,
+      showTaxAmount: true,
     },
     'Stripe - One Time Coupon with Tax'
   );
@@ -141,6 +143,7 @@ export const SubscriptionSubsequentInvoiceStripeNoProratedWithTax = createStory(
     invoiceTaxAmount: '$2.00',
     discountType: null,
     discountDuration: null,
+    showTaxAmount: true,
   },
   'Stripe - With Tax'
 );


### PR DESCRIPTION
## Because

- Some of the SubPlat emails were not loading due to undefined props.

## This pull request

- Corrects `subscriptionFirstInvoice` and `subscriptionSubsequentInvoice` email stories by adding missing prop `showTaxAmount`.
- Corrects `subscriptionCancellation` email story by adding missing props `showOutstandingBalance` and `cancelAtEnd`.

## Issue that this pull request solves

Closes: FXA-6171

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).