### PR TITLE
bug(ci): Broken ci image build

### DIFF
--- a/_dev/docker/ci/Dockerfile
+++ b/_dev/docker/ci/Dockerfile
@@ -26,7 +26,7 @@ ENV YARN_CHECKSUM_BEHAVIOR=throw
 ENV FXA_AUTO_INSTALL=0
 RUN _scripts/l10n/clone.sh
 RUN yarn install --immutable; \
-    yarn gql:allowlist \
+    yarn gql:allowlist; \
     yarn workspaces foreach \
         -pv \
         --topological-dev \


### PR DESCRIPTION
## Because

- Deploy ci image was failing

## This pull request

- Adds a missing ';'

## Other information (Optional)
Noticed while poking around circleci pipelines.
