### PR TITLE
feat(metrics): add view Glean event for TOTP form

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -104,6 +104,10 @@ export const GleanMetrics = {
     view: createEventFn('login_email_confirmation_view'),
     submit: createEventFn('login_email_confirmation_submit'),
   },
+
+  totpForm: {
+    view: createEventFn('login_totp_form_view'),
+  },
 };
 
 export default GleanMetrics;

--- a/packages/fxa-content-server/app/scripts/views/sign_in_totp_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_totp_code.js
@@ -5,6 +5,7 @@
 import AuthErrors from 'lib/auth-errors';
 import Cocktail from 'cocktail';
 import FormView from './form';
+import GleanMetrics from '../lib/glean';
 import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/sign_in_totp_code.mustache';
 import VerificationReasonMixin from './mixins/verification-reason-mixin';
@@ -26,6 +27,11 @@ const View = FormView.extend({
     if (!account || !account.get('sessionToken')) {
       this.navigate(this._getAuthPage());
     }
+  },
+
+  logView() {
+    GleanMetrics.totpForm.view();
+    return FormView.prototype.logView.call(this);
   },
 
   submit() {

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -217,22 +217,50 @@ describe('lib/glean', () => {
     });
 
     describe('registration', () => {
-      it('submit a ping with the reg_view event name', () => {
+      it('submits a ping with the reg_view event name', () => {
         GleanMetrics.registration.view();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'reg_view');
       });
 
-      it('submit a ping with the reg_submit event name', () => {
+      it('submits a ping with the reg_submit event name', () => {
         GleanMetrics.registration.submit();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'reg_submit');
       });
 
-      it('submit a ping with the reg_submit_success event name', () => {
+      it('submits a ping with the reg_submit_success event name', () => {
         GleanMetrics.registration.success();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'reg_submit_success');
+      });
+    });
+
+    describe('loginConfirmation', () => {
+      it('submits a ping with the login_email_confirmation_view event name', () => {
+        GleanMetrics.loginConfirmation.view();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'login_email_confirmation_view'
+        );
+      });
+
+      it('submits a ping with the reg_submit event name', () => {
+        GleanMetrics.loginConfirmation.submit();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'login_email_confirmation_submit'
+        );
+      });
+    });
+
+    describe('totpForm', () => {
+      it('submits a ping with the login_totp_form_view event name', () => {
+        GleanMetrics.totpForm.view();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'login_totp_form_view');
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_totp_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_totp_code.js
@@ -9,6 +9,7 @@ import Account from 'models/account';
 import AuthErrors from 'lib/auth-errors';
 import Backbone from 'backbone';
 import BaseBroker from 'models/auth_brokers/base';
+import GleanMetrics from '../../../scripts/lib/glean';
 import Metrics from 'lib/metrics';
 import Relier from 'models/reliers/relier';
 import sinon from 'sinon';
@@ -258,6 +259,23 @@ describe('views/sign_in_totp_code', () => {
           'correct error thrown'
         );
       });
+    });
+  });
+
+  describe('logView', () => {
+    let viewMetricsEventStub;
+
+    beforeEach(() => {
+      viewMetricsEventStub = sinon.stub(GleanMetrics.totpForm, 'view');
+    });
+
+    afterEach(() => {
+      viewMetricsEventStub.restore();
+    });
+
+    it('submits a reg_view Glean ping', () => {
+      view.logView();
+      sinon.assert.calledOnce(viewMetricsEventStub);
     });
   });
 });


### PR DESCRIPTION
This commit also adds some missing tests for previously implemented events.
