### PR TITLE
fix(payments): on upgrade next invoice date fix

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -126,8 +126,12 @@ export const SubscriptionUpgrade = ({
   );
 
   const nextInvoiceDate =
-    invoicePreview.line_items.find((item) => item.id === selectedPlan.plan_id)
-      ?.period.end || upgradeFromSubscription.current_period_end;
+    selectedPlan.interval === upgradeFromPlan.interval &&
+    selectedPlan.interval_count === upgradeFromPlan.interval_count
+      ? upgradeFromSubscription.current_period_end
+      : invoicePreview.line_items.find(
+          (item) => item.id === selectedPlan.plan_id
+        )?.period.end || upgradeFromSubscription.current_period_end;
 
   return (
     <>
@@ -181,7 +185,7 @@ export const SubscriptionUpgrade = ({
                 startingDate: getLocalizedDate(nextInvoiceDate),
               }}
             >
-              <p>
+              <p data-testid="sub-update-copy">
                 Your plan will change immediately, and you’ll be charged an
                 adjusted amount for the rest of your billing cycle. Starting
                 {getLocalizedDateString(nextInvoiceDate)} you’ll be charged the


### PR DESCRIPTION
## Because

- Upgrades where the interval and interval count do not change, the next invoice date is taken from the invoice preview.

## This pull request

- Fixes the invoice date for scenarioes where interval and interval count do not change, by using the date of the current subscription.

## Issue that this pull request solves

Closes: #FXA-7060

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
