### PR TITLE
bug(nx): Fix crashing nx daemon

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -79,8 +79,8 @@
         "{projectRoot}/server/config/local.json",
         "{projectRoot}/var",
         "{projectRoot}/vendor/ejs.js",
-        "{workspaceRoot}/external/l10n",
-        "{workspaceRoot}/external/legal-docs"
+        "{workspaceRoot}/external/l10n/**/*.@(ftl|po|js|json|sh|py|json)",
+        "{workspaceRoot}/external/legal-docs/**/*.@(md|json)"
       ]
     },
     "restart": {
@@ -141,7 +141,7 @@
     "lint": ["{projectRoot}/**/*.@(js|jsx|ts|tsx)"],
     "production": [
       "default",
-      "{workspaceRoot}/external/l10n/**/*.ftl",
+      "{workspaceRoot}/external/l10n/**/*.@(ftl|po)",
       "{workspaceRoot}/external/legal-docs/**/*.md",
       "!{projectRoot}/.eslintrc.json",
       "!{projectRoot}/.storybook/**/*",


### PR DESCRIPTION
## Because

- The daemon was crashing due to a file change on a .gitignore file in a sub repo
- This is a edge case in the nx code

## This pull request

- Configures nx to only watch and cache the improtant files in {workspaceRoot}/External

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/mozilla/fxa/assets/94418270/14744382-aab3-4487-8b29-0747d97bb256)

![image](https://github.com/mozilla/fxa/assets/94418270/a4f73316-6738-487f-a160-17ac4385e3c1)



## Other information (Optional)

The edge case that trips this error can be seen here: https://github.com/nrwl/nx/blob/6d686564faf83f29ecc6129a0ed7ee8b29983e28/packages/nx/src/daemon/server/watcher.ts#L85C23-L85C23
