### PR TITLE
task(settings): Support OAuth Login Event

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -7,6 +7,7 @@ export enum FirefoxCommand {
   Logout = 'fxaccounts:logout',
   Loaded = 'fxaccounts:loaded',
   Error = 'fxError',
+  OAuthLogin = 'fxaccounts:oauth_login',
 }
 
 export interface FirefoxMessage {
@@ -68,6 +69,13 @@ export type FxALoginRequest = {
   uid: hexstring;
   unwrapBKey: string;
   verified: boolean;
+};
+
+export type FxAOAuthLogin = {
+  action: string;
+  code: string;
+  redirect: string;
+  state: string;
 };
 
 export class Firefox extends EventTarget {
@@ -210,6 +218,10 @@ export class Firefox extends EventTarget {
 
   fxaLoaded(options: any) {
     this.send(FirefoxCommand.Loaded, options);
+  }
+
+  fxaOAuthLogin(options: FxAOAuthLogin) {
+    this.send(FirefoxCommand.OAuthLogin, options);
   }
 }
 


### PR DESCRIPTION
## Because

- We want to send fxaccounts:oauth_login events

## This pull request

- Adds new FirefoxCommand, OAuthLogin.
- Adds new type for OAuthLogins
- Adds ability to send command

## Issue that this pull request solves

Closes: FXA-6616

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was just a one pointer. There will be more testing when the change is actually integrated. The data type for FxAOAuthLogin was determined by looking at [existing code](https://github.com/mozilla/fxa/blob/6707c39c029f6e1898f12965f686a64c8b6e1526/packages/fxa-content-server/app/scripts/models/auth_brokers/pairing/supplicant-webchannel.js#L18). This data type seems typical of data associated with a login event.
