### PR TITLE
fix(ci): Fix broken ci images due to missing allowlist folder

### DIFF
--- a/_dev/docker/ci/Dockerfile.dockerignore
+++ b/_dev/docker/ci/Dockerfile.dockerignore
@@ -12,3 +12,5 @@
 **/artifacts
 **/configs
 **/temp
+
+!configs/gql/allowlist


### PR DESCRIPTION
## Because

- Our CI image build was failing

## This pull request

- Makes an exception for the `configs/gql/allowlist` folder in the dockerignore file

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
