### PR TITLE
fix(payments): add auth to coupon API

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -1059,7 +1059,11 @@ export const stripeRoutes = (
       path: '/oauth/subscriptions/coupon',
       options: {
         ...SUBSCRIPTIONS_DOCS.OAUTH_SUBSCRIPTIONS_COUPON_POST,
-        auth: false,
+        auth: {
+          payload: false,
+          strategy: 'oauthToken',
+          mode: 'try',
+        },
         response: {
           schema: couponDTO.couponDetailsSchema as any,
         },


### PR DESCRIPTION
## Because

- Coupon endpoint should support credentialed requests.

## This pull request

- Adds support for optional auth credentials.

## Issue that this pull request solves

Closes: #FXA-7451

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
