### PR TITLE
feat(payments): google analytics deny consent

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -138,9 +138,22 @@ export function useReactGA4Setup(config: Config, productId: string) {
     );
 
     try {
+      // Deny all consent types to disable cookies
+      // https://developers.google.com/tag-platform/devguides/privacy#consent_mode_terminology
+      ReactGA.gtag('consent', 'default', {
+        ad_storage: 'denied',
+        analytics_storage: 'denied',
+        functionality_storage: 'denied',
+        personalization_storage: 'denied',
+        security_storage: 'denied',
+      });
+
       ReactGA.initialize(measurementId, {
         nonce: cspNonce,
         testMode,
+        gtagOptions: {
+          debug_mode: true,
+        },
       });
     } catch (error) {
       console.error('Error initializing GA script\n', error);


### PR DESCRIPTION
## Because

- SubPlat currently does not request cookie consent from customers, therefore Google Analytics should be configured to not use any cookies.

## This pull request

- Sets Google Analytics default consent to denied for all consent types.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
