### PR TITLE
bug(admin,gql): Fix startup behavior in dev mode

### DIFF
--- a/packages/fxa-admin-server/nest-cli.json
+++ b/packages/fxa-admin-server/nest-cli.json
@@ -2,9 +2,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": [
-      "**/*.gql"
-    ],
+    "assets": ["**/*.gql"],
     "watchAssets": true
-  }
+  },
+  "entryFile": "src/packages/admin-server/main.js"
 }

--- a/packages/fxa-graphql-api/nest-cli.json
+++ b/packages/fxa-graphql-api/nest-cli.json
@@ -1,4 +1,5 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "entryFile": "packages/fxa-graphql-api/src/main.js"
 }


### PR DESCRIPTION
## Because

- Nest APIs could fail to start because `main.js` wasn't found
- NX work changed structure of dist folder

## This pull request

- Adjust the path to point to the new location of main.js

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I think this went unnoticed because it would only become a failure after the dist folder was cleaned out.

IIRC to reproduce the issue on main, run `nx run fxa-gql-api:build` then run `nx run fxa-gql-api:start`.
