### PR TITLE
fix(fxa-settings): Resolve recovery key confirm pwd button disabled

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -50,13 +50,6 @@ export const FlowRecoveryKeyConfirmPwd = ({
   const [bannerText, setBannerText] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
   const [actionType, setActionType] = useState<RecoveryKeyAction>();
-  const mounted = useRef(true);
-
-  useEffect(() => {
-    return () => {
-      mounted.current = false;
-    };
-  });
 
   useEffect(() => {
     if (account.recoveryKey === true) {
@@ -115,10 +108,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
         setBannerText(localizedError);
       }
       logViewEvent(`flow.${viewName}`, 'confirm-password.fail');
-    } finally {
-      if (mounted.current) {
-        setIsLoading(false);
-      }
+      setIsLoading(false);
     }
   }, [
     account,


### PR DESCRIPTION
## Because

* In the new account recovery key creation flow, the confirm password CTA would remain disabled after an incorrect password was entered and the user retypes in the input, making it impossible to correct the password and retry

## This pull request

* Enable the button when the password confirmation fails and an error message is displayed

## Issue that this pull request solves

Closes: #FXA-8092

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
