### PR TITLE
feat(third-party-auth): Conditionally render login buttons on signin

### DIFF
--- a/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
+++ b/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
@@ -62,9 +62,9 @@ test.describe('OAuth signin token code', () => {
     // This will cause the token become 'invalid' and ultimately cause an
     // INVALID_TOKEN error to be thrown.
     await login.destroySession(email);
-    await page.waitForNavigation({ waitUntil: 'networkidle' }),
-      // Destroying the session should direct user back to sign in page
-      expect(await login.passwordHeader.isVisible()).toBeTruthy();
+    await page.waitForURL(/oauth\/signin/);
+    // Destroying the session should direct user back to sign in page
+    await login.passwordHeader.waitFor({ state: 'visible' });
   });
 
   test('verified - valid code', async ({

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -710,8 +710,11 @@ export default class AuthClient {
     return this.request('GET', `/account/status?uid=${uid}`);
   }
 
-  async accountStatusByEmail(email: string) {
-    return this.request('POST', '/account/status', { email });
+  async accountStatusByEmail(
+    email: string,
+    options: { thirdPartyAuthStatus?: boolean } = {}
+  ) {
+    return this.request('POST', '/account/status', { email, ...options });
   }
 
   async accountProfile(sessionToken: hexstring) {

--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -265,9 +265,9 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     return PasswordChangeToken.fromHex(data.tokenData, data);
   };
 
-  DB.prototype.accountRecord = async function (email) {
+  DB.prototype.accountRecord = async function (email, options) {
     log.trace('DB.accountRecord', { email });
-    const account = await Account.findByPrimaryEmail(email);
+    const account = await Account.findByPrimaryEmail(email, options);
     if (!account) {
       throw error.unknownAccount(email);
     }

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -111,6 +111,7 @@ const DB_METHOD_NAMES = [
   'getLinkedAccount',
   'createLinkedAccount',
   'deleteLinkedAccount',
+  'accountExists',
 ];
 
 const LOG_METHOD_NAMES = [
@@ -308,6 +309,9 @@ function mockDB(data, errors) {
         },
       ]);
     }),
+    accountExists: sinon.spy(() => {
+      return Promise.resolve(data.exists ?? true);
+    }),
     accountRecord: sinon.spy(() => {
       if (errors.emailRecord) {
         return Promise.reject(errors.emailRecord);
@@ -339,6 +343,7 @@ function mockDB(data, errors) {
         uid: data.uid,
         wrapWrapKb: crypto.randomBytes(32),
         verifierSetAt: data.verifierSetAt ?? Date.now(),
+        linkedAccounts: data.linkedAccounts,
       });
     }),
     consumeSigninCode: sinon.spy(() => {

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -1571,6 +1571,39 @@ describe('#integration - remote db', function () {
       });
     });
 
+    it('can retrieve linked account', async () => {
+      const linkedAccount = await db.createLinkedAccount(
+        account.uid,
+        'googleid',
+        'google'
+      );
+      // linkedAccount UID comes back as a buffer but we want a hex string
+      // comparison to see what accountRecord retrieves
+      if (linkedAccount.uid instanceof Buffer) {
+        linkedAccount.uid = linkedAccount.uid.toString('hex');
+      }
+
+      const accountRecord = await db.accountRecord(account.email, {
+        linkedAccounts: true,
+      });
+
+      assert.deepEqual(
+        linkedAccount,
+        accountRecord.linkedAccounts[0],
+        'should contain an array of linked accounts'
+      );
+    });
+
+    it('does not retrieve linked account without option specified', async () => {
+      await db.createLinkedAccount(account.uid, 'googleid', 'google');
+      const accountRecord = await db.accountRecord(account.email);
+      assert.strictEqual(
+        accountRecord.linkedAccounts,
+        undefined,
+        'linkedAccounts should be undefined'
+      );
+    });
+
     it('returns unknown account', () => {
       return db
         .accountRecord('idontexist@email.com')

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -208,6 +208,27 @@ FxaClientWrapper.prototype = {
   }),
 
   /**
+   * Check if the account's email is registered and retrieve third-party auth related values.
+   * @param {String} email
+   * @returns {Promise<{
+   *  exists: boolean,
+   *  hasLinkedAccount: boolean,
+   *  hasPassword: boolean
+   * }>}
+   */
+  checkAccountStatus: withClient((client, email) => {
+    return client
+      .accountStatusByEmail(email, { thirdPartyAuthStatus: true })
+      .then(function ({ exists, hasLinkedAccount, hasPassword }) {
+        return {
+          exists,
+          hasLinkedAccount,
+          hasPassword,
+        };
+      });
+  }),
+
+  /**
    * Authenticate a user.
    *
    * @method signIn

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -74,6 +74,8 @@ const DEFAULTS = _.extend(
     verificationReason: undefined,
     totpVerified: undefined,
     providerUid: undefined,
+    hasLinkedAccount: undefined,
+    hasPassword: undefined,
   },
   PERSISTENT
 );
@@ -816,6 +818,27 @@ const Account = Backbone.Model.extend(
      */
     checkEmailExists() {
       return this._fxaClient.checkAccountExistsByEmail(this.get('email'));
+    },
+
+    /**
+     * Check if the account's email is registered and retrieve third-party auth related values.
+     * Sets the third-party auth values onto the model.
+     * @returns {Promise<{
+     *  exists: boolean,
+     *  hasLinkedAccount: boolean,
+     *  hasPassword: boolean
+     * }>}
+     */
+    async checkAccountStatus() {
+      const { hasLinkedAccount, hasPassword, exists } =
+        await this._fxaClient.checkAccountStatus(this.get('email'));
+      this.set('hasLinkedAccount', hasLinkedAccount);
+      this.set('hasPassword', hasPassword);
+      return {
+        hasLinkedAccount,
+        hasPassword,
+        exists,
+      };
     },
 
     /**

--- a/packages/fxa-content-server/app/scripts/models/user.js
+++ b/packages/fxa-content-server/app/scripts/models/user.js
@@ -714,6 +714,26 @@ var User = Backbone.Model.extend({
   },
 
   /**
+   * Check whether an Account's `email` is registered. Removes the account
+   * from storage if account no longer exists on the server.
+   * Additionally, retrieves third-party auth related values.
+   * @param {Object} account - account to check
+   * @returns {Promise<{
+   *  exists: boolean,
+   *  hasLinkedAccount: boolean,
+   *  hasPassword: boolean
+   * }>}
+   */
+  checkAccountStatus(account) {
+    return account.checkAccountStatus().then((result) => {
+      if (!result.exists) {
+        this.removeAccount(account);
+      }
+      return result;
+    });
+  },
+
+  /**
    * Reject the unblockCode for the given account. This invalidates
    * the unblock code and logs the signin attempt as suspicious.
    *

--- a/packages/fxa-content-server/app/scripts/templates/partial/third-party-auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/third-party-auth.mustache
@@ -1,5 +1,7 @@
-<aside class="third-party-auth">
-  <div class="separator">{{#t}}or{{/t}}</div>
-  <button id="google-login-button" class="button login-button"><span class="google-logo"></span>{{#t}}Continue with Google{{/t}}</button>
-  <button id="apple-login-button" class="button login-button"><span class="apple-logo"></span>{{#t}}Continue with Apple{{/t}}</button>
+<aside class="third-party-auth {{^isSignup}}mb-4{{/isSignup}}">
+  {{#isSignup}}
+    <div class="separator">{{#t}}or{{/t}}</div>
+  {{/isSignup}}
+    <button id="google-login-button" class="button login-button"><span class="google-logo"></span>{{#t}}Continue with Google{{/t}}</button>
+    <button id="apple-login-button" class="button login-button"><span class="apple-logo"></span>{{#t}}Continue with Apple{{/t}}</button>
 </aside>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -27,41 +27,50 @@
 
     {{{ userCardHTML }}}
 
-    <form novalidate>
-      <input type="email" class="email hidden" value="{{ email }}" disabled />
+    {{^hasLinkedAccountAndNoPassword}}
+      <form novalidate>
+        <input type="email" class="email hidden" value="{{ email }}" disabled />
 
-      {{#isPasswordNeeded}}
-        <div class="tooltip-container mb-5">
-          <input id="password" type="password" class="input-text tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus />
+        {{#isPasswordNeeded}}
+          <div class="tooltip-container mb-5">
+            <input id="password" type="password" class="input-text tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus />
+          </div>
+        {{/isPasswordNeeded}}
+
+        <!-- This non-fulfilled input tricks the browser, when
+          - trying to sign in with the wrong password, into not
+          - showing the doorhanger. -->
+        <input class="hidden" required />
+
+        <div class="flex">
+          <button id="{{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}{{#isPasswordNeeded}}submit-btn{{/isPasswordNeeded}}" class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}" type="submit">{{#t}}Sign in{{/t}}</button>
         </div>
-      {{/isPasswordNeeded}}
 
-      <!-- This non-fulfilled input tricks the browser, when
-         - trying to sign in with the wrong password, into not
-         - showing the doorhanger. -->
-      <input class="hidden" required />
+          <div id="tos-pp" class="text-grey-500 my-5 text-xs">
+            {{#isPocketClient}}
+              {{#unsafeTranslate}}
+                By proceeding, you agree to:<br />
+                Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/en/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/en/privacy/">Privacy Notice</a><br />
+                Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.
+              {{/unsafeTranslate}}
+            {{/isPocketClient}}
+            {{^isPocketClient}}
+              {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+            {{/isPocketClient}}
+          </div>
+        </form>
+      {{/hasLinkedAccountAndNoPassword}}
 
-      <div class="flex">
-        <button id="{{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}{{#isPasswordNeeded}}submit-btn{{/isPasswordNeeded}}" class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}" type="submit">{{#t}}Sign in{{/t}}</button>
-      </div>
+      {{#hasLinkedAccountAndNoPassword}}
+        {{{ unsafeThirdPartyAuthHTML }}}
+      {{/hasLinkedAccountAndNoPassword}}
 
-        <div id="tos-pp" class="text-grey-500 my-5 text-xs">
-          {{#isPocketClient}}
-            {{#unsafeTranslate}}
-              By proceeding, you agree to:<br />
-              Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/en/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/en/privacy/">Privacy Notice</a><br />
-              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.
-            {{/unsafeTranslate}}
-          {{/isPocketClient}}
-          {{^isPocketClient}}
-            {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
-          {{/isPocketClient}}
-        </div>
 
       <div class="flex justify-between">
         <a href="/" id="use-different" class="link-blue me-2" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a>
-        <a href="/reset_password" class="link-blue" data-flow-event="forgot-password" id="reset-password">{{#t}}Forgot password?{{/t}}</a>
+        {{^hasLinkedAccountAndNoPassword}}
+          <a href="/reset_password" class="link-blue" data-flow-event="forgot-password" id="reset-password">{{#t}}Forgot password?{{/t}}</a>
+        {{/hasLinkedAccountAndNoPassword}}
       </div>
-    </form>
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -17,6 +17,8 @@ import ServiceMixin from './mixins/service-mixin';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignInMixin from './mixins/signin-mixin';
 import Template from 'templates/sign_in_password.mustache';
+import ThirdPartyAuthMixin from './mixins/third-party-auth-mixin';
+import ThirdPartyAuth from '../templates/partial/third-party-auth.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 
@@ -51,14 +53,40 @@ const SignInPasswordView = FormView.extend({
     if (account && account.get('metricsEnabled') === false) {
       GleanMetrics.setEnabled(false);
     }
+
+    // We need an explicit call here in case a user directly navigates to
+    // /signin or they're redirected, e.g. when directly accessing settings.
+    // However, we don't want to call this if the previous enter email screen
+    // already called this, verified the account exists, and set the third party
+    // auth data because of rate limiting on the POST account/status endpoint.
+    // We can't use account/status GET since we don't always have the uid.
+    if (
+      account &&
+      (account.get('hasLinkedAccount') === undefined ||
+        account.get('hasPassword') === undefined)
+    ) {
+      return account.checkAccountStatus().catch(() => {
+        // Unlikely, but if this errors, it's probably due to rate limiting,
+        // see note above. Regardless, don't block the user from proceeding
+        // because this check failed, and assume they have a password set
+        // (since most users do) via defaults set in setInitialContext.
+        // See https://github.com/mozilla/fxa/pull/15456#discussion_r1237799514
+      });
+    }
   },
 
   setInitialContext(context) {
     const account = this.getAccount();
+    const hasLinkedAccount = account.get('hasLinkedAccount') ?? false;
+    const hasPassword = account.get('hasPassword') ?? true;
 
     context.set({
       email: account.get('email'),
-      isPasswordNeeded: this.isPasswordNeededForAccount(account),
+      isPasswordNeeded: this.isPasswordNeededForAccount(account) && hasPassword,
+      hasLinkedAccountAndNoPassword: hasLinkedAccount && !hasPassword,
+      unsafeThirdPartyAuthHTML: this.renderTemplate(ThirdPartyAuth, {
+        isSignup: false,
+      }),
     });
   },
 
@@ -102,6 +130,7 @@ Cocktail.mixin(
   ServiceMixin,
   SignInMixin,
   SignedInNotificationMixin,
+  ThirdPartyAuthMixin,
   UserCardMixin,
   PocketMigrationMixin
 );

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1191,6 +1191,28 @@ describe('lib/fxa-client', function () {
     });
   });
 
+  describe('checkAccountStatus', function () {
+    it('calls accountStatusByEmail as expected and returns expected data', function () {
+      const accountStatusData = {
+        exists: true,
+        hasLinkedAccount: true,
+        hasPassword: false,
+      };
+      sinon.stub(realClient, 'accountStatusByEmail').callsFake(function () {
+        return Promise.resolve(accountStatusData);
+      });
+
+      return client.checkAccountStatus(email).then(function (statusData) {
+        assert.isTrue(
+          realClient.accountStatusByEmail.calledWith(email, {
+            thirdPartyAuthStatus: true,
+          })
+        );
+        assert.deepEqual(accountStatusData, statusData);
+      });
+    });
+  });
+
   describe('checkPassword', function () {
     it('returns error if password is incorrect', function () {
       email = trim(email);

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -2752,6 +2752,24 @@ describe('models/account', function () {
     });
   });
 
+  describe('checkAccountStatus', () => {
+    beforeEach(() => {
+      sinon.stub(fxaClient, 'checkAccountStatus').callsFake(() =>
+        Promise.resolve({
+          exists: true,
+          hasLinkedAccount: true,
+          hasPassword: true,
+        })
+      );
+    });
+
+    it('sets states on model', async () => {
+      await account.checkAccountStatus();
+      assert.isTrue(account.get('hasLinkedAccount'));
+      assert.isTrue(account.get('hasPassword'));
+    });
+  });
+
   describe('isPasswordResetComplete', () => {
     beforeEach(() => {
       sinon

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -387,9 +387,13 @@ describe('views/index', () => {
       it('navigates to signin using the stored account so that profile images can be displayed', () => {
         const storedAccount = user.initAccount({});
 
-        sinon
-          .stub(user, 'checkAccountEmailExists')
-          .callsFake(() => Promise.resolve(true));
+        sinon.stub(user, 'checkAccountStatus').callsFake(() =>
+          Promise.resolve({
+            exists: true,
+            hasPassword: true,
+            hasLinkedAccount: false,
+          })
+        );
         sinon.stub(user, 'getAccountByEmail').callsFake(() => storedAccount);
 
         return view.checkEmail(EMAIL).then(() => {
@@ -413,8 +417,8 @@ describe('views/index', () => {
     describe('email is not registered', () => {
       it('navigates to signup with email domain MX record validation', () => {
         sinon
-          .stub(user, 'checkAccountEmailExists')
-          .callsFake(() => Promise.resolve(false));
+          .stub(user, 'checkAccountStatus')
+          .callsFake(() => Promise.resolve({ exists: false }));
         sinon.stub(view, '_validateEmailDomain').resolves();
         return view.checkEmail(EMAIL).then(() => {
           assert.isTrue(view.navigate.calledOnceWith('signup'));
@@ -424,7 +428,7 @@ describe('views/index', () => {
       });
 
       it('does not navigate away if checkEmailDomain rejects', () => {
-        sinon.stub(user, 'checkAccountEmailExists').resolves(false);
+        sinon.stub(user, 'checkAccountStatus').resolves({ exists: false });
         sinon.stub(view, '_validateEmailDomain').rejects();
         return view.checkEmail(EMAIL).then(() => {
           assert.isFalse(view.navigate.called);
@@ -445,7 +449,7 @@ describe('views/index', () => {
         const config = { mxRecordValidation: { enabled: false } };
         const options = { ...viewOptions, config };
         createView(options);
-        sinon.stub(user, 'checkAccountEmailExists').resolves(false);
+        sinon.stub(user, 'checkAccountStatus').resolves({ exists: false });
         sinon.spy(view, 'navigate');
         return view.checkEmail(email).then(() => {
           assert.isTrue(view.navigate.calledOnceWith('signup'));
@@ -460,7 +464,7 @@ describe('views/index', () => {
         };
         const options = { ...viewOptions, config };
         createView(options);
-        sinon.stub(user, 'checkAccountEmailExists').resolves(false);
+        sinon.stub(user, 'checkAccountStatus').resolves({ exists: false });
         sinon.spy(view, 'navigate');
         return view
           .render()

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -9,7 +9,10 @@ import Broker from 'models/auth_brokers/base';
 import FormPrefill from 'models/form-prefill';
 import Notifier from 'lib/channels/notifier';
 import Relier from 'models/reliers/relier';
-import { SIGNIN_PASSWORD } from '../../../../tests/functional/lib/selectors';
+import {
+  SIGNIN_PASSWORD,
+  THIRD_PARTY_AUTH,
+} from '../../../../tests/functional/lib/selectors';
 import sinon from 'sinon';
 import User from 'models/user';
 import View from 'views/sign_in_password';
@@ -17,7 +20,7 @@ import GleanMetrics from '../../../scripts/lib/glean';
 
 const EMAIL = 'testuser@testuser.com';
 
-const Selectors = SIGNIN_PASSWORD;
+const Selectors = { ...SIGNIN_PASSWORD, THIRD_PARTY_AUTH };
 
 describe('views/sign_in_password', () => {
   let account;
@@ -73,6 +76,11 @@ describe('views/sign_in_password', () => {
     });
 
     it('redirects to `/` if no account', () => {
+      sinon.stub(account, 'checkAccountStatus').callsFake(() =>
+        Promise.resolve({
+          exists: false,
+        })
+      );
       sinon.stub(view, 'getAccount').callsFake(() => null);
       view.beforeRender();
 
@@ -91,6 +99,26 @@ describe('views/sign_in_password', () => {
       view.beforeRender();
       assert.isTrue(GleanMetrics.setEnabled.calledOnce);
       assert.equal(GleanMetrics.setEnabled.args[0][0], false);
+    });
+
+    describe('checkAccountStatus', () => {
+      beforeEach(() => {
+        sinon.stub(account, 'checkAccountStatus').callsFake(() =>
+          Promise.resolve({
+            exists: false,
+          })
+        );
+      });
+      it('calls if values are not set', () => {
+        view.beforeRender();
+        assert.isTrue(account.checkAccountStatus.calledOnce);
+      });
+
+      it('does not call if values exist', () => {
+        sinon.stub(account, 'get').callsFake(() => true);
+        view.beforeRender();
+        assert.isFalse(account.checkAccountStatus.called);
+      });
     });
   });
 
@@ -116,9 +144,29 @@ describe('views/sign_in_password', () => {
       assert.lengthOf(view.$('input[type=email]'), 1);
       assert.equal(view.$('input[type=email]').val(), EMAIL);
       assert.lengthOf(view.$('input[type=password]'), 1);
-      assert.isTrue(notifier.trigger.calledOnce);
+      // assert.isTrue(notifier.trigger.calledOnce);
       assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
       assert.lengthOf(view.$('#tos-pp'), 1);
+    });
+
+    it('renders as expected when user has a linked account and no password', () => {
+      account.set({
+        hasLinkedAccount: true,
+        hasPassword: false,
+      });
+
+      return view.render().then(() => {
+        assert.include(view.$(Selectors.HEADER).text(), 'Sign in');
+        assert.lengthOf(view.$('input[type=email]'), 0);
+        assert.lengthOf(view.$('input[type=password]'), 0);
+
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 1);
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 1);
+
+        assert.lengthOf(view.$('.separator'), 0);
+        assert.lengthOf(view.$('#use-different'), 1);
+        assert.lengthOf(view.$('#tos-pp'), 0);
+      });
     });
   });
 

--- a/packages/fxa-shared/db/models/auth/account.ts
+++ b/packages/fxa-shared/db/models/auth/account.ts
@@ -430,7 +430,10 @@ export class Account extends BaseAuthModel {
     return now;
   }
 
-  static async findByPrimaryEmail(email: string) {
+  static async findByPrimaryEmail(
+    email: string,
+    options: { linkedAccounts?: boolean } = {}
+  ) {
     let account: Account | null = null;
     const { rows } = await Account.callProcedure(Proc.AccountRecord, email);
     if (rows.length) {
@@ -449,6 +452,9 @@ export class Account extends BaseAuthModel {
     }
     account.emails = await Email.findByUid(account.uid);
     account.primaryEmail = account.emails?.find((email) => email.isPrimary);
+    if (options.linkedAccounts) {
+      account.linkedAccounts = await LinkedAccount.findByUid(account.uid);
+    }
     return account;
   }
 


### PR DESCRIPTION
Because:
* Users that have an account via third-party auth and have not yet set a password should be shown a login screen that shows the login button(s) relevant to them instead of the 'enter a password' view

This commit:
* Adds necessary conditional logic to sign_in_password
* Updates the account/status endpoint to return third party auth status data when requested

closes FXA-4776

--

Still need to write tests. Opening early for correspondence with @vbudhram.

