### PR TITLE
fix(ci): Capture grep -q exit code 1 to fix string extraction job

### DIFF
--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -64,8 +64,10 @@ jobs:
           then
             echo "No changes found."
           else
-            gh pr view $PR_NUMBER --json reviewRequests | jq -r ".reviewRequests[].name" | grep -q "fxa-l10n"
-            if [ $? -ne 0 ]; then
+            # `grep -p "fxa-l10n` fails w/exit code 1 when 'fxa-l10n' is not found in the review list and breaks the
+            # command pipeline. Capture this with `GREP_STATUS` to directly check against the grep exit code
+            gh pr view $PR_NUMBER --json reviewRequests | jq -r ".reviewRequests[].name" | grep -q "fxa-l10n" || GREP_STATUS=$?
+            if [ $GREP_STATUS -ne 0 ]; then
                 # Check if someone from the Localization Team already reviewed the PR.
                 # Get the list of fxa-l10n reviewers, excluding non-l10n members
                 L10N_REVIEWERS=$(gh api -H "Accept: application/vnd.github+json" /orgs/mozilla/teams/fxa-l10n/members | jq -r '(.[].login | select(. != "clouserw"))' | sort)


### PR DESCRIPTION
Because:
* Our string extraction CI job is failing when changes are found and fxa-l10n has not been requested for review yet

This commit:
* Captures grep exit code to compare against directly, as grep -q "fxa-l10n" was failing and breaking out of the command pipeline with exit code 1

---

A [different fix](https://github.com/mozilla/fxa/pull/15532) was made previously, as it appeared to least at least fix the job in [this case](https://github.com/mozilla/fxa/pull/15472). Looks like that worked for when fxa-l10n was already added, but I didn't realize I'd neglected to test the case where l10n hadn't been requested yet.

I hit that case in #15561 - this change is in that branch at the time of writing to show its success, [see CI job](https://github.com/mozilla/fxa/actions/runs/5627381616/job/15249817173) under "Extract gettext and flag for review."