### PR TITLE
test(functional) : rewrite sync sign up with CWTS tests

### DIFF
--- a/packages/functional-tests/pages/forceAuth/index.ts
+++ b/packages/functional-tests/pages/forceAuth/index.ts
@@ -6,7 +6,7 @@ import { BaseLayout } from '../layout';
 import uaStrings from '../../lib/ua-strings';
 import { Credentials } from '../../lib/targets/base';
 
-export abstract class ForceAuthPage extends BaseLayout {
+export class ForceAuthPage extends BaseLayout {
   readonly path = 'force_auth';
   context;
   service;

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -7,6 +7,7 @@ import { DeleteAccountPage } from './settings/deleteAccount';
 import { DisplayNamePage } from './settings/displayName';
 import { FourOhFourPage } from './fourOhFour';
 import { FxDesktopV3ForceAuthPage } from './forceAuth/fxDesktopV3';
+import { ForceAuthPage } from './forceAuth';
 import { LoginPage } from './login';
 import { RecoveryKeyPage } from './settings/recoveryKey';
 import { RelierPage } from './relier';
@@ -31,6 +32,7 @@ export function create(page: Page, target: BaseTarget) {
     displayName: new DisplayNamePage(page, target),
     fourOhFour: new FourOhFourPage(page, target),
     fxDesktopV3ForceAuth: new FxDesktopV3ForceAuthPage(page, target),
+    forceAuth: new ForceAuthPage(page, target),
     login: new LoginPage(page, target),
     page,
     recoveryKey: new RecoveryKeyPage(page, target),

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -408,7 +408,7 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.CWTS_ENGINE_HISTORY).isVisible();
   }
 
-  async isCWTSEnginePassword() {
+  async isCWTSEnginePasswords() {
     return this.page.locator(selectors.CWTS_ENGINE_PASSWORDS).isVisible();
   }
 

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -50,9 +50,17 @@ export const selectors = {
   NOT_EMAIL_MET: '#password-same-as-email.password-strength-met',
   NOT_EMAIL_FAIL: '#password-same-as-email.password-strength-fail',
   PERMISSION_ACCEPT: '#accept',
-  CWTS_HEADER: 'text="Choose what to sync"',
+  CWTS_ENGINE_HEADER: 'text="Choose what to sync"',
   CWTS_ENGINE_BOOKMARKS: '#sync-engine-bookmarks',
   CWTS_ENGINE_HISTORY: '#sync-engine-history',
+  CWTS_ENGINE_PASSWORDS: '#sync-engine-passwords',
+  CWTS_ENGINE_ADDONS: '#sync-engine-addons',
+  CWTS_ENGINE_TABS: '#sync-engine-tabs',
+  CWTS_ENGINE_PREFS: '#sync-engine-prefs',
+  CWTS_ENGINE_CREDITCARDS: '#sync-engine-creditcards',
+  CWTS_ENGINE_ADDRESSES: '#sync-engine-addresses',
+  DO_NOT_SYNC: '#do-not-sync-device',
+  CWTS_PAGE_HEADER: '#fxa-choose-what-to-sync-header',
 };
 
 type FirstSignUpOptions = {
@@ -378,22 +386,58 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.SUBMIT).click();
   }
 
-  async waitForCWTSHeader() {
-    await this.page.waitForSelector(selectors.CWTS_HEADER, {
-      timeout: 100,
+  async waitForCWTSEngineHeader() {
+    await this.page.waitForSelector(selectors.CWTS_ENGINE_HEADER, {
+      timeout: 2000,
     });
   }
 
-  async waitForCWTSEngineBookmarks() {
-    await this.page.waitForSelector(selectors.CWTS_ENGINE_BOOKMARKS, {
-      timeout: 100,
-    });
+  async isCWTSPageHeader() {
+    return this.page.locator(selectors.CWTS_PAGE_HEADER).isVisible();
   }
 
-  async waitForCWTSEngineHistory() {
-    await this.page.waitForSelector(selectors.CWTS_ENGINE_HISTORY, {
-      timeout: 100,
-    });
+  async isCWTSEngineCreditCards() {
+    return this.page.locator(selectors.CWTS_ENGINE_CREDITCARDS).isVisible();
+  }
+
+  async isCWTSEngineBookmarks() {
+    return this.page.locator(selectors.CWTS_ENGINE_BOOKMARKS).isVisible();
+  }
+
+  async isCWTSEngineHistory() {
+    return this.page.locator(selectors.CWTS_ENGINE_HISTORY).isVisible();
+  }
+
+  async isCWTSEnginePassword() {
+    return this.page.locator(selectors.CWTS_ENGINE_PASSWORDS).isVisible();
+  }
+
+  async isCWTSEngineAddons() {
+    return this.page.locator(selectors.CWTS_ENGINE_ADDONS).isVisible();
+  }
+
+  async isCWTSEnginePrefs() {
+    return this.page.locator(selectors.CWTS_ENGINE_PREFS).isVisible();
+  }
+
+  async isCWTSEngineTabs() {
+    return this.page.locator(selectors.CWTS_ENGINE_TABS).isVisible();
+  }
+
+  async isCWTSEngineAddresses() {
+    return this.page.locator(selectors.CWTS_ENGINE_ADDRESSES).isVisible();
+  }
+
+  async isDoNotSync() {
+    return this.page.locator(selectors.DO_NOT_SYNC).isVisible();
+  }
+
+  async uncheckCWTSEngineHistory() {
+    await this.page.locator(selectors.CWTS_ENGINE_HISTORY).click();
+  }
+
+  async uncheckCWTSEnginePasswords() {
+    await this.page.locator(selectors.CWTS_ENGINE_PASSWORDS).click();
   }
 
   async isSyncConnectedHeader() {

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -9,6 +9,7 @@ export const selectors = {
   VPASSWORD: '#vpassword',
   PASSWORD: '#password',
   RESEND_RESET_PASSWORD_LINK: '#resend',
+  REMEMBER_PASSWORD: 'text="Remember password? Sign in"',
   RESEND_SUCCESS: '.success',
   UNKNOWN_ACCOUNT_ERROR: '.error',
   RESET_PASSWORD_COMPLETE_HEADER: '#fxa-reset-password-complete-header',
@@ -68,6 +69,10 @@ export class ResetPasswordPage extends BaseLayout {
 
   async clickResend() {
     await this.page.locator(selectors.RESEND_RESET_PASSWORD_LINK).click();
+  }
+
+  async clickRememberPassword() {
+    await this.page.locator(selectors.REMEMBER_PASSWORD).click();
   }
 
   async resendSuccessMessage() {

--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+test.describe('force auth', () => {
+  test('with a registered email, registered uid', async ({
+    credentials,
+    pages: { login, forceAuth },
+  }) => {
+    await forceAuth.open(credentials);
+    await login.setPassword(credentials.password);
+    await login.submit();
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('forgot password flow via force_auth', async ({
+    credentials,
+    pages: { login, resetPassword, forceAuth },
+  }) => {
+    await forceAuth.open(credentials);
+    await login.clickForgotPassword();
+
+    // Verify reset password header
+    expect(await resetPassword.resetPasswordHeader()).toBe(true);
+
+    //Verify email is prefilled
+    expect(await login.getPrefilledEmail()).toContain(credentials.email);
+
+    //Click 'Remember password? Sign in', redirected to force auth page
+    await resetPassword.clickRememberPassword();
+    expect(await login.getPrefilledEmail()).toContain(credentials.email);
+
+    //Click forgot password again
+    await login.clickForgotPassword();
+    await resetPassword.clickBeginReset();
+
+    //Verify confirm reset password header
+    expect(await resetPassword.confirmResetPasswordHeader()).toBe(true);
+
+    //Click 'Remember password? Sign in', redirected to force auth page
+    await resetPassword.clickRememberPassword();
+    expect(await login.getPrefilledEmail()).toContain(credentials.email);
+  });
+
+  test('form prefill information is cleared after sign in->sign out', async ({
+    credentials,
+    pages: { login, forceAuth, settings },
+  }) => {
+    await forceAuth.open(credentials);
+    await login.setPassword(credentials.password);
+    await login.submit();
+    expect(await login.loginHeader()).toBe(true);
+
+    //Sign out
+    await settings.signOut();
+
+    //Verify user need to enter email
+    expect(await login.isEmailHeader()).toBe(true);
+    await login.setEmail(credentials.email);
+    await login.submit();
+
+    //Verify password is empty and user need to enter password
+    expect(await login.isPasswordHeader()).toBe(true);
+    expect(await login.getPasswordInput()).toContain('');
+    await login.setPassword(credentials.password);
+    await login.submit();
+    expect(await login.loginHeader()).toBe(true);
+  });
+});

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -34,9 +34,9 @@ test.describe('oauth webchannel', () => {
     await login.submit();
 
     // the CWTS form is on the same signup page
-    await login.waitForCWTSHeader();
-    await login.waitForCWTSEngineBookmarks();
-    await login.waitForCWTSEngineHistory();
+    await login.waitForCWTSEngineHeader();
+    expect(await login.isCWTSEngineBookmarks()).toBe(true);
+    expect(await login.isCWTSEngineHistory()).toBe(true);
 
     await login.fillOutFirstSignUp(email, PASSWORD, {
       enterEmail: false,

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import uaStrings from '../../lib/ua-strings';
+import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+
+const password = 'passwordzxcv';
+let email;
+let syncBrowserPages;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Sync v3 sign up and CWTS', () => {
+  test.beforeEach(async ({ target }) => {
+    //Sync tests run a little slower and flake
+    test.slow();
+    syncBrowserPages = await newPagesForSync(target);
+    const { login } = syncBrowserPages;
+    email = login.createEmail('sync{id}');
+  });
+
+  test.afterEach(async () => {
+    await syncBrowserPages.browser?.close();
+  });
+
+  test('verify with signup code and CWTS', async ({ target }) => {
+    const { login, page, signinTokenCode, connectAnotherDevice } =
+      syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: null,
+        capabilities: {
+          choose_what_to_sync: true,
+          multiService: true,
+          engines: ['history'],
+        },
+      }
+    );
+    const eventDetailLinkAccount = createCustomEventDetail(
+      FirefoxCommand.LinkAccount,
+      {
+        ok: true,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.respondToWebChannelMessage(eventDetailLinkAccount);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    await login.setEmail(email);
+    await signinTokenCode.clickSubmitButton();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.setAge('21');
+
+    // The CWTS form is on the same signup page
+    await login.waitForCWTSEngineHeader();
+    expect(await login.isCWTSEngineBookmarks()).toBe(true);
+    expect(await login.isCWTSEngineHistory()).toBe(true);
+    expect(await login.isCWTSEnginePassword()).toBe(true);
+    expect(await login.isCWTSEngineTabs()).toBe(true);
+    expect(await login.isCWTSEnginePrefs()).toBe(true);
+    expect(await login.isCWTSEngineAddresses()).toBe(false);
+
+    // Uncheck the passwords and history engines
+    await login.uncheckCWTSEngineHistory();
+    await login.uncheckCWTSEnginePasswords();
+    await signinTokenCode.clickSubmitButton();
+    await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
+    await login.fillOutSignUpCode(email);
+    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+  });
+
+  test('verify at CWTS', async ({ target }) => {
+    const { login, page, signinTokenCode, connectAnotherDevice } =
+      syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_58'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: null,
+        capabilities: {
+          multiService: false,
+        },
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`,
+      {
+        waitUntil: 'load',
+      }
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    await login.setEmail(email);
+    await signinTokenCode.clickSubmitButton();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.setAge('21');
+    await login.submit();
+
+    // Verify the CWTS page and the checkboxes
+    expect(await login.isCWTSPageHeader()).toBe(true);
+    expect(await login.isCWTSEngineAddresses()).toBe(false);
+    expect(await login.isDoNotSync()).toBe(false);
+    expect(await login.isCWTSEngineCreditCards()).toBe(false);
+    await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
+    await login.noSuchWebChannelMessage(FirefoxCommand.Login);
+    await signinTokenCode.clickSubmitButton();
+    await login.fillOutSignUpCode(email);
+    await login.checkWebChannelMessage(FirefoxCommand.Login);
+    expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+  });
+
+  test('engines not supported', async ({ target }) => {
+    const { login, page, signinTokenCode } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_58'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: null,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    await login.setEmail(email);
+    await signinTokenCode.clickSubmitButton();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.setAge('21');
+    await login.submit();
+
+    // Verify the CWTS page and the checkboxes
+    expect(await login.isCWTSPageHeader()).toBe(true);
+    expect(await login.isCWTSEngineAddresses()).toBe(false);
+    expect(await login.isCWTSEngineCreditCards()).toBe(false);
+  });
+
+  test('neither `creditcards` nor `addresses` supported', async ({
+    target,
+  }) => {
+    const { login, page, signinTokenCode } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_58'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        capabilities: {
+          engines: [],
+        },
+        signedInUser: null,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    await login.setEmail(email);
+    await signinTokenCode.clickSubmitButton();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.setAge('21');
+    await login.submit();
+
+    // Verify the CWTS page and the checkboxes
+    expect(await login.isCWTSPageHeader()).toBe(true);
+    expect(await login.isCWTSEngineAddresses()).toBe(false);
+    expect(await login.isCWTSEngineCreditCards()).toBe(false);
+  });
+
+  test('`creditcards` and `addresses` supported', async ({ target }) => {
+    const { login, page, signinTokenCode } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_58'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        capabilities: {
+          engines: ['creditcards', 'addresses'],
+        },
+        signedInUser: null,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    await login.setEmail(email);
+    await signinTokenCode.clickSubmitButton();
+    await login.setPassword(password);
+    await login.confirmPassword(password);
+    await login.setAge('21');
+    await login.submit();
+
+    // Verify the CWTS page and the checkboxes
+    expect(await login.isCWTSPageHeader()).toBe(true);
+    expect(await login.isCWTSEngineAddresses()).toBe(true);
+    expect(await login.isCWTSEngineCreditCards()).toBe(true);
+  });
+});

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -66,7 +66,7 @@ test.describe('Sync v3 sign up and CWTS', () => {
     await login.waitForCWTSEngineHeader();
     expect(await login.isCWTSEngineBookmarks()).toBe(true);
     expect(await login.isCWTSEngineHistory()).toBe(true);
-    expect(await login.isCWTSEnginePassword()).toBe(true);
+    expect(await login.isCWTSEnginePasswords()).toBe(true);
     expect(await login.isCWTSEngineTabs()).toBe(true);
     expect(await login.isCWTSEnginePrefs()).toBe(true);
     expect(await login.isCWTSEngineAddresses()).toBe(false);


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [sync sign up with CWTS tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js) and [force auth tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/force_auth.js) have been rewritten in this PR.

## This pull request

contains the [sync sign up with CWTS tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js) and [force auth tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/force_auth.js)

## Issue that this pull request solves

Closes: FXA-5928

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
