### PR TITLE
bug(ci): Fix broken stage/prod smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ commands:
             else
               export FEATURE_FLAGS_SHOW_RECOVERY_KEY_V2=true
             fi
+            npx nx build fxa-auth-client
             cd packages/functional-tests/tests
             TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
             cd ..


### PR DESCRIPTION
## Because

- In train-266 stage smoke tests failed
- The auth client build was missing
- The auth client build used to be part of the docker image, but this changed now that we cache builds in nx.

## This pull request

- Builds auth client with nx prior to running smoke tests.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
