### PR TITLE
fix(bug): Fix race condition in third party auth sign-in

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -528,6 +528,11 @@ export class LoginPage extends BaseLayout {
     });
   }
 
+  async clickContinueWithGoogle() {
+    await this.page.getByText('Continue with Google').click();
+    await this.page.waitForURL(/accounts\.google\.com/);
+  }
+
   async clearCache() {
     await this.page.goto(`${this.target.contentServerUrl}/clear`, {
       waitUntil: 'load',

--- a/packages/functional-tests/tests/thirdPartyAuth/thirdPartyAuth.spec.ts
+++ b/packages/functional-tests/tests/thirdPartyAuth/thirdPartyAuth.spec.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test } from '../../lib/fixtures/standard';
+import { authenticator } from 'otplib';
+
+const GOOGLE_TEST_EMAIL = process.env.GOOGLE_TEST_EMAIL || 'fxalive2022@gmail.com';
+const GOOGLE_TEST_PASSWORD = process.env.GOOGLE_TEST_PASSWORD;
+const GOOGLE_TEST_2FA_SECRET = process.env.GOOGLE_TEST_2FA_SECRET;
+
+test.describe('third party auth', () => {
+ test('Google signin to settings', async ({
+                                    target,
+                                    pages: { login, page },
+                                   }) => {
+  const shouldSkip = !GOOGLE_TEST_EMAIL || !GOOGLE_TEST_PASSWORD || !GOOGLE_TEST_2FA_SECRET;
+  test.skip(shouldSkip, 'Please contact FxA admin to get credentials for Google account');
+  test.slow();
+  await page.goto(
+   target.contentServerUrl + '?forceExperiment=thirdPartyAuth&forceExperimentGroup=treatment',
+   { waitUntil: 'load' },
+  );
+
+  await login.clickContinueWithGoogle();
+
+  await page.locator('input[type="email"]').fill(GOOGLE_TEST_EMAIL);
+  await page.getByText('Next').click();
+  await page.waitForURL(/v3\/signin\/challenge\/pwd/);
+
+  await page.locator('input[type="password"]').fill(GOOGLE_TEST_PASSWORD);
+  await page.getByText('Next').click();
+
+  let token = authenticator.generate(GOOGLE_TEST_2FA_SECRET);
+  await page.locator('#totpPin').fill(token);
+  await page.locator('#totpNext').getByRole('button', { name: 'Next' }).click();
+
+  const invalidCodeLocator = await page.getByText('Wrong code. Try again.');
+  if (await invalidCodeLocator.isVisible()) {
+   // Per chance the 2FA code expired, wait few seconds and try a new code 
+   await page.waitForTimeout(5000);
+   token = authenticator.generate(GOOGLE_TEST_2FA_SECRET);
+   await page.locator('#totpPin').fill(token);
+   await page.locator('#totpNext').getByRole('button', { name: 'Next' }).click();
+  }
+
+  await page.waitForURL(/settings/);
+ });
+});

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -53,7 +53,11 @@ export default {
     const thirdPartyAuth = Storage.factory('localStorage', this.window).get(
       'fxa_third_party_params'
     );
-    if (thirdPartyAuth) {
+    
+    // Since this mixin is loaded from multiple views it is possible to have
+    // a race condition and call complete multiple times. We only want to call it
+    // on the `enter-email` view.
+    if (thirdPartyAuth && this.viewName ==='enter-email') {
       return this.completeSignIn();
     }
 
@@ -197,7 +201,7 @@ export default {
     );
     const code = authParams.code;
     const provider = authParams.provider || 'google';
-
+    
     return this.user
       .verifyAccountThirdParty(account, this.relier, code, provider)
       .then((updatedAccount) => {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
@@ -96,7 +96,8 @@ describe('views/mixins/third-party-auth-mixin', function () {
       assert.isTrue(view.logViewEvent.calledOnceWith('thirdPartyAuth'));
     });
 
-    it('with third party auth set', () => {
+    it('with third party auth set from `enter-email`', () => {
+      view.viewName = 'enter-email';
       Storage.factory('localStorage', windowMock).set(
         'fxa_third_party_params',
         'some params'
@@ -106,6 +107,15 @@ describe('views/mixins/third-party-auth-mixin', function () {
       assert.isTrue(notifier.trigger.calledOnce);
       assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
       assert.isFalse(view.logViewEvent.called);
+    });
+
+    it('with third party auth set from other', () => {
+      Storage.factory('localStorage', windowMock).set(
+        'fxa_third_party_params',
+        'some params'
+      );
+      view.beforeRender();
+      assert.isTrue(view.completeSignIn.notCalled);
     });
 
     it('google login deeplink', () => {


### PR DESCRIPTION
## Because

- The `/linked_account/login` route could be called multiple times and create a duplicate record error in the database

## This pull request

- Adds a check to call the completeSignin function on the correct view
- Adds a basic functional test for Google sign-in

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7959

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
