### PR TITLE
Follow-up of #15195 / dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The Firefox Accounts (fxa) monorepo
 [Getting Started](#getting-started)\
 [Contributing](#contributing)\
 [Documentation](#documentation)
-[Documentation for Scripts](#documentation-for-scripts)
 
 ---
 


### PR DESCRIPTION
#15195 removed a section but a previous link to this section remained. This is a minor fix for this.