### PR TITLE
bug(event-broker): Missing profile data changed events

### DIFF
--- a/packages/fxa-auth-server/lib/profile/updates.js
+++ b/packages/fxa-auth-server/lib/profile/updates.js
@@ -20,7 +20,7 @@ module.exports = function (log) {
         // server is also listening for these events but will only
         // clear its cache when received.
         await log.notifyAttachedServices(
-          'profileDataChanged',
+          'profileDataChange',
           {},
           {
             uid,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -130,7 +130,7 @@ export class StripeHandler {
       this.profile.deleteCache(uid),
     ]);
     await this.push.notifyProfileUpdated(uid, devices);
-    this.log.notifyAttachedServices('profileDataChanged', request, {
+    this.log.notifyAttachedServices('profileDataChange', request, {
       uid,
       email,
     });

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -155,7 +155,7 @@ module.exports = (log, db, mailer, customs, config) => {
         // See #5154.
         await db.verifyTokensWithMethod(sessionToken.id, 'email-2fa');
 
-        await log.notifyAttachedServices('profileDataChanged', request, {
+        await log.notifyAttachedServices('profileDataChange', request, {
           uid,
         });
 
@@ -305,7 +305,7 @@ module.exports = (log, db, mailer, customs, config) => {
             tokenId: sessionToken && sessionToken.id,
           });
 
-          await log.notifyAttachedServices('profileDataChanged', request, {
+          await log.notifyAttachedServices('profileDataChange', request, {
             uid: sessionToken.uid,
           });
         }

--- a/packages/fxa-auth-server/test/local/profile/updates.js
+++ b/packages/fxa-auth-server/test/local/profile/updates.js
@@ -69,7 +69,7 @@ describe('profile updates', () => {
 
         assert.ok(
           log.notifyAttachedServices.calledWithExactly(
-            'profileDataChanged',
+            'profileDataChange',
             {},
             { uid }
           )

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -530,7 +530,7 @@ describe('DirectStripeRoutes', () => {
 
       assert.isTrue(
         directStripeRoutesInstance.log.notifyAttachedServices.calledOnceWith(
-          'profileDataChanged',
+          'profileDataChange',
           VALID_REQUEST,
           { uid: UID, email: TEST_EMAIL }
         ),

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -131,7 +131,7 @@ describe('totp', () => {
         );
         assert.equal(
           args[0],
-          'profileDataChanged',
+          'profileDataChange',
           'first argument was event name'
         );
         assert.equal(args[1], request, 'second argument was request object');
@@ -235,7 +235,7 @@ describe('totp', () => {
         );
         assert.equal(
           args[0],
-          'profileDataChanged',
+          'profileDataChange',
           'first argument was event name'
         );
         assert.equal(args[1], request, 'second argument was request object');

--- a/packages/fxa-event-broker/nest-cli.json
+++ b/packages/fxa-event-broker/nest-cli.json
@@ -1,4 +1,5 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "entryFile": "packages/fxa-event-broker/src/main.js"
 }

--- a/packages/fxa-event-broker/pm2.config.js
+++ b/packages/fxa-event-broker/pm2.config.js
@@ -17,6 +17,7 @@ module.exports = {
       max_restarts: '1',
       env: {
         NODE_ENV: 'development',
+        NODE_OPTIONS: '--dns-result-order=ipv4first',
         TS_NODE_TRANSPILE_ONLY: 'true',
         TS_NODE_FILES: 'true',
         WORKER_HOST: '0.0.0.0',

--- a/packages/fxa-event-broker/src/config.ts
+++ b/packages/fxa-event-broker/src/config.ts
@@ -81,7 +81,7 @@ const conf = convict({
     keyFilename: {
       default: path.resolve(
         __dirname,
-        '../../fxa-auth-server/config/secret-key.json'
+        '../../../../../fxa-auth-server/config/secret-key.json'
       ),
       doc: 'Path to GCP key file',
       env: 'FIRESTORE_KEY_FILE',
@@ -156,7 +156,7 @@ const conf = convict({
     keyFile: {
       default: path.resolve(
         __dirname,
-        '../../fxa-auth-server/config/secret-key.json'
+        '../../../../../fxa-auth-server/config/secret-key.json'
       ),
       doc: 'OpenID Keyfile',
       env: 'OPENID_KEYFILE',
@@ -236,9 +236,13 @@ const conf = convict({
 // files to process, which will be overlayed in order, in the CONFIG_FILES
 // environment variable.
 
-// Need to move two dirs up as we're in the compiled directory now
-const configDir = path.dirname(__dirname);
-let envConfig = path.join(configDir, 'config', `${conf.get('env')}.json`);
+// Need to move up several directories as we're in the compiled directory now
+let envConfig = path.join(
+  __dirname,
+  '../../../../config',
+  `${conf.get('env')}.json`
+);
+
 envConfig = `${envConfig},${process.env.CONFIG_FILES || ''}`;
 const files = envConfig.split(',').filter(fs.existsSync);
 conf.loadFile(files);

--- a/packages/fxa-event-broker/src/queueworker/queueworker.module.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.module.ts
@@ -8,9 +8,10 @@ import { ClientCapabilityModule } from '../client-capability/client-capability.m
 import { FirestoreModule } from '../firestore/firestore.module';
 import { GooglePubsubFactory } from '../google-pubsub.service';
 import { QueueworkerService } from './queueworker.service';
+import { ClientWebhooksModule } from '../client-webhooks/client-webhooks.module';
 
 @Module({
-  imports: [ClientCapabilityModule, FirestoreModule],
+  imports: [ClientCapabilityModule, ClientWebhooksModule, FirestoreModule],
   providers: [QueueworkerService, MetricsFactory, GooglePubsubFactory],
 })
 export class QueueworkerModule {}

--- a/packages/fxa-profile-server/lib/events.js
+++ b/packages/fxa-profile-server/lib/events.js
@@ -55,12 +55,12 @@ module.exports = function (server) {
       });
   }
 
-  function profileDataChanged(message) {
+  function profileDataChange(message) {
     var userId = getUserId(message);
     return P.resolve()
       .then(function () {
         server.methods.profileCache.drop(userId).then(() => {
-          logger.info('profileDataChanged:cacheCleared', { uid: userId });
+          logger.info('profileDataChange:cacheCleared', { uid: userId });
         });
       })
       .then(function () {
@@ -78,8 +78,8 @@ module.exports = function (server) {
             return deleteUser(message);
           case 'primaryEmailChanged':
             return primaryEmailChanged(message);
-          case 'profileDataChanged':
-            return profileDataChanged(message);
+          case 'profileDataChange':
+            return profileDataChange(message);
           default:
             return;
         }

--- a/packages/fxa-profile-server/test/events.js
+++ b/packages/fxa-profile-server/test/events.js
@@ -227,7 +227,7 @@ describe('#integration - events', function () {
       function Message(type, onDel) {
         if (typeof type === 'function') {
           onDel = type;
-          type = 'profileDataChanged';
+          type = 'profileDataChange';
         }
         return {
           event: type,
@@ -259,7 +259,7 @@ describe('#integration - events', function () {
       function Message(type, onDel) {
         if (typeof type === 'function') {
           onDel = type;
-          type = 'profileDataChanged';
+          type = 'profileDataChange';
         }
         return {
           event: type,


### PR DESCRIPTION
## Because

- The event-broker was not emmiting events for profile change events.

## This pull request

- Fixes the naming of these events
- Changes profileDataChanged to profileDataChange, which is what the event-broker expects

## Issue that this pull request solves

Closes: FXA-7465

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I ran into some other issues while debugging this. See this [PR](https://github.com/mozilla/fxa/pull/15403) for fixes that get the event-broker starting up locally again. Once this lands, the changes in this PR should seem much smaller.
