### PR TITLE
test(functional-tests) - Update recoveryKey tests for new flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,11 @@ commands:
           name: Running Playwright tests
           # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
           command: |
+            if [[ "<< parameters.project >>" == "production" ]]; then
+              export FEATURE_FLAGS_SHOW_RECOVERY_KEY_V2=false
+            else
+              export FEATURE_FLAGS_SHOW_RECOVERY_KEY_V2=true
+            fi
             cd packages/functional-tests
             TEST_FILES=$(circleci tests glob "tests/**/*.spec.ts")
             echo $TEST_FILES | circleci tests run --command="xargs yarn playwright test --project=<< parameters.project >>" --verbose --split-by=timings

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -44,7 +44,7 @@ export class ResetPasswordPage extends BaseLayout {
     return resetPass.isVisible();
   }
 
-  async resetPasswordLinkExpriredHeader() {
+  async resetPasswordLinkExpiredHeader() {
     const resetPass = this.page.locator(
       selectors.RESET_PASSWORD_EXPIRED_HEADER
     );

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -89,6 +89,14 @@ export class RecoveryKeyRow extends UnitRow {
   clickCreate() {
     return this.clickCta();
   }
+
+  clickDelete() {
+    return this.page
+      .getByRole('button', { name: 'Delete account recovery key' })
+      .click();
+  }
+
+  // TODO FXA-7419 delete this function
   clickRemove() {
     return this.clickShowModal();
   }

--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -35,10 +35,56 @@ export class RecoveryKeyPage extends SettingsLayout {
     ]);
   }
 
+  // TODO in FXA-7419 - delete this method
   clickClose() {
     return Promise.all([
       this.page.locator('[data-testid=close-button]').click(),
       this.page.waitForNavigation(),
     ]);
+  }
+
+  async clickStart() {
+    return this.page
+      .getByRole('button', { name: 'Start creating your account recovery key' })
+      .click();
+  }
+
+  async clickChange() {
+    return this.page
+      .getByRole('button', { name: 'Change account recovery key' })
+      .click();
+  }
+
+  async clickDownload() {
+    const [download] = await Promise.all([
+      this.page.waitForEvent('download'),
+      this.page.getByText('Download your account recovery key').click(),
+    ]);
+    return download;
+  }
+
+  async clickCopy(): Promise<string> {
+    // override writeText so we can capture the value
+    await this.page.evaluate(() => {
+      //@ts-ignore
+      window.clipboardText = null;
+      //@ts-ignore
+      navigator.clipboard.writeText = (text) => (window.clipboardText = text);
+    });
+    await this.page.getByRole('button', { name: 'Copy' }).click();
+    //@ts-ignore
+    return this.page.evaluate(() => window.clipboardText);
+  }
+
+  async clickNext() {
+    return this.page.getByRole('link', { name: 'Next' }).click();
+  }
+
+  setHint(hint: string) {
+    return this.page.getByRole('textbox').fill(hint);
+  }
+
+  async clickFinish() {
+    return this.page.getByRole('button', { name: 'Finish' }).click();
   }
 }

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -66,23 +66,27 @@ test.describe('severity-3 #smoke', () => {
     await expect(settings.bentoMenu).toBeHidden();
   });
 
+  // TODO in FXA-7419 - delete this test, no longer needed with new flow
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293423
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293440
   test('settings data-trio component works #1293423 #1293440', async ({
     credentials,
-    pages: { settings, recoveryKey },
+    pages: { login, settings, recoveryKey },
   }) => {
-    await settings.goto();
-    await settings.recoveryKey.clickCreate();
-    await recoveryKey.setPassword(credentials.password);
-    await recoveryKey.submit();
-    const dl = await recoveryKey.dataTrio.clickDownload();
-    expect(dl.suggestedFilename()).toBe(
-      `${credentials.email} Firefox account recovery key.txt`
-    );
-    const clipboard = await recoveryKey.dataTrio.clickCopy();
-    expect(clipboard).toEqual(await recoveryKey.getKey());
-    const printed = await recoveryKey.dataTrio.clickPrint();
-    expect(printed).toBe(true);
+    const config = await login.getConfig();
+    if (config.featureFlags.showRecoveryKeyV2 !== true) {
+      await settings.goto();
+      await settings.recoveryKey.clickCreate();
+      await recoveryKey.setPassword(credentials.password);
+      await recoveryKey.submit();
+      const dl = await recoveryKey.dataTrio.clickDownload();
+      expect(dl.suggestedFilename()).toBe(
+        `${credentials.email} Firefox account recovery key.txt`
+      );
+      const clipboard = await recoveryKey.dataTrio.clickCopy();
+      expect(clipboard).toEqual(await recoveryKey.getKey());
+      const printed = await recoveryKey.dataTrio.clickPrint();
+      expect(printed).toBe(true);
+    }
   });
 });

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -51,5 +51,8 @@
   },
   "showReactApp": {
     "simpleRoutes": true
+  },
+  "featureFlags": {
+    "showRecoveryKeyV2": true
   }
 }

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -47,6 +47,7 @@ module.exports = function (config) {
   const APPLE_AUTH_CONFIG = config.get('appleAuthConfig');
   const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
   const SHOW_REACT_APP = config.get('showReactApp');
+  const SHOW_RECOVERY_KEY_V2 = config.get('featureFlags.showRecoveryKeyV2');
 
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
@@ -98,6 +99,9 @@ module.exports = function (config) {
     subscriptions: SUBSCRIPTIONS,
     webpackPublicPath: WEBPACK_PUBLIC_PATH,
     showReactApp: SHOW_REACT_APP,
+    featureFlags: {
+      showRecoveryKeyV2: SHOW_RECOVERY_KEY_V2,
+    },
 
     glean: {
       // feature toggle

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
@@ -67,7 +67,7 @@ describe('ButtonDownloadRecoveryKey', () => {
     expect(downloadButtonDownloadAttribute).toContain(
       `Firefox-Recovery-Key_${date}_${account.primaryEmail.email}.txt`
     );
-    expect(downloadButtonDownloadAttribute!.length).toBeLessThanOrEqual(70);
+    expect(downloadButtonDownloadAttribute!.length).toBeLessThanOrEqual(75);
   });
 
   it('sets the filename with a truncated email as expected when the email is very long', () => {
@@ -82,10 +82,10 @@ describe('ButtonDownloadRecoveryKey', () => {
     const currentDate = new Date();
     const date = currentDate.toISOString().split('T')[0];
     const fullFilename = `Firefox-Recovery-Key_${date}_${accountWithLongEmail.primaryEmail.email}.txt`;
-    // Full filene would be longer than 70 char if not truncated
-    expect(fullFilename.length).toBeGreaterThan(70);
+    // Full filename would be longer than 75 char if not truncated
+    expect(fullFilename.length).toBeGreaterThan(75);
     // actual filename is truncated
-    expect(downloadButtonDownloadAttribute!.length).toBeLessThanOrEqual(70);
+    expect(downloadButtonDownloadAttribute!.length).toBeLessThanOrEqual(75);
     // filename still contains full prefix and date
     expect(downloadButtonDownloadAttribute).toContain('Firefox-Recovery-Key');
     expect(downloadButtonDownloadAttribute).toContain(date);

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -85,7 +85,7 @@ export const ButtonDownloadRecoveryKey = ({
     const date = currentDate.toISOString().split('T')[0];
     // Windows has a max directory length of 260 characters (including path)
     // filename should be kept much shorter (maxLength is arbitrary).
-    const maxLength = 70;
+    const maxLength = 75;
     const prefix = 'Firefox-Recovery-Key';
     let email = primaryEmail.email;
     let filename = `${prefix}_${date}_${email}.txt`;

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
@@ -62,10 +62,7 @@ export const FlowRecoveryKeyDownload = ({
         <DataBlock
           value={recoveryKeyValue}
           onCopy={() =>
-            logViewEvent(
-              'flow.settings.account-recovery',
-              `recovery-key.copy-option`
-            )
+            logViewEvent(`flow.${viewName}`, `recovery-key.copy-option`)
           }
           isInline
         />

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -82,15 +82,13 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
 
       {/* Confirm password and generate recovery key */}
       {currentStep === 2 && (
-        <>
-          <FlowRecoveryKeyConfirmPwd
-            {...{
-              ...sharedStepProps,
-              action,
-              setFormattedRecoveryKey,
-            }}
-          />
-        </>
+        <FlowRecoveryKeyConfirmPwd
+          {...{
+            ...sharedStepProps,
+            action,
+            setFormattedRecoveryKey,
+          }}
+        />
       )}
 
       {/* Download recovery key */}


### PR DESCRIPTION
## Because

- We need to update functional tests to support the new account recovery key creation flow

## This pull request

- Update the recovery key page model
- Update `misc`, `password` and `recoveryKey` tests behind feature flag
- Update `react-conversion/recoveryKey` test

## Issue that this pull request solves

Closes: #FXA-7250

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

**The "old" flow (still live on stage and prod at the moment) :**

![image](https://github.com/mozilla/fxa/assets/22231637/2dbed887-9060-45c9-8df4-312d6fcbe7b4)

![image](https://github.com/mozilla/fxa/assets/22231637/3502ff23-5826-4b9d-b7a1-ab066e4f9691)

![image](https://github.com/mozilla/fxa/assets/22231637/bd6bcc17-3ae2-42fa-864a-de8dcc170673)

With the old flow, the user had to click "remove" then "create" to delete an existing key and create a new one.

![image](https://github.com/mozilla/fxa/assets/22231637/0b07c491-3156-4f8f-a1db-ab909c5f32f5)

**The new flow for creating a key:**

![image](https://github.com/mozilla/fxa/assets/22231637/d3dca42e-4713-496d-85b0-a80095eea85f)

![image](https://github.com/mozilla/fxa/assets/22231637/772f9774-099c-442b-a249-b8041e59f7d1)

![image](https://github.com/mozilla/fxa/assets/22231637/bdcf1826-422b-431c-a5d2-08ae931058b8)

![image](https://github.com/mozilla/fxa/assets/22231637/1c604d1e-db76-455e-af5f-353d0c2f220e)

![image](https://github.com/mozilla/fxa/assets/22231637/3cde8544-0368-402c-a793-6eb2943c5770)

With the new flow, users can choose to change or delete an existing key:

![image](https://github.com/mozilla/fxa/assets/22231637/88097e11-5f19-40d1-b7c1-0b66f2a544fd)

If they click change, they are taken to a slightly modified version of the key creation flow.

![image](https://github.com/mozilla/fxa/assets/22231637/60574fbd-4213-4de6-9c8f-048d2fb5c1ce)

![image](https://github.com/mozilla/fxa/assets/22231637/c3b19228-144d-480b-9cdc-3e65b4e650ab)

## Other information (Optional)

This PR enables the `showRecoveryKeyV2` flag on local - running the functional tests with this flag enabled with only run the recoveryKey tests that apply to the new flow ("old" tests will be skipped). 

To check that the "old" tests still work for the previous flow, remove the following lines from `local.json-dist`:
```
"featureFlags": {
    "showRecoveryKeyV2": true
  }
```
