### PR TITLE
fix(payments): on sub confirm show invoice date

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/en.ftl
@@ -12,6 +12,8 @@ payment-confirmation-thanks-subheading-account-exists = You’ll receive an emai
 
 payment-confirmation-order-heading = Order details
 payment-confirmation-invoice-number = Invoice #{ $invoiceNumber }
+# $invoiceDate (Date) - Start date of the latest invoice
+payment-confirmation-invoice-date = { $invoiceDate }
 payment-confirmation-details-heading-2 = Payment information
 
 payment-confirmation-amount = { $amount } per { $interval }

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -15,7 +15,18 @@ import { FilteredSetupIntent } from '../lib/apiClient';
 import { Customer, Plan, Profile } from '../store/types';
 
 const invoice: LatestInvoiceItems = {
-  line_items: [],
+  line_items: [
+    {
+      id: '123doneProMonthly',
+      name: 'Pro level',
+      currency: 'USD',
+      amount: 735,
+      period: {
+        start: Date.now() / 1000 - 86400 * 31,
+        end: Date.now() / 1000 + 86400 * 31,
+      },
+    },
+  ],
   subtotal: 735,
   subtotal_excluding_tax: null,
   total: 735,


### PR DESCRIPTION
## Because

- The subscription confirmation page shows the current date instead of the latest invoice date.

## This pull request

- Shows the latest invoice date
- Does not show the Order details section if invoice number and date could not be found

## Issue that this pull request solves

Closes: #FXA-5805

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
