### PR TITLE
test(functional): rewrite fx desktop handshake tests

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -28,6 +28,8 @@ export const selectors = {
   RESET_PASSWORD_EXPIRED_HEADER: '#fxa-reset-link-expired-header',
   RESET_PASSWORD_HEADER: '#fxa-reset-password-header',
   SIGN_UP_CODE_HEADER: '#fxa-confirm-signup-code-header',
+  SIGNIN_BOUNCED_HEADER: '#fxa-signin-bounced-header',
+  BOUNCED_CREATE_ACCOUNT: '#create-account',
   SIGN_IN_CODE_HEADER: '#fxa-signin-code-header',
   CONFIRM_EMAIL: '.email',
   SIGNIN_HEADER: '#fxa-signin-header',
@@ -258,6 +260,10 @@ export class LoginPage extends BaseLayout {
     return this.page.click(selectors.LINK_USE_RECOVERY_CODE);
   }
 
+  async clickBouncedCreateAccount() {
+    return this.page.locator(selectors.BOUNCED_CREATE_ACCOUNT).click();
+  }
+
   async setCode(code: string) {
     return this.page.fill(selectors.RECOVERY_KEY_TEXT_INPUT, code);
   }
@@ -355,6 +361,12 @@ export class LoginPage extends BaseLayout {
 
   async isSigninHeader() {
     return this.page.isVisible(selectors.SIGNIN_HEADER, {
+      timeout: 100,
+    });
+  }
+
+  async isSigninBouncedHeader() {
+    return this.page.isVisible(selectors.SIGNIN_BOUNCED_HEADER, {
       timeout: 100,
     });
   }

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -100,4 +100,31 @@ test.describe('signin here', () => {
     // Verify the header after login
     expect(await login.loginHeader()).toBe(true);
   });
+
+  test('with bounced email', async ({
+    target,
+    page,
+    pages: { login, settings },
+  }) => {
+    const email = login.createEmail('sync{id}');
+    const password = 'password123';
+    await target.createAccount(email, password);
+    await page.goto(
+      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`
+    );
+    await login.fillOutEmailFirstSignIn(email, password);
+
+    // Verify the header after login
+    expect(await login.isSignInCodeHeader()).toBe(true);
+    await target.auth.accountDestroy(email, password);
+    await page.waitForURL(/signin_bounced/);
+
+    //Verify sign in bounced header
+    expect(await login.isSigninBouncedHeader()).toBe(true);
+    await login.clickBouncedCreateAccount();
+
+    //Verify user redirected to login page
+    expect(await login.isEmailHeader()).toBe(true);
+    expect(await login.getEmailInput()).toContain('');
+  });
 });

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -1,0 +1,274 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+
+import uaStrings from '../../lib/ua-strings';
+
+const password = 'passwordzxcv';
+let syncBrowserPages;
+let browserSignedInEmail;
+let browserSignedInAccount;
+
+let otherEmail;
+let otherAccount;
+
+const ensureUsers = async (page, target, login) => {
+  // Ensure browserSignedInAccount
+  if (!browserSignedInAccount) {
+    browserSignedInEmail = login.createEmail();
+    await target.auth.signUp(browserSignedInEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    (_browserSignedInAccount) => {
+      browserSignedInAccount = _browserSignedInAccount;
+      browserSignedInAccount.email = browserSignedInEmail;
+      browserSignedInAccount.verified = true;
+      login.clearCache();
+    };
+  }
+  // Ensure otherAccount
+  if (!otherAccount) {
+    otherEmail = login.createEmail();
+    await target.auth.signUp(otherEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    (_otherAccount) => {
+      otherAccount = _otherAccount;
+      otherAccount.email = otherEmail;
+      otherAccount.verified = true;
+    };
+  }
+};
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Firefox desktop user info handshake', () => {
+  test.beforeEach(async ({ target, page }) => {
+    test.slow();
+    syncBrowserPages = await newPagesForSync(target);
+    const { login } = syncBrowserPages;
+    await login.clearCache();
+    await ensureUsers(page, target, login);
+  });
+
+  test.afterEach(async () => {
+    await syncBrowserPages.browser?.close();
+  });
+
+  test('Non-Sync - user signed into browser, user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: null,
+      }
+    );
+    await page.goto(
+      `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    await login.fillOutEmailFirstSignIn(otherEmail, password);
+    expect(await login.loginHeader()).toBe(true);
+
+    // Then, sign in the user again, synthesizing the user having signed
+    // into Sync after the initial sign in.
+    const eventDetailStatusSignIn = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: browserSignedInAccount,
+      }
+    );
+    await page.goto(
+      `${target.contentServerUrl}?/automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatusSignIn);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+
+    expect(await login.getPrefilledEmail()).toContain(otherEmail);
+    await login.clickSignIn();
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('Sync - no user signed into browser, no user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+    });
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&${query.toString()}`
+    );
+    expect(await login.isEmailHeader()).toBe(true);
+    expect(await login.getEmailInput()).toContain('');
+  });
+
+  test('Sync - no user signed into browser, user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+    });
+    await page.goto(
+      `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
+    );
+    await login.fillOutEmailFirstSignIn(otherEmail, password);
+    expect(await login.loginHeader()).toBe(true);
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
+    );
+    expect(await login.getPrefilledEmail()).toContain(otherEmail);
+  });
+
+  test('Non-Sync - no user signed into browser, no user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: null,
+      }
+    );
+    await page.goto(
+      `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    expect(await login.getEmailInput()).toContain('');
+  });
+
+  test('Sync force_auth page - user signed into browser is different to requested user', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+      email: otherEmail,
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: browserSignedInAccount,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?force_auth&automatedBrowser=true&context=fx_desktop_v3&service=sync&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    expect(await login.getPrefilledEmail()).toContain(otherEmail);
+  });
+
+  test('Non-Sync force_auth page - user signed into browser is different to requested user', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+      email: otherEmail,
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: browserSignedInAccount,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?force_auth&automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    expect(await login.getPrefilledEmail()).toContain(otherEmail);
+  });
+
+  test('Sync - user signed into browser, no user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+      email: browserSignedInEmail,
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: browserSignedInEmail,
+      }
+    );
+    await page.goto(
+      `${
+        target.contentServerUrl
+      }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    expect(await login.getPrefilledEmail()).toContain(browserSignedInEmail);
+  });
+
+  test('Non-Sync - user signed into browser, no user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+      email: browserSignedInEmail,
+    });
+    const eventDetailStatus = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        signedInUser: browserSignedInEmail,
+      }
+    );
+    await page.goto(
+      `${target.contentServerUrl}?/automatedBrowser=true&${query.toString()}`
+    );
+    await login.respondToWebChannelMessage(eventDetailStatus);
+    await login.checkWebChannelMessage('fxaccounts:fxa_status');
+    expect(await login.getPrefilledEmail()).toContain(browserSignedInEmail);
+    await login.setPassword(password);
+    await login.clickSubmit();
+    expect(await login.loginHeader()).toBe(true);
+  });
+
+  test('Non-Sync settings page - no user signed into browser, user signed in locally', async ({
+    target,
+  }) => {
+    const { login, page, settings } = syncBrowserPages;
+    const query = new URLSearchParams({
+      forceUA: uaStrings['desktop_firefox_71'],
+    });
+    await page.goto(
+      `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
+    );
+    await login.fillOutEmailFirstSignIn(otherEmail, password);
+    expect(await login.loginHeader()).toBe(true);
+
+    await settings.goto();
+    const primaryEmail = await settings.primaryEmail.statusText();
+    expect(primaryEmail).toEqual(otherEmail);
+  });
+});


### PR DESCRIPTION
## Because

As part of the playwright test migration, the [fx desktop handshake tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js) and sign in with bounced email (happy path) test have been rewritten in this PR.

## This pull request

contains the [fx desktop handshake tests](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js) and sign in with bounced email (happy path) test 

## Issue that this pull request solves

Closes: FXA-5907

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
