### PR TITLE
feat: update adjust.com URL

### DIFF
--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
@@ -91,7 +91,7 @@ export const BentoMenu = () => {
                   <li>
                     <LinkExternal
                       data-testid="pocket-link"
-                      href="https://app.adjust.com/hr2n0yz?engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
+                      href="https://app.adjust.com/hr2n0yz?redirect_macos=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&redirect_windows=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
                       className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
                     >
                       <div className={iconClassNames}>


### PR DESCRIPTION
Because:

* The old URL would send desktop users to Apple's store

This commit:

* Updates the URL

Closes FXA-7444
