### PR TITLE
feat(fxa-settings): Update recovery key copy and l10n

### DIFF
--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -44,21 +44,13 @@ export class RecoveryKeyPage extends SettingsLayout {
   }
 
   async clickStart() {
-    return this.page
-      .getByRole('button', { name: 'Start creating your account recovery key' })
-      .click();
-  }
-
-  async clickChange() {
-    return this.page
-      .getByRole('button', { name: 'Change account recovery key' })
-      .click();
+    return this.page.getByRole('button', { name: 'Get started' }).click();
   }
 
   async clickDownload() {
     const [download] = await Promise.all([
       this.page.waitForEvent('download'),
-      this.page.getByText('Download your account recovery key').click(),
+      this.page.getByText('Download and continue').click(),
     ]);
     return download;
   }
@@ -77,7 +69,9 @@ export class RecoveryKeyPage extends SettingsLayout {
   }
 
   async clickNext() {
-    return this.page.getByRole('link', { name: 'Next' }).click();
+    return this.page
+      .getByRole('link', { name: 'Continue without downloading' })
+      .click();
   }
 
   setHint(hint: string) {

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -265,7 +265,7 @@ test.describe('new recovery key test', () => {
     // Create new recovery key
     await settings.recoveryKey.clickCreate();
     // View 1/4 info
-    await recoveryKey.clickChange();
+    await recoveryKey.clickStart();
     // View 2/4 confirm password and generate key
     await recoveryKey.setPassword(credentials.password);
     await recoveryKey.submit();
@@ -358,7 +358,7 @@ test.describe('new recovery key test', () => {
     // Create new recovery key
     await settings.recoveryKey.clickCreate();
     // View 1/4 info
-    await recoveryKey.clickChange();
+    await recoveryKey.clickStart();
     // View 2/4 confirm password and generate key
     await recoveryKey.setPassword(credentials.password);
     await recoveryKey.submit();

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
@@ -2,10 +2,11 @@
 ## Clicking on this button downloads a plain text file that contains the user's account recovery key
 ## The account recovery key can be used to recover data when users forget their account password
 
-# Button to download the account recovery key as a plain text file
+# Button to download the account recovery key as a plain text file and continue to the next step
+# "key" here refers to the "account recovery key"
 # .title will displayed as a tooltip on the button
-recovery-key-download-button-v2 = Download your account recovery key
-  .title = Download
+recovery-key-download-button-v3 = Download and continue
+  .title = Download and continue
 
 # Heading in the text file. No CSS styling will be applied to the text.
 # All caps is used in English to show this is a header.
@@ -17,19 +18,18 @@ recovery-key-file-instructions = Store this file containing your account recover
 
 # { $recoveryKeyValue } is the account recovery key, a randomly generated code in latin characters
 # "Key" here refers to the term "account recovery key"
-# 🔑 is included for visual interest and to draw attention to the key
-recovery-key-file-key-value = 🔑 Key:  { $recoveryKeyValue }
+recovery-key-file-key-value-v2 = Key: { $recoveryKeyValue }
 
 # { $email }  - The primary email associated with the account
-recovery-key-file-user-email = • { -product-firefox-account }: { $email }
+recovery-key-file-user-email-v2 = * { -product-firefox-account }: { $email }
 
 # Date when the account recovery key was created and this file was downloaded
 # "Key" here refers to the term "account recovery key"
 # { $downloadDate } is a formatted date in the user's preferred locale
 # e.g., "12/11/2012" if run in en-US locale with time zone America/Los_Angeles
-recovery-key-file-download-date = • Key generated: { $downloadDate }
+recovery-key-file-download-date-v2 = * Key generated: { $downloadDate }
 
 # Link to get more information and support
 # { $supportUrl } will be a URL such as https://mzl.la/3bNrM1I
 # The URL will not be hyperlinked and will be presented as plain text in the downloaded file
-recovery-key-file-support = • Learn more about your account recovery key: { $supportURL }
+recovery-key-file-support-v2 = * Learn more about your account recovery key: { $supportURL }

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
@@ -39,7 +39,7 @@ describe('ButtonDownloadRecoveryKey', () => {
         <ButtonDownloadRecoveryKey {...{ recoveryKeyValue, viewName }} />
       </AppContext.Provider>
     );
-    screen.getByText('Download your account recovery key');
+    screen.getByText('Download and continue');
   });
 
   it('sets the filename as expected with a reasonably-sized email', () => {
@@ -49,7 +49,7 @@ describe('ButtonDownloadRecoveryKey', () => {
       </AppContext.Provider>
     );
     const downloadButtonDownloadAttribute = screen
-      .getByText('Download your account recovery key')
+      .getByText('Download and continue')
       .getAttribute('download');
 
     // Test the date formatting
@@ -77,7 +77,7 @@ describe('ButtonDownloadRecoveryKey', () => {
       </AppContext.Provider>
     );
     const downloadButtonDownloadAttribute = screen
-      .getByText('Download your account recovery key')
+      .getByText('Download and continue')
       .getAttribute('download');
     const currentDate = new Date();
     const date = currentDate.toISOString().split('T')[0];
@@ -100,9 +100,7 @@ describe('ButtonDownloadRecoveryKey', () => {
         <ButtonDownloadRecoveryKey {...{ recoveryKeyValue, viewName }} />
       </AppContext.Provider>
     );
-    const downloadButton = screen.getByText(
-      'Download your account recovery key'
-    );
+    const downloadButton = screen.getByText('Download and continue');
     fireEvent.click(downloadButton);
 
     expect(logViewEvent).toHaveBeenCalledWith(

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -37,28 +37,28 @@ export const ButtonDownloadRecoveryKey = ({
   );
 
   const fileKey = ftlMsgResolver.getMsg(
-    'recovery-key-file-key-value',
-    `🔑 Key:  ${recoveryKeyValue}`,
+    'recovery-key-file-key-value-v2',
+    `Key: ${recoveryKeyValue}`,
     { recoveryKeyValue }
   );
 
   const fileUserEmail = ftlMsgResolver.getMsg(
-    'recovery-key-file-user-email',
-    `• Firefox account: ${primaryEmail.email}`,
+    'recovery-key-file-user-email-v2',
+    `* Firefox account: ${primaryEmail.email}`,
     { email: primaryEmail.email }
   );
 
   const fileDate = ftlMsgResolver.getMsg(
-    'recovery-key-file-download-date',
-    `• Key generated: ${downloadDateInLocale}`,
+    'recovery-key-file-download-date-v2',
+    `* Key generated: ${downloadDateInLocale}`,
     { downloadDate: downloadDateInLocale }
   );
 
   const supportURL = 'https://mzl.la/3bNrM1I';
 
   const fileSupport = ftlMsgResolver.getMsg(
-    'recovery-key-file-support',
-    `• Learn more about your account recovery key: ${supportURL}`,
+    'recovery-key-file-support-v2',
+    `* Learn more about your account recovery key: ${supportURL}`,
     { supportURL }
   );
 
@@ -99,9 +99,9 @@ export const ButtonDownloadRecoveryKey = ({
   };
 
   return (
-    <FtlMsg id="recovery-key-download-button-v2" attrs={{ title: true }}>
+    <FtlMsg id="recovery-key-download-button-v3" attrs={{ title: true }}>
       <a
-        title="Download"
+        title="Download and continue"
         href={URL.createObjectURL(fileContent)}
         download={getFilename()}
         data-testid="recovery-key-download"
@@ -111,7 +111,7 @@ export const ButtonDownloadRecoveryKey = ({
           navigateForward && navigateForward();
         }}
       >
-        Download your account recovery key
+        Download and continue
       </a>
     </FtlMsg>
   );

--- a/packages/fxa-settings/src/components/IconListItem/index.tsx
+++ b/packages/fxa-settings/src/components/IconListItem/index.tsx
@@ -13,12 +13,17 @@ import { ReactElement } from 'react-markdown/lib/react-markdown';
 
 interface IconListItemProps {
   icon: ReactElement;
+  listItemClassnames?: string;
   children: string | ReactElement;
 }
 
-export const IconListItem = ({ icon, children }: IconListItemProps) => {
+export const IconListItem = ({
+  icon,
+  listItemClassnames,
+  children,
+}: IconListItemProps) => {
   return (
-    <li className="flex gap-2 items-start my-2">
+    <li className={`flex gap-2 items-start my-2 ${listItemClassnames}`}>
       <span
         className="ltr:mr-1 rtl:ml-1 text-grey-400"
         aria-hidden="true"
@@ -33,11 +38,13 @@ export const IconListItem = ({ icon, children }: IconListItemProps) => {
 };
 
 export const FolderIconListItem = ({
+  listItemClassnames,
   children,
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
     <IconListItem
       icon={<IconFolder className="w-5 h-5 items-center justify-center" />}
+      {...{ listItemClassnames }}
     >
       {children}
     </IconListItem>
@@ -45,10 +52,12 @@ export const FolderIconListItem = ({
 };
 
 export const GlobeIconListItem = ({
+  listItemClassnames,
   children,
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
     <IconListItem
+      {...{ listItemClassnames }}
       icon={<IconGlobe className="w-5 h-5 items-center justify-center" />}
     >
       {children}
@@ -57,11 +66,13 @@ export const GlobeIconListItem = ({
 };
 
 export const KeyIconListItem = ({
+  listItemClassnames,
   children,
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
     <IconListItem
       icon={<IconKey className="w-5 h-5 items-center justify-center" />}
+      {...{ listItemClassnames }}
     >
       {children}
     </IconListItem>
@@ -69,11 +80,13 @@ export const KeyIconListItem = ({
 };
 
 export const LockIconListItem = ({
+  listItemClassnames,
   children,
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
     <IconListItem
       icon={<IconLock className="w-5 h-5 items-center justify-center" />}
+      {...{ listItemClassnames }}
     >
       {children}
     </IconListItem>
@@ -81,11 +94,13 @@ export const LockIconListItem = ({
 };
 
 export const PrinterIconListItem = ({
+  listItemClassnames,
   children,
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
     <IconListItem
       icon={<IconPrinter className="w-5 h-5 items-center justify-center" />}
+      {...{ listItemClassnames }}
     >
       {children}
     </IconListItem>
@@ -93,6 +108,7 @@ export const PrinterIconListItem = ({
 };
 
 export const ShieldIconListItem = ({
+  listItemClassnames,
   children,
 }: Omit<IconListItemProps, 'icon'>) => {
   return (
@@ -100,6 +116,7 @@ export const ShieldIconListItem = ({
       icon={
         <IconShield className="w-5 h-5 translate-y-0.5 px-[1.75px] items-center justify-center" />
       }
+      {...{ listItemClassnames }}
     >
       {children}
     </IconListItem>

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/en.ftl
@@ -2,7 +2,10 @@
 ## Users see this view when they are generating a new account recovery key
 ## This screen asks the user to confirm their password before generating a new key
 
-flow-recovery-key-confirm-pwd-heading = Enter your password again to get started
+flow-recovery-key-confirm-pwd-heading-v2 = Re-enter your password for security
 flow-recovery-key-confirm-pwd-input-label = Enter your password
 # Clicking on this button will check the password and create an account recovery key
 flow-recovery-key-confirm-pwd-submit-button = Create account recovery key
+# For users with an existing account recovery key, clicking on this button will
+# check the password, delete the existing key and create a new account recovery key
+flow-recovery-key-confirm-pwd-submit-button-change-key = Create new account recovery key

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
@@ -91,7 +91,7 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
     renderFlowPage(accountWithSuccess, RecoveryKeyAction.Create);
 
     screen.getByRole('heading', {
-      name: 'Enter your password again to get started',
+      name: 'Re-enter your password for security',
     });
     screen.getByLabelText('Enter your password');
     screen.getByRole('button', { name: 'Create account recovery key' });
@@ -251,17 +251,17 @@ describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
     renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
 
     screen.getByRole('heading', {
-      name: 'Enter your password again to get started',
+      name: 'Re-enter your password for security',
     });
     screen.getByLabelText('Enter your password');
-    screen.getByRole('button', { name: 'Create account recovery key' });
+    screen.getByRole('button', { name: 'Create new account recovery key' });
     screen.getByRole('link', { name: 'Cancel' });
   });
 
   it('disables the submit button when the input is empty', async () => {
     renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
     const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create account recovery key',
+      name: 'Create new account recovery key',
     });
     const passwordInput = screen.getByLabelText('Enter your password');
     expect(createRecoveryKeyButton).toHaveAttribute('disabled');
@@ -284,7 +284,7 @@ describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
   it('emits the expected metrics when the form is submitted with success', async () => {
     renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
     const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create account recovery key',
+      name: 'Create new account recovery key',
     });
     const passwordInput = screen.getByLabelText('Enter your password');
     // input a password to enable form submission
@@ -311,7 +311,7 @@ describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
   it('renders an error message when the requests are throttled', async () => {
     renderFlowPage(accountWithThrottledError, RecoveryKeyAction.Change);
     const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create account recovery key',
+      name: 'Create new account recovery key',
     });
     const passwordInput = screen.getByLabelText('Enter your password');
     // input a password to enable form submission
@@ -339,7 +339,7 @@ describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
   it('renders an error message when the password is incorrect', async () => {
     renderFlowPage(accountWithPasswordError, RecoveryKeyAction.Change);
     const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create account recovery key',
+      name: 'Create new account recovery key',
     });
     const passwordInput = screen.getByLabelText('Enter your password');
     // input a password to enable form submission
@@ -367,7 +367,7 @@ describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
   it('renders an error message for unexpected errors', async () => {
     renderFlowPage(accountWithUnexpectedError, RecoveryKeyAction.Change);
     const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create account recovery key',
+      name: 'Create new account recovery key',
     });
     const passwordInput = screen.getByLabelText('Enter your password');
     // input a password to enable form submission

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -125,9 +125,9 @@ export const FlowRecoveryKeyConfirmPwd = ({
         )}
         <LockImage className="mx-auto my-4" />
 
-        <FtlMsg id="flow-recovery-key-confirm-pwd-heading">
+        <FtlMsg id="flow-recovery-key-confirm-pwd-heading-v2">
           <h2 className="font-bold text-xl">
-            Enter your password again to get started
+            Re-enter your password for security
           </h2>
         </FtlMsg>
 
@@ -153,15 +153,28 @@ export const FlowRecoveryKeyConfirmPwd = ({
               {...{ errorText }}
             />
           </FtlMsg>
-          <FtlMsg id="flow-recovery-key-confirm-pwd-submit-button">
-            <button
-              className="cta-primary cta-xl w-full mt-4"
-              type="submit"
-              disabled={!formState.isDirty || !!formState.errors.password}
-            >
-              Create account recovery key
-            </button>
-          </FtlMsg>
+          {action === RecoveryKeyAction.Create && (
+            <FtlMsg id="flow-recovery-key-confirm-pwd-submit-button">
+              <button
+                className="cta-primary cta-xl w-full mt-4"
+                type="submit"
+                disabled={!formState.isDirty || !!formState.errors.password}
+              >
+                Create account recovery key
+              </button>
+            </FtlMsg>
+          )}
+          {action === RecoveryKeyAction.Change && (
+            <FtlMsg id="flow-recovery-key-confirm-pwd-submit-button-change-key">
+              <button
+                className="cta-primary cta-xl w-full mt-4"
+                type="submit"
+                disabled={!formState.isDirty || !!formState.errors.password}
+              >
+                Create new account recovery key
+              </button>
+            </FtlMsg>
+          )}
         </form>
         {action === RecoveryKeyAction.Change && (
           <FtlMsg id="flow-recovery-key-info-cancel-link">

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/en.ftl
@@ -2,14 +2,8 @@
 ## Users see this view when they are generating a new account recovery key
 ## This screen displays the generated key and allows users to download or copy the key
 
-flow-recovery-key-download-heading = Account recovery key generated — store it in a place you’ll remember
+flow-recovery-key-download-heading-v2 = Account recovery key created — Download and store it now
 # The "key" here refers to the term "account recovery key"
-flow-recovery-key-download-info = This key will help recover your data if you forget your password.
-# This heading is shown above a list of options for storing the account recovery key
-flow-recovery-key-download-storage-ideas-heading = Some ideas for storing your account recovery key:
-flow-recovery-key-download-storage-ideas-folder = Memorable folder in your device
-flow-recovery-key-download-storage-ideas-cloud = Trusted cloud storage
-flow-recovery-key-download-storage-ideas-print = Print and keep a physical copy
-flow-recovery-key-download-storage-ideas-pwd-manager = Password manager
+flow-recovery-key-download-info-v2 = This key allows you to recover your data if you forget your password. Download it now and store it somewhere you’ll remember — you won’t be able to return to this page later.
 # This link allows user to proceed to the next step without clicking the download button
-flow-recovery-key-download-next-link = Next
+flow-recovery-key-download-next-link-v2 = Continue without downloading

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -47,25 +47,27 @@ describe('FlowRecoveryKeyDownload', () => {
 
     screen.getByRole('heading', {
       level: 2,
-      name: 'Account recovery key generated — store it in a place you’ll remember',
+      name: 'Account recovery key created — Download and store it now',
     });
     screen.getByText(
-      'This key will help recover your data if you forget your password.'
+      'This key allows you to recover your data if you forget your password. Download it now and store it somewhere you’ll remember — you won’t be able to return to this page later.'
     );
+
+    screen.getByText(MOCK_RECOVERY_KEY_VALUE);
+    screen.getByRole('button', { name: 'Copy' });
+
     screen.getByRole('heading', {
       level: 3,
-      name: 'Some ideas for storing your account recovery key:',
+      name: 'Places to store your key:',
     });
     const list = screen.getByRole('list', {
-      name: 'Some ideas for storing your account recovery key:',
+      name: 'Places to store your key:',
     });
     const listItems = within(list).getAllByRole('listitem');
     expect(listItems.length).toBe(4);
 
-    screen.getByText(MOCK_RECOVERY_KEY_VALUE);
-    screen.getByRole('button', { name: 'Copy' });
-    screen.getByText('Download your account recovery key');
-    screen.getByRole('link', { name: 'Next' });
+    screen.getByText('Download and continue');
+    screen.getByRole('link', { name: 'Continue without downloading' });
   });
 
   it('emits the expected metrics when user copies the recovery key', async () => {
@@ -82,9 +84,7 @@ describe('FlowRecoveryKeyDownload', () => {
 
   it('emits the expected metrics when user downloads the recovery key', () => {
     renderFlowPage();
-    const downloadButton = screen.getByText(
-      'Download your account recovery key'
-    );
+    const downloadButton = screen.getByText('Download and continue');
     fireEvent.click(downloadButton);
     expect(logViewEvent).toBeCalledWith(
       `flow.${viewName}`,
@@ -94,7 +94,9 @@ describe('FlowRecoveryKeyDownload', () => {
 
   it('emits the expected metrics when user navigates forward without downloading the key', () => {
     renderFlowPage();
-    const nextPageLink = screen.getByRole('link', { name: 'Next' });
+    const nextPageLink = screen.getByRole('link', {
+      name: 'Continue without downloading',
+    });
     fireEvent.click(nextPageLink);
     expect(navigateForward).toBeCalledTimes(1);
     expect(logViewEvent).toBeCalledWith(

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
@@ -6,17 +6,17 @@ import React from 'react';
 import FlowContainer from '../FlowContainer';
 import ProgressBar from '../ProgressBar';
 import DataBlock from '../../DataBlock';
+import ButtonDownloadRecoveryKey from '../../ButtonDownloadRecoveryKey';
+import { Link } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { RecoveryKeyImage } from '../../images';
+import { logViewEvent } from '../../../lib/metrics';
 import {
   FolderIconListItem,
   GlobeIconListItem,
   LockIconListItem,
   PrinterIconListItem,
 } from '../../IconListItem';
-import ButtonDownloadRecoveryKey from '../../ButtonDownloadRecoveryKey';
-import { Link } from '@reach/router';
-import { FtlMsg } from 'fxa-react/lib/utils';
-import { RecoveryKeyImage } from '../../images';
-import { logViewEvent } from '../../../lib/metrics';
 
 export type FlowRecoveryKeyDownloadProps = {
   localizedBackButtonTitle: string;
@@ -48,14 +48,16 @@ export const FlowRecoveryKeyDownload = ({
         <ProgressBar currentStep={3} numberOfSteps={4} />
         <RecoveryKeyImage className="my-6 mx-auto" />
 
-        <FtlMsg id="flow-recovery-key-download-heading">
+        <FtlMsg id="flow-recovery-key-download-heading-v2">
           <h2 className="font-bold text-xl">
-            Account recovery key generated — store it in a place you’ll remember
+            Account recovery key created — Download and store it now
           </h2>
         </FtlMsg>
-        <FtlMsg id="flow-recovery-key-download-info">
+        <FtlMsg id="flow-recovery-key-download-info-v2">
           <p>
-            This key will help recover your data if you forget your password.
+            This key allows you to recover your data if you forget your
+            password. Download it now and store it somewhere you’ll remember —
+            you won’t be able to return to this page later.
           </p>
         </FtlMsg>
         <DataBlock
@@ -65,37 +67,40 @@ export const FlowRecoveryKeyDownload = ({
           }
           isInline
         />
-        <FtlMsg id="flow-recovery-key-download-storage-ideas-heading">
-          <h3 id="key-storage-ideas" className="font-semibold -mb-4">
-            Some ideas for storing your account recovery key:
-          </h3>
-        </FtlMsg>
-        <ul aria-labelledby="key-storage-ideas">
-          <FolderIconListItem>
-            <FtlMsg id="flow-recovery-key-download-storage-ideas-folder">
-              Memorable folder in your device
-            </FtlMsg>
-          </FolderIconListItem>
-          <GlobeIconListItem>
-            <FtlMsg id="flow-recovery-key-download-storage-ideas-cloud">
-              Trusted cloud storage
-            </FtlMsg>
-          </GlobeIconListItem>
-          <PrinterIconListItem>
-            <FtlMsg id="flow-recovery-key-download-storage-ideas-print">
-              Print and keep a physical copy
-            </FtlMsg>
-          </PrinterIconListItem>
-          <LockIconListItem>
-            <FtlMsg id="flow-recovery-key-download-storage-ideas-pwd-manager">
-              <p>Password manager</p>
-            </FtlMsg>
-          </LockIconListItem>
-        </ul>
+        <div className="bg-grey-10 p-4 rounded-lg text-grey-400 text-sm">
+          <FtlMsg id="flow-recovery-key-download-storage-ideas-heading-v2">
+            <h3 id="key-storage-ideas" className="font-semibold mb-2">
+              Places to store your key:
+            </h3>
+          </FtlMsg>
+          <ul aria-labelledby="key-storage-ideas" className="flex flex-wrap">
+            <FolderIconListItem listItemClassnames="mobileLandscape:basis-1/2">
+              <FtlMsg id="flow-recovery-key-download-storage-ideas-folder-v2">
+                Folder on secure device
+              </FtlMsg>
+            </FolderIconListItem>
+            <GlobeIconListItem listItemClassnames="mobileLandscape:basis-1/2">
+              <FtlMsg id="flow-recovery-key-download-storage-ideas-cloud">
+                Trusted cloud storage
+              </FtlMsg>
+            </GlobeIconListItem>
+            <PrinterIconListItem listItemClassnames="mobileLandscape:basis-1/2">
+              <FtlMsg id="flow-recovery-key-download-storage-ideas-print-v2">
+                Printed physical copy
+              </FtlMsg>
+            </PrinterIconListItem>
+            <LockIconListItem listItemClassnames="mobileLandscape:basis-1/2">
+              <FtlMsg id="flow-recovery-key-download-storage-ideas-pwd-manager">
+                Password manager
+              </FtlMsg>
+            </LockIconListItem>
+          </ul>
+        </div>
+
         <ButtonDownloadRecoveryKey
           {...{ navigateForward, recoveryKeyValue, viewName }}
         />
-        <FtlMsg id="flow-recovery-key-download-next-link">
+        <FtlMsg id="flow-recovery-key-download-next-link-v2">
           <Link
             to=""
             className="text-sm link-blue text-center py-2 mx-auto"
@@ -104,7 +109,7 @@ export const FlowRecoveryKeyDownload = ({
               navigateForward();
             }}
           >
-            Next
+            Continue without downloading
           </Link>
         </FtlMsg>
       </div>

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/en.ftl
@@ -3,21 +3,27 @@
 ## Prompts the user to save an (optional) storage hint about the location of their account recovery key.
 
 # The header of the fourth step in the account recovery key creation flow
-# "Storage hint" can be any information the user finds useful to help them remember where they saved or stored their account recovery key.
-flow-recovery-key-hint-header = Great! Now add a storage hint
+# "key" here refers to the "account recovery key"
+flow-recovery-key-hint-header-v2 = Add a hint to help find your key
 # This message explains why saving a storage hint can be helpful. The account recovery key could be "stored" in a physical (e.g., printed) or virtual location (e.g., in a device folder or in the cloud).
-flow-recovery-key-hint-message = Add a hint about where you stored your account recovery key. We can show it to you during the password reset to recover your data.
+flow-recovery-key-hint-message-v2 = This hint should help you remember where you stored your account recovery key. We’ll show it to you when you use it to recover your data.
 # The label for the text input where the user types in the storage hint they want to save.
 # The storage hint is optional, and users can leave this blank.
-flow-recovery-key-hint-input =
-  .label = Enter your storage hint (optional)
+flow-recovery-key-hint-input-v2 =
+  .label = Enter a hint (optional)
 # The text of the "submit" button. Clicking on this button will save the hint (if provided) and exit the account recovery key creation flow.
 # "Finish" refers to "Finish the account recovery key creation process"
 flow-recovery-key-hint-cta-text = Finish
-# Success message displayed in alert bar after the user has completed the account recovery key creation flow without saving a hint.
-flow-recovery-key-success-alert-no-hint = Account recovery key enabled.
-# Success message displayed in alert bar after the user has completed the account recovery key creation flow and saved a hint.
-flow-recovery-key-success-alert-with-hint = Account recovery key enabled and storage hint saved.
+# This heading is shown above a list of options for storing the account recovery key
+# "key" here refers to "account recovery key"
+flow-recovery-key-download-storage-ideas-heading-v2 = Places to store your key:
+flow-recovery-key-download-storage-ideas-folder-v2 = Folder on secure device
+flow-recovery-key-download-storage-ideas-cloud = Trusted cloud storage
+flow-recovery-key-download-storage-ideas-print-v2 = Printed physical copy
+flow-recovery-key-download-storage-ideas-pwd-manager = Password manager
+
+# Success message displayed in alert bar after the user has finished creating an account recovery key.
+flow-recovery-key-success-alert = Account recovery key created
 # Error displayed in a tooltip if the hint entered by the user exceeds the character limit.
 # "Hint" refers to "storage hint"
 flow-recovery-key-hint-char-limit-error = The hint must contain fewer than 255 characters.

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { logViewEvent } from '../../../lib/metrics';
 import { Account, AppContext } from '../../../models';
 import FlowRecoveryKeyHint, { maxHintLength } from '.';
@@ -68,12 +68,12 @@ describe('FlowRecoveryKeyHint', () => {
     screen.getByRole('progressbar', { name: 'Step 4 of 4.' });
     screen.getByRole('heading', {
       level: 2,
-      name: 'Great! Now add a storage hint',
+      name: 'Add a hint to help find your key',
     });
     screen.getByText(
-      'Add a hint about where you stored your account recovery key. We can show it to you during the password reset to recover your data.'
+      'This hint should help you remember where you stored your account recovery key. We’ll show it to you when you use it to recover your data.'
     );
-    screen.getByRole('textbox', { name: 'Enter your storage hint (optional)' });
+    screen.getByRole('textbox', { name: 'Enter a hint (optional)' });
     screen.getByRole('button', { name: 'Finish' });
   });
 
@@ -87,7 +87,7 @@ describe('FlowRecoveryKeyHint', () => {
     renderWithContext(accountWithSuccess);
     const hintValue = 'Ye Olde Hint';
     const textInput = screen.getByRole('textbox', {
-      name: 'Enter your storage hint (optional)',
+      name: 'Enter a hint (optional)',
     });
     const submitButton = screen.getByText('Finish');
     fireEvent.input(textInput, {
@@ -111,7 +111,7 @@ describe('FlowRecoveryKeyHint', () => {
     renderWithContext(accountWithSuccess);
     const hintValueTooLong = 'a'.repeat(maxHintLength + 5);
     const textInput = screen.getByRole('textbox', {
-      name: 'Enter your storage hint (optional)',
+      name: 'Enter a hint (optional)',
     });
     const submitButton = screen.getByText('Finish');
     fireEvent.input(textInput, {
@@ -135,7 +135,7 @@ describe('FlowRecoveryKeyHint', () => {
     renderWithContext(accountWithError);
     const hintValue = 'Ye Olde Hint';
     const textInput = screen.getByRole('textbox', {
-      name: 'Enter your storage hint (optional)',
+      name: 'Enter a hint (optional)',
     });
     const submitButton = screen.getByText('Finish');
     fireEvent.input(textInput, {

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -73,18 +73,22 @@ export const FlowRecoveryKeyHint = ({
     return undefined;
   };
 
+  const navigateForwardAndAlertSuccess = () => {
+    navigateForward();
+    alertBar.success(
+      ftlMsgResolver.getMsg(
+        'flow-recovery-key-success-alert-v2',
+        'Account recovery key created'
+      )
+    );
+  };
+
   const onSubmit = async ({ hint }: FormData) => {
     const trimmedHint = hint.trim();
 
     if (trimmedHint.length === 0) {
       logViewEvent(viewName, 'create-hint.skip');
-      navigateForward();
-      alertBar.success(
-        ftlMsgResolver.getMsg(
-          'flow-recovery-key-success-alert-no-hint',
-          'Account recovery key enabled.'
-        )
-      );
+      navigateForwardAndAlertSuccess();
     } else {
       const hintErrorText = getHintError(trimmedHint);
       if (hintErrorText) {
@@ -95,13 +99,7 @@ export const FlowRecoveryKeyHint = ({
           logViewEvent(viewName, 'create-hint.submit');
           await account.updateRecoveryKeyHint(trimmedHint);
           logViewEvent(viewName, 'create-hint.success');
-          navigateForward();
-          alertBar.success(
-            ftlMsgResolver.getMsg(
-              'flow-recovery-key-success-alert-with-hint',
-              'Account recovery key enabled and storage hint saved.'
-            )
-          );
+          navigateForwardAndAlertSuccess();
         } catch (e) {
           let localizedError: string;
           if (e.errno && AuthUiErrorNos[e.errno]) {
@@ -163,22 +161,24 @@ export const FlowRecoveryKeyHint = ({
           </Banner>
         )}
         <LightbulbImage className="mx-auto my-10" />
-        <FtlMsg id="flow-recovery-key-hint-header">
+        <FtlMsg id="flow-recovery-key-hint-header-v2">
           <h2 className="font-bold text-xl mb-4">
-            Great! Now add a storage hint
+            Add a hint to help find your key
           </h2>
         </FtlMsg>
-        <FtlMsg id="flow-recovery-key-hint-message">
+
+        <FtlMsg id="flow-recovery-key-hint-message-v2">
           <p className="text-md mb-4">
-            Add a hint about where you stored your account recovery key. We can
-            show it to you during the password reset to recover your data.
+            This hint should help you remember where you stored your account
+            recovery key. We’ll show it to you when you use it to recover your
+            data.
           </p>
         </FtlMsg>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <FtlMsg id="flow-recovery-key-hint-input" attrs={{ label: true }}>
+          <FtlMsg id="flow-recovery-key-hint-input-v2" attrs={{ label: true }}>
             <InputText
               name="hint"
-              label="Enter your storage hint (optional)"
+              label="Enter a hint (optional)"
               prefixDataTestId="hint"
               autoFocus
               inputRef={register()}

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/en.ftl
@@ -5,12 +5,10 @@ flow-recovery-key-info-header = Create an account recovery key in case you forge
 # The header of the first view in the Recovery Key Create flow when replacing an existing recovery key
 flow-recovery-key-info-header-change-key = Change your account recovery key
 # In the first view of the PageRecoveryKeyCreate flow, this is the first of two bullet points explaining why the user should create an account recovery key
-flow-recovery-key-info-shield-bullet-point = We encrypt browsing data –– passwords, bookmarks, and more. It’s great for privacy, but it means we can’t recover your data if you forget your password.
+flow-recovery-key-info-shield-bullet-point-v2 = We encrypt browsing data –– passwords, bookmarks, and more. It’s great for privacy, but you may lose your data if you forget your password.
 # In the first view of the PageRecoveryKeyCreate flow, this is the second of two bullet points explaining why the user should create an account recovery key
-flow-recovery-key-info-key-bullet-point = That’s why creating an account recovery key is so important –– you can use your key to get your data back.
-# The text of the "submit" button in the first view of the PageRecoveryKeyCreate flow
-flow-recovery-key-info-cta-text-v2 = Start creating your account recovery key
-# The text of the "submit" button in the first view of the Account Recovery Key Create flow
-flow-recovery-key-info-cta-text-change-key = Change account recovery key
+flow-recovery-key-info-key-bullet-point-v2 = That’s why creating an account recovery key is so important –– you can use it to restore your data.
+# The text of the "submit" button to start creating (or changing) an account recovery key
+flow-recovery-key-info-cta-text-v3 = Get started
 # Link to cancel account recovery key change and return to settings
 flow-recovery-key-info-cancel-link = Cancel

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.test.tsx
@@ -47,7 +47,7 @@ describe('FlowRecoveryKeyInfo for key creation', () => {
       name: 'Create an account recovery key in case you forget your password',
     });
     screen.getByRole('button', {
-      name: 'Start creating your account recovery key',
+      name: 'Get started',
     });
   });
 
@@ -61,7 +61,7 @@ describe('FlowRecoveryKeyInfo for key creation', () => {
     renderFlowPage(RecoveryKeyAction.Create);
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Start creating your account recovery key',
+        name: 'Get started',
       })
     );
     expect(navigateForward).toBeCalledTimes(1);
@@ -90,7 +90,7 @@ describe('FlowRecoveryKeyInfo for key replacement', () => {
     screen.getByRole('heading', {
       name: 'Change your account recovery key',
     });
-    screen.getByRole('button', { name: 'Change account recovery key' });
+    screen.getByRole('button', { name: 'Get started' });
     screen.getByRole('link', { name: 'Cancel' });
   });
 
@@ -104,7 +104,7 @@ describe('FlowRecoveryKeyInfo for key replacement', () => {
     renderFlowPage(RecoveryKeyAction.Change);
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Change account recovery key',
+        name: 'Get started',
       })
     );
     expect(navigateForward).toBeCalledTimes(1);

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.tsx
@@ -65,51 +65,39 @@ export const FlowRecoveryKeyInfo = ({
 
       <ul>
         <ShieldIconListItem>
-          <FtlMsg id="flow-recovery-key-info-shield-bullet-point">
+          <FtlMsg id="flow-recovery-key-info-shield-bullet-point-v2">
             <p className="text-sm">
               We encrypt browsing data –– passwords, bookmarks, and more. It’s
-              great for privacy, but it means we can’t recover your data if you
-              forget your password.
+              great for privacy, but you may lose your data if you forget your
+              password.
             </p>
           </FtlMsg>
         </ShieldIconListItem>
         <KeyIconListItem>
-          <FtlMsg id="flow-recovery-key-info-key-bullet-point">
+          <FtlMsg id="flow-recovery-key-info-key-bullet-point-v2">
             <p className="text-sm">
               That’s why creating an account recovery key is so important –– you
-              can use your key to get your data back.
+              can use it to restore your data.
             </p>
           </FtlMsg>
         </KeyIconListItem>
       </ul>
-      {action === RecoveryKeyAction.Create && (
-        <FtlMsg id="flow-recovery-key-info-cta-text-v2">
-          <button
-            className="cta-primary cta-xl mt-4"
-            type="button"
-            onClick={() => {
+
+      <FtlMsg id="flow-recovery-key-info-cta-text-v3">
+        <button
+          className="cta-primary cta-xl mt-4"
+          type="button"
+          onClick={() => {
+            action === RecoveryKeyAction.Create &&
               logViewEvent(`flow.${viewName}`, 'create-key.start');
-              navigateForward();
-            }}
-          >
-            Start creating your account recovery key
-          </button>
-        </FtlMsg>
-      )}
-      {action === RecoveryKeyAction.Change && (
-        <FtlMsg id="flow-recovery-key-info-cta-text-change-key">
-          <button
-            className="cta-primary cta-xl mt-4"
-            type="button"
-            onClick={() => {
+            action === RecoveryKeyAction.Change &&
               logViewEvent(`flow.${viewName}`, 'change-key.start');
-              navigateForward();
-            }}
-          >
-            Change account recovery key
-          </button>
-        </FtlMsg>
-      )}
+            navigateForward();
+          }}
+        >
+          Get started
+        </button>
+      </FtlMsg>
 
       {action === RecoveryKeyAction.Change && (
         <FtlMsg id="flow-recovery-key-info-cancel-link">

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -68,12 +68,12 @@ describe('PageRecoveryKeyCreate when recovery key not enabled', () => {
 
     // Go to page 2
     const flowPage1Button = screen.getByRole('button', {
-      name: 'Start creating your account recovery key',
+      name: 'Get started',
     });
     fireEvent.click(flowPage1Button);
     await waitFor(() =>
       screen.getByRole('heading', {
-        name: 'Enter your password again to get started',
+        name: 'Re-enter your password for security',
       })
     );
 
@@ -91,17 +91,19 @@ describe('PageRecoveryKeyCreate when recovery key not enabled', () => {
     fireEvent.click(flowPage2Button);
     await waitFor(() => {
       screen.getByRole('heading', {
-        name: 'Account recovery key generated — store it in a place you’ll remember',
+        name: 'Account recovery key created — Download and store it now',
       });
     });
 
     // Go to page 4
-    const flowPage3Button = screen.getByRole('link', { name: 'Next' });
+    const flowPage3Button = screen.getByRole('link', {
+      name: 'Continue without downloading',
+    });
     fireEvent.click(flowPage3Button);
     await waitFor(() =>
       screen.getByRole('heading', {
         level: 2,
-        name: 'Great! Now add a storage hint',
+        name: 'Add a hint to help find your key',
       })
     );
   });
@@ -127,7 +129,7 @@ describe('PageRecoveryKeyCreate when recovery key is enabled', () => {
       level: 2,
       name: 'Change your account recovery key',
     });
-    screen.getByRole('button', { name: 'Change account recovery key' });
+    screen.getByRole('button', { name: 'Get started' });
     screen.getByRole('link', { name: 'Cancel' });
   });
 
@@ -136,19 +138,19 @@ describe('PageRecoveryKeyCreate when recovery key is enabled', () => {
 
     // Go to page 2
     const flowPage1Button = screen.getByRole('button', {
-      name: 'Change account recovery key',
+      name: 'Get started',
     });
     fireEvent.click(flowPage1Button);
     await waitFor(() => {
       screen.getByRole('heading', {
-        name: 'Enter your password again to get started',
+        name: 'Re-enter your password for security',
       });
       screen.getByRole('link', { name: 'Cancel' });
     });
 
     // Go to page 3
     const flowPage2Button = screen.getByRole('button', {
-      name: 'Create account recovery key',
+      name: 'Create new account recovery key',
     });
     // input a password to enable form submission
     fireEvent.input(screen.getByLabelText('Enter your password'), {
@@ -160,17 +162,19 @@ describe('PageRecoveryKeyCreate when recovery key is enabled', () => {
     fireEvent.click(flowPage2Button);
     await waitFor(() => {
       screen.getByRole('heading', {
-        name: 'Account recovery key generated — store it in a place you’ll remember',
+        name: 'Account recovery key created — Download and store it now',
       });
     });
 
     // Go to page 4
-    const flowPage3Button = screen.getByRole('link', { name: 'Next' });
+    const flowPage3Button = screen.getByRole('link', {
+      name: 'Continue without downloading',
+    });
     fireEvent.click(flowPage3Button);
     await waitFor(() =>
       screen.getByRole('heading', {
         level: 2,
-        name: 'Great! Now add a storage hint',
+        name: 'Add a hint to help find your key',
       })
     );
   });

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -80,7 +80,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
         <FlowRecoveryKeyInfo {...{ action, ...sharedStepProps }} />
       )}
 
-      {/* Confirm password and generate recovery key */}
+      {/* Confirm password and create recovery key */}
       {currentStep === 2 && (
         <FlowRecoveryKeyConfirmPwd
           {...{

--- a/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
@@ -7,7 +7,7 @@ import { screen } from '@testing-library/react';
 import Security from '.';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
-import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { getFtlBundle, testAllL10n, testL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 
 describe('Security', () => {
@@ -83,8 +83,7 @@ describe('Security', () => {
       );
       const passwordRouteLink = screen.getByTestId('password-unit-row-route');
 
-      const ftlMsgMock = screen.getByTestId('ftlmsg-mock');
-      testL10n(ftlMsgMock, bundle, {
+      testAllL10n(screen, bundle, {
         date: createDate,
       });
 

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/en.ftl
@@ -7,7 +7,6 @@ rk-action-create = Create
 # Button to delete the existing account recovery key and create a new one
 rk-action-change-button = Change
 rk-action-remove = Remove
-rk-cannot-refresh-1 = Sorry, there was a problem refreshing the account recovery key.
 rk-key-removed-2 = Account recovery key removed
 rk-cannot-remove-key = Your account recovery key could not be removed.
 rk-refresh-key-1 = Refresh account recovery key
@@ -16,7 +15,6 @@ rk-cannot-verify-session-4 = Sorry, there was a problem confirming your session
 rk-remove-modal-heading-1 = Remove account recovery key?
 rk-remove-modal-content-1 = In the event you reset your password, you won’t be
   able to use your account recovery key to access your data. You can’t undo this action.
-rk-refresh-error-1 = Sorry, there was a problem refreshing the account recovery key.
 rk-remove-error-2 = Your account recovery key could not be removed
 # Icon button to delete user's account recovery key. Text appears in tooltip on hover and as alt text for screen readers.
 unit-row-recovery-key-delete-icon-button-title = Delete account recovery key

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
@@ -203,7 +203,6 @@ describe('UnitRowRecoveryKey', () => {
         'Delete account recovery key'
       );
     });
-    // TODO Only one delete button should be visible
   });
 
   it('renders version 2 as expected when account recovery key is not set', () => {

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
@@ -16,7 +16,7 @@ import UnitRow from '../UnitRow';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { ButtonIconReload, ButtonIconTrash } from '../ButtonIcon';
 import { HomePath } from '../../../constants';
-import { Localized } from '@fluent/react';
+import { FtlMsg } from 'fxa-react/lib/utils';
 
 export const UnitRowRecoveryKey = () => {
   const account = useAccount();
@@ -146,11 +146,11 @@ export const UnitRowRecoveryKey = () => {
         )
       }
     >
-      <Localized id="rk-content-explain">
+      <FtlMsg id="rk-content-explain">
         <p className="text-sm mt-3">
-          Restores your information when you forget your password.
+          Restore your information when you forget your password.
         </p>
-      </Localized>
+      </FtlMsg>
       {(deleteModalVisible || modalRevealed) && (
         <VerifiedSessionGuard
           onDismiss={hideModal}
@@ -182,21 +182,21 @@ export const UnitRowRecoveryKey = () => {
             headerId="recovery-key-header"
             descId="recovery-key-desc"
           >
-            <Localized id="rk-remove-modal-heading-1">
+            <FtlMsg id="rk-remove-modal-heading-1">
               <h2
                 id="recovery-key-header"
                 className="font-bold text-xl text-center mb-2"
               >
                 Remove account recovery key?
               </h2>
-            </Localized>
-            <Localized id="rk-remove-modal-content-1">
-              <p id="recovery-key-desc" className="my-6 text-center">
-                In the event you reset your password, you won't be able to use
-                your account recovery key to access your data. You can't undo
+            </FtlMsg>
+            <FtlMsg id="rk-remove-modal-content-1">
+              <p className="my-6 text-center">
+                In the event you reset your password, you wonʼt be able to use
+                your account recovery key to access your data. You canʼt undo
                 this action.
               </p>
-            </Localized>
+            </FtlMsg>
           </Modal>
         </VerifiedSessionGuard>
       )}


### PR DESCRIPTION
## Because

* Content Design has recommended copy changes for the Account recovery key creation flow

## This pull request

* Update ftl strings and fallback text
* Move storage ideas from download to hint flow page, and update styling
* Update tests

## Issue that this pull request solves

Closes: #FXA-7613

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/mozilla/fxa/assets/22231637/b235682e-87b3-464f-b644-51bd9274aadd)

![image](https://github.com/mozilla/fxa/assets/22231637/beeda0b7-8350-4d46-ba6f-d959b3229282)

![image](https://github.com/mozilla/fxa/assets/22231637/eb3793d2-79e5-4a6d-9018-87eb752a37c0)

![image](https://github.com/mozilla/fxa/assets/22231637/724d6bd1-dd60-4655-ac84-cc09c4b8d3e7)

![image](https://github.com/mozilla/fxa/assets/22231637/f8155c3a-8efd-4b6a-9922-ea590ab292de)

![image](https://github.com/mozilla/fxa/assets/22231637/478e0a51-d901-4f27-ad3a-e319c0caea0c)

![image](https://github.com/mozilla/fxa/assets/22231637/4355d26a-e5d3-4eda-9d71-75a8d73d88b7)

![image](https://github.com/mozilla/fxa/assets/22231637/d1fc477b-a531-440e-b397-add18439cc32)

![image](https://github.com/mozilla/fxa/assets/22231637/01aead42-6d8b-4871-b398-c0bbf67d33ca)

## Other information (Optional)

Any other information that is important to this pull request.
