### PR TITLE
feat(auth): update Invoice Preview to Handle Prorations

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -2,20 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as invoiceDTO from 'fxa-shared/dto/auth/payments/invoice';
+import { InvoicePreview } from 'fxa-shared/subscriptions/types';
 import { Stripe } from 'stripe';
+import { config } from '../../config';
 
 /**
  * Formats a Stripe Invoice to the FirstInvoicePreview DTO format.
  */
 export function stripeInvoiceToFirstInvoicePreviewDTO(
-  invoice: Stripe.UpcomingInvoice
+  invoice: InvoicePreview
 ): invoiceDTO.FirstInvoicePreview {
   const invoicePreview: invoiceDTO.firstInvoicePreviewSchema = {
-    subtotal: invoice.subtotal,
-    subtotal_excluding_tax: invoice.subtotal_excluding_tax,
-    total: invoice.total,
-    total_excluding_tax: invoice.total_excluding_tax,
-    line_items: invoice.lines.data.map((line) => ({
+    subtotal: invoice[0].subtotal,
+    subtotal_excluding_tax: invoice[0].subtotal_excluding_tax,
+    total: invoice[0].total,
+    total_excluding_tax: invoice[0].total_excluding_tax,
+    line_items: invoice[0].lines.data.map((line) => ({
       amount: line.amount,
       currency: line.currency,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -29,8 +31,8 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
   };
 
   // Add tax if it exists
-  if (invoice.total_tax_amounts.length > 0) {
-    invoicePreview.tax = invoice.total_tax_amounts.map((tax) => ({
+  if (invoice[0].total_tax_amounts.length > 0) {
+    invoicePreview.tax = invoice[0].total_tax_amounts.map((tax) => ({
       amount: tax.amount,
       inclusive: tax.inclusive,
       display_name:
@@ -41,13 +43,28 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
   }
 
   // Add discount if it exists
-  if (invoice.discount && invoice.total_discount_amounts) {
+  if (invoice[0].discount && invoice[0].total_discount_amounts) {
     invoicePreview.discount = {
-      amount: invoice.total_discount_amounts[0].amount,
-      amount_off: invoice.discount.coupon.amount_off,
-      percent_off: invoice.discount.coupon.percent_off,
+      amount: invoice[0].total_discount_amounts[0].amount,
+      amount_off: invoice[0].discount.coupon.amount_off,
+      percent_off: invoice[0].discount.coupon.percent_off,
     };
   }
+
+  if (
+    invoice[1] &&
+    config.getProperties().subscriptions.stripeInvoiceImmediately
+  ) {
+    const proration = invoice[1].lines.data.find(
+      (lineItem) => lineItem.proration
+    );
+
+    if (proration) {
+      invoicePreview.prorated_amount = proration.amount;
+      invoicePreview.one_time_charge = invoice[1].total;
+    }
+  }
+
   return invoicePreview;
 }
 
@@ -91,5 +108,5 @@ export function stripeInvoicesToSubsequentInvoicePreviewsDTO(
 export function stripeInvoiceToLatestInvoiceItemsDTO(
   invoice: Stripe.Invoice
 ): invoiceDTO.LatestInvoiceItems {
-  return stripeInvoiceToFirstInvoicePreviewDTO(invoice);
+  return stripeInvoiceToFirstInvoicePreviewDTO([invoice, undefined]);
 }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -61,9 +61,10 @@ export class MozillaSubscriptionHandler {
     const response: {
       customerId?: string;
       subscriptions: MozillaSubscription[];
-    } & Partial<PaymentBillingDetails> = stripeBillingDetailsAndSubscriptions || {
-      subscriptions: [],
-    };
+    } & Partial<PaymentBillingDetails> =
+      stripeBillingDetailsAndSubscriptions || {
+        subscriptions: [],
+      };
 
     return {
       ...response,
@@ -91,10 +92,9 @@ export class MozillaSubscriptionHandler {
 
     const targetPlanId = request.params.planId;
 
-    const eligibility = await this.capabilityService.getPlanEligibility(
-      uid,
-      targetPlanId
-    );
+    const eligibility = (
+      await this.capabilityService.getPlanEligibility(uid, targetPlanId)
+    )[0];
 
     return {
       eligibility,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -108,10 +108,12 @@ export class PayPalHandler extends StripeWebhookHandler {
       }
 
       // Validate that the user doesn't have conflicting subscriptions, for instance via IAP
-      const eligibility = await this.capabilityService.getPlanEligibility(
-        customer.metadata.userid,
-        priceId
-      );
+      const eligibility = (
+        await this.capabilityService.getPlanEligibility(
+          customer.metadata.userid,
+          priceId
+        )
+      )[0];
       if (eligibility !== SubscriptionEligibilityResult.CREATE) {
         throw error.userAlreadySubscribedToProduct();
       }

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -479,18 +479,16 @@ describe('CapabilityService', () => {
       capabilityService.fetchSubscribedPricesFromAppStore = sinon.fake.resolves(
         ['plan_123456']
       );
-      const actual = await capabilityService.getPlanEligibility(
-        UID,
-        'plan_ABCDEF'
-      );
+      const actual = (
+        await capabilityService.getPlanEligibility(UID, 'plan_ABCDEF')
+      )[0];
       assert.equal(actual, 'blocked_iap');
     });
 
     it('returns create for targetPlan with productSet user is not subscribed to', async () => {
-      const actual = await capabilityService.getPlanEligibility(
-        UID,
-        'plan_ABCDEF'
-      );
+      const actual = (
+        await capabilityService.getPlanEligibility(UID, 'plan_ABCDEF')
+      )[0];
       assert.equal(actual, 'create');
     });
 
@@ -498,10 +496,9 @@ describe('CapabilityService', () => {
       capabilityService.fetchSubscribedPricesFromStripe = sinon.fake.resolves([
         'plan_123456',
       ]);
-      const actual = await capabilityService.getPlanEligibility(
-        UID,
-        'plan_ABCDEF'
-      );
+      const actual = (
+        await capabilityService.getPlanEligibility(UID, 'plan_ABCDEF')
+      )[0];
       assert.equal(actual, 'upgrade');
     });
 
@@ -509,10 +506,9 @@ describe('CapabilityService', () => {
       capabilityService.fetchSubscribedPricesFromStripe = sinon.fake.resolves([
         'plan_ABCDEF',
       ]);
-      const actual = await capabilityService.getPlanEligibility(
-        UID,
-        'plan_123456'
-      );
+      const actual = (
+        await capabilityService.getPlanEligibility(UID, 'plan_123456')
+      )[0];
       assert.equal(actual, 'downgrade');
     });
 
@@ -520,10 +516,9 @@ describe('CapabilityService', () => {
       capabilityService.fetchSubscribedPricesFromStripe = sinon.fake.resolves([
         'plan_ABCDEF',
       ]);
-      const actual = await capabilityService.getPlanEligibility(
-        UID,
-        'plan_NOPRODUCTORDER'
-      );
+      const actual = (
+        await capabilityService.getPlanEligibility(UID, 'plan_NOPRODUCTORDER')
+      )[0];
       assert.equal(actual, 'invalid');
     });
   });

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/customer1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/customer1.json
@@ -85,6 +85,7 @@
           "data": [
             {
               "id": "si_G8xrQI1ybSfVm9",
+              "subscription": "sub_test1",
               "object": "subscription_item",
               "billing_thresholds": null,
               "created": 1573252096,

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -30,9 +30,10 @@ function buildExpectedLineItems(invoice) {
 
 describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
   it('formats an invoice with tax', () => {
-    const invoice = stripeInvoiceToFirstInvoicePreviewDTO(
-      deepCopy(previewInvoiceWithTax)
-    );
+    const invoice = stripeInvoiceToFirstInvoicePreviewDTO([
+      deepCopy(previewInvoiceWithTax),
+      undefined,
+    ]);
     const expectedLineItems = buildExpectedLineItems(invoice);
 
     assert.deepEqual(invoice.line_items, expectedLineItems);
@@ -51,9 +52,10 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
   });
 
   it('formats an invoice with tax and discount', () => {
-    const invoice = stripeInvoiceToFirstInvoicePreviewDTO(
-      deepCopy(previewInvoiceWithDiscountAndTax)
-    );
+    const invoice = stripeInvoiceToFirstInvoicePreviewDTO([
+      deepCopy(previewInvoiceWithDiscountAndTax),
+      undefined,
+    ]);
     assert.equal(invoice.total, previewInvoiceWithDiscountAndTax.total);
     assert.equal(invoice.subtotal, previewInvoiceWithDiscountAndTax.subtotal);
     assert.equal(
@@ -84,7 +86,10 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     const invoicePreview = deepCopy(previewInvoiceWithTax);
     invoicePreview.total_tax_amounts[0].tax_rate.display_name = '';
 
-    const invoice = stripeInvoiceToFirstInvoicePreviewDTO(invoicePreview);
+    const invoice = stripeInvoiceToFirstInvoicePreviewDTO([
+      invoicePreview,
+      undefined,
+    ]);
 
     assert.equal(invoice.total, invoicePreview.total);
     assert.equal(invoice.subtotal, invoicePreview.subtotal);
@@ -94,6 +99,34 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     );
     assert.equal(invoice.tax[0].display_name, undefined);
     assert.equal(invoice.tax[0].inclusive, true);
+  });
+
+  it('formats an invoice with a prorated amount', () => {
+    const firstInvoice = deepCopy(previewInvoiceWithTax);
+    const proratedInvoice = deepCopy(previewInvoiceWithTax);
+    proratedInvoice.lines.data[0].proration = true;
+
+    const invoice = stripeInvoiceToFirstInvoicePreviewDTO([
+      firstInvoice,
+      proratedInvoice,
+    ]);
+    const expectedLineItems = buildExpectedLineItems(invoice);
+
+    assert.deepEqual(invoice.line_items, expectedLineItems);
+    assert.equal(invoice.total, previewInvoiceWithTax.total);
+    assert.equal(invoice.subtotal, previewInvoiceWithTax.subtotal);
+    assert.equal(
+      invoice.tax[0].amount,
+      previewInvoiceWithTax.total_tax_amounts[0].amount
+    );
+    assert.equal(
+      invoice.tax[0].display_name,
+      previewInvoiceWithTax.total_tax_amounts[0].tax_rate.display_name
+    );
+    assert.equal(invoice.tax[0].inclusive, true);
+    assert.isUndefined(invoice.discount);
+    assert.equal(invoice.one_time_charge, proratedInvoice.total);
+    assert.equal(invoice.prorated_amount, proratedInvoice.lines.data[0].amount);
   });
 });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
@@ -319,7 +319,7 @@ describe('mozilla-subscriptions', () => {
 describe('plan-eligibility', () => {
   beforeEach(() => {
     capabilityService = {
-      getPlanEligibility: sandbox.stub().resolves('eligibility'),
+      getPlanEligibility: sandbox.stub().resolves(['eligibility', undefined]),
     };
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -204,9 +204,10 @@ describe('subscriptions payPalRoutes', () => {
     beforeEach(() => {
       stripeHelper.findCustomerSubscriptionByPlanId =
         sinon.fake.returns(undefined);
-      capabilityService.getPlanEligibility = sinon.fake.resolves(
-        SubscriptionEligibilityResult.CREATE
-      );
+      capabilityService.getPlanEligibility = sinon.fake.resolves([
+        SubscriptionEligibilityResult.CREATE,
+        undefined,
+      ]);
       stripeHelper.cancelSubscription = sinon.fake.resolves({});
       payPalHelper.cancelBillingAgreement = sinon.fake.resolves({});
       profile.deleteCache = sinon.fake.resolves({});

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -457,9 +457,10 @@ describe('DirectStripeRoutes', () => {
       },
     };
     mockCapabilityService.getPlanEligibility = sinon.stub();
-    mockCapabilityService.getPlanEligibility.resolves(
-      SubscriptionEligibilityResult.CREATE
-    );
+    mockCapabilityService.getPlanEligibility.resolves([
+      SubscriptionEligibilityResult.CREATE,
+      undefined,
+    ]);
     Container.set(CapabilityService, mockCapabilityService);
 
     directStripeRoutesInstance = new DirectStripeRoutes(
@@ -662,7 +663,10 @@ describe('DirectStripeRoutes', () => {
   describe('previewInvoice', () => {
     it('returns the preview invoice', async () => {
       const expected = deepCopy(invoicePreviewTax);
-      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves(expected);
+      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves([
+        expected,
+        undefined,
+      ]);
       VALID_REQUEST.payload = {
         promotionCode: 'promotionCode',
         priceId: 'priceId',
@@ -680,7 +684,7 @@ describe('DirectStripeRoutes', () => {
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.fetchCustomer,
         UID,
-        ['tax']
+        ['subscriptions', 'tax']
       );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.previewInvoice,
@@ -689,9 +693,14 @@ describe('DirectStripeRoutes', () => {
           promotionCode: 'promotionCode',
           priceId: 'priceId',
           taxAddress: undefined,
+          isUpgrade: false,
+          sourcePlan: undefined,
         }
       );
-      assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
+      assert.deepEqual(
+        stripeInvoiceToFirstInvoicePreviewDTO([expected, undefined]),
+        actual
+      );
     });
 
     it('returns the preview invoice when Stripe tax is enabled', async () => {
@@ -703,7 +712,10 @@ describe('DirectStripeRoutes', () => {
         mockCustomer
       );
       const expected = deepCopy(invoicePreviewTax);
-      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves(expected);
+      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves([
+        expected,
+        undefined,
+      ]);
       VALID_REQUEST.payload = {
         promotionCode: 'promotionCode',
         priceId: 'priceId',
@@ -721,7 +733,7 @@ describe('DirectStripeRoutes', () => {
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.fetchCustomer,
         UID,
-        ['tax']
+        ['subscriptions', 'tax']
       );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.previewInvoice,
@@ -730,14 +742,22 @@ describe('DirectStripeRoutes', () => {
           promotionCode: 'promotionCode',
           priceId: 'priceId',
           taxAddress: undefined,
+          isUpgrade: false,
+          sourcePlan: undefined,
         }
       );
-      assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
+      assert.deepEqual(
+        stripeInvoiceToFirstInvoicePreviewDTO([expected, undefined]),
+        actual
+      );
     });
 
     it('returns the preview invoice even if fetch customer errors', async () => {
       const expected = deepCopy(invoicePreviewTax);
-      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves(expected);
+      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves([
+        expected,
+        undefined,
+      ]);
 
       const error = new Error('test');
       directStripeRoutesInstance.stripeHelper.fetchCustomer.throws(error);
@@ -782,14 +802,22 @@ describe('DirectStripeRoutes', () => {
             countryCode: 'US',
             postalCode: '92841',
           },
+          isUpgrade: false,
+          sourcePlan: undefined,
         }
       );
-      assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
+      assert.deepEqual(
+        stripeInvoiceToFirstInvoicePreviewDTO([expected, undefined]),
+        actual
+      );
     });
 
     it('does not call fetchCustomer if no credentials are provided, and returns invoice preview', async () => {
       const expected = deepCopy(invoicePreviewTax);
-      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves(expected);
+      directStripeRoutesInstance.stripeHelper.previewInvoice.resolves([
+        expected,
+        undefined,
+      ]);
 
       const request = deepCopy(VALID_REQUEST);
       request.payload = {
@@ -829,9 +857,14 @@ describe('DirectStripeRoutes', () => {
             countryCode: 'DE',
             postalCode: '92841',
           },
+          isUpgrade: false,
+          sourcePlan: undefined,
         }
       );
-      assert.deepEqual(stripeInvoiceToFirstInvoicePreviewDTO(expected), actual);
+      assert.deepEqual(
+        stripeInvoiceToFirstInvoicePreviewDTO([expected, undefined]),
+        actual
+      );
     });
 
     it('error with AppError invalidInvoicePreviewRequest', async () => {

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -74,6 +74,8 @@ export const firstInvoicePreviewSchema = joi.object({
     amount_off: joi.number().required().allow(null),
     percent_off: joi.number().required().allow(null),
   }),
+  one_time_charge: joi.number().optional(),
+  prorated_amount: joi.number().optional(),
 });
 
 type line_item = {
@@ -103,6 +105,8 @@ export type firstInvoicePreviewSchema = {
     amount_off: number | null;
     percent_off: number | null;
   };
+  one_time_charge?: number;
+  prorated_amount?: number;
 };
 
 /**

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -190,3 +190,13 @@ export class SubscriptionStripeError extends Error {
     this.name = 'SubscriptionStripeError';
   }
 }
+
+export type InvoicePreview = [
+  invoicePreview: Stripe.UpcomingInvoice,
+  proratedInvoice?: Stripe.UpcomingInvoice
+];
+
+export type SubscriptionChangeEligibility = [
+  subscriptionEligibilityResult: SubscriptionEligibilityResult,
+  eligibleSourcePlan?: AbbrevPlan
+];


### PR DESCRIPTION
Because:

* we want proration information (one_time_charge and prorated_amount) to be returned with the invoice preview

This commit:

* changes the return type of invoice preview to be a named tuple, one with and one without the proration information, and formats the API response accordingly

Closes #FXA-6690

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
