### PR TITLE
fix(functional-tests): Subscription funnel metrics tests are failing on stage

### DIFF
--- a/packages/functional-tests/lib/targets/base.ts
+++ b/packages/functional-tests/lib/targets/base.ts
@@ -8,6 +8,11 @@ export type Credentials = Awaited<ReturnType<AuthClient['signUp']>> & {
   secret?: string;
 };
 
+interface SubConfig {
+  product: string;
+  plan: string;
+}
+
 export abstract class BaseTarget {
   readonly auth: AuthClient;
   readonly email: EmailClient;
@@ -15,6 +20,7 @@ export abstract class BaseTarget {
   abstract readonly paymentsServerUrl: string;
   abstract readonly relierUrl: string;
   abstract readonly name: TargetName;
+  abstract readonly subscriptionConfig: SubConfig;
 
   constructor(readonly authServerUrl: string, emailUrl?: string) {
     this.auth = new AuthClient(authServerUrl);

--- a/packages/functional-tests/lib/targets/local.ts
+++ b/packages/functional-tests/lib/targets/local.ts
@@ -1,12 +1,19 @@
 import { TargetName } from '.';
 import { BaseTarget, Credentials } from './base';
 
+const SUB_PRODUCT = 'prod_GqM9ToKK62qjkK';
+const SUB_PLAN = 'plan_GqM9N6qyhvxaVk';
+
 export class LocalTarget extends BaseTarget {
   static readonly target = 'local';
   readonly name: TargetName = LocalTarget.target;
   readonly contentServerUrl = 'http://localhost:3030';
   readonly paymentsServerUrl = 'http://localhost:3031';
   readonly relierUrl = 'http://localhost:8080';
+  readonly subscriptionConfig = {
+    product: SUB_PRODUCT,
+    plan: SUB_PLAN,
+  };
 
   constructor() {
     super('http://localhost:9000', 'http://localhost:9001');

--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -10,6 +10,8 @@ const PAYMENTS_DOMAIN =
   'payments-stage.fxa.nonprod.cloudops.mozgcp.net';
 const RELIER_DOMAIN =
   process.env.RELIER_DOMAIN || 'stage-123done.herokuapp.com';
+const SUB_PRODUCT = 'prod_FfiuDs9u11ESbD';
+const SUB_PLAN = 'plan_FfiupsKXZ3mMZ6';
 
 export class StageTarget extends RemoteTarget {
   static readonly target = 'stage';
@@ -17,6 +19,10 @@ export class StageTarget extends RemoteTarget {
   readonly contentServerUrl = `https://${ACCOUNTS_DOMAIN}`;
   readonly paymentsServerUrl = `https://${PAYMENTS_DOMAIN}`;
   readonly relierUrl = `https://${RELIER_DOMAIN}`;
+  readonly subscriptionConfig = {
+    product: SUB_PRODUCT,
+    plan: SUB_PLAN,
+  };
 
   constructor() {
     super(`https://${ACCOUNTS_API_DOMAIN}`);

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { BaseLayout } from './layout';
+import { expect } from '../lib/fixtures/standard';
 
 export class RelierPage extends BaseLayout {
   goto(query?: string) {
@@ -112,10 +113,14 @@ export class RelierPage extends BaseLayout {
     });
   }
 
-  getUrl() {
-    return this.page
-      .locator('[data-testid=rp-flow-metrics]')
-      .getAttribute('href');
+  async getUrl() {
+    const expectedPathRegExp = new RegExp(
+      `\\/subscriptions\\/products\\/${this.target.subscriptionConfig.product}\\?plan=${this.target.subscriptionConfig.plan}&service=(\\w+)`,
+      'i'
+    );
+    const subscribeButton = this.page.locator('[data-testid=rp-flow-metrics]');
+    await expect(subscribeButton).toHaveAttribute('href', expectedPathRegExp);
+    return subscribeButton.getAttribute('href');
   }
 
   getRpAcquisitionParams(searchParams) {

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -172,7 +172,6 @@ test.describe('Flow, acquisition and new user checkout funnel metrics', () => {
       expect(page.url()).toContain('&flow_begin_time=');
     });
 
-    /*Disabling the test for Fxa-8078
     test('New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics', async ({
       pages: { settings, relier, page, subscribe },
     }, { project }) => {
@@ -228,6 +227,6 @@ test.describe('Flow, acquisition and new user checkout funnel metrics', () => {
         return event.type;
       });
       expect(actualEventTypes).toMatchObject(expectedEventTypes);
-    });*/
+    });
   });
 });


### PR DESCRIPTION
## Because

- it is returning the URL before query params have been added

## This pull request

- waits for the selector to have the query params before returning the URL

## Issue that this pull request solves

Closes: [FXA-8078](https://mozilla-hub.atlassian.net/browse/FXA-8078)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.


[FXA-8078]: https://mozilla-hub.atlassian.net/browse/FXA-8078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ