### PR TITLE
fix(settings): Remove label duplicated in InputText title attribute

### DIFF
--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -62,8 +62,8 @@ export class ResetPasswordPage extends BaseLayout {
     page: BaseLayout['page'] = this.page
   ) {
     if (this.react) {
-      await page.getByTitle('New password').fill(password);
-      await page.getByTitle('Re-enter password').fill(password);
+      await page.getByLabel('New password').fill(password);
+      await page.getByLabel('Re-enter password').fill(password);
       await page.locator(selectors.SUBMIT).click();
       return;
     }

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -138,7 +138,6 @@ export const InputText = ({
           )}
           data-testid={formatDataTestId('input-field')}
           onChange={textFieldChange}
-          title={label}
           ref={inputRef}
           {...{
             name,


### PR DESCRIPTION
## Because

* Input label should be narrated only once by screen readers, but it was duplicated due to the label text being applied to the input title.
* Title should only be used if it provides information in addition to the label.

## This pull request

* Remove the title from InputText component because it was only duplicating the label.
* Update reset password page model (for functional test) to `getByLabel` instead of `getByTitle`

## Issue that this pull request solves

Closes: #FXA-7565

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before fix, label duplicated:
![image](https://github.com/mozilla/fxa/assets/22231637/47ac286c-6191-4969-945c-bf0312a6e9ec)

After fix, label only present once in accessibility tree:
![Screenshot 2023-07-24 at 12 00 06 PM](https://github.com/mozilla/fxa/assets/22231637/030d9030-c534-4920-9b3c-901eae1cdfd4)

![Screenshot 2023-07-24 at 12 11 02 PM](https://github.com/mozilla/fxa/assets/22231637/c9e8bdaf-8e32-46a6-95c3-9ef81b320ce1)

## Other information (Optional)

Any other information that is important to this pull request.
