### PR TITLE
chore(react): Update local.json-dist for React routes, remove console log

### DIFF
--- a/packages/functional-tests/scripts/start-services.sh
+++ b/packages/functional-tests/scripts/start-services.sh
@@ -21,6 +21,7 @@ CI=true yarn workspaces foreach \
     --include fxa-profile-server \
     --include fxa-settings \
     run start > ~/.pm2/logs/startup.log
+    #start service finished
 
 # stop services that aren't needed. These are 'watching' services, and they just
 # consume memory. Ideally, we wouldn't even start these, but they are baked into

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -50,7 +50,10 @@
     "count": 3
   },
   "showReactApp": {
-    "simpleRoutes": true
+    "simpleRoutes": true,
+    "resetPasswordRoutes": true,
+    "signUpRoutes": true,
+    "signInRoutes": true,
   },
   "featureFlags": {
     "showRecoveryKeyV2": true

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -159,8 +159,6 @@ const AuthAndAccountSetupRoutes = (_: RouteComponentProps) => {
   const localAccount = currentAccount();
   const integration = useIntegration();
 
-  console.log('integration! in app', integration);
-
   return (
     <Router>
       <WebChannelExample path="/web_channel_example/*" />


### PR DESCRIPTION
Because:
* We've rolled out React reset PW routes and are working on signup and signin and don't wish to reset the config after every yarn install

This commit:
* Turns resetPasswordRoutes, signUpRoutes, and signInRoutes 'on' for local dev
* Removes stray console log