### PR TITLE
fix(react): Password reset unexpected error fixes, with and without recovery key

### DIFF
--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -67,6 +67,8 @@ test.describe('recovery key react', () => {
       status = await settings.recoveryKey.statusText();
       expect(status).toEqual('Enabled');
 
+      // Ensure password reset occurs with no session token available
+      login.clearCache();
       // Stash original encryption keys to be verified later
       const res = await target.auth.sessionReauth(
         credentials.sessionToken,

--- a/packages/fxa-auth-client/lib/recoveryKey.ts
+++ b/packages/fxa-auth-client/lib/recoveryKey.ts
@@ -89,7 +89,6 @@ export async function generateRecoveryKey(
  */
 export async function decryptRecoveryKeyData(
   recoveryKey: Uint8Array,
-  recoveryKeyId: string,
   recoveryData: string,
   uid: hexstring
 ): Promise<DecryptedRecoveryKeyData> {

--- a/packages/fxa-auth-client/test/recoveryKey.ts
+++ b/packages/fxa-auth-client/test/recoveryKey.ts
@@ -52,15 +52,17 @@ describe('lib/recoveryKey', () => {
 
   describe('decryptRecoveryKeyData', () => {
     it('matches the test vector', async () => {
-      const { recoveryKey, recoveryKeyId, recoveryData } =
-        await generateRecoveryKey(uid, keys, {
+      const { recoveryKey, recoveryData } = await generateRecoveryKey(
+        uid,
+        keys,
+        {
           testRecoveryKey: expectedRecoveryKey,
           testIV: iv,
-        });
+        }
+      );
 
       const result = await decryptRecoveryKeyData(
         recoveryKey,
-        recoveryKeyId,
         recoveryData,
         uid
       );

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -502,14 +502,18 @@ export class AccountResolver {
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => AccountResetInput })
     input: AccountResetInput
-  ) {
-    return this.authAPI.accountReset(
+  ): Promise<AccountResetPayload> {
+    const result = await this.authAPI.accountReset(
       input.email,
       input.newPassword,
       input.accountResetToken,
       input.options,
       headers
     );
+    return {
+      clientMutationId: input.clientMutationId,
+      ...result,
+    };
   }
 
   @Mutation((returns) => SignedUpAccountPayload, {

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -14,6 +14,22 @@ export interface OldSettingsData {
   metricsEnabled?: boolean;
 }
 
+export function getOldSettingsData({
+  uid,
+  sessionToken,
+  alertText,
+  displayName,
+  metricsEnabled,
+}: Record<string, any>): OldSettingsData {
+  return {
+    uid,
+    sessionToken,
+    alertText,
+    displayName,
+    metricsEnabled,
+  };
+}
+
 type LocalAccount = OldSettingsData | undefined;
 type LocalAccounts = Record<hexstring, LocalAccount> | undefined;
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -102,9 +102,8 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
       const decodedRecoveryKey = base32Decode(recoveryKey, 'Crockford');
       const uint8RecoveryKey = new Uint8Array(decodedRecoveryKey);
 
-      const decryptedData = await decryptRecoveryKeyData(
+      const { kB } = await decryptRecoveryKeyData(
         uint8RecoveryKey,
-        recoveryKeyId,
         recoveryData,
         uid
       );
@@ -113,7 +112,7 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
         state: {
           accountResetToken,
           recoveryKeyId,
-          kB: decryptedData.kB,
+          kB,
         },
       });
     },
@@ -123,21 +122,17 @@ const AccountRecoveryConfirmKey = (_: RouteComponentProps) => {
   const checkRecoveryKey = useCallback(
     async ({ recoveryKey, token, code, email, uid }: SubmitData) => {
       try {
-        if (!fetchedResetToken) {
+        let resetToken = fetchedResetToken;
+        if (!resetToken) {
           const { accountResetToken } = await account.verifyPasswordForgotToken(
             token,
             code
           );
           setFetchedResetToken(accountResetToken);
-          await getRecoveryBundleAndNavigate({
-            accountResetToken,
-            recoveryKey,
-            uid,
-            email,
-          });
+          resetToken = accountResetToken;
         }
         await getRecoveryBundleAndNavigate({
-          accountResetToken: fetchedResetToken,
+          accountResetToken: resetToken,
           recoveryKey,
           uid,
           email,


### PR DESCRIPTION
Because:
* There's an error when attempting to reset a password with an account recovery key, and other issues were uncovered during the fix

This commit:
* Fixes logic around accountResetToken, ensuring we only fetch getRecoveryBundle once with the same token
* Requests, receives, and sets sessionToken from account recovery reset and normal PW reset
* Uses this session token to perform other requests that must use authClient for now due to 'sessionToken.mustVerify' checks

Closes FXA-7189, FXA-7152

---

~I think we're going to have to unfortunately change all of our other reset PW apollo client calls back to auth client temporarily, which is probably going to fix at least a decent number of bugs. I'm guessing we've been accidentally doing a lot of testing while still authenticated, instead of actually signing out or trying to PW reset in another browser - if you "sign out" before any resets, you'll see lots of problems around us needing a session token to use our GQL API. See the [GQL & API calls section](https://docs.google.com/document/d/17dCwjxhxBKXDclkydmPHD91Pj3suIFihR6fZw6m126Q/edit#heading=h.5udps481u9ck) of the WIP Settings architecture doc. I'd like us to do this before we convert any other pages personally.~ Turns out this is not true, Vijay pinged me and let me know he'd done testing without a session token and that we can retrieve it during PW reset. I'll update our doc - the problem is that when we try to access account data via `useAccount` and the session token is null, or in the case now, when the session token is returning `mustVerify` (made notes in code).

I've tested:
* Reset w/o key or TOTP
* Reset w/o key, w TOTP
* Reset w key, w TOTP
* Reset w key, no TOTP, clicking "generate a new key" and going through the flow in Settings

The only difference with the old version is it this displays a flash of "Password reset" after a reset but before redirect to TOTP. This would be an a11y issue, but seeing as we don't display anything in the old version and we are working on the redesign directly after this is out, I think it's OK to leave.