### PR TITLE
task(all): Add nx linter to enforce module boundaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,10 +8,13 @@
     "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/no-empty-function": "off"
+    "@typescript-eslint/no-empty-function": "off",
+    "@nx/enforce-module-boundaries": [
+      "error", {}
+    ]
   },
   "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "@nx"],
   "parser": "@typescript-eslint/parser",
   "root": true
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     ]
   },
   "devDependencies": {
+    "@nx/devkit": "^16.6.0",
     "@nx/eslint-plugin": "^16.6.0",
     "@nx/jest": "16.6.0",
     "@nx/js": "^16.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9485,7 +9485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nx/devkit@npm:16.6.0":
+"@nx/devkit@npm:16.6.0, @nx/devkit@npm:^16.6.0":
   version: 16.6.0
   resolution: "@nx/devkit@npm:16.6.0"
   dependencies:
@@ -31083,6 +31083,7 @@ fsevents@~2.1.1:
   dependencies:
     "@faker-js/faker": ^8.0.2
     "@fluent/react": ^0.15.1
+    "@nx/devkit": ^16.6.0
     "@nx/eslint-plugin": ^16.6.0
     "@nx/jest": 16.6.0
     "@nx/js": ^16.6.0


### PR DESCRIPTION
## Because

- We have some circular references cropping up

## This pull request

- Adds linter to prevent this
- See https://nx.dev/core-features/enforce-module-boundaries

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

A circular dependency error can be triggered by executing this: `nx build fxa-payments-server`. As of this PR, circular dependencies will also be uncovered by running a lint operation. e.g. `nx run-many -t lint --all`. The linter output also shows exactly which file the circular dep comes from. 
<img width="964" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/fff6c0f3-29a2-4c94-ac9a-962f4534a704">

Note that the `nx graph` command can also be useful for visualizing the dependency graph and tracking down issues or incorrect relationships between projects. Sometimes there's a dependency that isn't circular, and therefor not an error, but is also clearly unnecessary.

