### PR TITLE
feat(metrics): send Glean ping on login error

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -8,7 +8,10 @@ const inherits = require('util').inherits;
 const OauthError = require('./oauth/error');
 const verror = require('verror');
 
-const { AUTH_SERVER_ERRNOS: ERRNO } = require('fxa-shared/lib/errors');
+const {
+  AUTH_SERVER_ERRNOS: ERRNO,
+  AUTH_SERVER_ERRNOS_REVERSE_MAP,
+} = require('fxa-shared/lib/errors');
 
 const DEFAULTS = {
   code: 500,
@@ -178,6 +181,12 @@ AppError.translate = function (request, response) {
     }
   }
   return error;
+};
+
+AppError.mapErrnoToKey = function (error) {
+  if (error && error.errno && AUTH_SERVER_ERRNOS_REVERSE_MAP[error.errno]) {
+    return AUTH_SERVER_ERRNOS_REVERSE_MAP[error.errno];
+  }
 };
 
 // Helper functions for creating particular response types.

--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -19,6 +19,7 @@ interface MetricsRequest extends Omit<AuthRequest, 'auth'> {
 
 type MetricsData = {
   uid?: string;
+  reason?: string;
 };
 
 let appConfig: ConfigType;
@@ -81,7 +82,7 @@ const createEventFn =
         ip_address: request.app.clientAddress,
         account_user_id_sha256: '',
         event_name: eventName,
-        event_reason: '',
+        event_reason: metricsData?.reason || '',
         relying_party_oauth_client_id: findOauthClientId(request),
         relying_party_service: await findServiceName(request),
         session_device_type: request.app.ua.deviceType || '',
@@ -120,6 +121,7 @@ export const gleanMetrics = (config: ConfigType) => {
 
     login: {
       success: createEventFn('login_success'),
+      error: createEventFn('login_submit_backend_error'),
       totpSuccess: createEventFn('login_totp_code_success'),
       totpFailure: createEventFn('login_totp_code_failure'),
     },

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1131,14 +1131,23 @@ export class AccountHandler {
       return response;
     };
 
-    await checkCustomsAndLoadAccount();
-    await checkEmailAndPassword();
-    await checkSecurityHistory();
-    await checkTotpToken();
-    await createSessionToken();
-    await sendSigninNotifications();
-    await createKeyFetchToken();
-    return await createResponse();
+    try {
+      await checkCustomsAndLoadAccount();
+      await checkEmailAndPassword();
+      await checkSecurityHistory();
+      await checkTotpToken();
+      await createSessionToken();
+      await sendSigninNotifications();
+      await createKeyFetchToken();
+      return await createResponse();
+    } catch (e) {
+      // we use the errno's key here because the human readable error message
+      // can be too verbose, while the short error title is too low resolution
+      // since some errors are grouped under the same title (e.g. "Bad
+      // Request")
+      this.glean.login.error(request, { reason: error.mapErrnoToKey(e) });
+      throw e;
+    }
   }
 
   async status(request: AuthRequest) {

--- a/packages/fxa-auth-server/test/local/error.js
+++ b/packages/fxa-auth-server/test/local/error.js
@@ -111,6 +111,12 @@ describe('AppErrors', () => {
     assert.equal(result.output.payload.message, result.message);
   });
 
+  it('maps an errno to its key', () => {
+    const error = AppError.cannotLoginNoPasswordSet();
+    const actual = AppError.mapErrnoToKey(error);
+    assert.equal(actual, 'UNABLE_TO_LOGIN_NO_PASSWORD_SET');
+  });
+
   it('backend error includes a cause error when supplied', () => {
     const originalError = new Error('Service timed out.');
     const err = AppError.backendServiceFailure(

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -138,6 +138,13 @@ describe('Glean server side events', () => {
           'b2710dc44cb98ec552e189e48b43e460366f1ae40f922bf325e2635b098962e7'
         );
       });
+
+      it('uses the "reason" event property from the data argument', async () => {
+        await glean.login.error(request, { reason: 'too_cool_for_school' });
+        const metrics = recordStub.args[0][0];
+
+        assert.equal(metrics['event_reason'], 'too_cool_for_school');
+      });
     });
 
     describe('oauth', () => {
@@ -301,9 +308,14 @@ describe('Glean server side events', () => {
   });
 
   describe('registration', () => {
+    let glean;
+
+    beforeEach(() => {
+      glean = gleanMetrics(config);
+    });
+
     describe('accountCreated', () => {
       it('logs a "reg_acc_created" event', async () => {
-        const glean = gleanMetrics(config);
         await glean.registration.accountCreated(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
@@ -313,7 +325,6 @@ describe('Glean server side events', () => {
 
     describe('confirmationEmailSent', () => {
       it('logs a "reg_email_sent" event', async () => {
-        const glean = gleanMetrics(config);
         await glean.registration.confirmationEmailSent(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
@@ -323,18 +334,32 @@ describe('Glean server side events', () => {
   });
 
   describe('login', () => {
+    let glean;
+
+    beforeEach(() => {
+      glean = gleanMetrics(config);
+    });
+
     describe('success', () => {
       it('logs a "login_success" event', async () => {
-        const glean = gleanMetrics(config);
         await glean.login.success(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
         assert.equal(metrics['event_name'], 'login_success');
       });
     });
+
+    describe('error', () => {
+      it('logs a "login_submit_backend_error" event', async () => {
+        await glean.login.error(request);
+        sinon.assert.calledOnce(recordStub);
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['event_name'], 'login_submit_backend_error');
+      });
+    });
+
     describe('totp', () => {
       it('logs a "login_totp_code_success" event', async () => {
-        const glean = gleanMetrics(config);
         await glean.login.totpSuccess(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
@@ -342,7 +367,6 @@ describe('Glean server side events', () => {
       });
 
       it('logs a "login_totp_code_failure" event', async () => {
-        const glean = gleanMetrics(config);
         await glean.login.totpFailure(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3630,6 +3630,7 @@ describe('/account/login', () => {
   });
 
   it('fails login when no password set', () => {
+    glean.login.error.reset();
     mockDB.accountRecord = sinon.spy(() => {
       return Promise.resolve({
         verifierSetAt: 0, // no password set
@@ -3644,6 +3645,10 @@ describe('/account/login', () => {
           'db.accountRecord was called'
         );
         assert.equal(err.errno, 210, 'correct errno called');
+        sinon.assert.calledOnce(glean.login.error);
+        sinon.assert.calledWith(glean.login.error, mockRequest, {
+          reason: 'UNABLE_TO_LOGIN_NO_PASSWORD_SET',
+        });
       }
     );
   });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -346,7 +346,6 @@ describe('subscriptions payPalRoutes', () => {
               'Create subscription with wrong planCurrency should fail.'
             );
           } catch (err) {
-            console.log('>>>>>>>>>>>', err);
             assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
             assert.equal(deleteAccountIfUnverifiedStub.calledOnce, true);
           }


### PR DESCRIPTION
Because:
 - we want to know when a login attempt failed

This commit:
 - sends a Glean ping with a reason for the login failure

