### PR TITLE
fix(auth): could not resolve ts paths on startup

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "yarn merge-ftl && yarn emails-scss && tsc --build && cp -R config public lib scripts dist/packages/fxa-auth-server",
+    "build": "yarn merge-ftl && yarn emails-scss && tsc --build && tsc-alias && cp -R config public lib scripts dist/packages/fxa-auth-server",
     "clean": "git clean -fXd",
     "compile": "tsc --noEmit",
     "create-mock-iap": "NODE_ENV=dev FIRESTORE_EMULATOR_HOST=localhost:9090 node -r esbuild-register ./scripts/create-mock-iap-subscriptions.ts",
@@ -220,6 +220,7 @@
     "sinon": "^9.0.3",
     "storybook": "^7.0.23",
     "through": "2.3.8",
+    "tsc-alias": "^1.8.7",
     "type-fest": "^3.12.0",
     "typesafe-node-firestore": "^1.4.1",
     "typescript": "^4.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24865,17 +24865,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^9.0.0, commander@npm:^9.4.1":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
+  languageName: node
+  linkType: hard
+
 "commander@npm:^9.1.0":
   version: 9.1.0
   resolution: "commander@npm:9.1.0"
   checksum: 1428319b6b90600a813c28fe1e413996d1be99bf01afe9ebc4a9fc6f8077ff3e75f11809b2d2f85bd9b13d7cb592154278e9bbfdb16dc5843cef97bcba6a9cfd
-  languageName: node
-  linkType: hard
-
-"commander@npm:^9.4.1":
-  version: 9.5.0
-  resolution: "commander@npm:9.5.0"
-  checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
   languageName: node
   linkType: hard
 
@@ -31450,6 +31450,7 @@ fsevents@~2.1.1:
     stripe: ^11.12.0
     superagent: ^8.0.0
     through: 2.3.8
+    tsc-alias: ^1.8.7
     type-fest: ^3.12.0
     typedi: ^0.8.0
     typesafe-node-firestore: ^1.4.1
@@ -42975,6 +42976,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"mylas@npm:^2.1.9":
+  version: 2.1.13
+  resolution: "mylas@npm:2.1.13"
+  checksum: f861d092137a9ac268cba88042392a5dc2a290eed5c8543954eae849d85e5961332211161d2c08c3644ad893f20dbe9de89b07f5dc027f1f92f13f2d38f4b81f
+  languageName: node
+  linkType: hard
+
 "mysql-patcher@npm:0.7.0":
   version: 0.7.0
   resolution: "mysql-patcher@npm:0.7.0"
@@ -45821,6 +45829,15 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"plimit-lit@npm:^1.2.6":
+  version: 1.5.0
+  resolution: "plimit-lit@npm:1.5.0"
+  dependencies:
+    queue-lit: ^1.5.0
+  checksum: a956e4e5e515a980403ca840b00c9e2381710a3a30e60e0e38f76b7842b24a345c9e59ef03568cb5925b4e9cdf67c088008148febec59e55bd47d1cb4003b024
+  languageName: node
+  linkType: hard
+
 "plist@npm:^3.0.6":
   version: 3.0.6
   resolution: "plist@npm:3.0.6"
@@ -48025,6 +48042,13 @@ fsevents@~2.1.1:
   version: 2.1.1
   resolution: "querystringify@npm:2.1.1"
   checksum: 4ce52606489365af22908e848c473599db77f681f4c1cc817f2dcec6a36e2cc5d4d8e2b17df5d207cb142150aff0f0368c3268f890ea77cd0b0ba94c5f2288d2
+  languageName: node
+  linkType: hard
+
+"queue-lit@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "queue-lit@npm:1.5.0"
+  checksum: 2e714b74072e1be9bd76356710af1d3b03763859f466a10ed74f36b5ccc524dbd0d299239adfc5cbd3a4a416c5fc69cf4af34f13ef4f95f6da70cad12cb79771
   languageName: node
   linkType: hard
 
@@ -54817,6 +54841,22 @@ resolve@1.1.7:
     typescript:
       optional: true
   checksum: c2a698b85d521298fe6f2435fbf2d3dc5834b423ea25abd321805ead3f399dbeedce7ca09492d7eb005b9d2c009c6b9587055bc3ab273dc6b9e40eefd7edb5b2
+  languageName: node
+  linkType: hard
+
+"tsc-alias@npm:^1.8.7":
+  version: 1.8.7
+  resolution: "tsc-alias@npm:1.8.7"
+  dependencies:
+    chokidar: ^3.5.3
+    commander: ^9.0.0
+    globby: ^11.0.4
+    mylas: ^2.1.9
+    normalize-path: ^3.0.0
+    plimit-lit: ^1.2.6
+  bin:
+    tsc-alias: dist/bin/index.js
+  checksum: 77f721ea797a62a7cc74acda0baf928bb654bccb210471b63fef1e70a27a823c60f5832f51aa5976d573412bc90731e90774abf9127f3b6b13f284839f988d47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- auth-server was failing to start after deploy due to tsconfig paths not resolving to the relevant libraries.

## This pull request

- Adds a tsc-alias to build step to resolve alias paths to relative paths.

## Issue that this pull request solves

Closes: # 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We ran into an issue when trying to startup the auth-server in stage. When starting up the server with run command, `node bin/key_server.js`, node didn't know what to do with the path aliases, for example `const { PayPalClient } = require('@fxa/payments/paypal');`

`tsc` does not resolve these path aliases to relative paths automatically. [Here is a discussion](https://github.com/microsoft/TypeScript/issues/10866) from a while back, where they go into a bit more detail. Maybe there's something more current?

One of the suggested approaches to resolve this issue, if you so choose, is to use `tsc-alias`, which this PR implements. This library resolve's the path aliases to the relative paths of the compiled dependencies. As a result, after `fxa-auth-server build`, this
- `const { PayPalClient } = require('@fxa/payments/paypal');`

changes to this.
- `const { PayPalClient } = require('../../../libs/payments/paypal/src/index.js');`

Some alternative approaches discussed are listed below.
- Adding a tsconfig-paths explicit bootstrap script as part of the run command, e.g. `node -r ./tsconfig-paths-bootstrap.js bin/key_server.js`, to translate to the relative path.
  - The explicit bootstrap script is necessary since tsconfig-paths can't automatically determine the correct relative path
- Add esbuild-register as part of the run command. e.g. `node -r esbuild-register bin/key_server.js`
  - esbuild-register seems to be able to determine the correct relative paths automatically using just the tsconfig.json