### PR TITLE
Test CI content-server string extraction

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -3,7 +3,7 @@
     <h1 id="fxa-signin-password-header" class="card-header">
       {{#isPasswordNeeded}}
         {{#unsafeTranslate}}
-          Enter your password <span class="card-subheader" id="subheader">for your Firefox account</span>
+          Testing CI gettext string extraction <span class="card-subheader" id="subheader">for your Firefox account</span>
         {{/unsafeTranslate}}
       {{/isPasswordNeeded}}
       {{^isPasswordNeeded}}
@@ -14,7 +14,7 @@
             {{#unsafeTranslate}}Continue to <div class="graphic %(serviceLogo)s">%(serviceName)s</div>{{/unsafeTranslate}}
           {{/serviceLogo}}
           {{^serviceLogo}}
-            {{#t}}Continue to %(serviceName)s{{/t}}
+            {{#t}}Testing CI gettext string extraction{{/t}}
           {{/serviceLogo}}
         </span>
       {{/isPasswordNeeded}}


### PR DESCRIPTION
I'm hitting an error in CI in #15456 that mirrors the error in #15340.

Running `npx grunt l10n-extract` in content-server on `main` gives me the same error locally that I'm seeing in my branch, confirmed to also be erroring by Valerie.

I checked back through other PRs and the same error apparently occurs but the job appears to pass, [see example](https://github.com/mozilla/fxa/actions/runs/5259178657/jobs/9504379339). 

Just want to see if it fails here.