### PR TITLE
fix(playwright): add exports in auth-client cjs dist

### DIFF
--- a/packages/fxa-auth-client/.cjs.package.json
+++ b/packages/fxa-auth-client/.cjs.package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fxa-auth-client",
+  "type": "commonjs",
+  "exports": {
+    ".": "./server.js",
+    "./lib/client": "./client.js",
+    "./lib/crypto": "./lib/crypto.js",
+    "./lib/hawk": "./lib/hawk.js",
+    "./lib/recoveryKey": "./lib/recoveryKey.js",
+    "./lib/utils": "./lib/utils.js",
+    "./lib/*": "./lib/*.js"
+  }
+}

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "postinstall": "(tsc --build tsconfig.browser.json && tsc --build) || true",
-    "build": "tsc --build tsconfig.browser.json && tsc --build && tsc --build tsconfig.cjs.json && echo '{ \"type\": \"commonjs\" }' > ./dist/server/cjs/packages/fxa-auth-client/package.json",
+    "build": "tsc --build tsconfig.browser.json && tsc --build && tsc --build tsconfig.cjs.json && cp .cjs.package.json ./dist/server/cjs/packages/fxa-auth-client/package.json",
     "compile": "tsc --noEmit",
     "ts-check": "tsc --noEmit",
     "test": "mocha -r esbuild-register test/*",


### PR DESCRIPTION
Because:
 - Playwright still cannot resolve the auth-client module

This commit:
 - adds a package.json with exports mapping
