### PR TITLE
fix(text): Don't display `Step 1 of 2` when deleting account with no password set

### DIFF
--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -468,7 +468,7 @@ const conf = convict({
   googleAuthConfig: {
     clientId: {
       default:
-        '210899493109-u0erdakhegg6b572faenm3mn9hf4mdp8.apps.googleusercontent.com',
+        '218517873053-th4taguk9dvf03rrgk8sigon84oigf5l.apps.googleusercontent.com',
       env: 'GOOGLE_AUTH_CLIENT_ID',
       format: String,
       doc: 'Google auth client id',

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -198,7 +198,7 @@ const convictConf = convict({
   googleAuthConfig: {
     clientId: {
       default:
-        '210899493109-u0erdakhegg6b572faenm3mn9hf4mdp8.apps.googleusercontent.com',
+        '218517873053-th4taguk9dvf03rrgk8sigon84oigf5l.apps.googleusercontent.com',
       env: 'GOOGLE_AUTH_CLIENT_ID',
       format: String,
       doc: 'Google auth client id',

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -364,7 +364,7 @@ const conf = (module.exports = convict({
     },
     clientId: {
       default:
-        '210899493109-u0erdakhegg6b572faenm3mn9hf4mdp8.apps.googleusercontent.com',
+        '218517873053-th4taguk9dvf03rrgk8sigon84oigf5l.apps.googleusercontent.com',
       env: 'GOOGLE_AUTH_CLIENT_ID',
       format: String,
       doc: 'Google auth client id',

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
@@ -164,6 +164,8 @@ describe('PageDeleteAccount', () => {
       </AppContext.Provider>
     );
 
+    expect(screen.queryByText('Step 1 of 2')).toBeNull();
+    
     await advanceStep();
 
     expect(logViewEvent).toHaveBeenCalledWith(

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState, ChangeEvent } from 'react';
+import React, { useCallback, useState, ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useAccount, useAlertBar } from '../../../models';
@@ -117,6 +117,12 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const goHome = useCallback(() => window.history.back(), []);
 
   const account = useAccount();
+  
+  useEffect(() => {
+    if (!account.hasPassword) {
+      setSubtitleText('');
+    }
+   }, [account.hasPassword]);
 
   const advanceStep = () => {
     // Accounts that do not have a password set, will delete immediately


### PR DESCRIPTION
## Because

- Showing `Step 1 of 2` doesn't make sense if there is no step 2

## This pull request

- Don't display any subtitle text when deleting account with no password

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7373

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I thought this made more sense to not show anything verses showing `Step 1 of 1`.
