### PR TITLE
RFC React container components prototype

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -78,6 +78,7 @@
     "@types/react-webcam": "^3.0.0",
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.2.0",
+    "class-validator": "^0.14.0",
     "classnames": "^2.3.1",
     "fxa-auth-client": "workspace:*",
     "fxa-common-password-list": "^0.0.4",

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
@@ -29,7 +29,7 @@ export const LinkExpiredResetPassword = ({
 
   const resendResetPasswordLink = async () => {
     try {
-      await account.resetPassword(email, serviceName);
+      // await account.resetPassword(email, serviceName);
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
       setResendStatus(ResendStatus['sent']);
     } catch (e) {

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -628,7 +628,7 @@ type ErrorVal = { errno: number; message: string; version?: number };
 
 export const composeAuthUiErrorTranslationId = (err: {
   errno?: number;
-  message: string;
+  message?: string;
 }) => {
   /* all of these checks for fields/values being present look a little wonky, but allow us to work with
    * the AuthUiError type, which has all optional fields. Previously this wasn't an issue bc we didn't use

--- a/packages/fxa-settings/src/lib/hooks/useValidate/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useValidate/index.tsx
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useMemo, useState } from 'react';
+import { validate, ValidationError } from 'class-validator';
+import { ReachRouterWindow } from '../../window';
+import { UrlQueryData } from '../../model-data';
+
+// ❌ TODO: improve types here. We may also want to tweak the shape of what this returns.
+export function useValidatedQueryParams<T extends Record<string, any>>(
+  Schema: new () => T
+) {
+  const [state, setState] = useState<{
+    queryParams: T | null;
+    queryParamErrors: Record<string, string> | null;
+  }>({ queryParams: null, queryParamErrors: null });
+
+  const urlQueryData = useMemo(
+    () => new UrlQueryData(new ReachRouterWindow()),
+    []
+  );
+
+  useEffect(() => {
+    const schema = new Schema();
+
+    for (let key in schema) {
+      const value = urlQueryData.get(key);
+      if (value) {
+        (schema as any)[key] = value;
+      }
+    }
+
+    validate(schema).then((validationErrors) => {
+      const queryParamErrors: Record<string, any> = {};
+      validationErrors.forEach((error: ValidationError) => {
+        if (error.constraints) {
+          queryParamErrors[error.property] = Object.values(
+            error.constraints
+          )[0];
+        }
+      });
+      setState({
+        queryParams: schema,
+        queryParamErrors: Object.keys(queryParamErrors).length
+          ? queryParamErrors
+          : null,
+      });
+    });
+  }, [Schema, urlQueryData]);
+
+  return state;
+}

--- a/packages/fxa-settings/src/lib/hooks/useValidate/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useValidate/index.tsx
@@ -24,7 +24,7 @@ export function useValidatedQueryParams<T extends Record<string, any>>(
   useEffect(() => {
     const schema = new Schema();
 
-    for (let key in schema) {
+    for (let key of Object.keys(schema)) {
       const value = urlQueryData.get(key);
       if (value) {
         (schema as any)[key] = value;

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -539,60 +539,6 @@ export class Account implements AccountData {
     });
   }
 
-  async resetPassword(
-    email: string,
-    service?: string
-  ): Promise<PasswordForgotSendCodePayload> {
-    try {
-      const result = await this.apolloClient.mutate({
-        mutation: gql`
-          mutation passwordForgotSendCode(
-            $input: PasswordForgotSendCodeInput!
-          ) {
-            passwordForgotSendCode(input: $input) {
-              passwordForgotToken
-            }
-          }
-        `,
-        variables: {
-          input: {
-            email,
-            // Only include the `service` option if the service is Sync.
-            // This becomes a query param (service=sync) on the email link.
-            // We need to modify this in FXA-7657 to send the `client_id` param
-            // when we work on the OAuth flow.
-            ...(service &&
-              service === MozServices.FirefoxSync && { service: 'sync' }),
-          },
-        },
-      });
-      return result.data.passwordForgotSendCode;
-    } catch (err) {
-      const graphQlError = ((err as ApolloError) || (err as ThrottledError))
-        .graphQLErrors[0];
-      const errno = graphQlError.extensions?.errno;
-      if (
-        errno &&
-        AuthUiErrorNos[errno] &&
-        errno === AuthUiErrors.THROTTLED.errno
-      ) {
-        const throttledErrorWithRetryAfter = {
-          ...AuthUiErrorNos[errno],
-          retryAfter: graphQlError.extensions?.retryAfter,
-          retryAfterLocalized: graphQlError.extensions?.retryAfterLocalized,
-        };
-        throw throttledErrorWithRetryAfter;
-      } else if (
-        errno &&
-        AuthUiErrorNos[errno] &&
-        errno !== AuthUiErrors.THROTTLED.errno
-      ) {
-        throw AuthUiErrorNos[errno];
-      }
-      throw AuthUiErrors.UNEXPECTED_ERROR;
-    }
-  }
-
   async resetPasswordStatus(passwordForgotToken: string): Promise<boolean> {
     try {
       await this.apolloClient.mutate({

--- a/packages/fxa-settings/src/models/reset-password/index.ts
+++ b/packages/fxa-settings/src/models/reset-password/index.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  IsEmail,
+  MinLength,
+  IsOptional,
+  IsNotEmpty,
+  ValidationArguments,
+} from 'class-validator';
+
+// ❌ ResetPassword doesn't require query params, but this is an example of
+// how we can make a schema for them using `class-validator` to validate.
+export class ResetPasswordQueryParams {
+  @IsEmail()
+  @IsNotEmpty()
+  email = '';
+
+  @IsOptional()
+  @MinLength(3, {
+    message: (args: ValidationArguments) => {
+      // probably want to handle this differently, this was pulled straight from the docs
+      // just to show this is possible
+      if (args.value.length === 1) {
+        return 'Too short, minimum length is 1 character';
+      } else {
+        return (
+          'Too short, minimum length is ' + args.constraints[0] + ' characters'
+        );
+      }
+    },
+  })
+  someOtherParam?: string;
+}
+
+// ❌ What AccountRecoveryKeyInfo might look like, e.g. a non-query param schema
+export class AccountRecoveryKeyInfo {
+  @IsNotEmpty()
+  accountResetToken = '';
+
+  @IsNotEmpty()
+  kB = '';
+
+  @IsNotEmpty()
+  recoveryKeyId = '';
+}

--- a/packages/fxa-settings/src/models/reset-password/verification/complete-reset-password-link.ts
+++ b/packages/fxa-settings/src/models/reset-password/verification/complete-reset-password-link.ts
@@ -27,3 +27,27 @@ export class CompleteResetPasswordLink extends ModelDataProvider {
   @bind([V.isHex, V.isRequired])
   uid: string = '';
 }
+
+// ❌ Here's what this might look like with `class-validator`.
+// hexstring regex probably needs tweaking, this just shows some possibilities:
+// export class CompleteResetPasswordLink {
+//   @IsEmail()
+//   @IsNotEmpty()
+//   email = '';
+//
+//   @IsOptional()
+//   @IsEmail()
+//   emailToHashWith = '';
+//
+//   @IsString()
+//   @IsNotEmpty()
+//   code = '';
+//
+//   @Matches(/^[0-9a-fA-F]+$/)
+//   @IsNotEmpty()
+//   token = '';
+//
+//   @Matches(/^[0-9a-fA-F]+$/)
+//   @IsNotEmpty()
+//   uid = '';
+// }

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -72,7 +72,8 @@ const ConfirmResetPassword = (_: RouteComponentProps) => {
 
   const resendEmailHandler = async () => {
     try {
-      const result = await account.resetPassword(email, serviceName);
+      const result = { passwordForgotToken: '123' };
+      // const result = await account.resetPassword(email, serviceName);
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
       setCurrentPasswordForgotToken(result.passwordForgotToken);
       setResendStatus(ResendStatus['sent']);

--- a/packages/fxa-settings/src/pages/ResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/container.test.tsx
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import ResetPasswordContainer, {
+  BEGIN_RESET_PASSWORD_MUTATION,
+  BeginResetPasswordResult,
+} from './container';
+import { GraphQLError } from 'graphql';
+import { MOCK_ACCOUNT } from '../../models/mocks';
+import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+
+interface MockResponseOptions {
+  email?: string;
+  service?: string;
+  error?: AuthUiError | BeginResetPasswordResult['error'];
+  data?: BeginResetPasswordResult['data'];
+  message?: string;
+}
+
+function createMockResponse({
+  email = 'john@dope.com',
+  service = 'sync',
+  error,
+  data,
+  message,
+}: MockResponseOptions) {
+  return {
+    request: {
+      query: BEGIN_RESET_PASSWORD_MUTATION,
+      variables: {
+        input: { email, service },
+      },
+    },
+    // ❌ After writing this I noticed we have still have notes in fxa-settings
+    //  on how to mock mutation errors so this probably needs to be refactored:
+    // https://github.com/mozilla/fxa/tree/main/packages/fxa-settings#mocking-mutation-errors
+    result: () => {
+      if (error) {
+        // TODO: why is `message` in `AuthServerError` possibly undefined?
+        throw new GraphQLError(message!, null, null, null, null, null, error);
+      }
+      return { data };
+    },
+    error: message ? new Error(message) : undefined,
+  };
+}
+
+const mockResponse = createMockResponse({
+  data: {
+    passwordForgotSendCode: {
+      passwordForgotToken: '123',
+    },
+  },
+});
+
+const mockResponseWithUnknownAccountError = createMockResponse({
+  error: AuthUiErrors.UNKNOWN_ACCOUNT,
+  message: 'Error!',
+});
+
+const mockResponseWithThrottledError = createMockResponse({
+  error: {
+    ...AuthUiErrors.THROTTLED,
+    retryAfterLocalized: 'in 15 minutes',
+  },
+  message: 'Throttled Error!',
+});
+
+const mockResponseWithNetworkError = createMockResponse({
+  message: 'Network error',
+});
+
+// ❌ We may want to consider using `MockedCache` which was deleted in a refactor:
+// https://github.com/mozilla/fxa/blob/7a2fef8b77778eaa1b85fd961b924f8aa5afdc14/packages/fxa-settings/src/models/_mocks.tsx#L119
+//
+// Alternatively, we can mock `beginPasswordResetResult.error` in ResetPassword.
+// However, it'd be nice to have some testing in container components to ensure
+// we're performing queries and mutations as expected and processing errors as
+// expected that we're going to pass into ResetPassword. This could provide a
+// separation of concerns between errors coming from API calls to be tested here
+// and ResetPassword tests dealing with other errors (like an empty email input).
+// We're currently lacking any tests in Account.ts.
+describe('PageResetPassword', () => {
+  it('should render without error', async () => {
+    render(
+      <MockedProvider mocks={[mockResponse]} addTypename={false}>
+        <ResetPasswordContainer />
+      </MockedProvider>
+    );
+    screen.getByRole('heading', { name: 'Reset Password' });
+  });
+
+  describe('should handle GraphQLErrors', () => {
+    it('should handle an unknown account', async () => {
+      render(
+        <MockedProvider
+          mocks={[mockResponseWithUnknownAccountError]}
+          addTypename={false}
+        >
+          <ResetPasswordContainer />
+        </MockedProvider>
+      );
+
+      fireEvent.input(screen.getByTestId('reset-password-input-field'), {
+        target: { value: MOCK_ACCOUNT.primaryEmail.email },
+      });
+
+      fireEvent.click(screen.getByRole('button'));
+      await waitFor(() => screen.findByText('Unknown account'));
+    });
+
+    it('should handle throttling', async () => {
+      render(
+        <MockedProvider
+          mocks={[mockResponseWithThrottledError]}
+          addTypename={false}
+        >
+          <ResetPasswordContainer />
+        </MockedProvider>
+      );
+
+      fireEvent.input(screen.getByTestId('reset-password-input-field'), {
+        target: { value: MOCK_ACCOUNT.primaryEmail.email },
+      });
+
+      fireEvent.click(screen.getByText('Begin reset'));
+
+      await waitFor(() =>
+        screen.findByText(
+          'You’ve tried too many times. Please try again in 15 minutes.'
+        )
+      );
+    });
+  });
+
+  it('should handle error state with network error', async () => {
+    render(
+      <MockedProvider
+        mocks={[mockResponseWithNetworkError]}
+        addTypename={false}
+      >
+        <ResetPasswordContainer />
+      </MockedProvider>
+    );
+
+    fireEvent.input(screen.getByTestId('reset-password-input-field'), {
+      target: { value: MOCK_ACCOUNT.primaryEmail.email },
+    });
+
+    fireEvent.click(screen.getByText('Begin reset'));
+    await waitFor(() => screen.findByText('Unexpected error'));
+  });
+});

--- a/packages/fxa-settings/src/pages/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/container.tsx
@@ -13,17 +13,15 @@ import {
 } from '../../lib/auth-errors/auth-errors';
 import { RouteComponentProps } from '@reach/router';
 import { GraphQLError } from 'graphql';
+import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
+import {
+  AccountRecoveryKeyInfo,
+  ResetPasswordQueryParams,
+} from '../../models/reset-password';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
 // WIP PROTOTYPE
 // ❌ = Note for prototype review. Comment will be removed in implementation.
-
-// TODO for another page requiring some data validation
-// function createResetPasswordModel(data) {
-//   // validate data
-//   return {
-//     email: data.email,
-//   };
-// }
 
 export interface PasswordForgotSendCodeResponse {
   passwordForgotSendCode: {
@@ -82,6 +80,18 @@ const ResetPasswordContainer = (_: RouteComponentProps) => {
   const [beginResetPasswordError, setBeginResetPasswordError] =
     useState<BeginResetPasswordResult['error']>(undefined);
 
+  // ❌ Validate all the things. We may prefer for the model to handle these
+  // variations for us, e.g. we have one model per page and we have it attempt
+  // to read from router state, then localStorage, then query params but,
+  // it may also be nice to be more explicit.
+  const { queryParams, queryParamErrors } = useValidatedQueryParams(
+    ResetPasswordQueryParams
+  );
+  // ❌ Haven't implemented, but same idea as useValidatedQueryParams
+  // const { routerState, routerStateErrors } = useValidatedRouterState(
+  //   AccountRecoveryKeyInfo
+  // );
+
   const beginResetPasswordHandler: BeginResetPasswordHandler = useCallback(
     async (email, service) => {
       try {
@@ -137,6 +147,17 @@ const ResetPasswordContainer = (_: RouteComponentProps) => {
     [beginResetPassword]
   );
 
+  // ❌ We may or may not want this per container component but we can show a loading
+  // spinner here if validation is required and hasn't occured yet.
+  if (queryParams === null) {
+    return <LoadingSpinner />;
+  }
+  // ❌ Handle query param validation errors, e.g. return LinkDamaged or whatever
+  // makes sense for that error. Can also access errors like `queryParamErrors.email`
+  if (queryParamErrors) {
+    console.log('queryParamErrors', queryParamErrors);
+  }
+
   // ❌ Create a result object per query or mutation whose name matches
   // the handler. On more complex pages we will be passing multiple handlers
   // and their results.
@@ -148,7 +169,7 @@ const ResetPasswordContainer = (_: RouteComponentProps) => {
 
   return (
     <ResetPassword
-      {...{ beginResetPasswordHandler, beginResetPasswordResult }}
+      {...{ beginResetPasswordHandler, beginResetPasswordResult, queryParams }}
     />
   );
 };

--- a/packages/fxa-settings/src/pages/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/container.tsx
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql, useMutation } from '@apollo/client';
+import ResetPassword from '.';
+import { MozServices } from '../../lib/types';
+import { useCallback, useState } from 'react';
+import {
+  AuthUiErrorNos,
+  AuthUiErrors,
+  composeAuthUiErrorTranslationId,
+} from '../../lib/auth-errors/auth-errors';
+import { RouteComponentProps } from '@reach/router';
+import { GraphQLError } from 'graphql';
+
+// WIP PROTOTYPE
+// ❌ = Note for prototype review. Comment will be removed in implementation.
+
+// TODO for another page requiring some data validation
+// function createResetPasswordModel(data) {
+//   // validate data
+//   return {
+//     email: data.email,
+//   };
+// }
+
+export interface PasswordForgotSendCodeResponse {
+  passwordForgotSendCode: {
+    passwordForgotToken: string;
+  };
+}
+
+export type BeginResetPasswordHandler = (
+  email: string,
+  service?: MozServices
+) => Promise<void>;
+
+export interface BeginResetPasswordResult {
+  // ❌ 'data' is undefined when the mutation is loading and is 'null' when there
+  //  is an error
+  data: PasswordForgotSendCodeResponse | null | undefined;
+  loading: boolean;
+  error?: {
+    errno: number;
+    message: string;
+    ftlId: string;
+    retryAfterLocalized?: string;
+  };
+}
+
+export const BEGIN_RESET_PASSWORD_MUTATION = gql`
+  mutation passwordForgotSendCode($input: PasswordForgotSendCodeInput!) {
+    passwordForgotSendCode(input: $input) {
+      passwordForgotToken
+    }
+  }
+`;
+
+// ❌ Every page component that needs an API call or data validation will have a
+// corresponding container component to handle it.
+const ResetPasswordContainer = (_: RouteComponentProps) => {
+  // ❌ Instead of model.method in page components, e.g. `account.resetPassword`,
+  // queries and mutations will be executed in a page container component. This
+  // is possible by wrapping our app in `<ApolloProvider>` and allows:
+  // 1) Keeping the presentation layer light. "Heavy lifting" in our components is
+  // one reason we created the Account model (see pull/8138)
+  // 2) Better separation of our API/network layer from our data model. The
+  // Account model acts as both and has grown too large; having a per-page
+  // container makes it easy to see what data needs to be fetched and used and
+  // what processing occurs for that page. Keeping GQL in only this layer also
+  // makes it easier to refactor away from GQL if we ever desire to in the future
+  // 3) Using hooks instead of `apolloClient.query` or `apolloClient.mutate`
+  // which has several benefits, including attaching to the React lifecycle,
+  // easier polling, and more documentation
+  // 4) Easier testing. By never using `useQuery` or `useMutation` in our
+  // presentation layer, we don't need to use `MockedProvider`, which can require
+  // heavy mocking and setup, _except_ for in page container tests. This also
+  // provides more inversion of control.
+  const [beginResetPassword, beginResetPasswordMutationResult] =
+    useMutation<PasswordForgotSendCodeResponse>(BEGIN_RESET_PASSWORD_MUTATION);
+  const [beginResetPasswordError, setBeginResetPasswordError] =
+    useState<BeginResetPasswordResult['error']>(undefined);
+
+  const beginResetPasswordHandler: BeginResetPasswordHandler = useCallback(
+    async (email, service) => {
+      try {
+        await beginResetPassword({
+          variables: {
+            input: {
+              email,
+              // Only include the `service` option if the service is Sync.
+              // This becomes a query param (service=sync) on the email link.
+              // We need to modify this in FXA-7657 to send the `client_id` param
+              // when we work on the OAuth flow.
+              ...(service &&
+                service === MozServices.FirefoxSync && { service: 'sync' }),
+            },
+          },
+        });
+        setBeginResetPasswordError(undefined);
+      } catch (error) {
+        // ❌ All error processing should occur here. Let the presentation component
+        // handle just the presentation.
+        const graphQLError: GraphQLError = error.graphQLErrors[0];
+        if (graphQLError && graphQLError.extensions) {
+          const { errno, retryAfterLocalized } = graphQLError.extensions;
+
+          setBeginResetPasswordError({
+            errno,
+            message: AuthUiErrorNos[errno].message,
+            // ❌ Because grabbing the FTL ID from an error always requires a call to
+            // composeAuthUiErrorTranslationId, it seemed best to do that here when
+            // creating a new error object. Allow actual l10n with FtlMsg or FtlMsgResolver
+            // to occur in the presentation layer.
+            ftlId: composeAuthUiErrorTranslationId({ errno }),
+            retryAfterLocalized,
+          });
+        } else {
+          // ❌ Prior to our Account refactor, we had a custom `useMutation` hook that
+          // would capture networkErrors in Sentry. We may want to use that here as well.
+          // https://github.com/mozilla/fxa/blob/690a6b31f787e1325f13776f3ab577f153f1f8b1/packages/fxa-settings/src/lib/hooks.tsx#L68
+          // See our docs that explain more:
+          // https://github.com/mozilla/fxa/tree/main/packages/fxa-settings#gql-error-handling
+
+          // TODO: why is `errno` in `AuthServerError` possibly undefined?
+          // might want to grab from `ERRORS.UNEXPECTED_ERROR` instead
+          const { errno = 999, message } = AuthUiErrors.UNEXPECTED_ERROR;
+          setBeginResetPasswordError({
+            errno,
+            message,
+            ftlId: composeAuthUiErrorTranslationId({ errno }),
+          });
+        }
+      }
+    },
+    [beginResetPassword]
+  );
+
+  // ❌ Create a result object per query or mutation whose name matches
+  // the handler. On more complex pages we will be passing multiple handlers
+  // and their results.
+  const beginResetPasswordResult: BeginResetPasswordResult = {
+    data: beginResetPasswordMutationResult.data,
+    loading: beginResetPasswordMutationResult.loading,
+    error: beginResetPasswordError,
+  };
+
+  return (
+    <ResetPassword
+      {...{ beginResetPasswordHandler, beginResetPasswordResult }}
+    />
+  );
+};
+
+export default ResetPasswordContainer;

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -5,15 +5,14 @@
 import React from 'react';
 import ResetPassword, { ResetPasswordProps } from '.';
 import { Meta } from '@storybook/react';
-import { MozServices } from '../../lib/types';
+// import { MozServices } from '../../lib/types';
 import { withLocalization } from '../../../.storybook/decorators';
-import {
-  mockAccountWithThrottledError,
-  mockAccountWithUnexpectedError,
-} from './mocks';
-import { renderStoryWithHistory } from '../../lib/storybook-utils';
+import // mockAccountWithThrottledError,
+// mockAccountWithUnexpectedError,
+'./mocks';
+// import { renderStoryWithHistory } from '../../lib/storybook-utils';
 import { Account } from '../../models';
-import { MOCK_ACCOUNT } from '../../models/mocks';
+// import { MOCK_ACCOUNT } from '../../models/mocks';
 
 export default {
   title: 'Pages/ResetPassword',
@@ -27,30 +26,36 @@ type RenderStoryOptions = {
   queryParams?: string;
 };
 
-function renderStory({ account, props, queryParams }: RenderStoryOptions = {}) {
-  return renderStoryWithHistory(
-    <ResetPassword {...props} />,
-    '/reset_password',
-    account,
-    queryParams
-  );
-}
+// ❌ We're going to get the Storybook v7 upgrade for free with the react-scripts
+// upgrade. Let's look at importing our stories in tests where we can.
+//
+// *stories are commented out for now just so the page renders*
+// https://storybook.js.org/docs/react/writing-tests/importing-stories-in-tests
 
-export const Default = () => renderStory();
+// function renderStory({ account, props, queryParams }: RenderStoryOptions = {}) {
+//   return renderStoryWithHistory(
+//     <ResetPassword {...props} />,
+//     '/reset_password',
+//     account,
+//     queryParams
+//   );
+// }
 
-export const WithServiceName = () =>
-  renderStory({ queryParams: `service=${MozServices.MozillaVPN}` });
+// export const Default = () => renderStory();
 
-export const WithForceAuth = () =>
-  renderStory({
-    props: {
-      prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
-      forceAuth: true,
-    },
-  });
+// export const WithServiceName = () =>
+//   renderStory({ queryParams: `service=${MozServices.MozillaVPN}` });
 
-export const WithThrottledErrorOnSubmit = () =>
-  renderStory({ account: mockAccountWithThrottledError });
+// export const WithForceAuth = () =>
+//   renderStory({
+//     props: {
+//       prefillEmail: MOCK_ACCOUNT.primaryEmail.email,
+//       forceAuth: true,
+//     },
+//   });
 
-export const WithUnexpectedErrorOnSubmit = () =>
-  renderStory({ account: mockAccountWithUnexpectedError });
+// export const WithThrottledErrorOnSubmit = () =>
+//   renderStory({ account: mockAccountWithThrottledError });
+
+// export const WithUnexpectedErrorOnSubmit = () =>
+//   renderStory({ account: mockAccountWithUnexpectedError });

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -24,6 +24,7 @@ import {
   BeginResetPasswordHandler,
   BeginResetPasswordResult,
 } from './container';
+import { ResetPasswordQueryParams } from '../../models/reset-password';
 
 export const viewName = 'reset-password';
 
@@ -33,6 +34,7 @@ export type ResetPasswordProps = {
   serviceName?: MozServices;
   beginResetPasswordHandler: BeginResetPasswordHandler;
   beginResetPasswordResult: BeginResetPasswordResult;
+  queryParams: ResetPasswordQueryParams;
 };
 
 type FormData = {

--- a/packages/fxa-settings/src/pages/ResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/mocks.tsx
@@ -8,8 +8,8 @@ import { Account } from '../../models';
 // No error message on submit
 export const mockDefaultAccount = { MOCK_ACCOUNT } as any as Account;
 
-mockDefaultAccount.resetPassword = () =>
-  Promise.resolve({ passwordForgotToken: 'mockPasswordForgotToken' });
+// mockDefaultAccount.resetPassword = () =>
+//   Promise.resolve({ passwordForgotToken: 'mockPasswordForgotToken' });
 
 // Mocked localized throttled error (not localized in storybook)
 export const mockAccountWithThrottledError = {
@@ -22,12 +22,12 @@ const throttledErrorObj = {
   retryAfterLocalized: 'in 15 minutes',
 };
 
-mockAccountWithThrottledError.resetPassword = () =>
-  Promise.reject(throttledErrorObj);
+// mockAccountWithThrottledError.resetPassword = () =>
+//   Promise.reject(throttledErrorObj);
 
-export const mockAccountWithUnexpectedError = {
-  MOCK_ACCOUNT,
-} as unknown as Account;
+// export const mockAccountWithUnexpectedError = {
+//   MOCK_ACCOUNT,
+// } as unknown as Account;
 
-mockAccountWithThrottledError.resetPassword = () =>
-  Promise.reject('some error');
+// mockAccountWithThrottledError.resetPassword = () =>
+//   Promise.reject('some error');

--- a/yarn.lock
+++ b/yarn.lock
@@ -29243,6 +29243,7 @@ fsevents@~2.1.1:
     babel-loader: ^8.3.0
     base32-decode: ^1.0.0
     base32-encode: ^1.2.0
+    class-validator: ^0.14.0
     classnames: ^2.3.1
     css-loader: ^3.6.0
     eslint: ^7.32.0


### PR DESCRIPTION
In #8138, we refactored API logic out of our components and created an Account class abstraction. Since then, `Account.ts` has grown to be too large as essentially our global API client + model and needs to be logically split up. We use the `useAccount` hook frequently and overfetch data on our new React pages, some data which is not available without a session token.

Please keep in mind this is WIP as well as [the architecture doc](https://docs.google.com/document/d/17dCwjxhxBKXDclkydmPHD91Pj3suIFihR6fZw6m126Q/) that goes into more detail on what this solves. This should end up as an implementation of "Option C" under ["Context & Model Solutions"](https://docs.google.com/document/d/17dCwjxhxBKXDclkydmPHD91Pj3suIFihR6fZw6m126Q/edit#heading=h.664sknl637co) and an ADR that comes out of this will take notes from that doc and comments I've written in-code (❌ emoji in a comment = a note for prototype review).

I'd still like to:
* ~Work on what validation can look like in container components~ [See comment](https://github.com/mozilla/fxa/pull/15493#issuecomment-1631674385)
* ~Work on pulling Relier-required values off of Context, but this may~ [will] end up being part of FXA-7308
* ~If there's time, show what this looks like for authClient~ Did not do

You can currently test this at `/reset_password?showReactApp=true`, though the next page hasn't been refactored so only the initial email submission (success and fail) works.

I focused time on implementation and tests. There's still a few failing ones since I didn't wrap the container tests in a context provider but it's done enough where you get the gist and can see how this would work; I'd like to focus on finishing out the rest of the points above.

Whatever comes out of this and that doc, I think we should refactor newly refactored React pages and then decide how we want to handle Settings. Maybe once we've taken out non-Settings bits out of `Account.ts` we'll want to leave it as it was prior to our new page conversions, or maybe we'll want to use one container component for the API calls.

**NOTE:** be sure to see [this comment](https://github.com/mozilla/fxa/pull/15493#issuecomment-1631674385) as well, the above was written in reference to the first commit.

will close FXA-7627