### PR TITLE
fix(content-server): Update ':locale/legal/privacy' route

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -213,7 +213,7 @@ Router = Router.extend({
       });
     },
     ':lang/legal/privacy(/)': function () {
-      this.createReactOrBackboneViewHandler(`legal/terms`, 'pp', {
+      this.createReactOrBackboneViewHandler('legal/privacy', 'pp', {
         contentRedirect: true,
       });
     },


### PR DESCRIPTION
Because:
* We are incorrectly redirecting users to legal/terms

This commit:
* Updates content-server router to direct to the correct path

fixes FXA-8050