### PR TITLE
fix(fxa-settings): ConfirmResetPassword should not automatically redi…

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -84,6 +84,7 @@ const ConfirmResetPassword = ({
   }, isPolling);
 
   const resendEmailHandler = async () => {
+    setIsPolling(null);
     try {
       if (isOAuthIntegration(integration)) {
         const result = await account.resetPassword(
@@ -106,6 +107,8 @@ const ConfirmResetPassword = ({
       );
       setResendStatus(ResendStatus.error);
       setErrorMessage(localizedErrorMessage);
+    } finally {
+      setIsPolling(POLLING_INTERVAL_MS);
     }
   };
 


### PR DESCRIPTION
## Because

* ConfirmResetPassword has polling behaviour to check if the password has been reset in a separate tab or device by polling for a change in the PasswordForgotToken. However, requesting a new email link invalidates the previous token and creates a new one.
* On stage, this occasionally leads to the page redirecting to signin after sending out a new link, even though the password has not been reset.
* ~~Considering that the reset password flow will soon be redesigned to use codes instead of links, and that there is a link to return to sign in on this page, the polling might add unnecessary complexity to this page.~~

## This pull request

* ~~Remove the polling behaviour that caused automatic redirects to signin when either 1) the password was reset or 2) the initial PasswordForgotToken becomes invalid.~~
* Updated 09/05/2023: As suggested by @vbudhram, a simpler solution is to temporarily disable the polling behaviour while the email is being resent, and to re-enable it once completed to make sure there is no redirect until the passwordForgotToken is updated. The polling behaviour will be preserved until the confirmation with link is replaced by a code.

## Issue that this pull request solves

Closes: #FXA-8197

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
