### PR TITLE
fix(auth): only Report Response Validation Errors

### DIFF
--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -77,7 +77,7 @@ describe('lib/server', () => {
 
   describe('logValidationError', () => {
     const msg = 'Invalid response payload';
-    let response = {
+    const response = {
       __proto__: {
         name: 'ValidationError',
       },
@@ -109,20 +109,6 @@ describe('lib/server', () => {
         response.stack,
         response
       );
-    });
-
-    it('does not log or report other types of errors', () => {
-      response = {
-        __proto__: {
-          name: 'OtherError',
-        },
-      };
-      const mockLog = {
-        error: sinon.stub(),
-      };
-      server._logValidationError(response, mockLog);
-      sinon.assert.notCalled(mockLog.error);
-      sinon.assert.notCalled(mockReportValidationError);
     });
   });
 
@@ -606,7 +592,6 @@ describe('lib/server', () => {
             errno: 125,
             error: 'Request blocked',
             info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
-            log: undefined,
             message: 'The request was blocked for security reasons',
           };
           beforeEach(() => {


### PR DESCRIPTION
Because:

* we do not want to be inundated with request validation errors that are outside of our control

This commit:

* updates the reporting logic to only report response validation errors for all environments

Closes #FXA-7664

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
