### PR TITLE
feat(infra): wait for db patches on startup

### DIFF
--- a/_dev/pm2/start.sh
+++ b/_dev/pm2/start.sh
@@ -16,3 +16,6 @@ echo "waiting for containers to start"
 _scripts/check-url.sh localhost:4100/health
 _scripts/check-url.sh localhost:9299/api/config
 _scripts/check-mysql.sh
+
+echo "waiting for DB patches"
+_scripts/check-db-patcher.sh

--- a/_scripts/check-db-patcher.sh
+++ b/_scripts/check-db-patcher.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+NAME="patcher.mjs" # nodejs script's name here
+RETRY=60
+
+# Wait for $NAME script to start
+for i in $(eval echo "{1..$RETRY}"); do
+  if [[ $(pgrep -f $NAME) == "" ]]; then
+    sleep 1
+  else
+    break;
+  fi
+done
+
+# Wait for $NAME script to finish
+for j in $(eval echo "{1..$RETRY}"); do
+  if [[ $(pgrep -f $NAME) == "" ]]; then
+    exit 0
+  else
+    if [ "$j" -lt $RETRY ]; then
+      sleep 1
+    fi
+  fi
+done
+
+exit 1


### PR DESCRIPTION
## Because

- On stack startup, services start before mysql patches have completed, causing profile-server to fail on startup.

## This pull request

- Adds script to check if patcher script has started and is still running.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
