### PR TITLE
chore(auth&payments): Remove feature flag

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -903,14 +903,6 @@ const convictConf = convict({
       format: String,
       doc: 'Stripe API key for direct Stripe integration',
     },
-    stripeInvoiceImmediately: {
-      enabled: {
-        default: false,
-        doc: 'Enables immediate invoicing for stripe in all subscription upgrades',
-        env: 'SUBSCRIPTIONS_STRIPE_INVOICE_IMMEDIATELY',
-        format: Boolean,
-      },
-    },
     stripeWebhookPayloadLimit: {
       default: 1048576,
       env: 'STRIPE_WEBHOOK_PAYLOAD_LIMIT',

--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -4,7 +4,6 @@
 import * as invoiceDTO from 'fxa-shared/dto/auth/payments/invoice';
 import { InvoicePreview } from 'fxa-shared/subscriptions/types';
 import { Stripe } from 'stripe';
-import { config } from '../../config';
 
 /**
  * Formats a Stripe Invoice to the FirstInvoicePreview DTO format.
@@ -51,10 +50,7 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
     };
   }
 
-  if (
-    invoice[1] &&
-    config.getProperties().subscriptions.stripeInvoiceImmediately
-  ) {
+  if (invoice[1]) {
     const proration = invoice[1].lines.data.find(
       (lineItem) => lineItem.proration
     );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -14,8 +14,6 @@ subscriptionUpgrade-upgrade-info = You have successfully upgraded from { $produc
 # $productPaymentCycleNew (String) - The interval of time from the end of one payment statement date to the next payment statement date of the new subscription, e.g. month
 # $productPaymentCycleOld (String) - The interval of time from the end of one payment statement date to the next payment statement date of the old subscription, e.g. month
 # $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
-# remove subscriptionUpgrade-content-charge-info in FXA-7796; additionally remove in subscriptionUpgrade/index.txt
-subscriptionUpgrade-content-charge-info = Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycleOld } to { $paymentAmountNew } per { $productPaymentCycleNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycleOld }.
 subscriptionUpgrade-content-charge-info-different-cycle = You will be charged a one-time fee of { $paymentProrated } to reflect your subscription’s higher price for the remainder of this { $productPaymentCycleOld }. Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycleOld } to { $paymentAmountNew } per { $productPaymentCycleNew }.
 
 # Variables:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -9,22 +9,15 @@
     <mj-text css-class="text-header">
       <span data-l10n-id="subscriptionUpgrade-title">Thank you for upgrading!</span>
     </mj-text>
-  </mj-column>
-</mj-section>
 
-<mj-section>
-  <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionUpgrade-upgrade-info" data-l10n-args="<%= JSON.stringify({productName, productNameOld}) %>">You have successfully upgraded from <%- productNameOld %> to <%- productName %>.</span>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <% if (!locals.invoiceImmediately && locals.productPaymentCycleOld === locals.productPaymentCycleNew) { %>
-        <span data-l10n-id="subscriptionUpgrade-content-charge-info" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>.</span>
-      <% } else { %>
-        <span data-l10n-id="subscriptionUpgrade-content-charge-info-different-cycle" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>.</span>
-      <% } %>
+      <span data-l10n-id="subscriptionUpgrade-content-charge-info-different-cycle" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycleNew, productPaymentCycleOld}) %>">You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>.</span>
     </mj-text>
+
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionUpgrade-install" data-l10n-args="<%= JSON.stringify({productName}) %>">If there is new software for you to install in order to use <%- productName %>, you will receive a separate email with download instructions.</span>
     </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
@@ -29,20 +29,3 @@ const createStory = subplatStoryWithProps(
 );
 
 export const Default = createStory();
-
-// remove in FXA-7796
-export const SubscriptionUpgradeDifferentBillingCycle = createStory(
-  {},
-  'Subscription upgrade - differnt billing cycle'
-);
-
-// remove in FXA-7796
-export const SubscriptionUpgradeSameBillingCycle = createStory(
-  {
-    paymentAmountNew: '£123,121.00',
-    paymentAmountOld: '¥99,991',
-    productPaymentCycleNew: 'month',
-    paymentProrated: '$5,231.00',
-  },
-  'Subscription upgrade - same billing cycle'
-);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
@@ -4,7 +4,7 @@ subscriptionUpgrade-title = "Thank you for upgrading!"
 
 subscriptionUpgrade-upgrade-info = "You have successfully upgraded from <%- productNameOld %> to <%- productName %>."
 
-<% if (locals.productPaymentCycleOld === locals.productPaymentCycleNew) { %>subscriptionUpgrade-content-charge-info = "Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycleOld %>."<% } else { %>subscriptionUpgrade-content-charge-info-different-cycle = "You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>."<% } %>
+subscriptionUpgrade-content-charge-info-different-cycle = "You will be charged a one-time fee of <%- paymentProrated %> to reflect your subscription’s higher price for the remainder of this <%- productPaymentCycleOld %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycleOld %> to <%- paymentAmountNew %> per <%- productPaymentCycleNew %>."
 
 subscriptionUpgrade-install = "If there is new software for you to install in order to use <%- productName %>, you will receive a separate email with download instructions."
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -2300,7 +2300,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ]), {updateTemplateValues: x => (
     {...x, discountType: 'repeating', discountDuration: 3})}
   ],
-  // subscription upgrade email for different billing cycle
+
   ['subscriptionUpgradeEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
     ['headers', new Map([
@@ -2332,39 +2332,6 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]]
   ]), {updateTemplateValues: x => (
     {...x, productName: MESSAGE.productNameNew })}
-  ],
-  // subscription upgrade email for same billing cycle
-  ['subscriptionUpgradeEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
-    ['headers', new Map([
-      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionUpgrade') }],
-      ['X-Template-Name', { test: 'equal', expected: 'subscriptionUpgrade' }],
-      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionUpgrade }],
-    ])],
-    ['html', [
-      { test: 'include', expected: `You have upgraded to ${MESSAGE.productNameNew}` },
-      { test: 'include', expected: 'Thank you for upgrading!' },
-      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-upgrade', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
-      { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-upgrade', 'subscription-terms')) },
-      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
-      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycleOld} to ${MESSAGE_FORMATTED.paymentAmountNew} per ${MESSAGE.productPaymentCycleOld}.` },
-      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
-      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
-      { test: 'notInclude', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect your subscription’s higher price for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
-      { test: 'notInclude', expected: 'utm_source=email' },
-    ]],
-    ['text', [
-      { test: 'include', expected: `You have upgraded to ${MESSAGE.productNameNew}` },
-      { test: 'include', expected: 'Thank you for upgrading!' },
-      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
-      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycleOld} to ${MESSAGE_FORMATTED.paymentAmountNew} per ${MESSAGE.productPaymentCycleOld}.` },
-      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
-      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
-      { test: 'notInclude', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect your subscription’s higher price for the remainder of this ${MESSAGE.productPaymentCycleOld}.` },
-      { test: 'notInclude', expected: 'utm_source=email' },
-    ]]
-  ]), {updateTemplateValues: x => (
-    {...x, productName: MESSAGE.productNameNew, productPaymentCycleNew: MESSAGE.productPaymentCycleOld })}
   ],
 
   // Template partial specific tests (choose a template containing the partial)

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -24,12 +24,6 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_STRIPE_TAX_ENABLED',
       format: Boolean,
     },
-    useStripeInvoiceImmediately: {
-      default: false,
-      doc: 'Enables immediate invoicing for stripe in all subscription upgrades',
-      env: 'SUBSCRIPTIONS_STRIPE_INVOICE_IMMEDIATELY',
-      format: Boolean,
-    }
   },
   amplitude: {
     enabled: {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -44,7 +44,6 @@ export const PlanUpgradeDetails = ({
   const role = isMobile ? undefined : 'complementary';
 
   const showTax = config.featureFlags.useStripeAutomaticTax;
-  const invoiceImmediately = config.featureFlags.useStripeInvoiceImmediately;
 
   const exclusiveTaxRates =
     invoicePreview.tax?.filter(
@@ -77,26 +76,20 @@ export const PlanUpgradeDetails = ({
         {showTax && !!subTotal && !!exclusiveTaxRates.length && (
           <>
             <div className="plan-details-item">
-              {invoiceImmediately ? (
-                <Localized
-                  id={`sub-update-new-plan-${formattedInterval}`}
-                  vars={{
-                    productName: productDetails.name || product_name,
-                  }}
-                >
-                  <div>
-                    {productDetails.name || product_name} (
-                    {formattedInterval.replace(/\w/, (firstLetter) =>
-                      firstLetter.toUpperCase()
-                    )}
-                    )
-                  </div>
-                </Localized>
-              ) : (
-                <Localized id="plan-details-list-price">
-                  <div>List Price</div>
-                </Localized>
-              )}
+              <Localized
+                id={`sub-update-new-plan-${formattedInterval}`}
+                vars={{
+                  productName: productDetails.name || product_name,
+                }}
+              >
+                <div data-testid={`sub-update-new-plan-${formattedInterval}`}>
+                  {productDetails.name || product_name} (
+                  {formattedInterval.replace(/\w/, (firstLetter) =>
+                    firstLetter.toUpperCase()
+                  )}
+                  )
+                </div>
+              </Localized>
 
               <PriceDetails
                 total={subTotal}
@@ -150,13 +143,18 @@ export const PlanUpgradeDetails = ({
           </div>
         )}
 
-        {invoiceImmediately && oneTimeCharge && (
+        {oneTimeCharge && (
           <>
             <hr className="m-0 my-5 unit-row-hr" />
 
             <div className="plan-details-item font-semibold mt-5">
               <Localized id="sub-update-prorated-upgrade">
-                <div className="total-label">Prorated Upgrade</div>
+                <div
+                  className="total-label"
+                  data-testid="sub-update-prorated-upgrade"
+                >
+                  Prorated Upgrade
+                </div>
               </Localized>
 
               <PriceDetails

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/en.ftl
@@ -2,10 +2,6 @@
 
 product-plan-change-heading = Review your change
 sub-change-failed = Plan change failed
-sub-update-copy =
-    Your plan will change immediately, and you’ll be charged an adjusted
-    amount for the rest of your billing cycle. Starting { $startingDate }
-    you’ll be charged the full amount.
 sub-update-acknowledgment =
     Your plan will change immediately, and you’ll be charged a prorated
     amount today for the rest of this billing cycle. Starting { $startingDate }

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -148,7 +148,6 @@ export const Default = storyWithContext({
       ...defaultAppContext.config,
       featureFlags: {
         useStripeAutomaticTax: true,
-        useStripeInvoiceImmediately: true,
       },
     },
   },
@@ -167,7 +166,6 @@ export const DefaultWithInclusiveTax = storyWithContext({
       ...defaultAppContext.config,
       featureFlags: {
         useStripeAutomaticTax: true,
-        useStripeInvoiceImmediately: true,
       },
     },
   },
@@ -186,7 +184,6 @@ export const DefaultWithExclusiveTax = storyWithContext({
       ...defaultAppContext.config,
       featureFlags: {
         useStripeAutomaticTax: true,
-        useStripeInvoiceImmediately: true,
       },
     },
   },
@@ -205,7 +202,6 @@ export const MultipleWithExclusiveTax = storyWithContext({
       ...defaultAppContext.config,
       featureFlags: {
         useStripeAutomaticTax: true,
-        useStripeInvoiceImmediately: true,
       },
     },
   },
@@ -221,9 +217,6 @@ export const LocalizedToPirate = storyWithContext({
     navigatorLanguages: ['xx-pirate'],
     config: {
       ...defaultAppContext.config,
-      featureFlags: {
-        useStripeInvoiceImmediately: true,
-      },
     },
   },
 });
@@ -241,9 +234,6 @@ export const Submitting = storyWithContext({
     ...defaultAppContext,
     config: {
       ...defaultAppContext.config,
-      featureFlags: {
-        useStripeInvoiceImmediately: true,
-      },
     },
   },
 });
@@ -265,9 +255,6 @@ export const InternalServerError = storyWithContext({
     ...defaultAppContext,
     config: {
       ...defaultAppContext.config,
-      featureFlags: {
-        useStripeInvoiceImmediately: true,
-      },
     },
   },
 });

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -44,7 +44,7 @@ import {
   getLocalizedDateString,
 } from '../../../lib/formats';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
-import { config, updateConfig } from '../../../lib/config';
+import { updateConfig } from '../../../lib/config';
 import { deepCopy } from '../../../lib/test-utils';
 
 jest.mock('../../../lib/sentry');
@@ -100,30 +100,29 @@ async function rendersAsExpected(
   expect(queryByTestId('plan-upgrade-subtotal')).not.toBeInTheDocument();
   expect(queryByTestId('plan-upgrade-tax-amount')).not.toBeInTheDocument();
 
-  if (config.featureFlags.useStripeInvoiceImmediately) {
-    expect(queryByTestId('sub-update-acknowledgment')).toHaveTextContent(
-      expectedInvoiceDate
-    );
+  expect(queryByTestId('sub-update-acknowledgment')).toHaveTextContent(
+    expectedInvoiceDate
+  );
+
+  // <Product Name (Interval)> (e.g. Better Upgrade Product (Monthly))
+  // only appears when there is exclusive tax
+  if (
+    invoicePreview?.subtotal_excluding_tax ||
+    invoicePreview?.total_excluding_tax
+  ) {
     expect(
       queryByTestId(`sub-update-new-plan-${selectedPlan.interval}`)
     ).toBeInTheDocument();
+  }
 
-    if (
-      !!invoicePreview.one_time_charge &&
-      invoicePreview.one_time_charge > 0
-    ) {
-      expect(queryByTestId('sub-update-prorated-upgrade')).toBeInTheDocument();
-      expect(queryByTestId('prorated-amount')).toBeInTheDocument();
-    } else {
-      expect(
-        queryByTestId('sub-update-prorated-upgrade')
-      ).not.toBeInTheDocument();
-      expect(queryByTestId('prorated-amount')).not.toBeInTheDocument();
-    }
+  if (!!invoicePreview.one_time_charge && invoicePreview.one_time_charge > 0) {
+    expect(queryByTestId('sub-update-prorated-upgrade')).toBeInTheDocument();
+    expect(queryByTestId('prorated-amount')).toBeInTheDocument();
   } else {
-    expect(queryByTestId('sub-update-copy')).toHaveTextContent(
-      expectedInvoiceDate
-    );
+    expect(
+      queryByTestId('sub-update-prorated-upgrade')
+    ).not.toBeInTheDocument();
+    expect(queryByTestId('prorated-amount')).not.toBeInTheDocument();
   }
 }
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -1,11 +1,10 @@
-import React, { useCallback, useEffect, useState, useContext } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Localized } from '@fluent/react';
 
 import { Plan, Customer, Profile } from '../../../store/types';
 import { SelectorReturns } from '../../../store/selectors';
 
 import * as Amplitude from '../../../lib/amplitude';
-import AppContext from '../../../lib/AppContext';
 
 import { getLocalizedDate, getLocalizedDateString } from '../../../lib/formats';
 import { useCallbackOnce } from '../../../lib/hooks';
@@ -61,7 +60,6 @@ export const SubscriptionUpgrade = ({
   resetUpdateSubscriptionPlan,
   discount,
 }: SubscriptionUpgradeProps) => {
-  const { config } = useContext(AppContext);
   const ariaLabelledBy = 'error-plan-change-failed-header';
   const ariaDescribedBy = 'error-plan-change-failed-description';
   const validator = useValidatorState();
@@ -201,35 +199,21 @@ export const SubscriptionUpgrade = ({
             {...{ validator, onSubmit }}
           >
             <hr className="my-6" />
-            {config.featureFlags.useStripeInvoiceImmediately ? (
-              <Localized
-                id="sub-update-acknowledgment"
-                vars={{
-                  startingDate: getLocalizedDate(nextInvoiceDate),
-                }}
-              >
-                <p data-testid="sub-update-acknowledgment">
-                  Your plan will change immediately, and you’ll be charged a
-                  prorated amount today for the rest of this billing cycle.
-                  Starting {getLocalizedDateString(nextInvoiceDate)} you’ll be
-                  charged the full amount.
-                </p>
-              </Localized>
-            ) : (
-              <Localized
-                id="sub-update-copy"
-                vars={{
-                  startingDate: getLocalizedDate(nextInvoiceDate),
-                }}
-              >
-                <p data-testid="sub-update-copy">
-                  Your plan will change immediately, and you’ll be charged an
-                  adjusted amount for the rest of your billing cycle. Starting
-                  {getLocalizedDateString(nextInvoiceDate)} you’ll be charged
-                  the full amount.
-                </p>
-              </Localized>
-            )}
+
+            <Localized
+              id="sub-update-acknowledgment"
+              vars={{
+                startingDate: getLocalizedDate(nextInvoiceDate),
+              }}
+            >
+              <p data-testid="sub-update-acknowledgment">
+                Your plan will change immediately, and you’ll be charged a
+                prorated amount today for the rest of this billing cycle.
+                Starting {getLocalizedDateString(nextInvoiceDate)} you’ll be
+                charged the full amount.
+              </p>
+            </Localized>
+
             <hr className="my-6" />
 
             <PaymentConsentCheckbox

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -82,9 +82,6 @@ export type StripeHelperConfig = {
     productConfigsFirestore: {
       enabled: boolean;
     };
-    stripeInvoiceImmediately: {
-      enabled: boolean;
-    };
   };
   authFirestore: {
     prefix: string;


### PR DESCRIPTION
## Because

- Enhanced Subscription Upgrade Experience is complete

## This pull request

- Removes the Stripe invoice immediately feature flag and all references and conditions in both auth and payments servers

## Issue that this pull request solves

Closes: [FXA-7796](https://mozilla-hub.atlassian.net/browse/FXA-7796)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

[FXA-7796]: https://mozilla-hub.atlassian.net/browse/FXA-7796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ