### PR TITLE
fix(logging): Rename field status to mailStatus to fix BigQuery export errors

### DIFF
--- a/packages/fxa-auth-server/lib/email/bounces.js
+++ b/packages/fxa-auth-server/lib/email/bounces.js
@@ -100,7 +100,7 @@ module.exports = function (log, error) {
           domain: emailDomain,
           bounce: !!message.bounce,
           diagnosticCode: recipient.diagnosticCode,
-          status: recipient.status,
+          mailStatus: recipient.status,
         };
         const bounce = {
           email: email,

--- a/packages/fxa-auth-server/test/local/email/bounce.js
+++ b/packages/fxa-auth-server/test/local/email/bounce.js
@@ -309,7 +309,7 @@ describe('bounce messages', () => {
         assert.equal(log.info.args[1][0], 'handleBounce');
         assert.equal(log.info.args[1][1].email, 'test@example.com');
         assert.equal(log.info.args[1][1].domain, 'other');
-        assert.equal(log.info.args[1][1].status, '5.0.0');
+        assert.equal(log.info.args[1][1].mailStatus, '5.0.0');
         assert.equal(log.info.args[1][1].action, 'failed');
         assert.equal(
           log.info.args[1][1].diagnosticCode,
@@ -319,7 +319,7 @@ describe('bounce messages', () => {
         assert.equal(log.info.args[2][1].email, 'test@example.com');
         assert.equal(log.info.args[4][0], 'handleBounce');
         assert.equal(log.info.args[4][1].email, 'verified@example.com');
-        assert.equal(log.info.args[4][1].status, '4.0.0');
+        assert.equal(log.info.args[4][1].mailStatus, '4.0.0');
       });
   });
 


### PR DESCRIPTION
## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
