### PR TITLE
fix(logs): Update password reset react pages to use auth client when neede

### DIFF
--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -8,7 +8,7 @@ import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 const NEW_PASSWORD = 'notYourAveragePassW0Rd';
 
-test.describe('reset password', () => {
+test.describe('reset password react', () => {
   test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     // Ensure that the feature flag is enabled


### PR DESCRIPTION
## Because

- Location in emails sent from React password reset pages were not showing the correct location
- There is an issue with using client -> GraphQL -> auth client -> auth server where the IP address from client is not getting propgated to the auth-server

## This pull request

- Updates the pages to use the auth-client directly so the correct IP address is geolocated

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

There are not unit test for these flows but things are covered with the functional tests.
