### PR TITLE
bug(CI): Current version not being set properly in docker build.

### DIFF
--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -38,7 +38,7 @@ FROM fxa-build-utils as fxa-build
 COPY --chown=app:app . /fxa
 USER app
 WORKDIR /fxa
-RUN _dev/docker/mono/build.sh
+RUN _dev/docker/mono/build.sh $(cat packages/version.json | jq -r '.version.version')
 
 # Final image
 FROM fxa-utils as fxa-mono


### PR DESCRIPTION
## Because

- Deployed services all had a version set to v0.0.0

## This pull request

- Determines version specified in `packages/version.json`
- Provides this version to `build.sh` ensuring it is set in packages

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This can be tested by letting the fxa-mono repo build and be deployed to docker hub. Assuming we are tagging train 259, the docker build logs should say something like `Updating version in package.json to v1.259.1`. Once the docker image is tag and pushed, this should also validate that the version was in fact updated. `docker run -it mozilla/fxa-mono:v1.259.0 bash -c 'cat /fxa/packages/fxa-auth-server/package.json | jq -r '.version''`
