### PR TITLE
fix(payments/paypal): convert undefined before request

### DIFF
--- a/libs/payments/paypal/src/lib/util.spec.ts
+++ b/libs/payments/paypal/src/lib/util.spec.ts
@@ -9,6 +9,7 @@ describe('util', () => {
     const obj = {
       NAME: 'Robert Moore',
       COMPANY: 'R. H. Moore & Associates',
+      EMAIL: undefined,
       L: [
         {
           EXAMPLE: 'val',
@@ -18,7 +19,7 @@ describe('util', () => {
     const result = objectToNVP(obj);
     // See https://developer.paypal.com/api/nvp-soap/NVPAPIOverview/#link-specifycredentialswithcurl
     expect(result).toEqual(
-      'COMPANY=R.+H.+Moore+%26+Associates&L_EXAMPLE0=val&NAME=Robert+Moore'
+      'COMPANY=R.+H.+Moore+%26+Associates&EMAIL=&L_EXAMPLE0=val&NAME=Robert+Moore'
     );
   });
 

--- a/libs/payments/paypal/src/lib/util.ts
+++ b/libs/payments/paypal/src/lib/util.ts
@@ -32,7 +32,11 @@ export function isIpnMerchPmt(
  * in compliance with https://developer.paypal.com/api/nvp-soap/NVPAPIOverview/#link-urlencoding
  */
 export function objectToNVP(object: Record<string, any>): string {
-  const urlSearchParams = new URLSearchParams(object);
+  // Convert undefined values to an empty string
+  const santizedObject = Object.fromEntries(
+    Object.entries(object).map(([k, v]) => [k, v === undefined ? '' : v])
+  );
+  const urlSearchParams = new URLSearchParams(santizedObject);
 
   // Convert array containing L_ objects to Paypal NVP list string
   if (object.L) {


### PR DESCRIPTION
## Because

- objectToNVP converts object properties with undefined values to a string with value undefined. PayPal expects undefined values to be an empty string param.

## This pull request

- Converts object properties with an undefined value to empty string.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
