### PR TITLE
feat(libs): allow packagename-based imports

### DIFF
--- a/libs/payments/cart/project.json
+++ b/libs/payments/cart/project.json
@@ -10,7 +10,7 @@
       "options": {
         "rootDir": ".",
         "outputPath": "dist/libs/payments/cart",
-        "main": "libs/payments/cart/src/index.ts",
+        "main": "libs/payments/cart/libs/payments/cart/src/index.ts",
         "tsConfig": "libs/payments/cart/tsconfig.lib.json",
         "assets": ["libs/payments/cart/*.md"]
       }

--- a/libs/payments/cart/src/lib/manager.ts
+++ b/libs/payments/cart/src/lib/manager.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { NotFoundError } from 'objection';
-import { Cart, CartState } from '../../../../shared/db/mysql/account/src';
-import { Logger } from '../../../../shared/log/src';
+import { Cart, CartState } from '@fxa/shared/db/mysql/account';
+import { Logger } from '@fxa/shared/log';
 import { InvoiceFactory } from './factories';
 import { Cart as CartType, SetupCart, UpdateCart } from './types';
 

--- a/libs/payments/paypal/project.json
+++ b/libs/payments/paypal/project.json
@@ -12,7 +12,7 @@
         "outputPath": "dist/libs/payments/paypal",
         "tsConfig": "libs/payments/paypal/tsconfig.lib.json",
         "packageJson": "libs/payments/paypal/package.json",
-        "main": "libs/payments/paypal/src/index.ts",
+        "main": "libs/payments/paypal/libs/payments/paypal/src/index.ts",
         "assets": ["libs/payments/paypal/*.md"]
       }
     },

--- a/libs/payments/paypal/src/lib/error.ts
+++ b/libs/payments/paypal/src/lib/error.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { BaseError, BaseMultiError } from '../../../../shared/error/src';
+import { BaseError, BaseMultiError } from '@fxa/shared/error';
 import { NVPErrorResponse } from './types';
 
 export class PayPalClientError extends BaseMultiError {

--- a/libs/shared/db/mysql/account/project.json
+++ b/libs/shared/db/mysql/account/project.json
@@ -12,7 +12,7 @@
         "outputPath": "dist/libs/shared/db/mysql/account",
         "tsConfig": "libs/shared/db/mysql/account/tsconfig.lib.json",
         "packageJson": "libs/shared/db/mysql/account/package.json",
-        "main": "libs/shared/db/mysql/account/src/index.ts",
+        "main": "libs/shared/db/mysql/account/libs/shared/db/mysql/account/src/index.ts",
         "assets": ["libs/shared/db/mysql/account/*.md"]
       }
     },

--- a/libs/shared/db/mysql/core/project.json
+++ b/libs/shared/db/mysql/core/project.json
@@ -12,7 +12,7 @@
         "outputPath": "dist/libs/shared/db/mysql/core",
         "tsConfig": "libs/shared/db/mysql/core/tsconfig.lib.json",
         "packageJson": "libs/shared/db/mysql/core/package.json",
-        "main": "libs/shared/db/mysql/core/src/index.ts",
+        "main": "libs/shared/db/mysql/core/libs/shared/db/mysql/core/src/index.ts",
         "assets": ["libs/shared/db/mysql/core/*.md"]
       }
     },

--- a/libs/shared/error/project.json
+++ b/libs/shared/error/project.json
@@ -10,7 +10,7 @@
       "options": {
         "rootDir": ".",
         "outputPath": "dist/libs/shared/error",
-        "main": "libs/shared/error/src/index.ts",
+        "main": "libs/shared/error/libs/shared/error/src/index.ts",
         "tsConfig": "libs/shared/error/tsconfig.lib.json",
         "assets": ["libs/shared/error/*.md"]
       }

--- a/libs/shared/log/project.json
+++ b/libs/shared/log/project.json
@@ -12,7 +12,7 @@
         "outputPath": "dist/libs/shared/log",
         "tsConfig": "libs/shared/log/tsconfig.lib.json",
         "packageJson": "libs/shared/log/package.json",
-        "main": "libs/shared/log/src/index.ts",
+        "main": "libs/shared/log/libs/shared/log/src/index.ts",
         "assets": ["libs/shared/log/*.md"]
       }
     },

--- a/libs/shared/metrics/statsd/project.json
+++ b/libs/shared/metrics/statsd/project.json
@@ -12,7 +12,7 @@
         "outputPath": "dist/shared/metrics/statsd",
         "tsConfig": "libs/shared/metrics/statsd/tsconfig.lib.json",
         "packageJson": "libs/shared/metrics/statsd/package.json",
-        "main": "libs/shared/metrics/statsd/src/index.ts",
+        "main": "libs/shared/metrics/statsd/libs/shared/metrics/statsd/src/index.ts",
         "assets": ["libs/shared/metrics/statsd/*.md"]
       }
     },

--- a/packages/fxa-auth-server/bin/email_notifications.js
+++ b/packages/fxa-auth-server/bin/email_notifications.js
@@ -45,7 +45,7 @@ if (config.subscriptions && config.subscriptions.stripeApiKey) {
   Container.set(StripeHelper, stripeHelper);
 
   if (config.subscriptions.paypalNvpSigCredentials.enabled) {
-    const { PayPalClient } = require('../../../libs/payments/paypal/src');
+    const { PayPalClient } = require('@fxa/payments/paypal');
     const { PayPalHelper } = require('../lib/payments/paypal/helper');
     const paypalClient = new PayPalClient(
       config.subscriptions.paypalNvpSigCredentials

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -107,7 +107,7 @@ async function run(config) {
     Container.set(StripeHelper, stripeHelper);
 
     if (config.subscriptions.paypalNvpSigCredentials.enabled) {
-      const { PayPalClient } = require('../../../libs/payments/paypal/src');
+      const { PayPalClient } = require('@fxa/payments/paypal');
       const { PayPalHelper } = require('../lib/payments/paypal/helper');
       const paypalClient = new PayPalClient(
         config.subscriptions.paypalNvpSigCredentials

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -8,7 +8,7 @@ import { tracingConfig } from 'fxa-shared/tracing/config';
 import path from 'path';
 import url from 'url';
 
-import { makeConvictMySQLConfig as makeMySQLConfig } from '../../../libs/shared/db/mysql/core/src/lib/config';
+import { makeConvictMySQLConfig as makeMySQLConfig } from '@fxa/shared/db/mysql/core';
 
 const DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages');
 const ONE_DAY = 1000 * 60 * 60 * 24;

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -20,7 +20,7 @@ import {
   SetExpressCheckoutOptions,
   TransactionSearchOptions,
   TransactionStatus,
-} from '../../../../../libs/payments/paypal/src';
+} from '@fxa/payments/paypal';
 import error from '../../error';
 import { CurrencyHelper } from '../currencies';
 import { StripeHelper } from '../stripe';

--- a/packages/fxa-auth-server/lib/payments/paypal/processor.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/processor.ts
@@ -6,7 +6,7 @@ import { Logger } from 'mozlog';
 import Stripe from 'stripe';
 import { Container } from 'typedi';
 
-import { PayPalClientError } from '../../../../../libs/payments/paypal/src';
+import { PayPalClientError } from '@fxa/payments/paypal';
 import { ConfigType } from '../../../config';
 import error from '../../error';
 import { StripeWebhookHandler } from '../../routes/subscriptions/stripe-webhook';

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -16,7 +16,7 @@ import {
   IpnMerchPmtType,
   isIpnMerchPmt,
   RefundType,
-} from '../../../../../libs/payments/paypal/src';
+} from '@fxa/payments/paypal';
 import { StripeHelper, SUBSCRIPTIONS_RESOURCE } from '../../payments/stripe';
 import { reportSentryError } from '../../sentry';
 import { AuthLogger, AuthRequest } from '../../types';

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../lib/sentry';
 import error from '../../error';
 import { PayPalHelper, RefusedError } from '../../payments/paypal';
-import { RefundType } from '../../../../../libs/payments/paypal/src';
+import { RefundType } from '@fxa/payments/paypal';
 import {
   CUSTOMER_RESOURCE,
   FormattedSubscriptionForEmail,

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -182,7 +182,7 @@
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "esbuild": "^0.17.15",
-    "esbuild-register": "^3.2.0",
+    "esbuild-register": "^3.3.3",
     "eslint": "^7.32.0",
     "fxa-shared": "workspace:*",
     "grunt": "^1.6.1",

--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -101,7 +101,7 @@ DB.connect(config).then(async (db) => {
     const { CurrencyHelper } = require('../lib/payments/currencies');
     const { StripeHelper } = require('../lib/payments/stripe');
     const { PayPalHelper } = require('../lib/payments/paypal');
-    const { PayPalClient } = require('../../../libs/payments/paypal/src');
+    const { PayPalClient } = require('@fxa/payments/paypal');
     const currencyHelper = new CurrencyHelper(config);
     Container.set(CurrencyHelper, currencyHelper);
     const paypalClient = new PayPalClient(

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -9,7 +9,7 @@ import Container from 'typedi';
 import { promisify } from 'util';
 
 import { PayPalHelper } from '../lib/payments/paypal/helper';
-import { PayPalClient } from '../../../libs/payments/paypal/src';
+import { PayPalClient } from '@fxa/payments/paypal';
 import { PaypalProcessor } from '../lib/payments/paypal/processor';
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
 

--- a/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
+++ b/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
@@ -8,7 +8,7 @@ import stripe from 'stripe';
 import Container from 'typedi';
 
 import { CurrencyHelper } from '../lib/payments/currencies';
-import { PayPalClient, RefundType } from '../../../libs/payments/paypal/src';
+import { PayPalClient, RefundType } from '@fxa/payments/paypal';
 import { PayPalHelper } from '../lib/payments/paypal/helper';
 import { STRIPE_INVOICE_METADATA, StripeHelper } from '../lib/payments/stripe';
 import { configureSentry } from '../lib/sentry';

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -6,7 +6,7 @@ cd "$DIR/.."
 export NODE_ENV=dev
 export CORS_ORIGIN="http://foo,http://bar"
 
-DEFAULT_ARGS="--require esbuild-register --recursive --timeout 5000 --exit "
+DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 5000 --exit "
 if [ "$TEST_TYPE" == 'unit' ]; then GREP_TESTS="--grep #integration --invert "; fi;
 if [ "$TEST_TYPE" == 'integration' ]; then GREP_TESTS="--grep #integration "; fi;
 

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -22,7 +22,7 @@ const {
   PayPalNVPError,
   nvpToObject,
   objectToNVP,
-} = require('../../../../../libs/payments/paypal/src');
+} = require('@fxa/payments/paypal');
 const {
   PAYPAL_BILLING_AGREEMENT_INVALID,
   PAYPAL_SOURCE_ERRORS,

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -16,7 +16,7 @@ const {
   RefundType,
   objectToNVP,
   nvpToObject,
-} = require('../../../../../libs/payments/paypal/src');
+} = require('@fxa/payments/paypal');
 const { PayPalHelper, RefusedError } = require('../../../lib/payments/paypal');
 const { mockLog } = require('../../mocks');
 const error = require('../../../lib/error');

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -32,7 +32,7 @@ const { PayPalNotificationHandler } = proxyquire(
 const { PayPalHelper } = require('../../../../lib/payments/paypal/helper');
 const { CapabilityService } = require('../../../../lib/payments/capability');
 
-import { RefundType } from '../../../../../../libs/payments/paypal/src';
+import { RefundType } from '@fxa/payments/paypal';
 import { SUBSCRIPTIONS_RESOURCE } from '../../../../lib/payments/stripe';
 
 const ACCOUNT_LOCALE = 'en-US';

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -48,7 +48,7 @@ const { CapabilityService } = require('../../../../lib/payments/capability');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
 const { asyncIterable } = require('../../../mocks');
 const { RefusedError } = require('../../../../lib/payments/paypal/error');
-const { RefundType } = require('../../../../../../libs/payments/paypal/src');
+const { RefundType } = require('@fxa/payments/paypal');
 
 let config, log, db, customs, push, mailer, profile, mockCapabilityService;
 

--- a/packages/fxa-graphql-api/jest.config.js
+++ b/packages/fxa-graphql-api/jest.config.js
@@ -1,0 +1,19 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig.build.json');
+module.exports = {
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+  modulePaths: ['<rootDir>/../dist/'],
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.spec.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+      },
+    ],
+  },
+  coverageDirectory: './coverage',
+  testEnvironment: 'node',
+};

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -14,13 +14,13 @@
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
     "delete": "pm2 delete pm2.config.js",
-    "test-unit": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --coverage --runInBand --logHeapUsage --forceExit -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
-    "test-integration": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml jest --coverage --runInBand --logHeapUsage -t '#integration' --ci --reporters=default --reporters=jest-junit && yarn test-e2e",
-    "test": "jest --runInBand --logHeapUsage && yarn test-e2e",
+    "test-unit": "npm run build && JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --coverage --runInBand --logHeapUsage --forceExit -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
+    "test-integration": "npm run build && JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml jest --coverage --runInBand --logHeapUsage -t '#integration' --ci --reporters=default --reporters=jest-junit && yarn test-e2e",
+    "test": "npm run build && jest --runInBand --logHeapUsage && yarn test-e2e",
     "test-watch": "jest --watch",
     "test-cov": "jest --coverage",
     "test-debug": "node --inspect-brk -r tsconfig-paths/register -r esbuild-register node_modules/.bin/jest --runInBand --logHeapUsage",
-    "test-e2e": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-e2e.xml jest --runInBand --logHeapUsage --config ./test/jest-e2e.json --ci --reporters=default --reporters=jest-junit",
+    "test-e2e": "npm run build && JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-e2e.xml jest --runInBand --logHeapUsage --config ./test/jest-e2e.config.js --ci --reporters=default --reporters=jest-junit",
     "email-bounce": "node -r esbuild-register ./scripts/email-bounce.ts"
   },
   "repository": {
@@ -100,7 +100,7 @@
     "audit-filter": "^0.5.0",
     "chance": "^1.1.8",
     "esbuild": "^0.17.15",
-    "esbuild-register": "^3.2.0",
+    "esbuild-register": "^3.4.2",
     "eslint": "^7.32.0",
     "jest": "29.3.1",
     "nock": "^13.3.0",
@@ -109,24 +109,5 @@
     "supertest": "^6.3.0",
     "ts-jest": "^29.1.0",
     "typescript": "^4.9.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".spec.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": [
-        "ts-jest",
-        {
-          "isolatedModules": true
-        }
-      ]
-    },
-    "coverageDirectory": "./coverage",
-    "testEnvironment": "node"
   }
 }

--- a/packages/fxa-graphql-api/src/database/database.service.ts
+++ b/packages/fxa-graphql-api/src/database/database.service.ts
@@ -10,7 +10,7 @@ import { Knex } from 'knex';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
-import { setupAccountDatabase } from '../../../../libs/shared/db/mysql/account/src';
+import { setupAccountDatabase } from '@fxa/shared/db/mysql/account';
 import { AppConfig } from '../config';
 
 @Injectable()

--- a/packages/fxa-graphql-api/src/gql/cart.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/cart.resolver.spec.ts
@@ -4,20 +4,20 @@
 import { Provider } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
-import { Logger } from '../../../../libs/shared/log/src';
+import { Logger } from '@fxa/shared/log';
 import {
   CartIdInputFactory,
   SetupCartInputFactory,
   UpdateCartInputFactory,
 } from './lib/factories';
-import { CartManager } from '../../../../libs/payments/cart/src';
+import { CartManager } from '@fxa/payments/cart';
 import { CartResolver } from './cart.resolver';
 const fakeSetupCart = jest.fn();
 const fakeRestartCart = jest.fn();
 const fakeCheckoutCart = jest.fn();
 const fakeUpdateCart = jest.fn();
 
-jest.mock('../../../../libs/payments/cart/src', () => {
+jest.mock('@fxa/payments/cart', () => {
   // Works and lets you check for constructor calls:
   return {
     CartManager: jest.fn().mockImplementation(() => {

--- a/packages/fxa-graphql-api/src/gql/cart.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/cart.resolver.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
-import { Cart } from '../../../../libs/shared/db/mysql/account/src';
+import { Cart } from '@fxa/shared/db/mysql/account';
 import { InvoiceFactory } from './lib/factories';
-import { CartManager } from '../../../../libs/payments/cart/src';
+import { CartManager } from '@fxa/payments/cart';
 import { Cart as CartType } from './model/cart.model';
 import { SetupCartInput } from './dto/input/setup-cart.input';
 import { CartIdInput } from './dto/input/cart-id.input';

--- a/packages/fxa-graphql-api/src/gql/lib/factories.ts
+++ b/packages/fxa-graphql-api/src/gql/lib/factories.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { CartState } from '../../../../../libs/shared/db/mysql/account/src';
+import { CartState } from '@fxa/shared/db/mysql/account';
 import { CartIdInput } from '../dto/input/cart-id.input';
 import { Cart } from '../model/cart.model';
 import { Invoice } from '../model/invoice.model';

--- a/packages/fxa-graphql-api/src/gql/model/cart.model.ts
+++ b/packages/fxa-graphql-api/src/gql/model/cart.model.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql';
-import { CartState } from '../../../../../libs/shared/db/mysql/account/src';
+import { CartState } from '@fxa/shared/db/mysql/account';
 import { TaxAddress } from './tax-address.model';
 import { Invoice } from './invoice.model';
 

--- a/packages/fxa-graphql-api/test/jest-e2e.config.js
+++ b/packages/fxa-graphql-api/test/jest-e2e.config.js
@@ -1,0 +1,13 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('../tsconfig.build.json');
+module.exports = {
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+  modulePaths: ['<rootDir>/../dist/'],
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testEnvironment: 'node',
+  testRegex: '.e2e-spec.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': ['ts-jest', { isolatedModules: true }],
+  },
+};

--- a/packages/fxa-graphql-api/test/jest-e2e.json
+++ b/packages/fxa-graphql-api/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": [ "ts-jest", { "isolatedModules": true } ]
-  }
-}

--- a/packages/fxa-graphql-api/tsconfig.build.json
+++ b/packages/fxa-graphql-api/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"],
+  "compilerOptions": {
+    "paths": {
+      "@fxa/shared/db/mysql/account": [
+        "libs/shared/db/mysql/account/src/index"
+      ],
+      "@fxa/payments/cart": ["libs/payments/cart/src/index"],
+      "@fxa/shared/log": ["libs/shared/log/src/index"]
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26851,7 +26851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-register@npm:^3.4.0":
+"esbuild-register@npm:^3.3.3, esbuild-register@npm:^3.4.0, esbuild-register@npm:^3.4.2":
   version: 3.4.2
   resolution: "esbuild-register@npm:3.4.2"
   dependencies:
@@ -30125,7 +30125,7 @@ fsevents@~2.1.1:
     email-addresses: 4.0.0
     emittery: ^0.13.1
     esbuild: ^0.17.15
-    esbuild-register: ^3.2.0
+    esbuild-register: ^3.3.3
     eslint: ^7.32.0
     fxa-customs-server: "workspace:*"
     fxa-geodb: "workspace:*"
@@ -30592,7 +30592,7 @@ fsevents@~2.1.1:
     convict-format-with-moment: ^6.2.0
     convict-format-with-validator: ^6.2.0
     esbuild: ^0.17.15
-    esbuild-register: ^3.2.0
+    esbuild-register: ^3.4.2
     eslint: ^7.32.0
     eslint-config-react-app: ^7.0.1
     express: ^4.17.3


### PR DESCRIPTION
## Because

- we want to be able to use packagename based imports, defined in
  tsconfig.base.json paths, throughout the repo.

## This pull request

- Adds a workaround fix to libs/**/project.json > main properties to
  ensure that the built dist/libs/**/.package.json has the correct
  main property.
- Upgrades esbuild-register to latest version, which includes
  tsconfig path resolution.
- Adds tsconfig-paths to auth-server mocha based tests.
- Adds various workarounds to [fxa-graphql-api](https://mozilla-hub.atlassian.net/browse/FXA-graphql-api) including the following
  - Adds paths from `tsconfig.base.json` to `tsconfig.build.json`
    excluding the extension.
  - Add pathToModuleNameMapper to all jest*.config.js
  - Add build step before tests are run

## Issue that this pull request solves

Closes: #FXA-8119

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).