### PR TITLE
bug(event-broker): Fix startup behavior for local development

### DIFF
--- a/packages/fxa-event-broker/nest-cli.json
+++ b/packages/fxa-event-broker/nest-cli.json
@@ -1,4 +1,5 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "entryFile": "packages/fxa-event-broker/src/main.js"
 }

--- a/packages/fxa-event-broker/pm2.config.js
+++ b/packages/fxa-event-broker/pm2.config.js
@@ -17,6 +17,7 @@ module.exports = {
       max_restarts: '1',
       env: {
         NODE_ENV: 'development',
+        NODE_OPTIONS: '--dns-result-order=ipv4first',
         TS_NODE_TRANSPILE_ONLY: 'true',
         TS_NODE_FILES: 'true',
         WORKER_HOST: '0.0.0.0',

--- a/packages/fxa-event-broker/src/config.ts
+++ b/packages/fxa-event-broker/src/config.ts
@@ -81,7 +81,7 @@ const conf = convict({
     keyFilename: {
       default: path.resolve(
         __dirname,
-        '../../fxa-auth-server/config/secret-key.json'
+        '../../../../../fxa-auth-server/config/secret-key.json'
       ),
       doc: 'Path to GCP key file',
       env: 'FIRESTORE_KEY_FILE',
@@ -156,7 +156,7 @@ const conf = convict({
     keyFile: {
       default: path.resolve(
         __dirname,
-        '../../fxa-auth-server/config/secret-key.json'
+        '../../../../../fxa-auth-server/config/secret-key.json'
       ),
       doc: 'OpenID Keyfile',
       env: 'OPENID_KEYFILE',
@@ -236,9 +236,13 @@ const conf = convict({
 // files to process, which will be overlayed in order, in the CONFIG_FILES
 // environment variable.
 
-// Need to move two dirs up as we're in the compiled directory now
-const configDir = path.dirname(__dirname);
-let envConfig = path.join(configDir, 'config', `${conf.get('env')}.json`);
+// Need to move up several directories as we're in the compiled directory now
+let envConfig = path.join(
+  __dirname,
+  '../../../../config',
+  `${conf.get('env')}.json`
+);
+
 envConfig = `${envConfig},${process.env.CONFIG_FILES || ''}`;
 const files = envConfig.split(',').filter(fs.existsSync);
 conf.loadFile(files);

--- a/packages/fxa-event-broker/src/queueworker/queueworker.module.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.module.ts
@@ -8,9 +8,10 @@ import { ClientCapabilityModule } from '../client-capability/client-capability.m
 import { FirestoreModule } from '../firestore/firestore.module';
 import { GooglePubsubFactory } from '../google-pubsub.service';
 import { QueueworkerService } from './queueworker.service';
+import { ClientWebhooksModule } from '../client-webhooks/client-webhooks.module';
 
 @Module({
-  imports: [ClientCapabilityModule, FirestoreModule],
+  imports: [ClientCapabilityModule, ClientWebhooksModule, FirestoreModule],
   providers: [QueueworkerService, MetricsFactory, GooglePubsubFactory],
 })
 export class QueueworkerModule {}


### PR DESCRIPTION
## Because

- Event broker would fail to start
- Event broker couldn't resolve client capabilities
- Event broker wasn't using devleopment config
- Nest couldn't resolve the ClientWebhooksService

## This pull request

- Configures the location of main.js
- Fixes a path resoultion of evn specific .json files
- Adds ipv4first dns result order node option to fix client capabilities startup
- Adds ClientWebhooksService to QueueworkerModule

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

These regressions were noticed while working on FXA-7465. It appears they only effect local development, and don't actually address the issue reported. To keep the PR succinct, these changes have been put up separately.
