### PR TITLE
feat(metrics): require country_code_source on upgrade events

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -291,7 +291,9 @@ export class StripeHandler {
 
     await this.customerChanged(request, uid, email);
 
-    return { subscriptionId };
+    const sourceCountry = customer?.shipping?.address?.country || null;
+
+    return { subscriptionId, sourceCountry };
   }
 
   async listPlans(request: AuthRequest) {
@@ -1178,6 +1180,12 @@ export const stripeRoutes = (
         auth: {
           payload: false,
           strategy: 'oauthToken',
+        },
+        response: {
+          schema: isA.object().keys({
+            subscriptionId: isA.string(),
+            sourceCountry: validators.subscriptionPaymentCountryCode.required(),
+          }) as any,
         },
         validate: {
           params: {

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/customer1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/customer1.json
@@ -26,7 +26,18 @@
   "name": null,
   "phone": null,
   "preferred_locales": [],
-  "shipping": null,
+  "shipping": {
+    "address": {
+      "city": null,
+      "country": "RO",
+      "line1": null,
+      "line2": null,
+      "postal_code": "98332",
+      "state": null
+    },
+    "name": "Testy McTesterson",
+    "phone": null
+  },
   "sources": {
     "object": "list",
     "data": [

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -2035,7 +2035,7 @@ describe('DirectStripeRoutes', () => {
 
     it('returns the subscription id when the plan is a valid upgrade', async () => {
       const subscriptionId = 'sub_123';
-      const expected = { subscriptionId: subscriptionId };
+      const expected = { subscriptionId: subscriptionId, sourceCountry: 'RO' };
       VALID_REQUEST.params = { subscriptionId: subscriptionId };
 
       directStripeRoutesInstance.stripeHelper.verifyPlanUpdateForSubscription.resolves();

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -379,7 +379,7 @@ export function updateSubscriptionPlan_PENDING(
 }
 
 export function updateSubscriptionPlan_FULFILLED(
-  eventProperties: EventProperties
+  eventProperties: SuccessfulSubscriptionEventProperties
 ) {
   safeLogAmplitudeEvent(
     eventGroupNames.changeSubscription,

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -198,7 +198,10 @@ export async function apiUpdateSubscriptionPlan(params: {
       `${config.servers.auth.url}/v1/oauth/subscriptions/active/${subscriptionId}`,
       { body: JSON.stringify({ planId }) }
     );
-    Amplitude.updateSubscriptionPlan_FULFILLED(metricsOptions);
+    Amplitude.updateSubscriptionPlan_FULFILLED({
+      ...metricsOptions,
+      country_code_source: result.sourceCountry,
+    });
     return result;
   } catch (error) {
     Amplitude.updateSubscriptionPlan_REJECTED({

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -34,6 +34,8 @@ declare global {
   }
 }
 
+export const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
+
 export const wait = (delay: number) =>
   new Promise((resolve) => setTimeout(resolve, delay));
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
@@ -1,22 +1,17 @@
-import React from 'react';
-import { Stripe, PaymentMethod, PaymentIntent } from '@stripe/stripe-js';
-import { storiesOf } from '@storybook/react';
 import { linkTo } from '@storybook/addon-links';
+import { storiesOf } from '@storybook/react';
+import { PaymentIntent, PaymentMethod, Stripe } from '@stripe/stripe-js';
+import React from 'react';
+
+import SubscriptionCreate, { SubscriptionCreateProps } from '.';
 import MockApp, {
   defaultAppContextValue,
 } from '../../../../.storybook/components/MockApp';
-import { CUSTOMER, PROFILE, PLAN, NEW_CUSTOMER } from '../../../lib/mock-data';
-import { APIError } from '../../../lib/apiClient';
-import { PickPartial } from '../../../lib/types';
 import { SignInLayout } from '../../../components/AppLayout';
-import SubscriptionCreate, { SubscriptionCreateProps } from './index';
-
-// TODO: Move to some shared lib?
-const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
-
-// TODO: Move to some shared lib?
-const wait = (delay: number) =>
-  new Promise((resolve) => setTimeout(resolve, delay));
+import { APIError } from '../../../lib/apiClient';
+import { CUSTOMER, NEW_CUSTOMER, PLAN, PROFILE } from '../../../lib/mock-data';
+import { deepCopy, wait } from '../../../lib/test-utils';
+import { PickPartial } from '../../../lib/types';
 
 function init() {
   storiesOf('routes/Product/SubscriptionCreate', module)

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -16,6 +16,7 @@ import waitForExpect from 'wait-for-expect';
 import SubscriptionCreate, { SubscriptionCreateProps } from '.';
 import { SignInLayout } from '../../../components/AppLayout';
 import { ButtonBaseProps } from '../../../components/PayPalButton';
+import { getFallbackTextByFluentId } from '../../../lib/errors';
 import { useNonce } from '../../../lib/hooks';
 import {
   CONFIRM_CARD_RESULT,
@@ -31,6 +32,7 @@ import {
   SUBSCRIPTION_RESULT,
 } from '../../../lib/mock-data';
 import {
+  deepCopy,
   defaultAppContextValue,
   elementChangeResponse,
   MOCK_CHECKOUT_TOKEN,
@@ -39,7 +41,6 @@ import {
   mockStripeElementOnChangeFns,
 } from '../../../lib/test-utils';
 import { PickPartial } from '../../../lib/types';
-import { getFallbackTextByFluentId } from '../../../lib/errors';
 
 jest.mock('../../../lib/hooks', () => {
   const refreshNonceMock = jest.fn().mockImplementation(Math.random);
@@ -48,9 +49,6 @@ jest.mock('../../../lib/hooks', () => {
     useNonce: () => [Math.random(), refreshNonceMock],
   };
 });
-
-// TODO: Move to some shared lib?
-const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
 
 type SubjectProps = PickPartial<
   SubscriptionCreateProps,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionIapItem/index.test.tsx
@@ -1,22 +1,19 @@
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { MockApp } from '../../../lib/test-utils';
+import { render } from '@testing-library/react';
+import { IapSubscription } from 'fxa-shared/subscriptions/types';
+
+import { SignInLayout } from '../../../components/AppLayout';
 import {
   IAP_APPLE_SUBSCRIPTION,
   IAP_GOOGLE_SUBSCRIPTION,
   SELECTED_PLAN,
 } from '../../../lib/mock-data';
-import { SignInLayout } from '../../../components/AppLayout';
-
-import { IapSubscription } from 'fxa-shared/subscriptions/types';
-
+import { deepCopy, MockApp } from '../../../lib/test-utils';
+import { PickPartial } from '../../../lib/types';
 import SubscriptionIapItem, {
   SubscriptionIapItemProps,
 } from './SubscriptionIapItem';
-import { PickPartial } from '../../../lib/types';
-
-const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
 
 type SubjectProps = PickPartial<
   SubscriptionIapItemProps,

--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -257,9 +257,11 @@
         "required": ["language"],
         "properties": {
           "user_properties": {
+            "type": "object",
             "required": ["flow_id"]
           },
           "event_properties": {
+            "type": "object",
             "required": ["plan_id", "product_id"]
           }
         }
@@ -279,6 +281,7 @@
       "then": {
         "properties": {
           "event_properties": {
+            "type": "object",
             "required": ["checkout_type"]
           }
         }
@@ -296,9 +299,16 @@
         }
       },
       "then": {
+        "required": ["user_id"],
         "properties": {
           "event_properties": {
-            "required": ["previous_plan_id", "previous_product_id", "subscription_id", "payment_provider"]
+            "type": "object",
+            "required": [
+              "previous_plan_id",
+              "previous_product_id",
+              "subscription_id",
+              "payment_provider"
+            ]
           }
         }
       }
@@ -317,6 +327,7 @@
       "then": {
         "properties": {
           "event_properties": {
+            "type": "object",
             "required": ["payment_provider"]
           }
         }
@@ -336,6 +347,7 @@
       "then": {
         "properties": {
           "event_properties": {
+            "type": "object",
             "required": ["error_id"]
           }
         }
@@ -348,13 +360,14 @@
         "properties": {
           "event_type": {
             "type": "string",
-            "pattern": "^fxa_pay_setup - success|fxa_subscribe - subscription_ended"
+            "pattern": "fxa_pay_subscription_change - success|fxa_pay_setup - success|fxa_subscribe - subscription_ended"
           }
         }
       },
       "then": {
         "properties": {
           "event_properties": {
+            "type": "object",
             "required": ["country_code_source"]
           }
         }


### PR DESCRIPTION
Because:

* We want to add `country_code` of payments on `fxa_pay_subscription_change - success` events

This commit:

* Updates the ajv schema to require it for success events
* Updates API endpoints to return the necessary data
* Passes it to the metrics endpoint
* Updates all applicable tests

Closes FXA-7391

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

## ToDo

- [X] Update unit tests for API endpoints
- [ ] Verify in BigQuery
- [X] (For Ivo): few cleanup tasks from previous PR