### PR TITLE
chore(react): Update local.json-dist for React routes, remove console log

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -50,7 +50,10 @@
     "count": 3
   },
   "showReactApp": {
-    "simpleRoutes": true
+    "simpleRoutes": true,
+    "resetPasswordRoutes": true,
+    "signUpRoutes": true,
+    "signInRoutes": true
   },
   "featureFlags": {
     "showRecoveryKeyV2": true

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -159,8 +159,6 @@ const AuthAndAccountSetupRoutes = (_: RouteComponentProps) => {
   const localAccount = currentAccount();
   const integration = useIntegration();
 
-  console.log('integration! in app', integration);
-
   return (
     <Router>
       <WebChannelExample path="/web_channel_example/*" />


### PR DESCRIPTION
Because:
* We've rolled out React reset PW routes and are working on signup and signin and don't wish to reset the config after every yarn install

This commit:
* Turns resetPasswordRoutes, signUpRoutes, and signInRoutes 'on' for local dev
* Removes stray console log

--

No idea why #15673 keeps failing to start playwright tests but #15683 is passing with same changes (... just noticed Ankita's doesn't have a trailing comma though? Is that it? 😅) so just opening another PR for it.