### PR TITLE
fix(CircleCI): Increase playwright resource class to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -792,7 +792,7 @@ workflows:
             - fail-fast
       - playwright-functional-tests:
           name: Functional Tests - Playwright (PR)
-          resource_class: large
+          resource_class: xlarge
           requires:
             - Build (PR)
       - build-and-deploy-storybooks:


### PR DESCRIPTION
## Because

- Some resubscription tests were failing/flaking/timing out

## This pull request

- Increase the playwright functional test resource class from large to xlarge.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
