### PR TITLE
feat(payments): update supported PayPal currencies list

### DIFF
--- a/packages/fxa-auth-server/lib/payments/currencies.ts
+++ b/packages/fxa-auth-server/lib/payments/currencies.ts
@@ -89,7 +89,7 @@ export class CurrencyHelper {
    * handled any restrictions.
    *
    */
-  static supportedPayPalCurrencies = ['USD', 'EUR', 'CHF'];
+  static supportedPayPalCurrencies = ['USD', 'EUR', 'CHF', 'CZK', 'DKK', 'PLN'];
 
   /*
    * List of valid country codes taken from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2


### PR DESCRIPTION
## Because

- We are aiming to launch VPN in 16 new countries in Europe.

## This pull request

- Adds additional currencies to `supportedPayPalCurrencies`.

## Issue that this pull request solves

Closes FXA-7606

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

BGN, HUF (decimals), RON and RSD are not currently supported by PayPal as per https://developer.paypal.com/api/nvp-soap/currency-codes/ and are therefore not included for the time being.
