### PR TITLE
fix(third-party-auth): ToS + Privacy link tweaks

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/third-party-auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/third-party-auth.mustache
@@ -1,4 +1,4 @@
-<aside class="third-party-auth {{^isSignup}}mb-4{{/isSignup}}">
+<aside class="third-party-auth">
   {{#isSignup}}
     <div class="separator">{{#t}}or{{/t}}</div>
   {{/isSignup}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -45,19 +45,6 @@
         <div class="flex">
           <button id="{{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}{{#isPasswordNeeded}}submit-btn{{/isPasswordNeeded}}" class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}" type="submit">{{#t}}Sign in{{/t}}</button>
         </div>
-
-          <div id="tos-pp" class="text-grey-500 my-5 text-xs">
-            {{#isPocketClient}}
-              {{#unsafeTranslate}}
-                By proceeding, you agree to:<br />
-                Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/en/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/en/privacy/">Privacy Notice</a><br />
-                Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.
-              {{/unsafeTranslate}}
-            {{/isPocketClient}}
-            {{^isPocketClient}}
-              {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
-            {{/isPocketClient}}
-          </div>
         </form>
       {{/hasLinkedAccountAndNoPassword}}
 
@@ -65,6 +52,18 @@
         {{{ unsafeThirdPartyAuthHTML }}}
       {{/hasLinkedAccountAndNoPassword}}
 
+      <div id="tos-pp" class="text-grey-500 my-5 text-xs">
+        {{#isPocketClient}}
+          {{#unsafeTranslate}}
+            By proceeding, you agree to:<br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.
+          {{/unsafeTranslate}}
+        {{/isPocketClient}}
+        {{^isPocketClient}}
+          {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+        {{/isPocketClient}}
+      </div>
 
       <div class="flex justify-between">
         <a href="/" id="use-different" class="link-blue me-2" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a>

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -76,7 +76,7 @@
         {{#isPocketClient}}
           {{#unsafeTranslate}}
             By proceeding, you agree to:<br />
-            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/en/tos/">Terms of Service</a> and <a class="link-grey" id="pocket-pp" href="https://getpocket.com/en/privacy/">Privacy Notice</a><br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a class="link-grey" id="pocket-pp" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
             Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -171,8 +171,10 @@
   .login-button {
     border: 1px solid #b2b2b2;
     background-color: white;
-    margin-bottom: 10px;
     font-weight: normal;
+    &:not(:last-of-type) {
+      margin-bottom: 10px;
+    }
     &:hover {
       border-color: #1a1a1a;
     }

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -165,7 +165,30 @@ describe('views/sign_in_password', () => {
 
         assert.lengthOf(view.$('.separator'), 0);
         assert.lengthOf(view.$('#use-different'), 1);
-        assert.lengthOf(view.$('#tos-pp'), 0);
+        assert.lengthOf(view.$('#fxa-pp'), 1);
+        assert.lengthOf(view.$('#fxa-tos'), 1);
+        // only renders if service is pocket
+        assert.lengthOf(view.$('#pocket-pp'), 0);
+        assert.lengthOf(view.$('#pocket-tos'), 0);
+      });
+    });
+
+    it('renders TOS as expected when service is pocket', () => {
+      relier.set({
+        clientId: '749818d3f2e7857f',
+      });
+      // Pocket TOS should always show for pocket clients despite
+      // linked account / password state
+      account.set({
+        hasLinkedAccount: true,
+        hasPassword: false,
+      });
+
+      return view.render().then(() => {
+        assert.lengthOf(view.$('#fxa-pp'), 1);
+        assert.lengthOf(view.$('#fxa-tos'), 1);
+        assert.lengthOf(view.$('#pocket-pp'), 1);
+        assert.lengthOf(view.$('#pocket-tos'), 1);
       });
     });
   });


### PR DESCRIPTION
Because:
* We are linking out to the English version of some links and want the site to handle language negotiation instead
* We want to display ToS and Privacy notice for Pocket and other users

This commit:
* Removes the hard-coded 'en' from these links
* Moves links out of signin `<form>`, always displays ToS and Privacy link and includes Pocket ToS and Privacy link when the client is Pocket

Closes FXA-7920
Closes FXA-7865

---

Ignore blurriness of 2nd pic, did something wonky during the resize. This is a normal login with a passwordless account and then through Pocket.

<img width="390" alt="377BE364-E4AC-43BD-9943-1707EBE6DA6B" src="https://github.com/mozilla/fxa/assets/13018240/465bb861-1587-40fd-895d-e36fef07ebf5">

<img src="https://github.com/mozilla/fxa/assets/13018240/a9f51d8d-d5e1-4d0e-b1a1-c50e39dc66ae" width="390">

