### PR TITLE
fix: add remaining rootDir for build to complete

### DIFF
--- a/libs/payments/paypal/project.json
+++ b/libs/payments/paypal/project.json
@@ -8,6 +8,7 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
+        "rootDir": ".",
         "outputPath": "dist/libs/payments/paypal",
         "tsConfig": "libs/payments/paypal/tsconfig.lib.json",
         "packageJson": "libs/payments/paypal/package.json",

--- a/libs/shared/error/project.json
+++ b/libs/shared/error/project.json
@@ -8,6 +8,7 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
+        "rootDir": ".",
         "outputPath": "dist/libs/shared/error",
         "main": "libs/shared/error/src/index.ts",
         "tsConfig": "libs/shared/error/tsconfig.lib.json",


### PR DESCRIPTION
Because:

* The build was failing due to missing rootDir in the project.json files.

This commit:

* Adds the missing rootDir to the project.json files.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
