### PR TITLE
fix(functional-tests): update forceAuth test

### DIFF
--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -23,7 +23,7 @@ test.describe('force auth', () => {
     await login.clickForgotPassword();
 
     // Verify reset password header
-    expect(await resetPassword.resetPasswordHeader()).toBe(true);
+    await resetPassword.resetPasswordHeader();
 
     //Verify email is prefilled
     expect(await login.getPrefilledEmail()).toContain(credentials.email);
@@ -37,7 +37,7 @@ test.describe('force auth', () => {
     await resetPassword.clickBeginReset();
 
     //Verify confirm reset password header
-    expect(await resetPassword.confirmResetPasswordHeader()).toBe(true);
+    await resetPassword.confirmResetPasswordHeader();
 
     //Click 'Remember password? Sign in', redirected to force auth page
     await resetPassword.clickRememberPassword();


### PR DESCRIPTION
## Because

- Changes introduced in #15478 removed the return value from method resetPasswordHeader and confirmResetPasswordHeader

## This pull request

- Updates test to no longer expect a return value from method resetPasswordHeader and confirmResetPasswordHeader

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).