### PR TITLE
chore(functional-tests): add coverage for P1 payments funnel events

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -1,7 +1,26 @@
+import { randomUUID } from 'crypto';
+
 import { BaseLayout } from '../layout';
 
 export class SubscribePage extends BaseLayout {
-  setFullName(name: string = 'Cave Johnson') {
+  async setEmailAndConfirmNewUser() {
+    // We can't reuse the same email address each time, as the form
+    // can't be submitted if the account already exists.
+    const email = `testo+${randomUUID()}@example.com`;
+    const inputFirst = this.page.locator(
+      '[data-testid="new-user-enter-email"]'
+    );
+    inputFirst.waitFor({ state: 'attached' });
+    await inputFirst.fill(email);
+
+    const inputSecond = this.page.locator(
+      '[data-testid="new-user-confirm-email"]'
+    );
+    inputSecond.waitFor({ state: 'attached' });
+    return inputSecond.fill(email);
+  }
+
+  setFullName(name = 'Cave Johnson') {
     const input = this.page.locator('[data-testid="name"]');
     input.waitFor({ state: 'attached' });
     return input.fill(name);
@@ -13,19 +32,25 @@ export class SubscribePage extends BaseLayout {
 
   async setCreditCardInfo() {
     const frame = this.page.frame({ url: /elements-inner-card/ });
-    await frame!.fill('.InputElement[name=cardnumber]', '');
-    await frame!.fill('.InputElement[name=cardnumber]', '4242424242424242');
-    await frame!.fill('.InputElement[name=exp-date]', '555');
-    await frame!.fill('.InputElement[name=cvc]', '333');
-    await frame!.fill('.InputElement[name=postal]', '66666');
+    if (!frame) {
+      throw new Error('No frame found');
+    }
+    await frame.fill('.InputElement[name=cardnumber]', '');
+    await frame.fill('.InputElement[name=cardnumber]', '4242424242424242');
+    await frame.fill('.InputElement[name=exp-date]', '555');
+    await frame.fill('.InputElement[name=cvc]', '333');
+    await frame.fill('.InputElement[name=postal]', '66666');
   }
 
   async setFailedCreditCardInfo() {
     const frame = this.page.frame({ url: /elements-inner-card/ });
-    await frame!.fill('.InputElement[name=cardnumber]', '4000000000000341');
-    await frame!.fill('.InputElement[name=exp-date]', '666');
-    await frame!.fill('.InputElement[name=cvc]', '444');
-    await frame!.fill('.InputElement[name=postal]', '77777');
+    if (!frame) {
+      throw new Error('No frame found');
+    }
+    await frame.fill('.InputElement[name=cardnumber]', '4000000000000341');
+    await frame.fill('.InputElement[name=exp-date]', '666');
+    await frame.fill('.InputElement[name=cvc]', '444');
+    await frame.fill('.InputElement[name=postal]', '77777');
   }
 
   async clickPayNow() {

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -99,7 +99,22 @@ export class RelierPage extends BaseLayout {
       .getAttribute('href');
   }
 
-  async getRpFlowParams(searchParams) {
+  getRpAcquisitionParams(searchParams) {
+    return {
+      entrypoint: searchParams.get('entrypoint'),
+      entrypoint_experiment: searchParams.get('entrypoint_experiment'),
+      entrypoint_variation: searchParams.get('entrypoint_variation'),
+      form_type: searchParams.get('form_type'),
+      utm_source: searchParams.get('utm_source'),
+      utm_campaign: searchParams.get('utm_campaign'),
+      utm_content: searchParams.get('utm_content'),
+      utm_term: searchParams.get('utm_term'),
+      utm_medium: searchParams.get('utm_medium'),
+      context: searchParams.get('context'),
+    };
+  }
+
+  getRpFlowParams(searchParams) {
     return {
       flow_id: searchParams.get('flow_id'),
       device_id: searchParams.get('device_id'),
@@ -107,7 +122,7 @@ export class RelierPage extends BaseLayout {
     };
   }
 
-  async getRpSearchParams(url) {
+  getRpSearchParams(url) {
     return new URL(url).searchParams;
   }
 }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -1088,7 +1088,7 @@ export class StripeWebhookHandler extends StripeHandler {
         : subscription.collection_method === 'charge_automatically'
         ? 'stripe'
         : 'not_chosen';
-    const countryCodeSource: string | null | undefined =
+    const countryCode: string | null | undefined =
       customer.shipping?.address?.country;
     const { id: planId, product: productId } = subscription.items.data[0].plan;
     // It is considered a voluntary cancellation when the customer cancels their subscription
@@ -1118,7 +1118,7 @@ export class StripeWebhookHandler extends StripeHandler {
     }
 
     return {
-      country_code_source: countryCodeSource,
+      country_code: countryCode,
       payment_provider: paymentProvider,
       plan_id: planId,
       product_id: productId,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -291,9 +291,7 @@ export class StripeHandler {
 
     await this.customerChanged(request, uid, email);
 
-    const sourceCountry = customer?.shipping?.address?.country || null;
-
-    return { subscriptionId, sourceCountry };
+    return { subscriptionId };
   }
 
   async listPlans(request: AuthRequest) {
@@ -1184,7 +1182,6 @@ export const stripeRoutes = (
         response: {
           schema: isA.object().keys({
             subscriptionId: isA.string(),
-            sourceCountry: validators.subscriptionPaymentCountryCode.required(),
           }) as any,
         },
         validate: {

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/customer1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/customer1.json
@@ -26,18 +26,7 @@
   "name": null,
   "phone": null,
   "preferred_locales": [],
-  "shipping": {
-    "address": {
-      "city": null,
-      "country": "RO",
-      "line1": null,
-      "line2": null,
-      "postal_code": "98332",
-      "state": null
-    },
-    "name": "Testy McTesterson",
-    "phone": null
-  },
+  "shipping": null,
   "sources": {
     "object": "list",
     "data": [

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -1117,7 +1117,7 @@ describe('StripeWebhookHandler', () => {
         const account = { email: mockCustomerFixture.email };
         const subscriptionEnded = subscriptionDeleted.data.object;
         const mockSubscriptionEndedEventDetails = {
-          country_code_source: mockCustomerFixture.shipping.address.country,
+          country_code: mockCustomerFixture.shipping.address.country,
           payment_provider: 'stripe',
           plan_id: subscriptionEnded.items.data[0].plan.id,
           product_id: subscriptionEnded.items.data[0].plan.product,
@@ -2396,7 +2396,7 @@ describe('StripeWebhookHandler', () => {
     const mockInvoice = deepCopy(invoiceFixture);
 
     const mockSubscriptionEndedEventDetails = {
-      country_code_source: mockCustomerFixture.shipping.address.country,
+      country_code: mockCustomerFixture.shipping.address.country,
       payment_provider: 'stripe',
       plan_id: subscriptionEnded.items.data[0].plan.id,
       product_id: subscriptionEnded.items.data[0].plan.product,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -2035,7 +2035,7 @@ describe('DirectStripeRoutes', () => {
 
     it('returns the subscription id when the plan is a valid upgrade', async () => {
       const subscriptionId = 'sub_123';
-      const expected = { subscriptionId: subscriptionId, sourceCountry: 'RO' };
+      const expected = { subscriptionId: subscriptionId };
       VALID_REQUEST.params = { subscriptionId: subscriptionId };
 
       directStripeRoutesInstance.stripeHelper.verifyPlanUpdateForSubscription.resolves();

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -379,7 +379,7 @@ export function updateSubscriptionPlan_PENDING(
 }
 
 export function updateSubscriptionPlan_FULFILLED(
-  eventProperties: SuccessfulSubscriptionEventProperties
+  eventProperties: EventProperties
 ) {
   safeLogAmplitudeEvent(
     eventGroupNames.changeSubscription,

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -269,20 +269,16 @@ describe('API requests', () => {
     };
 
     it('PUT {auth-server}/v1/oauth/subscriptions/active', async () => {
-      const expectedResponse = { ok: true, sourceCountry: 'RO' };
+      const expectedResponse = { ok: true };
       const requestMock = nock(AUTH_BASE_URL)
         .put(path(params.subscriptionId), { planId: params.planId })
         .reply(200, expectedResponse);
-      const metricsOptionsCountryCode = deepCopy({
-        ...metricsOptions,
-        country_code_source: expectedResponse.sourceCountry,
-      });
       expect(await apiUpdateSubscriptionPlan(params)).toEqual(expectedResponse);
       expect(updateSubscriptionPlan_PENDING as jest.Mock).toBeCalledWith(
         metricsOptions
       );
       expect(updateSubscriptionPlan_FULFILLED as jest.Mock).toBeCalledWith(
-        metricsOptionsCountryCode
+        metricsOptions
       );
       requestMock.done();
     });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -200,7 +200,6 @@ export async function apiUpdateSubscriptionPlan(params: {
     );
     Amplitude.updateSubscriptionPlan_FULFILLED({
       ...metricsOptions,
-      country_code_source: result.sourceCountry,
     });
     return result;
   } catch (error) {

--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -355,26 +355,6 @@
     },
     {
       "if": {
-        "$comment": "Additional required fields for when a subscription is successfully created or ended",
-        "required": ["event_type"],
-        "properties": {
-          "event_type": {
-            "type": "string",
-            "pattern": "fxa_pay_subscription_change - success|fxa_pay_setup - success|fxa_subscribe - subscription_ended"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "event_properties": {
-            "type": "object",
-            "required": ["country_code_source"]
-          }
-        }
-      }
-    },
-    {
-      "if": {
         "$comment": "Required fields for fxa_subscribe - subscription_ended events",
         "properties": {
           "event_type": {

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -704,7 +704,6 @@ describe('metrics/amplitude:', () => {
           const eventNoRequired = deepCopy(fxa_pay_setup_event);
           eventNoRequired.event_type = 'fxa_pay_setup - success';
           delete eventNoRequired.event_properties.payment_provider;
-          delete eventNoRequired.event_properties.country_code_source;
 
           try {
             amplitude.validate(eventNoRequired);
@@ -713,7 +712,7 @@ describe('metrics/amplitude:', () => {
             assert.isTrue(err instanceof Error);
             assert.equal(
               err.message,
-              `Invalid data: event/event_properties must have required property 'payment_provider', event must match "then" schema, event/event_properties must have required property 'country_code_source', event must match "then" schema`
+              `Invalid data: event/event_properties must have required property 'payment_provider', event must match "then" schema`
             );
           }
         });
@@ -752,7 +751,6 @@ describe('metrics/amplitude:', () => {
         },
         event_type: 'fxa_pay_subscription_change - view',
         event_properties: {
-          country_code_source: 'DE',
           service: 'qux',
           product_id: 'product',
           plan_id: 'plan',
@@ -772,7 +770,6 @@ describe('metrics/amplitude:', () => {
       it('success - valid with only required and none of the optional properties', () => {
         const eventNoOptional = deepCopy(fxa_pay_subscription_change_event);
         delete eventNoOptional.country_code;
-        delete eventNoOptional.event_properties.country_code_source;
         delete eventNoOptional.event_properties.error_id;
         delete eventNoOptional.event_properties.promotion_code;
         delete eventNoOptional.event_properties.subscribed_plan_ids;
@@ -805,24 +802,6 @@ describe('metrics/amplitude:', () => {
           );
         }
       });
-      describe('fxa_pay_subscription_change - success events', () => {
-        it('error - required field(s) are missing', () => {
-          const eventNoRequired = deepCopy(fxa_pay_subscription_change_event);
-          eventNoRequired.event_type = 'fxa_pay_subscription_change - success';
-          delete eventNoRequired.event_properties.country_code_source;
-
-          try {
-            amplitude.validate(eventNoRequired);
-            assert.fail('Validate is expected to fail');
-          } catch (err) {
-            assert.isTrue(err instanceof Error);
-            assert.equal(
-              err.message,
-              `Invalid data: event/event_properties must have required property 'country_code_source', event must match "then" schema`
-            );
-          }
-        });
-      });
       describe('fxa_pay_subscription_change - fail events', () => {
         it('error - required field(s) are missing', () => {
           const eventNoRequired = deepCopy(fxa_pay_subscription_change_event);
@@ -852,7 +831,7 @@ describe('metrics/amplitude:', () => {
         user_id: '9ce8626e11ab4238981287fb95c8545e',
         user_properties: {},
         event_properties: {
-          country_code_source: 'BC',
+          country_code: 'BC',
           payment_provider: 'stripe',
           plan_id: 'def',
           product_id: 'ghi',


### PR DESCRIPTION
Because:

* We need assurances that we are recording the expected data on P1 conversion funnel events.

This commit:

* Extend the `MetricsObserver` to support checking acquisition query parameters with a new method, `getAcquisitionParamsFromEvents`.
* Extend an existing test case to verify acquisition query parameters are sent for the new user checkout flow.
  - Add `setEmailAndConfirmNewUser` method to `SubscribePage` class.
* Extend existing test cases to verify all required event-specific fields are sent for the following critical flows:
  - new user checkout flow, success
  - new user checkout flow, failure
  - existing user checkout flow, success
  - existing user checkout flow, failure
  - existing user plan change (i.e. upgrade) flow, success

Closes #FXA-7364

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Until now, all subscription tests that complete a successful checkout flow tested the existing user checkout flow. I therefore had to add a new helper to the `SubscribePage` class, `setEmailAndConfirmNewUser`, to correctly fill out the `NewUserEmailForm` component to test the new user checkout flow. As a consequence of this, we now will have functional test coverage that tests the new user checkout flow.

To reduce overhead, I extended existing test cases rather than creating entirely new ones, since they perform the same set of steps. I also covered both failure and success events in a single test case for each checkout flow (new versus existing users) by first failing to subscribe and then succeeding.
