### PR TITLE
paypal processor fixes

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1454,7 +1454,7 @@ export class StripeHelper extends StripeHelperBase {
       expand: ['data.customer', 'data.subscription'],
     })) {
       const subscription = invoice.subscription as Stripe.Subscription;
-      if (ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
+      if (subscription && ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
         yield invoice;
       }
     }

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -99,7 +99,7 @@ export async function init() {
         }
       );
     } catch (err) {
-      throw new Error(`Cannot acquire lock to run: ${err.message}`);
+      throw new Error(`Cannot acquire lock to run`, { cause: err });
     }
   } else {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -8,6 +8,7 @@
     "checkJs": false,
     "outDir": "./dist",
     "types": ["accept-language", "mocha", "mozlog", "node", "fxa-geodb"],
+    "lib": ["ESNext"]
   },
   "include": [
     "bin/*",


### PR DESCRIPTION
- fix(scripts): Chain original error from redlock
- fix(stripe): Skip over open invoices without subscriptions

## Because

- The stage paypal processor is failing on every run

## This pull request

- Adds more details error messages and fixes the one error we know about

## Other information (Optional)

Slack convo: https://mozilla.slack.com/archives/CLV3KMZ8B/p1690414747187909
