### PR TITLE
feat(payments): Add react-ga4 payments events

### DIFF
--- a/packages/fxa-payments-server/src/lib/account.ts
+++ b/packages/fxa-payments-server/src/lib/account.ts
@@ -6,6 +6,7 @@ import {
   apiCreatePasswordlessAccount,
   updateAPIClientToken,
 } from './apiClient';
+import { GAEvent, ReactGALog } from './reactga-event';
 import { AuthServerErrno, GeneralError } from './errors';
 import sentry from './sentry';
 export const FXA_SIGNUP_ERROR: GeneralError = {
@@ -25,6 +26,7 @@ export async function handlePasswordlessSignUp({
       clientId,
     });
     updateAPIClientToken(accessToken);
+    ReactGALog.logEvent({ eventName: GAEvent.SignUp });
   } catch (e) {
     if (e.body?.errno !== AuthServerErrno.ACCOUNT_EXISTS) {
       sentry.captureException(e);

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -13,6 +13,7 @@ import {
 
 import { FilteredSetupIntent } from '../lib/apiClient';
 import { Customer, Plan, Profile } from '../store/types';
+import { GAEvent, GAPaymentType, GAPurchaseType } from '../lib/reactga-event';
 
 const invoice: LatestInvoiceItems = {
   line_items: [
@@ -494,4 +495,40 @@ export const INVOICE_PREVIEW_EXCLUSIVE_TAX: FirstInvoicePreview = {
       display_name: 'Sales Tax',
     },
   ],
+};
+
+export const MOCK_EVENTS = {
+  AddPaymentInfo: (plan: Plan) => ({
+    eventName: GAEvent.AddPaymentInfo,
+    paymentType: GAPaymentType.CreditCard,
+    plan,
+  }),
+  AddPayPalPaymentInfo: (plan: Plan) => ({
+    eventName: GAEvent.AddPaymentInfo,
+    paymentType: GAPaymentType.PayPal,
+    plan,
+  }),
+  PurchaseSubmitNew: (plan: Plan) => ({
+    eventName: GAEvent.PurchaseSubmit,
+    plan,
+    purchaseType: GAPurchaseType.New,
+  }),
+  PurchaseSubmitUpgrade: (plan: Plan) => ({
+    eventName: GAEvent.PurchaseSubmit,
+    plan,
+    purchaseType: GAPurchaseType.Upgrade,
+  }),
+  PurchaseNew: (plan: Plan) => ({
+    eventName: GAEvent.Purchase,
+    plan,
+    purchaseType: GAPurchaseType.New,
+  }),
+  PurchaseUpgrade: (plan: Plan) => ({
+    eventName: GAEvent.Purchase,
+    plan,
+    purchaseType: GAPurchaseType.Upgrade,
+  }),
+  SignUp: {
+    eventName: GAEvent.SignUp,
+  },
 };

--- a/packages/fxa-payments-server/src/lib/reactga-event.ts
+++ b/packages/fxa-payments-server/src/lib/reactga-event.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ReactGA from 'react-ga4';
+import { Plan } from 'fxa-shared/subscriptions/types';
+
+export enum GAEvent {
+  AddPaymentInfo = 'add_payment_info',
+  Purchase = 'purchase',
+  PurchaseSubmit = 'purchase_submit',
+  SignUp = 'sign_up',
+}
+
+export enum GAPaymentType {
+  CreditCard = 'Credit Card',
+  PayPal = 'PayPal',
+  NotChosen = 'Not chosen',
+  Undefined = 'Not chosen',
+}
+
+export enum GAPurchaseType {
+  New = 'new purchase',
+  Upgrade = 'upgrade',
+}
+
+type ReactGALogProps = {
+  eventName: (typeof GAEvent)[keyof typeof GAEvent];
+  paymentType?: (typeof GAPaymentType)[keyof typeof GAPaymentType];
+  plan?: Plan;
+  purchaseType?: (typeof GAPurchaseType)[keyof typeof GAPurchaseType];
+  discount?: number | undefined;
+};
+
+type ItemsProps = {
+  item_id: string;
+  item_name: string | undefined;
+  item_brand?: string;
+  item_variant?: string;
+  price?: number | null | undefined;
+  discount?: number;
+};
+
+type PlanOptionsProps = {
+  currency: string;
+  value: number | null;
+  payment_type?: (typeof GAPaymentType)[keyof typeof GAPaymentType];
+  items: ItemsProps[];
+  purchase_type?: (typeof GAPurchaseType)[keyof typeof GAPurchaseType];
+};
+
+export const ReactGALog = {
+  logEvent: ({
+    eventName,
+    paymentType,
+    plan,
+    purchaseType,
+    discount,
+  }: ReactGALogProps) => {
+    if (plan) {
+      const {
+        amount,
+        currency: currencyCode,
+        interval,
+        plan_id: planId,
+        plan_name: planName,
+        product_name: productName,
+      } = plan;
+
+      let planOptions: PlanOptionsProps = {
+        currency: currencyCode,
+        value: amount,
+        payment_type: paymentType,
+        items: [
+          {
+            item_id: planId,
+            item_name: planName,
+            item_brand: productName,
+            item_variant: interval,
+            price: amount,
+            discount,
+          },
+        ],
+        purchase_type: purchaseType,
+      };
+      return ReactGA.event(eventName, planOptions);
+    } else {
+      return ReactGA.event(eventName);
+    }
+  },
+};

--- a/packages/fxa-payments-server/src/lib/reactga-events.test.ts
+++ b/packages/fxa-payments-server/src/lib/reactga-events.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReactGALog } from './reactga-event';
+import { MOCK_EVENTS, PLAN } from './mock-data';
+import { cleanup } from '@testing-library/react';
+
+jest.mock('./reactga-event.ts');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  return cleanup();
+});
+
+describe('ReactGALog', () => {
+  it('logs sign_up event', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.SignUp);
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.SignUp);
+  });
+
+  it('logs add_payment_info event - Stripe', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.AddPaymentInfo(PLAN));
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.AddPaymentInfo(PLAN));
+  });
+
+  it('logs add_payment_info event - PayPal', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.AddPayPalPaymentInfo(PLAN));
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.AddPayPalPaymentInfo(PLAN));
+  });
+
+  it('logs purchase_submit event - new', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.PurchaseSubmitNew(PLAN));
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.PurchaseSubmitNew(PLAN));
+  });
+
+  it('logs purchase_submit event - upgrade', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.PurchaseSubmitUpgrade(PLAN));
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.PurchaseSubmitUpgrade(PLAN));
+  });
+
+  it('logs purchase event - new', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.PurchaseNew(PLAN));
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.PurchaseNew(PLAN));
+  });
+
+  it('logs purchase event - upgrade', async () => {
+    const gaSpy = jest.spyOn(ReactGALog, 'logEvent');
+    ReactGALog.logEvent(MOCK_EVENTS.PurchaseUpgrade(PLAN));
+    expect(gaSpy).toBeCalledWith(MOCK_EVENTS.PurchaseUpgrade(PLAN));
+  });
+});

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -28,6 +28,7 @@ import {
   CUSTOMER,
   INACTIVE_PLAN_ID,
   MOCK_CURRENCY_ERROR,
+  MOCK_EVENTS,
   MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR,
   MOCK_GENERAL_PAYPAL_ERROR,
   MOCK_STRIPE_CARD_ERROR,
@@ -57,6 +58,7 @@ import {
   apiSignupForNewsletter,
 } from '../../lib/apiClient';
 import { ButtonBaseProps } from '../../components/PayPalButton';
+import { ReactGALog } from '../../lib/reactga-event';
 
 jest.mock('../../lib/apiClient', () => {
   return {
@@ -90,6 +92,8 @@ jest.mock('react-router-dom', () => ({
     productId: mockProductId,
   }),
 }));
+
+jest.mock('../../lib/reactga-event.ts');
 
 describe('routes/Checkout', () => {
   let authServer = '';
@@ -139,6 +143,7 @@ describe('routes/Checkout', () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
     return cleanup();
   });
 
@@ -338,6 +343,17 @@ describe('routes/Checkout', () => {
       });
 
       expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
+      expect(ReactGALog.logEvent).toBeCalledTimes(4);
+      expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.SignUp);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseNew(PLANS[0])
+      );
     });
 
     it('retries apiFetchCustomer', async () => {
@@ -382,6 +398,13 @@ describe('routes/Checkout', () => {
       expect(paymentErrorComponent).toHaveTextContent(
         getFallbackTextByFluentId(getErrorMessageId(FXA_SIGNUP_ERROR))
       );
+      expect(ReactGALog.logEvent).toBeCalledTimes(2);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
+      );
     });
 
     it('displays an error when payment failed', async () => {
@@ -412,6 +435,14 @@ describe('routes/Checkout', () => {
       expect(paymentErrorComponent).toBeInTheDocument();
       expect(paymentErrorComponent).toHaveTextContent(
         getFallbackTextByFluentId(getErrorMessageId(MOCK_STRIPE_CARD_ERROR))
+      );
+      expect(ReactGALog.logEvent).toBeCalledTimes(3);
+      expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.SignUp);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
       );
     });
 
@@ -445,6 +476,17 @@ describe('routes/Checkout', () => {
           getErrorMessageId(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
         )
       );
+      expect(ReactGALog.logEvent).toBeCalledTimes(4);
+      expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.SignUp);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseNew(PLANS[0])
+      );
     });
 
     it('displays a message when fetching customer failed', async () => {
@@ -476,6 +518,17 @@ describe('routes/Checkout', () => {
         getFallbackTextByFluentId(
           getErrorMessageId(MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR)
         )
+      );
+      expect(ReactGALog.logEvent).toBeCalledTimes(4);
+      expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.SignUp);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseNew(PLANS[0])
       );
     });
 
@@ -628,6 +681,17 @@ describe('routes/Checkout', () => {
       });
 
       expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
+      expect(ReactGALog.logEvent).toBeCalledTimes(4);
+      expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.SignUp);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPayPalPaymentInfo(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseNew(PLANS[0])
+      );
     });
 
     it('shows an error when account creation failed', async () => {
@@ -664,6 +728,7 @@ describe('routes/Checkout', () => {
       expect(paymentErrorComponent).toHaveTextContent(
         getFallbackTextByFluentId(getErrorMessageId(FXA_SIGNUP_ERROR))
       );
+      expect(ReactGALog.logEvent).not.toBeCalled();
     });
 
     it('shows an error when failed to get a PayPal checkout token', async () => {
@@ -691,6 +756,8 @@ describe('routes/Checkout', () => {
           email: newAccountEmail,
           clientId: mockConfig.servers.oauth.clientId,
         });
+        expect(ReactGALog.logEvent).toBeCalledTimes(1);
+        expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.SignUp);
         expect(updateAPIClientToken).toHaveBeenCalledWith(
           STUB_ACCOUNT_RESULT.access_token
         );
@@ -757,6 +824,10 @@ describe('routes/Checkout', () => {
       await waitForExpect(() => {
         expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
         expect(apiCapturePaypalPayment).toHaveBeenCalledTimes(1);
+        expect(ReactGALog.logEvent).toBeCalledTimes(1);
+        expect(ReactGALog.logEvent).toBeCalledWith(
+          MOCK_EVENTS.PurchaseSubmitNew(PLANS[0])
+        );
         expect(apiFetchProfile).not.toHaveBeenCalled();
         expect(apiFetchCustomer).not.toHaveBeenCalled();
       });
@@ -767,6 +838,7 @@ describe('routes/Checkout', () => {
         getFallbackTextByFluentId(getErrorMessageId(MOCK_GENERAL_PAYPAL_ERROR))
       );
     });
+
     describe('newsletter', () => {
       it('POSTs to /newsletters if the newsletter checkbox is checked when subscription succeeds', async () => {
         const paypalButtonBase = ({

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -195,6 +195,7 @@ export const Checkout = ({
           clientId: config.servers.oauth.clientId,
           customer: null,
           checkoutType: CheckoutType.WITHOUT_ACCOUNT,
+          discount: coupon?.discountAmount,
           stripe: stripeOverride || stripeFormParams,
           selectedPlan,
           retryStatus,
@@ -227,6 +228,7 @@ export const Checkout = ({
       refreshSubmitNonce,
       validEmail,
       config.servers.oauth.clientId,
+      coupon,
       stripeOverride,
       selectedPlan,
       retryStatus,
@@ -474,6 +476,7 @@ export const Checkout = ({
                 setTransactionInProgress={setTransactionInProgress}
                 ButtonBase={paypalButtonBase}
                 promotionCode={coupon?.promotionCode}
+                discount={coupon?.discountAmount}
                 checkoutType={CheckoutType.WITHOUT_ACCOUNT}
               />
             )}
@@ -513,6 +516,7 @@ export const Checkout = ({
                     accountExists ||
                     invalidEmailDomain ||
                     !emailsMatch,
+                  discount: coupon?.discountAmount,
                 }}
               />
             </div>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -17,6 +17,7 @@ import {
   CUSTOMER,
   DETACH_PAYMENT_METHOD_RESULT,
   IAP_CUSTOMER,
+  MOCK_EVENTS,
   NEW_CUSTOMER,
   PAYMENT_METHOD_RESULT,
   PAYPAL_CUSTOMER,
@@ -36,6 +37,7 @@ import {
   renderWithLocalizationProvider,
 } from '../../../lib/test-utils';
 import { PickPartial } from '../../../lib/types';
+import { ReactGALog } from '../../../lib/reactga-event';
 
 jest.mock('../../../lib/hooks', () => {
   const refreshNonceMock = jest.fn().mockImplementation(Math.random);
@@ -44,6 +46,8 @@ jest.mock('../../../lib/hooks', () => {
     useNonce: () => [Math.random(), refreshNonceMock],
   };
 });
+
+jest.mock('../../../lib/reactga-event');
 
 type SubjectProps = PickPartial<
   SubscriptionCreateProps,
@@ -118,6 +122,7 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   afterEach(() => {
     if (consoleSpy) consoleSpy.mockRestore();
+    jest.clearAllMocks();
     return cleanup();
   });
 
@@ -621,6 +626,11 @@ describe('routes/Product/SubscriptionCreate', () => {
     expect(
       screen.queryByTestId('error-payment-submission')
     ).not.toBeInTheDocument();
+    expect(ReactGALog.logEvent).toBeCalledTimes(2);
+    expect(ReactGALog.logEvent).toBeCalledWith(
+      MOCK_EVENTS.PurchaseSubmitNew(PLAN)
+    );
+    expect(ReactGALog.logEvent).toBeCalledWith(MOCK_EVENTS.PurchaseNew(PLAN));
   });
 
   it('creates a new customer if needed for PayPal', async () => {
@@ -651,6 +661,10 @@ describe('routes/Product/SubscriptionCreate', () => {
       fireEvent.click(screen.getByTestId('paypal-button'));
     });
     expect(apiClientOverrides.apiCreateCustomer).toHaveBeenCalled();
+    expect(ReactGALog.logEvent).toBeCalledTimes(1);
+    expect(ReactGALog.logEvent).toBeCalledWith(
+      MOCK_EVENTS.PurchaseSubmitNew(PLAN)
+    );
   });
 
   const commonCreateSubscriptionFailureTest =
@@ -689,6 +703,13 @@ describe('routes/Product/SubscriptionCreate', () => {
       expect(
         screen.queryByTestId('error-payment-submission')
       ).not.toBeInTheDocument()
+    );
+    expect(ReactGALog.logEvent).toBeCalledTimes(2);
+    expect(ReactGALog.logEvent).toBeCalledWith(
+      MOCK_EVENTS.AddPaymentInfo(PLAN)
+    );
+    expect(ReactGALog.logEvent).toBeCalledWith(
+      MOCK_EVENTS.PurchaseSubmitNew(PLAN)
     );
   });
 
@@ -783,6 +804,13 @@ describe('routes/Product/SubscriptionCreate', () => {
         screen.queryByTestId('error-payment-submission')
       ).toBeInTheDocument();
       expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+      expect(ReactGALog.logEvent).toBeCalledTimes(2);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLAN)
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLAN)
+      );
     });
 
     it('displays for unexpected payment intent status', async () => {
@@ -810,6 +838,13 @@ describe('routes/Product/SubscriptionCreate', () => {
         screen.queryByTestId('error-payment-submission')
       ).toBeInTheDocument();
       expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+      expect(ReactGALog.logEvent).toBeCalledTimes(2);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLAN)
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLAN)
+      );
     });
 
     it('displays if client secret is missing from payment intent', async () => {
@@ -850,6 +885,13 @@ describe('routes/Product/SubscriptionCreate', () => {
       );
       expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
       expect(stripeOverride.confirmCardPayment).not.toHaveBeenCalled();
+      expect(ReactGALog.logEvent).toBeCalledTimes(2);
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.AddPaymentInfo(PLAN)
+      );
+      expect(ReactGALog.logEvent).toBeCalledWith(
+        MOCK_EVENTS.PurchaseSubmitNew(PLAN)
+      );
     });
 
     it('displays apiGetPaypalCheckoutToken failure', async () => {
@@ -880,6 +922,7 @@ describe('routes/Product/SubscriptionCreate', () => {
       expect(
         screen.queryByTestId('error-payment-submission')
       ).toBeInTheDocument();
+      expect(ReactGALog.logEvent).not.toBeCalled();
     });
   });
 
@@ -902,6 +945,7 @@ describe('routes/Product/SubscriptionCreate', () => {
     expect(
       screen.queryByTestId('error-payment-submission')
     ).toBeInTheDocument();
+    expect(ReactGALog.logEvent).not.toBeCalled();
   });
 
   it('displays apiCapturePaypalPayment failure', async () => {
@@ -935,6 +979,10 @@ describe('routes/Product/SubscriptionCreate', () => {
       fireEvent.click(screen.getByTestId('paypal-button'));
     });
     expect(apiClientOverrides.apiCapturePaypalPayment).toHaveBeenCalledTimes(1);
+    expect(ReactGALog.logEvent).toBeCalledTimes(1);
+    expect(ReactGALog.logEvent).toBeCalledWith(
+      MOCK_EVENTS.PurchaseSubmitNew(PLAN)
+    );
     expect(
       screen.queryByTestId('error-payment-submission')
     ).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -103,7 +103,7 @@ export const SubscriptionCreate = ({
         ...selectedPlan,
         checkoutType: checkoutType,
       }),
-    [selectedPlan]
+    [checkoutType, selectedPlan]
   );
 
   const onFormEngaged = useCallback(
@@ -112,7 +112,7 @@ export const SubscriptionCreate = ({
         ...selectedPlan,
         checkoutType: checkoutType,
       }),
-    [selectedPlan]
+    [checkoutType, selectedPlan]
   );
 
   const [paypalScriptLoaded, setPaypalScriptLoaded] = useState(false);
@@ -159,6 +159,7 @@ export const SubscriptionCreate = ({
             selectedPlan,
             customer,
             checkoutType,
+            discount: coupon?.discountAmount,
             retryStatus,
             onSuccess: refreshSubscriptions,
             onFailure: setSubscriptionError,
@@ -183,6 +184,8 @@ export const SubscriptionCreate = ({
         customer,
         retryStatus,
         apiClientOverrides,
+        checkoutType,
+        coupon,
         stripeOverride,
         setInProgress,
         refreshSubscriptions,
@@ -209,7 +212,13 @@ export const SubscriptionCreate = ({
         setInProgress(false);
         refreshSubmitNonce();
       },
-      [setInProgress, refreshSubmitNonce, refreshSubscriptions, selectedPlan]
+      [
+        setInProgress,
+        refreshSubmitNonce,
+        refreshSubscriptions,
+        checkoutType,
+        selectedPlan,
+      ]
     );
 
   const onSubmit = getPaymentProviderMappedVal<

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -9,6 +9,11 @@ import AppContext from '../../../lib/AppContext';
 
 import { getLocalizedDate, getLocalizedDateString } from '../../../lib/formats';
 import { useCallbackOnce } from '../../../lib/hooks';
+import {
+  GAEvent,
+  GAPurchaseType,
+  ReactGALog,
+} from '../../../lib/reactga-event';
 
 import { Form, SubmitButton } from '../../../components/fields';
 import { useValidatorState } from '../../../lib/validator';
@@ -36,6 +41,7 @@ export type SubscriptionUpgradeProps = {
   upgradeFromPlan: Plan;
   upgradeFromSubscription: WebSubscription;
   invoicePreview: FirstInvoicePreview;
+  discount?: number;
   isMobile?: boolean;
   updateSubscriptionPlanStatus: SelectorReturns['updateSubscriptionPlanStatus'];
   updateSubscriptionPlanAndRefresh: ProductProps['updateSubscriptionPlanAndRefresh'];
@@ -53,6 +59,7 @@ export const SubscriptionUpgrade = ({
   updateSubscriptionPlanStatus,
   updateSubscriptionPlanAndRefresh,
   resetUpdateSubscriptionPlan,
+  discount,
 }: SubscriptionUpgradeProps) => {
   const { config } = useContext(AppContext);
   const ariaLabelledBy = 'error-plan-change-failed-header';
@@ -103,6 +110,12 @@ export const SubscriptionUpgrade = ({
   const onSubmit = useCallback(
     (ev) => {
       ev.preventDefault();
+      ReactGALog.logEvent({
+        eventName: GAEvent.PurchaseSubmit,
+        plan: selectedPlan,
+        purchaseType: GAPurchaseType.Upgrade,
+        discount,
+      });
       if (validator.allValid()) {
         updateSubscriptionPlanAndRefresh(
           upgradeFromSubscription.subscription_id,
@@ -110,6 +123,12 @@ export const SubscriptionUpgrade = ({
           selectedPlan,
           paymentProvider
         );
+        ReactGALog.logEvent({
+          eventName: GAEvent.Purchase,
+          plan: selectedPlan,
+          purchaseType: GAPurchaseType.Upgrade,
+          discount,
+        });
       }
 
       if (!checkboxSet) {
@@ -124,6 +143,7 @@ export const SubscriptionUpgrade = ({
       selectedPlan,
       paymentProvider,
       checkboxSet,
+      discount,
     ]
   );
 

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -442,6 +442,7 @@ export const Product = ({
             resetUpdateSubscriptionPlan,
             updateSubscriptionPlanStatus,
             invoicePreview: invoicePreview.result,
+            discount: coupon?.discountAmount,
           }}
         />
       );


### PR DESCRIPTION
## Because

- there is a request to add GA to SubPlat checkout page

## This pull request

- Adds react-ga4 to the following events:
  - [x] `sign_up`
  - [x] `add_payment_info` [1]
    - [x] Stripe
    - [x] PayPal
  - [x] `purchase_submit`[1][3]
    - [x] Stripe - new purchase
    - [x] PayPal - new purchase
    - [x] Upgrade (Stripe and PayPal)
  - [x] `purchase` [1]
    - [x] Stripe - new purchase
    - [x] PayPal - new purchase
    - [x] Upgrade (Stripe and PayPal)

- To open a follow-up ticket in order to resolve bugs (though they potentially are on GA's end):
  - [1] `discount` in `items` array appears in GA Debugger Console, but not in DebugView; `discount` appears in DebugView if it is moved outside of `items`
  - [3] `items` array is missing in custom `purchase_submit` event
  - [`price` is multiplied by one million in GA](https://github.com/firebase/firebase-ios-sdk/issues/8280)
## Issue that this pull request solves

Closes: [FXA-7671](https://mozilla-hub.atlassian.net/browse/FXA-7671)
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information
To test, update `googleAnalytics` -> `enabled`: `true` and `measurementId`, in the following files:
- `fxa-payments-server/server/config/index.js`
- `fxa-payments-server/src/lib/config.ts`

[FXA-7671]: https://mozilla-hub.atlassian.net/browse/FXA-7671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ