### PR TITLE
task(sentry): Scrub PII on validation errors

### DIFF
--- a/packages/fxa-shared/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/sentry/pii-filter-actions.ts
@@ -287,7 +287,7 @@ export const CommonPiiActions = {
   /**
    * Limits objects to 5 levels of depth
    */
-  depthFilter: new DepthFilter(5),
+  depthFilter: new DepthFilter(6),
 
   /**
    * Makes sure the user name / password is stripped out of the url.

--- a/packages/fxa-shared/sentry/pii-filters.ts
+++ b/packages/fxa-shared/sentry/pii-filters.ts
@@ -70,6 +70,7 @@ export class SentryPiiFilter extends FilterBase {
   public filter(event: Sentry.Event) {
     // Target key parts of sentry event structure
     this.scrubMessage(event)
+      .scrubContext(event)
       .scrubBreadCrumbs(event)
       .scrubRequest(event)
       .scrubTags(event)
@@ -152,6 +153,13 @@ export class SentryPiiFilter extends FilterBase {
   protected scrubUser(event: Sentry.Event) {
     if (event.user) {
       event.user = this.applyFilters(event.user);
+    }
+    return this;
+  }
+
+  protected scrubContext(event: Sentry.Event) {
+    if (event.contexts) {
+      event.contexts = this.applyFilters(event.contexts);
     }
     return this;
   }

--- a/packages/fxa-shared/test/sentry/pii-filters.ts
+++ b/packages/fxa-shared/test/sentry/pii-filters.ts
@@ -43,6 +43,28 @@ describe('pii-filters', () => {
     it('filters event', () => {
       let event: Sentry.Event = {
         message: 'A foo message.',
+        contexts: {
+          ValidationError: {
+            _original: {
+              email: `foo@bar.com`,
+            },
+            details: [
+              {
+                context: {
+                  key: 'email',
+                  label: 'email',
+                  name: '[undefined]',
+                  regex: {},
+                  value: 'none',
+                },
+                message: `foo@bar.com fails to match email pattern`,
+                path: ['email'],
+                type: 'string.pattern.base',
+              },
+            ],
+            type: 'ValidationError',
+          },
+        },
         breadcrumbs: [
           {
             message: 'A foo breadcrumb',
@@ -133,6 +155,28 @@ describe('pii-filters', () => {
 
       expect(event).to.deep.equal({
         message: `A ${FILTERED} message.`,
+        contexts: {
+          ValidationError: {
+            _original: {
+              email: '[Filtered]',
+            },
+            details: [
+              {
+                context: {
+                  key: 'email',
+                  label: 'email',
+                  name: '[undefined]',
+                  regex: {},
+                  value: 'none',
+                },
+                message: '[Filtered] fails to match email pattern',
+                path: ['email'],
+                type: 'string.pattern.base',
+              },
+            ],
+            type: 'ValidationError',
+          },
+        },
         breadcrumbs: [
           {
             message: `A ${FILTERED} breadcrumb`,
@@ -186,7 +230,9 @@ describe('pii-filters', () => {
             l2: {
               l3: {
                 l4: {
-                  l5: TRUNCATED,
+                  l5: {
+                    l6: TRUNCATED,
+                  },
                 },
               },
             },


### PR DESCRIPTION
## Because

- We want to sanitize validation errors which are held in sentry event 'context'

## This pull request

- Scrubs event.context
- Increase default depth to 6 because it's condusive to validation errors.
- Updates pii test with semi realistic validation error data.

## Issue that this pull request solves

Closes: FXA-7667

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
