### PR TITLE
fix(auth): Always show third party auth options except for certain Sync cases

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/third-party-auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/third-party-auth.mustache
@@ -1,7 +1,8 @@
 <aside class="third-party-auth">
-  {{#isSignup}}
-    <div class="separator">{{#t}}or{{/t}}</div>
-  {{/isSignup}}
+{{#showSeparator}}
+  <div class="separator">{{#t}}or{{/t}}</div>
+{{/showSeparator}}
+    
     <button id="google-login-button" class="button login-button"><span class="google-logo"></span>{{#t}}Continue with Google{{/t}}</button>
     <button id="apple-login-button" class="button login-button"><span class="apple-logo"></span>{{#t}}Continue with Apple{{/t}}</button>
 </aside>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -30,10 +30,10 @@
     {{^hasLinkedAccountAndNoPassword}}
       <form novalidate>
         <input type="email" class="email hidden" value="{{ email }}" disabled />
-
         {{#isPasswordNeeded}}
           <div class="tooltip-container mb-5">
-            <input id="password" type="password" class="input-text tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus />
+            <input id="password" type="password" class="input-text tooltip-below" placeholder="{{#t}}Password{{/t}}"
+                   value="{{ password }}" pattern=".{8,}" required autofocus />
           </div>
         {{/isPasswordNeeded}}
 
@@ -43,14 +43,34 @@
         <input class="hidden" required />
 
         <div class="flex">
-          <button id="{{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}{{#isPasswordNeeded}}submit-btn{{/isPasswordNeeded}}" class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}" type="submit">{{#t}}Sign in{{/t}}</button>
+          <button
+            id="{{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}{{#isPasswordNeeded}}submit-btn{{/isPasswordNeeded}}"
+            class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}" type="submit">{{#t}}
+            Sign in{{/t}}</button>
         </div>
-        </form>
-      {{/hasLinkedAccountAndNoPassword}}
+      </form>
+    {{/hasLinkedAccountAndNoPassword}}
 
-      {{#hasLinkedAccountAndNoPassword}}
+    {{#hasLinkedAccount}}
+      <!-- Case OAuth RP user has a linked account, show third party auth -->
+      {{^isSync}}
         {{{ unsafeThirdPartyAuthHTML }}}
-      {{/hasLinkedAccountAndNoPassword}}
+      {{/isSync}}
+    
+      <!-- Case where Sync user has a linked account but doesn't have a password set, show third party auth -->
+      {{#isSync}}
+        {{^hasPassword}}
+          {{{ unsafeThirdPartyAuthHTML }}}
+        {{/hasPassword}}
+      {{/isSync}}
+    {{/hasLinkedAccount}}
+    
+    {{^hasLinkedAccount}}
+      <!-- Don't show third party login options for Sync user -->
+      {{^isSync}}
+        {{{ unsafeThirdPartyAuthHTML }}}
+      {{/isSync}}
+    {{/hasLinkedAccount}}
 
       <div id="tos-pp" class="text-grey-500 my-5 text-xs">
         {{#isPocketClient}}

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -41,7 +41,7 @@ class IndexView extends FormView {
   setInitialContext(context) {
     context.set({
       unsafeThirdPartyAuthHTML: this.renderTemplate(ThirdPartyAuth, {
-        isSignup: true,
+        showSeparator: true
       }),
     });
   }

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -84,13 +84,15 @@ const SignInPasswordView = FormView.extend({
     const account = this.getAccount();
     const hasLinkedAccount = account.get('hasLinkedAccount') ?? false;
     const hasPassword = account.get('hasPassword') ?? true;
-
+    const hasLinkedAccountAndNoPassword = hasLinkedAccount && !hasPassword;
     context.set({
       email: account.get('email'),
       isPasswordNeeded: this.isPasswordNeededForAccount(account) && hasPassword,
       hasLinkedAccountAndNoPassword: hasLinkedAccount && !hasPassword,
+      hasLinkedAccount: hasLinkedAccount,
+      hasPassword: hasPassword,
       unsafeThirdPartyAuthHTML: this.renderTemplate(ThirdPartyAuth, {
-        isSignup: false,
+        showSeparator: !hasLinkedAccountAndNoPassword,
       }),
     });
   },

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -177,6 +177,59 @@ describe('views/sign_in_password', () => {
       });
     });
 
+    it('renders as expected when user has a linked account and password', () => {
+      account.set({
+        hasLinkedAccount: true,
+        hasPassword: true,
+      });
+
+      return view.render().then(() => {
+        assert.include(view.$(Selectors.HEADER).text(), 'Enter your password');
+        assert.lengthOf(view.$('input[type=password]'), 1);
+
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 1);
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 1);
+
+        assert.lengthOf(view.$('.separator'), 1);
+        assert.lengthOf(view.$('#use-different'), 1);
+      });
+    });
+
+    it('renders as expected when user has a password', () => {
+      account.set({
+        hasLinkedAccount: false,
+        hasPassword: true,
+      });
+
+      return view.render().then(() => {
+        assert.include(view.$(Selectors.HEADER).text(), 'Enter your password');
+        assert.lengthOf(view.$('input[type=password]'), 1);
+
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 1);
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 1);
+
+        assert.lengthOf(view.$('.separator'), 1);
+        assert.lengthOf(view.$('#use-different'), 1);
+      });
+    });
+
+    it('renders as expected when user has a password (Sync)', () => {
+      sinon.stub(relier, 'isSync').callsFake(() => true);
+
+      account.set({
+        hasLinkedAccount: false,
+        hasPassword: true,
+      });
+      
+      return view.render().then(() => {
+        assert.include(view.$(Selectors.HEADER).text(), 'Enter your password');
+        assert.lengthOf(view.$('input[type=password]'), 1);
+
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 0);
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 0);
+      });
+    });
+
     it('renders TOS as expected when service is pocket', () => {
       relier.set({
         clientId: '749818d3f2e7857f',


### PR DESCRIPTION
## Because

- We didn't always surface that a user could use third party auth login options (specifically when they have a password set)

## This pull request

- Updates the code so that third party auth is shown for almost all cases. The exception is for Sync (unless they already have a linked account)

## Issue that this pull request solves

Closes:  https://mozilla-hub.atlassian.net/browse/FXA-8233

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

See https://mozilla-hub.atlassian.net/browse/FXA-8233 for screenshots
