### PR TITLE
task(fxa-settings): Revert localized content in key download file

### DIFF
--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/en.ftl
@@ -16,9 +16,9 @@ recovery-key-file-header = SAVE YOUR ACCOUNT RECOVERY KEY
 # Password resets without this account recovery key can result in data loss.
 recovery-key-file-instructions = Store this file containing your account recovery key in a place you’ll remember. Or print it and keep a physical copy. Your account recovery key can help you recover { -brand-firefox } data if you forget your password.
 
-# { $recoveryKeyValue } is the account recovery key, a randomly generated code in latin characters
-# "Key" here refers to the term "account recovery key"
-recovery-key-file-key-value-v2 = Key: { $recoveryKeyValue }
+# "Key" here refers to the term "account recovery key", a randomly generated 32-character code
+# containing a mix of numbers and letters (excluding I, L, O, U)
+recovery-key-file-key-value-v3 = Key:
 
 # { $email }  - The primary email associated with the account
 recovery-key-file-user-email-v2 = * { -product-firefox-account }: { $email }

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.stories.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
-import ButtonDownloadRecoveryKey from '.';
+import ButtonDownloadRecoveryKey, { fileContentVariation } from '.';
 import { withLocalization } from '../../../.storybook/decorators';
 import { Account, AppContext } from '../../models';
 import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
@@ -28,12 +28,16 @@ const accountWithLongEmail = {
   },
 } as unknown as Account;
 
-const storyWithContext = (account: Account) => {
+const storyWithContext = (
+  account: Account,
+  fileType?: fileContentVariation
+) => {
   const story = () => (
     <AppContext.Provider value={mockAppContext({ account })}>
       <AppLayout>
-        {' '}
-        <ButtonDownloadRecoveryKey {...{ recoveryKeyValue, viewName }} />
+        <ButtonDownloadRecoveryKey
+          {...{ recoveryKeyValue, viewName, fileType }}
+        />
       </AppLayout>
     </AppContext.Provider>
   );
@@ -43,3 +47,19 @@ const storyWithContext = (account: Account) => {
 export const Default = storyWithContext(account);
 
 export const WithVeryLongEmail = storyWithContext(accountWithLongEmail);
+
+// The following stories are added for testing purposes
+export const DetailedDownloadWithBOM = storyWithContext(
+  account,
+  fileContentVariation['withBOM']
+);
+
+export const DetailedDownloadWithCharSet = storyWithContext(
+  account,
+  fileContentVariation['withCharSet']
+);
+
+export const DetailedDownloadWithTextEncoder = storyWithContext(
+  account,
+  fileContentVariation['withTextEncoder']
+);

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.test.tsx
@@ -8,6 +8,9 @@ import { Account, AppContext } from '../../models';
 import { ButtonDownloadRecoveryKey } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { logViewEvent } from '../../lib/metrics';
+import { TextEncoder } from 'util';
+
+Object.assign(global, { TextEncoder });
 
 const recoveryKeyValue = 'WXYZ WXYZ WXYZ WXYZ WXYZ WXYZ WXYZ WXYZ';
 const viewName = 'settings.account-recovery';

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKey/index.tsx
@@ -2,30 +2,72 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAccount, useFtlMsgResolver } from '../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../lib/metrics';
+import { searchParams } from '../../lib/utilities';
+
+export enum fileContentVariation {
+  'keyOnly',
+  'withBOM',
+  'withCharSet',
+  'withTextEncoder',
+}
 
 interface ButtonDownloadRecoveryKeyProps {
   navigateForward?: () => void;
   recoveryKeyValue: string;
   viewName: string;
+  // Temporary addition for storybook testing
+  fileType?: fileContentVariation;
 }
 
 export const ButtonDownloadRecoveryKey = ({
   navigateForward,
   recoveryKeyValue,
   viewName,
+  fileType = fileContentVariation['keyOnly'],
 }: ButtonDownloadRecoveryKeyProps) => {
-  // TODO: format by locale
   const { primaryEmail } = useAccount();
   const currentDate = new Date();
   const downloadDateInLocale = currentDate.toLocaleDateString(
     navigator.language
   );
   const ftlMsgResolver = useFtlMsgResolver();
+  const [contentType, setContentType] = useState(
+    fileContentVariation['keyOnly']
+  );
 
+  // Optional `downloadOption` search param can be used to test
+  // character encoding options. Related to FXA-7572
+  // By default, the downloaded file will only contain the recovery key
+  // unless one of the following params is added to the URL.
+
+  // The file type can also be defined by passing in a `fileType` prop
+  // - this is used for storybook.
+  const params = searchParams(window.location.search);
+
+  useEffect(() => {
+    if (
+      fileType === fileContentVariation['withBOM'] ||
+      params.fileContentType === 'withBOM'
+    ) {
+      setContentType(fileContentVariation['withBOM']);
+    } else if (
+      fileType === fileContentVariation['withCharSet'] ||
+      params.fileContentType === 'withCharSet'
+    ) {
+      setContentType(fileContentVariation['withCharSet']);
+    } else if (
+      fileType === fileContentVariation['withTextEncoder'] ||
+      params.fileContentType === 'withTextEncoder'
+    ) {
+      setContentType(fileContentVariation['withTextEncoder']);
+    }
+  }, [fileType, params, setContentType]);
+
+  // Localized strings for detailed file (currently disabled unless `downloadOption` param is added to URL)
   const fileHeading = ftlMsgResolver.getMsg(
     'recovery-key-file-header',
     'SAVE YOUR ACCOUNT RECOVERY KEY'
@@ -37,9 +79,8 @@ export const ButtonDownloadRecoveryKey = ({
   );
 
   const fileKey = ftlMsgResolver.getMsg(
-    'recovery-key-file-key-value-v2',
-    `Key: ${recoveryKeyValue}`,
-    { recoveryKeyValue }
+    'recovery-key-file-key-value-v3',
+    `Key:`
   );
 
   const fileUserEmail = ftlMsgResolver.getMsg(
@@ -62,13 +103,29 @@ export const ButtonDownloadRecoveryKey = ({
     { supportURL }
   );
 
-  const fileContent = new Blob(
+  // Localized content in the download file is currently *disabled* by default due to an issue with encoding recognition on Android.
+  // Non-latin text (e.g., Hebrew) may be displayed as jibberish due to incorrect encoding detection.
+  // In addition, localized strings contain important directionality markers that are hidden on Mac
+  // but visible on many other devices. On Apple devices, these directionality markers get copied with the key,
+  // and the key is rejected as invalid during password reset.
+
+  // Adding BOM ahead of detailed file content could possibly force detection of UTF-8 encoding.
+  // https://learn.microsoft.com/en-us/globalization/encoding/byte-order-mark
+  // To test, add `downloadOption=withBOM` to the query params when entering the account recovery key creation flow and hit enter to reload
+  const BOM = new Uint8Array([0xef, 0xbb, 0xbf]);
+
+  const fileContentWithBOM = new Blob(
     [
+      BOM,
+      '*WITH BOM*',
+      '\r\n\r\n',
       fileHeading,
       '\r\n\r\n',
       fileInstructions,
       '\r\n\r\n',
       fileKey,
+      '\r\n\r\n',
+      recoveryKeyValue,
       '\r\n\r\n',
       fileUserEmail,
       '\r\n',
@@ -80,6 +137,64 @@ export const ButtonDownloadRecoveryKey = ({
       type: 'text/plain',
     }
   );
+
+  // Specifying the char set of the blob might be sufficient
+  // To test, add `downloadOption=withCharSet` to the query params when entering the account recovery key creation flow and hit enter to reload
+  const fileContentWithCharSet = new Blob(
+    [
+      '*WITH CHARSET*',
+      '\r\n\r\n',
+      fileHeading,
+      '\r\n\r\n',
+      fileInstructions,
+      '\r\n\r\n',
+      fileKey,
+      '\r\n\r\n',
+      recoveryKeyValue,
+      '\r\n\r\n',
+      fileUserEmail,
+      '\r\n',
+      fileDate,
+      '\r\n',
+      fileSupport,
+    ],
+    {
+      type: 'text/plain;charset=UTF-8',
+    }
+  );
+
+  // Using TextEncoder generates a byte stream with UTF-8 encoding
+  // To test, add `downloadOption=withTextEncoder` to the query params when entering the account recovery key creation flow and hit enter to reload
+  let encoder = new TextEncoder();
+  const fileContentWithTextEncoder = new Blob(
+    [
+      '*WITH TEXT ENCODER*',
+      '\r\n\r\n',
+      encoder.encode(fileHeading),
+      '\r\n\r\n',
+      encoder.encode(fileInstructions),
+      '\r\n\r\n',
+      encoder.encode(fileKey),
+      '\r\n\r\n',
+      encoder.encode(recoveryKeyValue),
+      '\r\n\r\n',
+      encoder.encode(fileUserEmail),
+      '\r\n',
+      encoder.encode(fileDate),
+      '\r\n',
+      encoder.encode(fileSupport),
+    ],
+    {
+      type: 'text/plain',
+    }
+  );
+
+  // Default file content
+  // While investigation into encoding of localized text is ongoing,
+  // we have reverted to a text file containing only the key.
+  const fileContentWithKeyOnly = new Blob([recoveryKeyValue], {
+    type: 'text/plain',
+  });
 
   const getFilename = () => {
     const date = currentDate.toISOString().split('T')[0];
@@ -98,11 +213,35 @@ export const ButtonDownloadRecoveryKey = ({
     return filename;
   };
 
+  // Get the URL for the selected file content
+  const getURL = () => {
+    let fileContent;
+    switch (contentType) {
+      case fileContentVariation['withBOM']: {
+        fileContent = fileContentWithBOM;
+        break;
+      }
+      case fileContentVariation['withCharSet']: {
+        fileContent = fileContentWithCharSet;
+        break;
+      }
+      case fileContentVariation['withTextEncoder']: {
+        fileContent = fileContentWithTextEncoder;
+        break;
+      }
+      default: {
+        fileContent = fileContentWithKeyOnly;
+        break;
+      }
+    }
+    return URL.createObjectURL(fileContent);
+  };
+
   return (
     <FtlMsg id="recovery-key-download-button-v3" attrs={{ title: true }}>
       <a
         title="Download and continue"
-        href={URL.createObjectURL(fileContent)}
+        href={getURL()}
         download={getFilename()}
         data-testid="recovery-key-download"
         className="cta-primary cta-xl w-full"

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -9,6 +9,9 @@ import { logViewEvent } from '../../../lib/metrics';
 import FlowRecoveryKeyDownload from './';
 import { renderWithRouter } from '../../../models/mocks';
 import { MOCK_RECOVERY_KEY_VALUE } from './mocks';
+import { TextEncoder } from 'util';
+
+Object.assign(global, { TextEncoder });
 
 const localizedBackButtonTitle = 'Back to settings';
 const localizedPageTitle = 'Account Recovery Key';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -12,6 +12,9 @@ import {
   renderWithRouter,
 } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
+import { TextEncoder } from 'util';
+
+Object.assign(global, { TextEncoder });
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),


### PR DESCRIPTION
## Because

* Localized plain text file is not rendering as expected on Android and Windows.
* Hidden directionality characters get copied with key, resulting in the key being marked as invalid during password reset.
* Reversal is temporary to prevent this issue from blocking deployment while next steps are determined.

## This pull request

* Serve key only in the file download.

## Issue that this pull request solves

Closes: #FXA-7688

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
