### PR TITLE
feat(auth): Update Google authorization endpoint to not show disclaimer

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -102,6 +102,8 @@ export default {
       access_type: 'offline',
       prompt: 'consent',
       response_type: 'code',
+      disallow_webview: true,
+      ack_webview_shutdown:'2024-09-30'
     };
     /* eslint-enable camelcase */
     for (const p in params) {
@@ -148,7 +150,7 @@ export default {
       access_type: 'offline',
       prompt: 'consent',
       response_type: 'code id_token',
-      response_mode: 'form_post',
+      response_mode: 'form_post'
     };
     /* eslint-enable camelcase */
     for (const p in params) {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
@@ -145,7 +145,7 @@ describe('views/mixins/third-party-auth-mixin', function () {
       )
     );
 
-    assert.equal(mockInput.setAttribute.args.length, 21);
+    assert.equal(mockInput.setAttribute.args.length, 27);
 
     assertInputEl(mockInput, 'client_id', config.googleAuthConfig.clientId);
     assertInputEl(mockInput, 'scope', 'openid email profile');
@@ -164,8 +164,10 @@ describe('views/mixins/third-party-auth-mixin', function () {
     assertInputEl(mockInput, 'access_type', 'offline');
     assertInputEl(mockInput, 'prompt', 'consent');
     assertInputEl(mockInput, 'response_type', 'code');
+    assertInputEl(mockInput, 'disallow_webview', true);
+    assertInputEl(mockInput, 'ack_webview_shutdown', '2024-09-30');
 
-    assert.equal(mockForm.appendChild.args.length, 7);
+    assert.equal(mockForm.appendChild.args.length, 9);
     assert.isTrue(mockForm.submit.calledOnce);
   });
 


### PR DESCRIPTION
## Because

- These query params will show the error message if we are impacted

## This pull request

- Adds the query params to Google authorization endpoint

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7136

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I tested this in the iOS simulator and did not see any error messages on Google sign-in page. It is hard to verify this with Pocket unless it is in production. This is safe to land since users have to opt in to third party auth anyways.
