### PR TITLE
fix(auth): adds missing strict mode type "object" in json file

### DIFF
--- a/packages/fxa-auth-server/lib/pushpayloads.schema.json
+++ b/packages/fxa-auth-server/lib/pushpayloads.schema.json
@@ -32,6 +32,7 @@
   "definitions": {
     "deviceConnected": {
       "required": ["version", "command", "data"],
+      "type": "object",
       "properties": {
         "version": {
           "type": "integer",
@@ -57,6 +58,7 @@
       "additionalProperties": false
     },
     "deviceDisconnected": {
+      "type": "object",
       "required": ["version", "command", "data"],
       "properties": {
         "version": {
@@ -81,6 +83,7 @@
       "additionalProperties": false
     },
     "profileUpdated": {
+      "type": "object",
       "required": ["version", "command"],
       "properties": {
         "version": {
@@ -94,6 +97,7 @@
       "additionalProperties": false
     },
     "collectionsChanged": {
+      "type": "object",
       "required": ["version", "command", "data"],
       "properties": {
         "version": {
@@ -137,6 +141,7 @@
       "additionalProperties": false
     },
     "passwordChanged": {
+      "type": "object",
       "required": ["version", "command"],
       "properties": {
         "version": {
@@ -150,6 +155,7 @@
       "additionalProperties": false
     },
     "passwordReset": {
+      "type": "object",
       "required": ["version", "command"],
       "properties": {
         "version": {
@@ -163,6 +169,7 @@
       "additionalProperties": false
     },
     "accountDestroyed": {
+      "type": "object",
       "required": ["version", "command", "data"],
       "properties": {
         "version": {
@@ -187,6 +194,7 @@
       "additionalProperties": false
     },
     "commandReceived": {
+      "type": "object",
       "required": ["version", "command", "data"],
       "properties": {
         "version": {


### PR DESCRIPTION
## Because

- Auth strict mode type "object" was missing from some properties in `pushpayloads.schema.json` file and throwing a warning whenever a test is run in `auth`.

## This pull request

- Adds strict mode type "object" to aforementioned `json` file.

## Issue that this pull request solves

Closes [FXA-7952](https://mozilla-hub.atlassian.net/browse/FXA-7952)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).


[FXA-7952]: https://mozilla-hub.atlassian.net/browse/FXA-7952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ