### PR TITLE
feat: polsih error refactor

### DIFF
--- a/libs/payments/paypal/src/index.ts
+++ b/libs/payments/paypal/src/index.ts
@@ -4,5 +4,5 @@
 
 export { PayPalClient } from './lib/client';
 export * from './lib/types';
-export { PayPalClientError } from '../../../shared/error/src';
+export { PayPalClientError, PayPalNVPError } from './lib/error';
 export { nvpToObject, objectToNVP, isIpnMerchPmt } from './lib/util';

--- a/libs/payments/paypal/src/lib/client.ts
+++ b/libs/payments/paypal/src/lib/client.ts
@@ -6,10 +6,6 @@ import pRetry from 'p-retry';
 import superagent from 'superagent';
 
 import {
-  PayPalClientError,
-  PayPalNVPError,
-} from '../../../../shared/error/src';
-import {
   PAYPAL_LIVE_API,
   PAYPAL_LIVE_IPN,
   PAYPAL_SANDBOX_API,
@@ -17,6 +13,7 @@ import {
   PAYPAL_VERSION,
   PLACEHOLDER_URL,
 } from './constants';
+import { PayPalClientError, PayPalNVPError } from './error';
 import {
   BAUpdateOptions,
   CreateBillingAgreementOptions,
@@ -125,7 +122,7 @@ export class PayPalClient {
     } else {
       // TypeScript doesn't narrow ACK, necessitating a cast
       throw new PayPalClientError(
-        PayPalClient.getListOfPayPalClientErrors(
+        PayPalClient.getListOfPayPalNVPErrors(
           result.text,
           resultObj as NVPErrorResponse
         ),
@@ -135,10 +132,7 @@ export class PayPalClient {
     }
   }
 
-  public static getListOfPayPalClientErrors(
-    raw: string,
-    data: NVPErrorResponse
-  ) {
+  public static getListOfPayPalNVPErrors(raw: string, data: NVPErrorResponse) {
     const errors: PayPalNVPError[] = [];
     if (!data.L || !data.L.length) {
       const message =

--- a/libs/payments/paypal/src/lib/error.spec.ts
+++ b/libs/payments/paypal/src/lib/error.spec.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { faker } from '@faker-js/faker';
+import { MultiError, VError } from 'verror';
+
+import {
+  NVPErrorFactory,
+  NVPErrorResponseFactory,
+} from '../../../../payments/paypal/src/lib/factories';
+import { PayPalClientError, PayPalNVPError } from './error';
+
+describe('PayPal Errors', () => {
+  const message = faker.word.words();
+
+  describe('PayPalClientError', () => {
+    const raw = faker.word.words();
+    const data = NVPErrorResponseFactory({
+      L: [NVPErrorFactory()],
+    });
+
+    it('should have the expected properties', () => {
+      const multiErrorMessage = `first of 1 error: ${message}`;
+      const nvpError = new PayPalNVPError(raw, data, { message });
+      const error = new PayPalClientError([nvpError], raw, data);
+      expect(error.name).toEqual('PayPalClientError');
+      expect(error.message).toEqual(multiErrorMessage);
+      expect(error).toBeInstanceOf(MultiError);
+      expect(error.raw).toEqual(raw);
+      expect(error.data).toStrictEqual(data);
+    });
+  });
+
+  describe('PayPalNVPError', () => {
+    const raw = faker.word.words();
+    const data = NVPErrorResponseFactory({
+      L: [NVPErrorFactory()],
+    });
+
+    it('should have the expected properties', () => {
+      const error = new PayPalNVPError(raw, data, { message });
+      expect(error.name).toEqual('PayPalNVPError');
+      expect(error.message).toEqual(message);
+      expect(error).toBeInstanceOf(VError);
+      expect(error.raw).toEqual(raw);
+      expect(error.data).toStrictEqual(data);
+    });
+  });
+});

--- a/libs/payments/paypal/src/lib/error.ts
+++ b/libs/payments/paypal/src/lib/error.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { BaseError, BaseMultiError } from '../../../../shared/error/src';
+import { NVPErrorResponse } from './types';
+
+export class PayPalClientError extends BaseMultiError {
+  public raw: string;
+  public data: NVPErrorResponse;
+
+  constructor(errors: PayPalNVPError[], raw: string, data: NVPErrorResponse) {
+    super(errors);
+    this.name = 'PayPalClientError';
+    this.raw = raw;
+    this.data = data;
+  }
+
+  getPrimaryError(): PayPalNVPError {
+    // TS is not picking up the type otherwise, so have to cast.
+    return this.errors()[0] as PayPalNVPError;
+  }
+
+  static hasPayPalNVPError(err: Error | PayPalClientError): boolean {
+    return (
+      err instanceof PayPalClientError &&
+      err.getPrimaryError() instanceof PayPalNVPError
+    );
+  }
+}
+
+export class PayPalNVPError extends BaseError {
+  public raw: string;
+  public data: NVPErrorResponse;
+  public errorCode: number;
+
+  constructor(raw: string, data: NVPErrorResponse, params: any) {
+    const { message, cause, errorCode } = params;
+    super(
+      {
+        name: 'PayPalNVPError',
+        ...(cause && { cause }),
+      },
+      message
+    );
+    this.raw = raw;
+    this.data = data;
+    this.errorCode = errorCode;
+  }
+}

--- a/libs/shared/error/README.md
+++ b/libs/shared/error/README.md
@@ -1,6 +1,6 @@
 # shared-error
 
-This library was generated with [Nx](https://nx.dev).
+This library serves as the base errors used via inheritance throughout the nx integrated libraries and applications. Many third-party libraries use the `verror` package, by extending our own version we can use `instanceOf` checks to easily identify their errors from our own.
 
 ## Building
 

--- a/libs/shared/error/src/index.ts
+++ b/libs/shared/error/src/index.ts
@@ -1,10 +1,4 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-export {
-  ContentfulClientError,
-  PayPalClientError,
-  PayPalNVPError,
-  TypeError,
-} from './lib/error';
+export { BaseError, BaseMultiError, TypeError } from './lib/error';

--- a/libs/shared/error/src/lib/error.spec.ts
+++ b/libs/shared/error/src/lib/error.spec.ts
@@ -2,71 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { faker } from '@faker-js/faker';
-import { MultiError, VError } from 'verror';
-
-import {
-  NVPErrorFactory,
-  NVPErrorResponseFactory,
-} from '../../../../payments/paypal/src/lib/factories';
-import {
-  ContentfulClientError,
-  PayPalClientError,
-  PayPalNVPError,
-  TypeError,
-} from './error';
 
 describe('Error', () => {
   const message = faker.word.words();
-
-  describe('ContentfulClientError', () => {
-    it('should have the expected properties', () => {
-      const error = new ContentfulClientError(message);
-      expect(error.name).toEqual('ContentfulClientError');
-      expect(error.message).toEqual(message);
-      expect(error).toBeInstanceOf(VError);
-    });
-  });
-
-  describe('PayPalClientError', () => {
-    const raw = faker.word.words();
-    const data = NVPErrorResponseFactory({
-      L: [NVPErrorFactory()],
-    });
-
-    it('should have the expected properties', () => {
-      const multiErrorMessage = `first of 1 error: ${message}`;
-      const nvpError = new PayPalNVPError(raw, data, { message });
-      const error = new PayPalClientError([nvpError], raw, data);
-      expect(error.name).toEqual('PayPalClientError');
-      expect(error.message).toEqual(multiErrorMessage);
-      expect(error).toBeInstanceOf(MultiError);
-      expect(error.raw).toEqual(raw);
-      expect(error.data).toStrictEqual(data);
-    });
-  });
-
-  describe('PayPalNVPError', () => {
-    const raw = faker.word.words();
-    const data = NVPErrorResponseFactory({
-      L: [NVPErrorFactory()],
-    });
-
-    it('should have the expected properties', () => {
-      const error = new PayPalNVPError(raw, data, { message });
-      expect(error.name).toEqual('PayPalNVPError');
-      expect(error.message).toEqual(message);
-      expect(error).toBeInstanceOf(VError);
-      expect(error.raw).toEqual(raw);
-      expect(error.data).toStrictEqual(data);
-    });
-  });
 
   describe('TypeError', () => {
     const error = new TypeError(message);
     it('should have the expected properties', () => {
       expect(error.name).toEqual('TypeError');
       expect(error.message).toEqual(message);
-      expect(error).toBeInstanceOf(VError);
+      expect(error).toBeInstanceOf(TypeError);
     });
   });
 });

--- a/libs/shared/error/src/lib/error.ts
+++ b/libs/shared/error/src/lib/error.ts
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { MultiError, VError, WError } from 'verror';
+import { MultiError, VError } from 'verror';
 
-import { NVPErrorResponse } from '../../../../payments/paypal/src';
+export class BaseError extends VError {}
 
-export class TypeError extends VError {
+export class BaseMultiError extends MultiError {}
+
+export class TypeError extends BaseError {
   constructor(message: string, cause?: Error) {
     super(
       {
@@ -18,61 +19,3 @@ export class TypeError extends VError {
     );
   }
 }
-
-export class ContentfulClientError extends VError {
-  constructor(message: string, cause?: Error) {
-    super(
-      {
-        name: 'ContentfulClientError',
-        ...(cause && { cause }),
-      },
-      message
-    );
-  }
-}
-
-export class PayPalClientError extends MultiError {
-  public raw: string;
-  public data: NVPErrorResponse;
-
-  constructor(errors: PayPalNVPError[], raw: string, data: NVPErrorResponse) {
-    super(errors);
-    this.name = 'PayPalClientError';
-    this.raw = raw;
-    this.data = data;
-  }
-
-  getPrimaryError(): PayPalNVPError {
-    // TS is not picking up the type otherwise, so have to cast.
-    return this.errors()[0] as PayPalNVPError;
-  }
-
-  static hasPayPalNVPError(err: Error | PayPalClientError): boolean {
-    return (
-      err instanceof PayPalClientError &&
-      err.getPrimaryError() instanceof PayPalNVPError
-    );
-  }
-}
-
-export class PayPalNVPError extends VError {
-  public raw: string;
-  public data: NVPErrorResponse;
-  public errorCode: number;
-
-  constructor(raw: string, data: NVPErrorResponse, params: any) {
-    const { message, cause, errorCode } = params;
-    super(
-      {
-        name: 'PayPalNVPError',
-        ...(cause && { cause }),
-      },
-      message
-    );
-    this.raw = raw;
-    this.data = data;
-    this.errorCode = errorCode;
-  }
-}
-
-export { MultiError };

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -7,9 +7,6 @@ import { Logger } from 'mozlog';
 import Stripe from 'stripe';
 import { Container } from 'typedi';
 
-import error from '../../error';
-import { CurrencyHelper } from '../currencies';
-import { StripeHelper } from '../stripe';
 import {
   BAUpdateOptions,
   CreateBillingAgreementOptions,
@@ -17,12 +14,16 @@ import {
   IpnMessage,
   nvpToObject,
   PayPalClient,
+  PayPalClientError,
   RefundTransactionOptions,
   RefundType,
   SetExpressCheckoutOptions,
   TransactionSearchOptions,
   TransactionStatus,
 } from '../../../../../libs/payments/paypal/src';
+import error from '../../error';
+import { CurrencyHelper } from '../currencies';
+import { StripeHelper } from '../stripe';
 import { RefusedError } from './error';
 import {
   PAYPAL_APP_ERRORS,
@@ -30,7 +31,6 @@ import {
   PAYPAL_RETRY_ERRORS,
   PAYPAL_SOURCE_ERRORS,
 } from './error-codes';
-import { PayPalClientError } from '../../../../../libs/shared/error/src/';
 
 type PaypalHelperOptions = {
   log: Logger;

--- a/packages/fxa-auth-server/lib/payments/paypal/processor.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/processor.ts
@@ -6,6 +6,7 @@ import { Logger } from 'mozlog';
 import Stripe from 'stripe';
 import { Container } from 'typedi';
 
+import { PayPalClientError } from '../../../../../libs/payments/paypal/src';
 import { ConfigType } from '../../../config';
 import error from '../../error';
 import { StripeWebhookHandler } from '../../routes/subscriptions/stripe-webhook';
@@ -17,7 +18,6 @@ import {
   PAYPAL_SOURCE_ERRORS,
 } from './error-codes';
 import { PayPalHelper, TransactionSearchResult } from './helper';
-import { PayPalClientError } from '../../../../../libs/shared/error/src';
 
 /**
  * Generest a timestamp in seconds that is `hours` before the current

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -19,6 +19,7 @@ const customer1 = require('./fixtures/stripe/customer1.json');
 const failedDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_failure.json');
 const {
   PayPalClientError,
+  PayPalNVPError,
   nvpToObject,
   objectToNVP,
 } = require('../../../../../libs/payments/paypal/src');
@@ -28,7 +29,6 @@ const {
 } = require('../../../lib/payments/paypal/error-codes');
 const { CurrencyHelper } = require('../../../lib/payments/currencies');
 const { CapabilityService } = require('../../../lib/payments/capability');
-const { PayPalNVPError } = require('../../../../../libs/shared/error/src');
 
 const sandbox = sinon.createSandbox();
 

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -12,6 +12,7 @@ const { Container } = require('typedi');
 const {
   PayPalClient,
   PayPalClientError,
+  PayPalNVPError,
   RefundType,
   objectToNVP,
   nvpToObject,
@@ -34,7 +35,6 @@ const {
   PAYPAL_APP_ERRORS,
   PAYPAL_RETRY_ERRORS,
 } = require('../../../lib/payments/paypal/error-codes');
-const { PayPalNVPError } = require('../../../../../libs/shared/error/src');
 
 describe('PayPalHelper', () => {
   /** @type PayPalHelper */


### PR DESCRIPTION
Because:

* We had some last minute tweaks to the error arrangement.

This commit:

* Moves the error class to the library using it and inherits from a shared base error.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
