### PR TITLE
feat(invoice): add Env Vars for Stripe Invoice Immediately

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -901,6 +901,14 @@ const convictConf = convict({
       format: String,
       doc: 'Stripe API key for direct Stripe integration',
     },
+    stripeInvoiceImmediately: {
+      enabled: {
+        default: false,
+        doc: 'Enables immediate invoicing for stripe in all subscription upgrades',
+        env: 'SUBSCRIPTIONS_STRIPE_INVOICE_IMMEDIATELY',
+        format: Boolean,
+      },
+    },
     stripeWebhookPayloadLimit: {
       default: 1048576,
       env: 'STRIPE_WEBHOOK_PAYLOAD_LIMIT',

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -24,6 +24,12 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_STRIPE_TAX_ENABLED',
       format: Boolean,
     },
+    useStripeInvoiceImmediately: {
+      default: false,
+      doc: 'Enables immediate invoicing for stripe in all subscription upgrades',
+      env: 'SUBSCRIPTIONS_STRIPE_INVOICE_IMMEDIATELY',
+      format: Boolean,
+    }
   },
   amplitude: {
     enabled: {


### PR DESCRIPTION
Because:

* we want to use feature flags to enable/disable work

This commit:

* adds an env var for the stripe invoice immediately epic

Closes #FXA-7847

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
