### PR TITLE
fix(react): Hide loading spinner on CompleteResetPassword only when checks complete

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -94,11 +94,11 @@ describe('CompleteResetPassword page', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the component as expected', () => {
+  it('renders the component as expected', async () => {
     renderSubject(account);
     // testAllL10n(screen, bundle);
 
-    screen.getByRole('heading', {
+    await screen.findByRole('heading', {
       name: 'Create new password',
     });
     screen.getByLabelText('New password');
@@ -112,7 +112,9 @@ describe('CompleteResetPassword page', () => {
   it('displays password requirements when the new password field is in focus', async () => {
     renderSubject(account);
 
-    const newPasswordField = screen.getByTestId('new-password-input-field');
+    const newPasswordField = await screen.findByTestId(
+      'new-password-input-field'
+    );
 
     expect(screen.queryByText('Password requirements')).not.toBeInTheDocument();
 
@@ -192,8 +194,10 @@ describe('CompleteResetPassword page', () => {
 
       renderSubject(account);
 
-      fireEvent.input(screen.getByTestId('new-password-input-field'), {
-        target: { value: PASSWORD },
+      await waitFor(() => {
+        fireEvent.input(screen.getByTestId('new-password-input-field'), {
+          target: { value: PASSWORD },
+        });
       });
 
       fireEvent.input(screen.getByTestId('verify-password-input-field'), {
@@ -246,7 +250,7 @@ describe('CompleteResetPassword page', () => {
       hasRecoveryKey: jest.fn().mockResolvedValue(true),
     } as unknown as Account;
 
-    it('redirects as expected', () => {
+    it('redirects as expected', async () => {
       account = {
         resetPasswordStatus: jest.fn().mockResolvedValue(true),
         completeResetPassword: jest.fn().mockResolvedValue(true),
@@ -254,6 +258,8 @@ describe('CompleteResetPassword page', () => {
       } as unknown as Account;
 
       renderSubject(account);
+
+      screen.getByLabelText('Loading…');
 
       expect(account.hasRecoveryKey).toHaveBeenCalledWith(
         mockCompleteResetPasswordParams.email
@@ -285,8 +291,10 @@ describe('CompleteResetPassword page', () => {
 
   describe('can submit', () => {
     async function enterPasswordAndSubmit() {
-      fireEvent.input(screen.getByTestId('new-password-input-field'), {
-        target: { value: PASSWORD },
+      await waitFor(() => {
+        fireEvent.input(screen.getByTestId('new-password-input-field'), {
+          target: { value: PASSWORD },
+        });
       });
       fireEvent.input(screen.getByTestId('verify-password-input-field'), {
         target: { value: PASSWORD },

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -116,11 +116,14 @@ const CompleteResetPassword = ({
       }
     };
 
-    if (!location.state?.lostRecoveryKey) {
-      checkForRecoveryKeyAndNavigate(params.email);
-    }
+    const handleRecoveryKeyStatus = async () => {
+      if (!location.state?.lostRecoveryKey) {
+        await checkForRecoveryKeyAndNavigate(params.email);
+      }
+      setShowLoadingSpinner(false);
+    };
 
-    setShowLoadingSpinner(false);
+    handleRecoveryKeyStatus();
   }, [
     account,
     navigate,
@@ -142,8 +145,6 @@ const CompleteResetPassword = ({
     };
 
     checkPasswordForgotToken(params.token);
-
-    setShowLoadingSpinner(false);
   }, [params.token, account, setLinkStatus]);
 
   const alertSuccessAndNavigate = useCallback(() => {


### PR DESCRIPTION
Because:
* Users with a recovery key see a flash of CompleteResetPassword before being redirected to AccountRecoveryConfirmKey

This commit:
* Adjusts the loading spinner state to only hide when recovery key checks have completed

Fixes FXA-7170

---

See ticket for before.

Here's with this patch, hitting it twice (since it's fast) and then clicking "Don't have a an account recovery key?":
<img src="https://github.com/mozilla/fxa/assets/13018240/4e366d1e-d6a2-4a80-93da-7c829ee73606" width="400">

I also tested with an expired link and without a recovery key.

I tried using `account.loading` here because we have a `withLoadingStatus` on the account model and are using `account.loading` in just a couple of other places but there's something weird about it, it seems to load two inputs like it’s showing the complete reset PW screen without text; didn't dig further since we have plans to refactor some of this anyway.
<img src="https://github.com/mozilla/fxa/assets/13018240/54c459bb-8c93-4fe4-aaa7-e70f3d829364" width="400">
