### PR TITLE
fix(third-party-auth): Don't show Google/Apple login buttons in the Sync flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -43,7 +43,14 @@
     </form>
 
     {{#isInThirdPartyAuthExperiment}}
-      {{{ unsafeThirdPartyAuthHTML }}}
+      {{^isSync}}
+        {{{ unsafeThirdPartyAuthHTML }}}
+      {{/isSync}}
+      {{#isSync}}
+        <p class="text-xs text-grey-500 mb-0 mt-5" id="firefox-family-services">
+          {{#t}}A Firefox account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
+        </p>
+      {{/isSync}}
     {{/isInThirdPartyAuthExperiment}}
 
     {{^isInThirdPartyAuthExperiment}}

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -784,6 +784,10 @@ module.exports = {
     VPASSWORD: '#vpassword',
     ...CWTS_ENGINES,
   },
+  THIRD_PARTY_AUTH: {
+    GOOGLE: '#google-login-button',
+    APPLE: '#apple-login-button',
+  },
   TOS: {
     HEADER: '#fxa-tos-header',
     LINK_BACK: '#fxa-tos-back',


### PR DESCRIPTION
Because:
* Users have to have an FxA account to register/login to Sync so we should not allow them to login with third-party auth in this flow

This commit:
* Hides these buttons if the flow is Sync

Fixes FXA-7655

---

Test locally @ [here](http://localhost:3030/?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email&forceExperiment=thirdPartyAuth&forceExperimentGroup=treatment) before and after patch. Looked better to me to leave the "firefox family" text when third party auth buttons are hidden - there's a nicer way to do this in Backbone/Mustache than have two sets of `#firefox-family-services` references in the mustache file (like setting a `shouldShowThirdPartyAuth` method) but we're refactoring this all soon enough so 🤷‍♀️ as-is seems fine to me.