### PR TITLE
fix(nx): Disable Nx daemon in local

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,8 @@
           "test-integration",
           "test-unit"
         ],
-        "accessToken": "YzRhMzhiNjEtODE0OS00Njg1LTg2NDktMGJlZjBjNmJjMTc1fHJlYWQtb25seQ=="
+        "accessToken": "YzRhMzhiNjEtODE0OS00Njg1LTg2NDktMGJlZjBjNmJjMTc1fHJlYWQtb25seQ==",
+        "useDaemonProcess": false
       }
     }
   },


### PR DESCRIPTION
## Because

- `NX - Daemon processes terminated and closed the connect` appears when attempting to start the stack

## This pull request

- turns off Nx Daemon by setting useDaemonProcess to false in the runners options in nx.json as referenced [here](https://nx.dev/concepts/more-concepts/nx-daemon#turning-it-off)

## Issue that this pull request solves

Closes:

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
