### PR TITLE
bug(admin-server,graphql): Fix missing allowlists

### DIFF
--- a/packages/fxa-admin-server/nest-cli.json
+++ b/packages/fxa-admin-server/nest-cli.json
@@ -2,8 +2,18 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "assets": ["**/*.gql"],
-    "watchAssets": true
+    "assets": [
+      {
+        "include": "**/*.gql",
+        "outDir": "dist/packages/fxa-admin-server/src",
+        "watchAssets": true
+      },
+      {
+        "include": "config/gql/allowlist/",
+        "outDir": "dist/packages/fxa-admin-server/src",
+        "watchAssets": true
+      }
+    ]
   },
   "entryFile": "src/packages/admin-server/main.js"
 }

--- a/packages/fxa-graphql-api/nest-cli.json
+++ b/packages/fxa-graphql-api/nest-cli.json
@@ -1,5 +1,15 @@
 {
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
-  "entryFile": "packages/fxa-graphql-api/src/main.js"
+  "entryFile": "packages/fxa-graphql-api/src/main.js",
+
+  "compilerOptions": {
+    "assets": [
+      {
+        "include": "config/gql/allowlist/",
+        "outDir": "dist/packages/fxa-graphql-api/src",
+        "watchAssets": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Because

- Allowlists weren't getting copied to build directory

## This pull request

- Includes allowlists as assets

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This issue surfaced in the train 263.1 build. During development and test we run code with nest start which was not affected and able to resolve the allowlist config files. For production we use nest build to 'compile' our code into the dist folder. This required some extra 'asset' configuration to ensure the allowlists were copied over correctly.
