### PR TITLE
fix(redirect): Fix double encoded `redirect_to` query param

### DIFF
--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { errorHandler, pagesRequiringAuthentication } from './gql';
+import { errorHandler } from './gql';
 import { ErrorResponse } from '@apollo/client/link/error';
 import { Operation, NextLink, ServerError } from '@apollo/client/core';
 import { GraphQLError } from 'graphql';
@@ -43,7 +43,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-      '/signin?redirect_to=https%253A%252F%252Faccounts.firefox.com%252Fsettings'
+      '/signin?redirect_to=https%3A%2F%2Faccounts.firefox.com%2Fsettings'
     );
   });
 
@@ -60,7 +60,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-     '/signin?redirect_to=https%253A%252F%252Faccounts.firefox.com%252Fsettings'
+     '/signin?redirect_to=https%3A%2F%2Faccounts.firefox.com%2Fsettings'
     );
   });
 

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -43,7 +43,7 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
     // When doing a redirect and going to signin, we want to ensure that original query params
     // are sent as well, otw we would strip out utms and context params
     const queryParams = new URLSearchParams(window.location.search);
-    queryParams.set('redirect_to', encodeURIComponent(window.location.href));
+    queryParams.set('redirect_to', window.location.href);
     window.location.replace(
       `/signin?${queryParams.toString()}`
     );


### PR DESCRIPTION
## Because

- This was being encoded twice causing it to fail the url validation

## This pull request

- Remove the double encoding, `URLSearchParam` class handles it already

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7573

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

