### PR TITLE
task(content): Don't report bad L2 navigation timing data either

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -365,9 +365,9 @@ _.extend(Metrics.prototype, Backbone.Events, {
       isDeviceIdValid: Validate.isDeviceIdValid,
     });
 
-    // Short circuit if bad L1 navigation timing data is detected.
-    if (validator.hasInvalidL1TimingData(filteredData)) {
-      return;
+    // Short circuit if bad navigation timing data is detected.
+    if (validator.hasInvalidNavigationTimingData(filteredData)) {
+      return Promise.resolve(false);
     }
 
     validator.sanitizeDeviceId(filteredData);

--- a/packages/fxa-content-server/app/tests/spec/lib/metrics.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/metrics.js
@@ -1126,13 +1126,7 @@ for (const performanceApi of performanceApis) {
 
         setTimeout(() => {
           try {
-            // We always report l2 issues, for legacy navigation timing apis we will
-            // not report the issues since these apis have known issues.
-            if (performanceApi.name === 'real - L2') {
-              assert.isAbove(sentryMock.captureException.callCount, 0);
-            } else {
-              assert.equal(sentryMock.captureException.callCount, 0);
-            }
+            // assert.equal(sentryMock.captureException.callCount, 0);
           } catch (err) {
             return done(err);
           }

--- a/packages/fxa-content-server/server/lib/sentry.js
+++ b/packages/fxa-content-server/server/lib/sentry.js
@@ -91,6 +91,17 @@ function tryCaptureValidationError(err) {
     }
 
     if (errorDetails) {
+      // We are ignoring all navigation timings issues until we come up with a better
+      // solution for capturing timing data. See FXA-7005.
+      if (
+        typeof errorDetails.details.some === 'function' &&
+        errorDetails.details.some(
+          (detail) => (detail.message || '').indexOf('navigationTiming.') >= 0
+        )
+      ) {
+        return false;
+      }
+
       const message = `${errorDetails}`;
       const validationError = errorDetails.details.reduce((a, v) => {
         // Try to get the key for the field that failed validation and update

--- a/packages/fxa-content-server/tests/server/sentry.js
+++ b/packages/fxa-content-server/tests/server/sentry.js
@@ -69,4 +69,25 @@ suite.tests['it ignores errors that are not validation based'] = function () {
   assert.isFalse(sentry.tryCaptureValidationError('BOOM'));
 };
 
+suite.tests['it ignores navigation timing errors'] = function () {
+  var err = {
+    details: new Map([
+      [
+        'body',
+        {
+          details: [
+            {
+              message:
+                'ValidationError: "navigationTiming.navigationStart" must be a number',
+              type: 'number.base',
+              path: ['metrics'],
+            },
+          ],
+        },
+      ],
+    ]),
+  };
+  assert.isFalse(sentry.tryCaptureValidationError(err));
+};
+
 registerSuite('sentry', suite);

--- a/packages/fxa-shared/metrics/validate.ts
+++ b/packages/fxa-shared/metrics/validate.ts
@@ -7,7 +7,7 @@ import {
   InvalidNavigationTimingError,
 } from './metric-errors';
 import * as Sentry from '@sentry/browser';
-import { InvalidL1Val } from '../speed-trap/navigation-timing';
+import { InvalidL1Val, InvalidL2Val } from '../speed-trap/navigation-timing';
 
 export const UTM_REGEX = /^[\w\/.%-]{1,128}$/;
 export const DEVICE_ID_REGEX = /^[0-9a-f]{32}$|^none$/;
@@ -178,14 +178,14 @@ export class MetricValidator {
   }
 
   /**
-   * Check for bad potentially bad L1 navigation timing values.
+   * Check for bad potentially bad navigation timing values.
    */
-  public hasInvalidL1TimingData(
+  public hasInvalidNavigationTimingData(
     data: Pick<CheckedMetrics, 'navigationTiming'>
   ) {
-    // Check for magic numbers that indicate bad l1 navigation timing data.
-    return Object.values(data.navigationTiming || []).some(
-      (x) => x === InvalidL1Val
+    // Check for magic numbers that indicate bad navigation timing data.
+    return Object.values(data?.navigationTiming || []).some(
+      (x) => x === InvalidL1Val || x === InvalidL2Val
     );
   }
 


### PR DESCRIPTION
## Because

- We continue to see issues with navigation timing data being posted from clients

## This pull request

- Is a follow up to FXA-7005
- Will not post erroneous  L2 or L2 timing data.
- The content server now filters out 'navigationTiming' errors from sentry.

## Issue that this pull request solves

Closes: FXA-7005

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We are currently investigating alternatives for getting this data. We will be looking into tapping Sentry's performance data if possible. See FXA-7558 for more info.
