### PR TITLE
fix(fxa-settings): Disable double-clicking on buttons in account recovery key flow

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -50,6 +50,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
 
   const [errorText, setErrorText] = useState<string>();
   const [bannerText, setBannerText] = useState<string>();
+  const [isLoading, setIsLoading] = useState(false);
 
   const { formState, getValues, handleSubmit, register } = useForm<FormData>({
     mode: 'all',
@@ -92,6 +93,8 @@ export const FlowRecoveryKeyConfirmPwd = ({
         setBannerText(localizedError);
       }
       logViewEvent(`flow.${viewName}`, 'confirm-password.fail');
+    } finally {
+      setIsLoading(false);
     }
   }, [
     account,
@@ -133,6 +136,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
 
         <form
           onSubmit={handleSubmit(({ password }) => {
+            setIsLoading(true);
             createRecoveryKey();
           })}
         >
@@ -156,7 +160,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
               <button
                 className="cta-primary cta-xl w-full mt-4"
                 type="submit"
-                disabled={!formState.isDirty || !!formState.errors.password}
+                disabled={isLoading || !formState.isDirty}
               >
                 Create account recovery key
               </button>
@@ -167,7 +171,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
               <button
                 className="cta-primary cta-xl w-full mt-4"
                 type="submit"
-                disabled={!formState.isDirty || !!formState.errors.password}
+                disabled={isLoading || !formState.isDirty}
               >
                 Create new account recovery key
               </button>

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -43,6 +43,7 @@ export const FlowRecoveryKeyHint = ({
   const alertBar = useAlertBar();
   const [bannerText, setBannerText] = useState<string>();
   const [hintError, setHintError] = useState<string>();
+  const [isLoading, setIsLoading] = useState(false);
   const ftlMsgResolver = useFtlMsgResolver();
 
   const { control, getValues, handleSubmit, register } = useForm<FormData>({
@@ -84,6 +85,7 @@ export const FlowRecoveryKeyHint = ({
   };
 
   const onSubmit = async ({ hint }: FormData) => {
+    setIsLoading(true);
     const trimmedHint = hint.trim();
 
     if (trimmedHint.length === 0) {
@@ -117,6 +119,8 @@ export const FlowRecoveryKeyHint = ({
           }
           setBannerText(localizedError);
           logViewEvent(viewName, 'create-hint.fail', e);
+        } finally {
+          setIsLoading(false);
         }
       }
     }
@@ -194,6 +198,7 @@ export const FlowRecoveryKeyHint = ({
             <button
               className="cta-primary cta-xl w-full mt-6 mb-4"
               type="submit"
+              disabled={isLoading}
             >
               Finish
             </button>

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import { useEscKeydownEffect, useChangeFocusEffect } from '../../../lib/hooks';
 import classNames from 'classnames';
@@ -25,6 +25,7 @@ type ModalProps = {
   confirmText?: string;
   confirmBtnClassName?: string;
   'data-testid'?: string;
+  isLoading?: boolean;
 };
 
 export const Modal = ({
@@ -40,6 +41,7 @@ export const Modal = ({
   confirmText,
   confirmBtnClassName = 'cta-primary cta-base-p',
   'data-testid': testid = 'modal',
+  isLoading = false,
 }: ModalProps) => {
   const modalInsideRef = useClickOutsideEffect<HTMLDivElement>(onDismiss);
   const tabFenceRef = useChangeFocusEffect();
@@ -119,7 +121,10 @@ export const Modal = ({
                   <button
                     className={classNames('mx-2 flex-1', confirmBtnClassName)}
                     data-testid="modal-confirm"
-                    onClick={(event) => onConfirm()}
+                    onClick={(event) => {
+                      onConfirm();
+                    }}
+                    disabled={isLoading}
                   >
                     {confirmText || localizedDefaultConfirmText}
                   </button>

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
@@ -27,6 +27,7 @@ export const UnitRowRecoveryKey = () => {
   const alertBar = useAlertBar();
   const [deleteModalVisible, setDeleteModalVisible] = useState<boolean>(false);
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const ftlMsgResolver = useFtlMsgResolver();
 
   const deleteRecoveryKey = useCallback(async () => {
@@ -51,6 +52,8 @@ export const UnitRowRecoveryKey = () => {
         )
       );
       logViewEvent('flow.settings.account-recovery', 'confirm-revoke.fail');
+    } finally {
+      setIsLoading(false);
     }
   }, [account, hideModal, alertBar, ftlMsgResolver]);
 
@@ -171,6 +174,7 @@ export const UnitRowRecoveryKey = () => {
               setDeleteModalVisible(false);
             }}
             onConfirm={() => {
+              setIsLoading(true);
               deleteRecoveryKey();
               logViewEvent(
                 'flow.settings.account-recovery',
@@ -181,6 +185,7 @@ export const UnitRowRecoveryKey = () => {
             confirmText={ftlMsgResolver.getMsg('rk-action-remove', 'Remove')}
             headerId="recovery-key-header"
             descId="recovery-key-desc"
+            isLoading={isLoading}
           >
             <FtlMsg id="rk-remove-modal-heading-1">
               <h2


### PR DESCRIPTION
## Because

* We want to prevent users from clicking on submit buttons multiple times while account updates are in progress, and also provide users with feedback that the form has been submitted.
* Clicking on the confirm password button multiple times would result in an error banner "Account recovery key already exists"

## This pull request

* Disable submit button when account is in loading state.

## Issue that this pull request solves

Closes: #FXA-7551

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

https://github.com/mozilla/fxa/assets/22231637/1efb0666-82a8-4b58-8ef9-2cefa15b528f

## Other information (Optional)

Any other information that is important to this pull request.
