### PR TITLE
feat(crons): adds sentry monitoring for a cron job

### DIFF
--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@golevelup/ts-jest": "^0.3.2",
     "@google-cloud/firestore": "^6.6.0",
+    "@sentry/node": "^7.65.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "convict": "^6.2.4",


### PR DESCRIPTION
Because:

* We don't get much feedback on crons

This commit:

* Adds Sentry cron monitoring to a single job and lets see if we like it

Related to FXA-7658 but doesn't close it all the way.

