### PR TITLE
fix(fxa-settings): Do not allow key change if password incorrect

### DIFF
--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -19,7 +19,7 @@ export const ButtonDownloadRecoveryKey = ({
   viewName,
 }: ButtonDownloadRecoveryKeyProps) => {
   // TODO: format by locale
-  const { primaryEmail } = useAccount();
+  const account = useAccount();
   const currentDate = new Date();
   const downloadDateInLocale = currentDate.toLocaleDateString(
     navigator.language
@@ -44,8 +44,8 @@ export const ButtonDownloadRecoveryKey = ({
 
   const fileUserEmail = ftlMsgResolver.getMsg(
     'recovery-key-file-user-email-v2',
-    `* Firefox account: ${primaryEmail.email}`,
-    { email: primaryEmail.email }
+    `* Firefox account: ${account.primaryEmail.email}`,
+    { email: account.primaryEmail.email }
   );
 
   const fileDate = ftlMsgResolver.getMsg(
@@ -87,7 +87,7 @@ export const ButtonDownloadRecoveryKey = ({
     // filename should be kept much shorter (maxLength is arbitrary).
     const maxLength = 75;
     const prefix = 'Firefox-Recovery-Key';
-    let email = primaryEmail.email;
+    let email = account.primaryEmail.email;
     let filename = `${prefix}_${date}_${email}.txt`;
 
     if (filename.length > maxLength) {

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
@@ -5,9 +5,11 @@
 import React, { useState } from 'react';
 import { FlowRecoveryKeyConfirmPwd } from '.';
 import { Meta } from '@storybook/react';
-import { useFtlMsgResolver } from '../../../models';
+import { Account, AppContext, useFtlMsgResolver } from '../../../models';
 import { withLocalization } from '../../../../.storybook/decorators';
-import { RecoveryKeyAction } from '../PageRecoveryKeyCreate';
+import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
+import AppLayout from '../AppLayout';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 
 export default {
   title: 'Components/Settings/FlowRecoveryKeyConfirmPwd',
@@ -18,16 +20,61 @@ export default {
 const viewName = 'example-view-name';
 
 const navigateBackward = () => {
-  alert('navigating to previous page');
+  alert('Going back!');
 };
 
 const navigateForward = () => {
-  alert('navigating to next view within wizard');
+  alert('Success!');
 };
 
-export const CreateKey = () => {
+const accountWithChangeKeySuccess = {
+  ...MOCK_ACCOUNT,
+  changeRecoveryKey: () => {
+    return new Uint8Array(20);
+  },
+  deleteRecoveryKey: () => {
+    return true;
+  },
+  recoveryKey: true,
+} as unknown as Account;
+
+const accountWithCreateKeySuccess = {
+  ...MOCK_ACCOUNT,
+  createRecoveryKey: () => {
+    return new Uint8Array(20);
+  },
+  deleteRecoveryKey: () => {
+    return true;
+  },
+  recoveryKey: false,
+} as unknown as Account;
+
+const accountWithInvalidPasswordOnSubmit = {
+  ...MOCK_ACCOUNT,
+  createRecoveryKey: () => {
+    throw AuthUiErrors.INCORRECT_PASSWORD;
+  },
+  deleteRecoveryKey: () => {
+    return true;
+  },
+  recoveryKey: false,
+} as unknown as Account;
+
+const accountWithThrottledErrorOnSubmit = {
+  ...MOCK_ACCOUNT,
+  createRecoveryKey: () => {
+    throw AuthUiErrors.THROTTLED;
+  },
+  deleteRecoveryKey: () => {
+    return true;
+  },
+  recoveryKey: false,
+} as unknown as Account;
+
+const StoryWithContext = (account: Account) => {
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>('');
   const ftlMsgResolver = useFtlMsgResolver();
+
   const localizedBackButtonTitle = ftlMsgResolver.getMsg(
     'recovery-key-create-back-button',
     'Back to settings'
@@ -38,42 +85,29 @@ export const CreateKey = () => {
   );
 
   return (
-    <FlowRecoveryKeyConfirmPwd
-      {...{
-        localizedBackButtonTitle,
-        localizedPageTitle,
-        navigateBackward,
-        navigateForward,
-        setFormattedRecoveryKey,
-        viewName,
-      }}
-    />
+    <AppContext.Provider value={mockAppContext({ account })}>
+      <AppLayout>
+        <FlowRecoveryKeyConfirmPwd
+          {...{
+            localizedBackButtonTitle,
+            localizedPageTitle,
+            navigateBackward,
+            navigateForward,
+            setFormattedRecoveryKey,
+            viewName,
+          }}
+        />
+      </AppLayout>
+    </AppContext.Provider>
   );
 };
 
-export const ChangeKey = () => {
-  const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>('');
-  const ftlMsgResolver = useFtlMsgResolver();
-  const localizedBackButtonTitle = ftlMsgResolver.getMsg(
-    'recovery-key-create-back-button',
-    'Back to settings'
-  );
-  const localizedPageTitle = ftlMsgResolver.getMsg(
-    'recovery-key-create-page-title',
-    'Account Recovery Key'
-  );
+export const CreateKey = () => StoryWithContext(accountWithCreateKeySuccess);
 
-  return (
-    <FlowRecoveryKeyConfirmPwd
-      action={RecoveryKeyAction.Change}
-      {...{
-        localizedBackButtonTitle,
-        localizedPageTitle,
-        navigateBackward,
-        navigateForward,
-        setFormattedRecoveryKey,
-        viewName,
-      }}
-    />
-  );
-};
+export const ChangeKey = () => StoryWithContext(accountWithChangeKeySuccess);
+
+export const WithTooltipErrorOnSubmit = () =>
+  StoryWithContext(accountWithInvalidPasswordOnSubmit);
+
+export const WithBannerErrorOnSubmit = () =>
+  StoryWithContext(accountWithThrottledErrorOnSubmit);

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { RecoveryKeyAction } from '../PageRecoveryKeyCreate';
 
 const localizedBackButtonTitle = 'Back to settings';
 const localizedPageTitle = 'Account Recovery Key';
@@ -33,43 +32,44 @@ jest.mock('base32-encode', () =>
 
 const setFormattedRecoveryKey = jest.fn();
 
-const accountWithSuccess = {
-  ...MOCK_ACCOUNT,
+const accountWithKeyCreationSuccess = {
+  accountRecovery: false,
   createRecoveryKey: jest.fn().mockResolvedValue(new Uint8Array(20)),
+} as unknown as Account;
+
+const accountWithKeyChangeSuccess = {
+  ...MOCK_ACCOUNT,
+  accountRecovery: true,
+  changeRecoveryKey: jest.fn().mockResolvedValue(new Uint8Array(20)),
   deleteRecoveryKey: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 
 const accountWithPasswordError = {
-  ...MOCK_ACCOUNT,
+  accountRecovery: false,
   createRecoveryKey: () => {
     throw AuthUiErrors.INCORRECT_PASSWORD;
   },
-  deleteRecoveryKey: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 
 const accountWithThrottledError = {
-  ...MOCK_ACCOUNT,
+  accountRecovery: false,
   createRecoveryKey: () => {
     throw AuthUiErrors.THROTTLED;
   },
-  deleteRecoveryKey: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 
 const accountWithUnexpectedError = {
-  ...MOCK_ACCOUNT,
+  accountRecovery: false,
   createRecoveryKey: () => {
     throw AuthUiErrors.UNEXPECTED_ERROR;
   },
-  deleteRecoveryKey: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 
-const renderFlowPage = (account: Account, action: RecoveryKeyAction) => {
-  window.URL.createObjectURL = jest.fn();
+const renderFlowPage = (account: Account) => {
   renderWithRouter(
     <AppContext.Provider value={mockAppContext({ account })}>
       <FlowRecoveryKeyConfirmPwd
         {...{
-          action,
           localizedBackButtonTitle,
           localizedPageTitle,
           navigateForward,
@@ -82,23 +82,26 @@ const renderFlowPage = (account: Account, action: RecoveryKeyAction) => {
   );
 };
 
-describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
+describe('FlowRecoveryKeyConfirmPwd', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders as expected', async () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Create);
+  it('renders as expected when the account does not have a key enabled', async () => {
+    renderFlowPage(accountWithKeyCreationSuccess);
 
     screen.getByRole('heading', {
       name: 'Re-enter your password for security',
     });
     screen.getByLabelText('Enter your password');
     screen.getByRole('button', { name: 'Create account recovery key' });
+    expect(
+      screen.queryByRole('link', { name: 'Cancel' })
+    ).not.toBeInTheDocument();
   });
 
   it('disables the submit button when the input is empty', async () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Create);
+    renderFlowPage(accountWithKeyCreationSuccess);
     const createRecoveryKeyButton = screen.getByRole('button', {
       name: 'Create account recovery key',
     });
@@ -121,7 +124,7 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
   });
 
   it('emits the expected metrics when the form is submitted with success', async () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Create);
+    renderFlowPage(accountWithKeyCreationSuccess);
     const createRecoveryKeyButton = screen.getByRole('button', {
       name: 'Create account recovery key',
     });
@@ -148,7 +151,7 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
   });
 
   it('renders an error message when the requests are throttled', async () => {
-    renderFlowPage(accountWithThrottledError, RecoveryKeyAction.Create);
+    renderFlowPage(accountWithThrottledError);
     const createRecoveryKeyButton = screen.getByRole('button', {
       name: 'Create account recovery key',
     });
@@ -176,7 +179,7 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
   });
 
   it('renders an error message when the password is incorrect', async () => {
-    renderFlowPage(accountWithPasswordError, RecoveryKeyAction.Create);
+    renderFlowPage(accountWithPasswordError);
     const createRecoveryKeyButton = screen.getByRole('button', {
       name: 'Create account recovery key',
     });
@@ -204,7 +207,7 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
   });
 
   it('renders an error message for unexpected errors', async () => {
-    renderFlowPage(accountWithUnexpectedError, RecoveryKeyAction.Create);
+    renderFlowPage(accountWithUnexpectedError);
     const createRecoveryKeyButton = screen.getByRole('button', {
       name: 'Create account recovery key',
     });
@@ -232,7 +235,7 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
   });
 
   it('emits the expected metrics when user navigates back', () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Create);
+    renderFlowPage(accountWithKeyCreationSuccess);
     fireEvent.click(screen.getByTestId('flow-container-back-btn'));
     expect(navigateBackward).toBeCalledTimes(1);
     expect(logViewEvent).toBeCalledWith(
@@ -240,15 +243,9 @@ describe('FlowRecoveryKeyConfirmPwd with Create Action', () => {
       'create-key.cancel'
     );
   });
-});
 
-describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('renders as expected', async () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
+  it('renders as expected when the account already has a key', async () => {
+    renderFlowPage(accountWithKeyChangeSuccess);
 
     screen.getByRole('heading', {
       name: 'Re-enter your password for security',
@@ -256,149 +253,5 @@ describe('FlowRecoveryKeyConfirmPwd with Change Action', () => {
     screen.getByLabelText('Enter your password');
     screen.getByRole('button', { name: 'Create new account recovery key' });
     screen.getByRole('link', { name: 'Cancel' });
-  });
-
-  it('disables the submit button when the input is empty', async () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
-    const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create new account recovery key',
-    });
-    const passwordInput = screen.getByLabelText('Enter your password');
-    expect(createRecoveryKeyButton).toHaveAttribute('disabled');
-    // input a password to enable form submission
-    fireEvent.input(passwordInput, {
-      target: { value: 'anypassword' },
-    });
-    await waitFor(() =>
-      expect(createRecoveryKeyButton).not.toHaveAttribute('disabled')
-    );
-    // clear password input disables the submit button
-    fireEvent.input(passwordInput, {
-      target: { value: '' },
-    });
-    await waitFor(() =>
-      expect(createRecoveryKeyButton).toHaveAttribute('disabled')
-    );
-  });
-
-  it('emits the expected metrics when the form is submitted with success', async () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
-    const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create new account recovery key',
-    });
-    const passwordInput = screen.getByLabelText('Enter your password');
-    // input a password to enable form submission
-    fireEvent.input(passwordInput, {
-      target: { value: 'anypassword' },
-    });
-    await waitFor(() =>
-      expect(createRecoveryKeyButton).not.toHaveAttribute('disabled')
-    );
-    fireEvent.click(createRecoveryKeyButton);
-    await waitFor(() => {
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.submit'
-      );
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.success'
-      );
-      expect(navigateForward).toBeCalledTimes(1);
-    });
-  });
-
-  it('renders an error message when the requests are throttled', async () => {
-    renderFlowPage(accountWithThrottledError, RecoveryKeyAction.Change);
-    const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create new account recovery key',
-    });
-    const passwordInput = screen.getByLabelText('Enter your password');
-    // input a password to enable form submission
-    fireEvent.input(passwordInput, {
-      target: { value: 'anypassword' },
-    });
-    await waitFor(() =>
-      expect(createRecoveryKeyButton).not.toHaveAttribute('disabled')
-    );
-    fireEvent.click(createRecoveryKeyButton);
-    await waitFor(() => {
-      screen.getByText(/You’ve tried too many times/);
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.submit'
-      );
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.fail'
-      );
-      expect(navigateForward).not.toBeCalled();
-    });
-  });
-
-  it('renders an error message when the password is incorrect', async () => {
-    renderFlowPage(accountWithPasswordError, RecoveryKeyAction.Change);
-    const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create new account recovery key',
-    });
-    const passwordInput = screen.getByLabelText('Enter your password');
-    // input a password to enable form submission
-    fireEvent.input(passwordInput, {
-      target: { value: 'anypassword' },
-    });
-    await waitFor(() =>
-      expect(createRecoveryKeyButton).not.toHaveAttribute('disabled')
-    );
-    fireEvent.click(createRecoveryKeyButton);
-    await waitFor(() => {
-      screen.getByText('Incorrect password');
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.submit'
-      );
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.fail'
-      );
-      expect(navigateForward).not.toBeCalled();
-    });
-  });
-
-  it('renders an error message for unexpected errors', async () => {
-    renderFlowPage(accountWithUnexpectedError, RecoveryKeyAction.Change);
-    const createRecoveryKeyButton = screen.getByRole('button', {
-      name: 'Create new account recovery key',
-    });
-    const passwordInput = screen.getByLabelText('Enter your password');
-    // input a password to enable form submission
-    fireEvent.input(passwordInput, {
-      target: { value: 'anypassword' },
-    });
-    await waitFor(() =>
-      expect(createRecoveryKeyButton).not.toHaveAttribute('disabled')
-    );
-    fireEvent.click(createRecoveryKeyButton);
-    await waitFor(() => {
-      screen.getByText('Unexpected error');
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.submit'
-      );
-      expect(logViewEvent).toBeCalledWith(
-        `flow.${viewName}`,
-        'confirm-password.fail'
-      );
-      expect(navigateForward).not.toBeCalled();
-    });
-  });
-
-  it('emits the expected metrics when user navigates back', () => {
-    renderFlowPage(accountWithSuccess, RecoveryKeyAction.Change);
-    fireEvent.click(screen.getByTestId('flow-container-back-btn'));
-    expect(navigateBackward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(
-      `flow.${viewName}`,
-      'change-key.cancel'
-    );
   });
 });

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -27,7 +27,6 @@ type FormData = {
 };
 
 export type FlowRecoveryKeyConfirmPwdProps = {
-  action?: RecoveryKeyAction;
   localizedBackButtonTitle: string;
   localizedPageTitle: string;
   navigateBackward: () => void;
@@ -37,7 +36,6 @@ export type FlowRecoveryKeyConfirmPwdProps = {
 };
 
 export const FlowRecoveryKeyConfirmPwd = ({
-  action = RecoveryKeyAction.Create,
   localizedBackButtonTitle,
   localizedPageTitle,
   navigateBackward,
@@ -50,6 +48,15 @@ export const FlowRecoveryKeyConfirmPwd = ({
 
   const [errorText, setErrorText] = useState<string>();
   const [bannerText, setBannerText] = useState<string>();
+  const [actionType, setActionType] = useState<RecoveryKeyAction>();
+
+  useEffect(() => {
+    if (account.recoveryKey === true) {
+      setActionType(RecoveryKeyAction.Change);
+    } else {
+      setActionType(RecoveryKeyAction.Create);
+    }
+  }, [account.recoveryKey]);
 
   const { formState, getValues, handleSubmit, register } = useForm<FormData>({
     mode: 'all',
@@ -62,10 +69,10 @@ export const FlowRecoveryKeyConfirmPwd = ({
     const password = getValues('password');
     logViewEvent(`flow.${viewName}`, 'confirm-password.submit');
     try {
-      if (action === RecoveryKeyAction.Change && account.recoveryKey) {
-        account.deleteRecoveryKey();
-      }
-      const recoveryKey = await account.createRecoveryKey(password);
+      const recoveryKey =
+        actionType === RecoveryKeyAction.Create
+          ? await account.createRecoveryKey(password)
+          : await account.changeRecoveryKey(password);
       setFormattedRecoveryKey(
         base32Encode(recoveryKey.buffer, 'Crockford').match(/.{4}/g)!.join(' ')
       );
@@ -74,13 +81,23 @@ export const FlowRecoveryKeyConfirmPwd = ({
     } catch (e) {
       let localizedError;
 
-      if (e.errno === AuthUiErrors.THROTTLED.errno && e.retryAfterLocalized) {
-        localizedError = ftlMsgResolver.getMsg(
-          composeAuthUiErrorTranslationId(e),
-          AuthUiErrorNos[e.errno].message,
-          { retryAfter: e.retryAfterLocalized }
-        );
-      } else {
+      if (e.errno === AuthUiErrors.THROTTLED.errno) {
+        if (e.retryAfterLocalized) {
+          localizedError = ftlMsgResolver.getMsg(
+            composeAuthUiErrorTranslationId(e),
+            AuthUiErrorNos[e.errno].message,
+            { retryAfter: e.retryAfterLocalized }
+          );
+        } else {
+          // For throttling errors where a localized retry after value is not available
+          localizedError = ftlMsgResolver.getMsg(
+            'auth-error-114-generic',
+            AuthUiErrorNos[114].message
+          );
+        }
+      }
+      // For any errors other than throttling
+      else {
         localizedError = ftlMsgResolver.getMsg(
           composeAuthUiErrorTranslationId(e),
           e.message
@@ -95,7 +112,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
     }
   }, [
     account,
-    action,
+    actionType,
     ftlMsgResolver,
     getValues,
     navigateForward,
@@ -110,7 +127,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
       title={localizedPageTitle}
       onBackButtonClick={() => {
         navigateBackward();
-        action === RecoveryKeyAction.Create
+        actionType === RecoveryKeyAction.Create
           ? logViewEvent(`flow.${viewName}`, 'create-key.cancel')
           : logViewEvent(`flow.${viewName}`, 'change-key.cancel');
       }}
@@ -153,7 +170,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
               {...{ errorText }}
             />
           </FtlMsg>
-          {action === RecoveryKeyAction.Create && (
+          {actionType === RecoveryKeyAction.Create && (
             <FtlMsg id="flow-recovery-key-confirm-pwd-submit-button">
               <button
                 className="cta-primary cta-xl w-full mt-4"
@@ -164,7 +181,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
               </button>
             </FtlMsg>
           )}
-          {action === RecoveryKeyAction.Change && (
+          {actionType === RecoveryKeyAction.Change && (
             <FtlMsg id="flow-recovery-key-confirm-pwd-submit-button-change-key">
               <button
                 className="cta-primary cta-xl w-full mt-4"
@@ -176,7 +193,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
             </FtlMsg>
           )}
         </form>
-        {action === RecoveryKeyAction.Change && (
+        {actionType === RecoveryKeyAction.Change && (
           <FtlMsg id="flow-recovery-key-info-cancel-link">
             {/* TODO: Remove feature flag param in FXA-7419 */}
             <Link

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -39,7 +39,7 @@ const accountWithoutKey = {
 const accountWithKey = {
   ...MOCK_ACCOUNT,
   recoveryKey: true,
-  createRecoveryKey: jest.fn().mockResolvedValue(new Uint8Array(20)),
+  changeRecoveryKey: jest.fn().mockResolvedValue(new Uint8Array(20)),
   deleteRecoveryKey: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -4,6 +4,9 @@ auth-error-102 = Unknown account
 auth-error-103 = Incorrect password
 auth-error-105-2 = Invalid confirmation code
 auth-error-110 = Invalid token
+# This string indicates that requests have been throttled
+# but the specific amount of time before retry is possible is unknown.
+auth-error-114-generic = You’ve tried too many times. Please try again later.
 # This string is the amount of time required before a user can attempt another request.
 # Variables:
 #   $retryAfter (String) - Time required before retrying a request. The variable is localized by our


### PR DESCRIPTION
## Because

* We want to make sure the password check is successful before deleting the key and creating a new one

## This pull request

* Add changeRecoveryKey method to account model to add reauth step before key deletion
* Fix error with throttled error localization when localizedRetryAfter value is not available by adding a generic string
* Update tests and add more stories

## Issue that this pull request solves

Closes: #FXA-7548

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
