### PR TITLE
fix(bug): Display tooltip when DataTrio buttons are clicked

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -306,7 +306,7 @@ module.exports = {
         '.caret-bottom-default': {
           borderLeft: '0.75rem solid transparent',
           borderRight: '0.75rem solid transparent',
-          borderTop: '0.75rem solid #3D3D3D',
+          borderTop: '0.75rem solid #5e5e72',
         },
         '.caret-bottom-error': {
           borderLeft: '0.75rem solid transparent',

--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -43,14 +43,14 @@ export const DataBlock = ({
 }: DataBlockProps) => {
   const valueIsArray = Array.isArray(value);
   const [performedAction, setPerformedAction] = useState<actions>();
+  const [tooltipVisible, setTooltipVisible] = useState(false);
   const dataTestId = prefixDataTestId
     ? `${prefixDataTestId}-datablock`
     : 'datablock';
   const actionCb: actionFn = (action) => {
     onAction(action);
 
-    // No feedback tooltip displayed for inline copy button
-    if (actionTypeToNotification[action] && !isInline) {
+    if (actionTypeToNotification[action]) {
       setPerformedAction(action);
     }
   };
@@ -82,25 +82,32 @@ export const DataBlock = ({
             {value}
           </span>
         )}
-        {performedAction && (
+        {performedAction && tooltipVisible && (
           <FtlMsg id={`datablock-${performedAction}`} attrs={{ message: true }}>
             <Tooltip
               prefixDataTestId={`datablock-${performedAction}`}
               message={actionTypeToNotification[performedAction]}
-              position="bottom"
+              anchorPosition={isInline ? 'end' : 'middle'}
+              position={isInline ? 'top' : 'bottom'}
               className="mt-1"
             ></Tooltip>
           </FtlMsg>
         )}
         {isInline && (
-          <GetDataCopySingletonInline {...{ value, onAction: actionCb }} />
+          <GetDataCopySingletonInline
+            {...{ value, onAction: actionCb, setTooltipVisible }}
+          />
         )}
       </div>
       {isIOS && !isInline && (
-        <GetDataCopySingleton {...{ value, onAction: actionCb }} />
+        <GetDataCopySingleton
+          {...{ value, onAction: actionCb, setTooltipVisible }}
+        />
       )}
       {!isIOS && !isInline && (
-        <GetDataTrio {...{ value, contentType, onAction: actionCb }} />
+        <GetDataTrio
+          {...{ value, contentType, onAction: actionCb, setTooltipVisible }}
+        />
       )}
     </div>
   );

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -255,7 +255,7 @@ export const FormPasswordWithBalloons = ({
                 required: true,
                 validate: (value: string) => value === getValues().newPassword,
               })}
-              anchorStart
+              anchorPosition="end"
               tooltipPosition="bottom"
               prefixDataTestId="verify-password"
             />

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -111,7 +111,7 @@ const FormVerifyCode = ({
         pattern={formAttributes.pattern}
         maxLength={formAttributes.maxLength}
         className="text-start"
-        anchorStart
+        anchorPosition="start"
         autoComplete="off"
         spellCheck={false}
         prefixDataTestId={viewName}

--- a/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import GetDataTrio, {
   GetDataCopySingleton,
@@ -16,20 +16,32 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
-  <div className="p-10 max-w-xs">
-    <GetDataTrio value="Copy that" />
-  </div>
-);
+export const Default = () => {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  return (
+    <div className="p-10 max-w-xs">
+      <GetDataTrio value="Copy that" {...{ setTooltipVisible }} />
+    </div>
+  );
+};
 
-export const SingleCopyButton = () => (
-  <div className="p-10 max-w-xs">
-    <GetDataCopySingleton value="Copy that" />
-  </div>
-);
+export const SingleCopyButton = () => {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  return (
+    <div className="p-10 max-w-xs">
+      <GetDataCopySingleton value="Copy that" {...{ setTooltipVisible }} />
+    </div>
+  );
+};
 
-export const SingleCopyButtonInline = () => (
-  <div className="p-10 max-w-xs">
-    <GetDataCopySingletonInline value="Copy that" />
-  </div>
-);
+export const SingleCopyButtonInline = () => {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  return (
+    <div className="p-10 max-w-xs">
+      <GetDataCopySingletonInline
+        value="Copy that"
+        {...{ setTooltipVisible }}
+      />
+    </div>
+  );
+};

--- a/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
@@ -14,12 +14,13 @@ const value = 'Sun Tea';
 const url = 'https://mozilla.org';
 
 const account = { ...MOCK_ACCOUNT } as unknown as Account;
+const setTooltipVisible = jest.fn();
 
 it('renders Trio as expected', () => {
   window.URL.createObjectURL = jest.fn();
   renderWithLocalizationProvider(
     <AppContext.Provider value={{ account }}>
-      <GetDataTrio {...{ value, contentType, url }} />
+      <GetDataTrio {...{ value, contentType, url, setTooltipVisible }} />
     </AppContext.Provider>
   );
   expect(screen.getByTestId('databutton-download')).toBeInTheDocument();
@@ -35,7 +36,7 @@ it('renders single Copy button as expected', () => {
   window.URL.createObjectURL = jest.fn();
   renderWithLocalizationProvider(
     <AppContext.Provider value={{ account }}>
-      <GetDataTrio {...{ value, contentType, url }} />
+      <GetDataTrio {...{ value, contentType, url, setTooltipVisible }} />
     </AppContext.Provider>
   );
   expect(screen.getByTestId('databutton-copy')).toBeInTheDocument();

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -27,9 +27,14 @@ export type GetDataTrioProps = {
   value: string | string[];
   contentType?: DownloadContentType;
   onAction?: (type: 'download' | 'copy' | 'print') => void;
+  setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-export const GetDataCopySingleton = ({ value, onAction }: GetDataTrioProps) => {
+export const GetDataCopySingleton = ({
+  value,
+  onAction,
+  setTooltipVisible,
+}: GetDataTrioProps) => {
   return (
     <FtlMsg id="get-data-trio-copy-2" attrs={{ title: true, ariaLabel: true }}>
       <button
@@ -39,7 +44,9 @@ export const GetDataCopySingleton = ({ value, onAction }: GetDataTrioProps) => {
           const copyValue = Array.isArray(value) ? value.join('\r\n') : value;
           await copy(copyValue);
           onAction?.('copy');
+          setTooltipVisible(true);
         }}
+        onBlur={() => setTooltipVisible(false)}
         data-testid="databutton-copy"
         className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
       >
@@ -57,26 +64,34 @@ export const GetDataCopySingleton = ({ value, onAction }: GetDataTrioProps) => {
 export const GetDataCopySingletonInline = ({
   value,
   onAction,
+  setTooltipVisible,
 }: GetDataTrioProps) => {
   return (
-    <FtlMsg id="get-data-trio-copy-2" attrs={{ title: true, ariaLabel: true }}>
-      <button
-        title="Copy"
-        type="button"
-        onClick={async () => {
-          const copyValue = Array.isArray(value) ? value.join('\r\n') : value;
-          await copy(copyValue);
-          onAction?.('copy');
-        }}
-        data-testid="databutton-copy"
-        className="-my-3 -me-4 p-3 rounded text-grey-500 bg-transparent border border-transparent hover:bg-grey-100 active:bg-grey-200 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 focus:bg-grey-50"
+    <>
+      <FtlMsg
+        id="get-data-trio-copy-2"
+        attrs={{ title: true, ariaLabel: true }}
       >
-        <InlineCopyIcon
-          aria-label="Copy"
-          className="w-6 h-6 items-center justify-center stroke-current"
-        />
-      </button>
-    </FtlMsg>
+        <button
+          title="Copy"
+          type="button"
+          onClick={async () => {
+            const copyValue = Array.isArray(value) ? value.join('\r\n') : value;
+            await copy(copyValue);
+            onAction?.('copy');
+            setTooltipVisible(true);
+          }}
+          onBlur={() => setTooltipVisible(false)}
+          data-testid="databutton-copy"
+          className="-my-3 -me-4 p-3 rounded text-grey-500 bg-transparent border border-transparent hover:bg-grey-100 active:bg-grey-200 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 focus:bg-grey-50"
+        >
+          <InlineCopyIcon
+            aria-label="Copy"
+            className="w-6 h-6 items-center justify-center stroke-current"
+          />
+        </button>
+      </FtlMsg>
+    </>
   );
 };
 
@@ -99,6 +114,7 @@ export const GetDataTrio = ({
   value,
   contentType,
   onAction,
+  setTooltipVisible,
 }: GetDataTrioProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
 
@@ -137,7 +153,13 @@ export const GetDataTrio = ({
           download={`${primaryEmail.email} ${contentType}.txt`}
           data-testid="databutton-download"
           className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
-          onClick={() => onAction?.('download')}
+          onClick={() => {
+            onAction?.('download');
+            setTooltipVisible(true);
+          }}
+          onBlur={() => {
+            setTooltipVisible(false);
+          }}
         >
           <DownloadIcon
             aria-label="Download"
@@ -148,7 +170,7 @@ export const GetDataTrio = ({
         </a>
       </FtlMsg>
 
-      <GetDataCopySingleton {...{ onAction, value }} />
+      <GetDataCopySingleton {...{ onAction, value, setTooltipVisible }} />
 
       {/** This only opens the page that is responsible
        *   for triggering the print screen.
@@ -163,7 +185,9 @@ export const GetDataTrio = ({
           onClick={() => {
             print();
             onAction?.('print');
+            setTooltipVisible(true);
           }}
+          onBlur={() => setTooltipVisible(false)}
           data-testid="databutton-print"
           className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
         >

--- a/packages/fxa-settings/src/components/InputPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.stories.tsx
@@ -47,7 +47,7 @@ export const WithErrorTooltip = () => (
       label="Still no good"
       hasErrors
       errorText="Anchored at the start, check me out in RTL"
-      anchorStart
+      anchorPosition="start"
     />
     <InputPassword
       label="You might need some practice."

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -25,7 +25,7 @@ export const InputPassword = ({
   name,
   prefixDataTestId = '',
   tooltipPosition,
-  anchorStart,
+  anchorPosition,
 }: InputPasswordProps) => {
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
   const [visible, setVisible] = useState<boolean>(false);
@@ -61,7 +61,7 @@ export const InputPassword = ({
         name,
         prefixDataTestId,
         tooltipPosition,
-        anchorStart,
+        anchorPosition,
       }}
     >
       <button

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -32,7 +32,7 @@ export type InputTextProps = {
   autoFocus?: boolean;
   maxLength?: number;
   pattern?: string;
-  anchorStart?: boolean;
+  anchorPosition?: 'start' | 'middle' | 'end';
   spellCheck?: boolean;
   autoComplete?: string;
   inputMode?: 'text' | 'numeric' | 'tel' | 'email';
@@ -60,7 +60,7 @@ export const InputText = ({
   autoFocus,
   maxLength,
   pattern,
-  anchorStart,
+  anchorPosition,
   spellCheck,
   autoComplete,
   inputMode,
@@ -160,7 +160,7 @@ export const InputText = ({
       {errorText && (
         <Tooltip
           type="error"
-          {...{ anchorStart }}
+          anchorPosition="start"
           position={tooltipPosition}
           className="-mb-px"
           message={errorText}

--- a/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
@@ -37,7 +37,11 @@ export const Bottom = () => (
 export const BottomAnchoredStart = () => (
   <>
     <p>Default tooltip pointing to this text</p>
-    <Tooltip message="My tooltip message here" position="bottom" anchorStart />
+    <Tooltip
+      message="My tooltip message here"
+      position="bottom"
+      anchorPosition="start"
+    />
   </>
 );
 export const Error = () => (

--- a/packages/fxa-settings/src/components/Tooltip/index.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.tsx
@@ -11,7 +11,7 @@ export type PositionType = 'top' | 'bottom';
 type TooltipProps = {
   message: string;
   type?: TooltipType;
-  anchorStart?: boolean;
+  anchorPosition?: 'start' | 'middle' | 'end';
   className?: string;
   position?: PositionType;
   prefixDataTestId?: string;
@@ -36,7 +36,7 @@ export const Tooltip = ({
   message,
   className,
   type = 'default',
-  anchorStart = false,
+  anchorPosition = 'middle',
   position = 'top',
   prefixDataTestId,
 }: TooltipProps) => {
@@ -57,18 +57,21 @@ export const Tooltip = ({
         className,
         {
           'ltr:left-1/2 ltr:-translate-x-1/2 rtl:right-1/2 rtl:translate-x-1/2':
-            !anchorStart,
-          'ltr:left-0 rtl:right-0': anchorStart,
+            anchorPosition === 'middle',
+          'start-0': anchorPosition === 'start',
+          'end-0': anchorPosition === 'end',
           'bottom-full': position === 'top',
           'top-full': position === 'bottom',
         }
       )}
+      aria-live="polite"
     >
       <span
         className={classNames('absolute', caretClass(type, position), {
           'ltr:left-1/2 ltr:-translate-x-1/2 rtl:right-1/2 rtl:translate-x-1/2':
-            !anchorStart,
-          'ltr:left-ten rtl:right-ten w-auto': anchorStart,
+            anchorPosition === 'middle',
+          'start-ten w-auto': anchorPosition === 'start',
+          'end-ten w-auto': anchorPosition === 'end',
           'top-full': position === 'top',
           'bottom-full': position === 'bottom',
         })}

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -68,7 +68,7 @@ const InlineRecoverySetup = ({
                 <InputText
                   label={localizedInputTextLabel}
                   className="tooltip-below recovery-code text-start my-4"
-                  anchorStart
+                  anchorPosition="start"
                   required
                   autoFocus
                   autoComplete="off"

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -266,7 +266,7 @@ const AccountRecoveryConfirmKey = ({
             // uppercase here but don't bother transforming the submit data to match
             inputOnlyClassName="uppercase"
             className="text-start"
-            anchorStart
+            anchorPosition="start"
             autoComplete="off"
             spellCheck={false}
             onChange={() => {

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -256,7 +256,7 @@ const ResetPassword = ({
               autoFocus
               errorText={errorText}
               className="text-start"
-              anchorStart
+              anchorPosition="start"
               autoComplete="off"
               spellCheck={false}
               prefixDataTestId="reset-password"

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -109,7 +109,7 @@ const Signin = ({
 
           {isPasswordNeeded && (
             <InputPassword
-              anchorStart
+              anchorPosition="start"
               className="mb-5 text-start"
               label={localizedPasswordFormLabel}
               hasErrors={error.length > 0}

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -231,7 +231,7 @@ const Signup = ({
             })}
             errorText={ageCheckErrorText}
             tooltipPosition="bottom"
-            anchorStart
+            anchorPosition="start"
           />
         </FtlMsg>
         <FtlMsg id="signup-coppa-check-explanation-link">


### PR DESCRIPTION
## Because

* No feedback was displayed in the new account recovery key flow when the key was copied to the clipboard.
* The tooltips on other GetDataTrio buttons were never dismissed.

## This pull request

* Display a tooltip when the key is copied to the clipboard, and hide on blur.
* Update the Tooltip component to allow anchor end in addition to anchor middle and anchor start
* Does not change the focus behaviour of the copy button - it is intentional that the focus outline stay visible while keyboard focus is on the button. Focus is removed on blur.

## Issue that this pull request solves

Closes: #FXA-7541, FXA-7544

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

After:

https://github.com/mozilla/fxa/assets/22231637/ba1f64a3-227b-4479-b5f4-70b651db99d5

## Other information (Optional)

Any other information that is important to this pull request.
