### PR TITLE
fix(auth): use Firestore set method to update Apple IAP subscriptions

### DIFF
--- a/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscription-manager.ts
+++ b/packages/fxa-auth-server/scripts/create-mock-iap-subscriptions/mock-iap-subscription-manager.ts
@@ -17,7 +17,12 @@ export class MockIapSubscriptionManager {
 
   private async insert(purchasesDbRef: CollectionReference, records: any[]) {
     for (const record of records) {
-      await purchasesDbRef.add(record);
+      // The document ID for Apple IAP subscriptions is the originalTransactionId
+      // and for Google IAP is purchaseToken
+      const purchaseRecordDoc = await purchasesDbRef
+        .doc(record.originalTransactionId || record.purchaseToken)
+        .get();
+      await purchaseRecordDoc.ref.set(record);
     }
   }
 

--- a/packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap.ts
+++ b/packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import program from 'commander';
+
+import { AppStoreHelper } from '../lib/payments/iap/apple-app-store/app-store-helper';
+import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+import { SubscriptionPurchaseUpdater } from './set-subscription-purchases-apple-iap/set-subscription-purchases-apple-iap';
+
+const pckg = require('../package.json');
+
+const parseBatchSize = (batchSize: string | number) => {
+  return parseInt(batchSize.toString(), 10);
+};
+
+const parseRateLimit = (rateLimit: string | number) => {
+  return parseInt(rateLimit.toString(), 10);
+};
+
+async function init() {
+  program
+    .version(pckg.version)
+    .option(
+      '-b, --batch-size [number]',
+      'Number of subscriptions to query from firestore at a time.  Defaults to 100.',
+      100
+    )
+    // https://developer.apple.com/documentation/appstoreserverapi/identifying_rate_limits
+    // We use the "Get All Subscription Statuses" endpoint
+    .option(
+      '-r, --rate-limit [number]',
+      'Rate limit for Apple. Defaults to 50 rps',
+      50
+    )
+    .option(
+      '--dry-run',
+      'List the originalTransactionIds that would be updated without actually updating'
+    )
+    .parse(process.argv);
+
+  const { log } = await setupProcessingTaskObjects(
+    'set-subscription-purchases-apple-iap'
+  );
+
+  const appStoreHelper = new AppStoreHelper();
+
+  const batchSize = parseBatchSize(program.batchSize);
+  const rateLimit = parseRateLimit(program.rateLimit);
+
+  const dryRun = !!program.dryRun;
+
+  const subscriptionPurchaseUpdater = new SubscriptionPurchaseUpdater(
+    batchSize,
+    appStoreHelper,
+    log,
+    dryRun,
+    rateLimit
+  );
+
+  await subscriptionPurchaseUpdater.update();
+
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap/set-subscription-purchases-apple-iap.ts
+++ b/packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap/set-subscription-purchases-apple-iap.ts
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Firestore } from '@google-cloud/firestore';
+import { PurchaseManager } from 'fxa-shared/payments/iap/apple-app-store/purchase-manager';
+import { AppStoreSubscriptionPurchase } from 'fxa-shared/payments/iap/apple-app-store/subscription-purchase';
+import PQueue from 'p-queue';
+import Container from 'typedi';
+
+import { ConfigType } from '../../config';
+import { APPLE_APP_STORE_FORM_OF_PAYMENT } from '../../lib/payments/iap/apple-app-store/subscription-purchase';
+import { AppConfig, AuthFirestore, AuthLogger } from '../../lib/types';
+import { AppStoreHelper } from '../../lib/payments/iap/apple-app-store/app-store-helper';
+
+// General note: For the Apple IAP collection, the Firestore document ID
+// is the original transaction ID (which is the App Store's analog to the
+// Stripe subscription ID).
+
+/**
+ * Firestore subscriptions contain additional expanded information
+ * on top of the base AppStoreSubscriptionPurchase type.
+ */
+export interface FirestoreSubscription extends AppStoreSubscriptionPurchase {
+  formOfPayment: typeof APPLE_APP_STORE_FORM_OF_PAYMENT;
+}
+
+export class SubscriptionPurchaseUpdater {
+  private config: ConfigType;
+  private firestore: Firestore;
+  private purchaseManager: PurchaseManager;
+  private rateLimitQueue: PQueue;
+  private subscriptionCollection: string;
+
+  /**
+   * An updater to fetch the latest App Store subscription information from Apple and
+   * update Firestore.
+   * @param batchSize Number of subscriptions to fetch from Firestore at a time
+   * @param purchaseManager An instance of the Apple IAP PurchaseManager
+   * @param log An instance of AuthLogger
+   * @param dryRun True to log the updates we would make to Firestore without actually
+   * writing to Firestore.
+   * @param rateLimit A limit for number of App Store Server API requests within the
+   * period of 1 second
+   */
+  constructor(
+    private batchSize: number,
+    private appStoreHelper: AppStoreHelper,
+    private log: AuthLogger,
+    public dryRun: boolean,
+    rateLimit: number
+  ) {
+    const config = Container.get<ConfigType>(AppConfig);
+    this.config = config;
+
+    const firestore = Container.get<Firestore>(AuthFirestore);
+    this.firestore = firestore;
+
+    this.rateLimitQueue = new PQueue({
+      intervalCap: rateLimit,
+      interval: 1000, // The App Store Server API measures it's rate limit per second
+    });
+
+    const collectionPrefix = `${this.config.authFirestore.prefix}iap-`;
+    this.subscriptionCollection = `${collectionPrefix}app-store-purchases`;
+    const purchasesDbRef = this.firestore.collection(
+      this.subscriptionCollection
+    );
+    this.purchaseManager = new PurchaseManager(
+      purchasesDbRef,
+      appStoreHelper,
+      log
+    );
+  }
+
+  /**
+   * Update all Apple IAP subscriptions from the App Store Server API's
+   * Gett All Subscription Statuses endpoint to Firestore in batches
+   */
+  async update() {
+    let startAfter: string | null = null;
+    let hasMore = true;
+
+    while (hasMore) {
+      const subscriptions = await this.fetchSubsBatch(startAfter);
+
+      startAfter = subscriptions.at(-1)?.originalTransactionId as string;
+      if (!startAfter) hasMore = false;
+
+      await Promise.all(
+        subscriptions.map((sub) => this.updateSubscription(sub))
+      );
+    }
+  }
+
+  /**
+   * Fetches subscriptions from Firestore paginated by batchSize
+   * @param startAfter originalTransactionId of the last element of the previous
+   * batch for pagination.
+   * @returns A list of subscriptions from Firestore
+   */
+  async fetchSubsBatch(startAfter: string | null) {
+    const subscriptionSnap = await this.firestore
+      .collectionGroup(this.subscriptionCollection)
+      .orderBy('originalTransactionId')
+      .startAfter(startAfter)
+      .limit(this.batchSize)
+      .get();
+
+    const subscriptions = subscriptionSnap.docs.map(
+      (doc) => doc.data() as FirestoreSubscription
+    );
+
+    return subscriptions;
+  }
+
+  /**
+   * Attempts to update an Apple IAP subscription in Firestore with
+   * the latest subscription information from the App Store Server.
+   * @param firestoreSubscription The subscription to convert
+   */
+  async updateSubscription(firestoreSubscription: FirestoreSubscription) {
+    const { bundleId, originalTransactionId } = firestoreSubscription;
+
+    try {
+      if (!this.dryRun) {
+        await this.fetchAppleSubscription(bundleId, originalTransactionId);
+      }
+
+      console.log(originalTransactionId);
+    } catch (e) {
+      console.error(originalTransactionId, e);
+    }
+  }
+
+  /**
+   * Retrieves an Apple IAP subscription record directly from Apple
+   * @param bundleId The App Store bundle ID for the subscription
+   * @param originalTransactionId The App Store original transaction ID for
+   * the subscription
+   * @returns The subscription record for the ids provided, or null if not
+   * found or deleted
+   */
+  async fetchAppleSubscription(
+    bundleId: string,
+    originalTransactionId: string
+  ) {
+    const subscription = await this.enqueueRequest(
+      async () =>
+        await this.purchaseManager.querySubscriptionPurchase(
+          bundleId,
+          originalTransactionId
+        )
+    );
+
+    if (!subscription) return null;
+
+    return subscription;
+  }
+
+  async enqueueRequest<T>(callback: () => T): Promise<T> {
+    return this.rateLimitQueue.add(callback, {
+      throwOnTimeout: true,
+    });
+  }
+}

--- a/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
@@ -125,8 +125,14 @@ export class PurchaseManager {
       const firestoreObject = subscriptionPurchase.toFirestoreObject();
 
       if (purchaseRecordDoc.exists) {
-        // STEP 3a. We have this purchase cached in Firestore. Update our cache with the newly received response from the App Store Server API
-        await purchaseRecordDoc.ref.update(firestoreObject);
+        // STEP 3a. We have this purchase cached in Firestore. Update our cache with the
+        // newly received response from the App Store Server API, while preserving the
+        // userId if present.
+        const userId = purchaseRecordDoc.data()?.userId;
+        await purchaseRecordDoc.ref.set({
+          ...(!!userId && { userId }),
+          ...firestoreObject,
+        });
 
         // STEP 4a. Merge other fields of our purchase record in Firestore (such as userId) with our SubscriptionPurchase object and return to caller.
         mergePurchaseWithFirestorePurchaseRecord(


### PR DESCRIPTION
Because:

* The update method only updates existing fields and doesn't remove optional fields.
* The set method replaces the entire document.

This commit:

* Uses the set method instead of update, so we don't have stale optional properties left on the subscription in Firestore.

Closes #FXA-7118

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

- To test locally:
	- You need App Store Server API sandbox credentials (see Ecosystem docs for how to obtain)
	    - Alternatively, I can show you this working for me locally or send you an `apiResponse` to temporarily stub out the API call.
	- Start FxA locally
	- Create a local FxA account and note the uid
	- `cd packages/fxa-auth-server && yarn run create-mock-iap --uid=${uidYouJustCreated}`
	- Go into stage Firestore, for the `fxa-auth-stage-iap-app-store-purchases` collection and select a document to test with. Note the OTID (`originalTransactionId`)  and `bundleId` (e.g. `'1000000728852404'` and `'org.mozilla.ios.FirefoxVPN'`.
	- In the local Firestore emulator GUI, edit the fake Apple IAP document you created via the `yarn run` script previously to update the `originalTransactionId` and `bundleId` accordingly.
	- Take note of the current fields/values for this document in your local Firestore emulator, as they are about to be updated.
	- Run the script; sample command (optionally pass the `--dry-run` parameter as desired):
		- `SUBSCRIPTIONS_APP_STORE_API_ENABLED=true APP_STORE_SANDBOX=true APP_STORE_CREDENTIALS='(redacted)' FIRESTORE_EMULATOR_HOST=localhost:9090 NODE_ENV=dev node --inspect -r esbuild-register packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap.ts`
	- Observe the output in the terminal and the field changes to the document in your local Firestore emulator relative to the values for the fields for the document with the same OTID in stage Firestore.
		- `purchaseDate` and `transactionId` may be present with the update but not in the stage Firestore record as they were fields added later on after the initial integration was deployed to production.
		- `verifiedAt` will change to the timestamp the App Store Server API was hit as part of running the script.
