### PR TITLE
fix(metrics): await Glean submissions

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -19,6 +19,7 @@ import {
 } from '../../../scripts/lib/glean/session';
 import * as utm from '../../../scripts/lib/glean/utm';
 import sinon from 'sinon';
+import { assert } from 'chai';
 
 const sandbox = sinon.createSandbox();
 const mockConfig = {
@@ -225,6 +226,52 @@ describe('lib/glean', () => {
       sinon.assert.calledWith(setUtmTermStub, mockFlowEventMetadata.utmTerm);
     });
 
+    it('submits the pings in order', async () => {
+      // the await is on populating the metrics so we'll give a different value
+      // for a metric on each ping
+
+      userAgent.genericDeviceType = sandbox
+        .stub()
+        .onFirstCall()
+        .returns('phone')
+        .onSecondCall()
+        .returns('blade')
+        .onThirdCall()
+        .returns('bananaphone');
+
+      // not await on these calls
+      GleanMetrics.registration.view();
+      GleanMetrics.registration.submit();
+      GleanMetrics.registration.success();
+
+      // the ping submissions are await'd internally in GleanMetrics...
+      await new Promise((resovle) =>
+        setTimeout(() => {
+          sinon.assert.calledWithExactly(setDeviceTypeStub.getCall(0), 'phone');
+          sinon.assert.calledWithExactly(setDeviceTypeStub.getCall(1), 'blade');
+          sinon.assert.calledWithExactly(
+            setDeviceTypeStub.getCall(2),
+            'bananaphone'
+          );
+
+          // more importantly the set name call is after the await of the ping
+          // ahead of it...
+          assert.isTrue(
+            setDeviceTypeStub
+              .getCall(0)
+              .calledBefore(setEventNameStub.getCall(1))
+          );
+          assert.isTrue(
+            setDeviceTypeStub
+              .getCall(1)
+              .calledBefore(setEventNameStub.getCall(2))
+          );
+
+          resovle();
+        }, 150)
+      );
+    });
+
     describe('hashed uid', async () => {
       let accountGetterStub;
       beforeEach(() => {
@@ -241,14 +288,20 @@ describe('lib/glean', () => {
       });
 
       it('logs hashed uid when session token exists', async () => {
-        await GleanMetrics.login.success();
-        sinon.assert.calledTwice(accountGetterStub);
-        sinon.assert.calledWith(accountGetterStub, 'sessionToken');
-        sinon.assert.calledWith(accountGetterStub, 'uid');
-        sinon.assert.calledOnce(setuserIdSha256Stub);
-        sinon.assert.calledWith(
-          setuserIdSha256Stub,
-          '7ca0172850c53065046beeac3cdec3fe921532dbfebdf7efeb5c33d019cd7798'
+        GleanMetrics.login.success();
+        // the ping submissions are await'd internally in GleanMetrics...
+        await new Promise((resovle) =>
+          setTimeout(() => {
+            sinon.assert.calledTwice(accountGetterStub);
+            sinon.assert.calledWith(accountGetterStub, 'sessionToken');
+            sinon.assert.calledWith(accountGetterStub, 'uid');
+            sinon.assert.calledOnce(setuserIdSha256Stub);
+            sinon.assert.calledWith(
+              setuserIdSha256Stub,
+              '7ca0172850c53065046beeac3cdec3fe921532dbfebdf7efeb5c33d019cd7798'
+            );
+            resovle();
+          }, 80)
         );
       });
     });


### PR DESCRIPTION
Because:
 - hashing the uid is async (`crypto.subtle.digest`), thus making the Glean ping calls async.  And preferably we don't block the UI on metrics.  However, we cannot overlap (not await) multiple Glean pings.  When that happened with the successful registration submission event overlapping the registration confirmation view event, we "lost" all the succession registration event because that event has an empty event name.  And the confirmation view event was submitted with the properties of the successful registration submission event.

This commit:
 - calls and awaits the ping submissions in order inside GleanMetrics
