### PR TITLE
fix(auth-client): Add 'declaration: true' compile option

### DIFF
--- a/packages/fxa-auth-client/tsconfig.cjs.json
+++ b/packages/fxa-auth-client/tsconfig.cjs.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "module": "commonjs",
-    "outDir": "./dist/server/cjs",
-  },
+    "outDir": "./dist/server/cjs"
+  }
 }


### PR DESCRIPTION
Because:
* Some packages can't locate fxa-auth-client

This commit:
* Adds 'declaration: true' to compilerOptions tsconfig.cjs.json