### PR TITLE
fix(auth): fix path resolution for local tests

### DIFF
--- a/packages/fxa-auth-server/scripts/test-local.sh
+++ b/packages/fxa-auth-server/scripts/test-local.sh
@@ -12,7 +12,7 @@ if [ -z "$FIRESTORE_EMULATOR_HOST" ]; then export FIRESTORE_EMULATOR_HOST="local
 if [ "$TEST_TYPE" == 'unit' ]; then GREP_TESTS="--grep #integration --invert "; fi;
 if [ "$TEST_TYPE" == 'integration' ]; then GREP_TESTS="--grep #integration "; fi;
 
-DEFAULT_ARGS="--require esbuild-register --recursive --timeout 5000 --exit"
+DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 5000 --exit"
 
 if [[ ! -e config/secret-key.json ]]; then
   node -r esbuild-register ./scripts/gen_keys.js


### PR DESCRIPTION
## Because

- Auth server tests run locally are failing with "Cannot find module" error.

## This pull request

- Add tsconfig-paths to arguments used by mocha tests.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

