### PR TITLE
Revert "chore(ci): use large instances for functional tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -810,7 +810,7 @@ workflows:
             - Build (PR)
       - playwright-functional-tests:
           name: Functional Tests - Playwright (PR)
-          resource_class: large
+          resource_class: xlarge
           requires:
             - Build (PR)
       - build-and-deploy-storybooks:
@@ -999,7 +999,7 @@ workflows:
             - Build
       - playwright-functional-tests:
           name: Functional Tests - Playwright
-          resource_class: large
+          resource_class: xlarge
           filters:
             branches:
               ignore: /.*/
@@ -1095,7 +1095,7 @@ workflows:
             - Build (nightly)
       - playwright-functional-tests:
           name: Functional Tests - Playwright (nightly)
-          resource_class: large
+          resource_class: xlarge
           requires:
             - Build (nightly)
       - on-complete:


### PR DESCRIPTION
Reverts mozilla/fxa#15679

I think this is causing flakiness in several functional tests.