### PR TITLE
chore(scripts): increase check-url.sh RETRY value

### DIFF
--- a/_scripts/check-url.sh
+++ b/_scripts/check-url.sh
@@ -3,7 +3,7 @@
 echo "Checking for response from: $1"
 
 
-RETRY=120
+RETRY=240
 for i in $(eval echo "{1..$RETRY}"); do
   if [ "$(curl -s -o /dev/null --silent -w "%{http_code}"  http://$1)" == "${2:-200}" ]; then
     echo "$1 responded in $SECONDS seconds"


### PR DESCRIPTION
Because:

* Mac M1 and M2 machines are slower to start up infrastructure like Redis and Firestore (which runs under emulation).

This commit:

* Doubles the RETRY period from 120 to 240s as most of the time, the `__heartbeat__` (or similar) response for fxa-auth-server (port 9000) and firestore processes (port 9299 among others) responded between 140 - 190s.

[skip ci]

Closes #No ticket

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

It'd be nice to specifically wait for any and all dependencies that these processes have to start up, and we should consider that if this becomes a larger issue for more engineers. Right now, only Valerie and I are hitting this AFAIK.
