### PR TITLE
fix(fxa-settings): Ensure useWatch uses current input value as default

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -45,7 +45,7 @@ export const FlowRecoveryKeyHint = ({
   const [hintError, setHintError] = useState<string>();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const { control, handleSubmit, register } = useForm<FormData>({
+  const { control, getValues, handleSubmit, register } = useForm<FormData>({
     mode: 'onTouched',
     defaultValues: {
       hint: '',
@@ -56,7 +56,7 @@ export const FlowRecoveryKeyHint = ({
     logViewEvent(viewName, 'hint-step-view');
   }, [viewName]);
 
-  const getHintError = (hint: string) => {
+  const checkForHintError = (hint: string) => {
     if (hint.length > maxHintLength) {
       const localizedCharLimitError = ftlMsgResolver.getMsg(
         'flow-recovery-key-hint-char-limit-error',
@@ -90,7 +90,7 @@ export const FlowRecoveryKeyHint = ({
       logViewEvent(viewName, 'create-hint.skip');
       navigateForwardAndAlertSuccess();
     } else {
-      const hintErrorText = getHintError(trimmedHint);
+      const hintErrorText = checkForHintError(trimmedHint);
       if (hintErrorText) {
         setHintError(hintErrorText);
         return;
@@ -130,7 +130,7 @@ export const FlowRecoveryKeyHint = ({
     const hint: string = useWatch({
       control,
       name: 'hint',
-      defaultValue: '',
+      defaultValue: getValues().hint,
     });
     const isTooLong: boolean = hint.length > maxHintLength;
     return (

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -166,7 +166,7 @@ const ResetPassword = ({
     const email: string = useWatch({
       control,
       name: 'email',
-      defaultValue: '',
+      defaultValue: getValues().email,
     });
     return <LinkRememberPassword {...{ email }} />;
   };


### PR DESCRIPTION
## Because

* Controlled components that use `useWatch` to obtain the current input value would reset to default (empty string) on submit or re-render
* We want to ensure that if the submit aborts due to an error or if the page re-renders, controlled components will display the current input value and not an empty string.

## This pull request

* Use `getValues` to set the default input value for `useWatch` in both places where it is used in the codebase (`FlowRecoveryKeyHint` and `ResetPassword`)

## Issue that this pull request solves

Closes: #FXA-7547

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
