### PR TITLE
fix(l10n/payments): update placeable in translation with text

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/en.ftl
@@ -2,5 +2,5 @@
 
 payment-method-header = Choose your payment method
 # This message is used to indicate the second step in a multi step process.
-payment-method-header-second-step = 2. { payment-method-header }
+payment-method-header-step = 2. Choose your payment method
 payment-method-first-approve = First you’ll need to approve your subscription

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -61,7 +61,7 @@ describe('components/PaymentMethodHeader', () => {
     });
 
     it('returns correct heading with prefix', async () => {
-      const msgId = 'payment-method-header-second-step';
+      const msgId = 'payment-method-header-step';
       const expected = '2. Choose your payment method';
       const actual = getLocalizedMessage(bundle, msgId, {});
 

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -14,7 +14,7 @@ const returnPaymentMethodHeader = (type: PaymentMethodHeaderType) => {
   switch (type) {
     case PaymentMethodHeaderType.SecondStep:
       return (
-        <Localized id="payment-method-header-second-step">
+        <Localized id="payment-method-header-step">
           <h2 className="step-header" data-testid="header-prefix">
             2. Choose your payment method
           </h2>


### PR DESCRIPTION
## Because

- An (untranslated) placeable was used in another (translated) translation, causing the ID to be shown instead of the correct text.

## This pull request

- Updates the placeable with text.

## Issue that this pull request solves

Closes: FXA-5508

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
