### PR TITLE
chore(docs): Updated third party swagger docs

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -176,6 +176,7 @@ const DESCRIPTIONS = {
   productName: 'The name of the product purchased.',
   promotionCode: 'A customer-redeemable code for a coupon.',
   promotionDuration: 'Indicates how long the coupon is valid for.',
+  providerUid: 'The user id associated with a particular third party provider.',
   publicKey:
     'The key to sign (run bin/generate-keypair from [**browserid-crypto**](https://github.com/mozilla/browserid-crypto)).',
   pushPayload:


### PR DESCRIPTION
## Because

- Swagger docs for third party routes was missing some bits

## This pull request

- Updates the response on third party auth routes so swagger picks them up

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8167

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
-
## Other information (Optional)

Updated [ecosystem](https://github.com/mozilla/ecosystem-platform/commit/95f8b7ed609eb52e4b98e02348e800400948b77f) docs as well.
