### PR TITLE
bug(auth): Token pruner wouldn't accept --wait arg

### DIFF
--- a/packages/fxa-auth-server/scripts/prune-tokens.ts
+++ b/packages/fxa-auth-server/scripts/prune-tokens.ts
@@ -70,7 +70,11 @@ export async function init() {
       'When maxSessions is greater than 0, this value controls the number of deletions that are batched together at one time. e.g. A batch size of 1 would delete one token at a time.',
       1e3
     )
-    .option('--wait', 'Amount of time to sleep in milliseconds between batches (i.e. between deletions).', 5e3)
+    .option(
+      '--wait <number>',
+      'Amount of time to sleep in milliseconds between batches (i.e. between deletions).',
+      5e3
+    )
     .on('--help', function () {
       console.log(`
 Example:

--- a/packages/fxa-auth-server/test/scripts/prune-tokens.js
+++ b/packages/fxa-auth-server/test/scripts/prune-tokens.js
@@ -207,6 +207,24 @@ describe('#integration - scripts/prune-tokens', () => {
     assert.isTrue(/skipping token pruning operation./.test(stderr));
   });
 
+  it('parses args', async () => {
+    const { stderr } = await exec(
+      `NODE_ENV=dev node -r esbuild-register scripts/prune-tokens.ts --maxTokenAge=0 --maxCodeAge=0 --maxSessions=0 --maxSessionsMaxAccounts=0 --maxSessionsMaxDeletions=0  --maxSessionsBatchSize=0 --wait=1`,
+      {
+        cwd,
+        shell: '/bin/bash',
+      }
+    );
+
+    assert.match(stderr, /"maxTokenAge":"0"/);
+    assert.match(stderr, /"maxCodeAge":"0"/);
+    assert.match(stderr, /"maxSessions":"0"/);
+    assert.match(stderr, /"maxSessionsMaxAccounts":"0"/);
+    assert.match(stderr, /"maxSessionsMaxDeletions":"0"/);
+    assert.match(stderr, /"maxSessionsBatchSize":"0"/);
+    assert.match(stderr, /"wait":"1"/);
+  });
+
   describe('prune tokens', () => {
     let token;
 
@@ -373,14 +391,17 @@ describe('#integration - scripts/prune-tokens', () => {
     }
 
     it('limits with --maxSessionsBatchSize=1000', async () => {
-      await testScript(`--maxSessions=10 --maxSessionsBatchSize=1000 `, {
-        remaining: size - 10,
-        totalDeletions: 10 * 2,
-      });
+      await testScript(
+        `--maxSessions=10 --maxSessionsBatchSize=1000 --wait=10 `,
+        {
+          remaining: size - 10,
+          totalDeletions: 10 * 2,
+        }
+      );
     });
 
     it('limits with --maxSessionsBatchSize=2', async () => {
-      await testScript(`--maxSessions=10 --maxSessionsBatchSize=2 `, {
+      await testScript(`--maxSessions=10 --maxSessionsBatchSize=2 --wait=10`, {
         remaining: size - 10,
         totalDeletions: 10 * 2,
       });
@@ -388,7 +409,7 @@ describe('#integration - scripts/prune-tokens', () => {
 
     it('limits with --maxSessionsMaxDeletions=2', async () => {
       await testScript(
-        `--maxSessions=10 --maxSessionsMaxDeletions=2 --maxSessionsBatchSize=2`,
+        `--maxSessions=10 --maxSessionsMaxDeletions=2 --maxSessionsBatchSize=2 --wait=10`,
         {
           remaining: size - 2,
           totalDeletions: 2 * 2,
@@ -397,17 +418,23 @@ describe('#integration - scripts/prune-tokens', () => {
     });
 
     it('limits with --maxSessionsMaxDeletions=0', async () => {
-      await testScript(`--maxSessions=10 --maxSessionsMaxDeletions=0`, {
-        remaining: size,
-        totalDeletions: 0,
-      });
+      await testScript(
+        `--maxSessions=10 --maxSessionsMaxDeletions=0 --wait=10`,
+        {
+          remaining: size,
+          totalDeletions: 0,
+        }
+      );
     });
 
     it('limits with --maxSessionsMaxAccounts=0', async () => {
-      await testScript(`--maxSessions=10 --maxSessionsMaxAccounts=0`, {
-        remaining: size,
-        totalDeletions: 0,
-      });
+      await testScript(
+        `--maxSessions=10 --maxSessionsMaxAccounts=0 --wait=10`,
+        {
+          remaining: size,
+          totalDeletions: 0,
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
## Because

- `--wait=100` not having an effect

## This pull request

- Specifies that `--wait` is a number which fixes the problem

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

