### PR TITLE
feat(auth): pass In 'always_invoice' On Subscription Upgrade

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1927,6 +1927,11 @@ export class StripeHelper extends StripeHelperBase {
       plan_change_date: moment().unix(),
     };
 
+    const prorationBehavior = this.config.subscriptions.stripeInvoiceImmediately
+      .enabled
+      ? 'always_invoice'
+      : 'create_prorations';
+
     const updatedSubscription = await this.updateSubscriptionAndBackfill(
       subscription,
       {
@@ -1937,6 +1942,7 @@ export class StripeHelper extends StripeHelperBase {
             plan: newPlanId,
           },
         ],
+        proration_behavior: prorationBehavior,
         metadata: updatedMetadata,
       }
     );

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -82,6 +82,9 @@ export type StripeHelperConfig = {
     productConfigsFirestore: {
       enabled: boolean;
     };
+    stripeInvoiceImmediately: {
+      enabled: boolean;
+    };
   };
   authFirestore: {
     prefix: string;


### PR DESCRIPTION
Because:

* we want to invoice immediately when subscriptions are upgraded

This commit:

* passes in the parameter to stripe (conditionally on env var) to invoice immediately on sub upgrades

Closes #FXA-7438

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
