### PR TITLE
fix(fxa-settings): Fix l10n and a11y of confirm password input

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -136,23 +136,21 @@ export const FlowRecoveryKeyConfirmPwd = ({
             createRecoveryKey();
           })}
         >
-          <FtlMsg
-            id="flow-recovery-key-confirm-pwd-input-label"
-            attrs={{ label: true }}
-          >
-            <InputPassword
-              name="password"
-              label="Enter your password"
-              onChange={() => {
-                errorText && setErrorText(undefined);
-                bannerText && setBannerText(undefined);
-              }}
-              inputRef={register({
-                required: true,
-              })}
-              {...{ errorText }}
-            />
-          </FtlMsg>
+          <InputPassword
+            name="password"
+            label={ftlMsgResolver.getMsg(
+              'flow-recovery-key-confirm-pwd-input-label',
+              'Enter your password'
+            )}
+            onChange={() => {
+              errorText && setErrorText(undefined);
+              bannerText && setBannerText(undefined);
+            }}
+            inputRef={register({
+              required: true,
+            })}
+            {...{ errorText }}
+          />
           {action === RecoveryKeyAction.Create && (
             <FtlMsg id="flow-recovery-key-confirm-pwd-submit-button">
               <button


### PR DESCRIPTION
## Because

* The account recovery key creation flow's password input label must be localized.
* The label should only be read once by speech readers.

## This pull request

* Use ftlMsgResolver for the label's l10n.

## Issue that this pull request solves

Closes: #FXA-7565

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before (not localized)
![image](https://github.com/mozilla/fxa/assets/22231637/001d096b-3bab-414a-87ab-ce94d9e93c6c)

After (localized)
![image](https://github.com/mozilla/fxa/assets/22231637/4920b6de-9da7-4fe9-aedb-bce4a6cec80f)

## Other information (Optional)

Tested with VoiceOver on MacOS - reproduced that label was previously read twice, and now only once with this PR.
