### PR TITLE
chore(payments): remove RSD from approved currencies

### DIFF
--- a/packages/fxa-auth-server/lib/payments/currencies.ts
+++ b/packages/fxa-auth-server/lib/payments/currencies.ts
@@ -451,7 +451,6 @@ export class CurrencyHelper {
     'PYG',
     'QAR',
     'RON',
-    'RSD',
     'RUB',
     'RWF',
     'SAR',


### PR DESCRIPTION
## Because

- There are no plans configured to support RSD and, currently, PayPal does not support it.

## This pull request

- Removes RSD from approved currencies list.

## Issue that this pull request solves

Closes FXA-7815

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).