### PR TITLE
DRAFT task(functional-tests): Add missing reset password tests in Playwright

### DIFF
--- a/packages/functional-tests/lib/ci-reporter.ts
+++ b/packages/functional-tests/lib/ci-reporter.ts
@@ -37,8 +37,8 @@ class CIReporter implements Reporter {
       }`
     );
     if (test.outcome() === 'unexpected') {
-      console.log(result.error.stack);
-      console.log(result.error.message);
+      console.log(result.error?.stack);
+      console.log(result.error?.message);
     }
   }
 

--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -87,7 +87,7 @@ export class EmailClient {
     emailAddress: string,
     type: EmailType,
     header?: EmailHeader,
-    timeout: number = 15000
+    timeout = 15000
   ) {
     const expires = Date.now() + timeout;
     while (Date.now() < expires) {

--- a/packages/functional-tests/lib/react-flag.ts
+++ b/packages/functional-tests/lib/react-flag.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseTarget } from './targets/base';
+
+export function getReactFeatureFlagUrl(
+  target: BaseTarget,
+  path: string,
+  params?: string
+) {
+  if (params) {
+    return `${target.contentServerUrl}${path}?showReactApp=true&${params}`;
+  } else {
+    return `${target.contentServerUrl}${path}?showReactApp=true`;
+  }
+}

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -1,5 +1,4 @@
 import { BaseLayout } from './layout';
-import { LoginPage } from './login';
 
 export const selectors = {
   RESET_PASSWORD_EXPIRED_HEADER: '#fxa-reset-link-expired-header',
@@ -28,6 +27,14 @@ export class ResetPasswordPage extends BaseLayout {
     return resetPass.isVisible();
   }
 
+  async beginResetPasswordHeadingReact() {
+    const beginResetPasswordHeading = this.page.getByRole('heading', {
+      name: 'Reset password to continue to account settings',
+    });
+    await beginResetPasswordHeading.waitFor();
+    return beginResetPasswordHeading.isVisible();
+  }
+
   async confirmResetPasswordHeader() {
     const resetPass = this.page.locator(
       selectors.CONFIRM_RESET_PASSWORD_HEADER
@@ -36,12 +43,28 @@ export class ResetPasswordPage extends BaseLayout {
     return resetPass.isVisible();
   }
 
-  async completeResetPasswordHeader() {
-    const resetPass = this.page.locator(
-      selectors.RESET_PASSWORD_COMPLETE_HEADER
-    );
-    await resetPass.waitFor();
-    return resetPass.isVisible();
+  async confirmResetPasswordHeadingReact() {
+    const confirmResetPasswordHeading = this.page.getByRole('heading', {
+      name: 'Reset email sent',
+    });
+    await confirmResetPasswordHeading.waitFor();
+    return confirmResetPasswordHeading.isVisible();
+  }
+
+  async hasCompleteResetPasswordHeading(page: BaseLayout['page'] = this.page) {
+    const completeResetPasswordHeading = page.getByRole('heading', {
+      name: 'Create new password',
+    });
+    await completeResetPasswordHeading.waitFor();
+    return completeResetPasswordHeading.isVisible();
+  }
+
+  async resetPasswordConfirmedReact(page: BaseLayout['page'] = this.page) {
+    const resetPasswordConfirmedHeading = page.getByRole('heading', {
+      name: 'Your password has been reset',
+    });
+    await resetPasswordConfirmedHeading.waitFor();
+    return resetPasswordConfirmedHeading.isVisible();
   }
 
   async resetPasswordLinkExpiredHeader() {
@@ -52,10 +75,24 @@ export class ResetPasswordPage extends BaseLayout {
     return resetPass.isVisible();
   }
 
-  async resetNewPassword(password: string) {
-    await this.page.locator(selectors.PASSWORD).fill(password);
-    await this.page.locator(selectors.VPASSWORD).fill(password);
-    await this.page.locator(selectors.SUBMIT).click();
+  async resetNewPassword(
+    password: string,
+    page: BaseLayout['page'] = this.page
+  ) {
+    await page.locator(selectors.PASSWORD).fill(password);
+    await page.locator(selectors.VPASSWORD).fill(password);
+    await page.locator(selectors.SUBMIT).click();
+  }
+
+  async submitNewPasswordReact(
+    password: string,
+    page: BaseLayout['page'] = this.page
+  ) {
+    await page.getByRole('textbox', { name: 'New password' }).fill(password);
+    await page
+      .getByRole('textbox', { name: 'Re-enter password' })
+      .fill(password);
+    await page.locator(selectors.SUBMIT).click();
   }
 
   async fillOutResetPassword(email) {

--- a/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-import { BaseTarget } from '../../lib/targets/base';
-
-function getReactFeatureFlagUrl(target: BaseTarget, path: string) {
-  return `${target.contentServerUrl}${path}?showReactApp=true`;
-}
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.beforeEach(async ({ pages: { login } }) => {
   // This test requires simple react routes to be enabled

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -3,15 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-import { BaseTarget } from '../../lib/targets/base';
-
-function getReactFeatureFlagUrl(
-  target: BaseTarget,
-  path: string,
-  showReactApp = true
-) {
-  return `${target.contentServerUrl}${path}?showReactApp=${showReactApp}`;
-}
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.beforeEach(async ({ pages: { login } }) => {
   // This test requires simple react routes to be enabled

--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -1,20 +1,12 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
-import { BaseTarget } from '../../lib/targets/base';
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 let key;
 let hint;
 let originalEncryptionKeys;
 
 const NEW_PASSWORD = 'notYourAveragePassW0Rd';
-
-function getReactFeatureFlagUrl(
-  target: BaseTarget,
-  path: string,
-  showReactApp = true
-) {
-  return `${target.contentServerUrl}${path}?showReactApp=${showReactApp}`;
-}
 
 test.describe('recovery key react', () => {
   test.beforeEach(

--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -3,12 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-import { BaseTarget } from '../../lib/targets/base';
 import { EmailHeader, EmailType } from '../../lib/email';
-
-function getReactFeatureFlagUrl(target: BaseTarget, path: string) {
-  return `${target.contentServerUrl}${path}?showReactApp=true`;
-}
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 const NEW_PASSWORD = 'notYourAveragePassW0Rd';
 
@@ -20,31 +16,29 @@ test.describe('reset password', () => {
     test.skip(config.showReactApp.resetPasswordRoutes !== true);
   });
 
-  test('can reset password', async ({ page, target, credentials, context }) => {
+  test('can reset password', async ({
+    page,
+    target,
+    credentials,
+    context,
+    pages: { login, resetPassword, settings },
+  }) => {
     await page.goto(getReactFeatureFlagUrl(target, '/reset_password'));
 
     // Verify react page has been loaded
     await page.waitForSelector('#root');
 
-    await page.locator('input').fill(credentials.email);
-    let waitForNavigation = page.waitForNavigation();
-    await page.locator('text="Begin reset"').click();
-    await waitForNavigation;
+    await resetPassword.fillOutResetPassword(credentials.email);
 
-    // Verify confirm password reset page elements
-    expect(
-      await page.locator('text="Reset email sent"').isEnabled()
-    ).toBeTruthy();
-    expect(
-      await page.locator('text="Remember your password? Sign in"').isEnabled()
-    ).toBeTruthy();
-    expect(
-      await page
-        .locator('text="Not in inbox or spam folder? Resend"')
-        .isVisible()
-    ).toBeTruthy();
+    // Wait for navigation after email submitted
+    await page.waitForURL(
+      getReactFeatureFlagUrl(target, '/confirm_reset_password')
+    );
 
-    // We need to append `&showReactApp=true` to reset link inorder to enroll in reset password experiment
+    // Verify confirm password reset page rendered
+    expect(await resetPassword.confirmResetPasswordHeadingReact()).toBe(true);
+
+    // We need to append `&showReactApp=true` to reset link in order to enroll in reset password experiment
     let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,
@@ -56,52 +50,186 @@ test.describe('reset password', () => {
     const diffPage = await context.newPage();
     await diffPage.goto(link);
 
-    // Loads the React version
-    expect(await diffPage.locator('#root').isEnabled()).toBeTruthy();
-    expect(
-      await diffPage.locator('text="Create new password"').isEnabled()
-    ).toBeTruthy();
-    expect(
-      await diffPage
-        .locator('text="Remember your password? Sign in"')
-        .isEnabled()
-    ).toBeTruthy();
+    // Renders the React version of complete password reset page
+    expect(await diffPage.locator('#root').isEnabled()).toBe(true);
+    expect(await resetPassword.hasCompleteResetPasswordHeading(diffPage)).toBe(
+      true
+    );
 
-    await diffPage.locator('input[name="newPassword"]').fill(NEW_PASSWORD);
-    await diffPage.locator('input[name="confirmPassword"]').fill(NEW_PASSWORD);
+    // Create and submit new password
+    await resetPassword.submitNewPasswordReact(NEW_PASSWORD, diffPage);
 
-    const pageWaitForNavigation = page.waitForNavigation();
-    const diffPageWaitForNavigation = diffPage.waitForNavigation();
-    await diffPage.locator('text="Reset password"').click();
-    await diffPageWaitForNavigation;
-    await pageWaitForNavigation;
+    // Wait for new page to navigate
+    await diffPage.waitForURL(
+      `${target.contentServerUrl}/reset_password_verified`
+    );
 
-    expect(
-      await diffPage.locator('text="Your password has been reset"').isEnabled()
-    ).toBeTruthy();
+    // Wait for initial page to automatically redirect once password is reset
+    await page.waitForURL(`${target.contentServerUrl}/signin`);
+
+    // Verify password reset confirmation page is rendered
+    expect(await resetPassword.resetPasswordConfirmedReact(diffPage)).toBe(
+      true
+    );
 
     await diffPage.close();
 
+    // Verify initial page redirected to sign in and sign in page rendered
+    expect(await login.emailHeader.isEnabled()).toBe(true);
+
+    await login.setEmail(credentials.email);
+    await login.clickSubmit();
+    await page.waitForURL(`${target.contentServerUrl}/signin`);
+
+    await login.setPassword(NEW_PASSWORD);
+    await login.clickSubmit();
+    await page.waitForURL(`${target.contentServerUrl}/settings`);
+
     expect(
-      await page.locator('text="Enter your email"').isEnabled()
-    ).toBeTruthy();
-
-    await page.locator('input[type=email]').fill(credentials.email);
-
-    waitForNavigation = page.waitForNavigation();
-    await page.locator('text="Sign up or sign in"').click();
-    await waitForNavigation;
-
-    await page.locator('#password').fill(NEW_PASSWORD);
-
-    waitForNavigation = page.waitForNavigation();
-    await page.locator('text="Sign in"').click();
-    await waitForNavigation;
-
-    const settingsHeader = await page.locator('text=Settings');
-    expect(await settingsHeader.isEnabled()).toBeTruthy();
+      await page
+        .getByRole('heading', { name: 'Settings', level: 2 })
+        .isEnabled()
+    ).toBe(true);
 
     // Cleanup requires setting this value to correct password
     credentials.password = NEW_PASSWORD;
+  });
+
+  /* TODO test reset pw validation errors
+   * - short password (e.g., "pass")
+   * - common password (e.g., "password")
+   * - user emails (e.g., credentials.email)
+   *
+   * In these cases, confirm that error feedback is displayed and form is not submitted
+   */
+
+  test('visit confirmation screen without initiating reset_password, user is redirected to /reset_password', async ({
+    target,
+    page,
+    pages: { resetPassword },
+  }) => {
+    await page.goto(getReactFeatureFlagUrl(target, '/confirm_reset_password'));
+
+    // Verify its redirected to react reset password page
+    expect(await page.locator('#root').isEnabled()).toBe(true);
+    expect(await resetPassword.beginResetPasswordHeadingReact()).toBe(true);
+  });
+
+  test('open /reset_password page from /signin', async ({
+    credentials,
+    page,
+    pages: { login },
+  }) => {
+    await login.goto();
+    await login.setEmail(credentials.email);
+    await login.submit();
+    await login.clickForgotPassword();
+    // Verify react page has been loaded - to be enabled when link to react page from sign in is active
+    // await page.waitForSelector('#root');
+  });
+
+  test('enter an email with leading whitespace', async ({
+    credentials,
+    target,
+    page,
+    pages: { resetPassword },
+  }) => {
+    await page.goto(getReactFeatureFlagUrl(target, '/reset_password'));
+    await resetPassword.fillOutResetPassword(' ' + credentials.email);
+    await page.waitForURL(
+      getReactFeatureFlagUrl(target, '/confirm_reset_password')
+    );
+    expect(await resetPassword.confirmResetPasswordHeadingReact()).toBe(true);
+  });
+
+  test('enter an email with trailing whitespace', async ({
+    credentials,
+    target,
+    page,
+    pages: { resetPassword },
+  }) => {
+    await page.goto(getReactFeatureFlagUrl(target, '/reset_password'));
+    await resetPassword.fillOutResetPassword(credentials.email + ' ');
+    await page.waitForURL(
+      getReactFeatureFlagUrl(target, '/confirm_reset_password')
+    );
+    expect(await resetPassword.confirmResetPasswordHeadingReact()).toBe(true);
+  });
+
+  test('open confirm_reset_password page, click resend', async ({
+    credentials,
+    target,
+    page,
+    pages: { resetPassword },
+  }) => {
+    await page.goto(getReactFeatureFlagUrl(target, '/reset_password'));
+
+    // Verify react page is loaded
+    await page.waitForSelector('#root');
+
+    await resetPassword.fillOutResetPassword(credentials.email);
+    await page.waitForURL(
+      getReactFeatureFlagUrl(target, '/confirm_reset_password')
+    );
+    expect(await resetPassword.confirmResetPasswordHeadingReact()).toBe(true);
+
+    const resendButton = await page.getByRole('button', {
+      name: 'Not in inbox or spam folder? Resend',
+    });
+    expect(await resendButton.isEnabled()).toBeTruthy();
+    expect(await resendButton.isVisible()).toBeTruthy();
+    await resendButton.click();
+    expect(
+      await page
+        .getByText(
+          'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+        )
+        .isEnabled()
+    ).toBeTruthy();
+  });
+
+  test('open /reset_password page, enter unknown email, wait for error', async ({
+    target,
+    page,
+    pages: { login, resetPassword },
+  }) => {
+    await page.goto(getReactFeatureFlagUrl(target, '/reset_password'));
+
+    // Verify react page is loaded
+    expect(await page.locator('#root').isEnabled()).toBe(true);
+
+    await page
+      .getByRole('textbox', { name: 'Email' })
+      .fill('email@restmail.net');
+    await page.getByRole('button', { name: 'Begin reset' }).click();
+    expect(await page.getByText('Unknown account').isEnabled()).toBeTruthy();
+  });
+
+  test('browse directly to page with email on query params', async ({
+    credentials,
+    target,
+    page,
+    pages: { resetPassword },
+  }) => {
+    await page.goto(
+      getReactFeatureFlagUrl(
+        target,
+        '/reset_password',
+        `email=${credentials.email}`
+      )
+    );
+
+    // Verify react page is loaded
+    expect(await page.locator('#root').isEnabled()).toBe(true);
+
+    //The email shouldn't be pre-filled
+    const emailInput = await resetPassword.getEmailValue();
+    expect(emailInput).toHaveValue('');
+    await resetPassword.fillOutResetPassword(credentials.email);
+    await page.waitForURL(
+      getReactFeatureFlagUrl(target, '/confirm_reset_password')
+    );
+    expect(await page.locator('#root').isEnabled()).toBe(true);
+    expect(await resetPassword.confirmResetPasswordHeadingReact()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { EmailHeader, EmailType } from '../../lib/email';
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Firefox Desktop Sync v3 reset password react', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    // Ensure that the feature flag is enabled
+    const config = await login.getConfig();
+    test.skip(config.showReactApp.resetPasswordRoutes !== true);
+  });
+
+  test('reset pw for sync user', async ({ credentials, target }) => {
+    const { browser, page, resetPassword } = await newPagesForSync(target);
+    await page.goto(
+      getReactFeatureFlagUrl(
+        target,
+        '/reset_password',
+        'context=fx_desktop_v3&service=sync'
+      )
+    );
+
+    // Verify react page has been loaded
+    await page.waitForSelector('#root');
+
+    // Check that the sync relier is in the heading
+    expect(await page.getByRole('heading')).toHaveText(
+      'Reset password to continue to Firefox Sync'
+    );
+
+    await resetPassword.fillOutResetPassword(credentials.email);
+
+    // We need to append `&showReactApp=true` to reset link in order to enroll in reset password experiment
+    let link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    link = `${link}&showReactApp=true`;
+
+    await page.goto(link);
+
+    const waitForNavigation = page.waitForURL(
+      `${target.contentServerUrl}/reset_password_verified`,
+      {
+        waitUntil: 'networkidle',
+      }
+    );
+    await resetPassword.submitNewPasswordReact('Newpassword@');
+    await waitForNavigation;
+
+    expect(await resetPassword.resetPasswordConfirmedReact()).toBe(true);
+
+    // Update credentials file so that account can be deleted as part of test cleanup
+    credentials.password = 'Newpassword@';
+
+    await browser?.close();
+  });
+});

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -56,7 +56,7 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
     expect(await login.notCommonPasswordUnmetError()).toBe(true);
 
     await resetPassword.resetNewPassword('Newpassword@');
-    expect(await resetPassword.completeResetPasswordHeader()).toBe(true);
+    expect(await resetPassword.hasCompleteResetPasswordHeading()).toBe(true);
 
     // Update credentials file so that account can be deleted as part of test cleanup
     credentials.password = 'Newpassword@';


### PR DESCRIPTION
DRAFT - NOT READY FOR REVIEW

## Because

* We need to enable all tests for react reset password flows while continuing to test backbone reset password flows (still in production)

## This pull request

* Add playwright test for backbone reset password route
* Add additional tests for react reset password route
* Add react reset password test for sync

## Issue that this pull request solves

Closes: #FXA-7248

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
