### PR TITLE
feat(react): Send fxaLogin webchannel message conditionally after password reset

### DIFF
--- a/packages/fxa-graphql-api/src/gql/dto/payload/password-forgot.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/password-forgot.ts
@@ -64,4 +64,7 @@ export class AccountResetPayload {
 
   @Field({ nullable: true })
   public keyFetchToken?: string;
+
+  @Field({ nullable: true })
+  public unwrapBKey?: string;
 }

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useAccount } from '../../models';
+import { CreateRelier, useAccount } from '../../models';
 import { ResendStatus } from '../../lib/types';
 import { logViewEvent } from 'fxa-settings/src/lib/metrics';
 import { REACT_ENTRYPOINT } from 'fxa-settings/src/constants';
@@ -20,6 +20,8 @@ export const LinkExpiredResetPassword = ({
 }: LinkExpiredResetPasswordProps) => {
   // TODO in FXA-7630 add metrics event and associated tests for users hitting the LinkExpired page
   const account = useAccount();
+  const relier = CreateRelier();
+  const serviceName = relier.getServiceName();
 
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
@@ -27,7 +29,7 @@ export const LinkExpiredResetPassword = ({
 
   const resendResetPasswordLink = async () => {
     try {
-      await account.resendResetPassword(email);
+      await account.resetPassword(email, serviceName);
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
       setResendStatus(ResendStatus['sent']);
     } catch (e) {

--- a/packages/fxa-settings/src/lib/storybook-utils.ts
+++ b/packages/fxa-settings/src/lib/storybook-utils.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReactElement } from 'react';
+import {
+  MOCK_ACCOUNT,
+  createAppContext,
+  createHistoryWithQuery,
+  produceComponent,
+} from '../models/mocks';
+import { Account } from '../models';
+
+export function renderStoryWithHistory(
+  component: ReactElement,
+  route: string,
+  account = MOCK_ACCOUNT as unknown as Account,
+  queryParams?: string
+) {
+  const history = createHistoryWithQuery(route, queryParams);
+  return produceComponent(
+    component,
+    { route, history },
+    {
+      ...createAppContext(history),
+      account,
+    }
+  );
+}

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
@@ -7,25 +7,26 @@ import { Account } from '../../../models';
 import AccountRecoveryConfirmKey from '.';
 import { Meta } from '@storybook/react';
 import {
+  getSubject,
   mockCompleteResetPasswordParams,
   paramsWithMissingEmail,
-  Subject,
 } from './mocks';
+import { produceComponent } from '../../../models/mocks';
 
 export default {
   title: 'Pages/ResetPassword/AccountRecoveryConfirmKey',
   component: AccountRecoveryConfirmKey,
 } as Meta;
 
-const storyWithSubject = (
-  account: Account,
-  params: Record<string, string>,
+function renderStory(
+  { account = accountValid, params = mockCompleteResetPasswordParams } = {},
   storyName?: string
-) => {
-  const story = () => <Subject {...{ account, params }} />;
+) {
+  const { Subject, history, appCtx } = getSubject(account, params);
+  const story = () => produceComponent(<Subject />, { history }, appCtx);
   story.storyName = storyName;
-  return story;
-};
+  return story();
+}
 
 const accountValid = {
   resetPasswordStatus: () => Promise.resolve(true),
@@ -45,23 +46,29 @@ const accountWithInvalidRecoveryKey = {
   verifyPasswordForgotToken: () => Promise.resolve(true),
 } as unknown as Account;
 
-export const OnConfirmValidKey = storyWithSubject(
-  accountValid,
-  mockCompleteResetPasswordParams,
-  'Valid recovery key. Users will be redirected to AccountRecoveryResetPassword on confirm'
-);
+export const OnConfirmValidKey = () => {
+  return renderStory(
+    {},
+    'Valid recovery key (32 characters). Users will be redirected to AccountRecoveryResetPassword on confirm'
+  );
+};
 
-export const OnConfirmInvalidKey = storyWithSubject(
-  accountWithInvalidRecoveryKey,
-  mockCompleteResetPasswordParams
-);
+export const OnConfirmInvalidKey = () => {
+  return renderStory({
+    account: accountWithInvalidRecoveryKey,
+    params: mockCompleteResetPasswordParams,
+  });
+};
 
-export const OnConfirmLinkExpired = storyWithSubject(
-  accountWithExpiredLink,
-  mockCompleteResetPasswordParams
-);
+export const OnConfirmLinkExpired = () => {
+  return renderStory({
+    account: accountWithExpiredLink,
+    params: mockCompleteResetPasswordParams,
+  });
+};
 
-export const WithDamagedLink = storyWithSubject(
-  accountValid,
-  paramsWithMissingEmail
-);
+export const WithDamagedLink = () => {
+  return renderStory({
+    params: paramsWithMissingEmail,
+  });
+};

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -10,7 +10,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { logPageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { viewName } from '.';
 import {
-  Subject,
   MOCK_RECOVERY_KEY,
   MOCK_RESET_TOKEN,
   MOCK_RECOVERY_KEY_ID,
@@ -19,12 +18,13 @@ import {
   paramsWithMissingToken,
   paramsWithMissingCode,
   paramsWithMissingEmail,
+  getSubject,
 } from './mocks';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { Account } from '../../../models';
 import { typeByLabelText } from '../../../lib/test-utils';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
+import { MOCK_ACCOUNT, renderWithRouter } from '../../../models/mocks';
 
 jest.mock('../../../lib/metrics', () => ({
   logPageViewEvent: jest.fn(),
@@ -76,7 +76,8 @@ const renderSubject = ({
   account = accountWithValidResetToken,
   params = mockCompleteResetPasswordParams,
 } = {}) => {
-  render(<Subject {...{ account, params }} />);
+  const { Subject, history, appCtx } = getSubject(account, params);
+  return renderWithRouter(<Subject />, { history }, appCtx);
 };
 
 describe('PageAccountRecoveryConfirmKey', () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -248,7 +248,9 @@ describe('AccountRecoveryResetPassword page', () => {
     describe('successful reset', () => {
       beforeEach(async () => {
         mockAccount.setLastLogin = jest.fn();
-        mockAccount.resetPasswordWithRecoveryKey = jest.fn();
+        mockAccount.resetPasswordWithRecoveryKey = jest
+          .fn()
+          .mockResolvedValue(mocks.MOCK_RESET_DATA);
         mockAccount.isSessionVerifiedAuthClient = jest.fn();
         mockAccount.hasTotpAuthClient = jest.fn().mockResolvedValue(false);
 
@@ -327,7 +329,9 @@ describe('AccountRecoveryResetPassword page', () => {
     beforeEach(async () => {
       window.location.href = originalWindow.href;
       mockAccount.setLastLogin = jest.fn();
-      mockAccount.resetPasswordWithRecoveryKey = jest.fn();
+      mockAccount.resetPasswordWithRecoveryKey = jest
+        .fn()
+        .mockResolvedValue(mocks.MOCK_RESET_DATA);
       mockAccount.isSessionVerifiedAuthClient = jest.fn();
       mockAccount.hasTotpAuthClient = jest.fn().mockResolvedValue(true);
       await renderPage();

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -252,7 +252,9 @@ const AccountRecoveryResetPassword = ({
           verificationInfo.emailToHashWith || verificationInfo.email,
       };
 
-      await account.resetPasswordWithRecoveryKey(options);
+      const accountResetData = await account.resetPasswordWithRecoveryKey(
+        options
+      );
       // must come after completeResetPassword since that receives the sessionToken
       // required for this check
       const sessionIsVerified = await account.isSessionVerifiedAuthClient();
@@ -267,8 +269,22 @@ const AccountRecoveryResetPassword = ({
       logViewEvent(viewName, 'verification.success');
 
       switch (integration.type) {
+        // NOTE: SyncBasic check is temporary until we implement codes
+        // See https://docs.google.com/document/d/1K4AD69QgfOCZwFLp7rUcMOkOTslbLCh7jjSdR9zpAkk/edit#heading=h.kkt4eylho93t
         case IntegrationType.SyncDesktop:
-          notifyFirefoxOfLogin(account, sessionIsVerified);
+        case IntegrationType.SyncBasic:
+          notifyFirefoxOfLogin(
+            {
+              authAt: accountResetData.authAt,
+              email: verificationInfo.email,
+              keyFetchToken: accountResetData.keyFetchToken,
+              sessionToken: accountResetData.sessionToken,
+              uid: accountResetData.uid,
+              unwrapBKey: accountResetData.unwrapBKey,
+              verified: accountResetData.verified,
+            },
+            sessionIsVerified
+          );
           break;
         case IntegrationType.OAuth:
           if (

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
@@ -277,3 +277,10 @@ export function mockContext() {
 }
 
 export const MOCK_SERVICE_NAME = MozServices.FirefoxSync;
+export const MOCK_RESET_DATA = {
+  authAt: 12345,
+  keyFetchToken: 'keyFetchToken',
+  sessionToken: 'sessionToken',
+  unwrapBKey: 'unwrapBKey',
+  verified: true,
+};

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -3,26 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { Account } from '../../../models';
 import { logPageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT, SHOW_BALLOON_TIMEOUT } from '../../../constants';
 import {
+  getSubject,
+  MOCK_RESET_DATA,
   mockCompleteResetPasswordParams,
   paramsWithMissingCode,
   paramsWithMissingEmail,
   paramsWithMissingEmailToHashWith,
   paramsWithMissingToken,
   paramsWithSyncDesktop,
-  Subject,
 } from './mocks';
 import { notifyFirefoxOfLogin } from '../../../lib/channels/helpers';
+import { renderWithRouter } from '../../../models/mocks';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 
@@ -76,9 +72,10 @@ jest.mock('@reach/router', () => ({
   useLocation: () => mockLocation(),
 }));
 
-function renderSubject(account: Account, params?: Record<string, string>) {
-  render(<Subject {...{ account, params }} />);
-}
+const renderSubject = (account: Account, params?: Record<string, string>) => {
+  const { Subject, history, appCtx } = getSubject(account, params);
+  return renderWithRouter(<Subject />, { history }, appCtx);
+};
 
 describe('CompleteResetPassword page', () => {
   // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
@@ -92,7 +89,7 @@ describe('CompleteResetPassword page', () => {
 
     account = {
       resetPasswordStatus: jest.fn().mockResolvedValue(true),
-      completeResetPassword: jest.fn().mockResolvedValue(true),
+      completeResetPassword: jest.fn().mockResolvedValue(MOCK_RESET_DATA),
       hasRecoveryKey: jest.fn().mockResolvedValue(false),
       hasTotpAuthClient: jest.fn().mockResolvedValue(false),
       isSessionVerifiedAuthClient: jest.fn().mockResolvedValue(true),
@@ -140,6 +137,7 @@ describe('CompleteResetPassword page', () => {
 
   it('renders the component as expected when provided with an expired link', async () => {
     account = {
+      ...account,
       resetPasswordStatus: jest.fn().mockResolvedValue(false),
     } as unknown as Account;
 
@@ -252,7 +250,7 @@ describe('CompleteResetPassword page', () => {
   describe('account has recovery key', () => {
     const accountWithRecoveryKey = {
       resetPasswordStatus: jest.fn().mockResolvedValue(true),
-      completeResetPassword: jest.fn().mockResolvedValue(true),
+      completeResetPassword: jest.fn().mockResolvedValue(MOCK_RESET_DATA),
       hasRecoveryKey: jest.fn().mockResolvedValue(true),
     } as unknown as Account;
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -175,7 +175,7 @@ const CompleteResetPassword = ({
         // how account password hashing works previously.
         const emailToUse = emailToHashWith || email;
 
-        await account.completeResetPassword(
+        const accountResetData = await account.completeResetPassword(
           token,
           code,
           emailToUse,
@@ -196,8 +196,22 @@ const CompleteResetPassword = ({
 
         let hardNavigate = false;
         switch (integration.type) {
+          // NOTE: SyncBasic check is temporary until we implement codes
+          // See https://docs.google.com/document/d/1K4AD69QgfOCZwFLp7rUcMOkOTslbLCh7jjSdR9zpAkk/edit#heading=h.kkt4eylho93t
           case IntegrationType.SyncDesktop:
-            notifyFirefoxOfLogin(account, sessionIsVerified);
+          case IntegrationType.SyncBasic:
+            notifyFirefoxOfLogin(
+              {
+                authAt: accountResetData.authAt,
+                email,
+                keyFetchToken: accountResetData.keyFetchToken,
+                sessionToken: accountResetData.sessionToken,
+                uid: accountResetData.uid,
+                unwrapBKey: accountResetData.unwrapBKey,
+                verified: accountResetData.verified,
+              },
+              sessionIsVerified
+            );
             break;
           case IntegrationType.OAuth:
             if (

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
@@ -4,14 +4,9 @@
 
 import React from 'react';
 import ConfirmResetPassword from '.';
-import {
-  LocationProvider,
-  createHistory,
-  createMemorySource,
-} from '@reach/router';
 import { Meta } from '@storybook/react';
-import { MOCK_EMAIL, MOCK_PASSWORD_FORGOT_TOKEN } from './mocks';
 import { withLocalization } from '../../../../.storybook/decorators';
+import { renderStoryWithHistory } from '../../../lib/storybook-utils';
 
 export default {
   title: 'Pages/ResetPassword/ConfirmResetPassword',
@@ -19,15 +14,5 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const source = createMemorySource('/fake-memories');
-const history = createHistory(source);
-history.location.state = {
-  email: MOCK_EMAIL,
-  passwordForgotToken: MOCK_PASSWORD_FORGOT_TOKEN,
-};
-
-export const Default = () => (
-  <LocationProvider history={history}>
-    <ConfirmResetPassword />
-  </LocationProvider>
-);
+export const Default = () =>
+  renderStoryWithHistory(<ConfirmResetPassword />, '/confirm_reset_password');

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import { POLLING_INTERVAL_MS, REACT_ENTRYPOINT } from '../../../constants';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ResendStatus } from '../../../lib/types';
-import { useAccount, useInterval } from '../../../models';
+import { CreateRelier, useAccount, useInterval } from '../../../models';
 import AppLayout from '../../../components/AppLayout';
 import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
@@ -24,6 +24,8 @@ export type ConfirmResetPasswordLocationState = {
 
 const ConfirmResetPassword = (_: RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  const relier = CreateRelier();
+  const serviceName = relier.getServiceName();
 
   const navigate = useNavigate();
   let { state } = useLocation();
@@ -70,7 +72,7 @@ const ConfirmResetPassword = (_: RouteComponentProps) => {
 
   const resendEmailHandler = async () => {
     try {
-      const result = await account.resendResetPassword(email);
+      const result = await account.resetPassword(email, serviceName);
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
       setCurrentPasswordForgotToken(result.passwordForgotToken);
       setResendStatus(ResendStatus['sent']);

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
@@ -3,14 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import ResetPasswordWithRecoveryKeyVerified from '.';
+import ResetPasswordWithRecoveryKeyVerified, {
+  ResetPasswordWithRecoveryKeyVerifiedProps,
+} from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from '../../../../.storybook/decorators';
-import {
-  produceComponent,
-  createAppContext,
-  createHistoryWithQuery,
-} from '../../../models/mocks';
+import { Account } from '../../../models';
+import { renderStoryWithHistory } from '../../../lib/storybook-utils';
 
 export default {
   title: 'Pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified',
@@ -18,19 +17,29 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const route = '/reset_password_with_recovery_key_verified';
+type RenderStoryOptions = {
+  account?: Account;
+  props?: ResetPasswordWithRecoveryKeyVerifiedProps;
+  queryParams?: string;
+};
 
-function render(isSignedIn: boolean, queryParams?: string) {
-  const history = createHistoryWithQuery(route, queryParams);
-  const appCtx = createAppContext(history);
-  return produceComponent(
-    <ResetPasswordWithRecoveryKeyVerified isSignedIn={isSignedIn} />,
-    { route, history },
-    appCtx
+function renderStory({
+  account,
+  props = { isSignedIn: false },
+  queryParams,
+}: RenderStoryOptions = {}) {
+  return renderStoryWithHistory(
+    <ResetPasswordWithRecoveryKeyVerified {...props} />,
+    '/reset_password_with_recovery_key_verified',
+    account,
+    queryParams
   );
 }
 
-export const DefaultAccountSignedIn = () => render(true);
-export const DefaultAccountSignedOut = () => render(false);
-export const WithSyncAccountSignedIn = () => render(true, `service=sync`);
-export const WithSyncAccountSignedOut = () => render(false, `service=sync`);
+export const DefaultAccountSignedIn = () =>
+  renderStory({ props: { isSignedIn: true } });
+export const DefaultAccountSignedOut = () => renderStory();
+export const WithSyncAccountSignedIn = () =>
+  renderStory({ props: { isSignedIn: true }, queryParams: `service=sync` });
+export const WithSyncAccountSignedOut = () =>
+  renderStory({ queryParams: `service=sync` });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -11,7 +11,7 @@ import { REACT_ENTRYPOINT } from '../../../constants';
 import AppLayout from '../../../components/AppLayout';
 import { CreateRelier, useFtlMsgResolver } from '../../../models';
 
-type ResetPasswordWithRecoveryKeyVerifiedProps = {
+export type ResetPasswordWithRecoveryKeyVerifiedProps = {
   isSignedIn: boolean;
 };
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -4,23 +4,16 @@
 
 import React from 'react';
 import ResetPassword, { ResetPasswordProps } from '.';
-import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
-import { MOCK_ACCOUNT } from '../../models/mocks';
 import { MozServices } from '../../lib/types';
 import { withLocalization } from '../../../.storybook/decorators';
-import { Account, AppContext } from '../../models';
 import {
   mockAccountWithThrottledError,
   mockAccountWithUnexpectedError,
-  mockDefaultAccount,
 } from './mocks';
-
-import {
-  produceComponent,
-  createAppContext,
-  createHistoryWithQuery,
-} from '../../models/mocks';
+import { renderStoryWithHistory } from '../../lib/storybook-utils';
+import { Account } from '../../models';
+import { MOCK_ACCOUNT } from '../../models/mocks';
 
 export default {
   title: 'Pages/ResetPassword',
@@ -28,47 +21,36 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const route = '/reset_password';
+type RenderStoryOptions = {
+  account?: Account;
+  props?: Partial<ResetPasswordProps>;
+  queryParams?: string;
+};
 
-function render(
-  account: Account,
-  props?: Partial<ResetPasswordProps>,
-  queryParams?: string
-) {
-  const history = createHistoryWithQuery(route, queryParams);
-  return produceComponent(
+function renderStory({ account, props, queryParams }: RenderStoryOptions = {}) {
+  return renderStoryWithHistory(
     <ResetPassword {...props} />,
-    { route, history },
-    {
-      ...createAppContext(history),
-      account,
-    }
+    '/reset_password',
+    account,
+    queryParams
   );
 }
 
-export const Default = () => {
-  return render(mockDefaultAccount);
-};
+export const Default = () => renderStory();
 
-export const WithServiceName = () => {
-  return render(
-    mockDefaultAccount,
-    undefined,
-    `service=${MozServices.MozillaVPN}`
-  );
-};
+export const WithServiceName = () =>
+  renderStory({ queryParams: `service=${MozServices.MozillaVPN}` });
 
-export const WithForceAuth = () => {
-  return render(mockDefaultAccount, {
-    prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
-    forceAuth: true,
+export const WithForceAuth = () =>
+  renderStory({
+    props: {
+      prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
+      forceAuth: true,
+    },
   });
-};
 
-export const WithThrottledErrorOnSubmit = () => {
-  return render(mockAccountWithThrottledError);
-};
+export const WithThrottledErrorOnSubmit = () =>
+  renderStory({ account: mockAccountWithThrottledError });
 
-export const WithUnexpectedErrorOnSubmit = () => {
-  return render(mockAccountWithUnexpectedError);
-};
+export const WithUnexpectedErrorOnSubmit = () =>
+  renderStory({ account: mockAccountWithUnexpectedError });

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -13,7 +13,7 @@ import ResetPassword, { viewName } from '.';
 import { REACT_ENTRYPOINT } from '../../constants';
 
 import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
-import { Account, AppContext } from '../../models';
+import { Account } from '../../models';
 import { AuthUiErrorNos } from '../../lib/auth-errors/auth-errors';
 import { typeByLabelText } from '../../lib/test-utils';
 import {
@@ -21,6 +21,7 @@ import {
   createHistoryWithQuery,
   renderWithRouter,
 } from '../../models/mocks';
+import { MozServices } from '../../lib/types';
 
 const mockLogViewEvent = jest.fn();
 const mockLogPageViewEvent = jest.fn();
@@ -148,7 +149,8 @@ describe('PageResetPassword', () => {
     });
 
     expect(account.resetPassword).toHaveBeenCalledWith(
-      MOCK_ACCOUNT.primaryEmail.email
+      MOCK_ACCOUNT.primaryEmail.email,
+      MozServices.Default
     );
 
     expect(mockNavigate).toHaveBeenCalledWith(

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -100,7 +100,7 @@ const ResetPassword = ({
     async (email: string) => {
       try {
         clearError();
-        const result = await account.resetPassword(email);
+        const result = await account.resetPassword(email, serviceName);
         navigateToConfirmPwReset({
           passwordForgotToken: result.passwordForgotToken,
           email,


### PR DESCRIPTION
Because:
* The browser should be be notified when a PW reset occurs on a verified account through the Sync flow, as this logs the user in

This commit:
* Conditionally runs the fxaLogin command with required account data after a password reset with or without recovery key, when the flow is sync
* Receives other values off the account reset call needed for webchannel account data
* Temporarily checks for SyncBasic and SyncDesktop flows to run the check because we don't need to port over context in local storage logic (which would account for SyncDesktop only), since we are switching to codes soon
* Sends up `service` with the email request so we can append the param and check when link is received (causing the  SyncBasic integration)
* Removes resendResetPassword and calls resetPassword where needed since the code was duplicated

Fixes FXA-7172