### PR TITLE
task(ci): Fix netcat install after updating docker base image to node:18.17-slim

### DIFF
--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 # Utilities for fxa services
 FROM fxa-base as fxa-utils
 RUN apt-get update && apt-get install -y \
-    netcat \
+    netcat-traditional \
     openssl \
     jq \
     curl \


### PR DESCRIPTION
## Because

- Docker build in was failing when trying to install netcat

## This pull request

- Changes the install to `netcat-traditional`, because `netcat` isn't a valid package name anymore.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This was encountered during release of train-266. The regression was introduced when we updated our base image to use `node:18.17-slim`.
