### PR TITLE
feat(metrics): disable Glean metrics based on acct pref

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -5,6 +5,7 @@
 // Shared implementation of `signIn` view method
 
 import AuthErrors from '../../lib/auth-errors';
+import GleanMetrics from '../../lib/glean';
 import OAuthErrors from '../../lib/oauth-errors';
 import NavigateBehavior from '../behaviors/navigate';
 import ResumeTokenMixin from './resume-token-mixin';
@@ -243,6 +244,10 @@ export default {
       // for a deleted account. See #4316
       this.relier.set('email', account.get('email'));
       this.relier.set('uid', account.get('uid'));
+    }
+
+    if (account.get('metricsEnabled') === false) {
+      GleanMetrics.setEnabled(false);
     }
 
     // This is the generic signin.success metric. The one

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -10,6 +10,7 @@ import Cocktail from 'cocktail';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
+import GleanMetrics from '../lib/glean';
 import PasswordMixin from './mixins/password-mixin';
 import preventDefaultThen from './decorators/prevent_default_then';
 import ServiceMixin from './mixins/service-mixin';
@@ -43,6 +44,12 @@ const SignInPasswordView = FormView.extend({
     const account = this.getAccount();
     if (!account || !account.get('email')) {
       this.navigate('/');
+    }
+
+    // If a previously authenticated account was found locally and it had opted
+    // out of data collection
+    if (account && account.get('metricsEnabled') === false) {
+      GleanMetrics.setEnabled(false);
     }
   },
 

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -13,6 +13,7 @@ import { SIGNIN_PASSWORD } from '../../../../tests/functional/lib/selectors';
 import sinon from 'sinon';
 import User from 'models/user';
 import View from 'views/sign_in_password';
+import GleanMetrics from '../../../scripts/lib/glean';
 
 const EMAIL = 'testuser@testuser.com';
 
@@ -29,7 +30,7 @@ describe('views/sign_in_password', () => {
   let view;
 
   beforeEach(() => {
-    account = new Account({ email: EMAIL });
+    account = new Account({ email: EMAIL, metricsEnabled: false });
     broker = new Broker();
     formPrefill = new FormPrefill();
     model = new Backbone.Model({ account });
@@ -64,6 +65,11 @@ describe('views/sign_in_password', () => {
   describe('beforeRender', () => {
     beforeEach(() => {
       sinon.spy(view, 'navigate');
+      sinon.spy(GleanMetrics, 'setEnabled');
+    });
+
+    afterEach(() => {
+      GleanMetrics.setEnabled.restore();
     });
 
     it('redirects to `/` if no account', () => {
@@ -79,6 +85,12 @@ describe('views/sign_in_password', () => {
       view.beforeRender();
 
       assert.isFalse(view.navigate.called);
+    });
+
+    it('disables Glean metrics on pref', () => {
+      view.beforeRender();
+      assert.isTrue(GleanMetrics.setEnabled.calledOnce);
+      assert.equal(GleanMetrics.setEnabled.args[0][0], false);
     });
   });
 


### PR DESCRIPTION
Because:
 - we should not send Glean pings if the account has opted out of data collection

This commit:
 - disable Glean when we know the account's data collection setting before or after signing in
