### PR TITLE
fix(react): class-validator decorator tweaks around query params

### DIFF
--- a/packages/fxa-settings/src/models/integrations/client-info.ts
+++ b/packages/fxa-settings/src/models/integrations/client-info.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  IsBoolean,
   IsHexadecimal,
   IsOptional,
   IsString,
+  IsBoolean,
 } from 'class-validator';
 import {
   bind,

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -16,12 +16,12 @@ import { IntegrationFlags } from '../../lib/integrations';
 import { BaseIntegrationData } from './web-integration';
 import {
   IsBoolean,
+  IsBooleanString,
   IsEmail,
   IsHexadecimal,
   IsIn,
   IsNotEmpty,
   IsOptional,
-  IsPositive,
   IsString,
   MaxLength,
   MinLength,
@@ -109,10 +109,11 @@ export class OAuthIntegrationData extends BaseIntegrationData {
   @bind(T.snakeCase)
   idTokenHint: string | undefined;
 
-  @IsPositive()
+  // TODO: Validation - this should be converted to a number and then checked if it's >= 0
   @IsOptional()
+  @IsString()
   @bind(T.snakeCase)
-  maxAge: number | undefined;
+  maxAge: string | undefined;
 
   @IsOptional()
   @IsString()
@@ -143,10 +144,10 @@ export class OAuthIntegrationData extends BaseIntegrationData {
   @bind(T.snakeCase)
   redirectUri: string | undefined;
 
-  @IsBoolean()
+  @IsBooleanString()
   @IsOptional()
   @bind(T.snakeCase)
-  returnOnError: boolean | undefined;
+  returnOnError: 'true' | 'false' | undefined;
 
   // TODO - Validation - Should scope be required?
   @IsOptional()

--- a/packages/fxa-settings/src/models/integrations/signin-signup-info.ts
+++ b/packages/fxa-settings/src/models/integrations/signin-signup-info.ts
@@ -4,14 +4,12 @@
 
 import {
   IsBase64,
-  IsBoolean,
+  IsBooleanString,
   IsEmail,
   IsHexadecimal,
   IsIn,
-  IsInt,
   IsNotEmpty,
   IsOptional,
-  IsPositive,
   IsString,
 } from 'class-validator';
 import {
@@ -71,11 +69,11 @@ export class SignInSignUpInfo extends ModelDataProvider {
   @bind(T.snakeCase)
   loginHint: string | undefined;
 
+  // TODO: Validation - this should be converted to a number and then checked if it's >= 0
   @IsOptional()
-  @IsInt()
-  @IsPositive()
+  @IsString()
   @bind(T.snakeCase)
-  maxAge: number | undefined;
+  maxAge: string | undefined;
 
   @IsOptional()
   @IsIn(['consent', 'none', 'login'])
@@ -95,9 +93,9 @@ export class SignInSignUpInfo extends ModelDataProvider {
   redirectTo: string | undefined;
 
   @IsOptional()
-  @IsBoolean()
+  @IsBooleanString()
   @bind(T.snakeCase)
-  returnOnError: boolean | undefined;
+  returnOnError: 'true' | 'false' | undefined;
 
   @IsOptional()
   @IsString()

--- a/packages/fxa-settings/src/models/integrations/web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/web-integration.ts
@@ -26,7 +26,10 @@ export class BaseIntegrationData extends ModelDataProvider {
   context: string | undefined;
 
   @IsOptional()
-  @IsEmail()
+  // TODO - Validation - change this to 'IsEmail'. Requiring this to be an email
+  // causes this to throw when we have a separate model, like a query param or
+  // link model for a page, where we validate this instead.
+  @IsString()
   @bind()
   email: string | undefined;
 


### PR DESCRIPTION
Because:
* Some validation checks are incorrect since params are always strings unless transformed, causing a blank page to show in some cases

This commit:
* Uses the 'isBooleanString' decorator instead of 'isBoolean' until we can better validate with (probably) a custom decorator

---

There are a couple of things this fixes:
* When the email param is not valid in a reset PW link, we were showing a blank page instead of the expired link. This tweak is needed for my signup PR as well
* In at least one OAuth flow (Monitor staging), the page is also blank, because `max_age` comes through as `'0'` and we were checking for a positive number

I went ahead and adjusted other 'boolean' checks to `IsBooleanString` since I tested them and they were causing errors. We should get a follow up filed to address the validation TODOs.

closes FXA-8198