### PR TITLE
task(settings): Roll out new account recovery key flow to 100% of users

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/new-recovery-key-UI.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/new-recovery-key-UI.js
@@ -16,10 +16,10 @@ const GROUPS = [
   'treatment',
 ];
 
-// This experiment is disabled by default. If you would like to go through
-// the flow, load email-first screen and append query params
-// `?forceExperiment=newRecoveryKeyUI&forceExperimentGroup=treatment`
-const ROLLOUT_RATE = 0.15;
+// This experiment is enabled by default for all users.
+// To see the old flow, load email-first screen and append query params
+// `?forceExperiment=newRecoveryKeyUI&forceExperimentGroup=control`
+const ROLLOUT_RATE = 1.0;
 
 module.exports = class NewRecoveryKeyUI extends BaseGroupingRule {
   constructor() {


### PR DESCRIPTION
## Because

- We want to increase the rollout of the new account recovery key flow from 15% to 100%

## This pull request

- Increase rollout rate of experiment

## Issue that this pull request solves

Closes: # FXA-8237

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
