### PR TITLE
task(ci): Include max-old-space-size node option in build.sh

### DIFF
--- a/_dev/docker/mono/build.sh
+++ b/_dev/docker/mono/build.sh
@@ -32,7 +32,7 @@ done
 # `npx yarn` because `npm i -g yarn` needs sudo
 npx yarn install
 npx yarn gql:allowlist
-SKIP_PREFLIGHT_CHECK=true npx nx run-many -t build --all --verbose
+NODE_OPTIONS="--max-old-space-size=7168" SKIP_PREFLIGHT_CHECK=true npx nx run-many -t build --all --verbose
 
 # This will reduce packages to only production dependencies
 npx yarn workspaces focus --production --all


### PR DESCRIPTION
## Because

- The CI job `Create FxA Image` ran out of memory

## This pull request

- Applies the the `--max-old-space-size=7168` node option, which should prevent the OOM.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The root cause of this regression was like the node version upgrade.
