### PR TITLE
fix(ci): Add -rf to dir removal to fix string extraction test

### DIFF
--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: mozilla/fxa-content-server-l10n
-          path: "fxa-l10n"
+          path: 'fxa-l10n'
       - name: Clone FxA code repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-          path: "fxa-code"
+          path: 'fxa-code'
       - name: Install npm packages
         run: |
           cd fxa-l10n
@@ -52,7 +52,7 @@ jobs:
 
           # Extract gettext
           cd ./packages/fxa-content-server
-          rm ./locale/templates/LC_MESSAGES/*
+          rm -rf ./locale/templates/LC_MESSAGES/*
           npx grunt l10n-extract
           cd ../..
 


### PR DESCRIPTION
Because:
* This directory is not always present. When we try to just 'rm' when it doesn't exist, a hidden error is thrown

This commit:
* Simply adds "-rf" to the rm command for ./locale/templates/LC_MESSAGES/*

Fixes FXA-7862

---

Currently not sure _why_ this isn't always present, but I remember some branch last week that I later force-pushed to that had this passing with string changes so I didn't remove the line instead. I can investigate more if we want and find that CI run, but, @bcolsson tagging you for review since you'd written part of this script.

Facepalming a bit here since I got there by process of elimination, but see #15472 (I forgot to add back one file in that final commit). I'm not sure why [this error](https://github.com/mozilla/fxa/actions/runs/5558663789/jobs/10154019214) was buried/hidden but we definitely went down some rabbit holes, would be nice if we could look into that sometime.