### PR TITLE
fix(payments): Manage button from Subscription management page does nothing when clicked

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
@@ -78,7 +78,12 @@ export const ActionButton = ({
     <button
       data-testid="reveal-payment-modal-button"
       className="button settings-button error-button"
-      onClick={revealFixPaymentModal}
+      onClick={(e) => {
+        // The stopPropagation prevents the "onDismiss" function to be called as soon
+        // as the FixPaymentModal initially loads.
+        e.stopPropagation();
+        revealFixPaymentModal();
+      }}
     >
       <Localized id="pay-update-manage-btn">
         <span className="manage-button" data-testid="manage-button">


### PR DESCRIPTION
## Because

- the Manage button from Subscription Management page did nothing when clicked

## This pull request

- fixes it so the Manage button opens up a modal when clicked

## Issue that this pull request solves

Closes: [FXA-8047](https://mozilla-hub.atlassian.net/browse/FXA-8047)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

[FXA-8047]: https://mozilla-hub.atlassian.net/browse/FXA-8047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ