### PR TITLE
fix(settings): Show localized auth errors in React Reset Password banners

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -82,6 +82,8 @@ export type AuthServerError = Error & {
   errno?: number;
   message?: string;
   code?: number;
+  retryAfter?: number;
+  retryAfterLocalized?: string;
 };
 
 export interface MetricsContext {

--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -147,9 +147,9 @@ can be overridden in two ways:
 
 ### Rate-limiting config
 
-Rate-limiting and blocking is handled by fxa-customs-server. By default, these policies are _enabled_ in dev environment via `"customsUrl":"http://localhost:7000"` in `fxa-auth-server/config/dev.json`, but disabled for circleCI. Enabling the customs server allows error messages to be displayed when rate limiting occurs. Default rate-limiting values are found in `fxa-customs-server/lib/config/config.js` and can be modified with environment variables or by adding a `dev.json` file to `fxa-customs-server/config/`.
+Rate-limiting and blocking is handled by fxa-customs-server. By default, these policies are _disabled_ in dev environment via `"customsUrl":"none"` in `fxa-auth-server/config/dev.json`. Enabling the customs server allows error messages to be displayed when rate limiting occurs. Default rate-limiting values are found in `fxa-customs-server/lib/config/config.js` and can be modified with environment variables or by adding a `dev.json` file to `fxa-customs-server/config/`.
 
-The customs-server can be disabled for testing by changing the dev config to `"customsUrl":"none"`.
+The customs-server can be enabled for local testing by changing the dev config to `"customsUrl":"http://localhost:7000"`.
 
 ### Email config
 

--- a/packages/fxa-settings/src/components/Banner/en.ftl
+++ b/packages/fxa-settings/src/components/Banner/en.ftl
@@ -10,6 +10,4 @@ banner-dismiss-button =
 # $accountsEmail is the senderʼs email address (origin of the email containing a new link). (e.g. accounts@firefox.com)
 link-expired-resent-link-success-message = Email resent. Add { $accountsEmail } to your contacts to ensure a smooth delivery.
 # Error message displayed in an error banner. This is a general message when the cause of the error is unclear.
-link-expired-resent-link-error-message = Something went wrong. A new link could not be sent.
-# Error message displayed in an error banner. This is a general message when the cause of the error is unclear.
 link-expired-resent-code-error-message = Something went wrong. A new code could not be sent.

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -14,7 +14,7 @@ export enum BannerType {
   error = 'error',
 }
 
-type DefaultProps = { type: BannerType; children: ReactElement };
+type DefaultProps = { type: BannerType; children: ReactElement | string };
 
 type OptionalProps =
   | {
@@ -68,16 +68,6 @@ export const ResendEmailSuccessBanner = () => {
       >
         {`Email resent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a
     smooth delivery.`}
-      </FtlMsg>
-    </Banner>
-  );
-};
-
-export const ResendLinkErrorBanner = () => {
-  return (
-    <Banner type={BannerType.error}>
-      <FtlMsg id="link-expired-resent-link-error-message">
-        Something went wrong. A new link could not be sent.
       </FtlMsg>
     </Banner>
   );

--- a/packages/fxa-settings/src/components/ConfirmWithLink/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/index.stories.tsx
@@ -4,8 +4,6 @@
 
 import React from 'react';
 import ConfirmWithLink from '.';
-import AppLayout from '../../components/AppLayout';
-import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import {
   SubjectWithEmailResendError,

--- a/packages/fxa-settings/src/components/ConfirmWithLink/index.test.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/index.test.tsx
@@ -18,12 +18,8 @@ jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
 }));
 
-const mockCallback = jest.fn();
-
 describe('ConfirmWithLink component', () => {
-  // TODO: add tests for all metrics as they are added
-
-  it("renders default view as expected with user's email", () => {
+  it('renders default view as expected on initial page load', () => {
     renderWithLocalizationProvider(<SubjectWithEmailResendSuccess />);
 
     const headingEl = screen.getByRole('heading', { level: 1 });
@@ -32,37 +28,44 @@ describe('ConfirmWithLink component', () => {
       `Open the mock link sent to ${MOCK_ACCOUNT.primaryEmail.email}`
     );
     screen.getByRole('button', { name: 'Not in inbox or spam folder? Resend' });
+    expect(
+      screen.queryByRole('button', { name: 'Back' })
+    ).not.toBeInTheDocument();
   });
 
-  it('displays a success banner when resending a link is successful', () => {
+  it('displays a success banner when resend status is set to sent', () => {
     renderWithLocalizationProvider(<SubjectWithEmailResendSuccess />);
     const resendEmailButton = screen.getByRole('button', {
       name: 'Not in inbox or spam folder? Resend',
     });
+    expect(
+      screen.queryByText(
+        'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+      )
+    ).not.toBeInTheDocument();
     fireEvent.click(resendEmailButton);
     screen.getByText(
       'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
     );
   });
 
-  it('displays an error banner when resending a link is unsuccessful', () => {
+  it('displays an error banner when resend status is set to error and an error message is provided', () => {
     renderWithLocalizationProvider(<SubjectWithEmailResendError />);
     const resendEmailButton = screen.getByRole('button', {
       name: 'Not in inbox or spam folder? Resend',
     });
+    expect(
+      screen.queryByText('Uh oh something went wrong')
+    ).not.toBeInTheDocument();
     fireEvent.click(resendEmailButton);
-    screen.getByText('Something went wrong. A new link could not be sent.');
+    screen.getByText('Uh oh something went wrong');
   });
 
-  it('renders the expected view with the Back button when user can go back', async () => {
+  it('renders a back button when provided with navigateBackHandler', async () => {
     renderWithLocalizationProvider(
-      <SubjectCanGoBack navigateBackHandler={mockCallback} />
+      <SubjectCanGoBack navigateBackHandler={jest.fn()} />
     );
 
-    const backLink = screen.getByRole('button', {
-      name: 'Back',
-    });
-    fireEvent.click(backLink);
-    expect(mockCallback).toHaveBeenCalled();
+    screen.getByRole('button', { name: 'Back' });
   });
 });

--- a/packages/fxa-settings/src/components/ConfirmWithLink/index.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/index.tsx
@@ -7,7 +7,7 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { MailImage } from '../../components/images';
 import CardHeader from '../CardHeader';
 import { ResendStatus } from '../../lib/types';
-import { ResendLinkErrorBanner, ResendEmailSuccessBanner } from '../Banner';
+import Banner, { BannerType, ResendEmailSuccessBanner } from '../Banner';
 
 export type ConfirmWithLinkProps = {
   confirmWithLinkPageStrings: ConfirmWithLinkPageStrings;
@@ -15,6 +15,7 @@ export type ConfirmWithLinkProps = {
   navigateBackHandler?: () => void;
   resendEmailHandler: () => void;
   resendStatus: ResendStatus;
+  errorMessage?: string;
 };
 
 export type ConfirmWithLinkPageStrings = {
@@ -30,6 +31,7 @@ const ConfirmWithLink = ({
   navigateBackHandler,
   resendEmailHandler,
   resendStatus,
+  errorMessage,
 }: ConfirmWithLinkProps) => {
   // (temporarily?) removed `Open With Webmail` functionality
   // Not currently functional in content-server/prod so requires fix/new utility
@@ -43,7 +45,9 @@ const ConfirmWithLink = ({
       />
 
       {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}
-      {resendStatus === ResendStatus['error'] && <ResendLinkErrorBanner />}
+      {resendStatus === ResendStatus['error'] && errorMessage && (
+        <Banner type={BannerType.error}>{errorMessage}</Banner>
+      )}
 
       <div className="flex justify-center">
         <MailImage />
@@ -56,7 +60,7 @@ const ConfirmWithLink = ({
       <div className="flex flex-col gap-3">
         <FtlMsg id="confirm-with-link-resend-link-button">
           <button
-            className="mx-auto link-blue text-sm opacity-0 animate-delayed-fade-in"
+            className="mx-auto link-blue text-sm"
             onClick={resendEmailHandler}
           >
             Not in inbox or spam folder? Resend
@@ -65,7 +69,7 @@ const ConfirmWithLink = ({
         {navigateBackHandler && (
           <FtlMsg id="confirm-with-link-back-link">
             <button
-              className="mx-auto link-blue text-sm opacity-0 animate-delayed-fade-in"
+              className="mx-auto link-blue text-sm"
               onClick={navigateBackHandler}
             >
               Back

--- a/packages/fxa-settings/src/components/ConfirmWithLink/mocks.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/mocks.tsx
@@ -8,7 +8,7 @@ import { ResendStatus } from '../../lib/types';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import AppLayout from '../AppLayout';
 
-const MOCK_STRINGS = {
+export const MOCK_STRINGS = {
   headingFtlId: 'mock-confirmation-heading',
   headingText: 'Confirm something',
   instructionFtlId: 'mock-confirmation-instruction',
@@ -16,7 +16,7 @@ const MOCK_STRINGS = {
 };
 
 export const MOCK_GOBACK_CB = () => {
-  alert('Navigating back! (alert for storybook only)');
+  alert('Navigating back!');
 };
 
 export const SubjectWithEmailResendSuccess = () => {
@@ -45,10 +45,12 @@ export const SubjectWithEmailResendError = () => {
   const [mockResendStatus, setMockResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
   );
+  const [mockErrorMessage, setMockErrorMessage] = useState('');
 
   const MOCK_EMAIL_RESEND_FAIL = () => {
     Promise.resolve(false);
     setMockResendStatus(ResendStatus.error);
+    setMockErrorMessage('Uh oh something went wrong');
   };
 
   return (
@@ -58,6 +60,7 @@ export const SubjectWithEmailResendError = () => {
         confirmWithLinkPageStrings={MOCK_STRINGS}
         resendEmailHandler={MOCK_EMAIL_RESEND_FAIL}
         resendStatus={mockResendStatus}
+        errorMessage={mockErrorMessage}
       />
     </AppLayout>
   );

--- a/packages/fxa-settings/src/components/LinkExpired/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../CardHeader';
 import AppLayout from '../AppLayout';
 import { ResendStatus } from '../../lib/types';
-import { ResendLinkErrorBanner, ResendEmailSuccessBanner } from '../Banner';
+import Banner, { ResendEmailSuccessBanner, BannerType } from '../Banner';
 
 export type LinkExpiredProps = {
   headingText: string;
@@ -16,6 +16,7 @@ export type LinkExpiredProps = {
   messageFtlId: string;
   resendLinkHandler: () => Promise<void>;
   resendStatus: ResendStatus;
+  errorMessage?: string | ReactElement;
 };
 
 export const LinkExpired = ({
@@ -25,13 +26,16 @@ export const LinkExpired = ({
   messageFtlId,
   resendLinkHandler,
   resendStatus,
+  errorMessage,
 }: LinkExpiredProps) => {
   return (
     <AppLayout>
       <CardHeader {...{ headingText, headingTextFtlId }} />
 
       {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}
-      {resendStatus === ResendStatus['error'] && <ResendLinkErrorBanner />}
+      {resendStatus === ResendStatus['error'] && errorMessage && (
+        <Banner type={BannerType.error}>{errorMessage}</Banner>
+      )}
 
       <FtlMsg id={messageFtlId}>
         <p className="text-sm my-4">{messageText}</p>

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.test.tsx
@@ -86,9 +86,7 @@ describe('LinkExpiredResetPassword', () => {
     });
     fireEvent.click(receiveNewLinkButton);
     await waitFor(() => {
-      expect(
-        screen.getByText(`Something went wrong. A new link could not be sent.`)
-      ).toBeInTheDocument();
+      expect(screen.getByText(`Unexpected error`)).toBeInTheDocument();
     });
   });
 });

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -73,6 +73,16 @@ const Ready = ({
 
   const templateValues = getTemplateValues(viewName);
 
+  const showReadyToUseService =
+    !isSync && isSignedIn && serviceName && serviceName !== 'account settings';
+
+  const showReadyToUseSettings =
+    !isSync &&
+    isSignedIn &&
+    (!serviceName || serviceName === 'account settings');
+
+  const showAccountReady = !isSync && !isSignedIn;
+
   const startBrowsing = () => {
     const eventName = `${viewName}.start-browsing`;
     logViewEvent(viewName, eventName, REACT_ENTRYPOINT);
@@ -112,19 +122,19 @@ const Ready = ({
             </div>
           </>
         )}
-        {!isSync && isSignedIn && serviceName && (
+        {showReadyToUseService && (
           <FtlMsg id="ready-use-service" vars={{ serviceName }}>
             <p className="my-4 text-sm">{`You’re now ready to use ${serviceName}`}</p>
           </FtlMsg>
         )}
-        {!isSync && isSignedIn && !serviceName && (
+        {showReadyToUseSettings && (
           <FtlMsg id="ready-use-service-default">
             <p className="my-4 text-sm">
               You’re now ready to use account settings
             </p>
           </FtlMsg>
         )}
-        {!isSync && !isSignedIn && (
+        {showAccountReady && (
           <FtlMsg id="ready-account-ready">
             <p className="my-4 text-sm">Your account is ready!</p>
           </FtlMsg>

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -16,6 +16,7 @@ auth-error-114 = You’ve tried too many times. Please try again { $retryAfter }
 auth-error-138-2 = Unconfirmed session
 auth-error-139 = Secondary email must be different than your account email
 auth-error-155 = TOTP token not found
+auth-error-159 = Invalid account recovery key
 auth-error-183-2 = Invalid or expired confirmation code
 auth-error-999 = Unexpected error
 auth-error-1003 = Local storage or cookies are still disabled

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/en.ftl
@@ -16,9 +16,5 @@ account-recovery-confirm-key-input =
   .label = Enter account recovery key
 # Clicking this button checks if the recovery key provided by the user is correct and associated with their account
 account-recovery-confirm-key-button = Confirm account recovery key
-# Error displayed in an alert banner when the recovery key confirmation is unsuccessful
-account-recovery-confirm-key-error-general = Invalid account recovery key
-# Error displayed in a tooltip when then account recovery input field is left blank when the request is submitted
-account-recovery-confirm-key-empty-input-error = Account recovery key required
 # Link that leads to the password reset page (without recovery code)
 account-recovery-lost-recovery-key-link = Don’t have an account recovery key?

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -84,7 +84,6 @@ jest.mock('../../../lib/metrics', () => {
 
 const route = '/reset_password';
 const render = (ui = <Subject />, account = mockAccount()) => {
-  console.log('account in render', account);
   const history = createHistoryWithQuery(route);
   return renderWithRouter(
     ui,

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/en.ftl
@@ -9,4 +9,5 @@ complete-reset-password-success-alert = Password set
 # An error occurred while attempting to set a new password (password reset flow)
 # Displayed in an alert bar
 complete-reset-password-error-alert = Sorry, there was a problem setting your password
-complete-reset-password-recovery-key-error = Sorry, there was a problem checking if you have an account recovery key. <hasRecoveryKeyErrorLink>Reset your password with your account recovery key.</hasRecoveryKeyErrorLink>
+complete-reset-password-recovery-key-error-v2 = Sorry, there was a problem checking if you have an account recovery key.
+complete-reset-password-recovery-key-link = Reset your password with your account recovery key.

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
@@ -7,13 +7,18 @@ import { Meta } from '@storybook/react';
 import CompleteResetPassword from '.';
 import { Account } from '../../../models';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { Subject, paramsWithMissingEmail } from './mocks';
+import {
+  Subject,
+  mockAccountNoRecoveryKey,
+  mockAccountWithRecoveryKeyStatusError,
+  mockAccountWithThrottledError,
+  paramsWithMissingEmail,
+} from './mocks';
 import {
   createAppContext,
   mockAppContext,
   produceComponent,
 } from '../../../models/mocks';
-// import { resetMocks } from '../AccountRecoveryResetPassword/mocks';
 
 export default {
   title: 'Pages/ResetPassword/CompleteResetPassword',
@@ -27,7 +32,7 @@ type RenderStoryOptions = {
 };
 
 function renderStory(
-  { account = accountNoRecoveryKey, params }: RenderStoryOptions = {},
+  { account = mockAccountNoRecoveryKey, params }: RenderStoryOptions = {},
   storyName?: string
 ) {
   const story = () =>
@@ -45,18 +50,6 @@ function renderStory(
   return story();
 }
 
-const accountNoRecoveryKey = {
-  resetPasswordStatus: () => Promise.resolve(true),
-  hasRecoveryKey: () => Promise.resolve(false),
-} as unknown as Account;
-
-const accountWithRecoveryKeyStatusError = {
-  resetPasswordStatus: () => Promise.resolve(true),
-  hasRecoveryKey: () => {
-    throw new Error('boop');
-  },
-} as unknown as Account;
-
 const accountWithFalseyResetPasswordStatus = {
   resetPasswordStatus: () => Promise.resolve(false),
 } as unknown as Account;
@@ -70,9 +63,16 @@ export const NoRecoveryKeySet = () => {
 
 export const ErrorCheckingRecoveryKeyStatus = () => {
   return renderStory({
-    account: accountWithRecoveryKeyStatusError,
+    account: mockAccountWithRecoveryKeyStatusError,
   });
 };
+
+export const ThrottledErrorOnSubmit = () => {
+  return renderStory({
+    account: mockAccountWithThrottledError,
+  });
+};
+
 export const WithExpiredLink = () => {
   return renderStory({
     account: accountWithFalseyResetPasswordStatus,
@@ -81,7 +81,7 @@ export const WithExpiredLink = () => {
 
 export const WithDamagedLink = () => {
   return renderStory({
-    account: accountNoRecoveryKey,
+    account: mockAccountNoRecoveryKey,
     params: paramsWithMissingEmail,
   });
 };

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -248,9 +248,7 @@ describe('CompleteResetPassword page', () => {
 
       fireEvent.click(screen.getByText('Reset password'));
 
-      await screen.findByText(
-        'Sorry, there was a problem setting your password'
-      );
+      await screen.findByText('Unexpected error');
     });
 
     it('displays account recovery key check error', async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { LinkType } from 'fxa-settings/src/lib/types';
 import CompleteResetPassword from '.';
-import { Integration, IntegrationType } from '../../../models';
+import { Account, Integration, IntegrationType } from '../../../models';
 import { MOCK_ACCOUNT, mockUrlQueryData } from '../../../models/mocks';
 import { CompleteResetPasswordLink } from '../../../models/reset-password/verification';
 import {
@@ -21,6 +21,31 @@ import {
 
 // TODO: combine a lot of mocks with AccountRecoveryResetPassword
 const fxDesktopV3ContextParam = { context: 'fx_desktop_v3' };
+
+export const mockAccountNoRecoveryKey = {
+  resetPasswordStatus: () => Promise.resolve(true),
+  hasRecoveryKey: () => Promise.resolve(false),
+} as unknown as Account;
+
+export const mockAccountWithRecoveryKeyStatusError = {
+  resetPasswordStatus: () => Promise.resolve(true),
+  hasRecoveryKey: () => {
+    throw new Error('boop');
+  },
+} as unknown as Account;
+
+const throttledErrorObjWithRetryAfter = {
+  errno: 114,
+  retryAfter: 500,
+  retryAfterLocalized: 'in 15 minutes',
+};
+
+// Mocked throttled error with retryAfter value
+export const mockAccountWithThrottledError = {
+  resetPasswordStatus: () => Promise.resolve(true),
+  hasRecoveryKey: () => Promise.resolve(false),
+  completeResetPassword: () => Promise.reject(throttledErrorObjWithRetryAfter),
+} as unknown as Account;
 
 export const mockCompleteResetPasswordParams = {
   email: MOCK_ACCOUNT.primaryEmail.email,

--- a/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.stories.tsx
@@ -8,6 +8,7 @@ import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import {
+  mockAccountWithGenericThrottledError,
   createMockResetPasswordOAuthIntegration,
   createMockResetPasswordWebIntegration,
   mockAccountWithThrottledError,
@@ -52,7 +53,7 @@ function renderStory({
 
 export const Default = () => renderStory();
 
-export const WithServiceName = () =>
+export const HeaderWithServiceName = () =>
   renderStory({
     integrationType: IntegrationType.OAuth,
     queryParams: `service=${MozServices.MozillaVPN}`,
@@ -65,6 +66,9 @@ export const WithForceAuth = () =>
       forceAuth: true,
     },
   });
+
+export const WithGenericThrottledErrorOnSubmit = () =>
+  renderStory({ account: mockAccountWithGenericThrottledError });
 
 export const WithThrottledErrorOnSubmit = () =>
   renderStory({ account: mockAccountWithThrottledError });

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -10,6 +10,7 @@ import {
   AuthUiErrorNos,
   AuthUiErrors,
   composeAuthUiErrorTranslationId,
+  getLocalizedErrorMessage,
 } from '../../lib/auth-errors/auth-errors';
 import { usePageViewEvent, useMetrics } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
@@ -126,34 +127,8 @@ const ResetPassword = ({
           });
         }
       } catch (err) {
-        let localizedError;
-        if (err.errno && AuthUiErrorNos[err.errno]) {
-          if (
-            err.errno === AuthUiErrors.THROTTLED.errno &&
-            err.retryAfterLocalized
-          ) {
-            localizedError = ftlMsgResolver.getMsg(
-              composeAuthUiErrorTranslationId(err),
-              AuthUiErrorNos[err.errno].message,
-              { retryAfter: err.retryAfterLocalized }
-            );
-          } else {
-            localizedError = ftlMsgResolver.getMsg(
-              composeAuthUiErrorTranslationId(err),
-              AuthUiErrorNos[err.errno].message
-            );
-          }
-        } else {
-          // TEMPORARY deliberate log to help debug FXA-7347, this should be captured server-side
-          // but for some reason isn't logging to Sentry
-          sentryMetrics.captureException(err);
-          const unexpectedError = AuthUiErrors.UNEXPECTED_ERROR;
-          localizedError = ftlMsgResolver.getMsg(
-            composeAuthUiErrorTranslationId(unexpectedError),
-            unexpectedError.message
-          );
-        }
-        setErrorMessage(localizedError);
+        const errorMessage = getLocalizedErrorMessage(ftlMsgResolver, err);
+        setErrorMessage(errorMessage);
       }
     },
     [account, clearError, ftlMsgResolver, navigateToConfirmPwReset, integration]

--- a/packages/fxa-settings/src/pages/ResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { MOCK_ACCOUNT } from '../../models/mocks';
 import { Account, IntegrationType } from '../../models';
 import {
   ResetPasswordBaseIntegration,
@@ -12,31 +11,34 @@ import { MozServices } from '../../lib/types';
 import { MOCK_REDIRECT_URI, MOCK_SERVICE } from '../mocks';
 
 // No error message on submit
-export const mockDefaultAccount = { MOCK_ACCOUNT } as any as Account;
+export const mockDefaultAccount = {
+  resetPassword: () =>
+    Promise.resolve({ passwordForgotToken: 'mockPasswordForgotToken' }),
+} as any as Account;
 
-mockDefaultAccount.resetPassword = () =>
-  Promise.resolve({ passwordForgotToken: 'mockPasswordForgotToken' });
-
-// Mocked localized throttled error (not localized in storybook)
-export const mockAccountWithThrottledError = {
-  MOCK_ACCOUNT,
-} as unknown as Account;
-
-const throttledErrorObj = {
+const throttledErrorObjWithRetryAfter = {
   errno: 114,
   retryAfter: 500,
   retryAfterLocalized: 'in 15 minutes',
 };
 
-mockAccountWithThrottledError.resetPassword = () =>
-  Promise.reject(throttledErrorObj);
-
-export const mockAccountWithUnexpectedError = {
-  MOCK_ACCOUNT,
+// Mocked throttled error with retryAfter value
+export const mockAccountWithThrottledError = {
+  resetPassword: () => Promise.reject(throttledErrorObjWithRetryAfter),
 } as unknown as Account;
 
-mockAccountWithThrottledError.resetPassword = () =>
-  Promise.reject('some error');
+const genericThrottledErrorObj = {
+  errno: 114,
+};
+
+// Mocked throttled error without retryAfter value
+export const mockAccountWithGenericThrottledError = {
+  resetPassword: () => Promise.reject(genericThrottledErrorObj),
+} as unknown as Account;
+
+export const mockAccountWithUnexpectedError = {
+  resetPassword: () => Promise.reject('some error'),
+} as unknown as Account;
 
 export function createMockResetPasswordWebIntegration(): ResetPasswordBaseIntegration {
   return {

--- a/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ConfirmSignin/index.tsx
@@ -10,6 +10,8 @@ import ConfirmWithLink, {
 } from '../../../components/ConfirmWithLink';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { ResendStatus } from '../../../lib/types';
+import { useFtlMsgResolver } from '../../../models';
+import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 
 export type ConfirmSigninProps = {
   email: string;
@@ -24,9 +26,12 @@ const ConfirmSignin = ({
 }: RouteComponentProps & ConfirmSigninProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
+  const ftlMsgResolver = useFtlMsgResolver();
+
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
   );
+  const [errorMessage, setErrorMessage] = useState<string>();
 
   const confirmSigninPageText: ConfirmWithLinkPageStrings = {
     headingFtlId: 'confirm-signin-heading',
@@ -39,9 +44,15 @@ const ConfirmSignin = ({
     try {
       // TO-DO: signin confirmation email to user.
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
+      setErrorMessage('');
       setResendStatus(ResendStatus['sent']);
-    } catch (e) {
+    } catch (err) {
+      const localizedErrorMessage = getLocalizedErrorMessage(
+        ftlMsgResolver,
+        err
+      );
       setResendStatus(ResendStatus['error']);
+      setErrorMessage(localizedErrorMessage);
     }
   };
 
@@ -52,6 +63,7 @@ const ConfirmSignin = ({
           email,
           resendEmailHandler,
           resendStatus,
+          errorMessage,
         }}
         confirmWithLinkPageStrings={confirmSigninPageText}
       />

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
@@ -125,8 +125,8 @@ describe('Confirm page', () => {
       });
       fireEvent.click(resendEmailButton);
       expect(account.sendVerificationCode).toBeCalled();
-      const successBannerText = `Something went wrong. A new link could not be sent.`;
-      expect(screen.getByText(successBannerText)).toBeInTheDocument();
+      const bannerText = `Unexpected error`;
+      expect(screen.getByText(bannerText)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Because

* Generic error banners were displayed on CompleteResetPassword page, ConfirmWithLink component and LinkExpired component.
* We want to display relevant and localized auth error messages where possible, and otherwise default to "Unexpected error"
* We were repeating similar error handling in multiple pages/components.

## This pull request

* Standardize error handling for CompleteResetPassword, ResetPassword, FlowRecoveryKeyConfirmPwd, LinkExpired, ConfirmWithLink to handle throttled errors with localizedRetryAfter, throttled errors without retryAfter value, other recognized authUiErrors as well as unexpected errors
* Create a reusable `getLocalizedErrorMessage` function in lib/auth-errors to simplify error handling in pages/components.
* Updates tests/stories.
## Issue that this pull request solves

Closes: #FXA-8089

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

FIXED Complete Reset Password with expected throttled error:
- verified that remaining time changes after successive attempts
- verified that error message is localized
![image](https://github.com/mozilla/fxa/assets/22231637/4e97d1cf-3449-43a3-bd4a-8d12994a865e)

ISSUE Confirm Reset Password (after resend link) with generic error message:
![image](https://github.com/mozilla/fxa/assets/22231637/d2af13fd-b994-404b-a237-ec4f2deae042)

FIXED Confirm Reset Password (after resend link) with expected throttled error:
![image](https://github.com/mozilla/fxa/assets/22231637/5d45a624-3a77-4deb-8df8-c231dc06cbd5)

Also corrected a l10n issue, where 'account settings' was passed in as an unlocalized variable on the `/reset_password_verified` page.
![image](https://github.com/mozilla/fxa/assets/22231637/f092aae1-296c-4455-b013-46fdaab69bd1)

![image](https://github.com/mozilla/fxa/assets/22231637/7d67e1c8-4de4-44c5-b881-8daab96cba20)

## Other information (Optional)

Any other information that is important to this pull request.
