### PR TITLE
fix(ip): Set x-forwarded-for header from gql to auth-server

### DIFF
--- a/packages/fxa-graphql-api/src/decorators.ts
+++ b/packages/fxa-graphql-api/src/decorators.ts
@@ -45,6 +45,13 @@ export const GqlXHeaders = createParamDecorator(
     // We don't need to propagate the authorization token because
     // it needs to be updated to originate from gql server.
     delete headers['authorization'];
+    
+    // Set the x-forwarded-for header since the auth-server will use this
+    // to determine client geolocation
+    if (ctx.req?.ip) {
+     headers['x-forwarded-for'] = ctx.req?.ip;
+    }
+    
     return new Headers(headers);
   }
 );


### PR DESCRIPTION
## Because

- The correct ip address was not being sent to auth-server from graphql server

## This pull request

- Sets the `x-forwarded-for` header to the cllient ip address, the auth-server uses this value to perform geo location

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6858

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
