### PR TITLE
task(ci): Make integration tests run on large resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,7 +607,7 @@ jobs:
         default: run-many
       resource_class:
         type: string
-        default: medium
+        default: large
     executor: fullstack-executor
     resource_class: << parameters.resource_class >>
     steps:
@@ -970,7 +970,7 @@ workflows:
       - integration-test:
           name: Integration Test - Frontends
           resource_class: large
-          projects: --tag=scope:frontend
+          projects: --exclude '*,!tag:scope:frontend'
           filters:
             branches:
               ignore: /.*/
@@ -980,7 +980,7 @@ workflows:
             - Build
       - integration-test:
           name: Integration Test - Servers
-          projects: --tag=scope:server
+          projects: --exclude '*,!tag:scope:server'
           filters:
             branches:
               ignore: /.*/
@@ -990,7 +990,7 @@ workflows:
             - Build
       - integration-test:
           name: Integration Test - Servers - Auth
-          projects: --tag=scope:server:auth
+          projects: --exclude '*,!tag:scope:server:auth'
           filters:
             branches:
               ignore: /.*/
@@ -1000,7 +1000,7 @@ workflows:
             - Build
       - integration-test:
           name: Integration Test - Libraries
-          projects: --tag=scope:shared*
+          projects: --exclude '*,!tag:scope:shared:*'
           filters:
             branches:
               ignore: /.*/
@@ -1086,24 +1086,23 @@ workflows:
       - integration-test:
           name: Integration Test - Frontends (nightly)
           resource_class: large
-          projects: --tag=scope:frontend
+          projects: --exclude '*,!tag:scope:frontend'
           requires:
             - Build (nightly)
       - integration-test:
           name: Integration Test - Servers (nightly)
-          projects: --tag=scope:server
+          projects: --exclude '*,!tag:scope:server'
           requires:
             - Build (nightly)
       - integration-test:
           name: Integration Test - Servers - Auth (nightly)
-          projects: --tag=scope:server:auth
+          projects: --exclude '*,!tag:scope:server:auth'
           target: --targets test-integration-local test-integration-remote test-integration-scripts
           requires:
             - Build (nightly)
       - integration-test:
           name: Integration Test - Libraries (nightly)
-          # TODO - Get payments cart tests working
-          projects: --tag=scope:shared* --exclude=payments-cart
+          projects: --exclude '*,!tag:scope:shared:*'
           requires:
             - Build (nightly)
       - playwright-functional-tests:


### PR DESCRIPTION
## Because

- We were running out of memory in CI

## This pull request

- Has integration tests use the large resource class
- Fixes 'projects' param on integration-test jobs

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We should investigate why memory is spiking happening. This is a temporary fix.
