### PR TITLE
fix(test): replace isVisible() check with waitForSelector()

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -228,24 +228,28 @@ export class LoginPage extends BaseLayout {
     await this.submit();
   }
 
-  async isEmailHeader() {
-    return this.page.locator(selectors.EMAIL_HEADER).isVisible();
+  async waitForEmailHeader() {
+    await this.page.waitForSelector(selectors.EMAIL_HEADER, {
+      timeout: 2000,
+    });
   }
 
   async cannotCreateAccountHeader() {
     return this.page.locator(selectors.COPPA_HEADER).isVisible();
   }
 
-  async isSignUpCodeHeader() {
-    const header = this.page.locator(selectors.SIGN_UP_CODE_HEADER);
-    await header.waitFor({ state: 'visible' });
-    return header.isVisible();
+  async waitForSignUpCodeHeader() {
+    await this.page.waitForSelector(selectors.SIGN_UP_CODE_HEADER,
+      {
+      timeout: 2000,
+    });
   }
 
-  async isSignInCodeHeader() {
-    const header = this.page.locator(selectors.SIGN_IN_CODE_HEADER);
-    await header.waitFor({ state: 'visible' });
-    return header.isVisible();
+  async waitForSignInCodeHeader() {
+    await this.page.waitForSelector(selectors.SIGN_IN_CODE_HEADER,
+      {
+      timeout: 2000,
+    });
   }
 
   async confirmEmail() {
@@ -276,7 +280,7 @@ export class LoginPage extends BaseLayout {
     return this.page.fill(selectors.RECOVERY_KEY_TEXT_INPUT, code);
   }
 
-  async loginHeader() {
+  async isUserLoggedIn() {
     const header = this.page.locator(selectors.FIREFOX_HEADER);
     await header.waitFor();
     return header.isVisible();
@@ -286,10 +290,10 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.PERMISSION_ACCEPT).click();
   }
 
-  async signinUnblockHeader() {
-    const header = this.page.locator(selectors.SIGNIN_UNBLOCK_HEADER);
-    await header.waitFor();
-    return header.isVisible();
+  async waitForSigninUnblockHeader() {
+    await this.page.waitForSelector(selectors.SIGNIN_UNBLOCK_HEADER, {
+      timeout: 2000,
+    });
   }
 
   async signInError() {
@@ -378,10 +382,10 @@ export class LoginPage extends BaseLayout {
     });
   }
 
-  async isPasswordHeader() {
-    const header = await this.page.locator(selectors.PASSWORD_HEADER);
-    await header.waitFor();
-    return header.isVisible();
+  async waitForPasswordHeader() {
+    await this.page.waitForSelector(selectors.PASSWORD_HEADER, {
+      timeout: 2000,
+    });
   }
 
   async clickSignIn() {

--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -44,7 +44,7 @@ test.describe('cookies disabled', () => {
     });
 
     //Verify Email header
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
 
     //Goto cookies disabled url
     await page.goto(`${target.contentServerUrl}/cookies_disabled`, {
@@ -63,7 +63,7 @@ test.describe('cookies disabled', () => {
     await page.waitForLoadState();
 
     //Verify Email header
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
   });
 
   test('visit verify page with localStorage disabled', async ({

--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -12,7 +12,7 @@ test.describe('force auth', () => {
     await forceAuth.open(credentials);
     await login.setPassword(credentials.password);
     await login.submit();
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('forgot password flow via force_auth', async ({
@@ -51,21 +51,21 @@ test.describe('force auth', () => {
     await forceAuth.open(credentials);
     await login.setPassword(credentials.password);
     await login.submit();
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     //Sign out
     await settings.signOut();
 
     //Verify user need to enter email
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
     await login.setEmail(credentials.email);
     await login.submit();
 
     //Verify password is empty and user need to enter password
-    expect(await login.isPasswordHeader()).toBe(true);
+    await login.waitForPasswordHeader();
     expect(await login.getPasswordInput()).toContain('');
     await login.setPassword(credentials.password);
     await login.submit();
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -36,7 +36,7 @@ test.describe('oauth permissions for trusted reliers', () => {
     await login.fillOutFirstSignUp(email, password, { verify: false });
 
     //no permissions asked for, straight to confirm
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
   });
 
   test('signup with `prompt=consent`', async ({
@@ -57,7 +57,8 @@ test.describe('oauth permissions for trusted reliers', () => {
     await login.acceptOauthPermissions();
 
     //Verify sign up code header
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
+
   });
 
   test('signin without `prompt=consent`', async ({

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -93,7 +93,7 @@ test.describe('oauth prompt none', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
     await target.auth.accountDestroy(email, password);
 
     const query = new URLSearchParams({
@@ -122,7 +122,7 @@ test.describe('oauth prompt none', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify sign up code header
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
 
     const query = new URLSearchParams({
       login_hint: email,
@@ -175,7 +175,7 @@ test.describe('oauth prompt none with emails', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     const query = new URLSearchParams({
       return_on_error: 'false',
@@ -205,7 +205,7 @@ test.describe('oauth prompt none with emails', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     const query = new URLSearchParams({
       login_hint: login.createEmail(),
@@ -236,7 +236,7 @@ test.describe('oauth prompt none with emails', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     const query = new URLSearchParams({
       login_hint: email,

--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -29,7 +29,8 @@ test.describe('Oauth sign up', () => {
     await login.fillOutFirstSignUp(email, password, { verify: false });
 
     //Verify sign up code header
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
+
     await login.fillOutSignUpCode(email);
 
     //Verify logged in on relier page
@@ -47,7 +48,7 @@ test.describe('Oauth sign up', () => {
     await login.fillOutFirstSignUp(bouncedEmail, password, { verify: false });
 
     //Verify sign up code header
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
     await client.accountDestroy(bouncedEmail, password);
 
     //Verify error message
@@ -59,7 +60,7 @@ test.describe('Oauth sign up', () => {
     await login.fillOutFirstSignUp(email, password, { verify: false });
 
     //Verify sign up code header
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
     await login.fillOutSignUpCode(email);
 
     //Verify logged in on relier page

--- a/packages/functional-tests/tests/postVerify/accountRecovery.spec.ts
+++ b/packages/functional-tests/tests/postVerify/accountRecovery.spec.ts
@@ -42,7 +42,7 @@ test.describe('post verify - account recovery', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await page.goto(
       `${target.contentServerUrl}/post_verify/account_recovery/add_recovery_key`,
@@ -85,7 +85,7 @@ test.describe('post verify - account recovery', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await page.goto(
       `${target.contentServerUrl}/post_verify/account_recovery/add_recovery_key`,
@@ -99,7 +99,7 @@ test.describe('post verify - account recovery', () => {
     await postVerify.clickMaybeLater();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('abort account recovery at confirm_recovery_key', async ({
@@ -112,7 +112,7 @@ test.describe('post verify - account recovery', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await page.goto(
       `${target.contentServerUrl}/post_verify/account_recovery/add_recovery_key`,
@@ -127,6 +127,6 @@ test.describe('post verify - account recovery', () => {
     await postVerify.clickMaybeLater();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
@@ -50,7 +50,7 @@ test.describe('post verify - force password change', () => {
     await postVerify.submit();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('force change password on login - oauth', async ({

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -98,7 +98,7 @@ test.describe('old recovery key test', () => {
     await login.login(credentials.email, credentials.password);
 
     // Verify login successful
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('can reset password when forgot recovery key', async ({
@@ -134,7 +134,7 @@ test.describe('old recovery key test', () => {
     await login.login(credentials.email, credentials.password);
 
     // Verify login successful
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('cannot reuse recovery key', async ({
@@ -342,7 +342,7 @@ test.describe('new recovery key test', () => {
     await settings.signOut();
     expect(credentials.password).toContain('_new');
     await login.login(credentials.email, credentials.password);
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Verify key revoked after use
     const status = await settings.recoveryKey.statusText();
@@ -416,7 +416,7 @@ test.describe('new recovery key test', () => {
     await login.login(credentials.email, credentials.password);
 
     // Verify login successful with password reset with new recovery key
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Verify that new account recovery key revoked
     status = await settings.recoveryKey.statusText();
@@ -457,7 +457,7 @@ test.describe('new recovery key test', () => {
     await login.login(credentials.email, credentials.password);
 
     // Verify login successful
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Verify that account recovery key has been revoked after password reset
     status = await settings.recoveryKey.statusText();
@@ -497,7 +497,7 @@ test.describe('new recovery key test', () => {
     await login.login(credentials.email, credentials.password);
 
     // Verify login successful
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Verify that account recovery key has been revoked after password reset
     status = await settings.recoveryKey.statusText();

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -30,7 +30,7 @@ test.describe('two step auth', () => {
     // Login to verify no prompt for code
     await settings.signOut();
     await login.login(credentials.email, credentials.password);
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293445

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -35,7 +35,7 @@ test.describe('signup here', () => {
     await login.fillOutFirstSignUp(emailWithSpace, password, { verify: false });
 
     // Verify the confirm code header and the email
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
     expect(await login.confirmEmail()).toContain(emailWithoutSpace);
 
     // Need to clear the cache to get the new email
@@ -46,8 +46,7 @@ test.describe('signup here', () => {
     emailWithoutSpace = email;
     emailWithSpace = email + ' ';
     await login.fillOutFirstSignUp(emailWithSpace, password, { verify: false });
-
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
     expect(await login.confirmEmail()).toContain(emailWithoutSpace);
   });
 
@@ -121,11 +120,11 @@ test.describe('signup here', () => {
 
     // The original tab should transition to the settings page w/ success
     // message.
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
     await settings.signOut();
 
     // check the email address was cleared
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
     expect(await login.getEmailInput()).toContain('');
 
     await login.setEmail(login.createEmail());
@@ -157,7 +156,7 @@ test.describe('signup here', () => {
 
     // The original tab should transition to the settings page w/ success
     // message.
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Verify the account is in local storage and has a correct state
     const currentAccountUid = await page.evaluate(() => {
@@ -185,13 +184,13 @@ test.describe('signup here', () => {
 
     // The original tab should transition to the settings page w/ success
     // message.
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
     await settings.signOut();
 
     await login.setEmail(email);
     await login.clickSubmit();
     await login.setPassword(password);
     await login.submit();
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -22,7 +22,7 @@ test.describe('Sign up with code ', () => {
     await login.fillOutFirstSignUp(email, PASSWORD);
 
     await client.accountDestroy(email, PASSWORD);
-    expect(await login.isPasswordHeader()).toBe(true);
+    await login.waitForPasswordHeader();
   });
 
   test('valid code then click back', async ({
@@ -35,7 +35,7 @@ test.describe('Sign up with code ', () => {
     });
     await login.fillOutFirstSignUp(email, PASSWORD, {waitForNavOnSubmit: false});
     await page.goBack({waitUntil: 'load'});
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('invalid code', async ({

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -41,7 +41,7 @@ test.describe('signin here', () => {
     );
 
     // Verify the header after login
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Need to clear the cache to get the new email
     await login.clearCache();
@@ -54,7 +54,7 @@ test.describe('signin here', () => {
     );
 
     // Verify the header after login
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('signin verified with password that incorrectly has leading whitespace', async ({
@@ -86,7 +86,7 @@ test.describe('signin here', () => {
     );
 
     // Verify the header after login
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Sign out
     await settings.signOut();
@@ -98,7 +98,7 @@ test.describe('signin here', () => {
     await login.clickSubmit();
 
     // Verify the header after login
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('with bounced email', async ({
@@ -115,7 +115,7 @@ test.describe('signin here', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     // Verify the header after login
-    expect(await login.isSignInCodeHeader()).toBe(true);
+    await login.waitForSignInCodeHeader();
     await target.auth.accountDestroy(email, password);
     await page.waitForURL(/signin_bounced/);
 
@@ -124,7 +124,7 @@ test.describe('signin here', () => {
     await login.clickBouncedCreateAccount();
 
     //Verify user redirected to login page
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
     expect(await login.getEmailInput()).toContain('');
   });
 });

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -50,14 +50,14 @@ test.describe('signin blocked', () => {
     await login.fillOutEmailFirstSignIn(blockedEmail, password);
 
     //Verify sign in block header
-    expect(await login.signinUnblockHeader()).toBe(true);
+    await login.waitForSigninUnblockHeader();
     expect(await login.getUnblockEmail()).toContain(blockedEmail);
 
     //Unblock the email
     await login.unblock(blockedEmail);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('incorrect code entered', async ({ target, page, pages: { login } }) => {
@@ -67,7 +67,7 @@ test.describe('signin blocked', () => {
     await login.fillOutEmailFirstSignIn(blockedEmail, password);
 
     //Verify sign in block header
-    expect(await login.signinUnblockHeader()).toBe(true);
+    await login.waitForSigninUnblockHeader();
     expect(await login.getUnblockEmail()).toContain(blockedEmail);
     await login.enterUnblockCode('incorrect');
 
@@ -80,7 +80,7 @@ test.describe('signin blocked', () => {
     await login.unblock(blockedEmail);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('resend', async ({ target, page, pages: { login, resetPassword } }) => {
@@ -90,7 +90,7 @@ test.describe('signin blocked', () => {
     await login.fillOutEmailFirstSignIn(blockedEmail, password);
 
     //Verify sign in block header
-    expect(await login.signinUnblockHeader()).toBe(true);
+    await login.waitForSigninUnblockHeader();
     expect(await login.getUnblockEmail()).toContain(blockedEmail);
 
     //Click resend link
@@ -105,7 +105,7 @@ test.describe('signin blocked', () => {
     await login.unblock(blockedEmail);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('with primary email changed', async ({
@@ -119,7 +119,7 @@ test.describe('signin blocked', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await settings.goto();
     await settings.secondaryEmail.clickAdd();
@@ -133,14 +133,14 @@ test.describe('signin blocked', () => {
     await login.fillOutEmailFirstSignIn(newEmail, password);
 
     //Verify sign in block header
-    expect(await login.signinUnblockHeader()).toBe(true);
+    await login.waitForSigninUnblockHeader();
     expect(await login.getUnblockEmail()).toContain(newEmail);
 
     //Unblock the email
     await login.unblock(newEmail);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('unverified', async ({ target, page, pages: { login } }) => {
@@ -150,18 +150,18 @@ test.describe('signin blocked', () => {
     await login.fillOutEmailFirstSignIn(unverifiedEmail, password);
 
     //Verify sign in block header
-    expect(await login.signinUnblockHeader()).toBe(true);
+    await login.waitForSigninUnblockHeader();
     expect(await login.getUnblockEmail()).toContain(unverifiedEmail);
 
     //Unblock the email
     await login.unblock(unverifiedEmail);
 
     //Verify confirm code header
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
 
     await login.fillOutSignInCode(unverifiedEmail);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -46,7 +46,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await login.clearSessionStorage();
     await page.goto(target.contentServerUrl, {
@@ -56,7 +56,7 @@ test.describe('signin cached', () => {
     await login.clickSignIn();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('sign in with incorrect email case before normalization fix, on second attempt canonical form is used', async ({
@@ -70,7 +70,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await login.clearSessionStorage();
     await page.goto(target.contentServerUrl, {
@@ -83,7 +83,7 @@ test.describe('signin cached', () => {
     await login.clickSignIn();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     //Verify email is normalized
     const primary = await settings.primaryEmail.statusText();
@@ -101,7 +101,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
     await page.goto(target.contentServerUrl, {
       waitUntil: 'load',
     });
@@ -111,7 +111,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email2, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // testing to make sure cached signin comes back after a refresh
     await page.goto(target.contentServerUrl, {
@@ -132,7 +132,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await login.destroySession(email);
     await page.goto(target.contentServerUrl, {
@@ -145,7 +145,7 @@ test.describe('signin cached', () => {
     await login.clickSubmit();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('cached credentials that expire while on page', async ({
@@ -159,7 +159,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await page.goto(target.contentServerUrl, {
       waitUntil: 'load',
@@ -179,7 +179,7 @@ test.describe('signin cached', () => {
     await login.clickSubmit();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('unverified cached signin redirects to confirm email', async ({
@@ -198,7 +198,7 @@ test.describe('signin cached', () => {
     await login.fillOutEmailFirstSignIn(email_unverified, password);
 
     //Verify sign up code header is visible
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
     await page.goto(target.contentServerUrl, {
       waitUntil: 'load',
     });
@@ -207,12 +207,12 @@ test.describe('signin cached', () => {
     await login.clickSignIn();
 
     //Cached login should still go to email confirmation screen for unverified accounts
-    expect(await login.isSignUpCodeHeader()).toBe(true);
+    await login.waitForSignUpCodeHeader();
 
     //Fill the code and submit
     await login.fillOutSignUpCode(email_unverified);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -10,7 +10,7 @@ test.describe('support form without valid session', () => {
     await page.goto(`${target.contentServerUrl}/support`, {
       waitUntil: 'load',
     });
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
   });
 });
 
@@ -25,7 +25,7 @@ test.describe('support form without active subscriptions', () => {
       waitUntil: 'load',
     });
     await page.waitForURL(/settings/);
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 });
 

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -68,7 +68,7 @@ test.describe('Firefox desktop user info handshake', () => {
     await login.respondToWebChannelMessage(eventDetailStatus);
     await login.checkWebChannelMessage('fxaccounts:fxa_status');
     await login.fillOutEmailFirstSignIn(otherEmail, password);
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     // Then, sign in the user again, synthesizing the user having signed
     // into Sync after the initial sign in.
@@ -86,7 +86,7 @@ test.describe('Firefox desktop user info handshake', () => {
 
     expect(await login.getPrefilledEmail()).toContain(otherEmail);
     await login.clickSignIn();
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('Sync - no user signed into browser, no user signed in locally', async ({
@@ -101,7 +101,7 @@ test.describe('Firefox desktop user info handshake', () => {
         target.contentServerUrl
       }?context=fx_desktop_v3&service=sync&${query.toString()}`
     );
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
     expect(await login.getEmailInput()).toContain('');
   });
 
@@ -116,7 +116,7 @@ test.describe('Firefox desktop user info handshake', () => {
       `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
     );
     await login.fillOutEmailFirstSignIn(otherEmail, password);
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
     await page.goto(
       `${
         target.contentServerUrl
@@ -240,7 +240,7 @@ test.describe('Firefox desktop user info handshake', () => {
     expect(await login.getPrefilledEmail()).toContain(browserSignedInEmail);
     await login.setPassword(password);
     await login.clickSubmit();
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
   });
 
   test('Non-Sync settings page - no user signed into browser, user signed in locally', async ({
@@ -254,7 +254,7 @@ test.describe('Firefox desktop user info handshake', () => {
       `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
     );
     await login.fillOutEmailFirstSignIn(otherEmail, password);
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     await settings.goto();
     const primaryEmail = await settings.primaryEmail.statusText();

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -33,7 +33,8 @@ test.describe('Firefox Desktop Sync v3 settings', () => {
     );
     await login.respondToWebChannelMessage(customEventDetail);
     await login.fillOutEmailFirstSignIn(email, firstPassword);
-    expect(await login.isSignInCodeHeader()).toBe(true);
+    await login.waitForSignInCodeHeader();
+
     await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
     await login.fillOutSignInCode(email);
     await login.checkWebChannelMessage(FirefoxCommand.Login);

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -129,7 +129,7 @@ test.describe('Firefox Desktop Sync v3 sign up', () => {
     );
 
     // Verify user lands on the sign in password page
-    expect(await login.isPasswordHeader()).toBe(true);
+    await login.waitForPasswordHeader();
 
     // Verify the correct email is displayed
     expect(await login.getPrefilledEmail()).toContain(credentials.email);

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -48,7 +48,7 @@ test.describe('sync signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify sign up code header is visible
-    expect(await login.isSignInCodeHeader()).toBe(true);
+    await login.waitForSignInCodeHeader();
 
     const query = { email: email2 };
     const queryParam = new URLSearchParams(query);
@@ -65,7 +65,7 @@ test.describe('sync signin cached', () => {
     await connectAnotherDevice.clickNotNow();
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     //Reset prefill and context
     await login.clearSessionStorage();
@@ -76,7 +76,7 @@ test.describe('sync signin cached', () => {
     });
     expect(await login.getPrefilledEmail()).toContain(email);
     await login.useDifferentAccountLink();
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
   });
 
   test('sign in with desktop context then no context, desktop credentials should persist', async ({
@@ -89,18 +89,18 @@ test.describe('sync signin cached', () => {
     await login.fillOutEmailFirstSignIn(email, password);
 
     //Verify sign up code header is visible
-    expect(await login.isSignInCodeHeader()).toBe(true);
+    await login.waitForSignInCodeHeader();
 
     await page.goto(target.contentServerUrl, {
       waitUntil: 'load',
     });
     expect(await login.getPrefilledEmail()).toContain(email);
     await login.useDifferentAccountLink();
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
     await login.fillOutEmailFirstSignIn(email2, password);
 
     //Verify logged in on Settings page
-    expect(await login.loginHeader()).toBe(true);
+    expect(await login.isUserLoggedIn()).toBe(true);
 
     //Reset prefill and context
     await login.clearSessionStorage();
@@ -111,6 +111,6 @@ test.describe('sync signin cached', () => {
     });
     expect(await login.getPrefilledEmail()).toContain(email);
     await login.useDifferentAccountLink();
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
   });
 });

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -39,7 +39,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     await page.waitForTimeout(1000);
 
     // refresh sends the user back to the first step
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
   });
 
   test('open directly to /signin page, refresh on the /signin page', async ({
@@ -58,14 +58,14 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     await login.submit();
 
     // Verify user is redirected to the password page
-    expect(await login.isPasswordHeader()).toBe(true);
+    await login.waitForPasswordHeader();
 
     //Refresh the page
     await page.reload({ waitUntil: 'load' });
     await page.waitForTimeout(1000);
 
     // refresh sends the user back to the first step
-    expect(await login.isEmailHeader()).toBe(true);
+    await login.waitForEmailHeader();
   });
 
   test('enter a firefox.com address', async ({ target }) => {


### PR DESCRIPTION
## Because

- isVisible() doesn't have the default timeout set and becomes flaky when the selector/page takes a few more secs to resolve. hence replacing it with waitForSelector() as it has default timeout set and works more efficiently. 
- changed the name for `loginHeader()` to `isUserLoggedIn()`

## This pull request

replaces isVisible() with waitForSelector() wherever seems necessary.

## Issue that this pull request solves

Closes: FXA-7793

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
