### PR TITLE
fix(react): Grab service name from integration in AccountRecoveryConfirmKey

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -197,6 +197,7 @@ const AuthAndAccountSetupRoutes = (_: RouteComponentProps) => {
             {...{
               setLinkStatus,
               linkModel,
+              integration,
             }}
           />
         )}

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
@@ -8,6 +8,8 @@ import AccountRecoveryConfirmKey from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import {
+  createMockOAuthIntegration,
+  createMockWebIntegration,
   getSubject,
   mockCompleteResetPasswordParams,
   paramsWithMissingEmail,
@@ -21,10 +23,14 @@ export default {
 } as Meta;
 
 function renderStory(
-  { account = accountValid, params = mockCompleteResetPasswordParams } = {},
+  {
+    account = accountValid,
+    params = mockCompleteResetPasswordParams,
+    integration = createMockWebIntegration(),
+  } = {},
   storyName?: string
 ) {
-  const { Subject, history, appCtx } = getSubject(account, params);
+  const { Subject, history, appCtx } = getSubject(account, params, integration);
   const story = () => produceComponent(<Subject />, { history }, appCtx);
   story.storyName = storyName;
   return story();
@@ -59,6 +65,12 @@ export const OnConfirmInvalidKey = () => {
   return renderStory({
     account: accountWithInvalidRecoveryKey,
     params: mockCompleteResetPasswordParams,
+  });
+};
+
+export const ThroughRelyingParty = () => {
+  return renderStory({
+    integration: createMockOAuthIntegration(),
   });
 };
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -19,12 +19,16 @@ import {
   paramsWithMissingCode,
   paramsWithMissingEmail,
   getSubject,
+  createMockWebIntegration,
+  createMockOAuthIntegration,
 } from './mocks';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { Account } from '../../../models';
 import { typeByLabelText } from '../../../lib/test-utils';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { MOCK_ACCOUNT, renderWithRouter } from '../../../models/mocks';
+import { MozServices } from '../../../lib/types';
+import { MOCK_SERVICE } from '../../mocks';
 
 jest.mock('../../../lib/metrics', () => ({
   logPageViewEvent: jest.fn(),
@@ -75,8 +79,9 @@ const accountWithValidResetToken = {
 const renderSubject = ({
   account = accountWithValidResetToken,
   params = mockCompleteResetPasswordParams,
+  integration = createMockWebIntegration(),
 } = {}) => {
-  const { Subject, history, appCtx } = getSubject(account, params);
+  const { Subject, history, appCtx } = getSubject(account, params, integration);
   return renderWithRouter(<Subject />, { history }, appCtx);
 };
 
@@ -105,6 +110,18 @@ describe('PageAccountRecoveryConfirmKey', () => {
     screen.getByRole('button', { name: 'Confirm account recovery key' });
     screen.getByRole('link', {
       name: "Don't have an account recovery key?",
+    });
+  });
+
+  describe('serviceName', () => {
+    it('renders the default', async () => {
+      renderSubject();
+      await screen.findByText(`to continue to ${MozServices.Default}`);
+    });
+
+    it('renders non-default', async () => {
+      renderSubject({ integration: createMockOAuthIntegration() });
+      await screen.findByText(`to continue to ${MOCK_SERVICE}`);
     });
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/interfaces.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LinkStatus } from '../../../lib/types';
+import { BaseIntegration, IntegrationType } from '../../../models';
+import { CompleteResetPasswordLink } from '../../../models/reset-password/verification';
+
+export interface AccountRecoveryConfirmKeyFormData {
+  recoveryKey: string;
+}
+
+interface RequiredParamsAccountRecoveryConfirmKey {
+  email: string;
+  token: string;
+  code: string;
+  uid: string;
+}
+
+export type AccountRecoveryConfirmKeySubmitData = {
+  recoveryKey: string;
+} & RequiredParamsAccountRecoveryConfirmKey;
+
+export interface AccountRecoveryConfirmKeyProps {
+  linkModel: CompleteResetPasswordLink;
+  setLinkStatus: React.Dispatch<React.SetStateAction<LinkStatus>>;
+  integration: AccountRecoveryConfirmKeyBaseIntegration;
+}
+
+export interface AccountRecoveryConfirmKeyBaseIntegration {
+  type: IntegrationType;
+  getServiceName: () => ReturnType<BaseIntegration['getServiceName']>;
+}


### PR DESCRIPTION
Because:
* We were only rendering the default service name

This commit:
* Sets the service name from the integration
* Sets up mock integration functions for that page and creates interfaces file for that page

closes FXA-8141

---

I'm on PTO early next week so this will need to be merged for me 🙏 