### PR TITLE
test(react): Add signup P1 playwright tests in react

### DIFF
--- a/packages/functional-tests/pages/config.ts
+++ b/packages/functional-tests/pages/config.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseLayout } from './layout';
+export class ConfigPage extends BaseLayout {
+  readonly path = '';
+  config: any;
+
+  async getConfig() {
+    if (!this.config) {
+      // Create a new page
+      const page = await this.page.context().newPage();
+
+      await page.goto(this.baseUrl);
+
+      // Content server config is stored in the `meta` tag of the html page.
+      // We can check this tag to see if the content server has enabled this React feature flag.
+      const metaConfig = page.locator('meta[name="fxa-content-server/config"]');
+      const config = await metaConfig.getAttribute('content');
+
+      this.config = JSON.parse(decodeURIComponent(config));
+
+      await page.close();
+    }
+
+    return this.config;
+  }
+}

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -23,7 +23,8 @@ import { LegalPage } from './legal';
 import { CookiesDisabledPage } from './cookiesDisabled';
 import { PostVerifyPage } from './postVerify';
 import { ResetPasswordReactPage } from './resetPasswordReact';
-
+import { SignupReactPage } from './signupReact';
+import { ConfigPage } from './config';
 export function create(page: Page, target: BaseTarget) {
   return {
     avatar: new AvatarPage(page, target),
@@ -50,5 +51,7 @@ export function create(page: Page, target: BaseTarget) {
     legal: new LegalPage(page, target),
     cookiesDisabled: new CookiesDisabledPage(page, target),
     postVerify: new PostVerifyPage(page, target),
+    signupReact: new SignupReactPage(page, target),
+    configPage: new ConfigPage(page, target),
   };
 }

--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -16,7 +16,7 @@ export abstract class BaseLayout {
 
   goto(
     waitUntil: 'networkidle' | 'domcontentloaded' | 'load' = 'load',
-    query?: string
+    query?: string | URLSearchParams
   ) {
     const url = query ? `${this.url}?${query}` : this.url;
     return this.page.goto(url, { waitUntil });

--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -1,0 +1,57 @@
+import { BaseLayout } from './layout';
+import { getReactFeatureFlagUrl } from '../lib/react-flag';
+
+export class SignupReactPage extends BaseLayout {
+  readonly path = 'signup';
+
+  goto(route = '/', params = new URLSearchParams()) {
+    params.set('forceExperiment', 'generalizedReactApp');
+    params.set('forceExperimentGroup', 'react');
+    return this.page.goto(
+      getReactFeatureFlagUrl(this.target, route, params.toString())
+    );
+  }
+
+  get passwordHeader() {
+    return this.page.getByText('Set your password');
+  }
+
+  setEmail(value: string) {
+    return this.page.fill('[name="email"]', value);
+  }
+  setPassword(value: string) {
+    return this.page.fill('[name="newPassword"]', value);
+  }
+
+  setPasswordConfirm(value: string) {
+    return this.page.fill('[name="confirmPassword"]', value);
+  }
+
+  async setAge(value: string) {
+    await this.page.fill('[name="age"]', value);
+    return this.page.locator('[name="age"]').blur();
+  }
+
+  async fillOutSignupForm(password: string) {
+    await this.setPassword(password);
+    await this.setPasswordConfirm(password);
+    await this.setAge('21');
+    await this.submit();
+    await this.page.waitForURL(/confirm_signup_code/);
+  }
+
+  async fillOutCodeForm(code: string) {
+    await this.page.fill('[name="code"]', code);
+    return this.submit();
+  }
+
+  async fillOutEmailFirst(email: string) {
+    await this.setEmail(email);
+    await this.submit();
+    await this.page.waitForURL(/signup/);
+  }
+
+  async submit() {
+    await this.page.locator('button[type="submit"]').click();
+  }
+}

--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -5,8 +5,8 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('force auth', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
-    const config = await login.getConfig();
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
     // TODO: Remove forceAuth tests. React pages don't have this flow.
     test.skip(config.showReactApp.resetPasswordRoutes === true);
   });

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('OAuth force auth', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
-    const config = await login.getConfig();
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
     // TODO: Remove forceAuth tests. React pages don't have this flow.
     test.skip(config.showReactApp.resetPasswordRoutes === true);
   });

--- a/packages/functional-tests/tests/oauth/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/oauth/resetPassword.spec.ts
@@ -6,10 +6,10 @@ import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
 
 test.describe('oauth reset password', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
     test.slow();
 
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     test.skip(config.showReactApp.resetPasswordRoutes === true);
     test.skip(config.showReactApp.oauthRoutes === true);
   });

--- a/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
@@ -5,9 +5,9 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
-test.beforeEach(async ({ pages: { login } }) => {
+test.beforeEach(async ({ pages: { configPage } }) => {
   // This test requires simple react routes to be enabled
-  const config = await login.getConfig();
+  const config = await configPage.getConfig();
   test.skip(config.showReactApp.simpleRoutes !== true);
 });
 

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -5,9 +5,9 @@
 import { test, expect } from '../../lib/fixtures/standard';
 import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
-test.beforeEach(async ({ pages: { login } }) => {
+test.beforeEach(async ({ pages: { configPage } }) => {
   // This test requires simple react routes to be enabled
-  const config = await login.getConfig();
+  const config = await configPage.getConfig();
   test.skip(config.showReactApp.simpleRoutes !== true);
 });
 

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -8,12 +8,12 @@ import { EmailHeader, EmailType } from '../../lib/email';
 test.describe('oauth reset password react', () => {
   let resetPasswordReactFlag = false;
 
-  test.beforeEach(async ({ pages: { login, resetPassword } }) => {
+  test.beforeEach(async ({ pages: { configPage, resetPassword } }) => {
     resetPasswordReactFlag = resetPassword.react;
     resetPassword.react = true;
     test.slow();
 
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     test.skip(config.showReactApp.resetPasswordRoutes !== true);
   });
 

--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -12,13 +12,13 @@ test.describe('recovery key react', () => {
     async ({
       target,
       credentials,
-      pages: { login, settings, recoveryKey },
+      pages: { login, configPage, settings, recoveryKey },
     }) => {
       // Generating and consuming recovery keys is a slow process
       test.slow();
 
       // Ensure that the react reset password route feature flag is enabled
-      const config = await login.getConfig();
+      const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
 
       await settings.goto();

--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -9,10 +9,10 @@ import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 const NEW_PASSWORD = 'notYourAveragePassW0Rd';
 
 test.describe('reset password react', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
     test.slow();
     // Ensure that the feature flag is enabled
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     test.skip(config.showReactApp.resetPasswordRoutes !== true);
   });
 

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, newPagesForSync, test } from '../../lib/fixtures/standard';
+import { EmailHeader, EmailType } from '../../lib/email';
+import { createCustomEventDetail, FirefoxCommand } from '../../lib/channels';
+
+const PASSWORD = 'passwordzxcv';
+
+test.describe('signup react', () => {
+  let email;
+  test.beforeEach(async ({ pages: { login, configPage } }) => {
+    test.slow();
+    // Ensure that the feature flag is enabled
+    const config = await configPage.getConfig();
+    test.skip(config.showReactApp.signUpRoutes !== true);
+
+    email = login.createEmail('signup_react{id}');
+  });
+
+  test.afterEach(async ({ target }) => {
+    if (email) {
+      // Cleanup any accounts created during the test
+      try {
+        await target.auth.accountDestroy(email, PASSWORD);
+      } catch (e) {
+        // Ignore errors
+      }
+    }
+  });
+
+  test('signup web', async ({ page, target, pages: { signupReact } }) => {
+    await signupReact.goto();
+    await signupReact.fillOutEmailFirst(email);
+    await signupReact.fillOutSignupForm(PASSWORD);
+
+    const code = await target.email.waitForEmail(
+      email,
+      EmailType.verifyShortCode,
+      EmailHeader.shortCode
+    );
+
+    await signupReact.fillOutCodeForm(code);
+
+    // Verify logged into settings page
+    await page.waitForURL(/settings/);
+  });
+
+  test('signup oauth', async ({
+    target,
+    pages: { page, signupReact, relier },
+  }) => {
+    await relier.goto();
+    await relier.clickEmailFirst();
+
+    const { searchParams } = new URL(page.url());
+    searchParams.set('email', email);
+
+    // We want to append the experiment params here, but also keep the original oauth params
+    await signupReact.goto('/oauth/signup', searchParams);
+    await signupReact.fillOutSignupForm(PASSWORD);
+
+    // TODO: This needs to be uncommented once oauth is redirecting back to relier
+    // const code = await target.email.waitForEmail(
+    //   email,
+    //   EmailType.verifyShortCode,
+    //   EmailHeader.shortCode
+    // );
+
+    // await signupReact.fillOutCodeForm(code);
+
+    // Verify logged in on relier page
+    // expect(await relier.isLoggedIn()).toBe(true);
+    // await page.waitForURL(/settings/);
+  });
+
+  test('signup oauth webchannel', async ({
+    page,
+    target,
+    pages: { login, relier, signupReact },
+  }) => {
+    const customEventDetail = createCustomEventDetail(
+      FirefoxCommand.FxAStatus,
+      {
+        capabilities: {
+          choose_what_to_sync: true,
+          engines: ['bookmarks', 'history'],
+        },
+        signedInUser: null,
+      }
+    );
+
+    await relier.goto('context=oauth_webchannel_v1&automatedBrowser=true');
+    await relier.clickEmailFirst();
+
+    await login.respondToWebChannelMessage(customEventDetail);
+
+    // TODO: CTWS has not been implemented yet, probably better to pull into signupReact page
+    // await login.waitForCWTSEngineHeader();
+    // expect(await login.isCWTSEngineBookmarks()).toBe(true);
+    // expect(await login.isCWTSEngineHistory()).toBe(true);
+
+    const { searchParams } = new URL(page.url());
+    searchParams.set('email', email);
+
+    // We want to append the experiment params here, but also keep the original oauth params
+    await signupReact.goto('/oauth/signup', searchParams);
+    await signupReact.fillOutSignupForm(PASSWORD);
+
+    // TODO: This needs to be implemented as well
+    // const code = await target.email.waitForEmail(
+    //   email,
+    //   EmailType.verifyShortCode,
+    //   EmailHeader.shortCode
+    // );
+    //
+    // await signupReact.fillOutCodeForm(code);
+    // await login.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+  });
+
+  test('signup sync', async ({ target }) => {
+    test.slow();
+    const syncBrowserPages = await newPagesForSync(target);
+    const { login, signupReact } = syncBrowserPages;
+
+    email = login.createEmail('sync{id}');
+
+    await signupReact.goto(
+      '/',
+      new URLSearchParams({
+        context: 'fx_desktop_v3',
+        service: 'sync',
+        action: 'email',
+      })
+    );
+
+    await signupReact.fillOutEmailFirst(email);
+    await signupReact.fillOutSignupForm(PASSWORD);
+
+    const code = await target.email.waitForEmail(
+      email,
+      EmailType.verifyShortCode,
+      EmailHeader.shortCode
+    );
+
+    await signupReact.fillOutCodeForm(code);
+
+    // TODO Uncomment once sync is working
+    // expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
+
+    await syncBrowserPages.browser?.close();
+  });
+});

--- a/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
@@ -10,10 +10,10 @@ test.describe.configure({ mode: 'parallel' });
 let syncBrowserPages;
 
 test.describe('Firefox Desktop Sync v3 reset password react', () => {
-  test.beforeEach(async ({ target, pages: { login } }) => {
+  test.beforeEach(async ({ target, pages: { configPage } }) => {
     test.slow();
     // Ensure that the feature flag is enabled
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     test.skip(config.showReactApp.resetPasswordRoutes !== true);
 
     syncBrowserPages = await newPagesForSync(target);

--- a/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
@@ -4,10 +4,10 @@ import { EmailHeader, EmailType } from '../../lib/email';
 const NEW_PASSWORD = 'passwordzxcv';
 
 test.describe('Reset password current', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
     test.slow();
 
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     test.skip(config.showReactApp.resetPasswordRoutes === true);
   });
 

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -71,9 +71,9 @@ test.describe('severity-3 #smoke', () => {
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293440
   test('settings data-trio component works #1293423 #1293440', async ({
     credentials,
-    pages: { login, settings, recoveryKey },
+    pages: { configPage, settings, recoveryKey },
   }) => {
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     if (config.featureFlags.showRecoveryKeyV2 !== true) {
       await settings.goto();
       await settings.recoveryKey.clickCreate();

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -32,12 +32,12 @@ test.describe('severity-1 #smoke', () => {
     target,
     credentials,
     page,
-    pages: { settings, login, recoveryKey },
+    pages: { settings, login, configPage, recoveryKey },
   }, { project }) => {
     test.slow(project.name !== 'local', 'email delivery can be slow');
 
     // TODO in FXA-7419 - remove config definition
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
 
     await settings.goto();
     let status = await settings.recoveryKey.statusText();

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -10,11 +10,11 @@ let hint;
 // TODO in FXA-7419 - remove this first describe block that refers to the old account recovery generation flow
 test.describe('old recovery key test', () => {
   test.beforeEach(
-    async ({ credentials, pages: { login, settings, recoveryKey } }) => {
+    async ({ credentials, pages: { configPage, settings, recoveryKey } }) => {
       // Generating and consuming recovery keys is a slow process
       test.slow();
 
-      const config = await login.getConfig();
+      const config = await configPage.getConfig();
       test.skip(config.featureFlags.showRecoveryKeyV2 === true);
 
       await settings.goto();
@@ -224,12 +224,12 @@ test.describe('old recovery key test', () => {
 // TODO in FXA-7419 - rename describe block (remove "new")
 test.describe('new recovery key test', () => {
   test.beforeEach(
-    async ({ credentials, pages: { login, settings, recoveryKey } }) => {
+    async ({ credentials, pages: { configPage, settings, recoveryKey } }) => {
       // Generating and consuming recovery keys is a slow process
       // Mail delivery can also be slow
       test.slow();
 
-      const config = await login.getConfig();
+      const config = await configPage.getConfig();
       test.skip(config.featureFlags.showRecoveryKeyV2 !== true);
 
       await settings.goto('isInRecoveryKeyExperiment=true');

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -8,10 +8,10 @@ import { EmailHeader, EmailType } from '../../lib/email';
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Firefox Desktop Sync v3 reset password', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
     test.slow();
 
-    const config = await login.getConfig();
+    const config = await configPage.getConfig();
     test.skip(config.showReactApp.resetPasswordRoutes === true);
   });
 

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -68,6 +68,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'primary_email_verified',
         'signup_confirmed',
         'signup_verified',
+        'oauth/signup',
       ]),
     },
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -252,6 +252,7 @@ const AuthAndAccountSetupRoutes = (_: RouteComponentProps) => {
       />
 
       <SignupContainer path="/signup/*" {...{ integration }} />
+      <SignupContainer path="/oauth/signup/*" {...{ integration }} />
 
       <Confirm path="/confirm/*" {...{ sessionTokenId }} />
       <ConfirmSignupCode path="/confirm_signup_code/*" />


### PR DESCRIPTION
## Because

- We need to add P1 tests for all signup React flows

## This pull request

- Adds P1 tests for signup web, signup oauth, signup oauth webchannel and sigup sync flows
- Adds a new POM for config page, ensures that pulling config does not interfere with tests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7315

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
