### PR TITLE
feat(shared): hide fluent warning msgs in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ executors:
     parameters:
       resource_class:
         type: string
-        default: xlarge
+        default: large
     resource_class: << parameters.resource_class >>
     docker:
       - image: mozilla/fxa-circleci:ci-test-runner

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@faker-js/faker": "^8.0.2",
-    "@fluent/react": "^0.15.1",
+    "@fluent/react": "^0.15.2",
     "class-validator": "^0.14.0",
     "diffparser": "^2.0.1",
     "hot-shots": "^10.0.0",

--- a/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
@@ -12,6 +12,8 @@ import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 
 afterEach(cleanup);
 
+const reportError = () => {};
+
 const {
   product_metadata: {
     'product:termsOfServiceURL': termsOfServiceURL,
@@ -23,7 +25,10 @@ describe('AppLayout', () => {
   const subject = () => {
     return render(
       <AppContext.Provider value={defaultAppContext}>
-        <AppLocalizationProvider messages={{ en: ['testo: lol'] }}>
+        <AppLocalizationProvider
+          messages={{ en: ['testo: lol'] }}
+          reportError={reportError}
+        >
           <AppLayout>
             <div data-testid="children">
               <TermsAndPrivacy plan={SELECTED_PLAN} />
@@ -83,7 +88,10 @@ describe('SettingsLayout', () => {
 
     return render(
       <AppContext.Provider value={appContextValue}>
-        <AppLocalizationProvider messages={{ en: ['testo: lol'] }}>
+        <AppLocalizationProvider
+          messages={{ en: ['testo: lol'] }}
+          reportError={reportError}
+        >
           <SettingsLayout>
             <div data-testid="children">Testing</div>
           </SettingsLayout>

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -1103,20 +1103,17 @@ export function getLocalizedMessage(
 
 export function renderWithLocalizationProvider(
   children,
-  messages = { en: ['testo: lol'] }
+  messages: { [key: string]: string[] } = { en: ['testo: lol'] }
 ) {
-  // by default fluent warns about missing messages, but there's no way to
-  // disable it right now.  see
-  // https://github.com/projectfluent/fluent.js/issues/411
   return render(withLocalizationProvider(children, messages));
 }
 
 export function withLocalizationProvider(
   children,
-  messages = { en: ['testo: lol'] }
+  messages: { [key: string]: string[] } = { en: ['testo: lol'] }
 ) {
   return (
-    <AppLocalizationProvider messages={messages}>
+    <AppLocalizationProvider messages={messages} reportError={() => {}}>
       {children}
     </AppLocalizationProvider>
   );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -31,13 +31,26 @@ import {
 } from 'fxa-payments-server/src/lib/formats';
 import { defaultState } from 'fxa-payments-server/src/store/state';
 import { FluentBundle, FluentResource } from '@fluent/bundle';
-import { LocalizationProvider, ReactLocalization } from '@fluent/react';
+import {
+  LocalizationProvider,
+  MarkupParser,
+  ReactLocalization as _ReactLocalization,
+} from '@fluent/react';
 import { updateConfig } from '../../../lib/config';
 import AppContext, { defaultAppContext } from '../../../lib/AppContext';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
 jest.mock('../../../lib/amplitude');
 
 const { queryByTestId, queryByText, queryAllByText, getByTestId } = screen;
+
+class ReactLocalization extends _ReactLocalization {
+  constructor(
+    bundles: Iterable<FluentBundle>,
+    parseMarkup?: MarkupParser | null
+  ) {
+    super(bundles, parseMarkup, () => {});
+  }
+}
 
 const findMockPlan = (planId: string): Plan => {
   const plan = MOCK_PLANS.find((x) => x.plan_id === planId);

--- a/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
@@ -17,6 +17,7 @@ import AppLocalizationProvider from './AppLocalizationProvider';
 describe('<AppLocalizationProvider/>', () => {
   const locales = ['en-GB', 'en-US', 'es-ES'];
   const bundles = ['greetings', 'farewells'];
+  const reportError = () => {};
   function waitUntilTranslated() {
     return waitUntil(() => {
       // @ts-ignore
@@ -48,7 +49,11 @@ describe('<AppLocalizationProvider/>', () => {
 
   it('translate to en-US', async () => {
     const { getByTestId } = render(
-      <AppLocalizationProvider bundles={bundles} userLocales={['en-US']}>
+      <AppLocalizationProvider
+        bundles={bundles}
+        userLocales={['en-US']}
+        reportError={reportError}
+      >
         <main data-testid="result">
           <Localized id="hello">
             <div>untranslated</div>
@@ -66,7 +71,11 @@ describe('<AppLocalizationProvider/>', () => {
 
   it('translate to es-ES', async () => {
     const { getByTestId } = render(
-      <AppLocalizationProvider bundles={bundles} userLocales={['es-ES']}>
+      <AppLocalizationProvider
+        bundles={bundles}
+        userLocales={['es-ES']}
+        reportError={reportError}
+      >
         <main data-testid="result">
           <Localized id="hello">
             <div>untranslated</div>
@@ -85,7 +94,11 @@ describe('<AppLocalizationProvider/>', () => {
 
   it('translate to de', async () => {
     const { getByTestId } = render(
-      <AppLocalizationProvider bundles={bundles} userLocales={['de']}>
+      <AppLocalizationProvider
+        bundles={bundles}
+        userLocales={['de']}
+        reportError={reportError}
+      >
         <main data-testid="result">
           <Localized id="hello">
             <div>untranslated</div>
@@ -105,7 +118,11 @@ describe('<AppLocalizationProvider/>', () => {
 
   it('fallback to text content', async () => {
     const { getByTestId } = render(
-      <AppLocalizationProvider bundles={bundles} userLocales={locales}>
+      <AppLocalizationProvider
+        bundles={bundles}
+        userLocales={locales}
+        reportError={reportError}
+      >
         <Localized id="nonexistent">
           <div data-testid="result">untranslated</div>
         </Localized>
@@ -125,7 +142,11 @@ describe('<AppLocalizationProvider/>', () => {
 
   it('translate to en-NZ currency', async () => {
     const { getByTestId } = render(
-      <AppLocalizationProvider bundles={bundles} userLocales={['en-NZ']}>
+      <AppLocalizationProvider
+        bundles={bundles}
+        userLocales={['en-NZ']}
+        reportError={reportError}
+      >
         <main data-testid="result">
           <Localized id="hello" vars={{ amount: '$US123.00' }}>
             <div>untranslated</div>

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -80,6 +80,7 @@ type Props = {
   children: any;
   // pass messages directly in, used in testing
   messages?: { [key: string]: string[] };
+  reportError?: (error: Error) => void;
 };
 
 export default class AppLocalizationProvider extends Component<Props, State> {
@@ -88,6 +89,7 @@ export default class AppLocalizationProvider extends Component<Props, State> {
     userLocales: ['en'],
     bundles: ['main'],
     children: React.createElement('div'),
+    reportError: undefined,
   };
 
   constructor(props: Props) {
@@ -108,7 +110,9 @@ export default class AppLocalizationProvider extends Component<Props, State> {
           getBundleGenerator(
             Object.keys(this.props.messages),
             this.props.messages
-          )()
+          )(),
+          undefined,
+          this.props.reportError
         ),
       });
       return;
@@ -121,7 +125,13 @@ export default class AppLocalizationProvider extends Component<Props, State> {
       currentLocales,
       bundles
     );
-    this.setState({ l10n: new ReactLocalization(bundleGenerator()) });
+    this.setState({
+      l10n: new ReactLocalization(
+        bundleGenerator(),
+        undefined,
+        this.props.reportError
+      ),
+    });
   }
 
   render() {

--- a/packages/fxa-react/lib/test-utils/index.test.tsx
+++ b/packages/fxa-react/lib/test-utils/index.test.tsx
@@ -161,12 +161,12 @@ describe('testL10n', () => {
     let l10n: ReactLocalization;
 
     beforeAll(() => {
-      l10n = new ReactLocalization([bundle]);
+      l10n = new ReactLocalization([bundle], undefined, () => {});
       ftlMsgResolver = new FtlMsgResolver(l10n, true);
     });
 
     it('throws if there are no en bundles', () => {
-      const emptyL10n = new ReactLocalization([]);
+      const emptyL10n = new ReactLocalization([], undefined, () => {});
       const emptyResolver = new FtlMsgResolver(emptyL10n, true);
       expect(() => {
         emptyResolver.getMsg('test-foo', 'foo-bar');

--- a/packages/fxa-react/lib/test-utils/localizationProvider.tsx
+++ b/packages/fxa-react/lib/test-utils/localizationProvider.tsx
@@ -2,15 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 
+const reportError = () => {};
+
 export function renderWithLocalizationProvider(
   children: JSX.Element,
   messages = { en: ['testo: lol'] }
 ): ReturnType<typeof render> {
-  // by default fluent warns about missing messages, but there's no way to
-  // disable it right now.  see
-  // https://github.com/projectfluent/fluent.js/issues/411
   return render(
-    <AppLocalizationProvider {...{ messages }}>
+    <AppLocalizationProvider {...{ messages, reportError }}>
       {children}
     </AppLocalizationProvider>
   );
@@ -22,7 +21,7 @@ export function withLocalizationProvider(
   userLocales = navigator.languages || ['en']
 ) {
   return (
-    <AppLocalizationProvider {...{ baseDir, userLocales }}>
+    <AppLocalizationProvider {...{ baseDir, userLocales, reportError }}>
       {children}
     </AppLocalizationProvider>
   );

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -278,7 +278,10 @@ describe('App component', () => {
 
       ({ history } = renderWithRouter(
         <AppContext.Provider value={mockAppContext({ account, config })}>
-          <AppLocalizationProvider messages={{ en: ['testo: lol'] }}>
+          <AppLocalizationProvider
+            messages={{ en: ['testo: lol'] }}
+            reportError={() => {}}
+          >
             <App {...{ flowQueryParams }} />
           </AppLocalizationProvider>
         </AppContext.Provider>,

--- a/packages/fxa-settings/src/setupTests.tsx
+++ b/packages/fxa-settings/src/setupTests.tsx
@@ -22,7 +22,7 @@ jest.mock('fxa-react/lib/utils', () => {
 });
 
 const mockBundle = getFtlBundleSync('settings', 'en');
-const l10n = new ReactLocalization([mockBundle]);
+const l10n = new ReactLocalization([mockBundle], undefined, () => {});
 const mockL10n = { l10n, test: 'what!' };
 jest.mock('@fluent/react', () => {
   const originalModule = jest.requireActual('@fluent/react');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6720,16 +6720,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fluent/react@npm:^0.15.1":
-  version: 0.15.1
-  resolution: "@fluent/react@npm:0.15.1"
+"@fluent/react@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@fluent/react@npm:0.15.2"
   dependencies:
     "@fluent/sequence": ^0.8.0
     cached-iterable: ^0.3.0
   peerDependencies:
     "@fluent/bundle": ">=0.16.0"
     react: ">=16.8.0"
-  checksum: 0348d36f42bef691ea0a99f1476790f39de23df8f3583c5bb6f21cd7fcc920243650508749f5af7db28adf2008682e688b2f1d271407a9797db95d090ebecd20
+  checksum: 6115b45079e5fee8d2eea5ded9b5b380b0e4146c9663657c82a08a88e113e70fd5a454502dfb7d79dc3154f5864f95c7c57692f8bdcfdf09034afebebfc7cb96
   languageName: node
   linkType: hard
 
@@ -31082,7 +31082,7 @@ fsevents@~2.1.1:
   resolution: "fxa@workspace:."
   dependencies:
     "@faker-js/faker": ^8.0.2
-    "@fluent/react": ^0.15.1
+    "@fluent/react": ^0.15.2
     "@nx/eslint-plugin": ^16.6.0
     "@nx/jest": 16.6.0
     "@nx/js": ^16.6.0


### PR DESCRIPTION
## Because

- Fluent warning messages are slowing down tests.

## This pull request

- Updates to the latest @fluent/react version
- Adds a non-console.warn reportError to testing ReactLocalization instantiations.

## Issue that this pull request solves

Closes: # FXA-7958

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
