### PR TITLE
fix(content): Make sure startTime is an integer

### DIFF
--- a/packages/fxa-shared/speed-trap/timers.js
+++ b/packages/fxa-shared/speed-trap/timers.js
@@ -5,17 +5,17 @@
 class Timers {
   init(options) {
     if (!options || !options.performance) {
-      throw new Error('options.performance required')
+      throw new Error('options.performance required');
     }
 
     this.completed = {};
     this.running = {};
     this.performance = options.performance;
-    this.baseTime = options.performance.timeOrigin;
+    this.baseTime = parseInt(options.performance.timeOrigin);
   }
 
   start(name) {
-    var start = this.performance.now()
+    var start = this.performance.now();
     if (typeof this.running[name] === 'number') {
       throw new Error(name + ' timer already started');
     }
@@ -24,7 +24,7 @@ class Timers {
   }
 
   stop(name) {
-    var stop = this.performance.now()
+    var stop = this.performance.now();
 
     if (typeof this.running[name] !== 'number') {
       throw new Error(name + ' timer not started');


### PR DESCRIPTION
## Because

- Some devices may report performance.timeOrigin as a float instead of an int

## This pull request

- Converts performance.timeOrigin value to to an int

## Issue that this pull request solves

Closes: FXA-6477

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


