### PR TITLE
Attempt to send FXA_STATUS in settings page

### DIFF
--- a/packages/functional-tests/tests/settings/fxastatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxastatus.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+
+const password = 'passwordzxcv';
+let syncBrowserPages;
+let browserEmail;
+let otherEmail;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('fxa status web channel message in settings page', () => {
+  test.beforeEach(async ({ target }) => {
+    test.slow();
+    syncBrowserPages = await newPagesForSync(target);
+    const { login } = syncBrowserPages;
+    browserEmail = login.createEmail();
+    await target.auth.signUp(browserEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    otherEmail = login.createEmail();
+    await target.auth.signUp(otherEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    // First we sign the browser into an account
+    await login.goto('load', 'context=fx_desktop_v3&service=sync');
+    await login.fillOutEmailFirstSignIn(browserEmail, password);
+    // Then, we sign the content into a **different** account
+    await login.goto();
+    await login.useDifferentAccountLink();
+    await login.fillOutEmailFirstSignIn(otherEmail, password);
+  });
+
+  test.afterEach(async ({ target }) => {
+    await syncBrowserPages.browser?.close();
+    // Cleanup any accounts created during the test
+    try {
+      await target.auth.accountDestroy(browserEmail, password);
+      await target.auth.accountDestroy(otherEmail, password);
+    } catch (e) {
+      // Log the error here
+      console.error('An error occurred during account cleanup:', e);
+      // Then rethrow the error to propagate it further
+      throw e;
+    }
+  });
+  test.only('message is sent when loading with context = oauth_webchannel_v1', async () => {
+    const { settings } = syncBrowserPages;
+
+    // We verify that even though another email is signed in, when
+    // accessing the setting with a `context=oauth_webchannel_v1` the account
+    // signed into the browser takes precedence
+    await settings.goto('context=oauth_webchannel_v1');
+    expect(await settings.primaryEmail.statusText()).toBe(browserEmail);
+  });
+
+  test.only('message is not sent when loading without oauth web chanel context', async () => {
+    const { settings } = syncBrowserPages;
+
+    // We verify that when accessing the setting without the `context=oauth_webchannel_v1`
+    // the newer account takes precedence
+    await settings.goto();
+    expect(await settings.primaryEmail.statusText()).toBe(otherEmail);
+  });
+});

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -54,5 +54,8 @@
     "resetPasswordRoutes": true,
     "signUpRoutes": true,
     "signInRoutes": true
+  },
+  "featureFlags": {
+    "sendFxAStatusOnSettings": true
   }
 }

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -76,7 +76,7 @@ const settingsConfig = {
   brandMessagingMode: config.get('brandMessagingMode'),
   glean: { ...config.get('glean'), appDisplayVersion: config.get('version') },
   redirectAllowlist: config.get('redirect_check.allow_list'),
-  sendFxAStatusOnSettings: config.get('sendFxAStatusOnSettings'),
+  sendFxAStatusOnSettings: config.get('featureFlags.sendFxAStatusOnSettings'),
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -76,6 +76,7 @@ const settingsConfig = {
   brandMessagingMode: config.get('brandMessagingMode'),
   glean: { ...config.get('glean'), appDisplayVersion: config.get('version') },
   redirectAllowlist: config.get('redirect_check.allow_list'),
+  sendFxAStatusOnSettings: config.get('sendFxAStatusOnSettings'),
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -214,6 +214,12 @@ const conf = (module.exports = convict({
         format: 'int',
       },
     },
+    sendFxAStatusOnSettings: {
+      default: false,
+      doc: 'Sends an webchannel message on the settings page to request auth data from the browser',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS',
+    },
   },
   showReactApp: {
     simpleRoutes: {

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -72,8 +72,10 @@ try {
       document.getElementById('root')
     );
   };
-
-  if (shouldSendFxAStatus(flowQueryParams.context)) {
+  if (
+    config.sendFxAStatusOnSettings &&
+    shouldSendFxAStatus(flowQueryParams.context)
+  ) {
     firefox
       .fxaStatus({
         service:

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -51,14 +51,16 @@ export function currentAccount(account?: StoredAccountData) {
   const forceUid = searchParam('uid', window.location.search);
   if (forceUid && all[forceUid]) {
     storage.set('currentAccountUid', forceUid);
+  } else if (account?.uid) {
+    storage.set('currentAccountUid', account.uid);
   }
 
-  const uid = storage.get('currentAccountUid') as hexstring;
   if (account) {
     all[account.uid] = account;
     accounts(all);
     return account;
   }
+  const uid = storage.get('currentAccountUid') as hexstring;
   return all[uid];
 }
 

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -15,19 +15,28 @@ export enum FirefoxCommand {
   CanLinkAccount = 'fxaccounts:can_link_account',
 }
 
-export interface FirefoxMessage {
+const DEFAULT_SEND_TIMEOUT_LENGTH_MS: number = 5 * 1000; // 5 seconds in milliseconds
+
+export interface FirefoxMessageDetail {
   id: string;
-  message?: {
-    command: FirefoxCommand;
-    data: Record<string, any> & {
-      error?: {
-        message: string;
-        stack: string;
-      };
+  message?: FirefoxMessage;
+}
+
+export interface FirefoxMessage {
+  command: FirefoxCommand;
+  data: Record<string, any> & {
+    error?: {
+      message: string;
+      stack: string;
     };
-    messageId: string;
-    error?: string;
   };
+  messageId: string;
+  error?: string;
+}
+
+export interface FirefoxMessageError {
+  error?: string;
+  stack?: string;
 }
 
 interface ProfileUid {
@@ -39,13 +48,13 @@ interface ProfileMetricsEnabled {
 }
 
 type Profile = ProfileUid | ProfileMetricsEnabled;
-type FirefoxEvent = CustomEvent<FirefoxMessage | string>;
+type FirefoxEvent = CustomEvent<FirefoxMessageDetail | string>;
 
 // This is defined in the Firefox source code:
 // https://searchfox.org/mozilla-central/source/services/fxaccounts/tests/xpcshell/test_web_channel.js#348
 type FxAStatusRequest = {
-  service: string | undefined; // ex. 'sync'
-  context: string | undefined; // ex. 'fx_desktop_v3'
+  service?: string; // ex. 'sync'
+  context?: string; // ex. 'fx_desktop_v3'
 };
 
 export type FxAStatusResponse = {
@@ -121,12 +130,80 @@ function createMessageId() {
   return `${Date.now()}${++messageIdSuffix}`;
 }
 
+interface WebChannelRequest {
+  command: FirefoxCommand;
+  messageId: string;
+  timeoutId?: number;
+  reject(reason?: any): void;
+  resolve(value?: any): void;
+}
+
+interface OutstandingRequestOptions {
+  window: Window;
+  sendTimeoutLength?: number;
+}
+
+/**
+ * OutstandingRequests manages all Firefox WebChannel requests that
+ * the web application is waiting for a response for.
+ *
+ * This is particularly useful for the fxastatus request, where the the
+ * web application is requesting the signed in user data from the browser.
+ */
+class OutstandingRequests {
+  private window_: Window;
+  private sendTimeoutLength: number;
+  private requests: { [key: string]: WebChannelRequest };
+  constructor(options: OutstandingRequestOptions) {
+    this.window_ = options.window;
+    this.requests = {};
+    this.sendTimeoutLength =
+      options.sendTimeoutLength || DEFAULT_SEND_TIMEOUT_LENGTH_MS;
+  }
+
+  add(messageId: string, request: WebChannelRequest) {
+    this.remove(messageId);
+    request.timeoutId = this.window_.setTimeout(() => {
+      request.reject();
+      this.remove(messageId);
+    }, this.sendTimeoutLength);
+    this.requests[messageId] = request;
+  }
+
+  resolve(message: FirefoxMessage) {
+    const outstanding = this.requests[message.messageId];
+    if (outstanding) {
+      outstanding.resolve(message.data);
+      this.remove(message.messageId);
+    }
+  }
+
+  reject(messageId: string, error: FirefoxMessageError) {
+    const outstanding = this.requests[messageId];
+    if (outstanding) {
+      outstanding.reject(error);
+      this.remove(messageId);
+    }
+  }
+
+  remove(messageId: string) {
+    const outstanding = this.requests[messageId];
+    if (outstanding) {
+      this.window_.clearTimeout(outstanding.timeoutId);
+      delete this.requests[messageId];
+    }
+  }
+}
+
 export class Firefox extends EventTarget {
   private broadcastChannel?: BroadcastChannel;
+  private outstandingRequests: OutstandingRequests;
   readonly id: string;
   constructor() {
     super();
     this.id = 'account_updates';
+    this.outstandingRequests = new OutstandingRequests({ window });
+
     if (typeof BroadcastChannel !== 'undefined') {
       this.broadcastChannel = new BroadcastChannel('firefox_accounts');
       this.broadcastChannel.addEventListener('message', (event) =>
@@ -151,7 +228,7 @@ export class Firefox extends EventTarget {
     try {
       const detail =
         typeof event.detail === 'string'
-          ? (JSON.parse(event.detail) as FirefoxMessage)
+          ? (JSON.parse(event.detail) as FirefoxMessageDetail)
           : event.detail;
       if (detail.id !== this.id) {
         return;
@@ -163,10 +240,12 @@ export class Firefox extends EventTarget {
             message: message.error || message.data.error?.message,
             stack: message.data.error?.stack,
           };
+          this.outstandingRequests.reject(message.messageId, error);
           this.dispatchEvent(
             new CustomEvent(FirefoxCommand.Error, { detail: error })
           );
         } else {
+          this.outstandingRequests.resolve(message);
           this.dispatchEvent(
             new CustomEvent(message.command, { detail: message.data })
           );
@@ -201,17 +280,37 @@ export class Firefox extends EventTarget {
     return JSON.stringify(detail);
   }
 
-  // send a message to the browser chrome
+  // Send a message to the browser chrome
+  // does not wait for a response
   send(command: FirefoxCommand, data: any) {
-    // If two messages are created within the same millisecond, Date.now()
-    // returns the same value. Append a suffix that ensures uniqueness
-    const messageId = `${Date.now()}${++messageIdSuffix}`;
-    const detail = this.formatEventDetail(command, data, messageId);
+    const detail = this.formatEventDetail(command, data);
     window.dispatchEvent(
       new CustomEvent('WebChannelMessageToChrome', {
         detail,
       })
     );
+  }
+
+  // Request a message from the browser chrome
+  // returns a promise that resolves when a response arrives
+  // rejects if an error is received from the browser, or
+  // if the request times out.
+  request<T>(command: FirefoxCommand, data: any): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const messageId = createMessageId();
+      const detail = this.formatEventDetail(command, data, messageId);
+      this.outstandingRequests.add(messageId, {
+        command,
+        messageId,
+        resolve,
+        reject,
+      });
+      window.dispatchEvent(
+        new CustomEvent('WebChannelMessageToChrome', {
+          detail,
+        })
+      );
+    });
   }
 
   // broadcast a message to other tabs
@@ -250,8 +349,8 @@ export class Firefox extends EventTarget {
     this.broadcast(FirefoxCommand.ProfileChanged, profile);
   }
 
-  fxaStatus(options: FxAStatusRequest) {
-    this.send(FirefoxCommand.FxAStatus, options);
+  fxaStatus(options: FxAStatusRequest): Promise<FxAStatusResponse> {
+    return this.request(FirefoxCommand.FxAStatus, options);
   }
 
   async fxaLogin(options: FxALoginRequest): Promise<void> {

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -202,7 +202,10 @@ export class Firefox extends EventTarget {
   }
 
   // send a message to the browser chrome
-  send(command: FirefoxCommand, data: any, messageId?: string) {
+  send(command: FirefoxCommand, data: any) {
+    // If two messages are created within the same millisecond, Date.now()
+    // returns the same value. Append a suffix that ensures uniqueness
+    const messageId = `${Date.now()}${++messageIdSuffix}`;
     const detail = this.formatEventDetail(command, data, messageId);
     window.dispatchEvent(
       new CustomEvent('WebChannelMessageToChrome', {

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -44,8 +44,8 @@ type FirefoxEvent = CustomEvent<FirefoxMessage | string>;
 // This is defined in the Firefox source code:
 // https://searchfox.org/mozilla-central/source/services/fxaccounts/tests/xpcshell/test_web_channel.js#348
 type FxAStatusRequest = {
-  service: 'sync'; // ex. 'sync'
-  context: string; // ex. 'fx_desktop_v3'
+  service: string | undefined; // ex. 'sync'
+  context: string | undefined; // ex. 'fx_desktop_v3'
 };
 
 export type FxAStatusResponse = {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -77,6 +77,7 @@ export interface Config {
     debugViewTag: string;
   };
   redirectAllowlist: string[];
+  sendFxAStatusOnSettings: boolean;
 }
 
 export function getDefault() {
@@ -134,6 +135,7 @@ export function getDefault() {
       redirectUri: '',
       authorizationEndpoint: '',
     },
+<<<<<<< HEAD
     brandMessagingMode: 'prelaunch',
     glean: {
       enabled: false,
@@ -145,6 +147,9 @@ export function getDefault() {
       debugViewTag: '',
     },
     redirectAllowlist: ['localhost'],
+=======
+    sendFxAStatusOnSettings: false,
+>>>>>>> c47545e55e (Feature flags the fxa status message on settings page)
   } as Config;
 }
 

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -105,6 +105,13 @@ export function isMobileDevice(client?: AttachedClient) {
   return /mobi/i.test(navigator.userAgent);
 }
 
+export function shouldSendFxAStatus(context?: string) {
+  // Mobile clients may have a user that the setting page doesn't know about
+  // this is common if the mobile client signed in using pairing and thus the
+  // settings page does not yet have the session token for the user.
+  return context === 'oauth_webchannel_v1';
+}
+
 // Crockford base32 Regex. Case insensitive and excludes I, L, O, U
 const B32_STRING = /^[0-9A-HJ-KM-NP-TV-Z]+$/i;
 export function isBase32Crockford(value: string) {


### PR DESCRIPTION
## Because

- Users on Firefox iOS get asked to sign in again if they signed into Firefox iOS using pairing

## This pull request

- Attempts to send a web channel message to retrieve the user's session token from the browser

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7439, https://mozilla-hub.atlassian.net/browse/SYNC-3918

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information
I've only tested this in Firefox so far and I'm seeing the expected behavior (after clearing my session storage and refreshing the settings page, the settings page does not redirect to the sign in page and instead retrieves the session from the browser)

**Important**: 
- We should test this in non-Firefox browsers **and** in mobile. Testing in mobile is difficult till this hits stage 
- This implementation creates no guarantees that the browser has responded. It's really a best-effort attempt but if the browser doesn't respond in time, we will still get redirected.

cc @vbudhram I'm not comfortable enough with the setting page's initialization sequence here so happy to hand this over or change it up in any way that makes sense
