### PR TITLE
refactor: use typed config for paypal client

### DIFF
--- a/libs/payments/paypal/src/lib/client.config.ts
+++ b/libs/payments/paypal/src/lib/client.config.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Type } from 'class-transformer';
+import { IsBoolean, IsNumber, IsString, ValidateNested } from 'class-validator';
+
+export class PaypalRetryConfig {
+  @IsNumber()
+  public readonly retries!: number;
+
+  @IsNumber()
+  public readonly minTimeout!: number;
+
+  @IsNumber()
+  public readonly factor!: number;
+}
+
+export class PaypalClientConfig {
+  @IsBoolean()
+  public readonly sandbox!: boolean;
+
+  @IsString()
+  public readonly user!: string;
+
+  @IsString()
+  public readonly pwd!: string;
+
+  @IsString()
+  public readonly signature!: string;
+
+  @Type(() => PaypalRetryConfig)
+  @ValidateNested()
+  public readonly retryOptions?: PaypalRetryConfig;
+}

--- a/libs/payments/paypal/src/lib/client.ts
+++ b/libs/payments/paypal/src/lib/client.ts
@@ -29,7 +29,6 @@ import {
   NVPTransactionSearchResponse,
   PaypalMethods,
   PaypalNVPAckOptions,
-  PaypalOptions,
   RefundTransactionOptions,
   RefundType,
   ResponseEvent,
@@ -37,6 +36,7 @@ import {
   TransactionSearchOptions,
 } from './types';
 import { nvpToObject, objectToNVP, toIsoString } from './util';
+import { PaypalClientConfig } from './client.config';
 
 @Injectable()
 export class PayPalClient {
@@ -56,7 +56,7 @@ export class PayPalClient {
     listener: (response: ResponseEvent) => void
   ) => EventEmitter;
 
-  constructor(options: PaypalOptions) {
+  constructor(options: PaypalClientConfig) {
     this.url = options.sandbox ? PAYPAL_SANDBOX_API : PAYPAL_LIVE_API;
     this.ipnUrl = options.sandbox ? PAYPAL_SANDBOX_IPN : PAYPAL_LIVE_IPN;
     this.user = options.user;

--- a/libs/payments/paypal/src/lib/types.ts
+++ b/libs/payments/paypal/src/lib/types.ts
@@ -2,18 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export interface PaypalOptions {
-  sandbox: boolean;
-  user: string;
-  pwd: string;
-  signature: string;
-  retryOptions?: {
-    retries?: number;
-    minTimeout?: number;
-    factor?: number;
-  };
-}
-
 export enum PaypalMethods {
   BillAgreementUpdate = 'BillAgreementUpdate',
   CreateBillingAgreement = 'CreateBillingAgreement',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.4.0",
     "@nestjs/schedule": "^2.2.2",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "diffparser": "^2.0.1",
     "hot-shots": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32352,6 +32352,7 @@ fsevents@~2.1.1:
     "@typescript-eslint/parser": ^5.59.1
     autoprefixer: ^10.4.14
     babel-jest: ^29.4.1
+    class-transformer: ^0.5.1
     class-validator: ^0.14.0
     diffparser: ^2.0.1
     eslint: ^7.32.0


### PR DESCRIPTION
Because:

* The paypal client config is a basic interface, and we'd like to be
  able to use Nest-Typed-Config with a structured config file.

This commit:

* Adds a typed config class for the paypal client.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
