### PR TITLE
task(content): Make csp-report.blocked-uri validation check less strict

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/post-csp.js
+++ b/packages/fxa-content-server/server/lib/routes/post-csp.js
@@ -26,14 +26,7 @@ const BODY_SCHEMA = {
     .keys({
       // CSP 2, 3 required
       // `eval` and `inline` are specified in CSP 3 and sent by Chrome
-      'blocked-uri': LONG_URI_TYPE.allow('')
-        .allow('asset')
-        .allow('blob')
-        .allow('data')
-        .allow('eval')
-        .allow('inline')
-        .allow('self')
-        .optional(),
+      'blocked-uri': STRING_TYPE.allow('').optional(),
       // CSP 2, 3 optional
       'column-number': INTEGER_TYPE.min(0).optional(),
       // CSP 3 required, but not always sent


### PR DESCRIPTION
## Because

- We were generating a lot of error on this validation check
- This value is only used in a report, so the URI requirement isn't mandatory

## This pull request

- Removes the requirement that the string posted is a valid URL

## Issue that this pull request solves

Closes: FXA-7556

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

