### PR TITLE
fix(auth): Add support for settings password for third party auth via Sync

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -635,6 +635,19 @@ export default class AuthClient {
     });
   }
 
+  async setPasswordThirdParty(
+   authPW: string
+  ): Promise<{
+    uid: hexstring;
+    sessionToken: hexstring;
+    authPW: boolean;
+  }> {
+    const payload = {
+      authPW
+    };
+    return await this.request('POST', '/account/set_password_sync', payload);
+  }
+
   async accountKeys(
     keyFetchToken: hexstring,
     unwrapBKey: hexstring

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1381,15 +1381,23 @@ FxaClientWrapper.prototype = {
     });
   }),
 
-  verifyAccountThirdParty: withClient(
-    (client, relier, token, provider, metricsContext) => {
-      return client
-        .verifyAccountThirdParty(token, provider, metricsContext)
-        .then((accountData) => {
-          return getUpdatedSessionData(accountData.email, relier, accountData);
-        });
-    }
-  ),
+  verifyAccountThirdParty(relier, code, provider) {
+    return this._fxaClient
+      .verifyAccountThirdParty(
+        relier,
+        code,
+        provider,
+        this._metrics.getFlowEventMetadata()
+      )
+      .then(this.set.bind(this));
+  },
+
+  setPasswordThirdParty: withClient((client, relier, idToken, provider, email, password) => {
+    return client.setPasswordThirdParty(relier, idToken, provider, email, password)
+      .then((accountData) => {
+        return getUpdatedSessionData(email, relier, accountData);
+      })
+  }),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -36,6 +36,7 @@ import SignInTotpCodeView from '../views/sign_in_totp_code';
 import SignInUnblockView from '../views/sign_in_unblock';
 import SignUpPasswordView from '../views/sign_up_password';
 import ThirdPartyAuthCallbackView from '../views/post_verify/third_party_auth/callback';
+import ThirdPartyAuthSetPasswordView from '../views/post_verify/third_party_auth/set_password';
 import Storage from './storage';
 import SubscriptionsProductRedirectView from '../views/subscriptions_product_redirect';
 import SubscriptionsManagementRedirectView from '../views/subscriptions_management_redirect';
@@ -291,6 +292,9 @@ Router = Router.extend({
         ThirdPartyAuthCallbackView
       );
     },
+    
+    'post_verify/third_party_auth/set_password(/)': createViewHandler(ThirdPartyAuthSetPasswordView),
+
 
     'push/confirm_login(/)': createViewHandler('push/confirm_login'),
     'push/send_login(/)': createViewHandler('push/send_login'),

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1112,6 +1112,19 @@ const Account = Backbone.Model.extend(
         .then(this.set.bind(this));
     },
 
+    setPasswordThirdParty(relier, idToken, provider, email, password) {
+      return this._fxaClient
+        .verifyAccountThirdParty(
+          relier,
+          idToken,
+          provider,
+          email,
+          password,
+          this._metrics.getFlowEventMetadata()
+        )
+        .then(this.set.bind(this));
+    },
+
     /**
      * Fetch the account's list of attached clients.
      *

--- a/packages/fxa-content-server/app/scripts/models/user.js
+++ b/packages/fxa-content-server/app/scripts/models/user.js
@@ -615,6 +615,13 @@ var User = Backbone.Model.extend({
     });
   },
 
+  setPasswordThirdParty(account, relier, idToken, provider, email, password) {
+    return account.setPasswordThirdParty(relier, idToken, provider, email, password).then(() => {
+      this._notifyOfAccountSignIn(account);
+      return this.setSignedInAccount(account);
+    });
+  },
+
   /**
    * Complete a password reset for the account using an account recovery key. Notifies other tabs
    * of signin on success.

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
@@ -1,0 +1,54 @@
+<div class="card">
+  <header class="mb-2">
+    <h1 id="fxa-signup-password-header" class="card-header">
+      {{#t}}Set your password{{/t}}
+    </h1>
+  </header>
+
+  <section>
+    <div class="error"></div>
+    <div class="success"></div>
+
+    <form novalidate>
+      <p id="prefillEmail" class="text-base break-all mb-5">{{ email }}</p>
+
+      <p class="mb-5">
+        {{#t}}Please create a password to continue to Firefox Sync. Your data is encrypted with your password to protect your privacy.{{/t}}
+      </p>
+      
+      <div class="tooltip-container mb-5">
+        <input name="password" id="password" type="password" class="input-text tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />
+        <div id="password-strength-balloon-container" tabindex="-1"></div>
+      </div>
+
+      <div class="tooltip-container mb-5">
+        <input id="vpassword" type="password" class="input-text tooltip-below" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required data-synchronize-show="true" />
+
+        <div class="input-balloon hidden" id="vpassword-balloon">
+          <div class="before:content-key flex before:w-8">
+            <p class="ltr:pl-2 rtl:pr-2">
+              {{#unsafeTranslate}}You need this password to access any encrypted data you store with us.<br class="mb-3">A reset means potentially losing data like passwords and bookmarks.{{/unsafeTranslate}}
+            </p>
+          </div>
+        </div>
+      </div>
+
+        <header>
+          <h2 id="fxa-choose-what-to-sync-header" class="font-normal mb-5 text-base">
+            {{#t}}Choose what to sync{{/t}}
+          </h2>
+        </header>
+        <div class="flex flex-wrap text-start ltr:mobileLandscape:ml-6 rtl:mobileLandscape:mr-6 mb-1">
+          {{#engines}}
+            <div class="mb-4 relative flex-50% rtl:mobileLandscape:pr-6 ltr:mobileLandscape:pl-6 rtl:pr-3 ltr:pl-3 flex items-center">
+              <input name="sync-content" class="input-checkbox" id="sync-engine-{{id}}" type="checkbox" {{#checked}}checked="checked"{{/checked}} value="{{id}}" tabindex="{{tabindex}}" /><label class="input-checkbox-label" for="sync-engine-{{id}}">{{text}}</label>
+            </div>
+          {{/engines}}
+        </div>
+
+      <div class="flex">
+        <button id="submit-btn" class="cta-primary cta-xl" type="submit">{{#t}}Create Password{{/t}}</button>
+      </div>
+    </form>
+  </section>
+</div>

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -208,6 +208,9 @@ export default {
         this.metrics.flush();
 
         return this.signIn(updatedAccount);
+        
+        // TODO: If Sync, redirect user to set password if it hasn't already been
+        // set
       })
       .catch(() => {
         this.clearStoredParams();

--- a/packages/fxa-content-server/app/scripts/views/post_verify/third_party_auth/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/third_party_auth/set_password.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import _ from 'underscore';
+import AuthErrors from '../../../lib/auth-errors';
+import Cocktail from '../../../lib/cocktail';
+import Template from '../../../templates/post_verify/third_party_auth/set_password.mustache';
+import FormView from '../../form';
+import FlowEventsMixin from '../../mixins/flow-events-mixin';
+import PasswordMixin from '../../mixins/password-mixin';
+import PasswordStrengthMixin from '../../mixins/password-strength-mixin';
+import CWTSOnSignupPasswordMixin from '../../mixins/cwts-on-signup-password';
+import ServiceMixin from '../../mixins/service-mixin';
+import AccountSuggestionMixin from '../../mixins/account-suggestion-mixin';
+
+const PASSWORD_INPUT_SELECTOR = '#password';
+const VPASSWORD_INPUT_SELECTOR = '#vpassword';
+
+class SetPassword extends FormView {
+  template = Template;
+
+  _getPassword() {
+    return this.$(PASSWORD_INPUT_SELECTOR).val();
+  }
+
+  _getVPassword() {
+    return this.$(VPASSWORD_INPUT_SELECTOR).val();
+  }
+
+  isValidEnd() {
+    return this._getPassword() === this._getVPassword();
+  }
+
+  getAccount() {
+    return this.user.initAccount({
+      email: 'a@aa.com',
+    });
+  }
+
+  showValidationErrorsEnd() {
+    if (this._getPassword() !== this._getVPassword()) {
+      const err = AuthErrors.toError('PASSWORDS_DO_NOT_MATCH');
+      this.showValidationError(this.$(PASSWORD_INPUT_SELECTOR), err, true);
+    }
+  }
+
+  setInitialContext(context) {
+    const email = this.getAccount().get('email');
+    context.set({
+      email,
+    });
+  }
+
+  beforeRender() {
+
+  }
+
+  submit() {
+    const account = this.getAccount();
+    const password = this._getPassword();
+    const idToken = 'idToken'; // TODO: get idToken from somewhere
+
+    return this.user.setPasswordThirdParty(account, this.relier, idToken, 'google', account.get('email'), password)
+      .then(() => {
+        console.log("Finished setting password");
+      });
+  }
+}
+
+Cocktail.mixin(
+  SetPassword,
+  PasswordMixin,
+  CWTSOnSignupPasswordMixin,
+  PasswordStrengthMixin({
+    balloonEl: '#password-strength-balloon-container',
+    passwordEl: '#password',
+  }),
+  ServiceMixin,
+  AccountSuggestionMixin,
+  FlowEventsMixin,
+);
+
+export default SetPassword;

--- a/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
@@ -47,23 +47,24 @@ const View = FormView.extend({
         this.invokeBrokerMethod('beforeSignUpConfirmationPoll', account)
       )
       .then(() => {
-        this.waitForSessionVerification(this.getAccount(), () => {
-          // don't do anything on verification, that's taken care of in the submit handler.
-        });
+        debugger
+        // this.waitForSessionVerification(this.getAccount(), () => {
+        //   // don't do anything on verification, that's taken care of in the submit handler.
+        // });
       });
   },
 
   setInitialContext(context) {
-    const email = this.getAccount().get('email');
-
-    // This needs to point to correct support link
-    const supportLink = Constants.BLOCKED_SIGNIN_SUPPORT_URL;
-
-    context.set({
-      email,
-      escapedSupportLink: encodeURI(supportLink),
-      hasSupportLink: !!supportLink,
-    });
+    // const email = this.getAccount().get('email');
+    //
+    // // This needs to point to correct support link
+    // const supportLink = Constants.BLOCKED_SIGNIN_SUPPORT_URL;
+    //
+    // context.set({
+    //   email,
+    //   escapedSupportLink: encodeURI(supportLink),
+    //   hasSupportLink: !!supportLink,
+    // });
   },
 
   submit() {

--- a/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
@@ -53,6 +53,7 @@ const FRONTEND_ROUTES = [
   'post_verify/secondary_email/confirm_secondary_email',
   'post_verify/secondary_email/verified_secondary_email',
   'post_verify/third_party_auth/callback',
+  'post_verify/third_party_auth/set_password',
   'primary_email_verified',
   'push/completed',
   'push/confirm_login',


### PR DESCRIPTION
## Because

- We want to be able to set a password for a third party auth login when signing into Sync

## This pull request

- Adds support to set a password after a user has successfully authed

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7332

## Checklist

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
