### PR TITLE
Use bullseye as base image (instead of bookworm the current default)

### DIFF
--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -1,7 +1,7 @@
 # Multi stage docker build for fxa-mono repo. Note that stages should be cached due to docker layer caching being
 # turned on in CI.
 
-FROM node:18.17-slim AS fxa-base
+FROM node:18.17-bullseye-slim AS fxa-base
 RUN set -x \
     && addgroup --gid 10001 app \
     && adduser --disabled-password \


### PR DESCRIPTION
a workaround for https://github.com/nodejs/node/issues/43064