### PR TITLE
chore(metrics): add Glean event for reg_submit_success

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -91,6 +91,7 @@ export const GleanMetrics = {
   registration: {
     view: createEventFn('reg_view'),
     submit: createEventFn('reg_submit'),
+    success: createEventFn('reg_submit_success'),
   },
 };
 

--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -90,6 +90,7 @@ export const GleanMetrics = {
 
   registration: {
     view: createEventFn('reg_view'),
+    submit: createEventFn('reg_submit'),
   },
 };
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -79,6 +79,7 @@ export default {
   onSignUpSuccess(account) {
     this.logViewEvent('success');
     this.logViewEvent('signup.success');
+    GleanMetrics.registration.success();
 
     if (account.get('verificationMethod') === 'email-otp') {
       this.clearInput();

--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -4,6 +4,7 @@
 
 // Shared implementation of `signUp` view method
 
+import GleanMetrics from '../../lib/glean';
 import ResumeTokenMixin from './resume-token-mixin';
 
 export default {
@@ -28,6 +29,7 @@ export default {
         // because we want to log the real action that is being performed.
         // This is important for the infamous signin-from-signup feature.
         this.logFlowEvent('attempt', 'signup');
+        GleanMetrics.registration.submit();
 
         const options = {
           resume: this.getStringifiedResumeToken(account),

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -222,6 +222,12 @@ describe('lib/glean', () => {
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'reg_view');
       });
+
+      it('submit a ping with the reg_submit event name', () => {
+        GleanMetrics.registration.submit();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'reg_submit');
+      });
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -228,6 +228,12 @@ describe('lib/glean', () => {
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'reg_submit');
       });
+
+      it('submit a ping with the reg_submit_success event name', () => {
+        GleanMetrics.registration.success();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'reg_submit_success');
+      });
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
@@ -26,7 +26,7 @@ describe('views/mixins/signup-mixin', function () {
     let relier;
     let user;
     let view;
-    let regSubmitMetricEventStub;
+    let regSubmitMetricEventStub, regSuccessMetricEventStub;
 
     beforeEach(function () {
       account = new Account({
@@ -37,6 +37,10 @@ describe('views/mixins/signup-mixin', function () {
       regSubmitMetricEventStub = sinon.stub(
         GleanMetrics.registration,
         'submit'
+      );
+      regSuccessMetricEventStub = sinon.stub(
+        GleanMetrics.registration,
+        'success'
       );
       relier = new Relier();
       user = {
@@ -71,6 +75,7 @@ describe('views/mixins/signup-mixin', function () {
 
     afterEach(function () {
       regSubmitMetricEventStub.restore();
+      regSuccessMetricEventStub.restore();
     });
 
     describe('account needs permissions', function () {
@@ -230,6 +235,7 @@ describe('views/mixins/signup-mixin', function () {
         assert.equal(view.logViewEvent.callCount, 2);
         assert.isTrue(view.logViewEvent.calledWith('success'));
         assert.isTrue(view.logViewEvent.calledWith('signup.success'));
+        sinon.assert.calledOnce(regSuccessMetricEventStub);
 
         assert.isTrue(view.invokeBrokerMethod.calledOnce);
         const args = view.invokeBrokerMethod.args[0];


### PR DESCRIPTION
Because:
 - we want to send a Glean ping when some successfully registered a new
   account

This commit:
 - sends a ping for reg_submit_success
