### PR TITLE
 task(many): Switch nx test target to be test-unit

### DIFF
--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -45,7 +45,7 @@
         "buildTarget": "payments-next:build:production"
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/payments/cart/project.json
+++ b/libs/payments/cart/project.json
@@ -21,7 +21,7 @@
         "lintFilePatterns": ["libs/payments/cart/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/payments/paypal/project.json
+++ b/libs/payments/paypal/project.json
@@ -22,7 +22,7 @@
         "lintFilePatterns": ["libs/payments/paypal/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/shared/db/mysql/account/project.json
+++ b/libs/shared/db/mysql/account/project.json
@@ -22,7 +22,7 @@
         "lintFilePatterns": ["libs/shared/db/mysql/account/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/shared/db/mysql/core/project.json
+++ b/libs/shared/db/mysql/core/project.json
@@ -22,7 +22,7 @@
         "lintFilePatterns": ["libs/shared/db/mysql/core/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/shared/error/project.json
+++ b/libs/shared/error/project.json
@@ -21,7 +21,7 @@
         "lintFilePatterns": ["libs/shared/error/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/shared/error/src/lib/error.spec.ts
+++ b/libs/shared/error/src/lib/error.spec.ts
@@ -13,5 +13,10 @@ describe('Error', () => {
       expect(error.message).toEqual(message);
       expect(error).toBeInstanceOf(TypeError);
     });
+
+    // TODO: REMOVE! Just a temporary sanity check to make sure CI actually fails.
+    it('should fail in CI', () => {
+      expect(true).toBe(false); // :[]
+    });
   });
 });

--- a/libs/shared/log/project.json
+++ b/libs/shared/log/project.json
@@ -22,7 +22,7 @@
         "lintFilePatterns": ["libs/shared/log/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/shared/metrics/statsd/project.json
+++ b/libs/shared/metrics/statsd/project.json
@@ -22,7 +22,7 @@
         "lintFilePatterns": ["libs/shared/metrics/statsd/**/*.ts"]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/nx.json
+++ b/nx.json
@@ -5,14 +5,7 @@
     "default": {
       "runner": "nx-cloud",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "test-unit",
-          "test-integration",
-          "e2e"
-        ],
+        "cacheableOperations": ["build", "lint", "test-unit", "test-integration", "e2e"],
         "accessToken": "YzRhMzhiNjEtODE0OS00Njg1LTg2NDktMGJlZjBjNmJjMTc1fHJlYWQtb25seQ=="
       }
     }
@@ -25,7 +18,7 @@
     "lint": {
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json"]
     },
-    "test": {
+    "test-unit": {
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
     }
   },


### PR DESCRIPTION

## Because
- The CI already targets test-unit
- We want to draw a distinction between unit and integration tests.

## This pull request
- Renames "test" to "test-unit" in lib packages

## Issue that this pull request solves

Closes: FXA-8120

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

In general libs should monstly have unit tests. There maybe some exceptions like db or third party API wrappers which would require integration tests. For now, we will just start using the test-unit convention here and modify if necessary.
