### PR TITLE
task(settings): Use relier hook for ResetPassword flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -304,7 +304,10 @@ Router = Router.extend({
     'reset_password(/)': function () {
       this.createReactOrBackboneViewHandler(
         'reset_password',
-        ResetPasswordView
+        ResetPasswordView,
+        {
+          ...Url.searchParams(this.window.location.search),
+        }
       );
     },
 
@@ -349,22 +352,27 @@ Router = Router.extend({
         service,
         uniqueUserId,
       } = this.metrics.getFilteredData();
-      
+
       // Some flows can specify a redirect url after a client has logged in. This is
-      // useful when you want to ensure the user has authenticated. Our GQL client 
-      // also sets the `redirect_to` param if a user attempts to navigate directly 
+      // useful when you want to ensure the user has authenticated. Our GQL client
+      // also sets the `redirect_to` param if a user attempts to navigate directly
       // to a section in settings
       const searchParams = new URLSearchParams(this.window.location.search);
       const redirectUrl = searchParams.get('redirect_to');
       if (redirectUrl) {
         // Ignore query params when validating the redirect url
         const parsedRedirectUrl = redirectUrl.split('?')[0];
-        if (!this.isValidRedirect(parsedRedirectUrl, this.config.redirectAllowlist)) {
+        if (
+          !this.isValidRedirect(
+            parsedRedirectUrl,
+            this.config.redirectAllowlist
+          )
+        ) {
           throw new Error('Invalid redirect!');
         }
         return this.navigateAway(redirectUrl);
-      } 
-      
+      }
+
       // All other flows should redirect to the settings page
       const settingsEndpoint = '/settings';
       const settingsLink = `${settingsEndpoint}${Url.objToSearchString({
@@ -496,7 +504,6 @@ Router = Router.extend({
     backboneViewOptions
   ) {
     const showReactApp = this.showReactApp(routeName);
-
     if (showReactApp) {
       const { deviceId, flowBeginTime, flowId } =
         this.metrics.getFlowEventMetadata();

--- a/packages/fxa-settings/src/models/AppContext.ts
+++ b/packages/fxa-settings/src/models/AppContext.ts
@@ -5,14 +5,13 @@
 import { ApolloClient, gql } from '@apollo/client';
 import AuthClient from 'fxa-auth-client/browser';
 import React from 'react';
-import config, { Config, readConfigMeta } from '../lib/config';
+import config, { Config, readConfigMeta, getDefault } from '../lib/config';
 import { StorageData, UrlHashData, UrlQueryData } from '../lib/model-data';
 import firefox, { FirefoxCommand } from '../lib/channels/firefox';
 import { createApolloClient } from '../lib/gql';
 import { OAuthClient } from '../lib/oauth/oauth-client';
 import { Account, ACCOUNT_FIELDS, GET_PROFILE_INFO } from './Account';
 import { AlertBarInfo } from './AlertBarInfo';
-import { mockAppContext } from './mocks';
 import { Session } from './Session';
 import { LocationStateData } from '../lib/model-data/data-stores/location-state-data';
 import { ReachRouterWindow } from '../lib/window';
@@ -131,6 +130,63 @@ export function initializeAppContext() {
   return context;
 }
 
+export function defaultAppContext(context?: AppContextValue) {
+  const account = {
+    uid: 'abc123',
+    displayName: 'John Dope',
+    avatar: {
+      id: 'abc1234',
+      url: 'http://placekitten.com/512/512',
+      isDefault: false,
+    },
+    accountCreated: 123456789,
+    passwordCreated: 123456789,
+    hasPassword: true,
+    recoveryKey: true,
+    metricsEnabled: true,
+    attachedClients: [],
+    subscriptions: [],
+    primaryEmail: {
+      email: 'johndope@example.com',
+      isPrimary: true,
+      verified: true,
+    },
+    emails: [
+      {
+        email: 'johndope@example.com',
+        isPrimary: true,
+        verified: true,
+      },
+    ],
+    totp: {
+      exists: true,
+      verified: true,
+    },
+    linkedAccounts: [],
+    securityEvents: [],
+  };
+  const session = {
+    verified: true,
+    token: 'deadc0de',
+  };
+  const storageData = {
+    get: () => 'deadc0de',
+    setItem(_key: string, _value: string) {
+      return;
+    },
+  };
+  return Object.assign(
+    {
+      account,
+      session,
+      config: getDefault(),
+      alertBarInfo: new AlertBarInfo(),
+      storageData,
+    },
+    context
+  ) as AppContextValue;
+}
+
 export const AppContext = React.createContext<AppContextValue>(
-  mockAppContext()
+  defaultAppContext()
 );

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -4,57 +4,74 @@
 
 import React from 'react';
 import { AccountData, ProfileInfo, Session } from '.';
-import { AppContextValue } from './AppContext';
+import { AppContext, AppContextValue, defaultAppContext } from './AppContext';
+
 import {
   createHistory,
   createMemorySource,
   LocationProvider,
+  History,
 } from '@reach/router';
 import { render } from '@testing-library/react';
 import { getDefault } from '../lib/config';
 import { AlertBarInfo } from './AlertBarInfo';
+import { ReachRouterWindow } from '../lib/window';
+import { UrlHashData, UrlQueryData } from '../lib/model-data';
 
-export const MOCK_ACCOUNT: AccountData = {
-  uid: 'abc123',
-  displayName: 'John Dope',
-  avatar: {
-    id: 'abc1234',
-    url: 'http://placekitten.com/512/512',
-    isDefault: false,
-  },
-  accountCreated: 123456789,
-  passwordCreated: 123456789,
-  hasPassword: true,
-  recoveryKey: true,
-  metricsEnabled: true,
-  attachedClients: [],
-  subscriptions: [],
-  primaryEmail: {
-    email: 'johndope@example.com',
-    isPrimary: true,
-    verified: true,
-  },
-  emails: [
-    {
-      email: 'johndope@example.com',
-      isPrimary: true,
-      verified: true,
-    },
-  ],
-  totp: {
-    exists: true,
-    verified: true,
-  },
-  linkedAccounts: [],
-  securityEvents: [],
-};
+const DEFAULT_APP_CONTEXT = defaultAppContext();
+export const MOCK_ACCOUNT: AccountData =
+  DEFAULT_APP_CONTEXT.account as unknown as AccountData;
+
+export function createHistoryWithQuery(path: string, queryParams?: string) {
+  const history = createHistory(createMemorySource(path));
+  if (queryParams) {
+    history.location.search = queryParams;
+  }
+  return history;
+}
+
+export function createAppContext(history: History) {
+  const windowWrapper = new ReachRouterWindow(history);
+  const appCtx = {
+    windowWrapper,
+    urlQueryData: new UrlQueryData(windowWrapper),
+    urlHashData: new UrlHashData(windowWrapper),
+    oauthClient: {},
+    authClient: {},
+    storageData: {},
+  } as AppContextValue;
+  return appCtx;
+}
+
+export function produceComponent(
+  ui: any,
+  { route = '/', history = createHistory(createMemorySource(route)) } = {},
+  appCtx?: AppContextValue
+) {
+  if (appCtx) {
+    return (
+      <AppContext.Provider value={appCtx}>
+        <LocationProvider {...{ history }}>{ui}</LocationProvider>
+      </AppContext.Provider>
+    );
+  }
+  return <LocationProvider {...{ history }}>{ui}</LocationProvider>;
+}
 
 export function renderWithRouter(
   ui: any,
-  { route = '/', history = createHistory(createMemorySource(route)) } = {}
+  { route = '/', history = createHistory(createMemorySource('/')) } = {},
+  appCtx?: AppContextValue
 ) {
+  if (!appCtx) {
+    return {
+      ...render(<LocationProvider {...{ history }}>{ui}</LocationProvider>),
+      history,
+    };
+  }
+
   return {
-    ...render(<LocationProvider {...{ history }}>{ui}</LocationProvider>),
+    ...render(produceComponent(ui, { route, history }, appCtx)),
     history,
   };
 }

--- a/packages/fxa-settings/src/models/reliers/base-relier.ts
+++ b/packages/fxa-settings/src/models/reliers/base-relier.ts
@@ -9,6 +9,7 @@ import {
   ModelDataProvider,
   ModelValidation as V,
 } from '../../lib/model-data';
+import { MozServices } from '../../lib/types';
 
 export interface RelierSubscriptionInfo {
   subscriptionProductId: string;
@@ -53,6 +54,7 @@ export interface ResumeTokenInfo {
 }
 
 export interface Relier extends RelierData {
+  getServiceName(): MozServices;
   isOAuth(): boolean;
   isSync(): Promise<boolean>;
   shouldOfferToSync(view: string): boolean;
@@ -139,6 +141,26 @@ export class BaseRelier extends ModelDataProvider implements Relier {
   }
   async isSync(): Promise<boolean> {
     return false;
+  }
+
+  getServiceName(): MozServices {
+    switch (this.service) {
+      case MozServices.FirefoxSync:
+      case 'sync':
+        return MozServices.FirefoxSync;
+
+      case MozServices.FirefoxMonitor:
+        return MozServices.FirefoxMonitor;
+
+      case MozServices.MozillaVPN:
+        return MozServices.MozillaVPN;
+
+      case MozServices.Pocket:
+        return MozServices.Pocket;
+
+      default:
+        return MozServices.Default;
+    }
   }
   shouldOfferToSync(view: string): boolean {
     return false;

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
@@ -4,9 +4,13 @@
 
 import React from 'react';
 import ResetPasswordWithRecoveryKeyVerified from '.';
-import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from '../../../../.storybook/decorators';
+import {
+  produceComponent,
+  createAppContext,
+  createHistoryWithQuery,
+} from '../../../models/mocks';
 
 export default {
   title: 'Pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified',
@@ -14,20 +18,19 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const DefaultSignedIn = () => (
-  <LocationProvider>
-    <ResetPasswordWithRecoveryKeyVerified isSignedIn isSync={false} />
-  </LocationProvider>
-);
+const route = '/reset_password_with_recovery_key_verified';
 
-export const DefaultSignedOut = () => (
-  <LocationProvider>
-    <ResetPasswordWithRecoveryKeyVerified isSignedIn={false} isSync={false} />
-  </LocationProvider>
-);
+function render(isSignedIn: boolean, queryParams?: string) {
+  const history = createHistoryWithQuery(route, queryParams);
+  const appCtx = createAppContext(history);
+  return produceComponent(
+    <ResetPasswordWithRecoveryKeyVerified isSignedIn={isSignedIn} />,
+    { route, history },
+    appCtx
+  );
+}
 
-export const WithSync = () => (
-  <LocationProvider>
-    <ResetPasswordWithRecoveryKeyVerified isSignedIn isSync />
-  </LocationProvider>
-);
+export const DefaultAccountSignedIn = () => render(true);
+export const DefaultAccountSignedOut = () => render(false);
+export const WithSyncAccountSignedIn = () => render(true, `service=sync`);
+export const WithSyncAccountSignedOut = () => render(false, `service=sync`);

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -2,20 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../../lib/metrics';
 import Ready from '../../../components/Ready';
-import { MozServices } from '../../../lib/types';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import AppLayout from '../../../components/AppLayout';
-import { useFtlMsgResolver } from '../../../models';
+import { CreateRelier, useFtlMsgResolver } from '../../../models';
 
 type ResetPasswordWithRecoveryKeyVerifiedProps = {
   isSignedIn: boolean;
-  serviceName?: MozServices;
-  isSync?: boolean;
 };
 
 export const viewName = 'reset-password-with-recovery-key-verified';
@@ -26,11 +23,11 @@ export const viewName = 'reset-password-with-recovery-key-verified';
 // even when the user is not signed in.
 
 const ResetPasswordWithRecoveryKeyVerified = ({
-  serviceName,
   isSignedIn,
-  isSync,
 }: ResetPasswordWithRecoveryKeyVerifiedProps & RouteComponentProps) => {
   const navigate = useNavigate();
+  const relier = CreateRelier();
+  const serviceName = relier.getServiceName();
 
   const ftlMsgResolver = useFtlMsgResolver();
 
@@ -50,6 +47,13 @@ const ResetPasswordWithRecoveryKeyVerified = ({
     logViewEvent(`flow.${viewName}`, eventName, REACT_ENTRYPOINT);
     navigate('/settings', { replace: true });
   };
+
+  const [isSync, setIsSync] = useState<boolean>();
+  useEffect(() => {
+    (async () => {
+      setIsSync(await relier.isSync());
+    })();
+  });
 
   return (
     <AppLayout title={localizedPageTitle}>

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -16,41 +16,59 @@ import {
   mockDefaultAccount,
 } from './mocks';
 
+import {
+  produceComponent,
+  createAppContext,
+  createHistoryWithQuery,
+} from '../../models/mocks';
+
 export default {
   title: 'Pages/ResetPassword',
   component: ResetPassword,
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = (
+const route = '/reset_password';
+
+function render(
   account: Account,
-  props?: Partial<ResetPasswordProps>
-) => {
-  const story = () => (
-    <AppContext.Provider value={{ account }}>
-      <LocationProvider>
-        <ResetPassword {...props} />
-      </LocationProvider>
-    </AppContext.Provider>
+  props?: Partial<ResetPasswordProps>,
+  queryParams?: string
+) {
+  const history = createHistoryWithQuery(route, queryParams);
+  return produceComponent(
+    <ResetPassword {...props} />,
+    { route, history },
+    {
+      ...createAppContext(history),
+      account,
+    }
   );
-  return story;
+}
+
+export const Default = () => {
+  return render(mockDefaultAccount);
 };
 
-export const Default = storyWithProps(mockDefaultAccount);
+export const WithServiceName = () => {
+  return render(
+    mockDefaultAccount,
+    undefined,
+    `service=${MozServices.MozillaVPN}`
+  );
+};
 
-export const WithServiceName = storyWithProps(mockDefaultAccount, {
-  serviceName: MozServices.MozillaVPN,
-});
+export const WithForceAuth = () => {
+  return render(mockDefaultAccount, {
+    prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
+    forceAuth: true,
+  });
+};
 
-export const WithForceAuth = storyWithProps(mockDefaultAccount, {
-  prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
-  forceAuth: true,
-});
+export const WithThrottledErrorOnSubmit = () => {
+  return render(mockAccountWithThrottledError);
+};
 
-export const WithThrottledErrorOnSubmit = storyWithProps(
-  mockAccountWithThrottledError
-);
-
-export const WithUnexpectedErrorOnSubmit = storyWithProps(
-  mockAccountWithUnexpectedError
-);
+export const WithUnexpectedErrorOnSubmit = () => {
+  return render(mockAccountWithUnexpectedError);
+};

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -4,13 +4,7 @@
 
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 
@@ -19,10 +13,14 @@ import ResetPassword, { viewName } from '.';
 import { REACT_ENTRYPOINT } from '../../constants';
 
 import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
-import { MozServices } from '../../lib/types';
 import { Account, AppContext } from '../../models';
 import { AuthUiErrorNos } from '../../lib/auth-errors/auth-errors';
 import { typeByLabelText } from '../../lib/test-utils';
+import {
+  createAppContext,
+  createHistoryWithQuery,
+  renderWithRouter,
+} from '../../models/mocks';
 
 const mockLogViewEvent = jest.fn();
 const mockLogPageViewEvent = jest.fn();
@@ -42,12 +40,37 @@ jest.mock('@reach/router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-function renderWithAccount(account: Account) {
-  render(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <ResetPassword />
-    </AppContext.Provider>
+const route = '/reset_password';
+const render = (ui: any, queryParams = '', account?: Account) => {
+  const history = createHistoryWithQuery(route, queryParams);
+  if (account) {
+    return renderWithRouter(
+      ui,
+      {
+        route,
+        history,
+      },
+      mockAppContext({
+        ...createAppContext(history),
+        account,
+      })
+    );
+  }
+
+  return renderWithRouter(
+    ui,
+    {
+      route,
+      history,
+    },
+    mockAppContext({
+      ...createAppContext(history),
+    })
   );
+};
+
+function renderWithAccount(account: Account) {
+  render(<ResetPassword />, '', account);
 }
 
 describe('PageResetPassword', () => {
@@ -80,10 +103,10 @@ describe('PageResetPassword', () => {
   });
 
   it('renders a custom service name in the header when it is provided', () => {
-    render(<ResetPassword serviceName={MozServices.MozillaVPN} />);
+    render(<ResetPassword />, 'service=sync');
     const headingEl = screen.getByRole('heading', { level: 1 });
     expect(headingEl).toHaveTextContent(
-      `Reset password to continue to Mozilla VPN`
+      `Reset password to continue to Firefox Sync`
     );
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../lib/auth-errors/auth-errors';
 import { usePageViewEvent, useMetrics } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
-import { useAccount, useFtlMsgResolver } from '../../models';
+import { CreateRelier, useAccount, useFtlMsgResolver } from '../../models';
 
 import { FtlMsg } from 'fxa-react/lib/utils';
 
@@ -41,8 +41,6 @@ type FormData = {
 
 // eslint-disable-next-line no-empty-pattern
 const ResetPassword = ({
-  // TODO: Pull service name from Relier model FXA-6437
-  serviceName = MozServices.Default,
   prefillEmail,
   forceAuth,
 }: ResetPasswordProps & RouteComponentProps) => {
@@ -52,8 +50,11 @@ const ResetPassword = ({
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [hasFocused, setHasFocused] = useState<boolean>(false);
   const account = useAccount();
+  const relier = CreateRelier();
   const navigate = useNavigate();
   const ftlMsgResolver = useFtlMsgResolver();
+
+  const serviceName = relier.getServiceName();
 
   const { control, getValues, handleSubmit, register } = useForm<FormData>({
     mode: 'onTouched',


### PR DESCRIPTION
## Because

- We access these settings through the relier

## This pull request

- Uses the relier model to determine if relier is in sync mode
- Some clean up to mocks.tsx
- Removes circular dependency between AppContext and mocks.tsx


## Issue that this pull request solves

Closes: FXA-6804

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is the exact same PR as [this](https://github.com/mozilla/fxa/pull/15395). I amended a commit through VSCODE's IDE and then forced pushed. It turns out the commit must not have actually finished by the time I forced pushed. This resulted in pushing any empty branch, and github subsequently closed the PR, and it cannot be reopened now. The force push was an effort to address your feedback.
