### PR TITLE
bug(settings): Fix missing connected service name after password reset

### DIFF
--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -82,6 +82,11 @@ test.describe('reset password react', () => {
 
     await page.getByRole('heading', { name: 'Settings', level: 2 }).waitFor();
 
+    // Check that connected service name is not empty!
+    expect(await page.getByTestId('service-name').innerText()).toContain(
+      'Firefox'
+    );
+
     // Cleanup requires setting this value to correct password
     credentials.password = NEW_PASSWORD;
   });

--- a/packages/fxa-graphql-api/src/decorators.spec.ts
+++ b/packages/fxa-graphql-api/src/decorators.spec.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { extractRequiredHeaders } from './decorators';
+
+describe('gql decorators', () => {
+  describe('header extraction for auth server', () => {
+    const ip = '127.0.0.1';
+    const agent = 'Mozilla/5.0';
+
+    it('forwards ip', () => {
+      const headers = extractRequiredHeaders({ ip, headers: {} });
+      expect(headers.get('x-forwarded-for')).toEqual('127.0.0.1');
+    });
+
+    it('forwards relevant headers', () => {
+      const headers = extractRequiredHeaders({
+        ip,
+        headers: { 'user-agent': agent },
+      });
+      expect(headers.get('user-agent')).toEqual(agent);
+    });
+
+    it('does not forward irrelevant headers', () => {
+      const headers = extractRequiredHeaders({
+        ip,
+        headers: { Accept: '*/*' },
+      });
+      expect(headers.get('Accept')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Because

- Service name was blank for connected device after going through password reset flow

## This pull request

- Makes sure user agent propagates from graphql to auth-server
- Adds tests for our gql decorator class
- Adds logic to functional test to ensure the service name isn't blank

## Issue that this pull request solves

Closes: FXA-8123

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


