### PR TITLE
Emit account event for Pocket Apple user migration

### DIFF
--- a/packages/fxa-auth-server/test/scripts/apple-transfer-users.js
+++ b/packages/fxa-auth-server/test/scripts/apple-transfer-users.js
@@ -171,7 +171,7 @@ describe('ApplePocketFxAMigration', function() {
 });
 
 describe('AppleUser', function() {
-  let sandbox, dbStub, user, writeStreamStub;
+  let sandbox, dbStub, user, writeStreamStub, log;
   beforeEach(function() {
     sandbox = sinon.createSandbox();
     dbStub = {
@@ -184,7 +184,10 @@ describe('AppleUser', function() {
     writeStreamStub = {
       write: sandbox.stub()
     };
-    user = new AppleUser('pocket@example.com', 'transferSub', 'uid', ['altEmail@example.com'], dbStub, writeStreamStub, config);
+    log = {
+      notifyAttachedServices: sandbox.stub().resolves()
+    }
+    user = new AppleUser('pocket@example.com', 'transferSub', 'uid', ['altEmail@example.com'], dbStub, writeStreamStub, config, false, log);
   });
 
   afterEach(function() {
@@ -300,5 +303,15 @@ describe('AppleUser', function() {
     user.saveResult();
     const expectedOutput = 'transferSub,uid,fxa@example.com,apple@example.com,true,\n';
     assert.calledWith(user.writeStream.write, expectedOutput);
+    
+    assert.calledOnceWithExactly(user.log.notifyAttachedServices, 'appleUserMigration', {},
+      {
+        uid: 'uid',
+        appleEmail:'apple@example.com',
+        fxaEmail:'fxa@example.com',
+        transferSub: 'transferSub',
+        success: true,
+        err: '',
+      })
   });
 });

--- a/packages/fxa-event-broker/src/jwtset/jwtset.service.ts
+++ b/packages/fxa-event-broker/src/jwtset/jwtset.service.ts
@@ -116,4 +116,21 @@ export class JwtsetService {
       uid: delEvent.uid,
     });
   }
+  
+  public generateAppleMigrationSET(appleMigrationEvent: set.appleMigrationEvent): Promise<string> {
+    return this.generateSET({
+      uid: appleMigrationEvent.uid,
+      clientId: appleMigrationEvent.clientId,
+      events: {
+        [set.APPLE_USER_MIGRATION_ID]: {
+          fxaEmail: appleMigrationEvent.fxaEmail,
+          appleEmail: appleMigrationEvent.appleEmail,
+          transferSub: appleMigrationEvent.transferSub,
+          success: appleMigrationEvent.success,
+          err: appleMigrationEvent.err,
+          uid: appleMigrationEvent.uid,
+        }
+      }
+    });
+  }
 }

--- a/packages/fxa-event-broker/src/jwtset/set.interface.ts
+++ b/packages/fxa-event-broker/src/jwtset/set.interface.ts
@@ -11,6 +11,10 @@ export const PROFILE_EVENT_ID =
 export const SUBSCRIPTION_STATE_EVENT_ID =
   'https://schemas.accounts.firefox.com/event/subscription-state-change';
 
+export const APPLE_USER_MIGRATION_ID =
+ 'https://schemas.accounts.firefox.com/event/apple-user-migration';
+
+
 export type deleteEvent = {
   clientId: string;
   uid: string;
@@ -44,4 +48,14 @@ export type subscriptionEvent = {
   capabilities: string[];
   isActive: boolean;
   changeTime: number;
+};
+
+export type appleMigrationEvent = {
+  uid: string;
+  clientId: string;
+  fxaEmail: string;
+  appleEmail: string;
+  transferSub: string;
+  success: boolean;
+  err: string;
 };

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
@@ -196,6 +196,17 @@ export class PubsubProxyController {
           email: message.email,
         });
       }
+      case dto.APPLE_USER_MIGRATION_EVENT: {
+        return await this.jwtset.generateAppleMigrationSET({
+          clientId,
+          uid: message.uid,
+          fxaEmail: message.fxaEmail,
+          appleEmail: message.appleEmail,
+          transferSub: message.transferSub,
+          success: message.success,
+          err: message.error
+        });
+      }
       default:
         throw Error(`Invalid event: ${message.event}`);
     }

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -70,6 +70,18 @@ const baseProfileMessage = {
   event: 'profileDataChange',
 };
 
+const appleMigrationMessage = {
+  event: 'appleUserMigration',
+  timestamp: now,
+  ts: now / 1000,
+  uid: '993d26bac72b471991b197b3d298a5de',
+  fxaEmail: 'fxa@email.com',
+  appleEmail: 'apple@email.com',
+  transferSub: '123',
+  success: true,
+  err: '',
+};
+
 const updateStubMessage = (message: any) => {
   return {
     Body: JSON.stringify(message),
@@ -149,6 +161,7 @@ describe('QueueworkerService', () => {
       serviceNotificationQueueUrl:
         'https://sqs.us-east-2.amazonaws.com/queue.mozilla/321321321/notifications',
       log: { app: 'test' },
+      topicPrefix: 'rp',
     };
     const MockConfig: Provider = {
       provide: ConfigService,
@@ -249,6 +262,28 @@ describe('QueueworkerService', () => {
         '444c5d137fc34d82ae65441d7f26a504',
         'resource-server-client-id',
       ]);
+    });
+    
+    it('handles apple migration event', async () => {
+      const msg = updateStubMessage(appleMigrationMessage);
+      await (service as any).handleMessage(msg);
+      
+      const topicName = 'rp749818d3f2e7857f';
+      expect(pubsub.topic).toBeCalledWith(topicName);
+      expect(pubsub.topic(topicName).publishMessage).toBeCalledTimes(1);
+      expect(pubsub.topic(topicName).publishMessage).toBeCalledWith({
+        json: {
+          'appleEmail': 'apple@email.com',
+          'err': '',
+          'event': 'appleUserMigration',
+          'fxaEmail': 'fxa@email.com',
+          'success': true,
+          'timestamp': now,
+          'transferSub': '123',
+          'ts': now / 1000,
+          'uid': '993d26bac72b471991b197b3d298a5de',
+        },
+      });
     });
 
     const fetchOnValidMessage = {

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -162,7 +162,7 @@ export class QueueworkerService
    * @param eventType Event type to use for metrics
    */
   private async handleMessageFanout(
-    message: dto.deleteSchema | dto.profileSchema | dto.passwordSchema,
+    message: dto.deleteSchema | dto.profileSchema | dto.passwordSchema | dto.appleUserMigrationSchema,
     eventType: string
   ) {
     this.metrics.increment('message.type', { eventType });
@@ -262,6 +262,22 @@ export class QueueworkerService
   }
 
   /**
+   * Notify Pocket that a user's Apple account has been migrated.
+   *
+   * @param message Incoming SQS Message
+   */
+  private async handleAppleUserMigrationEvent(message: dto.appleUserMigrationSchema) {
+    // Note the hardcoded Pocket clientId, this value should not change in production
+    const clientId = '749818d3f2e7857f';
+    this.metrics.increment('message.type', { eventType: 'appleMigration' });
+    const rpMessage = {
+      timestamp: Date.now(),
+      ...message,
+    };
+    await this.publishMessage(clientId, rpMessage);
+  }
+
+  /**
    * Process a SQS message, dispatch based on message event type.
    *
    * @param sqsMessage Incoming SQS Message
@@ -304,6 +320,10 @@ export class QueueworkerService
       case dto.PASSWORD_CHANGE_EVENT:
       case dto.PASSWORD_RESET_EVENT: {
         await this.handleMessageFanout(message, 'password');
+        break;
+      }
+      case dto.APPLE_USER_MIGRATION_EVENT: {
+        await this.handleAppleUserMigrationEvent(message);
         break;
       }
       default:

--- a/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
+++ b/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
@@ -13,6 +13,7 @@ export type ServiceNotification =
   | dto.passwordSchema
   | dto.profileSchema
   | dto.subscriptionUpdateSchema
+  | dto.appleUserMigrationSchema
   | undefined;
 
 interface SchemaTable {
@@ -28,6 +29,7 @@ const eventSchemas = {
   [dto.PRIMARY_EMAIL_EVENT]: dto.PROFILE_CHANGE_SCHEMA,
   [dto.PASSWORD_CHANGE_EVENT]: dto.PASSWORD_CHANGE_SCHEMA,
   [dto.PASSWORD_RESET_EVENT]: dto.PASSWORD_CHANGE_SCHEMA,
+  [dto.APPLE_USER_MIGRATION_EVENT]: dto.APPLE_USER_MIGRATION_SCHEMA,
 };
 
 /**

--- a/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
+++ b/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
@@ -11,6 +11,7 @@ export const PASSWORD_RESET_EVENT = 'reset';
 export const PRIMARY_EMAIL_EVENT = 'primaryEmailChanged';
 export const PROFILE_CHANGE_EVENT = 'profileDataChange';
 export const SUBSCRIPTION_UPDATE_EVENT = 'subscription:update';
+export const APPLE_USER_MIGRATION_EVENT = 'appleUserMigration';
 
 // Message schemas
 export const CLIENT_ID = joi.string().regex(/[a-z0-9]{16}/);
@@ -91,6 +92,18 @@ export const PROFILE_CHANGE_SCHEMA = joi
   .unknown(true)
   .required();
 
+export const APPLE_USER_MIGRATION_SCHEMA = joi
+ .object()
+ .keys({
+  event: joi.string().valid(APPLE_USER_MIGRATION_EVENT),
+  timestamp: joi.number().optional(),
+  ts: joi.number().required(),
+  uid: joi.string().required(),
+ })
+ .unknown(true)
+ .required();
+
+
 export type deleteSchema = {
   event: typeof DELETE_EVENT;
   timestamp?: number;
@@ -136,3 +149,15 @@ export type subscriptionUpdateSchema = {
   ts: number;
   uid: string;
 };
+
+export type appleUserMigrationSchema = {
+  event: typeof APPLE_USER_MIGRATION_EVENT;
+  timestamp?: number;
+  ts: number;
+  uid: string;
+  fxaEmail: string;
+  appleEmail: string;
+  transferSub: string;
+  success: boolean;
+  err: string;
+}


### PR DESCRIPTION
## Because

- Pocket needs to do some account reconcilation after FxA imports the user

## This pull request

- Emits an account event via the event-broker that contains updated account information

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7666

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

@dschom Tagging you for review on this since you reviewed the original script. I wasn't able to verify the SQS message, but I was able to test that the event gets emitted properly with the Pocket clientId.

Event broker log when running the script
```
18|event-broker  | 2023-06-23T16:34:15: DEBUG fxa-event-broker.default.from.sqsMessage: {"msg":{"uid":"14699a2d8b044ccbb2d43344e31d9e0a","appleEmail":"amberappletesting1@gmail.com","fxaEmail":"amberappletesting1@gmail.com","transferSub":"000107.r739567061c144a2b81c45269552ef591","success":true,"err":"","timestamp":1687552455789,"ts":1687552455.789,"iss":"localhost:9000","metricsContext":{},"event":"appleUserMigration"}}
```
