### PR TITLE
refactor: use typed config for Contentful client

### DIFF
--- a/libs/shared/contentful/src/lib/contentful-client.config.ts
+++ b/libs/shared/contentful/src/lib/contentful-client.config.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString, IsUrl } from 'class-validator';
+
+export class ContentfulClientConfig {
+  @IsUrl()
+  public readonly graphqlApiUri!: string;
+
+  @IsString()
+  public readonly graphqlApiKey!: string;
+}

--- a/libs/shared/contentful/src/lib/contentful-client.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful-client.spec.ts
@@ -12,6 +12,7 @@ import {
   ContentfulLinkError,
   ContentfulLocaleError,
 } from './errors';
+import { ContentfulClientConfig } from './contentful-client.config';
 
 const ApolloError = jest.requireActual('@apollo/client').ApolloError;
 
@@ -27,12 +28,17 @@ jest.mock('@apollo/client', () => ({
 
 describe('ContentfulClient', () => {
   let contentfulClient: ContentfulClient;
+  let contentfulClientConfig: ContentfulClientConfig;
 
   beforeEach(() => {
-    contentfulClient = new ContentfulClient(
-      faker.internet.url(),
-      faker.string.uuid()
-    );
+    contentfulClientConfig = new ContentfulClientConfig();
+    Object.defineProperty(contentfulClientConfig, 'graphqlApiKey', {
+      value: faker.string.uuid(),
+    });
+    Object.defineProperty(contentfulClientConfig, 'graphqlApiUri', {
+      value: faker.string.uuid(),
+    });
+    contentfulClient = new ContentfulClient(contentfulClientConfig);
   });
 
   describe('query', () => {

--- a/libs/shared/contentful/src/lib/contentful-client.ts
+++ b/libs/shared/contentful/src/lib/contentful-client.ts
@@ -17,18 +17,16 @@ import {
   ContentfulLocaleError,
 } from './errors';
 import { BaseError } from '@fxa/shared/error';
+import { ContentfulClientConfig } from './contentful-client.config';
 
 @Injectable()
 export class ContentfulClient {
   client = new ApolloClient({
-    uri: `${this.contentfulGraphqlApiUri}?access_token=${this.contentfulGraphqlApiKey}`,
+    uri: `${this.contentfulClientConfig.graphqlApiUri}?access_token=${this.contentfulClientConfig.graphqlApiKey}`,
     cache: new InMemoryCache(),
   });
 
-  constructor(
-    private contentfulGraphqlApiUri: string,
-    private contentfulGraphqlApiKey: string
-  ) {}
+  constructor(private contentfulClientConfig: ContentfulClientConfig) {}
 
   async query<Result, Variables>(
     query: TypedDocumentNode<Result, Variables>,


### PR DESCRIPTION
Because:

* We'd like to be able to use Nest-Typed-Config with a structured config file that can be validated at runtime if desired.

This commit:

* Adds a typed config class for the Contentful client.
* Reference PR: https://github.com/mozilla/fxa/pull/15724

Closes #No ticket

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
