### PR TITLE
feat(broker): add resource server support

### DIFF
--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -11,7 +11,7 @@
     "start": "../../_scripts/check-url.sh localhost:9000/__heartbeat__ && pm2 start pm2.config.js",
     "start-prod": "node dist/packages/fxa-event-broker/src/main",
     "lint": "eslint {src,test}/**/*.ts",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test-unit": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --coverage --forceExit --detectOpenHandles --logHeapUsage -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
     "test-integration": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml jest --coverage --logHeapUsage -t '#integration' --ci --reporters=default --reporters=jest-junit ",
     "test-watch": "jest --watch",

--- a/packages/fxa-event-broker/src/firestore/schemas.interface.ts
+++ b/packages/fxa-event-broker/src/firestore/schemas.interface.ts
@@ -18,7 +18,7 @@
  *
  * The collection is keyed by the FxA user ID.
  */
-export interface User {
+export interface UserDocument {
   oauth_clients: {
     [clientId: string]: boolean;
   };
@@ -30,8 +30,20 @@ export interface User {
  * RPs that have a registered webhookUrl in this collection will
  * have a message queued.
  *
+ * If the RP acts as a Resource Server, the `isResourceServer` flag
+ * should be set to `true`. This will resuult in the RP being sent
+ * all events for all users.
+ *
  * The collection is keyed by the Client ID.
  */
-export interface WebhookUrl {
+export interface WebhookUrlDocument {
   webhookUrl: string;
+  isResourceServer?: boolean;
+}
+
+/**
+ * Map of OAuth client IDs to WebhookUrl documents.
+ */
+export interface WebhookUrlDocumentMap {
+  [clientId: string]: WebhookUrlDocument;
 }


### PR DESCRIPTION
Because:

* We need to be able to send all events to resource servers.

This commit:

* Adds a new `isResourceServer` flag to the `ClientWebhooks` interface on the clients Firestore document.
* Includes a new field on the ClientWebhooksService for the queue worker to use to determine if the client is a resource server and distribute all events to it (subscription events if the resource server is configured for the subscription capability).

Closes FXA-7475

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
