### PR TITLE
task(settings): Ensure metrics are only emitted once

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -6,11 +6,12 @@ import React, { ReactNode } from 'react';
 import { render, act } from '@testing-library/react';
 import App from '.';
 import * as Metrics from '../../lib/metrics';
-import { useInitialState } from '../../models';
+import { useAccount, useInitialState } from '../../models';
 
 jest.mock('../../models', () => ({
   ...jest.requireActual('../../models'),
   useInitialState: jest.fn(),
+  useAccount: jest.fn(),
 }));
 
 jest.mock('react-markdown', () => {});
@@ -49,10 +50,19 @@ describe('metrics', () => {
   });
 
   it('Initializes metrics flow data when present', async () => {
+    const mockAccount = {
+      metricsEnabled: true,
+      recoveryKey: true,
+      totpActive: true,
+      hasSecondaryVerifiedEmail: false,
+    };
+    (useAccount as jest.Mock).mockReturnValue(mockAccount);
     (useInitialState as jest.Mock).mockReturnValue({ loading: true });
     const DEVICE_ID = 'yoyo';
     const BEGIN_TIME = 123456;
     const FLOW_ID = 'abc123';
+    const flowInit = jest.spyOn(Metrics, 'init');
+    const userPreferencesInit = jest.spyOn(Metrics, 'initUserPreferences');
     const updatedFlowQueryParams = {
       deviceId: DEVICE_ID,
       flowBeginTime: BEGIN_TIME,
@@ -68,6 +78,7 @@ describe('metrics', () => {
       flowId: FLOW_ID,
       flowBeginTime: BEGIN_TIME,
     });
+    expect(userPreferencesInit).toHaveBeenCalledWith(mockAccount);
     expect(window.location.replace).not.toHaveBeenCalled();
   });
 });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -53,7 +53,7 @@ export const App = ({
 
   const { showReactApp } = flowQueryParams;
   const { loading, error } = useInitialState();
-  const { metricsEnabled } = useAccount();
+  const account = useAccount();
   const [email, setEmail] = useState<string>();
   const [emailLookupComplete, setEmailLookupComplete] =
     useState<boolean>(false);
@@ -61,9 +61,14 @@ export const App = ({
   const config = useConfig();
   const sessionTokenId = sessionToken();
 
+  const { metricsEnabled } = account;
+
   useEffect(() => {
     Metrics.init(metricsEnabled || !isSignedIn, flowQueryParams);
-  }, [metricsEnabled, isSignedIn, flowQueryParams]);
+    if (metricsEnabled) {
+      Metrics.initUserPreferences(account);
+    }
+  }, [account, metricsEnabled, isSignedIn, flowQueryParams]);
 
   useEffect(() => {
     if (!loading && error?.message.includes('Invalid token')) {

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyAdd/index.test.tsx
@@ -10,6 +10,7 @@ import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import { PageRecoveryKeyAdd } from '.';
 import * as Metrics from '../../../lib/metrics';
+import { resetOnce } from '../../../lib/utilities';
 
 jest.mock('base32-encode', () =>
   jest.fn().mockReturnValue('00000000000000000000000000000000')
@@ -106,13 +107,14 @@ describe('PageRecoveryKeyAdd', () => {
         .spyOn(Metrics, 'logViewEvent')
         .mockImplementation();
       logPageViewEventSpy = jest
-        .spyOn(Metrics, 'logPageViewEvent')
+        .spyOn(Metrics, 'logPageViewEventOnce')
         .mockImplementation();
     });
 
     afterEach(() => {
       logViewEventSpy.mockReset();
       logPageViewEventSpy.mockReset();
+      resetOnce();
     });
 
     afterAll(() => {

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.test.tsx
@@ -10,6 +10,7 @@ import { PageSecondaryEmailAdd } from '.';
 import { Account, AppContext } from '../../../models';
 import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import * as Metrics from '../../../lib/metrics';
+import { resetOnce } from '../../../lib/utilities';
 
 window.console.error = jest.fn();
 
@@ -19,6 +20,10 @@ const account = {
 
 afterAll(() => {
   (window.console.error as jest.Mock).mockReset();
+});
+
+afterEach(() => {
+  resetOnce();
 });
 
 describe('PageSecondaryEmailAdd', () => {

--- a/packages/fxa-settings/src/lib/metrics.test.ts
+++ b/packages/fxa-settings/src/lib/metrics.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { MOCK_ACCOUNT } from '../models/mocks';
 import {
   init,
   reset,
@@ -13,10 +14,10 @@ import {
   addExperiment,
   setUserPreference,
   setNewsletters,
-  useUserPreferences,
   useViewEvent,
   usePageViewEvent,
   logErrorEvent,
+  initUserPreferences,
 } from './metrics';
 
 import { window } from './window';
@@ -90,6 +91,11 @@ function initFlow(enabled = true) {
     deviceId,
     flowBeginTime,
     flowId,
+  });
+  initUserPreferences({
+    hasSecondaryVerifiedEmail: MOCK_ACCOUNT.emails.length > 1,
+    recoveryKey: MOCK_ACCOUNT.recoveryKey,
+    totpActive: MOCK_ACCOUNT.totp.exists && MOCK_ACCOUNT.totp.verified,
   });
 }
 
@@ -404,7 +410,6 @@ describe('setUserPreference', () => {
 
 describe('setUserPreferences', () => {
   it('sets three user prefs', () => {
-    useUserPreferences();
     initAndLog();
     const payloadData = parsePayloadData();
     // strict equal since _all three_ properties must be present

--- a/packages/fxa-settings/src/lib/utilities.test.ts
+++ b/packages/fxa-settings/src/lib/utilities.test.ts
@@ -5,6 +5,8 @@
 import {
   deepMerge,
   isBase32Crockford,
+  once,
+  resetOnce,
   searchParam,
   searchParams,
 } from './utilities';
@@ -113,5 +115,35 @@ describe('isBase32Crockford', () => {
     expect(isBase32Crockford('L')).toBe(false);
     expect(isBase32Crockford('O')).toBe(false);
     expect(isBase32Crockford('U')).toBe(false);
+  });
+});
+
+describe('once', () => {
+  let count = 0;
+  const cb = () => {
+    count++;
+  };
+
+  beforeEach(() => {
+    count = 0;
+    resetOnce();
+  });
+
+  it('calls at least once', () => {
+    once('foo', cb);
+    expect(count).toEqual(1);
+  });
+
+  it('calls no more than once', () => {
+    once('foo', cb);
+    once('foo', cb);
+    expect(count).toEqual(1);
+  });
+
+  it('call no more than once per key', () => {
+    once('foo', cb);
+    once('bar', cb);
+    once('bar', cb);
+    expect(count).toEqual(2);
   });
 });

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -63,8 +63,9 @@ export function searchParams(str = '', allowedFields?: string[]) {
 /**
  * Return the value of a single query parameter in the string
  */
-export function searchParam(name: string, str?: string): string {
-  return searchParams(str)[name];
+export function searchParam(name: string, str?: string) {
+  const params = searchParams(str);
+  return params[name];
 }
 
 /**
@@ -73,7 +74,10 @@ export function searchParam(name: string, str?: string): string {
  * `&` is the expected delimiter between parameters.
  * `=` is the delimiter between a key and a value.
  */
-export function splitEncodedParams(str = '', allowedFields?: string[]) {
+export function splitEncodedParams(
+  str = '',
+  allowedFields?: string[]
+): Record<string, string> {
   const pairs = str.split('&');
   const terms: { [key: string]: string } = {};
 
@@ -105,4 +109,23 @@ export function isMobileDevice(client?: AttachedClient) {
 const B32_STRING = /^[0-9A-HJ-KM-NP-TV-Z]+$/i;
 export function isBase32Crockford(value: string) {
   return B32_STRING.test(value);
+}
+
+/**
+ * Ensures a given callback is called at most once per invocation with a given key.
+ * For example:
+ *  foo('bar', () => console.log(1));
+ *  foo('bar', () => console.log(2));
+ * Would print: 1
+ */
+let calls = new Set<string>();
+export function once(key: string, callback: () => void) {
+  if (calls.has(key)) {
+    return;
+  }
+  calls.add(key);
+  callback();
+}
+export function resetOnce() {
+  calls = new Set<string>();
 }


### PR DESCRIPTION
## Because

- We would see the same metric being emitted multiple times.

## This pull request

- Introduces a new 'once' utility function that memoizes calls based on key
- Uses this in favor of fancy, but potentially buggy react-ish ways of doing this with useEffect and passing empty dependencies.
- Adds a calls to `initUserPreferences` when metrics initialized in the root app component.
- Adds log to alert developers of situations where user preferences may not have been set.

## Issue that this pull request solves

Closes: FXA-7201

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I feel like there could potentially be a separate issue filed for looking more closely into page re-renders. Due to how we are using context it became apparent that re-renders could be triggered. It was unclear if these re-renders were intentional and needed for the page load correctly, or if they weren't actually necessary. 

Regardless, the changes in this PR create a separate mechanism for ensuring that events fire properly and are not double emitted regardless of a re-render. This approach seemed to be the most robust and should hold up going forwards regardless of any changes / optimizations that are made around page re-renders.
