### PR TITLE
fix(ipad): Reduce avatar size on mobileLandscape for iPad web view modal

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/user-card.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/user-card.mustache
@@ -1,4 +1,7 @@
 <div class="mt-9">
-  <div class="avatar-wrapper mx-auto h-24 w-24 mobileLandscape:h-40 mobileLandscape:w-40"></div>
+  {{! The avatar size must not increase until the tablet breakpoint due to logging into
+  Pocket with FxA and maybe others later: an Apple-controlled modal displays FxA in a web
+  view and we want the "Sign in" button to be displayed above the fold. See FXA-7425 */ }}
+  <div class="avatar-wrapper mx-auto h-24 w-24 tablet:h-40 tablet:w-40"></div>
   <div class="my-5 text-base break-all" id="prefillEmail">{{ email }}</div>
 </div>

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -98,7 +98,10 @@ const Signin = ({
         {/* Alerts and success messages originally went here */}
         <div className="mt-9">
           {/* When we get to the functionality stage, we can probably replace this with the Avatar component in Settings*/}
-          <div className="mx-auto h-24 w-24 mobileLandscape:h-40 mobileLandscape:w-40"></div>
+          {/* The avatar size must not increase until the tablet breakpoint due to logging into
+           * Pocket with FxA and maybe others later: an Apple-controlled modal displays FxA in a
+           * web view and we want the "Sign in" button to be displayed above the fold. See FXA-7425 */}
+          <div className="mx-auto h-24 w-24 tablet:h-40 tablet:w-40"></div>
           <div className="my-5 text-base break-all">{email}</div>
         </div>
         <form noValidate {...{ onSubmit }}>


### PR DESCRIPTION
Because:
* A web view modal is displayed when users are logging into FxA and on iPad the "Sign in" button is hidden unless the user scrolls

This commit:
* Reduces the size of the avatar, which increased at the mobileLandscape breakpoint and which is what the web view was displaying at, to increase at the tablet breakpoint instead

Fixes FXA-7425

---

There are a few different ways we could have tried to fix this:
1. Set a classname based on user agent and screen sizing, e.g. if iPad and still in `mobileLandscape` breakpoint. However, this is tricky for iPad because in the last few years, iOS for iPad has sent out a Desktop UA. We'd have to check if `iPad` (older iOS) or Desktop UA + check current screen size, and rerun when the window size changes... Would introduce a lot of overhead for such a tiny fix. Probably a way to do it without checking current window size, but either way, I'd love to avoid checking the UA for this since we can't nail down iPad-only UAs.
2. Add a new media query / breakpoint for this that checks height or tweak existing. Right now our `mobileLandscape` is `min-width: 480px` and our `tablet` is `min-width: 768px and min-height: 481px`. It looks like the modal in question is _around_ 600 across and 575 high. This is feasible, but feels messy since it's currently a one-off for iPad and our needs might change for other devices later.
3. What I did here: simply change the breakpoint when the image size increases. It previously increased in `mobileLandscape` and now, it increases in tablet.

This screenshot shows from left to right: the screenshot provided in the ticket with the embedded view / localhost with the window resized to match / localhost with this fix, to give you an idea of how much this scoots the button up.
![8F3D02C5-80EA-49B6-9540-5B1F3B9BDD88](https://github.com/mozilla/fxa/assets/13018240/5f883bf1-a6c9-47f3-94cd-15df1886236b)
