### PR TITLE
fix(payments): record checkout "engage" event for consent checkbox

### DIFF
--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -59,6 +59,7 @@ import {
 } from '../../lib/apiClient';
 import { ButtonBaseProps } from '../../components/PayPalButton';
 import { ReactGALog } from '../../lib/reactga-event';
+import { createSubscriptionEngaged } from '../../lib/amplitude';
 
 jest.mock('../../lib/apiClient', () => {
   return {
@@ -94,6 +95,8 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('../../lib/reactga-event.ts');
+
+jest.mock('../../lib/amplitude');
 
 describe('routes/Checkout', () => {
   let authServer = '';
@@ -217,6 +220,16 @@ describe('routes/Checkout', () => {
 
     const couponEl = getByTestId('coupon-component');
     expect(couponEl).toBeInTheDocument();
+  });
+
+  it('records an "engage" funnel event when the consent checkbox is clicked', async () => {
+    renderWithLocalizationProvider(<Subject />);
+    const { findByTestId } = screen;
+    const checkbox = await findByTestId('confirm');
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+    expect(createSubscriptionEngaged).toBeCalledTimes(1);
   });
 
   it('displays checkbox tooltip error when unchecking checkbox', async () => {

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 
 import { AppContext } from '../../lib/AppContext';
 import {
+  useCallbackOnce,
   useMatchMedia,
   useNonce,
   usePaypalButtonSetup,
@@ -160,14 +161,14 @@ export const Checkout = ({
     [productId, planId, plansByProductId]
   );
 
-  const onFormMounted = useCallback(() => {
+  const onFormMounted = useCallbackOnce(() => {
     Amplitude.createSubscriptionMounted({
       ...selectedPlan,
       checkoutType: CheckoutType.WITHOUT_ACCOUNT,
     });
   }, [selectedPlan]);
 
-  const onFormEngaged = useCallback(() => {
+  const onFormEngaged = useCallbackOnce(() => {
     Amplitude.createSubscriptionEngaged({
       ...selectedPlan,
       checkoutType: CheckoutType.WITHOUT_ACCOUNT,
@@ -439,6 +440,7 @@ export const Checkout = ({
           <PaymentMethodHeader
             plan={selectedPlan}
             onClick={() => {
+              onFormEngaged();
               setCheckboxSet(!checkboxSet);
               setShowTooltip(false);
             }}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../lib/test-utils';
 import { PickPartial } from '../../../lib/types';
 import { ReactGALog } from '../../../lib/reactga-event';
+import { createSubscriptionEngaged } from '../../../lib/amplitude';
 
 jest.mock('../../../lib/hooks', () => {
   const refreshNonceMock = jest.fn().mockImplementation(Math.random);
@@ -48,6 +49,8 @@ jest.mock('../../../lib/hooks', () => {
 });
 
 jest.mock('../../../lib/reactga-event');
+
+jest.mock('../../../lib/amplitude');
 
 type SubjectProps = PickPartial<
   SubscriptionCreateProps,
@@ -150,6 +153,16 @@ describe('routes/Product/SubscriptionCreate', () => {
       )
     ).toBeInTheDocument();
     expect(queryByTestId('coupon-component')).toBeInTheDocument();
+  });
+
+  it('records an "engage" funnel event when the consent checkbox is clicked', async () => {
+    renderWithLocalizationProvider(<Subject />);
+    const { findByTestId } = screen;
+    const checkbox = await findByTestId('confirm');
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+    expect(createSubscriptionEngaged).toBeCalledTimes(1);
   });
 
   it('displays checkbox tooltip error when unchecking checkbox', async () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -3,7 +3,11 @@ import classNames from 'classnames';
 import { Plan, Profile, Customer } from '../../../store/types';
 import { State as ValidatorState } from '../../../lib/validator';
 
-import { useNonce, usePaypalButtonSetup } from '../../../lib/hooks';
+import {
+  useCallbackOnce,
+  useNonce,
+  usePaypalButtonSetup,
+} from '../../../lib/hooks';
 
 import PlanDetails from '../../../components/PlanDetails';
 import Header from '../../../components/Header';
@@ -97,7 +101,7 @@ export const SubscriptionCreate = ({
   const [checkboxSet, setCheckboxSet] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const onFormMounted = useCallback(
+  const onFormMounted = useCallbackOnce(
     () =>
       Amplitude.createSubscriptionMounted({
         ...selectedPlan,
@@ -106,7 +110,7 @@ export const SubscriptionCreate = ({
     [checkoutType, selectedPlan]
   );
 
-  const onFormEngaged = useCallback(
+  const onFormEngaged = useCallbackOnce(
     () =>
       Amplitude.createSubscriptionEngaged({
         ...selectedPlan,
@@ -305,6 +309,7 @@ export const SubscriptionCreate = ({
           <PaymentMethodHeader
             plan={selectedPlan}
             onClick={() => {
+              onFormEngaged();
               setCheckboxSet(!checkboxSet);
               setShowTooltip(false);
             }}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -284,7 +284,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
     expect(getByText(expectedMessage)).toBeInTheDocument();
   });
 
-  it('calls updateSubscriptionPlanMounted and updateSubscriptionPlanEngaged', async () => {
+  it('records an "engage" funnel event when the consent checkbox is clicked', async () => {
     const { findByTestId, getByTestId } = renderWithLocalizationProvider(
       <Subject />
     );


### PR DESCRIPTION
Because:
* We are seeing fewer "engage" events relative to "submit", even though "engage" occurs upstream in the conversion funnel.
* We were not recording an "engage" event for clicking the consent checkbox.
* This is the only form field present in all scenarios and checkout flows on the payments server, so it likely makes up the majority of the missed events across all flows.

This commit:

* Records the "fxa_pay_setup - engage" event when clicking the consent checkbox.

Closes #FXA-7941

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
