### PR TITLE
fix(emails): correct amounts in upgrade email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1767,8 +1767,6 @@ module.exports = function (log, config, bounces) {
     const {
       email,
       uid,
-      invoiceTotalNewInCents,
-      invoiceTotalOldInCents,
       productId,
       planId,
       productIconURLNew,
@@ -1810,12 +1808,12 @@ module.exports = function (log, config, bounces) {
         productName: productNameNew,
         productNameOld,
         paymentAmountOld: this._getLocalizedCurrencyString(
-          invoiceTotalOldInCents || paymentAmountOldInCents,
+          paymentAmountOldInCents,
           paymentAmountOldCurrency,
           message.acceptLanguage
         ),
         paymentAmountNew: this._getLocalizedCurrencyString(
-          invoiceTotalNewInCents || paymentAmountNewInCents,
+          paymentAmountNewInCents,
           paymentAmountNewCurrency,
           message.acceptLanguage
         ),


### PR DESCRIPTION
## Because

- The incorrect amounts are showing in the upgrade email template for same and different billing cycles.

## This pull request

- Corrects amounts listed in same billing cycle upgrade email.
- Corrects amounts listed in different billing cycle upgrade email.
- Updates applicable stories and tests.

## Issue that this pull request solves

Closes: FXA-7349

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

The following scenarios were tested with both inclusive and exclusive tax(es) and for both same and different billing cycle (total of 16 different scenarios):

- single tax
- single tax with coupon
- multiple taxes
- multiple taxes with coupon

Additionally tested upgrading from exclusive to inclusive and vice versa with the aforementioned scenarios.
