### PR TITLE
feat(settings): Rollout new account recovery flow at 15%

### DIFF
--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -14,8 +14,12 @@ export abstract class BaseLayout {
     return `${this.baseUrl}/${this.path}`;
   }
 
-  goto(waitUntil: 'networkidle' | 'domcontentloaded' | 'load' = 'load') {
-    return this.page.goto(this.url, { waitUntil });
+  goto(
+    waitUntil: 'networkidle' | 'domcontentloaded' | 'load' = 'load',
+    query?: string
+  ) {
+    const url = query ? `${this.url}?${query}` : this.url;
+    return this.page.goto(url, { waitUntil });
   }
 
   screenshot() {

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -9,8 +9,8 @@ export abstract class SettingsLayout extends BaseLayout {
     return this.page.locator('[data-testid=drop-down-avatar-menu]');
   }
 
-  goto() {
-    return super.goto('load');
+  goto(query?: string) {
+    return super.goto('load', query);
   }
 
   async alertBarText() {

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -179,7 +179,7 @@ async function addAccountRecoveryKeyFlow({
   credentials,
   pages: { settings, recoveryKey },
 }) {
-  await settings.goto();
+  await settings.goto('isInRecoveryKeyExperiment=true');
   await settings.recoveryKey.clickCreate();
   await recoveryKey.clickStart();
   await recoveryKey.setPassword(credentials.password);

--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -24,11 +24,12 @@ test.describe('recovery key react', () => {
       await settings.goto();
       let status = await settings.recoveryKey.statusText();
       expect(status).toEqual('Not Set');
-      await settings.recoveryKey.clickCreate();
 
       // Check which account recovery key generation flow to use (based on feature flag)
       // TODO in FXA-7419 - remove the condition and else block that goes through the old key generation flow
       if (config.featureFlags.showRecoveryKeyV2 === true) {
+        await settings.goto('isInRecoveryKeyExperiment=true');
+        await settings.recoveryKey.clickCreate();
         // View 1/4 info
         await recoveryKey.clickStart();
         // View 2/4 confirm password and generate key
@@ -46,6 +47,7 @@ test.describe('recovery key react', () => {
         await recoveryKey.setHint(hint);
         await recoveryKey.clickFinish();
       } else {
+        await settings.recoveryKey.clickCreate();
         await recoveryKey.setPassword(credentials.password);
         await recoveryKey.submit();
 
@@ -91,7 +93,7 @@ test.describe('recovery key react', () => {
     await resetPasswordReact.fillEmailToResetPwd(credentials.email);
     await resetPasswordReact.confirmResetPasswordHeadingVisible();
 
-    // We need to append `&showReactApp=true` to reset link inorder to enroll in reset password experiment
+    // We need to append `&showReactApp=true` to reset link in order to enroll in reset password experiment
     let link = await target.email.waitForEmail(
       credentials.email,
       EmailType.recovery,

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -44,7 +44,7 @@ test.describe('severity-1 #smoke', () => {
     // Create recovery key
     // TODO in FXA-7419 - remove condition and only keep new recovery key flow (remove content of else block)
     if (config.featureFlags.showRecoveryKeyV2 === true) {
-      await settings.goto();
+      await settings.goto('isInRecoveryKeyExperiment=true');
 
       await settings.recoveryKey.clickCreate();
       // View 1/4 info

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -231,7 +231,7 @@ test.describe('new recovery key test', () => {
       const config = await login.getConfig();
       test.skip(config.featureFlags.showRecoveryKeyV2 !== true);
 
-      await settings.goto();
+      await settings.goto('isInRecoveryKeyExperiment=true');
       let status = await settings.recoveryKey.statusText();
       expect(status).toEqual('Not Set');
       await settings.recoveryKey.clickCreate();
@@ -355,6 +355,7 @@ test.describe('new recovery key test', () => {
     page,
     pages: { settings, recoveryKey, login },
   }) => {
+    await settings.goto('isInRecoveryKeyExperiment=true');
     // Create new recovery key
     await settings.recoveryKey.clickCreate();
     // View 1/4 info
@@ -510,6 +511,7 @@ test.describe('new recovery key test', () => {
   });
 
   test('revoke recovery key', async ({ pages: { settings } }) => {
+    await settings.goto('isInRecoveryKeyExperiment=true');
     await settings.recoveryKey.clickDelete();
     await settings.clickModalConfirm();
     await settings.waitForAlertBar();

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -17,6 +17,7 @@ const experimentGroupingRules = [
   require('./push'),
   require('./third-party-auth'),
   require('./generalized-react-app'),
+  require('./new-recovery-key-UI'),
 ].map((ExperimentGroupingRule) => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/new-recovery-key-UI.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/new-recovery-key-UI.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Feature flag for new account recovery key UI.
+ *
+ */
+'use strict';
+
+const BaseGroupingRule = require('./base');
+
+const GROUPS = [
+  'control',
+  // Treatment branch is the new account recovery key creation flow
+  'treatment',
+];
+
+// This experiment is disabled by default. If you would like to go through
+// the flow, load email-first screen and append query params
+// `?forceExperiment=newRecoveryKeyUI&forceExperimentGroup=treatment`
+const ROLLOUT_RATE = 0.15;
+
+module.exports = class NewRecoveryKeyUI extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'newRecoveryKeyUI';
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+  }
+
+  /**
+   * Enable new recovery key creation flow if user is in the treatment group.
+   *
+   * @param {Object} subject data used to decide
+   * @returns {Any}
+   */
+  choose(subject = {}) {
+    let choice = false;
+
+    if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+      choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+
+    return choice;
+  }
+};

--- a/packages/fxa-content-server/app/scripts/lib/new-recovery-key-UI-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/lib/new-recovery-key-UI-experiment-mixin.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from '../views/mixins/experiment-mixin';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  isInNewRecoveryKeyUIExperiment() {
+    const experimentGroup =
+      this.getAndReportExperimentGroup('newRecoveryKeyUI');
+    return experimentGroup === 'treatment';
+  },
+};

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -45,6 +45,7 @@ import VerificationReasons from './verification-reasons';
 import WouldYouLikeToSync from '../views/would_you_like_to_sync';
 import { isAllowed } from 'fxa-shared/configuration/convict-format-allow-list';
 import ReactExperimentMixin from './generalized-react-app-experiment-mixin';
+import RecoveryKeyExperimentMixin from './new-recovery-key-UI-experiment-mixin';
 import { getClientReactRouteGroups } from '../../../server/lib/routes/react-app/route-groups-client';
 
 const NAVIGATE_AWAY_IN_MOBILE_DELAY_MS = 75;
@@ -120,7 +121,7 @@ let Router = Backbone.Router.extend({
   },
 });
 
-Cocktail.mixin(Router, ReactExperimentMixin);
+Cocktail.mixin(Router, ReactExperimentMixin, RecoveryKeyExperimentMixin);
 
 Router = Router.extend({
   routes: {
@@ -389,6 +390,8 @@ Router = Router.extend({
         return this.navigateAway(redirectUrl);
       }
 
+      const isInRecoveryKeyExperiment = this.isInNewRecoveryKeyUIExperiment();
+
       // All other flows should redirect to the settings page
       const settingsEndpoint = '/settings';
       const settingsLink = `${settingsEndpoint}${Url.objToSearchString({
@@ -400,6 +403,7 @@ Router = Router.extend({
         isSampledUser,
         service,
         uniqueUserId,
+        ...(isInRecoveryKeyExperiment && { isInRecoveryKeyExperiment }),
       })}`;
       this.navigateAway(settingsLink);
     },

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 7);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/new-recovery-key-UI.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/new-recovery-key-UI.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Experiment from 'lib/experiments/grouping-rules/new-recovery-key-UI';
+
+describe('lib/experiments/grouping-rules/new-recovery-key-UI', () => {
+  let experiment;
+
+  beforeEach(() => {
+    experiment = new Experiment();
+  });
+
+  describe('choose', () => {
+    it('returns treatment if valid clientId', () => {
+      const rules = experiment.groups;
+      assert.isTrue(
+        rules.include(
+          experiment.choose({
+            experimentGroupingRules: { choose: () => experiment.name },
+            uniqueUserId: 'user-id',
+          })
+        )
+      );
+    });
+
+    it('returns false if rollout 0%', () => {
+      experiment.rolloutRate = 0;
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -51,7 +51,7 @@ export const App = ({
 }: { flowQueryParams: QueryParams } & RouteComponentProps) => {
   const [isSignedIn, setIsSignedIn] = useState<boolean>();
 
-  const { showReactApp } = flowQueryParams;
+  const { showReactApp, isInRecoveryKeyExperiment } = flowQueryParams;
   const { loading, error } = useInitialState();
   const account = useAccount();
   const [email, setEmail] = useState<string>();
@@ -62,6 +62,11 @@ export const App = ({
   const sessionTokenId = sessionToken();
 
   const { metricsEnabled } = account;
+
+  // TODO Remove feature flag and experiment logic in FXA-7419
+  const showRecoveryKeyV2 = !!(
+    config.showRecoveryKeyV2 && isInRecoveryKeyExperiment === 'true'
+  );
 
   useEffect(() => {
     Metrics.init(metricsEnabled || !isSignedIn, flowQueryParams);
@@ -227,7 +232,7 @@ export const App = ({
               <ThirdPartyAuthCallback path="/post_verify/third_party_auth/callback/*" />
             </>
           )}
-          <Settings path="/settings/*" />
+          <Settings path="/settings/*" {...{ showRecoveryKeyV2 }} />
         </ScrollToTop>
       </Router>
     </>

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import { HomePath } from '../../../constants';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { useAccount, useFtlMsgResolver } from '../../../models';
@@ -23,6 +23,7 @@ export enum RecoveryKeyAction {
 
 export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   usePageViewEvent(viewName);
+  const location = useLocation();
 
   const { recoveryKey } = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -48,7 +49,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
 
   // TODO: Remove feature flag param in FXA-7419
   const navigateBackward = () => {
-    navigate(HomePath);
+    navigate(`${HomePath}${location.search}`);
   };
 
   const navigateForward = (e?: React.MouseEvent<HTMLElement>) => {
@@ -57,7 +58,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
       setCurrentStep(currentStep + 1);
     } else {
       // TODO: Remove feature flag param in FXA-7419
-      navigate(HomePath);
+      navigate(`${HomePath}${location.search}`);
     }
   };
 

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -16,7 +16,11 @@ import { DeleteAccountPath } from 'fxa-settings/src/constants';
 import { Localized } from '@fluent/react';
 import DataCollection from '../DataCollection';
 
-export const PageSettings = (_: RouteComponentProps) => {
+export const PageSettings = ({
+  // This should technically never be `undefined` but because this is temporary,
+  // allowing `undefined` makes updating tests and stories easier.
+  showRecoveryKeyV2,
+}: { showRecoveryKeyV2?: boolean } & RouteComponentProps) => {
   const { uid } = useAccount();
 
   Metrics.setProperties({
@@ -32,7 +36,7 @@ export const PageSettings = (_: RouteComponentProps) => {
       </div>
       <div className="flex-7 max-w-full">
         <Profile />
-        <Security />
+        <Security {...{ showRecoveryKeyV2 }} />
         <ConnectedServices />
         <LinkedAccounts />
         <DataCollection />

--- a/packages/fxa-settings/src/components/Settings/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.tsx
@@ -36,7 +36,11 @@ const PwdDate = ({ passwordCreated }: { passwordCreated: number }) => {
   );
 };
 
-export const Security = () => {
+export const Security = ({
+  showRecoveryKeyV2,
+}: {
+  showRecoveryKeyV2?: boolean;
+}) => {
   const { passwordCreated, hasPassword } = useAccount();
   const { l10n } = useLocalization();
   const localizedNotSet = l10n.getString('security-not-set', null, 'Not Set');
@@ -81,7 +85,7 @@ export const Security = () => {
         </Localized>
         <hr className="unit-row-hr" />
 
-        <UnitRowRecoveryKey />
+        <UnitRowRecoveryKey {...{ showRecoveryKeyV2 }} />
         <hr className="unit-row-hr" />
         <UnitRowTwoStepAuth />
 

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
@@ -43,13 +43,14 @@ const featureFlagConfig = {
 
 const renderWithContext = (
   account: Partial<Account>,
-  config?: Partial<Config>
+  config?: Partial<Config>,
+  showRecoveryKeyV2?: boolean
 ) => {
   const context = { account: account as Account, config: config as Config };
 
   renderWithRouter(
     <AppContext.Provider value={mockAppContext(context)}>
-      <UnitRowRecoveryKey />
+      <UnitRowRecoveryKey {...{ showRecoveryKeyV2 }} />
     </AppContext.Provider>
   );
 };
@@ -189,7 +190,7 @@ describe('UnitRowRecoveryKey', () => {
 
   // NEW TESTS FOR VERSION 2
   it('renders version 2 as expected when account recovery key is set', () => {
-    renderWithContext(accountHasRecoveryKey, featureFlagConfig);
+    renderWithContext(accountHasRecoveryKey, featureFlagConfig, true);
     screen.getByRole('heading', { name: 'Account recovery key' });
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
@@ -206,7 +207,7 @@ describe('UnitRowRecoveryKey', () => {
   });
 
   it('renders version 2 as expected when account recovery key is not set', () => {
-    renderWithContext(accountWithoutRecoveryKey, featureFlagConfig);
+    renderWithContext(accountWithoutRecoveryKey, featureFlagConfig, true);
     screen.getByRole('heading', { name: 'Account recovery key' });
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
@@ -217,7 +218,7 @@ describe('UnitRowRecoveryKey', () => {
   });
 
   it('disables key creation in version 2 when account has no password', () => {
-    renderWithContext(accountWithoutPassword, featureFlagConfig);
+    renderWithContext(accountWithoutPassword, featureFlagConfig, true);
     screen.getByRole('heading', { name: 'Account recovery key' });
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value').textContent
@@ -253,7 +254,8 @@ describe('UnitRowRecoveryKey', () => {
 
       renderWithContext(
         accountHasRecoveryKeyWithDeleteSuccess,
-        featureFlagConfig
+        featureFlagConfig,
+        true
       );
 
       const deleteButtons = screen.getAllByRole('button', { hidden: false });
@@ -277,7 +279,8 @@ describe('UnitRowRecoveryKey', () => {
 
       renderWithContext(
         accountHasRecoveryKeyWithDeleteFailure,
-        featureFlagConfig
+        featureFlagConfig,
+        true
       );
 
       const deleteButtons = screen.getAllByRole('button', { hidden: false });

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
@@ -4,12 +4,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { useBooleanState } from 'fxa-react/lib/hooks';
-import {
-  useAccount,
-  useAlertBar,
-  useConfig,
-  useFtlMsgResolver,
-} from '../../../models';
+import { useAccount, useAlertBar, useFtlMsgResolver } from '../../../models';
 import { logViewEvent } from '../../../lib/metrics';
 import Modal from '../Modal';
 import UnitRow from '../UnitRow';
@@ -18,11 +13,13 @@ import { ButtonIconReload, ButtonIconTrash } from '../ButtonIcon';
 import { HomePath } from '../../../constants';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
-export const UnitRowRecoveryKey = () => {
+export const UnitRowRecoveryKey = ({
+  showRecoveryKeyV2,
+}: {
+  showRecoveryKeyV2?: boolean;
+}) => {
   const account = useAccount();
-  const config = useConfig();
-  // TODO Remove feature flag in FXA-7419
-  const { showRecoveryKeyV2 } = config;
+
   const recoveryKey = account.recoveryKey;
   const alertBar = useAlertBar();
   const [deleteModalVisible, setDeleteModalVisible] = useState<boolean>(false);

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -26,10 +26,10 @@ import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
 import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
 
-export const Settings = (props: RouteComponentProps) => {
+export const Settings = ({
+  showRecoveryKeyV2,
+}: { showRecoveryKeyV2?: boolean } & RouteComponentProps) => {
   const config = useConfig();
-  // TODO Remove in FXA-7419
-  const { showRecoveryKeyV2 } = config;
   const { metricsEnabled, hasPassword } = useAccount();
 
   useEffect(() => {
@@ -62,7 +62,7 @@ export const Settings = (props: RouteComponentProps) => {
       <Head />
       <Router basepath={HomePath}>
         <ScrollToTop default>
-          <PageSettings path="/" />
+          <PageSettings path="/" {...{ showRecoveryKeyV2 }} />
           <PageDisplayName path="/display_name" />
           <PageAvatar path="/avatar" />
           {hasPassword ? (

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -25,7 +25,8 @@ interface FlowQueryParams {
 
 // temporary until we can safely direct all users to all routes currently in content-server
 export interface QueryParams extends FlowQueryParams {
-  showReactApp?: boolean;
+  showReactApp?: string;
+  isInRecoveryKeyExperiment?: string;
 }
 
 try {


### PR DESCRIPTION
feat(settings): Rollout new account recovery flow at 15%

Because:

* We want to rollout the new account recovery key creation flow to 15% of users before rolling out to 100% on prod.

This commit:

* Add NewRecoveryKeyUI experiment with 15% rollout
* Passes experiment group to Settings App, allows forceExperiment
* Conditionally render new UI if user is in treatment group AND feature flag is turned on
* Update related tests

Closes #[FXA-8030](https://mozilla-hub.atlassian.net/browse/FXA-8030)


[FXA-8030]: https://mozilla-hub.atlassian.net/browse/FXA-8030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ