### PR TITLE
bug(functional-tests): Fix default domain for subscriptions on stage

### DIFF
--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -6,7 +6,8 @@ const ACCOUNTS_DOMAIN =
 const ACCOUNTS_API_DOMAIN =
   process.env.ACCOUNTS_API_DOMAIN || 'api-accounts.stage.mozaws.net';
 const PAYMENTS_DOMAIN =
-  process.env.PAYMENTS_DOMAIN || 'payments.stage.mozaws.net';
+  process.env.PAYMENTS_DOMAIN ||
+  'payments-stage.fxa.nonprod.cloudops.mozgcp.net';
 const RELIER_DOMAIN =
   process.env.RELIER_DOMAIN || 'stage-123done.herokuapp.com';
 


### PR DESCRIPTION
## Because

- We had the wrong default domain for subscriptions APIs

## This pull request

- Points at the correct domain (a gcp domain)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This caused problems in the 1.259.0 deployment.
