### PR TITLE
feat(metrics): add totp backend Glean pings

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -120,6 +120,8 @@ export const gleanMetrics = (config: ConfigType) => {
 
     login: {
       success: createEventFn('login_success'),
+      totpSuccess: createEventFn('login_totp_code_success'),
+      totpFailure: createEventFn('login_totp_code_failure'),
     },
   };
 };

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -147,7 +147,7 @@ module.exports = function (
     config.signinUnblock,
     customs
   );
-  const totp = require('./totp')(log, db, mailer, customs, config.totp);
+  const totp = require('./totp')(log, db, mailer, customs, config.totp, glean);
   const recoveryCodes = require('./recovery-codes')(
     log,
     db,

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -332,5 +332,22 @@ describe('Glean server side events', () => {
         assert.equal(metrics['event_name'], 'login_success');
       });
     });
+    describe('totp', () => {
+      it('logs a "login_totp_code_success" event', async () => {
+        const glean = gleanMetrics(config);
+        await glean.login.totpSuccess(request);
+        sinon.assert.calledOnce(recordStub);
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['event_name'], 'login_totp_code_success');
+      });
+
+      it('logs a "login_totp_code_failure" event', async () => {
+        const glean = gleanMetrics(config);
+        await glean.login.totpFailure(request);
+        sinon.assert.calledOnce(recordStub);
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['event_name'], 'login_totp_code_failure');
+      });
+    });
   });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -17,6 +17,7 @@ const sinon = require('sinon');
 const { normalizeEmail } = require('fxa-shared').email.helpers;
 const { Container } = require('typedi');
 const { AccountEventsManager } = require('../lib/account-events');
+const { gleanMetrics } = require('../lib/metrics/glean');
 
 const proxyquire = require('proxyquire');
 const amplitudeModule = proxyquire('../lib/metrics/amplitude', {
@@ -218,6 +219,7 @@ module.exports = {
   mockCustoms,
   mockDB,
   mockDevices,
+  mockGlean,
   mockLog: mockObject(LOG_METHOD_NAMES),
   mockMailer: mockObject(MAILER_METHOD_NAMES),
   mockMetricsContext,
@@ -901,4 +903,23 @@ function mockAccountEventsManager() {
 
 function unMockAccountEventsManager() {
   Container.remove(AccountEventsManager);
+}
+
+function mockGlean() {
+  const glean = gleanMetrics({
+    gleanMetrics: {
+      enabled: true,
+      applicationId: 'accounts_backend_test',
+      channel: 'test',
+      loggerAppName: 'auth-server-tests',
+    },
+  });
+
+  for (const i in glean) {
+    for (const j in glean[i]) {
+      glean[i][j] = sinon.stub();
+    }
+  }
+
+  return glean;
 }


### PR DESCRIPTION
Because:
 - we want backend Glean pings for totp success/failure during login

This commit:
 - adds the backend pings
 - adds a centralized glean mock


Fixes:
 - FXA-7284
 - FXA-7285