### PR TITLE
fix(esm-cjs-hell): add module type hints for Playwright

### DIFF
--- a/packages/functional-tests/lib/targets/base.ts
+++ b/packages/functional-tests/lib/targets/base.ts
@@ -1,4 +1,4 @@
-import AuthClient from 'fxa-auth-client';
+import AuthClient from 'fxa-auth-client/lib/client';
 import { EmailClient } from '../email';
 import { TargetName } from './index';
 

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -10,6 +10,10 @@
       "require": "./dist/server/cjs/packages/fxa-auth-client/server.js"
     },
     "./browser": "./dist/browser/packages/fxa-auth-client/browser.js",
+    "./lib/client": {
+      "import": "./dist/server/esm/packages/fxa-auth-client/lib/client.js",
+      "require": "./dist/server/cjs/packages/fxa-auth-client/lib/client.js"
+    },
     "./lib/crypto": {
       "import": "./dist/server/esm/packages/fxa-auth-client/lib/crypto.js",
       "require": "./dist/server/cjs/packages/fxa-auth-client/lib/crypto.js"
@@ -31,7 +35,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "postinstall": "(tsc --build tsconfig.browser.json && tsc --build) || true",
-    "build": "tsc --build tsconfig.browser.json && tsc --build && tsc --build tsconfig.cjs.json",
+    "build": "tsc --build tsconfig.browser.json && tsc --build && tsc --build tsconfig.cjs.json && echo '{ \"type\": \"commonjs\" }' > ./dist/server/cjs/packages/fxa-auth-client/package.json",
     "compile": "tsc --noEmit",
     "ts-check": "tsc --noEmit",
     "test": "mocha -r esbuild-register test/*",


### PR DESCRIPTION
Because:
 - fxa-auth-client is used directly in Playwright tests, and Playwright has its own require or import logic

This commit:
 - adds "type" in package.json for Playwright to figure it out
