### PR TITLE
chore(graphql): add Contentful API key env var

### DIFF
--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -41,6 +41,12 @@ const conf = convict({
       default: 'http://localhost:9000/v1',
     },
   },
+  contentfulApiKey: {
+    doc: 'GraphQL Content API key for Contentful hCMS to fetch RP-provided content',
+    format: String,
+    env: 'CONTENTFUL_API_KEY',
+    default: '',
+  },
   corsOrigin: {
     doc: 'Value for the Access-Control-Allow-Origin response header',
     format: Array,


### PR DESCRIPTION
Because:

* We will be using the Contentful hCMS (specifically their GraphQL Content API) to replace Stripe metadata for RP-provided content in SubPlat 3.0.

This commit:

* Adds the Contentful API key environment variable to the fxa-graphql-api service's config file.

Closes #FXA-7623

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

See this [summary](https://mozilla-hub.atlassian.net/browse/FXA-7623?focusedCommentId=715234) from a [team discussion yesterday](https://docs.google.com/document/d/1npPLTiWE3pjeq0sxQehOtgyOcbFgbectFyS2rSbwR1A/edit#bookmark=id.dduhnnqc8sgw) regarding which Contentful APIs we're using in which environments.
