### PR TITLE
fix(emails): Pass single locale to Moment for unlocalized dates

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -348,7 +348,7 @@ module.exports = function (log, config, bounces) {
     timeZone,
     acceptLanguage
   ) {
-    return constructLocalTimeString(timeZone, acceptLanguage);
+    return constructLocalTimeString(timeZone, determineLocale(acceptLanguage));
   };
 
   Mailer.prototype._constructLocalDateString = function (

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -2857,10 +2857,14 @@ describe('lib/senders/emails:', () => {
   });
 
   describe('constructLocalTimeString - returns date/time', () => {
+    // Moment expects a single locale identifier. This tests to ensure
+    // we account for this in _constructLocalTimeString
+    const enAcceptLanguageHeader = 'en,en-US;q=0.7,nl;q=0.3';
+
     it('returns date/time based on given values', () => {
       const message = {
         timeZone: 'America/Los_Angeles',
-        acceptLanguage: 'en',
+        acceptLanguage: enAcceptLanguageHeader,
       };
 
       const result = mailer._constructLocalTimeString(
@@ -2875,7 +2879,7 @@ describe('lib/senders/emails:', () => {
     it('returns date/time based on default timezone (UTC) if timezone is undefined', () => {
       const message = {
         timeZone: undefined,
-        acceptLanguage: 'en',
+        acceptLanguage: enAcceptLanguageHeader,
       };
       const result = mailer._constructLocalTimeString(
         message.timeZone,
@@ -2911,7 +2915,7 @@ describe('lib/senders/emails:', () => {
     it('returns date/time in another timezone (at the time of writing - EST', () => {
       const message = {
         timeZone: 'Europe/Berlin',
-        acceptLanguage: 'en',
+        acceptLanguage: MESSAGE.acceptLanguage,
       };
 
       const result = mailer._constructLocalTimeString(
@@ -2924,7 +2928,7 @@ describe('lib/senders/emails:', () => {
     it('returns date/time in Spanish', () => {
       const message = {
         timeZone: 'America/Los_Angeles',
-        acceptLanguage: 'es',
+        acceptLanguage: 'es,en-US;q=0.7,en;q=0.3',
       };
 
       const result = mailer._constructLocalTimeString(


### PR DESCRIPTION
Because:
* Many of our emails did not send with a correctly localized date

This commit:
* Sends the acceptLanguage header through our determineLocale helper before using it in Moment, which requires a single locale

fixes FXA-7930

---

You can test this by changing your language preference in-browser and observing in MailDev before and after this patch, I manually checked Dutch and Japanese. Any email that uses `_constructLocalTimeString` is affected. Our tests assumed the accept language was already a single locale.

This also adjusted the time output which looks more correct to me.

Before and after:

<img width="275" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/3c39daf5-2508-4bc1-a5c1-5364966e5366"> <img width="275" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/2ceea36a-13a0-4000-bf73-68d040fdd06f"> 

