### PR TITLE
bug(admin-panel): Fix missing server build ouptut

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "FxA Admin Panel",
   "scripts": {
-    "build": "yarn build-ts-server && yarn build-ts-client && yarn build-css && yarn build-react",
+    "build": "nx build-css && nx build-react && nx build-ts-client && nx build-ts-server",
     "build-ts-client": "tsc --build",
     "build-ts-server": "tsc -p server/tsconfig.json",
     "build-css": "npx tailwindcss -i ./src/styles/tailwind.css -o ./src/styles/tailwind.out.css --postcss",


### PR DESCRIPTION
## Because

- The build-ts-server output wasn't getting deleted

## This pull request

- Changes the order of operations in the admin-panel build script
- Running build-ts-server at the end ensures the build output is left intact

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Fix for:
<img width="854" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/c4efc27e-de37-4240-8142-ca5127f18507">


## Other information (Optional)

Any other information that is important to this pull request.
