### PR TITLE
Revert "chore(auth): allow profile scope on App Store registration route"

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/apple.js
@@ -84,15 +84,6 @@ describe('AppleIapHandler', () => {
       assert.deepEqual(result, { transactionIdValid: true });
     });
 
-    it('accepts a "profile" scope for auth', async () => {
-      request.auth.credentials.scope = ['profile'];
-      appleIap.purchaseManager = {
-        registerToUserAccount: sinon.fake.resolves({}),
-      };
-      iapConfig.getBundleId = sinon.fake.resolves('testPackage');
-      await appleIapHandler.registerOriginalTransactionId(request);
-    });
-
     it('throws on invalid package', async () => {
       appleIap.purchaseManager = {
         registerToUserAccount: sinon.fake.resolves({}),


### PR DESCRIPTION


This reverts commit c2c4ea035e8581f4f24ba7bb2fb4f41befc3208c.

Closes: #FXA-5848

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
