### PR TITLE
feat(metrics): add backend Glean ping for reg_acc_created

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -113,6 +113,10 @@ export const gleanMetrics = (config: ConfigType) => {
   });
 
   return {
+    registration: {
+      accountCreated: createEventFn('reg_acc_created'),
+    },
+
     login: {
       success: createEventFn('login_success'),
     },

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -177,6 +177,9 @@ export class AccountHandler {
     await request.emitMetricsEvent('account.created', {
       uid: account.uid,
     });
+    this.glean.registration.accountCreated(request, {
+      uid: account.uid,
+    });
 
     const geoData = request.app.geo;
     const country = geoData.location && geoData.location.country;

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -300,6 +300,18 @@ describe('Glean server side events', () => {
     });
   });
 
+  describe('registration', () => {
+    describe('accountCreated', () => {
+      it('logs a "reg_acc_created" event', async () => {
+        const glean = gleanMetrics(config);
+        await glean.registration.accountCreated(request);
+        sinon.assert.calledOnce(recordStub);
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['event_name'], 'reg_acc_created');
+      });
+    });
+  });
+
   describe('login', () => {
     describe('success', () => {
       it('logs a "login_success" event', async () => {


### PR DESCRIPTION
It adds a backend Glean ping for account creation.