### PR TITLE
Test cleanup

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -352,13 +352,12 @@ export class LoginPage extends BaseLayout {
 
   async submit(waitForNav = true) {
     if (waitForNav) {
-      const waitForNavigation = this.page.waitForNavigation();
+      const waitForNavigation = this.page.waitForEvent('framenavigated');
       await this.page.locator(selectors.SUBMIT).click();
       return waitForNavigation;
     }
-    // `waitForNavigation` is deprecated because it's "hard to make it work reliably",
-    // see https://github.com/microsoft/playwright/issues/20853. It's causing at least
-    // one set of test failures so give an option to opt-out here.
+    //using waitForNav just as parameters as
+    //waitForNavigation() has been deprecated
     await this.page.locator(selectors.SUBMIT).click();
   }
 

--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -70,9 +70,7 @@ export class SubscribePage extends BaseLayout {
     const paypalWindow = await paypalWindowPromise;
 
     await paypalWindow.waitForLoadState('load');
-    await paypalWindow.waitForNavigation({
-      url: /checkoutnow/,
-    });
+    await paypalWindow.waitForURL(/checkoutnow/);
     await paypalWindow.fill(
       'input[type=email]',
       'qa-test-no-balance-16@personal.example.com'

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -5,7 +5,7 @@ export class RelierPage extends BaseLayout {
     const url = query
       ? `${this.target.relierUrl}?${query}`
       : this.target.relierUrl;
-    return this.page.goto(url, { waitUntil: 'networkidle' });
+    return this.page.goto(url, { waitUntil: 'load' });
   }
 
   async isLoggedIn() {
@@ -34,19 +34,19 @@ export class RelierPage extends BaseLayout {
   }
 
   async clickEmailFirst() {
-    const waitForNavigation = this.page.waitForNavigation();
+    const waitForNavigation = this.page.waitForEvent('framenavigated');
     await this.page.locator('button.email-first-button').click();
     return waitForNavigation;
   }
 
   async clickSignIn() {
-    const waitForNavigation = this.page.waitForNavigation();
+    const waitForNavigation = this.page.waitForEvent('framenavigated');
     await this.page.locator('button.sign-in-button.signin').click();
     return waitForNavigation;
   }
 
   async clickForceAuth() {
-    const waitForNavigation = this.page.waitForNavigation();
+    const waitForNavigation = this.page.waitForEvent('framenavigated');
     await this.page.locator('button.force-auth').click();
     return waitForNavigation;
   }
@@ -60,7 +60,7 @@ export class RelierPage extends BaseLayout {
   }
 
   async promptNoneError() {
-    const error = await this.page.locator('.error');
+    const error = this.page.locator('.error');
     return error.innerText();
   }
 

--- a/packages/functional-tests/pages/settings/avatar.ts
+++ b/packages/functional-tests/pages/settings/avatar.ts
@@ -18,7 +18,7 @@ export class AvatarPage extends SettingsLayout {
   async clickRemove() {
     await Promise.all([
       this.page.click('[data-testid=remove-photo-btn]'),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
     // HACK we don't really have a good way to distinguish
     // between monogram avatars and user set images
@@ -30,7 +30,7 @@ export class AvatarPage extends SettingsLayout {
   clickSave() {
     return Promise.all([
       this.page.locator('[data-testid=save-button]').click(),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
   }
 

--- a/packages/functional-tests/pages/settings/changePassword.ts
+++ b/packages/functional-tests/pages/settings/changePassword.ts
@@ -85,7 +85,7 @@ export class ChangePasswordPage extends SettingsLayout {
   submit() {
     return Promise.all([
       this.page.locator('button[type=submit]').click(),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
   }
 }

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -5,7 +5,7 @@ export class UnitRow {
   constructor(readonly page: Page, readonly id: string) {}
 
   protected async clickCta() {
-    const waitForNavigation = this.page.waitForNavigation();
+    const waitForNavigation = this.page.waitForEvent('framenavigated');
     await this.page.locator(`[data-testid=${this.id}-unit-row-route]`).click();
     return waitForNavigation;
   }

--- a/packages/functional-tests/pages/settings/displayName.ts
+++ b/packages/functional-tests/pages/settings/displayName.ts
@@ -18,7 +18,7 @@ export class DisplayNamePage extends SettingsLayout {
   submit() {
     return Promise.all([
       this.page.locator('button[type=submit]').click(),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
   }
 }

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -66,7 +66,7 @@ export class SettingsPage extends SettingsLayout {
   clickDeleteAccount() {
     return Promise.all([
       this.page.locator('[data-testid=settings-delete-account]').click(),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
   }
 

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -10,7 +10,7 @@ export abstract class SettingsLayout extends BaseLayout {
   }
 
   goto() {
-    return super.goto('networkidle');
+    return super.goto('load');
   }
 
   async alertBarText() {

--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -39,7 +39,7 @@ export class RecoveryKeyPage extends SettingsLayout {
   clickClose() {
     return Promise.all([
       this.page.locator('[data-testid=close-button]').click(),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
   }
 

--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -13,7 +13,7 @@ export class SecondaryEmailPage extends SettingsLayout {
   }
 
   async submit() {
-    const waitForNavigation = this.page.waitForNavigation();
+    const waitForNavigation = this.page.waitForEvent('framenavigated');
     await this.page.locator('button[type=submit]').click();
     return waitForNavigation;
   }

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -44,7 +44,7 @@ export class TotpPage extends SettingsLayout {
   clickClose() {
     return Promise.all([
       this.page.locator('[data-testid=close-button]').click(),
-      this.page.waitForNavigation(),
+      this.page.waitForEvent('framenavigated'),
     ]);
   }
 

--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -5,7 +5,7 @@ test.describe('severity-1', () => {
     test.skip(project.name !== 'local', 'mocha tests are local only');
     test.slow();
     await page.goto(`${target.contentServerUrl}/tests/index.html`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await page.waitForTimeout(2000); // wait for mocha to load
     await page.evaluate(() =>
@@ -32,7 +32,7 @@ test.describe('severity-1', () => {
 test.describe('robots.txt', () => {
   test('should allow bots to access all pages', async ({ target, page }) => {
     await page.goto(`${target.contentServerUrl}/robots.txt`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     const text = await page.locator('body').innerText();
     expect(/^Allow:/gm.test(text)).toBeTruthy();

--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -17,9 +17,10 @@ test.describe('cookies disabled', () => {
     pages: { cookiesDisabled },
   }) => {
     //Goto cookies disabled url
-    await page.goto(`${target.contentServerUrl}/?disable_local_storage=1`, {
-      waitUntil: 'networkidle',
-    });
+    await page.goto(`${target.contentServerUrl}?disable_local_storage=1`);
+
+    //Adding the timeout as the page closes before loading
+    await page.waitForTimeout(500);
 
     //Verify the Cookies disabled header
     expect(await cookiesDisabled.isCookiesDisabledHeader()).toBe(true);
@@ -38,7 +39,7 @@ test.describe('cookies disabled', () => {
   }) => {
     //Goto cookies enabled url
     await page.goto(target.contentServerUrl, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
 
     //Verify Email header
@@ -46,15 +47,18 @@ test.describe('cookies disabled', () => {
 
     //Goto cookies disabled url
     await page.goto(`${target.contentServerUrl}/cookies_disabled`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
+
+    //Adding the timeout as the page closes before loading
+    await page.waitForTimeout(500);
 
     //Verify the Cookies disabled header
     expect(await cookiesDisabled.isCookiesDisabledHeader()).toBe(true);
 
     //Click retry
     await cookiesDisabled.clickRetry();
-    await page.waitForNavigation();
+    await page.waitForLoadState();
 
     //Verify Email header
     expect(await login.isEmailHeader()).toBe(true);
@@ -69,9 +73,12 @@ test.describe('cookies disabled', () => {
     await page.goto(
       `${target.contentServerUrl}/verify_email?disable_local_storage=1&uid=240103bbecd645848103021e7d245bcb&code=fc46f44802b2a2ce979f39b2187aa1c0`,
       {
-        waitUntil: 'networkidle',
+        waitUntil: 'load',
       }
     );
+
+    //Adding the timeout as the page closes before loading
+    await page.waitForTimeout(500);
 
     //Verify the Cookies disabled header
     expect(await cookiesDisabled.isCookiesDisabledHeader()).toBe(true);

--- a/packages/functional-tests/tests/misc/fourOhFour.spec.ts
+++ b/packages/functional-tests/tests/misc/fourOhFour.spec.ts
@@ -5,11 +5,11 @@ test.describe('404', () => {
     page,
     pages: { login, fourOhFour },
   }) => {
-    await fourOhFour.goto('networkidle');
+    await fourOhFour.goto('load');
     expect(await fourOhFour.header.isVisible()).toBeTruthy();
     expect(await fourOhFour.homeLink.isVisible()).toBeTruthy();
     await fourOhFour.homeLink.click();
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
+    await page.waitForLoadState();
     expect(await login.emailHeader.isVisible()).toBeTruthy();
   });
 });

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -47,7 +47,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     const query = { prompt: 'consent' };
     const queryParam = new URLSearchParams(query);
     await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await relier.clickEmailFirst();
     await login.fillOutFirstSignUp(email, password, { verify: false });
@@ -88,7 +88,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     const query = { prompt: 'consent' };
     const queryParam = new URLSearchParams(query);
     await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await relier.clickEmailFirst();
     await login.fillOutEmailFirstSignIn(email, password);
@@ -120,7 +120,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     const query = { prompt: 'consent' };
     const queryParam = new URLSearchParams(query);
     await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await relier.clickEmailFirst();
     await login.clickSignIn();

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -131,6 +131,7 @@ test.describe('oauth prompt none', () => {
     await page.goto(`${target.relierUrl}/?${query.toString()}`);
 
     await relier.signInPromptNone();
+    await page.waitForLoadState();
 
     //Verify error message
     expect(await relier.promptNoneError()).toContain(

--- a/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
+++ b/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
@@ -101,7 +101,7 @@ test.describe('OAuth signin token code', () => {
     );
     await signinTokenCode.input.fill(code);
     await signinTokenCode.submit.click();
-    await page.waitForNavigation({ waitUntil: 'networkidle' });
+    await page.waitForLoadState();
 
     const NOTES_REDIRECT_PAGE_SELECTOR = '#notes-by-firefox';
     await expect(page.locator(NOTES_REDIRECT_PAGE_SELECTOR)).toBeVisible();

--- a/packages/functional-tests/tests/postVerify/accountRecovery.spec.ts
+++ b/packages/functional-tests/tests/postVerify/accountRecovery.spec.ts
@@ -46,7 +46,7 @@ test.describe('post verify - account recovery', () => {
 
     await page.goto(
       `${target.contentServerUrl}/post_verify/account_recovery/add_recovery_key`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
 
     //Verify account recovery header
@@ -89,7 +89,7 @@ test.describe('post verify - account recovery', () => {
 
     await page.goto(
       `${target.contentServerUrl}/post_verify/account_recovery/add_recovery_key`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
 
     //Verify account recovery header
@@ -116,7 +116,7 @@ test.describe('post verify - account recovery', () => {
 
     await page.goto(
       `${target.contentServerUrl}/post_verify/account_recovery/add_recovery_key`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
 
     //Verify account recovery header

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
-import { BaseTarget } from '../../lib/targets/base';
 
 test.describe('severity-1 #smoke', () => {
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293389
@@ -12,7 +11,7 @@ test.describe('severity-1 #smoke', () => {
   }, { project }) => {
     test.slow(project.name !== 'local', 'email delivery can be slow');
     await page.goto(target.contentServerUrl + '/reset_password', {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await login.setEmail(credentials.email);
     await login.submit();
@@ -21,7 +20,7 @@ test.describe('severity-1 #smoke', () => {
       EmailType.recovery,
       EmailHeader.link
     );
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link, { waitUntil: 'load' });
     await login.setNewPassword(credentials.password);
     expect(page.url()).toContain(settings.url);
   });
@@ -71,7 +70,7 @@ test.describe('severity-1 #smoke', () => {
     }
 
     await page.goto(target.contentServerUrl + '/reset_password', {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await login.setEmail(credentials.email);
     await login.submit();
@@ -81,7 +80,7 @@ test.describe('severity-1 #smoke', () => {
       EmailHeader.link
     );
     link = `${link}&showReactApp=false`;
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link, { waitUntil: 'load' });
     await login.clickDontHaveRecoveryKey();
     await login.setNewPassword(credentials.password);
     await settings.waitForAlertBar();
@@ -93,7 +92,7 @@ test.describe('severity-1 #smoke', () => {
 test.describe('password strength tests', () => {
   test.beforeEach(async ({ target, credentials, page, pages: { login } }) => {
     const email = login.createEmail();
-    await page.goto(target.contentServerUrl, { waitUntil: 'networkidle' });
+    await page.goto(target.contentServerUrl, { waitUntil: 'load' });
     credentials.email = email;
 
     //Enter email at email first and then goto the sign up page

--- a/packages/functional-tests/tests/settings/passwordVisibility.spec.ts
+++ b/packages/functional-tests/tests/settings/passwordVisibility.spec.ts
@@ -7,7 +7,7 @@ test.describe('password visibility tests', () => {
     pages: { login },
   }) => {
     const email = login.createEmail();
-    await page.goto(target.contentServerUrl, { waitUntil: 'networkidle' });
+    await page.goto(target.contentServerUrl, { waitUntil: 'load' });
     await login.setEmail(email);
     await login.submit();
 

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -121,7 +121,7 @@ test.describe('old recovery key test', () => {
       EmailHeader.link
     );
     link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link, { waitUntil: 'load' });
     await recoveryKey.clickLostRecoveryKey();
 
     // Reset password
@@ -201,7 +201,7 @@ test.describe('old recovery key test', () => {
       EmailHeader.link
     );
     link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link, { waitUntil: 'load' });
     await login.setRecoveryKey(key);
     await login.submit();
     credentials.password = credentials.password + '_new';
@@ -331,7 +331,7 @@ test.describe('new recovery key test', () => {
       EmailHeader.link
     );
     link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link, { waitUntil: 'load' });
     await login.setRecoveryKey(key);
     await login.submit();
     credentials.password = credentials.password + '_new';
@@ -441,7 +441,7 @@ test.describe('new recovery key test', () => {
       EmailHeader.link
     );
     link = `${link}&forceExperiment=generalizedReactApp&forceExperimentGroup=control`;
-    await page.goto(link, { waitUntil: 'networkidle' });
+    await page.goto(link, { waitUntil: 'load' });
     // Directed to "confirm recovery key" page, but lost the key
     // Click on the lost recovery key link
     await recoveryKey.clickLostRecoveryKey();

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -17,7 +17,7 @@ test.describe('Sign up with code ', () => {
   test('bounced email', async ({ target, page, pages: { login } }) => {
     const client = await login.getFxaClient(target);
     await page.goto(target.contentServerUrl, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await login.fillOutFirstSignUp(email, PASSWORD);
 
@@ -28,14 +28,13 @@ test.describe('Sign up with code ', () => {
   test('valid code then click back', async ({
     target,
     page,
-    pages: { login, settings },
+    pages: { login },
   }) => {
     await page.goto(target.contentServerUrl, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
-    await login.fillOutFirstSignUp(email, PASSWORD);
-    await page.waitForNavigation();
-    await page.goBack({ waitUntil: 'networkidle' });
+    await login.fillOutFirstSignUp(email, PASSWORD, {waitForNavOnSubmit: false});
+    await page.goBack({waitUntil: 'load'});
     expect(await login.loginHeader()).toBe(true);
   });
 
@@ -45,7 +44,7 @@ test.describe('Sign up with code ', () => {
     pages: { login, signinTokenCode },
   }) => {
     await page.goto(target.contentServerUrl, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
     await login.setCode('1234');

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -11,12 +11,12 @@ test.describe('connect_another_device', () => {
 
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.fillOutFirstSignUp(credentials.email, credentials.password);
 
     // Move on to the connect another device page
-    await connectAnotherDevice.goto('networkidle');
+    await connectAnotherDevice.goto('load');
     await expect(connectAnotherDevice.header).toHaveCount(1);
     await expect(connectAnotherDevice.signInButton).toHaveCount(0);
     await expect(connectAnotherDevice.installFxDesktop).toHaveCount(1);

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -11,7 +11,7 @@ test.describe('severity-1 #smoke', () => {
     await page.goto(
       target.contentServerUrl +
         '?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email',
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await page.waitForTimeout(1000);
 
@@ -120,7 +120,7 @@ test.describe('severity-3 #smoke', () => {
     await page.click('#avatar-wrapper');
     await Promise.all([
       page.click('text=Sign Out'),
-      page.waitForNavigation({ waitUntil: 'networkidle' }),
+      page.waitForNavigation({ waitUntil: 'load' }),
     ]);
     await expect(page.locator('#sign-in-btn')).toBeVisible();
   });

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -8,7 +8,7 @@ test.describe('support form without valid session', () => {
   }) => {
     await login.clearCache();
     await page.goto(`${target.contentServerUrl}/support`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
     expect(await login.isEmailHeader()).toBe(true);
   });
@@ -22,9 +22,9 @@ test.describe('support form without active subscriptions', () => {
   }) => {
     test.slow();
     await page.goto(`${target.contentServerUrl}/support`, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
     });
-    await page.waitForNavigation();
+    await page.waitForURL(/settings/);
     expect(await login.loginHeader()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -145,7 +145,7 @@ test.describe('Firefox Desktop Sync v3 sign in', () => {
     // Sync sign in
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.login(credentials.email, credentials.password);
     await login.setTotp(credentials.secret);

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -27,7 +27,7 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
 
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.setEmail(email);
     await signinTokenCode.clickSubmitButton();
@@ -59,7 +59,7 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
       `${
         target.contentServerUrl
       }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.setEmail(email);
     await login.submit();

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -26,7 +26,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     const { page, login } = syncBrowserPages;
     await page.goto(
       `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.setEmail(email);
     await login.submit();
@@ -52,7 +52,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     });
     await page.goto(
       `${target.contentServerUrl}/signin?context=fx_desktop_v3&service=sync&action=email`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.setEmail(email);
     await login.submit();
@@ -72,7 +72,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     const { page, login, signinTokenCode } = syncBrowserPages;
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-      { waitUntil: 'networkidle' }
+      { waitUntil: 'load' }
     );
     await login.setEmail('testuser@firefox.com');
     await signinTokenCode.clickSubmitButton();


### PR DESCRIPTION
## Because
- The Playwright tests were using deprecated functions (`waitForNavigations()`) and use of `networkidle` and needed to be replaced.

## This pull request

- Removes and replaces deprecated functions `waitForNavigations()` and use of `networkidle`
- Also added a `waitForLoadState()` for the failing nightly test, to load the localhost website from  the relier page. Ran the full suite of tests thrice and it passed everytime.

## Issue that this pull request solves

Closes: FXA-7794 FXA-7792 FXA-7942

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
