### PR TITLE
fix(payments): only checkIpOnly if no credentials

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -74,7 +74,7 @@ export class SubscribePage extends BaseLayout {
   async couponErrorMessageText() {
     const msg = await this.page.innerText('[data-testid="coupon-error"]');
     if (msg === 'An error occurred processing the code. Please try again.') {
-      throw new Error('Stripe generic error, most likely rate limited');
+      throw new Error('Generic error, most likely rate limited');
     }
     return msg;
   }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -500,12 +500,18 @@ export class StripeHandler {
     request: AuthRequest
   ): Promise<couponDTO.couponDetailsSchema> {
     this.log.begin('subscriptions.retrieveCouponDetails', request);
-    await this.customs.checkIpOnly(request, 'retrieveCouponDetails');
 
     const { promotionCode, priceId } = request.payload as Record<
       string,
       string
     >;
+
+    if (request.auth.credentials) {
+      const { email } = await handleAuth(this.db, request.auth, true);
+      await this.customs.check(request, email, 'retrieveCouponDetails');
+    } else {
+      await this.customs.checkIpOnly(request, 'retrieveCouponDetails');
+    }
 
     const taxAddress = this.buildTaxAddress(
       request.app.clientAddress,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -1009,6 +1009,13 @@ describe('DirectStripeRoutes', () => {
       );
 
       sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.customs.check,
+        VALID_REQUEST,
+        TEST_EMAIL,
+        'retrieveCouponDetails'
+      );
+      sinon.assert.notCalled(directStripeRoutesInstance.customs.checkIpOnly);
+      sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.retrieveCouponDetails,
         {
           promotionCode: 'promotionCode',
@@ -1021,6 +1028,19 @@ describe('DirectStripeRoutes', () => {
       );
 
       assert.deepEqual(actual, expected);
+    });
+
+    it('calls customs checkIpOnly for unauthenticated customer', async () => {
+      const request = deepCopy(VALID_REQUEST);
+      request.auth.credentials = undefined;
+      await directStripeRoutesInstance.retrieveCouponDetails(request);
+
+      sinon.assert.calledOnceWithExactly(
+        directStripeRoutesInstance.customs.checkIpOnly,
+        request,
+        'retrieveCouponDetails'
+      );
+      sinon.assert.notCalled(directStripeRoutesInstance.customs.check);
     });
   });
 


### PR DESCRIPTION
## Because

- For the coupon endpoint, for logged in users, do not perform the customs.checkIpOnly.

## This pull request

- Only performs the customs.checkIpOnly check if auth credentials are not provided, otherwise use customs.check.
- Update playwright error message to indicate its not necessarily related to Stripe.

## Issue that this pull request solves

Closes: # FXA-7451

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

This is a similar fix as done for the `/invoice/preview` API as part of #14695.
