### PR TITLE
fix(auth): handle Empty String Tax Display Name

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -35,7 +35,7 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
       inclusive: tax.inclusive,
       display_name:
         typeof tax.tax_rate === 'object'
-          ? tax.tax_rate.display_name
+          ? tax.tax_rate.display_name || undefined
           : undefined,
     }));
   }
@@ -73,7 +73,7 @@ export function stripeInvoicesToSubsequentInvoicePreviewsDTO(
         inclusive: tax.inclusive,
         display_name:
           typeof tax.tax_rate === 'object'
-            ? tax.tax_rate.display_name
+            ? tax.tax_rate.display_name || undefined
             : undefined,
       }));
     }

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -79,6 +79,22 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
       previewInvoiceWithDiscountAndTax.discount.coupon.percent_off
     );
   });
+
+  it('formats an invoice where tax display_name is an empty string', () => {
+    const invoicePreview = deepCopy(previewInvoiceWithTax);
+    invoicePreview.total_tax_amounts[0].tax_rate.display_name = '';
+
+    const invoice = stripeInvoiceToFirstInvoicePreviewDTO(invoicePreview);
+
+    assert.equal(invoice.total, invoicePreview.total);
+    assert.equal(invoice.subtotal, invoicePreview.subtotal);
+    assert.equal(
+      invoice.tax[0].amount,
+      invoicePreview.total_tax_amounts[0].amount
+    );
+    assert.equal(invoice.tax[0].display_name, undefined);
+    assert.equal(invoice.tax[0].inclusive, true);
+  });
 });
 
 describe('stripeInvoicesToSubsequentInvoicePreviewsDTO', () => {
@@ -105,6 +121,25 @@ describe('stripeInvoicesToSubsequentInvoicePreviewsDTO', () => {
       previewInvoiceWithDiscountAndTax.period_end
     );
     assert.equal(invoice[1].total, previewInvoiceWithDiscountAndTax.total);
+  });
+
+  it('formats an invoice where tax display_name is an empty string', () => {
+    const invoicePreview = deepCopy(previewInvoiceWithTax);
+    invoicePreview.total_tax_amounts[0].tax_rate.display_name = '';
+
+    const invoices = stripeInvoicesToSubsequentInvoicePreviewsDTO([
+      invoicePreview,
+    ]);
+    const invoice = invoices[0];
+
+    assert.equal(invoice.total, invoicePreview.total);
+    assert.equal(invoice.subtotal, invoicePreview.subtotal);
+    assert.equal(
+      invoice.tax[0].amount,
+      invoicePreview.total_tax_amounts[0].amount
+    );
+    assert.equal(invoice.tax[0].display_name, undefined);
+    assert.equal(invoice.tax[0].inclusive, true);
   });
 });
 


### PR DESCRIPTION
Because:

* stripe started returning an empty string for tax display name which causes our response validation to fail

This commit:

* ORs an empty string with undefined so that undefined is returned when display name is an empty string

Closes #FXA-7811

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
