### PR TITLE
chore(build): upgrade nx to v16

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import { getJestProjects } from '@nrwl/jest';
+import { getJestProjects } from '@nx/jest';
 
 export default {
   projects: getJestProjects(),

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,3 @@
-const nxPreset = require('@nrwl/jest/preset').default;
+const nxPreset = require('@nx/jest/preset').default;
 
-module.exports = { ...nxPreset }
+module.exports = { ...nxPreset };

--- a/nx.json
+++ b/nx.json
@@ -5,24 +5,46 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "test-unit", "test-integration", "e2e"]
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test",
+          "test-unit",
+          "test-integration",
+          "e2e"
+        ]
       }
     }
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
     "lint": {
-      "inputs": ["default", "{workspaceRoot}/.eslintrc.json"]
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json"
+      ]
     },
     "test": {
-      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/jest.preset.js"
+      ]
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/.eslintrc.json",

--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
     ]
   },
   "devDependencies": {
-    "@nrwl/jest": "^15.9.2",
-    "@nrwl/js": "^15.9.2",
-    "@nrwl/workspace": "^15.9.2",
+    "@nx/jest": "16.3.1",
+    "@nx/js": "16.3.1",
+    "@nx/workspace": "16.3.1",
     "@types/jest": "^29.5.1",
     "@types/node": "^18.16.1",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
@@ -96,12 +96,12 @@
     "json": "^11.0.0",
     "mocha-junit-reporter": "^2.2.0",
     "mocha-multi": "^1.1.7",
-    "nx": "^15.9.2",
+    "nx": "16.3.1",
     "postcss": "^8.4.14",
     "stylelint": "^15.6.2",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-recommended-scss": "^12.0.0",
-    "ts-jest": "^29.1.0",
+    "ts-jest": "29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,8 +23,7 @@
     "esModuleInterop": true,
     "useUnknownInCatchVariables": false,
     "baseUrl": ".",
-    "paths": {
-    },
+    "paths": {},
     "typeRoots": [
       "./types",
       "./node_modules/@types",
@@ -32,9 +31,5 @@
     ],
     "jsx": "react-jsx"
   },
-  "exclude": [
-    "packages/*/node_modules",
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["packages/*/node_modules", "node_modules", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7447,180 +7447,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nrwl/cli@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/cli@npm:15.9.4"
+"@nrwl/devkit@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nrwl/devkit@npm:16.3.1"
   dependencies:
-    nx: 15.9.4
-  checksum: 039df998bbc56cc6d506a4c07500c97ce6662dff1ed0756d893d48398ffbfcfc9a1c274914011dbe331c0663b5c3e6de496ad6cdd05180ea0505fdcee19c67ff
+    "@nx/devkit": 16.3.1
+  checksum: 440629bca62a21d8e444cee066e793d751bcd63042796c3c881eccf0b5e4470dc098c467f48eb4c9d134166127128f3a8ac978409be6d2f6f2dff3422c6ff8d9
   languageName: node
   linkType: hard
 
-"@nrwl/devkit@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/devkit@npm:15.9.4"
+"@nrwl/jest@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nrwl/jest@npm:16.3.1"
   dependencies:
-    ejs: ^3.1.7
-    ignore: ^5.0.4
-    semver: 7.3.4
-    tmp: ~0.2.1
-    tslib: ^2.3.0
-  peerDependencies:
-    nx: ">= 14.1 <= 16"
-  checksum: 4207edab94384315bc80da673ae5c31bd63a8944c69ad1a2a2834d0e6f9ef5eb8a4118a1943ae855c6da889e326490cc4e5df718cb8df5853263e3b3c44d0148
+    "@nx/jest": 16.3.1
+  checksum: 9db6dbc5a8dcc3d03a0e853e99f823a9e7ff7af3cdf257b112a8bd22a6039a55e14b62ae9f14672a47d0483f023035cb51f050b87f851e525e8d0649be03bdd3
   languageName: node
   linkType: hard
 
-"@nrwl/jest@npm:^15.9.2":
-  version: 15.9.4
-  resolution: "@nrwl/jest@npm:15.9.4"
+"@nrwl/js@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nrwl/js@npm:16.3.1"
   dependencies:
-    "@jest/reporters": ^29.4.1
-    "@jest/test-result": ^29.4.1
-    "@nrwl/devkit": 15.9.4
-    "@nrwl/js": 15.9.4
-    "@phenomnomnominal/tsquery": 4.1.1
-    chalk: ^4.1.0
-    dotenv: ~10.0.0
-    identity-obj-proxy: 3.0.0
-    jest-config: ^29.4.1
-    jest-resolve: ^29.4.1
-    jest-util: ^29.4.1
-    resolve.exports: 1.1.0
-    tslib: ^2.3.0
-  checksum: de507ccc128a8eefb21fb7751d25d308fbe60bcee4f1180c740ae866b2526a3025bc00e8cfb0cfa69394fcff4861a85c1f1f62005ba41833b50986813f570432
+    "@nx/js": 16.3.1
+  checksum: db3dedc75c104244c43903fcd1ef6a564787783cf837c3f45878df2902d5b34e2a64c8cbcdd7cc805222edd5b52f944c3c2e82d6897f4cc3ef8638b93d7ea4ff
   languageName: node
   linkType: hard
 
-"@nrwl/js@npm:15.9.4, @nrwl/js@npm:^15.9.2":
-  version: 15.9.4
-  resolution: "@nrwl/js@npm:15.9.4"
+"@nrwl/tao@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nrwl/tao@npm:16.3.1"
   dependencies:
-    "@babel/core": ^7.15.0
-    "@babel/plugin-proposal-class-properties": ^7.14.5
-    "@babel/plugin-proposal-decorators": ^7.14.5
-    "@babel/plugin-transform-runtime": ^7.15.0
-    "@babel/preset-env": ^7.15.0
-    "@babel/preset-typescript": ^7.15.0
-    "@babel/runtime": ^7.14.8
-    "@nrwl/devkit": 15.9.4
-    "@nrwl/workspace": 15.9.4
-    "@phenomnomnominal/tsquery": 4.1.1
-    babel-plugin-const-enum: ^1.0.1
-    babel-plugin-macros: ^2.8.0
-    babel-plugin-transform-typescript-metadata: ^0.3.1
-    chalk: ^4.1.0
-    fast-glob: 3.2.7
-    fs-extra: ^11.1.0
-    ignore: ^5.0.4
-    js-tokens: ^4.0.0
-    minimatch: 3.0.5
-    source-map-support: 0.5.19
-    tree-kill: 1.2.2
-    tslib: ^2.3.0
-  checksum: 0f9daca23e83fbf4f1e609da62560422912ea0e44b5fe920b0f7fad5d2e3fec66336bbac29c80b8155154662a8a67ab220308b93388755a82ff2a8bb122ff9b3
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-darwin-arm64@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-darwin-arm64@npm:15.9.4"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-darwin-x64@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-darwin-x64@npm:15.9.4"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-linux-arm-gnueabihf@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-linux-arm-gnueabihf@npm:15.9.4"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-linux-arm64-gnu@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-linux-arm64-gnu@npm:15.9.4"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-linux-arm64-musl@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-linux-arm64-musl@npm:15.9.4"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-linux-x64-gnu@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-linux-x64-gnu@npm:15.9.4"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-linux-x64-musl@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-linux-x64-musl@npm:15.9.4"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-win32-arm64-msvc@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-win32-arm64-msvc@npm:15.9.4"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@nrwl/nx-win32-x64-msvc@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/nx-win32-x64-msvc@npm:15.9.4"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@nrwl/tao@npm:15.9.4":
-  version: 15.9.4
-  resolution: "@nrwl/tao@npm:15.9.4"
-  dependencies:
-    nx: 15.9.4
+    nx: 16.3.1
   bin:
     tao: index.js
-  checksum: 03acf914b443fc5b0a93674dbdf9d770856d48adf8956819869aef6c5378ecb52e9696361e8c8799c639fd384f7ab5d109189d44251a8975901adcfe77fa0c9e
+  checksum: 0b154ff061969461d4a09b53eb5b4e34c8cdb61ffb29b7f2f75f3ae1ce298b223155e0383c75263ed4eb0e55849fa491062f41d60e74608452fdd51eea664acc
   languageName: node
   linkType: hard
 
-"@nrwl/workspace@npm:15.9.4, @nrwl/workspace@npm:^15.9.2":
-  version: 15.9.4
-  resolution: "@nrwl/workspace@npm:15.9.4"
+"@nrwl/workspace@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nrwl/workspace@npm:16.3.1"
   dependencies:
-    "@nrwl/devkit": 15.9.4
-    "@parcel/watcher": 2.0.4
-    chalk: ^4.1.0
-    chokidar: ^3.5.1
-    cli-cursor: 3.1.0
-    cli-spinners: 2.6.1
-    dotenv: ~10.0.0
-    figures: 3.2.0
-    flat: ^5.0.2
-    glob: 7.1.4
-    ignore: ^5.0.4
-    minimatch: 3.0.5
-    npm-run-path: ^4.0.1
-    nx: 15.9.4
-    open: ^8.4.0
-    rxjs: ^6.5.4
-    tmp: ~0.2.1
-    tslib: ^2.3.0
-    yargs: ^17.6.2
-    yargs-parser: 21.1.1
-  checksum: c458f09b9211a28dcff760110de24702bbeea5ad16263e04569bbd1ee4164aa3c58895149559a252ac507a3eadb26b0cc8b76754e642e13b37f682e66ef61140
+    "@nx/workspace": 16.3.1
+  checksum: 5579e40525ce3287261d84d2db59c43af3f9a2c9905955120c6c9e6d0196c63134252c138615fd425e4bb8fff070d7935102fd4ed1228486138c839065af88de
   languageName: node
   linkType: hard
 
@@ -7634,6 +7504,177 @@ __metadata:
   bin:
     opencollective: bin/opencollective.js
   checksum: fd3737c12edf55b5c2279674664c3ed5e756410ea82e9cd324c3f0e032ed5ccd8df1959ec69ea97f2f1c9c33c884aae3d7a7108a73ea0faa90d74ea47cf364d4
+  languageName: node
+  linkType: hard
+
+"@nx/devkit@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/devkit@npm:16.3.1"
+  dependencies:
+    "@nrwl/devkit": 16.3.1
+    ejs: ^3.1.7
+    ignore: ^5.0.4
+    semver: 7.3.4
+    tmp: ~0.2.1
+    tslib: ^2.3.0
+  peerDependencies:
+    nx: ">= 15 <= 17"
+  checksum: 443ade26cb02d0b356c1e6928cba978bcdf4631222c20714ec9a11dc44e7731eedb707bfd241f7b04211385f22f6e002c7bf6afdc8f04d92cda0735befd7661b
+  languageName: node
+  linkType: hard
+
+"@nx/jest@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/jest@npm:16.3.1"
+  dependencies:
+    "@jest/reporters": ^29.4.1
+    "@jest/test-result": ^29.4.1
+    "@nrwl/jest": 16.3.1
+    "@nx/devkit": 16.3.1
+    "@nx/js": 16.3.1
+    "@phenomnomnominal/tsquery": ~5.0.1
+    chalk: ^4.1.0
+    dotenv: ~10.0.0
+    identity-obj-proxy: 3.0.0
+    jest-config: ^29.4.1
+    jest-resolve: ^29.4.1
+    jest-util: ^29.4.1
+    resolve.exports: 1.1.0
+    tslib: ^2.3.0
+  checksum: 430828c33d33cb96f7a9b0850fac630bdcf7cf8a131bf192b74287e2654af952cab0bf16c4db38963fcaf5e1a70b038b26a1cebaf863390f9918e1258c7b98d9
+  languageName: node
+  linkType: hard
+
+"@nx/js@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/js@npm:16.3.1"
+  dependencies:
+    "@babel/core": ^7.15.0
+    "@babel/plugin-proposal-class-properties": ^7.14.5
+    "@babel/plugin-proposal-decorators": ^7.14.5
+    "@babel/plugin-transform-runtime": ^7.15.0
+    "@babel/preset-env": ^7.15.0
+    "@babel/preset-typescript": ^7.15.0
+    "@babel/runtime": ^7.14.8
+    "@nrwl/js": 16.3.1
+    "@nx/devkit": 16.3.1
+    "@nx/workspace": 16.3.1
+    "@phenomnomnominal/tsquery": ~5.0.1
+    babel-plugin-const-enum: ^1.0.1
+    babel-plugin-macros: ^2.8.0
+    babel-plugin-transform-typescript-metadata: ^0.3.1
+    chalk: ^4.1.0
+    fast-glob: 3.2.7
+    fs-extra: ^11.1.0
+    ignore: ^5.0.4
+    js-tokens: ^4.0.0
+    minimatch: 3.0.5
+    source-map-support: 0.5.19
+    tslib: ^2.3.0
+  peerDependencies:
+    verdaccio: ^5.0.4
+  peerDependenciesMeta:
+    verdaccio:
+      optional: true
+  checksum: 557ed40b4e26d8086552691b73ba597c6f0c0e4a7b0688c06d4759a5816796f2b77c8415051db13d776692fadea67fb4981b373a9f8488e5fd02da32be52d910
+  languageName: node
+  linkType: hard
+
+"@nx/nx-darwin-arm64@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-darwin-arm64@npm:16.3.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-darwin-x64@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-darwin-x64@npm:16.3.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-freebsd-x64@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-freebsd-x64@npm:16.3.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm-gnueabihf@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-linux-arm-gnueabihf@npm:16.3.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm64-gnu@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-linux-arm64-gnu@npm:16.3.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm64-musl@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-linux-arm64-musl@npm:16.3.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-x64-gnu@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-linux-x64-gnu@npm:16.3.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-x64-musl@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-linux-x64-musl@npm:16.3.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@nx/nx-win32-arm64-msvc@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-win32-arm64-msvc@npm:16.3.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-win32-x64-msvc@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/nx-win32-x64-msvc@npm:16.3.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/workspace@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@nx/workspace@npm:16.3.1"
+  dependencies:
+    "@nrwl/workspace": 16.3.1
+    "@nx/devkit": 16.3.1
+    "@parcel/watcher": 2.0.4
+    chalk: ^4.1.0
+    chokidar: ^3.5.1
+    cli-cursor: 3.1.0
+    cli-spinners: 2.6.1
+    dotenv: ~10.0.0
+    figures: 3.2.0
+    flat: ^5.0.2
+    ignore: ^5.0.4
+    minimatch: 3.0.5
+    npm-run-path: ^4.0.1
+    nx: 16.3.1
+    open: ^8.4.0
+    rxjs: ^7.8.0
+    tmp: ~0.2.1
+    tslib: ^2.3.0
+    yargs: ^17.6.2
+    yargs-parser: 21.1.1
+  checksum: b46e00be64f9ff38c935dbe303049854e574bb6c0636b9a6abafb89679be04f0748b6bf579e26b7148641435627cbb1cfaeb60cdcca0a087b75f7461b931d331
   languageName: node
   linkType: hard
 
@@ -9073,14 +9114,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@phenomnomnominal/tsquery@npm:4.1.1":
-  version: 4.1.1
-  resolution: "@phenomnomnominal/tsquery@npm:4.1.1"
+"@phenomnomnominal/tsquery@npm:~5.0.1":
+  version: 5.0.1
+  resolution: "@phenomnomnominal/tsquery@npm:5.0.1"
   dependencies:
-    esquery: ^1.0.1
+    esquery: ^1.4.0
   peerDependencies:
-    typescript: ^3 || ^4
-  checksum: 64eb6d90aafa889f62fe73d128b7be2b3295dffde4d5dff63bad75d512b6bc1d8419d8fc784a1a60b45aba4cda2eaf6e233bf59797a1d91b26fac27d99dae047
+    typescript: ^3 || ^4 || ^5
+  checksum: d8636ece9edb1212394427411870285c67709f0a047c61453ab602e9277cb49c85069d00d4734e4934a5857ab159f24baecac84fae2530ea88bd6aff570eee03
   languageName: node
   linkType: hard
 
@@ -28765,9 +28806,9 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa@workspace:."
   dependencies:
-    "@nrwl/jest": ^15.9.2
-    "@nrwl/js": ^15.9.2
-    "@nrwl/workspace": ^15.9.2
+    "@nx/jest": 16.3.1
+    "@nx/js": 16.3.1
+    "@nx/workspace": 16.3.1
     "@types/jest": ^29.5.1
     "@types/node": ^18.16.1
     "@typescript-eslint/eslint-plugin": ^5.59.1
@@ -28786,7 +28827,7 @@ fsevents@~2.1.1:
     mocha-multi: ^1.1.7
     node-fetch: ^2.6.7
     nps: ^5.10.0
-    nx: ^15.9.2
+    nx: 16.3.1
     p-queue: ^7.3.4
     pm2: ^5.3.0
     postcss: ^8.4.14
@@ -28796,7 +28837,7 @@ fsevents@~2.1.1:
     stylelint: ^15.6.2
     stylelint-config-prettier: ^9.0.3
     stylelint-config-recommended-scss: ^12.0.0
-    ts-jest: ^29.1.0
+    ts-jest: 29.1.0
     ts-node: ^10.9.1
     tslib: ^2.5.0
     typescript: ^5.0.4
@@ -40565,21 +40606,21 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"nx@npm:15.9.4, nx@npm:^15.9.2":
-  version: 15.9.4
-  resolution: "nx@npm:15.9.4"
+"nx@npm:16.3.1":
+  version: 16.3.1
+  resolution: "nx@npm:16.3.1"
   dependencies:
-    "@nrwl/cli": 15.9.4
-    "@nrwl/nx-darwin-arm64": 15.9.4
-    "@nrwl/nx-darwin-x64": 15.9.4
-    "@nrwl/nx-linux-arm-gnueabihf": 15.9.4
-    "@nrwl/nx-linux-arm64-gnu": 15.9.4
-    "@nrwl/nx-linux-arm64-musl": 15.9.4
-    "@nrwl/nx-linux-x64-gnu": 15.9.4
-    "@nrwl/nx-linux-x64-musl": 15.9.4
-    "@nrwl/nx-win32-arm64-msvc": 15.9.4
-    "@nrwl/nx-win32-x64-msvc": 15.9.4
-    "@nrwl/tao": 15.9.4
+    "@nrwl/tao": 16.3.1
+    "@nx/nx-darwin-arm64": 16.3.1
+    "@nx/nx-darwin-x64": 16.3.1
+    "@nx/nx-freebsd-x64": 16.3.1
+    "@nx/nx-linux-arm-gnueabihf": 16.3.1
+    "@nx/nx-linux-arm64-gnu": 16.3.1
+    "@nx/nx-linux-arm64-musl": 16.3.1
+    "@nx/nx-linux-x64-gnu": 16.3.1
+    "@nx/nx-linux-x64-musl": 16.3.1
+    "@nx/nx-win32-arm64-msvc": 16.3.1
+    "@nx/nx-win32-x64-msvc": 16.3.1
     "@parcel/watcher": 2.0.4
     "@yarnpkg/lockfile": ^1.1.0
     "@yarnpkg/parsers": ^3.0.0-rc.18
@@ -40617,23 +40658,25 @@ fsevents@~2.1.1:
     "@swc-node/register": ^1.4.2
     "@swc/core": ^1.2.173
   dependenciesMeta:
-    "@nrwl/nx-darwin-arm64":
+    "@nx/nx-darwin-arm64":
       optional: true
-    "@nrwl/nx-darwin-x64":
+    "@nx/nx-darwin-x64":
       optional: true
-    "@nrwl/nx-linux-arm-gnueabihf":
+    "@nx/nx-freebsd-x64":
       optional: true
-    "@nrwl/nx-linux-arm64-gnu":
+    "@nx/nx-linux-arm-gnueabihf":
       optional: true
-    "@nrwl/nx-linux-arm64-musl":
+    "@nx/nx-linux-arm64-gnu":
       optional: true
-    "@nrwl/nx-linux-x64-gnu":
+    "@nx/nx-linux-arm64-musl":
       optional: true
-    "@nrwl/nx-linux-x64-musl":
+    "@nx/nx-linux-x64-gnu":
       optional: true
-    "@nrwl/nx-win32-arm64-msvc":
+    "@nx/nx-linux-x64-musl":
       optional: true
-    "@nrwl/nx-win32-x64-msvc":
+    "@nx/nx-win32-arm64-msvc":
+      optional: true
+    "@nx/nx-win32-x64-msvc":
       optional: true
   peerDependenciesMeta:
     "@swc-node/register":
@@ -40642,7 +40685,7 @@ fsevents@~2.1.1:
       optional: true
   bin:
     nx: bin/nx.js
-  checksum: 61b92c070db1474462eb31f86cf3ac5a5ab2a3f454bed307a0b931cf09ef5ee883c90f05b4440f5760ff57f3965ecdd744320ff3b0475fba9b52004840173b5f
+  checksum: 67ab0ed9ca5a5a089dafedde5d9358514c0c122b0704214eeb2054e0c0a0dfd7693ed8e7371bf6f6aa0501beb9b884ce34bc49e9b40e57c047864ff935a108c9
   languageName: node
   linkType: hard
 
@@ -46945,7 +46988,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"rxjs@npm:6.6.7, rxjs@npm:^6.1.0, rxjs@npm:^6.5.4, rxjs@npm:^6.6.0":
+"rxjs@npm:6.6.7, rxjs@npm:^6.1.0, rxjs@npm:^6.6.0":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -51027,7 +51070,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.1.0":
+"ts-jest@npm:29.1.0, ts-jest@npm:^29.1.0":
   version: 29.1.0
   resolution: "ts-jest@npm:29.1.0"
   dependencies:


### PR DESCRIPTION
## Because

* Nx released v16!

## This pull request

* Upgrades Nx to v16 using `nx migrate`

## Issue that this pull request solves

Closes FXA-7622
