### PR TITLE
Allow FxA to run locally on safari by disabling csp locally

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -43,7 +43,7 @@
   "allowed_parent_origins": ["http://localhost:8080"],
   "sourceMapType": "cheap-source-map",
   "csp": {
-    "enabled": true,
+    "enabled": false,
     "reportUri": "/_/csp-violation"
   },
   "recovery_codes": {


### PR DESCRIPTION
## Because

- Safari is upgrading the script fetching requests in the content server when it sees the Content-Security-Policy header includes `upgrade-insecure-requests`.
- The above prevents testing a local build of FxA against Firefox iOS, because firefox ios uses webkit which exhibits the same behaviour and tries to load resources using `https://localhost` (note the `https` here)

## This pull request

- Changes the local config for the content server to disable csp

cc @vbudhram 

## Issue that this pull request solves

Closes: N/A
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).