### PR TITLE
fix(settings): Show event names in recent account activity

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -55,6 +55,4 @@ cs-disconnect-suspicious-advice-content = If the disconnected device is indeed
 
 cs-sign-out-button = Sign out
 
-cs-recent-activity = Recent Account Activity
-
 ##

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/SecurityEvent.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/SecurityEvent.tsx
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import {
-  FtlMsg,
-  LocalizedDateOptions,
-  getLocalizedDate,
-} from 'fxa-react/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 
 enum SecurityEventName {
   Create = 'account.create',
@@ -16,50 +12,169 @@ enum SecurityEventName {
   Login = 'account.login',
   Reset = 'account.reset',
   ClearBounces = 'emails.clearBounces',
+  LoginFailure = 'account.login.failure',
+  TwoFactorAdded = 'account.two_factor_added',
+  TwoFactorRequested = 'account.two_factor_requested',
+  TwoFactorChallengeFailure = 'account.two_factor_challenge_failure',
+  TwoFactorChallengeSuccess = 'account.two_factor_challenge_success',
+  TwoFactorRemoved = 'account.two_factor_removed',
+  PasswordResetRequested = 'account.password_reset_requested',
+  PasswordResetSuccess = 'account.password_reset_success',
+  RecoveryKeyAdded = 'account.recovery_key_added',
+  RecoveryKeyChallengeFailure = 'account.recovery_key_challenge_failure',
+  RecoveryKeyChallengeSuccess = 'account.recovery_key_challenge_success',
+  RecoveryKeyRemoved = 'account.recovery_key_removed',
+  PasswordAdded = 'account.password_added',
+  PasswordChanged = 'account.password_changed',
+  SecondaryEmailAdded = 'account.secondary_email_added',
+  SecondaryEmailRemoved = 'account.secondary_email_removed',
+  PrimarySecondaryEmailSwapped = 'account.primary_secondary_swapped',
 }
 
 const getSecurityEventNameL10n = (name: string) => {
   switch (name) {
     case SecurityEventName.Create: {
       return {
-        ftlId: 'recent-activity-account-create',
-        fallbackText: 'Account was created',
+        ftlId: 'recent-activity-account-create-v2',
+        fallbackText: 'Account created',
       };
     }
     case SecurityEventName.Disable: {
       return {
-        ftlId: 'recent-activity-account-disable',
-        fallbackText: 'Account was disabled',
+        ftlId: 'recent-activity-account-disable-v2',
+        fallbackText: 'Account disabled',
       };
     }
     case SecurityEventName.Enable: {
       return {
-        ftlId: 'recent-activity-account-enable',
-        fallbackText: 'Account was enabled',
+        ftlId: 'recent-activity-account-enable-v2',
+        fallbackText: 'Account enabled',
       };
     }
     case SecurityEventName.Login: {
       return {
-        ftlId: 'recent-activity-account-login',
-        fallbackText: 'Account initiated login',
+        ftlId: 'recent-activity-account-login-v2',
+        fallbackText: 'Account login initiated',
       };
     }
     case SecurityEventName.Reset: {
       return {
-        ftlId: 'recent-activity-account-reset',
-        fallbackText: 'Account initiated password reset',
+        ftlId: 'recent-activity-account-reset-v2',
+        fallbackText: 'Password reset initiated',
       };
     }
     case SecurityEventName.ClearBounces: {
       return {
-        ftlId: 'recent-activity-account-reset',
-        fallbackText: 'Account cleared email bounces',
+        ftlId: 'recent-activity-emails-clearBounces-v2',
+        fallbackText: 'Email bounces cleared',
+      };
+    }
+    case SecurityEventName.LoginFailure: {
+      return {
+        ftlId: 'recent-activity-account-login-failure',
+        fallbackText: 'Account login attempt failed',
+      };
+    }
+    case SecurityEventName.TwoFactorAdded: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-added',
+        fallbackText: 'Two-step authentication enabled',
+      };
+    }
+    case SecurityEventName.TwoFactorRequested: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-requested',
+        fallbackText: 'Two-step authentication requested',
+      };
+    }
+    case SecurityEventName.TwoFactorChallengeFailure: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-failure',
+        fallbackText: 'Two-step authentication failed',
+      };
+    }
+    case SecurityEventName.TwoFactorChallengeSuccess: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-success',
+        fallbackText: 'Two-step authentication successful',
+      };
+    }
+    case SecurityEventName.TwoFactorRemoved: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-removed',
+        fallbackText: 'Two-step authentication removed',
+      };
+    }
+    case SecurityEventName.PasswordResetRequested: {
+      return {
+        ftlId: 'recent-activity-account-password-reset-requested',
+        fallbackText: 'Password reset requested',
+      };
+    }
+    case SecurityEventName.PasswordResetSuccess: {
+      return {
+        ftlId: 'recent-activity-account-password-reset-success',
+        fallbackText: 'Password reset successful',
+      };
+    }
+    case SecurityEventName.RecoveryKeyAdded: {
+      return {
+        ftlId: 'recent-activity-account-recovery-key-added',
+        fallbackText: 'Account recovery key enabled',
+      };
+    }
+    case SecurityEventName.RecoveryKeyChallengeFailure: {
+      return {
+        ftlId: 'recent-activity-account-recovery-key-challenge-failure',
+        fallbackText: 'Account recovery key verification failed',
+      };
+    }
+    case SecurityEventName.RecoveryKeyChallengeSuccess: {
+      return {
+        ftlId: 'recent-activity-account-recovery-key-challenge-success',
+        fallbackText: 'Account recovery key verification successful',
+      };
+    }
+    case SecurityEventName.RecoveryKeyRemoved: {
+      return {
+        ftlId: 'recent-activity-account-recovery-key-removed',
+        fallbackText: 'Account recovery key removed',
+      };
+    }
+    case SecurityEventName.PasswordAdded: {
+      return {
+        ftlId: 'recent-activity-account-password-added',
+        fallbackText: 'New password added',
+      };
+    }
+    case SecurityEventName.PasswordChanged: {
+      return {
+        ftlId: 'recent-activity-account-recovery-key-added',
+        fallbackText: 'Password changed',
+      };
+    }
+    case SecurityEventName.SecondaryEmailAdded: {
+      return {
+        ftlId: 'recent-activity-account-secondary-email-added',
+        fallbackText: 'Secondary email address added',
+      };
+    }
+    case SecurityEventName.SecondaryEmailRemoved: {
+      return {
+        ftlId: 'recent-activity-account-secondary-email-removed',
+        fallbackText: 'Secondary email address removed',
+      };
+    }
+    case SecurityEventName.PrimarySecondaryEmailSwapped: {
+      return {
+        ftlId: 'recent-activity-account-emails-swapped',
+        fallbackText: 'Primary and secondary emails swapped',
       };
     }
     default: {
       return {
         ftlId: 'recent-activity-unknown',
-        fallbackText: 'Unknown',
+        fallbackText: 'Other account activity',
       };
     }
   }
@@ -73,30 +188,17 @@ export function SecurityEvent({
   createdAt: number;
   verified?: boolean;
 }) {
-  const createdAtDateText = Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
+  const localizedDate = Intl.DateTimeFormat(navigator.language, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
   }).format(new Date(createdAt));
-
-  const createdAtDateFluent = getLocalizedDate(
-    createdAt,
-    LocalizedDateOptions.NumericDateAndTime
-  );
 
   const l10nName = getSecurityEventNameL10n(name);
   return (
-    <li className="mt-5 ml-4" data-testid={l10nName.ftlId}>
-      <div className="absolute w-3 h-3 bg-green-600 rounded-full mt-1.5 -left-1.5 border border-green-700"></div>
-      <div className="text-grey-900 text-sm mobileLandscape:mt-3">
-        <FtlMsg
-          id="recent-activity-created-at"
-          vars={{ date: createdAtDateFluent }}
-        >
-          {createdAtDateText}
-        </FtlMsg>
+    <li className="mt-5 ms-4" data-testid={l10nName.ftlId}>
+      <div className="absolute w-3 h-3 bg-green-600 rounded-full mt-1.5 -start-1.5 border border-green-700"></div>
+      <div className="text-grey-900 text-sm mobileLandscape:mt-3 text-start">
+        {localizedDate}
       </div>
       <FtlMsg id={l10nName.ftlId}>
         <p className="text-grey-400 text-xs mobileLandscape:mt-3">

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/en.ftl
@@ -1,13 +1,34 @@
-## Recent Activity
+## Recent account activity
+## All strings except title indicate an event that occurred from the user's account
+## These are displayed as a list with the date when the event occured
 
-recent-activity-title = Recent Account Activity
+recent-activity-title = Recent account activity
 
-recent-activity-account-create = Account was created
-recent-activity-account-disable = Account was disabled
-recent-activity-account-enable = Account was enabled
-recent-activity-account-login = Account initiated login
-recent-activity-account-reset = Account initiated password reset
-recent-activity-emails-clearBounces = Account cleared email bounces
+recent-activity-account-create-v2 = Account created
+recent-activity-account-disable-v2 = Account disabled
+recent-activity-account-enable-v2 = Account enabled
+recent-activity-account-login-v2 = Account login initiated
+recent-activity-account-reset-v2 = Password reset initiated
+# This string appears under recent account activity when there were email bounces associated with the account, but those were recently cleared (i.e. removed/deleted).
+# An email bounce is when an email is sent to an email address and fails/receives a non-delivery receipt from the recipient's mail server.
+recent-activity-emails-clearBounces-v2 = Email bounces cleared
+recent-activity-account-login-failure = Account login attempt failed
+recent-activity-account-two-factor-added = Two-step authentication enabled
+recent-activity-account-two-factor-requested = Two-step authentication requested
+recent-activity-account-two-factor-failure = Two-step authentication failed
+recent-activity-account-two-factor-success = Two-step authentication successful
+recent-activity-account-two-factor-removed = Two-step authentication removed
+recent-activity-account-password-reset-requested = Account requested password reset
+recent-activity-account-password-reset-success = Account password reset successful
+recent-activity-account-recovery-key-added = Account recovery key enabled
+recent-activity-account-recovery-key-verification-failure = Account recovery key verification failed
+recent-activity-account-recovery-key-verification-success = Account recovery key verification successful
+recent-activity-account-recovery-key-removed = Account recovery key removed
+recent-activity-account-password-added = New password added
+recent-activity-account-recovery-key-added = Password changed
+recent-activity-account-secondary-email-added = Secondary email address added
+recent-activity-account-secondary-email-removed = Secondary email address removed
+recent-activity-account-emails-swapped = Primary and secondary emails swapped
 
-## $date (Date) - Date recent activity was created
-recent-activity-created-at = { $date }
+# Security event was recorded, but the activity details are unknown or not shown to user
+recent-activity-unknown = Other account activity

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
@@ -37,14 +37,14 @@ describe('Recent Account Activity', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Recent Account Activity',
+        name: 'Recent account activity',
       })
     ).toBeInTheDocument();
-    screen.getByText('Account was created');
-    screen.getByText('Account was disabled');
-    screen.getByText('Account was enabled');
-    screen.getByText('Account initiated login');
-    screen.getByText('Account initiated password reset');
-    screen.getByText('Account cleared email bounces');
+    screen.getByText('Account created');
+    screen.getByText('Account disabled');
+    screen.getByText('Account enabled');
+    screen.getByText('Account login initiated');
+    screen.getByText('Password reset initiated');
+    screen.getByText('Email bounces cleared');
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
@@ -26,10 +26,10 @@ export const PageRecentActivity = (_: RouteComponentProps) => {
     <FlowContainer
       title={ftlMsgResolver.getMsg(
         'recent-activity-title',
-        'Recent Account Activity'
+        'Recent account activity'
       )}
     >
-      <ol className="mt-5 relative border-l border-gray-100">
+      <ol className="mt-5 relative border-s border-gray-100">
         {!!securityEvents &&
           securityEvents.map((securityEvent) => (
             <SecurityEventSection

--- a/packages/fxa-settings/src/components/Settings/Security/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/Security/en.ftl
@@ -10,3 +10,6 @@ security-password-created-date = Created { $date }
 security-not-set = Not Set
 security-action-create = Create
 security-set-password = Set a password to sync and use certain account security features.
+
+# Link opens a list of recent account activity (e.g., login attempts, password changes, etc.)
+security-recent-activity-link = View recent account activity

--- a/packages/fxa-settings/src/components/Settings/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.tsx
@@ -85,15 +85,17 @@ export const Security = () => {
         <hr className="unit-row-hr" />
         <UnitRowTwoStepAuth />
 
-        <div className="bg-white tablet:rounded-xl shadow px-4 tablet:px-6">
-          <div className="pb-5 text-center mobileLandscape:text-start">
-            <Localized id="cs-recent-activity">
+        <hr className="unit-row-hr" />
+
+        <div className="px-5 pt-4 pb-6">
+          <div className="text-center mobileLandscape:text-start">
+            <Localized id="security-recent-activity-link">
               <Link
                 data-testid="settings-recent-activity"
                 className="link-blue text-sm"
                 to="/settings/recent_activity"
               >
-                Recent Account Activity
+                View recent account activity
               </Link>
             </Localized>
           </div>


### PR DESCRIPTION
## Because

* Some real security events were showing as "unknown" in the user-facing "Recent account activity" list in account settings

## This pull request

* Update the list of security events in Settings to include user-facing names for all existing events and add corresponding FTL strings
* Update FTL messages and fallback text to standardize copy style
* Update styling of the "recent account activity" link in the security section

## Issue that this pull request solves

Closes: #FXA-7974, FXA-7102

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

New styling for link:
![image](https://github.com/mozilla/fxa/assets/22231637/83201d56-273d-4106-8596-0b3fbcd47a88)

Updated list styling for RTL and updated date formatting (screenshot is for hebrew, but strings are new/updated and not yet localized):
![image](https://github.com/mozilla/fxa/assets/22231637/2423b619-001c-4a8e-a7fd-3ae1646c5102)
