### PR TITLE
feat(metrics): add backend registration failure Glean ping

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -185,7 +185,8 @@ async function run(config) {
     config,
     routes,
     database,
-    statsd
+    statsd,
+    glean
   );
 
   try {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1131,23 +1131,14 @@ export class AccountHandler {
       return response;
     };
 
-    try {
-      await checkCustomsAndLoadAccount();
-      await checkEmailAndPassword();
-      await checkSecurityHistory();
-      await checkTotpToken();
-      await createSessionToken();
-      await sendSigninNotifications();
-      await createKeyFetchToken();
-      return await createResponse();
-    } catch (e) {
-      // we use the errno's key here because the human readable error message
-      // can be too verbose, while the short error title is too low resolution
-      // since some errors are grouped under the same title (e.g. "Bad
-      // Request")
-      this.glean.login.error(request, { reason: error.mapErrnoToKey(e) });
-      throw e;
-    }
+    await checkCustomsAndLoadAccount();
+    await checkEmailAndPassword();
+    await checkSecurityHistory();
+    await checkTotpToken();
+    await createSessionToken();
+    await sendSigninNotifications();
+    await createKeyFetchToken();
+    return await createResponse();
   }
 
   async status(request: AuthRequest) {

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -3,15 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import proxyquire from 'proxyquire';
-import sinon from 'sinon';
+import sinon, { SinonStub } from 'sinon';
 import { assert } from 'chai';
+import AppError from '../../../lib/error';
+import mocks from '../../mocks';
 
 const recordStub = sinon.stub();
-const { gleanMetrics } = proxyquire.load('../../../lib/metrics/glean', {
-  './server_events': {
-    createAccountsEventsEvent: () => ({ record: recordStub }),
-  },
-});
+const { gleanMetrics, logErrorWithGlean } = proxyquire.load(
+  '../../../lib/metrics/glean',
+  {
+    './server_events': {
+      createAccountsEventsEvent: () => ({ record: recordStub }),
+    },
+  }
+);
 
 const config = {
   gleanMetrics: {
@@ -351,6 +356,16 @@ describe('Glean server side events', () => {
         assert.equal(metrics['event_name'], 'reg_complete');
       });
     });
+
+    describe('reg_submit_error', () => {
+      it('logs a "reg_submit_error" event', async () => {
+        const glean = gleanMetrics(config);
+        await glean.registration.error(request);
+        sinon.assert.calledOnce(recordStub);
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['event_name'], 'reg_submit_error');
+      });
+    });
   });
 
   describe('login', () => {
@@ -391,6 +406,47 @@ describe('Glean server side events', () => {
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
         assert.equal(metrics['event_name'], 'login_totp_code_failure');
+      });
+    });
+  });
+
+  describe('logErrorWithGlean hapi preResponse error logger', () => {
+    const error = AppError.requestBlocked();
+    const glean = mocks.mockGlean();
+
+    describe('/account/create', () => {
+      it('logs a ping with glean.registration.error', () => {
+        (glean.registration.error as SinonStub).reset();
+        const request = { path: '/account/create' };
+        logErrorWithGlean({
+          glean,
+          request,
+          error,
+        });
+        sinon.assert.calledOnce(glean.registration.error as SinonStub);
+        sinon.assert.calledWithExactly(
+          glean.registration.error as SinonStub,
+          request,
+          { reason: 'REQUEST_BLOCKED' }
+        );
+      });
+    });
+
+    describe('/account/login', () => {
+      it('logs a ping with glean.login.error', () => {
+        (glean.login.error as SinonStub).reset();
+        const request = { path: '/account/login' };
+        logErrorWithGlean({
+          glean,
+          request,
+          error,
+        });
+        sinon.assert.calledOnce(glean.login.error as SinonStub);
+        sinon.assert.calledWithExactly(
+          glean.login.error as SinonStub,
+          request,
+          { reason: 'REQUEST_BLOCKED' }
+        );
       });
     });
   });

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3629,30 +3629,6 @@ describe('/account/login', () => {
       assert.equal(err.errno, error.ERRNO.DISABLED_CLIENT_ID);
     }
   });
-
-  it('fails login when no password set', () => {
-    glean.login.error.reset();
-    mockDB.accountRecord = sinon.spy(() => {
-      return Promise.resolve({
-        verifierSetAt: 0, // no password set
-      });
-    });
-    return runTest(route, mockRequest).then(
-      () => assert.ok(false),
-      (err) => {
-        assert.equal(
-          mockDB.accountRecord.callCount,
-          1,
-          'db.accountRecord was called'
-        );
-        assert.equal(err.errno, 210, 'correct errno called');
-        sinon.assert.calledOnce(glean.login.error);
-        sinon.assert.calledWith(glean.login.error, mockRequest, {
-          reason: 'UNABLE_TO_LOGIN_NO_PASSWORD_SET',
-        });
-      }
-    );
-  });
 });
 
 describe('/account/keys', () => {


### PR DESCRIPTION
This commit moves the Glean ping call out of the route handler and into hapi's `preResponse`.
