### PR TITLE
test(functional): rewrite oauth permissions tests

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -49,6 +49,7 @@ export const selectors = {
   NOT_EMAIL_UNMET: '#password-same-as-email.password-strength-unmet',
   NOT_EMAIL_MET: '#password-same-as-email.password-strength-met',
   NOT_EMAIL_FAIL: '#password-same-as-email.password-strength-fail',
+  PERMISSION_ACCEPT: '#accept',
 };
 
 export class LoginPage extends BaseLayout {
@@ -248,6 +249,10 @@ export class LoginPage extends BaseLayout {
     const header = this.page.locator(selectors.FIREFOX_HEADER);
     await header.waitFor();
     return header.isVisible();
+  }
+
+  async acceptOauthPermissions() {
+    return this.page.locator(selectors.PERMISSION_ACCEPT).click();
   }
 
   async signinUnblockHeader() {

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -55,6 +55,15 @@ export class RelierPage extends BaseLayout {
     return this.page.locator('button.sign-choose').click();
   }
 
+  async signInPromptNone() {
+    return this.page.locator('.ready .prompt-none').click();
+  }
+
+  async promptNoneError() {
+    const error = this.page.locator('.error');
+    return error.innerText();
+  }
+
   async clickSubscribe() {
     await this.page
       .getByRole('link', { name: 'Subscribe to Pro (USD)' })

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -28,7 +28,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     }
   });
 
-  test('signup without `prompt=consent', async ({
+  test('signup without `prompt=consent`', async ({
     pages: { login, relier },
   }) => {
     await relier.goto();
@@ -60,7 +60,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     expect(await login.isSignUpCodeHeader()).toBe(true);
   });
 
-  test('signin without `prompt=consent', async ({
+  test('signin without `prompt=consent`', async ({
     target,
     pages: { login, relier },
   }) => {
@@ -76,7 +76,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     expect(await relier.isLoggedIn()).toBe(true);
   });
 
-  test('signin with `prompt=consent', async ({
+  test('signin with `prompt=consent`', async ({
     target,
     page,
     pages: { login, relier },
@@ -163,7 +163,7 @@ test.describe('oauth permissions for trusted reliers', () => {
       prompt: 'consent',
       email: email,
     });
-    await page.goto(target.relierUrl + `/?${query.toString()}`);
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
     await relier.clickForceAuth();
     await login.setPassword(password);
     await login.submit();

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+let email;
+const password = 'passwordzxcv';
+
+test.describe('oauth permissions for trusted reliers', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    email = login.createEmail();
+    await login.clearCache();
+  });
+
+  test.afterEach(async ({ target }) => {
+    if (email) {
+      // Cleanup any accounts created during the test
+      try {
+        await target.auth.accountDestroy(email, password);
+      } catch (e) {
+        // Handle the error here
+        console.error('An error occurred during account cleanup:', e);
+        // Optionally, rethrow the error to propagate it further
+        throw e;
+      }
+    }
+  });
+
+  test('signup without `prompt=consent', async ({
+    pages: { login, relier },
+  }) => {
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await login.fillOutFirstSignUp(email, password, false);
+
+    //no permissions asked for, straight to confirm
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+  });
+
+  test('signup with `prompt=consent`', async ({
+    target,
+    page,
+    pages: { login, relier },
+  }) => {
+    const query = { prompt: 'consent' };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
+      waitUntil: 'networkidle',
+    });
+    await relier.clickEmailFirst();
+    await login.fillOutFirstSignUp(email, password, false);
+
+    //Verify permissions header
+    expect(await login.permissionsHeader()).toBe(true);
+    await login.acceptOauthPermissions();
+
+    //Verify sign up code header
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+  });
+
+  test('signin without `prompt=consent', async ({
+    target,
+    pages: { login, relier },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+
+  test('signin with `prompt=consent', async ({
+    target,
+    page,
+    pages: { login, relier },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    const query = { prompt: 'consent' };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
+      waitUntil: 'networkidle',
+    });
+    await relier.clickEmailFirst();
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify permissions header
+    expect(await login.permissionsHeader()).toBe(true);
+    await login.acceptOauthPermissions();
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+
+  test('signin without `prompt=consent`, then re-signin with `prompt=consent`', async ({
+    target,
+    page,
+    pages: { login, relier },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await relier.goto();
+    await relier.clickEmailFirst();
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+    await relier.signOut();
+    const query = { prompt: 'consent' };
+    const queryParam = new URLSearchParams(query);
+    await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
+      waitUntil: 'networkidle',
+    });
+    await relier.clickEmailFirst();
+    await login.clickSignIn();
+
+    //Verify permissions header
+    expect(await login.permissionsHeader()).toBe(true);
+    await login.acceptOauthPermissions();
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+
+  test('force_auth without `prompt=consent`', async ({
+    target,
+    pages: { login, relier },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await relier.goto(`email=${email}`);
+    await relier.clickForceAuth();
+    await login.setPassword(password);
+    await login.submit();
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+
+  test('force_auth with `prompt=consent`', async ({
+    target,
+    page,
+    pages: { login, relier },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    const query = new URLSearchParams({
+      prompt: 'consent',
+      email: email,
+    });
+    await page.goto(target.relierUrl + `/?${query.toString()}`);
+    await relier.clickForceAuth();
+    await login.setPassword(password);
+    await login.submit();
+
+    //Verify permissions header
+    expect(await login.permissionsHeader()).toBe(true);
+    await login.acceptOauthPermissions();
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+});

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+let email;
+const password = 'passwordzxcv';
+
+test.describe('oauth prompt none', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    email = login.createEmail();
+    await login.clearCache();
+  });
+
+  test('fails if no user logged in', async ({
+    page,
+    target,
+    pages: { relier },
+  }) => {
+    const query = new URLSearchParams({
+      login_hint: email,
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain('User is not signed in');
+  });
+
+  test('fails RP that is not allowed', async ({ page, pages: { relier } }, {
+    project,
+  }) => {
+    test.skip(
+      project.name !== 'local',
+      'we dont have an untrusted oauth for stage and prod'
+    );
+    const query = new URLSearchParams({
+      login_hint: email,
+      return_on_error: 'false',
+    });
+    await page.goto(`http://localhost:10139` + `/?${query.toString()}`);
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain(
+      'prompt=none is not enabled for this client'
+    );
+  });
+
+  test('fails if requesting keys', async ({
+    page,
+    target,
+    pages: { relier },
+  }) => {
+    const query = new URLSearchParams({
+      client_id: '7f368c6886429f19', // eslint-disable-line camelcase
+      forceUA:
+        'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36',
+      // eslint-disable-next-line camelcase
+      keys_jwk:
+        'eyJrdHkiOiJFQyIsImtpZCI6Im9DNGFudFBBSFZRX1pmQ09RRUYycTRaQlZYblVNZ2xISGpVRzdtSjZHOEEiLCJjcnYiOi' +
+        'JQLTI1NiIsIngiOiJDeUpUSjVwbUNZb2lQQnVWOTk1UjNvNTFLZVBMaEg1Y3JaQlkwbXNxTDk0IiwieSI6IkJCWDhfcFVZeHpTaldsdX' +
+        'U5MFdPTVZwamIzTlpVRDAyN0xwcC04RW9vckEifQ',
+      login_hint: email, // eslint-disable-line camelcase
+      redirect_uri: 'https://mozilla.github.io/notes/fxa/android-redirect.html', // eslint-disable-line camelcase
+      scope: 'profile https://identity.mozilla.com/apps/notes',
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain(
+      'prompt=none cannot be used when requesting keys'
+    );
+  });
+
+  test('fails if session is no longer valid', async ({
+    page,
+    target,
+    pages: { relier, login },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+    await target.auth.accountDestroy(email, password);
+
+    const query = new URLSearchParams({
+      login_hint: email,
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain('User is not signed in');
+  });
+
+  test('fails if account is not verified', async ({
+    page,
+    target,
+    pages: { relier, login },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'false',
+    });
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify sign up code header
+    expect(await login.isSignUpCodeHeader()).toBe(true);
+
+    const query = new URLSearchParams({
+      login_hint: email,
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain(
+      'Unverified user or session'
+    );
+  });
+});
+
+test.describe('oauth prompt none with emails', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    email = login.createEmail();
+    await login.clearCache();
+  });
+
+  test.afterEach(async ({ target }) => {
+    if (email) {
+      // Cleanup any accounts created during the test
+      try {
+        await target.auth.accountDestroy(email, password);
+      } catch (e) {
+        // Handle the error here
+        console.error('An error occurred during account cleanup:', e);
+        // Optionally, rethrow the error to propagate it further
+        throw e;
+      }
+    }
+  });
+
+  test('fails if no login_hint', async ({
+    page,
+    target,
+    pages: { relier, login },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+
+    const query = new URLSearchParams({
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain(
+      'Missing OAuth parameter: login_hint'
+    );
+  });
+
+  test('fails if login_hint is different to logged in user', async ({
+    page,
+    target,
+    pages: { relier, login },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+
+    const query = new URLSearchParams({
+      login_hint: login.createEmail(),
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+
+    await relier.signInPromptNone();
+
+    //Verify error message
+    expect(await relier.promptNoneError()).toContain(
+      'A different user is signed in'
+    );
+  });
+
+  test('succeeds if login_hint same as logged in user', async ({
+    page,
+    target,
+    pages: { relier, login },
+  }) => {
+    await target.auth.signUp(email, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    await page.goto(target.contentServerUrl, {
+      waitUntil: 'load',
+    });
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    //Verify logged in on Settings page
+    expect(await login.loginHeader()).toBe(true);
+
+    const query = new URLSearchParams({
+      login_hint: email,
+      return_on_error: 'false',
+    });
+    await page.goto(`${target.relierUrl}/?${query.toString()}`);
+
+    await relier.signInPromptNone();
+
+    //Verify logged in to relier
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+});

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -9,8 +9,7 @@ module.exports = testsSettings.concat([
   // new and flaky tests above here',
   'tests/functional/email_opt_in.js',
   'tests/functional/fx_desktop_handshake.js',
-  'tests/functional/oauth_permissions.js',
-  'tests/functional/oauth_prompt_none.js',
+
   'tests/functional/oauth_sign_up.js',
   'tests/functional/pages.js',
   'tests/functional/post_verify/force_password_change.js',
@@ -77,6 +76,8 @@ module.exports = testsSettings.concat([
   //'tests/functional/sync_v3_sign_in.js',
   //'tests/functional/sync_v3_reset_password.js',
   //'tests/functional/oauth_sync_sign_in.js',
+  //'tests/functional/oauth_permissions.js',
+  //'tests/functional/oauth_prompt_none.js',
 ]);
 
 // Mocha tests are only exposed during local dev, not on prod-like

--- a/packages/fxa-content-server/tests/functional_regression.js
+++ b/packages/fxa-content-server/tests/functional_regression.js
@@ -6,8 +6,6 @@ const testsSettings = require('./functional_settings');
 
 module.exports = testsSettings.concat([
   'tests/functional/oauth_settings_clients.js',
-  'tests/functional/oauth_prompt_none.js',
-  'tests/functional/oauth_permissions.js',
   // new and flaky tests above here',
   'tests/functional/avatar.js',
   'tests/functional/bounced_email.js',
@@ -15,9 +13,6 @@ module.exports = testsSettings.concat([
   'tests/functional/fx_desktop_handshake.js',
   'tests/functional/oauth_webchannel.js',
   'tests/functional/pages.js',
-  'tests/functional/post_verify/force_password_change.js',
-  'tests/functional/post_verify/account_recovery.js',
-  'tests/functional/post_verify/secondary_email.js',
   'tests/functional/sign_in.js',
   'tests/functional/sign_in_blocked.js',
 ]);


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [oauth permissions](https://github.com/pdehaan/fxa/blob/0ae60a1df256332e8581898db39b0e4997bab7b4/packages/fxa-content-server/tests/functional/oauth_permissions.js) and [oauth prompt none](https://github.com/pdehaan/fxa/blob/0ae60a1df256332e8581898db39b0e4997bab7b4/packages/fxa-content-server/tests/functional/oauth_prompt_none.js) have been rewritten in this PR.

## This pull request

contains the tests identified as 'Keep' in the [analysis sheet](https://docs.google.com/spreadsheets/d/11Wq-Y-ipeNFXqLHbr3GJCh_f_qEAG-CUuqBt5Dcnh5k/edit#gid=1966588528) for [oauth permissions](https://github.com/pdehaan/fxa/blob/0ae60a1df256332e8581898db39b0e4997bab7b4/packages/fxa-content-server/tests/functional/oauth_permissions.js) and [oauth prompt none](https://github.com/pdehaan/fxa/blob/0ae60a1df256332e8581898db39b0e4997bab7b4/packages/fxa-content-server/tests/functional/oauth_prompt_none.js)

## Issue that this pull request solves

Closes: FXA-5917 FXA-5920

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
