### PR TITLE
 bug(settings): FlowEventData not set for legal doc pages

### DIFF
--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -8,7 +8,7 @@ import { BaseTarget } from '../../lib/targets/base';
 function getReactFeatureFlagUrl(
   target: BaseTarget,
   path: string,
-  showReactApp: boolean = true
+  showReactApp = true
 ) {
   return `${target.contentServerUrl}${path}?showReactApp=${showReactApp}`;
 }

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -206,9 +206,15 @@ Router = Router.extend({
     'legal(/)': function () {
       this.createReactOrBackboneViewHandler('legal', 'legal');
     },
-    'legal/privacy(/)': createViewHandler('pp'),
+    'legal/privacy(/)': function () {
+      this.createReactOrBackboneViewHandler('legal/privacy', 'pp', {
+        contentRedirect: true,
+      });
+    },
     'legal/terms(/)': function () {
-      this.createReactOrBackboneViewHandler('legal/terms', 'tos');
+      this.createReactOrBackboneViewHandler('legal/terms', 'tos', {
+        contentRedirect: true,
+      });
     },
     'oauth(/)': createViewHandler(IndexView),
     'oauth/force_auth(/)': createViewHandler(ForceAuthView),

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -31,6 +31,8 @@ jest.mock('../Settings/ScrollToTop', () => ({
 }));
 
 describe('metrics', () => {
+  let flowInit: jest.SpyInstance;
+
   beforeEach(() => {
     //@ts-ignore
     delete window.location;
@@ -38,6 +40,12 @@ describe('metrics', () => {
       ...window.location,
       replace: jest.fn(),
     };
+
+    flowInit = jest.spyOn(Metrics, 'init');
+  });
+
+  afterEach(() => {
+    flowInit.mockReset();
   });
 
   it('Initializes metrics flow data when present', async () => {
@@ -45,7 +53,6 @@ describe('metrics', () => {
     const DEVICE_ID = 'yoyo';
     const BEGIN_TIME = 123456;
     const FLOW_ID = 'abc123';
-    const flowInit = jest.spyOn(Metrics, 'init');
     const updatedFlowQueryParams = {
       deviceId: DEVICE_ID,
       flowBeginTime: BEGIN_TIME,

--- a/packages/fxa-settings/src/components/LegalWithMarkdown/index.tsx
+++ b/packages/fxa-settings/src/components/LegalWithMarkdown/index.tsx
@@ -14,6 +14,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { REACT_ENTRYPOINT } from '../../constants';
 import { fetchLegalMd, LegalDocFile } from '../../lib/file-utils-legal';
 import { AppContext } from '../../models';
+import { searchParams } from '../../lib/utilities';
 
 export type FetchLegalDoc = (
   locale: string,
@@ -73,7 +74,10 @@ const LegalWithMarkdown = ({
 
   const buttonHandler = () => {
     logViewEvent(`flow.${viewName}`, 'back', REACT_ENTRYPOINT);
-    navigate(-1);
+
+    navigate(
+      (searchParams(window.location.search) as any).contentRedirect ? -2 : -1
+    );
   };
 
   return (


### PR DESCRIPTION
## Because

- We noticed errors when emitting metrics from legal doc pages

## This pull request

- Makes sure key flowEventData is set when metrics are initialized.
- Minor tweak to routes and back button issue. Fix was borrowed from cookies page.

## Issue that this pull request solves

Closes: FXA-7496

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

