### PR TITLE
feat(payments): remove branding from payments.ftl

### DIFF
--- a/packages/fxa-payments-server/Gruntfile.js
+++ b/packages/fxa-payments-server/Gruntfile.js
@@ -9,10 +9,6 @@ module.exports = function (grunt) {
     // in a later ticket - will require coordination with l10n to resolve
     // conflicting IDs for identical terms.
     'src/branding.ftl',
-    // Adding shared branding file to allow for gradual adoption of shared
-    // branding terms. There are currently no conflicting IDs between the
-    // two branding.ftl files.
-    '../fxa-shared/l10n/branding.ftl',
     'src/**/*.ftl',
   ];
 

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -8,7 +8,7 @@
     "postinstall": "yarn l10n:prime fxa-payments-server",
     "clean": "git clean -fXd",
     "l10n-prime": "yarn l10n:prime fxa-payments-server",
-    "l10n-bundle": "yarn l10n:bundle fxa-payments-server react,payments",
+    "l10n-bundle": "yarn l10n:bundle fxa-payments-server branding,react,payments",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "start": "tsc --build ../fxa-react && yarn build-css && yarn merge-ftl && pm2 start pm2.config.js && ../../_scripts/check-url.sh localhost:3031/__lbheartbeat__",
     "stop": "pm2 stop pm2.config.js",

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -100,10 +100,7 @@ export const App = ({
 
   return (
     <AppContext.Provider value={appContextValue}>
-      <AppLocalizationProvider
-        userLocales={navigatorLanguages}
-        bundles={['payments', 'react']}
-      >
+      <AppLocalizationProvider userLocales={navigatorLanguages}>
         <Head />
         <Localized id="document" attrs={{ title: true }}>
           <AppErrorBoundary>


### PR DESCRIPTION
## Because

- A recent change added shared branding to the payments.ftl file resulting in duplicate IDs during l10n string extraction.

## This pull request

- Removes the change that adds branding to payments.ftl
- Switches fxa-payments-server to use main.ftl instead of payments.ftl and react.ftl.

## Issue that this pull request solves

Closes: # FXA-7980

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
