### PR TITLE
task(settings): Use form component in ThirdpartyAuth component

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.stories.tsx
@@ -18,7 +18,7 @@ export default {
 export const Default = () => {
   return (
     <AppLayout>
-      <Subject enabled />
+      <Subject enabled showSeparator />
     </AppLayout>
   );
 };
@@ -26,7 +26,15 @@ export const Default = () => {
 export const Disabled = () => {
   return (
     <AppLayout>
-      <Subject />
+      <Subject showSeparator />
+    </AppLayout>
+  );
+};
+
+export const NoSeparator = () => {
+  return (
+    <AppLayout>
+      <Subject enabled showSeparator={false} />
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -12,10 +12,105 @@ function renderWith(props?: any) {
   return renderWithLocalizationProvider(<Subject {...props} />);
 }
 
-describe('ThirdPartyAuth component', () => {
-  it('renders as expected', async () => {
-    renderWith({ enabled: true });
-    expect(screen.getByText('Continue with Google')).toBeInTheDocument();
-    expect(screen.getByText('Continue with Apple')).toBeInTheDocument();
+const mockFormSubmit = jest.fn();
+
+describe('ThirdPartyAuthComponent', () => {
+  // Form submission not supported in jest test. Instead, prevent the submission
+  // and illustrate a 'short circuit' operation.
+  const onSubmit = (e: any) => {
+    e.preventDefault();
+    return false;
+  };
+  const onContinueWithApple = jest.fn().mockImplementation(onSubmit);
+  const onContinueWithGoogle = jest.fn().mockImplementation(onSubmit);
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders', async () => {
+    renderWith({
+      enabled: true,
+    });
+
+    await screen.findByText('Continue with Google');
+    await screen.findByText('Continue with Apple');
+    expect(mockFormSubmit).not.toBeCalled();
+
+    expect(
+      (await screen.findByTestId('google-signin-form-state')).getAttribute(
+        'value'
+      )
+    ).toEqual('');
+
+    expect(
+      (await screen.findByTestId('apple-signin-form-state')).getAttribute(
+        'value'
+      )
+    ).toEqual('');
+  });
+
+  it('submits apple form', async () => {
+    renderWith({
+      enabled: true,
+      showSeparator: true,
+      onContinueWithApple,
+      onContinueWithGoogle,
+    });
+
+    const button = await screen.findByText('Continue with Apple');
+    button.click();
+
+    // Ensure the hidden input for state was updated.
+    expect(
+      (await screen.findByTestId('apple-signin-form-state')).getAttribute(
+        'value'
+      )
+    ).not.toEqual('');
+    expect(onContinueWithApple).toBeCalled();
+    expect(onContinueWithGoogle).not.toBeCalled();
+  });
+
+  it('submits google form', async () => {
+    renderWith({
+      enabled: true,
+      showSeparator: true,
+      onContinueWithApple,
+      onContinueWithGoogle,
+    });
+
+    const button = await screen.findByText('Continue with Google');
+    button.click();
+
+    // Ensure the hidden input for state was updated.
+    expect(
+      (await screen.findByTestId('google-signin-form-state')).getAttribute(
+        'value'
+      )
+    ).not.toEqual('');
+    expect(onContinueWithGoogle).toBeCalled();
+    expect(onContinueWithApple).not.toBeCalled();
+  });
+
+  it('hides separator', async () => {
+    renderWith({
+      enabled: true,
+      showSeparator: false,
+      onContinueWithApple,
+      onContinueWithGoogle,
+    });
+
+    expect(screen.queryByText('Or')).toBeNull();
+  });
+
+  it('shows separator', async () => {
+    renderWith({
+      enabled: true,
+      showSeparator: true,
+      onContinueWithApple,
+      onContinueWithGoogle,
+    });
+
+    expect(screen.queryByText('Or')).toBeDefined();
   });
 });

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/mocks.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/mocks.tsx
@@ -12,7 +12,7 @@ export const Subject = (props: ThirdPartyAuthProps) => {
   return (
     <AppContext.Provider value={mockAppContext()}>
       <LocationProvider>
-        <ThirdPartyAuth {...props} />;
+        <ThirdPartyAuth {...props} />
       </LocationProvider>
     </AppContext.Provider>
   );


### PR DESCRIPTION
## Because

- We wanted the code in the third party auth to use react conventions

## This pull request
- Creates a third party sign in form that is rendered.
- Submits this form when click 'continueWith' buttons.

## Issue that this pull request solves

Closes: FXA-7319

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This component is not accessible via manual testing, because the routes for this have not yet been enabled, but it ca be manually tested in storybook.
