### PR TITLE
fix(storybooks): Update run command

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -47,7 +47,7 @@
     "subscription-reminders": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/subscription-reminders.ts",
     "audit-orphaned-stripe-accounts": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/audit-orphaned-customers.ts",
     "remove-unverified-accounts": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/remove-unverified-accounts.ts",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6010 --no-version-updates -s ./",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 6010 --no-version-updates -s ./",
     "merge-ftl": "nx l10n-merge",
     "merge-ftl-test": "nx l10n-merge",
     "watch-ftl": "nx l10n-watch"

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -30,7 +30,7 @@
     "test-unit": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --coverage --runInBand --logHeapUsage --verbose --config server/jest.config.js --forceExit -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
     "test-integration": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-integration.xml SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=/ INLINE_RUNTIME_CHUNK=false rescripts test --watchAll=false --ci --reporters=default --reporters=jest-junit",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 6006",
     "watch-ftl": "yarn l10n-watch"
   },
   "eslintConfig": {

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -30,7 +30,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "delete": "pm2 delete pm2.config.js",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6007 --no-version-updates",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 6007 --no-version-updates",
     "test": "yarn test-unit && yarn test-integration",
     "test-unit": "JEST_JUNIT_OUTPUT_FILE=../../artifacts/tests/$npm_package_name/jest-unit.xml jest --coverage --runInBand --logHeapUsage --env=jest-environment-jsdom -t '^(?!.*?#integration).*' --ci --reporters=default --reporters=jest-junit",
     "watch-ftl": "yarn l10n-watch"

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -25,7 +25,7 @@
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
     "delete": "pm2 delete pm2.config.js",
-    "storybook": "STORYBOOK_BUILD=1 yarn build-css && NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6008 --no-version-updates",
+    "storybook": "STORYBOOK_BUILD=1 yarn build-css && NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 6008 --no-version-updates",
     "test": "SKIP_PREFLIGHT_CHECK=true rescripts test",
     "test-watch": "SKIP_PREFLIGHT_CHECK=true rescripts test",
     "test-coverage": "yarn test --coverage --watchAll=false",


### PR DESCRIPTION
Because:
* We recently updated the 'storybook' command across packages, causing an error around 'start-storybook'

This commit:
* Changes 'start-storybook' references to 'storybook'

closes FXA-8245

--

See [Nx output](https://mozilla-hub.atlassian.net/jira/software/c/projects/FXA/boards/225?modal=detail&selectedIssue=FXA-8245) without this change, [where we changed](https://github.com/mozilla/fxa/pull/15698/files#diff-7476db00402b40902a9cf3a6834136ed6356ae6591cb4c40a2ed99c2c0a5464fL22) this, and [notes for v7](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed)