### PR TITLE
chore(metrics): add Glean event for reg_submit

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -90,6 +90,7 @@ export const GleanMetrics = {
 
   registration: {
     view: createEventFn('reg_view'),
+    submit: createEventFn('reg_submit'),
   },
 };
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -4,6 +4,7 @@
 
 // Shared implementation of `signUp` view method
 
+import GleanMetrics from '../../lib/glean';
 import ResumeTokenMixin from './resume-token-mixin';
 
 export default {
@@ -28,6 +29,7 @@ export default {
         // because we want to log the real action that is being performed.
         // This is important for the infamous signin-from-signup feature.
         this.logFlowEvent('attempt', 'signup');
+        GleanMetrics.registration.submit();
 
         const options = {
           resume: this.getStringifiedResumeToken(account),

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -222,6 +222,12 @@ describe('lib/glean', () => {
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'reg_view');
       });
+
+      it('submit a ping with the reg_submit event name', () => {
+        GleanMetrics.registration.submit();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'reg_submit');
+      });
     });
   });
 


### PR DESCRIPTION
Because:
 - we want to send a ping to Glean when someone attempts to register for
   an account

This commit:
 - send the Glean ping for 'reg_submit'
