### PR TITLE
revert(bug): Revert settings redirect in graphql to fix ios pairing bug

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -374,14 +374,7 @@ Router = Router.extend({
       const searchParams = new URLSearchParams(this.window.location.search);
       const redirectUrl = searchParams.get('redirect_to');
       if (redirectUrl) {
-        // Ignore query params when validating the redirect url
-        const parsedRedirectUrl = redirectUrl.split('?')[0];
-        if (
-          !this.isValidRedirect(
-            parsedRedirectUrl,
-            this.config.redirectAllowlist
-          )
-        ) {
+        if (!this.isValidRedirect(redirectUrl, this.config.redirectAllowlist)) {
           throw new Error('Invalid redirect!');
         }
         return this.navigateAway(redirectUrl);

--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { errorHandler } from './gql';
+import { errorHandler, pagesRequiringAuthentication } from './gql';
 import { ErrorResponse } from '@apollo/client/link/error';
 import { Operation, NextLink, ServerError } from '@apollo/client/core';
 import { GraphQLError } from 'graphql';
@@ -11,8 +11,8 @@ let errorResponse: ErrorResponse;
 let mockReplace: Mock;
 
 describe('errorHandler', () => {
-  const pageWhichRequiresAuthentication = 'https://accounts.firefox.com/settings';
-  const pageWhichDoesNotRequireAuthentication = 'https://accounts.firefox.com/signin';
+  const pageWhichRequiresAuthentication = pagesRequiringAuthentication[0];
+  const pageWhichDoesNotRequireAuthentication = 'foo';
   beforeAll(() => {
     mockReplace = jest.fn();
     Object.defineProperty(window, 'location', {
@@ -43,7 +43,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-      '/signin?redirect_to=https%3A%2F%2Faccounts.firefox.com%2Fsettings'
+      `/signin?redirect_to=${pageWhichRequiresAuthentication}`
     );
   });
 
@@ -60,7 +60,7 @@ describe('errorHandler', () => {
     errorHandler(errorResponse);
 
     expect(window.location.replace).toHaveBeenCalledWith(
-     '/signin?redirect_to=https%3A%2F%2Faccounts.firefox.com%2Fsettings'
+      `/signin?redirect_to=${pageWhichRequiresAuthentication}`
     );
   });
 
@@ -86,8 +86,7 @@ describe('errorHandler', () => {
       value: {
         replace: mockReplace,
         search: '',
-        pathname: 'signin',
-        href: pageWhichDoesNotRequireAuthentication,
+        pathname: pageWhichDoesNotRequireAuthentication,
       },
     });
 

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -40,11 +40,9 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
     }
   }
   if (reauth && currentPageRequiresAuthentication) {
-    // When doing a redirect and going to signin, we want to ensure that original query params
-    // are sent as well, otw we would strip out utms and context params
-    const queryParams = new URLSearchParams(window.location.search);
-    queryParams.set('redirect_to', window.location.href);
-    window.location.replace(`/signin?${queryParams.toString()}`);
+    window.location.replace(
+      `/signin?redirect_to=${encodeURIComponent(window.location.pathname)}`
+    );
   } else {
     if (!reauth) {
       console.error('graphql errors', graphQLErrors, networkError);


### PR DESCRIPTION
## Because

- Users could not access settings after pairing a device
- This issue was introduced in https://github.com/mozilla/fxa/pull/15362

## This pull request

- Revert the PR

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8214

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I couldn't revert via github since the files have changed, had to manually revert.
