### PR TITLE
task(functional-tests): Add missing reset password tests in Playwright

### DIFF
--- a/packages/functional-tests/lib/ci-reporter.ts
+++ b/packages/functional-tests/lib/ci-reporter.ts
@@ -37,8 +37,8 @@ class CIReporter implements Reporter {
       }`
     );
     if (test.outcome() === 'unexpected') {
-      console.log(result.error.stack);
-      console.log(result.error.message);
+      console.log(result.error?.stack);
+      console.log(result.error?.message);
     }
   }
 

--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -87,7 +87,7 @@ export class EmailClient {
     emailAddress: string,
     type: EmailType,
     header?: EmailHeader,
-    timeout: number = 15000
+    timeout = 15000
   ) {
     const expires = Date.now() + timeout;
     while (Date.now() < expires) {

--- a/packages/functional-tests/lib/react-flag.ts
+++ b/packages/functional-tests/lib/react-flag.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseTarget } from './targets/base';
+
+export function getReactFeatureFlagUrl(
+  target: BaseTarget,
+  path: string,
+  params?: string
+) {
+  if (params) {
+    return `${target.contentServerUrl}${path}?showReactApp=true&${params}`;
+  } else {
+    return `${target.contentServerUrl}${path}?showReactApp=true`;
+  }
+}

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -21,6 +21,7 @@ import { ResetPasswordPage } from './resetPassword';
 import { LegalPage } from './legal';
 import { CookiesDisabledPage } from './cookiesDisabled';
 import { PostVerifyPage } from './postVerify';
+import { ResetPasswordReactPage } from './resetPasswordReact';
 
 export function create(page: Page, target: BaseTarget) {
   return {
@@ -43,6 +44,7 @@ export function create(page: Page, target: BaseTarget) {
     totp: new TotpPage(page, target),
     subscriptionManagement: new SubscriptionManagementPage(page, target),
     resetPassword: new ResetPasswordPage(page, target),
+    resetPasswordReact: new ResetPasswordReactPage(page, target),
     legal: new LegalPage(page, target),
     cookiesDisabled: new CookiesDisabledPage(page, target),
     postVerify: new PostVerifyPage(page, target),

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -10,7 +10,7 @@ export class RelierPage extends BaseLayout {
 
   async isLoggedIn() {
     const login = this.page.locator('#loggedin');
-    await login.waitFor({ state: 'visible' });
+    await login.waitFor();
     return login.isVisible();
   }
 
@@ -60,7 +60,7 @@ export class RelierPage extends BaseLayout {
   }
 
   async promptNoneError() {
-    const error = this.page.locator('.error');
+    const error = await this.page.locator('.error');
     return error.innerText();
   }
 

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -4,6 +4,7 @@ export const selectors = {
   RESET_PASSWORD_EXPIRED_HEADER: '#fxa-reset-link-expired-header',
   RESET_PASSWORD_HEADER: '#fxa-reset-password-header',
   CONFIRM_RESET_PASSWORD_HEADER: '#fxa-confirm-reset-password-header',
+  COMPLETE_RESET_PASSWORD_HEADER: '#fxa-complete-reset-password-header',
   EMAIL: 'input[type=email]',
   SUBMIT: 'button[type=submit]',
   VPASSWORD: '#vpassword',
@@ -22,39 +23,32 @@ export class ResetPasswordPage extends BaseLayout {
   }
 
   async resetPasswordHeader() {
-    const resetPass = this.page.locator(selectors.RESET_PASSWORD_HEADER);
-    await resetPass.waitFor();
-    return resetPass.isVisible();
+    const header = this.page.locator(selectors.RESET_PASSWORD_HEADER);
+    await header.waitFor();
   }
 
   async confirmResetPasswordHeader() {
-    const resetPass = this.page.locator(
-      selectors.CONFIRM_RESET_PASSWORD_HEADER
-    );
-    await resetPass.waitFor();
-    return resetPass.isVisible();
+    const header = this.page.locator(selectors.CONFIRM_RESET_PASSWORD_HEADER);
+    await header.waitFor();
   }
 
-  async completeResetPasswordHeader() {
-    const resetPass = this.page.locator(
-      selectors.RESET_PASSWORD_COMPLETE_HEADER
-    );
-    await resetPass.waitFor();
-    return resetPass.isVisible();
+  async completeResetPasswordHeader(page: BaseLayout['page'] = this.page) {
+    const header = page.locator(selectors.COMPLETE_RESET_PASSWORD_HEADER);
+    await header.waitFor();
   }
 
   async resetPasswordLinkExpiredHeader() {
-    const resetPass = this.page.locator(
-      selectors.RESET_PASSWORD_EXPIRED_HEADER
-    );
-    await resetPass.waitFor();
-    return resetPass.isVisible();
+    const header = this.page.locator(selectors.RESET_PASSWORD_EXPIRED_HEADER);
+    await header.waitFor();
   }
 
-  async resetNewPassword(password: string) {
-    await this.page.locator(selectors.PASSWORD).fill(password);
-    await this.page.locator(selectors.VPASSWORD).fill(password);
-    await this.page.locator(selectors.SUBMIT).click();
+  async resetNewPassword(
+    password: string,
+    page: BaseLayout['page'] = this.page
+  ) {
+    await page.locator(selectors.PASSWORD).fill(password);
+    await page.locator(selectors.VPASSWORD).fill(password);
+    await page.locator(selectors.SUBMIT).click();
   }
 
   async fillOutResetPassword(email) {

--- a/packages/functional-tests/pages/resetPasswordReact.ts
+++ b/packages/functional-tests/pages/resetPasswordReact.ts
@@ -1,0 +1,110 @@
+import { getReactFeatureFlagUrl } from '../lib/react-flag';
+import { BaseLayout } from './layout';
+
+export class ResetPasswordReactPage extends BaseLayout {
+  readonly path = '';
+
+  goto(route = '/reset_password', query?: string) {
+    return this.page.goto(getReactFeatureFlagUrl(this.target, route, query));
+  }
+
+  // page can be passed in as an optional prop - useful when a test uses more than one page
+  getEmailValue(page: BaseLayout['page'] = this.page) {
+    return page.getByRole('textbox', { name: 'Email' }).inputValue();
+  }
+
+  async resetPasswordHeadingVisible(page: BaseLayout['page'] = this.page) {
+    const heading = page.getByRole('heading', {
+      // Full heading might include "continue to [relying party]"
+      name: /Reset password/,
+    });
+    await heading.waitFor();
+  }
+
+  async confirmResetPasswordHeadingVisible(
+    page: BaseLayout['page'] = this.page
+  ) {
+    const heading = page.getByRole('heading', {
+      name: 'Reset email sent',
+    });
+    await heading.waitFor();
+  }
+
+  async completeResetPwdHeadingVisible(page: BaseLayout['page'] = this.page) {
+    const heading = page.getByRole('heading', {
+      name: 'Create new password',
+    });
+    await heading.waitFor();
+  }
+
+  async resetPwdConfirmedHeadingVisible(page: BaseLayout['page'] = this.page) {
+    const heading = page.getByRole('heading', {
+      name: 'Your password has been reset',
+    });
+    await heading.waitFor();
+  }
+
+  async confirmRecoveryKeyHeadingVisible(page: BaseLayout['page'] = this.page) {
+    const heading = page.getByRole('heading', {
+      name: 'Reset password with account recovery key',
+    });
+    await heading.waitFor();
+  }
+
+  async resetPwdLinkExpiredHeadingVisible(
+    page: BaseLayout['page'] = this.page
+  ) {
+    const heading = page.getByRole('heading', {
+      name: 'Reset password link expired',
+    });
+    await heading.waitFor();
+  }
+
+  async submitNewPassword(
+    password: string,
+    page: BaseLayout['page'] = this.page
+  ) {
+    await page.getByRole('textbox', { name: 'New password' }).fill(password);
+    await page
+      .getByRole('textbox', { name: 'Re-enter password' })
+      .fill(password);
+    await page.getByRole('button', { name: 'Reset password' }).click();
+  }
+
+  async submitRecoveryKey(key: string, page: BaseLayout['page'] = this.page) {
+    const recoveryKeyInput = page.getByRole('textbox');
+    const submitButton = page.getByRole('button');
+    await recoveryKeyInput.fill(key);
+    await submitButton.click();
+  }
+
+  async fillEmailToResetPwd(email, page: BaseLayout['page'] = this.page) {
+    await page.getByRole('textbox', { name: 'Email' }).fill(email);
+    await page.getByRole('button', { name: 'Begin reset' }).click();
+  }
+
+  async clickResendLink(page: BaseLayout['page'] = this.page) {
+    const resendLink = await page.getByRole('link', {
+      name: 'Not in inbox or spam folder? Resend',
+    });
+    await resendLink.waitFor();
+    await resendLink.click();
+  }
+
+  async resendSuccessMessageVisible(page: BaseLayout['page'] = this.page) {
+    await page.getByText(/Email resent/).waitFor();
+  }
+
+  async unknownAccountError(page: BaseLayout['page'] = this.page) {
+    await page.getByText('Unknown account').waitFor();
+  }
+
+  async addQueryParamsToLink(link: string, query: object) {
+    query = query || {};
+    const parsedLink = new URL(link);
+    for (const paramName in query) {
+      parsedLink.searchParams.set(paramName, query[paramName]);
+    }
+    return parsedLink.toString();
+  }
+}

--- a/packages/functional-tests/tests/oauth/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/oauth/resetPassword.spec.ts
@@ -6,7 +6,7 @@ import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
 test.describe('oauth reset password', () => {
-  test.beforeEach(async ({ target, pages: { login } }) => {
+  test.beforeEach(async () => {
     test.slow();
   });
 
@@ -23,7 +23,7 @@ test.describe('oauth reset password', () => {
     await login.clickForgotPassword();
 
     // Verify reset password header
-    expect(await resetPassword.resetPasswordHeader()).toBe(true);
+    await resetPassword.resetPasswordHeader();
 
     await resetPassword.fillOutResetPassword(credentials.email);
 

--- a/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-import { BaseTarget } from '../../lib/targets/base';
-
-function getReactFeatureFlagUrl(target: BaseTarget, path: string) {
-  return `${target.contentServerUrl}${path}?showReactApp=true`;
-}
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.beforeEach(async ({ pages: { login } }) => {
   // This test requires simple react routes to be enabled

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -3,15 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-import { BaseTarget } from '../../lib/targets/base';
-
-function getReactFeatureFlagUrl(
-  target: BaseTarget,
-  path: string,
-  showReactApp = true
-) {
-  return `${target.contentServerUrl}${path}?showReactApp=${showReactApp}`;
-}
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.beforeEach(async ({ pages: { login } }) => {
   // This test requires simple react routes to be enabled

--- a/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, newPagesForSync } from '../../lib/fixtures/standard';
+import { EmailHeader, EmailType } from '../../lib/email';
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
+
+test.describe.configure({ mode: 'parallel' });
+let syncBrowserPages;
+
+test.describe('Firefox Desktop Sync v3 reset password react', () => {
+  test.beforeEach(async ({ target, pages: { login } }) => {
+    test.slow();
+    // Ensure that the feature flag is enabled
+    const config = await login.getConfig();
+    test.skip(config.showReactApp.resetPasswordRoutes !== true);
+
+    syncBrowserPages = await newPagesForSync(target);
+  });
+
+  test.afterEach(async () => {
+    await syncBrowserPages.browser?.close();
+  });
+
+  test('reset pw for sync user', async ({ credentials, target }) => {
+    const { page, resetPasswordReact } = syncBrowserPages;
+    await page.goto(
+      getReactFeatureFlagUrl(
+        target,
+        '/reset_password',
+        'context=fx_desktop_v3&service=sync'
+      )
+    );
+
+    // Verify react page has been loaded
+    await page.waitForSelector('#root');
+
+    // Check that the sync relier is in the heading
+    await page
+      .getByRole('heading', {
+        name: /Firefox Sync/,
+      })
+      .waitFor();
+
+    await resetPasswordReact.fillEmailToResetPwd(credentials.email);
+
+    // We need to append `&showReactApp=true` to reset link in order to enroll in reset password experiment
+    let link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    link = `${link}&showReactApp=true`;
+
+    await page.goto(link);
+
+    await resetPasswordReact.submitNewPassword('Newpassword@');
+    await page.waitForURL(/reset_password_verified/);
+
+    await resetPasswordReact.resetPwdConfirmedHeadingVisible();
+
+    // Update credentials file so that account can be deleted as part of test cleanup
+    credentials.password = 'Newpassword@';
+  });
+});

--- a/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
@@ -1,8 +1,63 @@
 import { test, expect } from '../../lib/fixtures/standard';
+import { EmailHeader, EmailType } from '../../lib/email';
+
+const NEW_PASSWORD = 'passwordzxcv';
 
 test.describe('Reset password current', () => {
-  test.beforeEach(async ({ target, credentials, pages: { login } }) => {
+  test.beforeEach(async () => {
     test.slow();
+  });
+
+  test('can reset password', async ({
+    page,
+    target,
+    credentials,
+    context,
+    pages: { login, resetPassword, settings },
+  }) => {
+    await page.goto(`${target.contentServerUrl}/reset_password`);
+
+    // Verify backbone page has been loaded
+    await page.waitForSelector('#stage');
+
+    await resetPassword.fillOutResetPassword(credentials.email);
+
+    // Verify confirm password reset page has rendered
+    await resetPassword.confirmResetPasswordHeader();
+
+    const link = await target.email.waitForEmail(
+      credentials.email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+
+    // Open link in a new window
+    const diffPage = await context.newPage();
+    await diffPage.goto(link);
+
+    await resetPassword.completeResetPasswordHeader(diffPage);
+
+    await resetPassword.resetNewPassword(NEW_PASSWORD, diffPage);
+
+    await page.getByRole('heading', { name: 'Settings', level: 2 }).waitFor();
+
+    await diffPage
+      .getByRole('heading', { name: 'Settings', level: 2 })
+      .waitFor();
+
+    await diffPage.close();
+    await settings.signOut();
+
+    // Verify that new password can be used to log in
+    await login.setEmail(credentials.email);
+    await login.submit();
+    await login.setPassword(NEW_PASSWORD);
+    await login.submit();
+
+    await page.getByRole('heading', { name: 'Settings', level: 2 }).waitFor();
+
+    // Cleanup requires setting this value to correct password
+    credentials.password = NEW_PASSWORD;
   });
 
   test('visit confirmation screen without initiating reset_password, user is redirected to /reset_password', async ({
@@ -15,7 +70,7 @@ test.describe('Reset password current', () => {
     );
 
     // Verify its redirected to reset password page
-    expect(await resetPassword.resetPasswordHeader()).toBe(true);
+    await resetPassword.resetPasswordHeader();
   });
 
   test('open /reset_password page from /signin', async ({
@@ -36,11 +91,11 @@ test.describe('Reset password current', () => {
   }) => {
     await page.goto(`${target.contentServerUrl}/reset_password`);
     await resetPassword.fillOutResetPassword(' ' + credentials.email);
-    expect(await resetPassword.confirmResetPasswordHeader()).toBe(true);
+    await resetPassword.confirmResetPasswordHeader();
 
     await page.goto(`${target.contentServerUrl}/reset_password`);
     await resetPassword.fillOutResetPassword(credentials.email + ' ');
-    expect(await resetPassword.confirmResetPasswordHeader()).toBe(true);
+    await resetPassword.confirmResetPasswordHeader();
   });
 
   test('open confirm_reset_password page, click resend', async ({
@@ -82,6 +137,6 @@ test.describe('Reset password current', () => {
     //The email shouldn't be pre-filled
     expect(await resetPassword.getEmailValue()).toBeEmpty();
     await resetPassword.fillOutResetPassword(credentials.email);
-    expect(await resetPassword.confirmResetPasswordHeader()).toBe(true);
+    await resetPassword.confirmResetPasswordHeader();
   });
 });

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -96,6 +96,6 @@ test.describe('change password tests', () => {
     await login.clickForgotPassword();
 
     // Verify it navigates to reset password page
-    expect(await resetPassword.resetPasswordHeader()).toBe(true);
+    await resetPassword.resetPasswordHeader();
   });
 });

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -506,7 +506,7 @@ test.describe('new recovery key test', () => {
     await page.goto(link, { waitUntil: 'load' });
 
     // Verify reset link expired
-    expect(await resetPassword.resetPasswordLinkExpiredHeader()).toBe(true);
+    await resetPassword.resetPasswordLinkExpiredHeader();
   });
 
   test('revoke recovery key', async ({ pages: { settings } }) => {

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -24,7 +24,7 @@ test.describe('signin here', () => {
     await login.clickForgotPassword();
 
     //Verify reset password header
-    expect(await resetPassword.resetPasswordHeader()).toBe(true);
+    await resetPassword.resetPasswordHeader();
   });
 
   test('signin with email with leading/trailing whitespace on the email', async ({

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -56,10 +56,7 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
     expect(await login.notCommonPasswordUnmetError()).toBe(true);
 
     await resetPassword.resetNewPassword('Newpassword@');
-    expect(await resetPassword.completeResetPasswordHeader()).toBe(true);
-
-    // Update credentials file so that account can be deleted as part of test cleanup
-    credentials.password = 'Newpassword@';
+    await resetPassword.completeResetPasswordHeader();
 
     await browser?.close();
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -165,6 +165,78 @@ describe('PageResetPassword', () => {
     );
   });
 
+  it('submit success with trailing space in email', async () => {
+    const account = {
+      resetPassword: jest.fn().mockResolvedValue({
+        passwordForgotToken: '123',
+      }),
+    } as unknown as Account;
+
+    renderWithAccount(account);
+
+    await waitFor(() =>
+      fireEvent.input(screen.getByTestId('reset-password-input-field'), {
+        target: { value: `${MOCK_ACCOUNT.primaryEmail.email} ` },
+      })
+    );
+
+    fireEvent.click(screen.getByText('Begin reset'));
+
+    await waitFor(() => {
+      expect(account.resetPassword).toHaveBeenCalledWith(
+        MOCK_ACCOUNT.primaryEmail.email,
+        MozServices.Default
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'confirm_reset_password?showReactApp=true',
+        {
+          replace: true,
+          state: {
+            email: 'johndope@example.com',
+            passwordForgotToken: '123',
+          },
+        }
+      );
+    });
+  });
+
+  it('submit success with leading space in email', async () => {
+    const account = {
+      resetPassword: jest.fn().mockResolvedValue({
+        passwordForgotToken: '123',
+      }),
+    } as unknown as Account;
+
+    renderWithAccount(account);
+
+    await waitFor(() =>
+      fireEvent.input(screen.getByTestId('reset-password-input-field'), {
+        target: { value: ` ${MOCK_ACCOUNT.primaryEmail.email}` },
+      })
+    );
+
+    fireEvent.click(screen.getByText('Begin reset'));
+
+    await waitFor(() => {
+      expect(account.resetPassword).toHaveBeenCalledWith(
+        MOCK_ACCOUNT.primaryEmail.email,
+        MozServices.Default
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'confirm_reset_password?showReactApp=true',
+        {
+          replace: true,
+          state: {
+            email: 'johndope@example.com',
+            passwordForgotToken: '123',
+          },
+        }
+      );
+    });
+  });
+
   describe('displays error and does not allow submission', () => {
     const account = {
       resetPassword: jest.fn().mockResolvedValue({

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -136,7 +136,7 @@ const ResetPassword = ({
         setErrorMessage(localizedError);
       }
     },
-    [account, clearError, ftlMsgResolver, navigateToConfirmPwReset]
+    [account, clearError, ftlMsgResolver, navigateToConfirmPwReset, serviceName]
   );
 
   const onSubmit = useCallback(async () => {


### PR DESCRIPTION
## Because

- We want to enable all reset password functional tests for both react and content-server

## This pull request

* Add playwright test for content-server reset password "happy path"
* Add additional tests for react reset password route
* Add react reset password test for sync
* Move some react reset password tests to unit tests 

## Issue that this pull request solves

Closes: #FXA-7248

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Previous [draft PR](https://github.com/mozilla/fxa/pull/15427) was closed due to an error in the ticket number.
