### PR TITLE
feat(payments): remove same billing copy from subscription upgrade

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -2,18 +2,22 @@
 # $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionUpgrade-subject = You have upgraded to { $productName }
 subscriptionUpgrade-title = Thank you for upgrading!
+
 # Variables:
 # $productNameOld (String) - The name of the previously subscribed product, e.g. Mozilla VPN
 # $productName (String) - The name of the new subscribed product, e.g. Mozilla VPN
 subscriptionUpgrade-upgrade-info = You have successfully upgraded from { $productNameOld } to { $productName }.
+
 # Variables:
 # $paymentAmountOld (String) - The amount of the previous subscription payment, including currency, e.g. $10.00
 # $paymentAmountNew (String) - The amount of the new subscription payment, including currency, e.g. $10.00
 # $productPaymentCycleNew (String) - The interval of time from the end of one payment statement date to the next payment statement date of the new subscription, e.g. month
 # $productPaymentCycleOld (String) - The interval of time from the end of one payment statement date to the next payment statement date of the old subscription, e.g. month
 # $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
+# remove subscriptionUpgrade-content-charge-info in FXA-7796; additionally remove in subscriptionUpgrade/index.txt
 subscriptionUpgrade-content-charge-info = Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycleOld } to { $paymentAmountNew } per { $productPaymentCycleNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycleOld }.
 subscriptionUpgrade-content-charge-info-different-cycle = You will be charged a one-time fee of { $paymentProrated } to reflect your subscription’s higher price for the remainder of this { $productPaymentCycleOld }. Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycleOld } to { $paymentAmountNew } per { $productPaymentCycleNew }.
+
 # Variables:
 # $productName (String) - The name of the new subscribed product, e.g. Mozilla VPN
 subscriptionUpgrade-install = If there is new software for you to install in order to use { $productName }, you will receive a separate email with download instructions.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -19,7 +19,7 @@
     </mj-text>
 
     <mj-text css-class="text-body">
-      <% if (locals.productPaymentCycleOld === locals.productPaymentCycleNew) { %>
+      <% if (!locals.invoiceImmediately && locals.productPaymentCycleOld === locals.productPaymentCycleNew) { %>
         <span data-l10n-id="subscriptionUpgrade-content-charge-info" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>.</span>
       <% } else { %>
         <span data-l10n-id="subscriptionUpgrade-content-charge-info-different-cycle" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>.</span>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
@@ -13,32 +13,36 @@ const createStory = subplatStoryWithProps(
   'subscriptionUpgrade',
   'Sent when a user upgrades their subscription.',
   {
-    paymentAmountNew: '£123,121.00',
-    paymentAmountOld: '¥99,991',
+    paymentAmountNew: '$69.89',
+    paymentAmountOld: '$9.89',
     productIconURLNew:
       'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     productIconURLOld:
       'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     productName: 'Product Name B',
     productNameOld: 'Product Name A',
-    productPaymentCycleNew: 'month',
+    productPaymentCycleNew: 'year',
     productPaymentCycleOld: 'month',
-    paymentProrated: '$5,231.00',
+    paymentProrated: '$60.00',
     subscriptionSupportUrl: 'http://localhost:3030/support',
   }
 );
 
-export const SubscriptionUpgradeSameBillingCycle = createStory(
+export const Default = createStory();
+
+// remove in FXA-7796
+export const SubscriptionUpgradeDifferentBillingCycle = createStory(
   {},
-  'Subscription upgrade - same billing cycle'
+  'Subscription upgrade - differnt billing cycle'
 );
 
-export const SubscriptionUpgradeDifferentBillingCycle = createStory(
+// remove in FXA-7796
+export const SubscriptionUpgradeSameBillingCycle = createStory(
   {
-    paymentAmountNew: '$69.89',
-    paymentAmountOld: '$9.89',
-    productPaymentCycleNew: 'year',
-    paymentProrated: '$60.00',
+    paymentAmountNew: '£123,121.00',
+    paymentAmountOld: '¥99,991',
+    productPaymentCycleNew: 'month',
+    paymentProrated: '$5,231.00',
   },
-  'Subscription upgrade - different billing cycle'
+  'Subscription upgrade - same billing cycle'
 );

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5962,6 +5962,8 @@ describe('#integration - StripeHelper', () => {
           const event = deepCopy(eventCustomerSubscriptionUpdated);
           const productIdOld = event.data.previous_attributes.plan.product;
           const productIdNew = event.data.object.plan.product;
+          const invoiceImmediately =
+            stripeHelper.config.subscriptions.stripeInvoiceImmediately.enabled;
 
           const baseDetails = {
             ...expectedBaseUpdateDetails,
@@ -6036,26 +6038,28 @@ describe('#integration - StripeHelper', () => {
             paymentAmountOldCurrency:
               event.data.previous_attributes.plan.currency,
             paymentAmountOldInCents:
-              upcomingInvoice && upcomingInvoice.total
+              upcomingInvoice && upcomingInvoice.total && !invoiceImmediately
                 ? upcomingInvoice.total
-                : mockInvoice.invoiceTotalOldInCents,
+                : baseDetails.invoiceTotalOldInCents,
             paymentAmountNewCurrency:
-              upcomingInvoice && upcomingInvoice.currency
+              upcomingInvoice && upcomingInvoice.currency && !invoiceImmediately
                 ? upcomingInvoice.currency
                 : mockInvoice.currency,
             paymentAmountNewInCents:
-              upcomingInvoice && upcomingInvoice.total
+              upcomingInvoice && upcomingInvoice.total && !invoiceImmediately
                 ? upcomingInvoice.total
                 : mockInvoice.total,
             paymentProratedCurrency:
-              upcomingInvoice && upcomingInvoice.currency
+              upcomingInvoice && upcomingInvoice.currency && !invoiceImmediately
                 ? upcomingInvoice.currency
                 : mockInvoice.currency,
-            paymentProratedInCents: upcomingInvoice
-              ? expectedPaymentProratedInCents
-              : mockInvoice.amount_due,
+            paymentProratedInCents:
+              upcomingInvoice && !invoiceImmediately
+                ? expectedPaymentProratedInCents
+                : mockInvoice.amount_due,
             invoiceNumber: mockInvoice.number,
             invoiceId: mockInvoice.id,
+            invoiceImmediately: invoiceImmediately,
           });
         };
 


### PR DESCRIPTION
## Because

- We are moving to immediately invoicing and combining same and different billing cycle email templates.

## This pull request

- Removes condition for same billing in `mjml` template.
- Updates stripe to remove references for same billing behaviour.
- Updates applicable tests.
- Updates applicable stories.

## Issue that this pull request solves

Closes FXA-6691

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
