### PR TITLE
fix(graphql): Only send the X-Forwarded-For header to the auth server

### DIFF
--- a/packages/fxa-graphql-api/src/decorators.ts
+++ b/packages/fxa-graphql-api/src/decorators.ts
@@ -41,17 +41,14 @@ export const GqlUserState = createParamDecorator(
 export const GqlXHeaders = createParamDecorator(
   (data: unknown, context: ExecutionContext): Headers => {
     const ctx = GqlExecutionContext.create(context).getContext();
-    const headers = ctx.req?.headers;
-    // We don't need to propagate the authorization token because
-    // it needs to be updated to originate from gql server.
-    delete headers['authorization'];
-    
+    const headers: Record<string, string> = {};
+
     // Set the x-forwarded-for header since the auth-server will use this
     // to determine client geolocation
     if (ctx.req?.ip) {
-     headers['x-forwarded-for'] = ctx.req?.ip;
+      headers['x-forwarded-for'] = ctx.req?.ip;
     }
-    
+
     return new Headers(headers);
   }
 );


### PR DESCRIPTION
## Because

- The graphql server sends requests to the auth server with the `Host: graphql` header from the client. In AWS this was harmless because each service was using it's own load balancer. In GCP this caused issues with host-based routing, and required us to create a separate load balancer for the auth server.

## This pull request

- Only sets the `X-Forwarded-For` header

## Other information (Optional)

Slack thread: https://mozilla.slack.com/archives/CLV3KMZ8B/p1690296747250679
