### PR TITLE
fix(fxa-setting): Add he-il lang variant for PDF generation

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -8,7 +8,7 @@
     "build": "nx build-l10n && nx build-ts && nx build-css && nx build-react",
     "build-ts": "tsc --build",
     "build-css": "NODE_ENV=production tailwindcss -i ./src/styles/tailwind.css -o ./src/styles/tailwind.out.css --postcss",
-    "build-storybook": "NODE_ENV=production STORYBOOK_BUILD=1 yarn build-css && NODE_OPTIONS=--openssl-legacy-provider storybook build && cp -r public/locales ./storybook-static/locales",
+    "build-storybook": "NODE_ENV=production STORYBOOK_BUILD=1 yarn build-css && NODE_OPTIONS=--openssl-legacy-provider sb build && cp -r public/locales ./storybook-static/locales",
     "build-l10n": "nx l10n-merge && nx l10n-bundle && nx l10n-merge-test",
     "build-react": "SKIP_PREFLIGHT_CHECK=true INLINE_RUNTIME_CHUNK=false NODE_OPTIONS=--openssl-legacy-provider rescripts build",
     "clean": "rimraf dist",

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/requiredFont.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/requiredFont.tsx
@@ -49,6 +49,7 @@ export interface FontData {
   family: string;
   sources: FontSource[];
   direction: 'ltr' | 'rtl';
+  breakwords: boolean;
 }
 
 export const getRequiredFont = (language: string) => {
@@ -82,6 +83,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: true,
       };
       break;
     // Georgian
@@ -106,10 +108,12 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: false,
       };
       break;
     // Hebrew
     case 'he':
+    case 'he-il':
       requiredFont = {
         family: 'Noto Sans Hebrew',
         sources: [
@@ -130,6 +134,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'rtl',
+        breakwords: false,
       };
       break;
     // Korean
@@ -156,6 +161,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: false,
       };
       break;
     // Punjabi
@@ -184,6 +190,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'rtl',
+        breakwords: false,
       };
       break;
     // Thai
@@ -208,6 +215,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: false,
       };
       break;
     // Chinese (Mainland) - Simplified Chinese
@@ -233,6 +241,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: true,
       };
       break;
     // Chinese (Taiwan) - Traditional Chinese
@@ -257,6 +266,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: true,
       };
       break;
     default:
@@ -280,6 +290,7 @@ export const getRequiredFont = (language: string) => {
           },
         ],
         direction: 'ltr',
+        breakwords: false,
       };
       break;
   }


### PR DESCRIPTION
## Because

- On iOS, account recovery key PDF text in Hebrew was rendered as rectangles instead of appropriate Hebrew fonts
- Long blocks of text in languages that don't use spaces between words (e.g., Chinese) were overflowing the PDF page instead of breaking to the next line.

## This pull request

- Add he-IL variant to PDF generation font selector
- Modify hyphenation rules to prevent page overflow for languages such as Chinese.

## Issue that this pull request solves

Closes: #FXA-8195

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before - Hebrew PDF on iOS with broken encoding
![image](https://github.com/mozilla/fxa/assets/22231637/69abf755-b976-42eb-aa49-c5c52520c050)

After - Hebrew PDF on iOS with correct encoding
![image](https://github.com/mozilla/fxa/assets/22231637/4e3f1f90-cc4e-4f01-a8f2-9427f2e849e8)

Before - Chinese overflowing page:
![image](https://github.com/mozilla/fxa/assets/22231637/b2e13aee-05a5-4e83-ac65-c86ee79812f2)

After - Chinese with line return:
![image](https://github.com/mozilla/fxa/assets/22231637/962d07ad-3134-40fc-a886-dab4fd2fa255)

## Other information (Optional)

To test Hebrew on iOS:
1. Open the staged storybook for the PDF download button on iOS:
https://storage.googleapis.com/mozilla-storybooks-fxa/commits/43f4ac8d60a9451ba94730446f324ab80d0a49f1/fxa-settings/index.html?path=/story/components-buttondownloadrecoverykeypdf--default
2. Change the OS language to Hebrew (device Settings > General > Language and Region > Add Language... (hebrew)
3. Return to storybook, refresh page (button text should now be in Hebrew) and download PDF
4. Observe the PDF text is in Hebrew

To test Chinese PDF, can follow steps above or view the storybook on desktop and change the preferred page language in the browser. (The text overflow issue was device independent)
