### PR TITLE
feat(url): Update settings redirect to append query params

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -357,7 +357,9 @@ Router = Router.extend({
       const searchParams = new URLSearchParams(this.window.location.search);
       const redirectUrl = searchParams.get('redirect_to');
       if (redirectUrl) {
-        if (!this.isValidRedirect(redirectUrl, this.config.redirectAllowlist)) {
+        // Ignore query params when validating the redirect url
+        const parsedRedirectUrl = redirectUrl.split('?')[0];
+        if (!this.isValidRedirect(parsedRedirectUrl, this.config.redirectAllowlist)) {
           throw new Error('Invalid redirect!');
         }
         return this.navigateAway(redirectUrl);

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -17,7 +17,7 @@
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js && yarn build-css",
     "delete": "pm2 delete pm2.config.js",
-    "start-production": "NODE_ENV=production grunt build && yarn build-css && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
+    "start-production": "NODE_ENV=production grunt build && yarn build-css && CONFIG_FILES=server/config/local.json,server/config/production.json,server/config/secrets.json grunt serverproc:dist",
     "start-remote": "scripts/run_remote_dev.sh",
     "test": "node tests/intern.js --unit=true",
     "test-circle": "node tests/intern.js --suites=circle --fxaAuthRoot=https://fxaci.dev.lcip.org/auth --fxaEmailRoot=http://restmail.net --fxaOAuthApp=https://oauth-fxaci.dev.lcip.org --fxaUntrustedOauthApp=https://321done-fxaci.dev.lcip.org --fxaProduction=true --bailAfterFirstFailure=true",

--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -11,15 +11,16 @@ let errorResponse: ErrorResponse;
 let mockReplace: Mock;
 
 describe('errorHandler', () => {
-  const pageWhichRequiresAuthentication = pagesRequiringAuthentication[0];
-  const pageWhichDoesNotRequireAuthentication = 'foo';
+  const pageWhichRequiresAuthentication = 'https://accounts.firefox.com/settings';
+  const pageWhichDoesNotRequireAuthentication = 'https://accounts.firefox.com/signin';
   beforeAll(() => {
     mockReplace = jest.fn();
     Object.defineProperty(window, 'location', {
       value: {
         replace: mockReplace,
         search: '',
-        pathname: pageWhichRequiresAuthentication,
+        pathname: 'settings',
+        href: pageWhichRequiresAuthentication,
       },
     });
 
@@ -42,7 +43,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-      `/signin?redirect_to=${pageWhichRequiresAuthentication}`
+      '/signin?redirect_to=https%253A%252F%252Faccounts.firefox.com%252Fsettings'
     );
   });
 
@@ -59,7 +60,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-      `/signin?redirect_to=${pageWhichRequiresAuthentication}`
+     '/signin?redirect_to=https%253A%252F%252Faccounts.firefox.com%252Fsettings'
     );
   });
 
@@ -85,7 +86,8 @@ describe('errorHandler', () => {
       value: {
         replace: mockReplace,
         search: '',
-        pathname: pageWhichDoesNotRequireAuthentication,
+        pathname: 'signin',
+        href: pageWhichDoesNotRequireAuthentication,
       },
     });
 

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -40,8 +40,12 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
     }
   }
   if (reauth && currentPageRequiresAuthentication) {
+    // When doing a redirect and going to signin, we want to ensure that original query params
+    // are sent as well, otw we would strip out utms and context params
+    const queryParams = new URLSearchParams(window.location.search);
+    queryParams.set('redirect_to', encodeURIComponent(window.location.href));
     window.location.replace(
-      `/signin?redirect_to=${encodeURIComponent(window.location.pathname)}`
+      `/signin?${queryParams.toString()}`
     );
   } else {
     if (!reauth) {


### PR DESCRIPTION
## Because

- We want to ensure that query params (ie `context`) are included when redirecting
- Updates the `redirect_to` to include the abolute url

## This pull request

- Updates gql to append the query params when doing to settings and in the `redirect_to` param

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7439

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

Here is an example of how the redirect works:
http://accounts.firefox.com/settings?context=oauth_webchannel_v1 redirects ->

https://accounts.firefox.com/signin?context=oauth_webchannel_v1&redirect_to=http%3A%2F%2Faccounts.firefox.com%2Fsettings%3Fcontext%3Doauth_webchannel_v1

Note that now the `context` param is loaded on the signin page. Depending on this param, the browser and FxA perform exchange information via webchannels to let web content know what user to load.