### PR TITLE
chore(metrics): add Glean ping for login submit error

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/event.js
+++ b/packages/fxa-content-server/app/scripts/lib/glean/event.js
@@ -18,3 +18,16 @@ export const name = new StringMetricType({
   lifetime: 'ping',
   disabled: false,
 });
+
+/**
+ * additional context-dependent (on event.name) info, e.g. the cause of an error
+ *
+ * Generated from `event.reason`.
+ */
+export const reason = new StringMetricType({
+  category: 'event',
+  name: 'reason',
+  sendInPings: ['accounts-events'],
+  lifetime: 'ping',
+  disabled: false,
+});

--- a/packages/fxa-content-server/app/scripts/lib/glean/utm.js
+++ b/packages/fxa-content-server/app/scripts/lib/glean/utm.js
@@ -7,7 +7,12 @@
 import StringMetricType from '@mozilla/glean/private/metrics/string';
 
 /**
- * UTM campaign
+ * A marketing campaign.  For example, if a user signs into FxA from selecting a
+ * Mozilla VPN plan on Mozilla VPN's product site, then value of this metric could
+ * be 'vpn-product-page'.  The value has a max length of 128 characters with the
+ * alphanumeric characters, _ (underscore), forward slash (/), . (period), %
+ * (percentage sign), and - (hyphen) in the allowed set of characters.  The
+ * special value of 'page+referral+-+not+part+of+a+campaign' is also allowed.
  *
  * Generated from `utm.campaign`.
  */
@@ -20,7 +25,12 @@ export const campaign = new StringMetricType({
 });
 
 /**
- * UTM content
+ * The content on which the user acted.  For example, if the user clicked on the
+ * "Get started here" link in "Looking for Firefox Sync? Get started here", then
+ * the value for this metric would be 'fx-sync-get-started'.  The value has a max
+ * length of 128 characters with the alphanumeric characters, _ (underscore),
+ * forward slash (/), . (period), % (percentage sign), and - (hyphen) in the
+ * allowed set of characters.
  *
  * Generated from `utm.content`.
  */
@@ -33,7 +43,11 @@ export const content = new StringMetricType({
 });
 
 /**
- * UTM medium
+ * The "medium" on which the user acted.  For example, if the user clicked on a
+ * link in an email, then the value of this metric would be 'email'.  The value
+ * has a max length of 128 characters with the alphanumeric characters, _
+ * (underscore), forward slash (/), . (period), % (percentage sign), and -
+ * (hyphen) in the allowed set of characters.
  *
  * Generated from `utm.medium`.
  */
@@ -46,7 +60,11 @@ export const medium = new StringMetricType({
 });
 
 /**
- * UTM source
+ * The source from where the user started.  For example, if the user clicked on a
+ * link on the Firefox accounts web site, this value could be 'fx-website'.  The
+ * value has a max length of 128 characters with the alphanumeric characters, _
+ * (underscore), forward slash (/), . (period), % (percentage sign), and -
+ * (hyphen) in the allowed set of characters.
  *
  * Generated from `utm.source`.
  */
@@ -59,7 +77,12 @@ export const source = new StringMetricType({
 });
 
 /**
- * UTM term
+ * This metric is similar to the `utm.source`; it is used in the Firefox
+ * browser.  For example, if the user started from about:welcome, then the value
+ * could be 'aboutwelcome-default-screen'.  The value has a max length of 128
+ * characters with the alphanumeric characters, _ (underscore), forward slash (/),
+ * . (period), % (percentage sign), and - (hyphen) in the allowed set of
+ * characters.
  *
  * Generated from `utm.term`.
  */

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -113,11 +113,16 @@ const SignInPasswordView = FormView.extend({
       this.logViewEvent('canceled');
       // if user canceled login, just stop
       return;
-    } else if (AuthErrors.is(err, 'ACCOUNT_RESET')) {
+    }
+
+    if (AuthErrors.is(err, 'ACCOUNT_RESET')) {
+      GleanMetrics.login.error({ reason: 'account locked' });
       return this.notifyOfResetAccount(account);
     } else if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
+      GleanMetrics.login.error({ reason: 'password incorrect' });
       return this.showValidationError(this.$('input[type=password]'), err);
     } else if (AuthErrors.is(err, 'UNABLE_TO_LOGIN_NO_PASSWORD_SET')) {
+      GleanMetrics.login.error({ reason: 'password missing' });
       return this.unsafeDisplayError(err);
     }
 


### PR DESCRIPTION
chore(metrics): add Glean ping for login submit error

Because:
 - we want know when a user failed to log into their account and why

This commit:
 - adds a labeled strings metric for event properties
 - adds a function for the failed login event