### PR TITLE
test(subplat): disable the funnel metrics test

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -172,6 +172,7 @@ test.describe('Flow, acquisition and new user checkout funnel metrics', () => {
       expect(page.url()).toContain('&flow_begin_time=');
     });
 
+    /*Disabling the test for Fxa-8078
     test('New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics', async ({
       pages: { settings, relier, page, subscribe },
     }, { project }) => {
@@ -227,6 +228,6 @@ test.describe('Flow, acquisition and new user checkout funnel metrics', () => {
         return event.type;
       });
       expect(actualEventTypes).toMatchObject(expectedEventTypes);
-    });
+    });*/
   });
 });


### PR DESCRIPTION
## Because

- The funnel metrics subplat tests have been failing on Stage and a bug has been created to fix it. https://mozilla-hub.atlassian.net/browse/FXA-8078. Disabling the test so that the Stage smoke test passes.

## This pull request

- Disables the funnel metrics test

## Issue that this pull request solves

Closes: FXA-8201

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
