### PR TITLE
task(react): Turn reset PW routes to 100% rollout

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -14,7 +14,7 @@ export const selectors = {
   EMAIL_PREFILLED: '#prefillEmail',
   EMAIL_HEADER: '#fxa-enter-email-header',
   ERROR: '.error',
-  LINK_LOST_RECOVERY_KEY: 'a.lost-recovery-key',
+  LINK_LOST_RECOVERY_KEY: 'a:has-text("Don’t have an account recovery key?")',
   LINK_RESET_PASSWORD: 'a[href^="/reset_password"]',
   LINK_USE_DIFFERENT: '#use-different',
   LINK_USE_RECOVERY_CODE: '#use-recovery-code-link',
@@ -497,8 +497,14 @@ export class LoginPage extends BaseLayout {
   }
 
   async setNewPassword(password: string) {
-    await this.page.locator(selectors.PASSWORD).fill(password);
-    await this.page.locator(selectors.VPASSWORD).fill(password);
+    const config = await this.getConfig();
+    if (config.showReactApp.resetPasswordRoutes === true) {
+      await this.page.getByLabel('New password').fill(password);
+      await this.page.getByLabel('Re-enter password').fill(password);
+    } else {
+      await this.page.locator(selectors.PASSWORD).fill(password);
+      await this.page.locator(selectors.VPASSWORD).fill(password);
+    }
     await this.submit();
   }
 
@@ -633,6 +639,7 @@ export class LoginPage extends BaseLayout {
       'meta[name="fxa-content-server/config"]'
     );
     const config = await metaConfig.getAttribute('content');
+    this.page.goBack();
     return JSON.parse(decodeURIComponent(config));
   }
 

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -21,7 +21,7 @@ export const selectors = {
 };
 
 export class ResetPasswordPage extends BaseLayout {
-  public react = false;
+  public react = true;
   readonly path = '';
 
   getEmailValue() {

--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -5,6 +5,11 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('force auth', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    const config = await login.getConfig();
+    // TODO: Remove forceAuth tests. React pages don't have this flow.
+    test.skip(config.showReactApp.resetPasswordRoutes === true);
+  });
   test('with a registered email, registered uid', async ({
     credentials,
     pages: { login, forceAuth },

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('OAuth force auth', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    const config = await login.getConfig();
+    // TODO: Remove forceAuth tests. React pages don't have this flow.
+    test.skip(config.showReactApp.resetPasswordRoutes === true);
+  });
   test('with a registered email', async ({
     credentials,
     pages: { login, relier },

--- a/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
@@ -4,8 +4,11 @@ import { EmailHeader, EmailType } from '../../lib/email';
 const NEW_PASSWORD = 'passwordzxcv';
 
 test.describe('Reset password current', () => {
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
+
+    const config = await login.getConfig();
+    test.skip(config.showReactApp.resetPasswordRoutes === true);
   });
 
   test('can reset password', async ({

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -22,7 +22,9 @@ test.describe('severity-1 #smoke', () => {
     );
     await page.goto(link, { waitUntil: 'load' });
     await login.setNewPassword(credentials.password);
-    expect(page.url()).toContain(settings.url);
+    // TODO: React reset PW does not currently take users to Settings, FXA-8266
+    // expect(page.url()).toContain(settings.url);
+    expect(page.url()).toContain('reset_password_verified');
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293431
@@ -83,7 +85,10 @@ test.describe('severity-1 #smoke', () => {
     await page.goto(link, { waitUntil: 'load' });
     await login.clickDontHaveRecoveryKey();
     await login.setNewPassword(credentials.password);
-    await settings.waitForAlertBar();
+    // TODO: React reset PW does not currently take users to Settings, FXA-8266
+    // await settings.waitForAlertBar();
+    await settings.goto();
+
     status = await settings.recoveryKey.statusText();
     expect(status).toEqual('Not Set');
   });

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -337,6 +337,8 @@ test.describe('new recovery key test', () => {
     target,
     pages: { page, login, settings },
   }) => {
+    // TODO: There is duplicate coverage in /react-conversion/recoveryKey.spec.ts
+    test.skip(true);
     await settings.signOut();
     // Reset password with recovery key
     await login.setEmail(credentials.email);
@@ -374,6 +376,8 @@ test.describe('new recovery key test', () => {
     page,
     pages: { settings, recoveryKey, login },
   }) => {
+    // TODO: Possibly duplicate coverage in /react-conversion/recoveryKey.spec.ts
+    test.skip(true);
     await settings.goto('isInRecoveryKeyExperiment=true');
     // Create new recovery key
     await settings.recoveryKey.clickCreate();
@@ -399,7 +403,6 @@ test.describe('new recovery key test', () => {
     expect(status).toEqual('Enabled');
 
     await settings.signOut();
-
     // Attempt to use old key to reset password
     await login.setEmail(credentials.email);
     await login.submit();
@@ -448,6 +451,8 @@ test.describe('new recovery key test', () => {
     page,
     pages: { settings, recoveryKey, login },
   }) => {
+    // TODO: Possibly duplicate coverage in /react-conversion/recoveryKey.spec.ts
+    test.skip(true);
     await settings.signOut();
 
     await login.setEmail(credentials.email);
@@ -489,6 +494,8 @@ test.describe('new recovery key test', () => {
     page,
     pages: { settings, recoveryKey, login, resetPassword },
   }) => {
+    // TODO: Possibly duplicate coverage in /react-conversion/recoveryKey.spec.ts
+    test.skip(true);
     await settings.signOut();
 
     await login.setEmail(credentials.email);

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -8,8 +8,11 @@ import { EmailHeader, EmailType } from '../../lib/email';
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Firefox Desktop Sync v3 reset password', () => {
-  test.beforeEach(() => {
+  test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
+
+    const config = await login.getConfig();
+    test.skip(config.showReactApp.resetPasswordRoutes === true);
   });
 
   test('reset pw, test pw validation, verify same browser', async ({

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -51,7 +51,7 @@ const NAVIGATE_AWAY_IN_MOBILE_DELAY_MS = 75;
 // React route groups specified here will effectively be set to
 // 100% roll out in production. Only add group names here once they've
 // been verified in production at the 15% experiment roll out.
-const ALWAYS_SHOWN_REACT_GROUPS = ['simpleRoutes'];
+const ALWAYS_SHOWN_REACT_GROUPS = ['simpleRoutes', 'resetPasswordRoutes'];
 
 function getView(ViewOrPath) {
   if (typeof ViewOrPath === 'string') {
@@ -147,7 +147,16 @@ Router = Router.extend({
     'complete_reset_password(/)': function () {
       this.createReactOrBackboneViewHandler(
         'complete_reset_password',
-        CompleteResetPasswordView
+        CompleteResetPasswordView,
+        {
+          ...Url.searchParams(this.window.location.search, [
+            'email',
+            'emailToHashWith',
+            'code',
+            'token',
+            'uid',
+          ]),
+        }
       );
     },
     'complete_signin(/)': createViewHandler(CompleteSignUpView, {

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -514,7 +514,10 @@ describe('lib/router', () => {
 
   describe('React-related methods', () => {
     beforeEach(() => {
-      const mockAlwaysShownReactGroups = ['simpleRoutes'];
+      const mockAlwaysShownReactGroups = [
+        'simpleRoutes',
+        'resetPasswordRoutes',
+      ];
       sinon
         .stub(router, 'ALWAYS_SHOWN_REACT_GROUPS')
         .value(mockAlwaysShownReactGroups);
@@ -559,7 +562,7 @@ describe('lib/router', () => {
         });
 
         it('when user is not in experiment', () => {
-          assert.isFalse(router.showReactApp('reset_password'));
+          assert.isFalse(router.showReactApp('report_signin'));
         });
 
         it('when routeName is not a simpleRoute, relier is OAuth, and user is in experiment', () => {
@@ -576,7 +579,7 @@ describe('lib/router', () => {
             config,
           });
 
-          assert.isFalse(router.showReactApp('reset_password'));
+          assert.isFalse(router.showReactApp('report_signin'));
         });
       });
     });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -109,7 +109,7 @@ describe('PageAccountRecoveryConfirmKey', () => {
     screen.getByLabelText('Enter account recovery key');
     screen.getByRole('button', { name: 'Confirm account recovery key' });
     screen.getByRole('link', {
-      name: "Don't have an account recovery key?",
+      name: 'Don’t have an account recovery key?',
     });
   });
 
@@ -397,7 +397,7 @@ describe('PageAccountRecoveryConfirmKey', () => {
 
       fireEvent.click(
         screen.getByRole('link', {
-          name: "Don't have an account recovery key?",
+          name: 'Don’t have an account recovery key?',
         })
       );
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -317,7 +317,7 @@ const AccountRecoveryConfirmKey = ({
             );
           }}
         >
-          Don't have an account recovery key?
+          Don’t have an account recovery key?
         </Link>
       </FtlMsg>
     </AppLayout>

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -63,8 +63,7 @@ const CompleteResetPassword = ({
   setLinkStatus,
   integration,
   finishOAuthFlowHandler,
-}:
-  CompleteResetPasswordProps) => {
+}: CompleteResetPasswordProps) => {
   const [bannerMessage, setBannerMessage] = useState<
     undefined | string | ReactElement
   >();
@@ -273,7 +272,7 @@ const CompleteResetPassword = ({
               isHardNavigate = true;
             }
             // TODO: if no TOTP, navigate users to /settings with the alert bar message
-            // for now, just navigate to reset_password_verified
+            // for now, just navigate to reset_password_verified. FXA-8266
             break;
           default:
           // TODO: run unpersistVerificationData in FXA-7308


### PR DESCRIPTION
Because:
* We want to increase React reset PW rollout from 15% to 100%

This commit:
* Adds 'resetPasswordRoutes' to the "always shown react routes" array
* Updates functional tests
* Modifies router.js to ensure query params are passed to complete reset PW link

closes FXA-8112