### PR TITLE
task(fxa-settings, fxa-content-server): tracking for recovery key

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -412,26 +412,32 @@ const EVENTS = {
   },
   // Create/Change Key
   // Info page
+  // The first step of the "recovery key" wizard loads for a user who is creating a key
   'flow.settings.account-recovery.create-key.info': {
     group: GROUPS.settings,
     event: 'account_recovery_create_key_info',
   },
+  // The first step of the "recovery key" wizard loads for a user who is changing an existing key
   'flow.settings.account-recovery.change-key.info': {
     group: GROUPS.settings,
     event: 'account_recovery_change_key_info',
   },
+  // A user on the first step of the "recovery key" wizard, who is trying to create a new key, clicks the "Start creating your account recovery key" button to proceed to the next step
   'flow.settings.account-recovery.create-key.start': {
     group: GROUPS.settings,
     event: 'account_recovery_create_key_start',
   },
+  // A user on the first step of the "recovery key" wizard, who is trying to change an existing key, clicks the button to proceed to the next step
   'flow.settings.account-recovery.change-key.start': {
     group: GROUPS.settings,
     event: 'account_recovery_change_key_start',
   },
+  // A user in the recovery key flow to create a key exits the flow
   'flow.settings.account-recovery.create-key.cancel': {
     group: GROUPS.settings,
     event: 'account_recovery_create_key_cancel',
   },
+  // A user in the recovery key flow to change an existing key exits the flow
   'flow.settings.account-recovery.change-key.cancel': {
     group: GROUPS.settings,
     event: 'account_recovery_change_key_cancel',
@@ -450,14 +456,17 @@ const EVENTS = {
     event: 'account_recovery_confirm_password_fail',
   },
   // Key download page
+  // A user on the "download" step of the account recovery flow downloads their key
   'flow.settings.account-recovery.recovery-key.download-option': {
     group: GROUPS.settings,
     event: 'account_recovery_option_download',
   },
+  // A user on the "download" step of the account recovery flow copies their key to their clipboard
   'flow.settings.account-recovery.recovery-key.copy-option': {
     group: GROUPS.settings,
     event: 'account_recovery_option_copy',
   },
+  // A user on the "download" step of the account recovery flow moves to the next step (or exits the flow) without downloading
   'flow.settings.account-recovery.recovery-key.skip-download': {
     group: GROUPS.settings,
     event: 'account_recovery_skip_download',
@@ -468,21 +477,23 @@ const EVENTS = {
     event: 'account_recovery_option_print',
   },
   // Save hint page
-  'flow.settings.account-recovery.hint-submit': {
+  // A user on the "hint" step of the account recovery flow clicks the submit button to save the hint they entered into the text input
+  'flow.settings.account-recovery.create-hint.submit': {
     group: GROUPS.settings,
-    event: 'account_recovery_hint_submit',
+    event: 'account_recovery_create_hint_submit',
   },
-  'flow.settings.account-recovery.hint-success': {
+  'flow.settings.account-recovery.create-hint.success': {
     group: GROUPS.settings,
-    event: 'account_recovery_hint_success',
+    event: 'account_recovery_create_hint_success',
   },
-  'flow.settings.account-recovery.hint-fail': {
+  'flow.settings.account-recovery.create-hint.fail': {
     group: GROUPS.settings,
-    event: 'account_recovery_hint_fail',
+    event: 'account_recovery_create_hint_fail',
   },
-  'flow.settings.account-recovery.hint-skip': {
+  // A user exits hint step of the account recovery key flow without saving a hint, either by exiting the flow entirely or by skipping to the next step
+  'flow.settings.account-recovery.create-hint.skip': {
     group: GROUPS.settings,
-    event: 'account_recovery_hint_skip',
+    event: 'account_recovery_create_hint_skip',
   },
   // Avatar
   'screen.settings.avatar.change': {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -741,6 +741,19 @@ registerSuite('amplitude', {
       );
     },
 
+    'flow.settings.account-recovery.recovery-key.skip-download': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.recovery-key.skip-download'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_skip_download'
+      );
+    },
+
+    // TODO remove in FXA-7419, print option not available in new UI
     'flow.settings.account-recovery.recovery-key.print-option': () => {
       createAmplitudeEvent(
         'flow.settings.account-recovery.recovery-key.print-option'
@@ -750,6 +763,107 @@ registerSuite('amplitude', {
       assert.equal(
         logger.info.args[0][1].event_type,
         'fxa_pref - account_recovery_option_print'
+      );
+    },
+
+    'flow.settings.account-recovery.create-hint.submit': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.create-hint.submit');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_hint_submit'
+      );
+    },
+
+    'flow.settings.account-recovery.create-hint.success': () => {
+      createAmplitudeEvent(
+        'flow.settings.account-recovery.create-hint.success'
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_hint_success'
+      );
+    },
+
+    'flow.settings.account-recovery.create-hint.fail': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.create-hint.fail');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_hint_fail'
+      );
+    },
+    'flow.settings.account-recovery.create-hint.skip': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.create-hint.skip');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_hint_skip'
+      );
+    },
+
+    'flow.settings.account-recovery.create-key.info': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.create-key.info');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_key_info'
+      );
+    },
+
+    'flow.settings.account-recovery.create-key.start': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.create-key.start');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_key_start'
+      );
+    },
+
+    'flow.settings.account-recovery.create-key.cancel': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.create-key.cancel');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_create_key_cancel'
+      );
+    },
+
+    'flow.settings.account-recovery.change-key.info': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.change-key.info');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_change_key_info'
+      );
+    },
+
+    'flow.settings.account-recovery.change-key.start': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.change-key.start');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_change_key_start'
+      );
+    },
+
+    'flow.settings.account-recovery.change-key.cancel': () => {
+      createAmplitudeEvent('flow.settings.account-recovery.change-key.cancel');
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_pref - account_recovery_change_key_cancel'
       );
     },
 

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
@@ -98,11 +98,11 @@ describe('FlowRecoveryKeyHint', () => {
     });
     fireEvent.click(submitButton);
     await waitFor(() => {
-      expect(logViewEvent).toBeCalledWith(viewName, 'hint-submit');
+      expect(logViewEvent).toBeCalledWith(viewName, 'create-hint.submit');
       expect(accountWithSuccess.updateRecoveryKeyHint).toBeCalledWith(
         hintValue
       );
-      expect(logViewEvent).toBeCalledWith(viewName, 'hint-success');
+      expect(logViewEvent).toBeCalledWith(viewName, 'create-hint.success');
       expect(navigateForward).toHaveBeenCalledTimes(1);
     });
   });
@@ -126,7 +126,7 @@ describe('FlowRecoveryKeyHint', () => {
         'The hint must contain fewer than 255 characters.'
       );
       expect(accountWithSuccess.updateRecoveryKeyHint).not.toBeCalled();
-      expect(logViewEvent).not.toBeCalledWith(viewName, 'hint-submit');
+      expect(logViewEvent).not.toBeCalledWith(viewName, 'create-hint.submit');
       expect(navigateForward).not.toBeCalled();
     });
   });
@@ -146,12 +146,12 @@ describe('FlowRecoveryKeyHint', () => {
     });
     fireEvent.click(submitButton);
     await waitFor(() => {
-      expect(logViewEvent).toBeCalledWith(viewName, 'hint-submit');
+      expect(logViewEvent).toBeCalledWith(viewName, 'create-hint.submit');
       expect(accountWithError.updateRecoveryKeyHint).toBeCalledWith(hintValue);
       // logs the error
       expect(logViewEvent).toBeCalledWith(
         viewName,
-        'hint-fail',
+        'create-hint.fail',
         gqlUnexpectedError
       );
       expect(navigateForward).not.toHaveBeenCalled();
@@ -166,7 +166,7 @@ describe('FlowRecoveryKeyHint', () => {
     fireEvent.click(submitButton);
     await waitFor(() => {
       expect(accountWithSuccess.updateRecoveryKeyHint).not.toBeCalled();
-      expect(logViewEvent).toHaveBeenCalledWith(viewName, 'hint-skip');
+      expect(logViewEvent).toHaveBeenCalledWith(viewName, 'create-hint.skip');
       expect(navigateForward).toHaveBeenCalledTimes(1);
     });
   });
@@ -175,6 +175,6 @@ describe('FlowRecoveryKeyHint', () => {
     renderWithContext(accountWithSuccess);
     fireEvent.click(screen.getByTitle('Back to settings'));
     expect(navigateBackward).toBeCalledTimes(1);
-    expect(logViewEvent).toHaveBeenCalledWith(viewName, 'hint-skip');
+    expect(logViewEvent).toHaveBeenCalledWith(viewName, 'create-hint.skip');
   });
 });

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -77,7 +77,7 @@ export const FlowRecoveryKeyHint = ({
     const trimmedHint = hint.trim();
 
     if (trimmedHint.length === 0) {
-      logViewEvent(viewName, 'hint-skip');
+      logViewEvent(viewName, 'create-hint.skip');
       navigateForward();
       alertBar.success(
         ftlMsgResolver.getMsg(
@@ -92,9 +92,9 @@ export const FlowRecoveryKeyHint = ({
         return;
       } else {
         try {
-          logViewEvent(viewName, 'hint-submit');
+          logViewEvent(viewName, 'create-hint.submit');
           await account.updateRecoveryKeyHint(trimmedHint);
-          logViewEvent(viewName, 'hint-success');
+          logViewEvent(viewName, 'create-hint.success');
           navigateForward();
           alertBar.success(
             ftlMsgResolver.getMsg(
@@ -118,7 +118,7 @@ export const FlowRecoveryKeyHint = ({
             );
           }
           setBannerText(localizedError);
-          logViewEvent(viewName, 'hint-fail', e);
+          logViewEvent(viewName, 'create-hint.fail', e);
         }
       }
     }
@@ -151,7 +151,7 @@ export const FlowRecoveryKeyHint = ({
       title={localizedPageTitle}
       localizedBackButtonTitle={localizedBackButtonTitle}
       onBackButtonClick={() => {
-        logViewEvent(viewName, 'hint-skip');
+        logViewEvent(viewName, 'create-hint.skip');
         navigateBackward();
       }}
     >


### PR DESCRIPTION
## Because:

* With the design updates to the Recovery Key flow, we wanted to do a higher level sweep of all the tracking of users entering/exiting/interacting with that flow. This PR updates the views to have all tracking events listed in
https://docs.google.com/spreadsheets/d/1-HsNgIjT4IJQf088o2mM3a-vn3OCNNXixHU5L0QH_GI/edit?usp=sharing. It also adds comments for which pre-existing event should be removed in clean-up.

## This commit:

* We document which event should be removed in cleanup, and update existing events to match the above document per feedback from Wil and Jess.

Closes #FXA-7249

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
