### PR TITLE
feat(legal): Add legal snippet to email first when third party option shown

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/third-party-auth.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/third-party-auth.js
@@ -13,7 +13,7 @@ const GROUPS = [
 // This experiment is disabled by default. If you would like to go through
 // the flow, load email-first screen and append query params
 // `?forceExperiment=thirdPartyAuth&forceExperimentGroup=treatment`
-const ROLLOUT_RATE = 0.0;
+const ROLLOUT_RATE = 1.0;
 
 module.exports = class ThirdPartyAuth extends BaseGroupingRule {
   constructor() {

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -1,5 +1,5 @@
 <div class="card">
-  <header class="mb-4">
+  <header class="mb-8">
     {{#isSync}}
       <h1 id="fxa-enter-email-header" class="card-header">
         {{#t}}Continue to Firefox accounts{{/t}}
@@ -45,6 +45,9 @@
     {{#isInThirdPartyAuthExperiment}}
       {{^isSync}}
         {{{ unsafeThirdPartyAuthHTML }}}
+        <div id="tos-pp" class="text-grey-500 -mb-2 mt-5 text-xs">
+            {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+        </div>
       {{/isSync}}
       {{#isSync}}
         <p class="text-xs text-grey-500 mb-0 mt-5" id="firefox-family-services">

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -173,7 +173,7 @@
     background-color: white;
     font-weight: normal;
     &:not(:last-of-type) {
-      margin-bottom: 10px;
+      margin-bottom: 12px;
     }
     &:hover {
       border-color: #1a1a1a;
@@ -195,13 +195,12 @@
   .separator {
     font-weight: 200;
     font-size: 16px;
-    line-height: 19px;
-    color: #919191;
-    text-transform: uppercase;
+    line-height: 14px;
+    color: #8f8f9d;
     display: flex;
     align-items: center;
     text-align: center;
-    margin: 24px 0 24px 0;
+    margin: 32px 0 32px 0;
   }
 
   .separator::before,
@@ -212,10 +211,10 @@
   }
 
   .separator:not(:empty)::before {
-    margin-right: 2em;
+    margin-right: 8px;
   }
 
   .separator:not(:empty)::after {
-    margin-left: 2em;
+    margin-left: 8px;
   }
 }


### PR DESCRIPTION
## Because

- We want to show the legal snippet on the email first page

## This pull request

- Adds the snippet
- Updates the spacing on the third party auth buttons to match ux specs
- Enables third party auth experiment to 100%

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8298

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="502" alt="Screenshot 2023-09-12 at 1 11 19 PM" src="https://github.com/mozilla/fxa/assets/1295288/69abff97-bb26-4c31-8776-806e62df50d1">


