### PR TITLE
bug(settings): Fix service name displayed in title on /reset_password…

### DIFF
--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -28,11 +28,13 @@ export class ResetPasswordPage extends BaseLayout {
     return this.page.locator(selectors.EMAIL);
   }
 
-  async resetPasswordHeader() {
+  async resetPasswordHeader(title?: string) {
     if (this.react) {
       const resetPass = await this.page.waitForSelector('#root .card-header');
       return (
-        (await resetPass.textContent())?.startsWith('Reset password') &&
+        (await resetPass.textContent())
+          ?.replace(/[^\x00-\x7F]/g, '')
+          ?.startsWith(title || 'Reset password') &&
         (await resetPass.isVisible())
       );
     }

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -247,7 +247,12 @@ async function passwordResetFlow(
   await checkForReactApp({ page });
 
   // Verify reset password header
-  expect(await resetPassword.resetPasswordHeader()).toBe(true);
+  expect(
+    await resetPassword.resetPasswordHeader(
+      'Reset password to continue to 123Done'
+    )
+  ).toBe(true);
+
   await resetPassword.fillOutResetPassword(credentials.email);
 
   // Step 2 - Get the confirmation email

--- a/packages/fxa-settings/src/models/reliers/base-relier.ts
+++ b/packages/fxa-settings/src/models/reliers/base-relier.ts
@@ -152,7 +152,7 @@ export class BaseRelier extends ModelDataProvider implements Relier {
 
   async getServiceName(): Promise<string> {
     // If the service is not defined, then check the client info
-    if (!!this.service) {
+    if (!this.service) {
       if (this.clientInfo) {
         const clientInfo = await this.clientInfo;
         if (clientInfo?.serviceName) {


### PR DESCRIPTION
## Because

- The RP's name wasn't showing up on in the card header

## This pull request

- Fixes a bug that prevented the client info from being used.

## Issue that this pull request solves

Closes: FXA-8086

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

After Fix:
![image](https://github.com/mozilla/fxa/assets/94418270/f4b5248b-94a3-4bb9-a49f-1cfd5eb44d0c)

## Other information (Optional)

The test coverage was done in playwright, since this is where the full flow actually happens. I attempted to also add an integration tests, but the mocks on the relier's client info proved cumbersome and I abandoned this effort.
