### PR TITLE
feat(auth): l10n changes for Mozilla Account branding (auth-server)

### DIFF
--- a/packages/fxa-auth-server/grunttasks/ftl.js
+++ b/packages/fxa-auth-server/grunttasks/ftl.js
@@ -5,6 +5,17 @@
 'use strict';
 
 module.exports = function (grunt) {
+  // make a copy of the local branding terms available for local development
+  // before they are extracted to the l10n repo
+  // this file will not be included in the string extraction process, so should not lead to duplication
+  grunt.config('copy', {
+    'branding-ftl': {
+      nonull: true,
+      src: '../fxa-shared/l10n/branding.ftl',
+      dest: 'public/locales/en/branding.ftl',
+    },
+  });
+
   grunt.config('concat', {
     ftl: {
       src: ['lib/l10n/server.ftl', 'lib/**/senders/emails/**/en.ftl'],
@@ -29,7 +40,7 @@ module.exports = function (grunt) {
     },
   });
 
-  grunt.registerTask('merge-ftl', ['concat:ftl']);
+  grunt.registerTask('merge-ftl', ['copy:branding-ftl', 'concat:ftl']);
   grunt.registerTask('merge-ftl:test', ['concat:ftl-test']);
   grunt.registerTask('watch-ftl', ['watch:ftl']);
 };

--- a/packages/fxa-auth-server/lib/l10n/server.ftl
+++ b/packages/fxa-auth-server/lib/l10n/server.ftl
@@ -1,4 +1,5 @@
 ## Non-email strings
 
 session-verify-send-push-title = Logging in to { -product-firefox-accounts }?
+session-verify-send-push-title-2 = Logging in to your { -product-mozilla-account }?
 session-verify-send-push-body-2 = Click here to confirm it’s you

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
@@ -4,7 +4,10 @@
 ## version. The strings are usually identical but sometimes they differ slightly.
 
 fxa-header-firefox-logo = <img data-l10n-name="fxa-logo" alt="{ -brand-firefox } logo">
+fxa-header-mozilla-logo = <img data-l10n-name="mozilla-logo" alt="{ -brand-mozilla } logo">
 fxa-header-sync-devices-image = <img data-l10n-name="sync-devices-image" alt="Sync devices">
 body-devices-image = <img data-l10n-name="devices-image" alt="Devices">
 fxa-privacy-url = { -brand-mozilla } Privacy Policy
+moz-accounts-privacy-url = { -product-mozilla-accounts(capitalization:"uppercase") } Privacy Policy
 fxa-service-url = { -product-firefox-cloud } Terms of Service
+moz-accounts-terms-url = { -product-mozilla-accounts(capitalization:"uppercase") } Terms of Service

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
@@ -1,4 +1,5 @@
 subplat-header-firefox-logo = <img data-l10n-name="fxa-logo-firefox" alt="{ -brand-firefox } logo">
+subplat-header-mozilla-logo = <img data-l10n-name="mozilla-logo" alt="{ -brand-mozilla } logo">
 subplat-footer-mozilla-logo = <img data-l10n-name="mozilla-logo" alt="{ -brand-mozilla } logo">
 subplat-automated-email = This is an automated email; if you received it in error, no action is required.
 subplat-privacy-notice = Privacy notice
@@ -10,13 +11,26 @@ subplat-update-billing-plaintext = { subplat-update-billing }:
 subplat-explainer-specific = You’re receiving this email because { $email } has a { -product-firefox-account } and you signed up for { $productName }.
 # Variables:
 #  $email (String) - A user's primary email address
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subplat-explainer-specific-2 = You’re receiving this email because { $email } has a { -product-mozilla-account } and you signed up for { $productName }.
+# Variables:
+#  $email (String) - A user's primary email address
 subplat-explainer-reminder-form = You’re receiving this email because { $email } has a { -product-firefox-account }.
+# Variables:
+#  $email (String) - A user's primary email address
+subplat-explainer-reminder-form-2 = You’re receiving this email because { $email } has a { -product-mozilla-account }.
 subplat-explainer-multiple = You’re receiving this email because { $email } has a { -product-firefox-account } and you have subscribed to multiple products.
+subplat-explainer-multiple-2 = You’re receiving this email because { $email } has a { -product-mozilla-account } and you have subscribed to multiple products.
 subplat-explainer-was-deleted = You’re receiving this email because { $email } was registered for a { -product-firefox-account }.
+subplat-explainer-was-deleted-2 = You’re receiving this email because { $email } was registered for a { -product-mozilla-account }.
 subplat-manage-account = Manage your { -product-firefox-account } settings by visiting your <a data-l10n-name="subplat-account-page">account page</a>.
+subplat-manage-account-2 = Manage your { -product-mozilla-account } settings by visiting your <a data-l10n-name="subplat-account-page">account page</a>.
 # Variables:
 #  $accountSettingsUrl (String) - URL to Account Settings
 subplat-manage-account-plaintext = Manage your { -product-firefox-account } settings by visiting your account page: { $accountSettingsUrl }
+# Variables:
+#  $accountSettingsUrl (String) - URL to Account Settings
+subplat-manage-account-plaintext-2 = Manage your { -product-mozilla-account } settings by visiting your account page: { $accountSettingsUrl }
 subplat-terms-policy = Terms and cancellation policy
 subplat-terms-policy-plaintext = { subplat-terms-policy }:
 subplat-cancel = Cancel subscription

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en.ftl
@@ -4,4 +4,4 @@ cadReminderFirst-action-plaintext = { cadReminderFirst-action }:
 # In the title of the email, "It takes two to sync", "two" refers to syncing two devices
 cadReminderFirst-title-1 = It takes two to sync
 cadReminderFirst-description-1 = Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use { -brand-firefox }. It’s like having magic in your { -brand-firefox } account!
-cadReminderFirst-description-2 = It only takes a sec to sync.
+cadReminderFirst-description-v2 = Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use { -brand-firefox }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.mjml
@@ -13,10 +13,6 @@
     <mj-text css-class="text-body">
       <span data-l10n-id="cadReminderFirst-description-1">Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!</span>
     </mj-text>
-
-    <mj-text css-class="text-body">
-      <span data-l10n-id="cadReminderFirst-description-2">It only takes a sec to sync.</span>
-    </mj-text>
   </mj-column>
 </mj-section>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.txt
@@ -2,8 +2,6 @@ cadReminderFirst-title-1 = "It takes two to sync"
 
 cadReminderFirst-description-1 = "Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!"
 
-cadReminderFirst-description-2 = "It only takes a sec to sync."
-
 cadReminderFirst-action-plaintext = "Sync another device:"
 <%- link %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/fraudulentAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/fraudulentAccountDeletion/en.ftl
@@ -1,7 +1,10 @@
 fraudulentAccountDeletion-subject = Your { -product-firefox-account } was deleted
+fraudulentAccountDeletion-subject-2 = Your { -product-mozilla-account } was deleted
 fraudulentAccountDeletion-title = Your account was deleted
 fraudulentAccountDeletion-content = Recently, a { -product-firefox-account } was created and a subscription was charged using this email address. As we do with all new accounts, we asked that you confirm your account by first validating this email address.
+fraudulentAccountDeletion-content-part1-v2 = Recently, a { -product-mozilla-account } was created and a subscription was charged using this email address. As we do with all new accounts, we asked that you confirm your account by first validating this email address.
 fraudulentAccountDeletion-content-2 = At present, we see that the account was never confirmed. Since this step was not completed, we are not sure if this was an authorized subscription. As a result, the { -product-firefox-account } registered to this email address was deleted and your subscription was canceled with all charges reimbursed.
+fraudulentAccountDeletion-content-part2-v2 = At present, we see that the account was never confirmed. Since this step was not completed, we are not sure if this was an authorized subscription. As a result, the { -product-mozilla-account } registered to this email address was deleted and your subscription was canceled with all charges reimbursed.
 fraudulentAccountDeletion-contact = If you have any questions, please contact our <a data-l10n-name="mozillaSupportUrl">support team</a>.
 # Variables:
 #  $mozillaSupportUrl (String) - Link to https://support.mozilla.org

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
@@ -1,9 +1,8 @@
 # Variables:
 # $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
 newDeviceLogin-subject = New sign-in to { $clientName }
-# Variables:
-# $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
 newDeviceLogin-title-2 = Your { -product-firefox-account } was used to sign in
+newDeviceLogin-title-3 = Your { -product-mozilla-account } was used to sign in
 # The "Not you?" question is asking whether the recipient of the email is the
 # person who performed the action that triggered the email.
 newDeviceLogin-change-password = Not you? <a data-l10n-name="passwordChangeLink">Change your password</a>.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/en.ftl
@@ -1,8 +1,8 @@
 passwordChangeRequired-subject = Suspicious activity detected
 passwordChangeRequired-title = Password Change Required
 passwordChangeRequired-suspicious-activity = We detected suspicious behavior on your { -product-firefox-account }. To prevent unauthorized access to your { -product-firefox-account }, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution.
+passwordChangeRequired-suspicious-activity-2 = We detected suspicious behavior on your { -product-mozilla-account }. To prevent unauthorized access to your { -product-mozilla-account }, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution.
 passwordChangeRequired-sign-in = Sign back into any device or service where you use your { -product-firefox-account } and follow the steps that will be presented to you.
+passwordChangeRequired-sign-in-2 = Sign back into any device or service where you use your { -product-mozilla-account } and follow the steps that will be presented to you.
 passwordChangeRequired-different-password = <b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account.
-passwordChangeRequired-signoff = Best,
-passwordChangeRequired-signoff-name = The { -product-firefox-accounts } team
 passwordChangeRequired-different-password-plaintext = Important: Pick a different password than what you were previously using and make sure that it is different from your email account.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.mjml
@@ -23,15 +23,5 @@
     <mj-text css-class="text-body align-left">
       <span data-l10n-id="passwordChangeRequired-different-password"><b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account.</span>
     </mj-text>
-
-    <mj-text css-class="text-body-lg-bottom-margin align-left">
-      <span data-l10n-id="passwordChangeRequired-signoff">
-        Best,
-      </span>
-      <br />
-      <span data-l10n-id="passwordChangeRequired-signoff-name">
-        The Firefox accounts team
-      </span>
-    </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.txt
@@ -6,7 +6,4 @@ passwordChangeRequired-sign-in = "Sign back into any device or service where you
 
 passwordChangeRequired-different-password-plaintext = "Important: Pick a different password than what you were previously using and make sure that it is different from your email account."
 
-passwordChangeRequired-signoff = "Best,"
-passwordChangeRequired-signoff-name = "The Firefox accounts team"
-
 <%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/en.ftl
@@ -1,3 +1,4 @@
 passwordChanged-subject = Password updated
 passwordChanged-title = Password changed successfully
 passwordChanged-description = Your { -product-firefox-account } password was successfully changed from the following device:
+passwordChanged-description-2 = Your { -product-mozilla-account } password was successfully changed from the following device:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddLinkedAccount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddLinkedAccount/en.ftl
@@ -1,5 +1,9 @@
 postAddLinkedAccount-subject = New account linked to { -brand-firefox }
+postAddLinkedAccount-subject-2 = New account linked to your { -product-mozilla-account }
 #  Variables:
 #  $providerName (String) - The name of the provider, e.g. Apple, Google
 postAddLinkedAccount-title = Your { $providerName } account has been linked to your { -product-firefox-account }
+#  Variables:
+#  $providerName (String) - The name of the provider, e.g. Apple, Google
+postAddLinkedAccount-title-2 = Your { $providerName } account has been linked to your { -product-mozilla-account }
 postAddLinkedAccount-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en.ftl
@@ -3,4 +3,7 @@ postChangePrimary-title = New primary email
 # Variables:
 #  $email (String) - A user's email address
 postChangePrimary-description = You have successfully changed your primary email to { $email }. This address is now your username for signing in to your { -product-firefox-account }, as well as receiving security notifications and sign-in confirmations.
+# Variables:
+#  $email (String) - A user's email address
+postChangePrimary-description-2 = You have successfully changed your primary email to { $email }. This address is now your username for signing in to your { -product-mozilla-account }, as well as receiving security notifications and sign-in confirmations.
 postChangePrimary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en.ftl
@@ -3,4 +3,7 @@ postRemoveSecondary-title = Secondary email removed
 # Variables:
 #  $secondaryEmail (String) - A user's email address
 postRemoveSecondary-description = You have successfully removed { $secondaryEmail } as a secondary email from your { -product-firefox-account }. Security notifications and sign-in confirmations will no longer be delivered to this address.
+# Variables:
+#  $secondaryEmail (String) - A user's email address
+postRemoveSecondary-description-2 = You have successfully removed { $secondaryEmail } as a secondary email from your { -product-mozilla-account }. Security notifications and sign-in confirmations will no longer be delivered to this address.
 postRemoveSecondary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en.ftl
@@ -3,5 +3,6 @@ postVerify-title-2 = Want to see the same tab on two devices?
 postVerify-description-2 = It’s easy! Just install { -brand-firefox } on another device and log in to sync. It’s like magic!
 postVerify-sub-description = (Psst… It also means you can get your bookmarks, passwords, and other { -brand-firefox } data everywhere you’re signed in.)
 postVerify-subject-3 = Welcome to { -brand-firefox }!
+postVerify-subject-4 = Welcome to { -brand-mozilla }!
 postVerify-setup-2 = Connect another device:
 postVerify-action-2 = Connect another device

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.stories.ts
@@ -16,6 +16,7 @@ const createStory = storyWithProps(
     link: 'http://localhost:3030/connect_another_device',
     desktopLink: 'https://firefox.com',
     onDesktopOrTabletDevice: true,
+    productName: 'Firefox',
   }
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en.ftl
@@ -3,4 +3,7 @@ postVerifySecondary-title = Secondary email added
 # Variables:
 #  $secondaryEmail (String) - A user's secondary email address
 postVerifySecondary-content-2 = You have successfully confirmed { $secondaryEmail } as a secondary email for your { -product-firefox-account }. Security notifications and sign-in confirmations will now be delivered to both email addresses.
+# Variables:
+#  $secondaryEmail (String) - A user's secondary email address
+postVerifySecondary-content-3 = You have successfully confirmed { $secondaryEmail } as a secondary email for your { -product-mozilla-account }. Security notifications and sign-in confirmations will now be delivered to both email addresses.
 postVerifySecondary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/en.ftl
@@ -3,6 +3,9 @@ recovery-title-2 = Forgot your password?
 # Information on the browser, IP address, date and time of the request that
 # triggered the email follows.
 recovery-request-origin = We received a request for a password change on your { -product-firefox-account } from:
+# Information on the browser, IP address, date and time of the request that
+# triggered the email follows.
+recovery-request-origin-2 = We received a request for a password change on your { -product-mozilla-account } from:
 recovery-new-password-button = Create a new password by clicking the button below. This link will expire within the next hour.
 recovery-copy-paste = Create a new password by copying and pasting the URL below into your browser. This link will expire within the next hour.
 recovery-action = Create new password

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -7,3 +7,8 @@ subscriptionAccountDeletion-title = Sorry to see you go
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
 subscriptionAccountDeletion-content-cancelled = You recently deleted your { -product-firefox-account }. As a result, we’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+subscriptionAccountDeletion-content-cancelled-2 = You recently deleted your { -product-mozilla-account }. As a result, we’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
@@ -6,4 +6,5 @@ subscriptionAccountFinishSetup-subject = Welcome to { $productName }: Please set
 subscriptionAccountFinishSetup-title = Welcome to { $productName }
 subscriptionAccountFinishSetup-content-processing = Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel.
 subscriptionAccountFinishSetup-content-create-2 = Next, you’ll create a { -product-firefox-account } password to start using your new subscription.
+subscriptionAccountFinishSetup-content-create-3 = Next, you’ll create a { -product-mozilla-account } password to start using your new subscription.
 subscriptionAccountFinishSetup-action-2 = Get started

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/en.ftl
@@ -1,6 +1,7 @@
 subscriptionAccountReminderFirst-subject = Reminder: Finish setting up your account
 subscriptionAccountReminderFirst-title = You can’t access your subscription yet
 subscriptionAccountReminderFirst-content-info-2 = A few days ago you created a { -product-firefox-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
+subscriptionAccountReminderFirst-content-info-3 = A few days ago you created a { -product-mozilla-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
 subscriptionAccountReminderFirst-content-select-2 = Select “Create Password” to set up a new password and finish confirming your account.
 subscriptionAccountReminderFirst-action = Create Password
 subscriptionAccountReminderFirst-action-plaintext = { subscriptionAccountReminderFirst-action }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/en.ftl
@@ -1,6 +1,8 @@
 subscriptionAccountReminderSecond-subject = Final reminder: Setup your account
 subscriptionAccountReminderSecond-title = Welcome to { -brand-firefox }!
+subscriptionAccountReminderSecond-title-2 = Welcome to { -brand-mozilla }!
 subscriptionAccountReminderSecond-content-info-2 = A few days ago you created a { -product-firefox-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
+subscriptionAccountReminderSecond-content-info-3 = A few days ago you created a { -product-mozilla-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
 subscriptionAccountReminderSecond-content-select-2 = Select “Create Password” to set up a new password and finish confirming your account.
 subscriptionAccountReminderSecond-action = Create Password
 subscriptionAccountReminderSecond-action-plaintext = { subscriptionAccountReminderSecond-action }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/en.ftl
@@ -1,4 +1,5 @@
 verificationReminderFinal-subject = Final reminder to confirm your account
 verificationReminderFinal-description = A couple of weeks ago you created a { -product-firefox-account }, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours.
+verificationReminderFinal-description-2 = A couple of weeks ago you created a { -product-mozilla-account }, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours.
 confirm-account = Confirm account
 confirm-account-plaintext = { confirm-account }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
@@ -1,6 +1,8 @@
 verificationReminderFirst-subject-2 = Remember to confirm your account
 verificationReminderFirst-title-2 = Welcome to { -brand-firefox }!
+verificationReminderFirst-title-3 = Welcome to { -brand-mozilla }!
 verificationReminderFirst-description-2 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.
+verificationReminderFirst-description-3 = A few days ago you created a { -product-mozilla-account }, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.
 verificationReminderFirst-sub-description-3 = Don’t miss out on the browser that puts you and your privacy first.
 confirm-email-2 = Confirm account
 confirm-email-plaintext-2 = { confirm-email-2 }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
@@ -1,6 +1,9 @@
 verificationReminderSecond-subject-2 = Remember to confirm your account
 verificationReminderSecond-title-2 = Don’t miss out on { -brand-firefox }!
+verificationReminderSecond-title-3 = Don’t miss out on { -brand-mozilla }!
 verificationReminderSecond-description-3 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.
+verificationReminderSecond-description-4 = A few days ago you created a { -product-mozilla-account }, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.
 verificationReminderSecond-second-description = Your { -product-firefox-account } lets you sync your info across devices and unlocks access to more privacy-protecting products from { -brand-mozilla }.
+verificationReminderSecond-second-description-2 = Your { -product-mozilla-account } lets you sync your info across devices and unlocks access to more privacy-protecting products from { -brand-mozilla }.
 verificationReminderSecond-sub-description-2 = Be part of our mission to transform the internet into a place that’s open for everyone.
 verificationReminderSecond-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/en.ftl
@@ -1,4 +1,6 @@
 verify-title-2 = Open the internet with { -brand-firefox }
+verify-title-3 = Open the internet with { -brand-mozilla }
 verify-description = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in starting with:
+verify-description-2 = Confirm your account and get the most out of { -brand-mozilla } everywhere you sign in starting with:
 verify-subject = Finish creating your account
 verify-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/en.ftl
@@ -4,5 +4,8 @@ verifySecondaryCode-action-2 = Confirm email
 # Variables:
 #  $email (string) A user's unverified secondary email address
 verifySecondaryCode-explainer = A request to use { $email } as a secondary email address has been made from the following { -product-firefox-account }:
+# Variables:
+#  $email (string) A user's unverified secondary email address
+verifySecondaryCode-explainer-2 = A request to use { $email } as a secondary email address has been made from the following { -product-mozilla-account }:
 verifySecondaryCode-prompt-2 = Use this confirmation code:
 verifySecondaryCode-expiry-notice-2 = It expires in 5 minutes. Once confirmed, this address will begin receiving security notifications and confirmations.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
@@ -2,7 +2,10 @@
 #  $code (Number) - e.g. 123456
 verifyShortCode-subject-3 = Confirm your account
 verifyShortCode-title-2 = Open the internet with { -brand-firefox }
+verifyShortCode-title-3 = Open the internet with { -brand-mozilla }
 # Information on the browser and device triggering this confirmation email follows below this string.
 verifyShortCode-title-subtext = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in starting with:
+# Information on the browser and device triggering this confirmation email follows below this string.
+verifyShortCode-title-subtext-2 = Confirm your account and get the most out of { -brand-mozilla } everywhere you sign in starting with:
 verifyShortCode-prompt-3 = Use this confirmation code:
 verifyShortCode-expiry-notice = It expires in 5 minutes.

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -47,7 +47,7 @@
     "subscription-reminders": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/subscription-reminders.ts",
     "audit-orphaned-stripe-accounts": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/audit-orphaned-customers.ts",
     "remove-unverified-accounts": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/remove-unverified-accounts.ts",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 6010 --no-version-updates -s ./",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 6010 --no-version-updates ./",
     "merge-ftl": "nx l10n-merge",
     "merge-ftl-test": "nx l10n-merge",
     "watch-ftl": "nx l10n-watch"

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -234,7 +234,6 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ['html', [
       { test: 'include', expected: 'It takes two to sync' },
       { test: 'include', expected: 'Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!' },
-      { test: 'include', expected: 'It only takes a sec to sync.' },
       { test: 'include', expected: decodeUrl(configHref('syncUrl', 'cad-reminder-first', 'connect-device')) },
       { test: 'include', expected: decodeUrl(config.smtp.androidUrl) },
       { test: 'include', expected: decodeUrl(config.smtp.iosUrl) },
@@ -252,7 +251,6 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ['text', [
       { test: 'include', expected: 'It takes two to sync' },
       { test: 'include', expected: 'Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use Firefox. It’s like having magic in your Firefox account!' },
-      { test: 'include', expected: 'It only takes a sec to sync.' },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-first', 'privacy')}` },
       { test: 'include', expected: config.smtp.syncUrl },
       { test: 'notInclude', expected: config.smtp.androidUrl },

--- a/packages/fxa-shared/l10n/branding.ftl
+++ b/packages/fxa-shared/l10n/branding.ftl
@@ -25,7 +25,12 @@
 -product-mozilla-account = Mozilla account
 
 # "accounts" can and should be localized, "Mozilla" must be treated as a brand. Plural "Mozilla accounts" is used when referring to something affecting all Mozilla accounts, not just the individual's account.
--product-mozilla-accounts = Mozilla accounts
+# "accounts" should be lowercase in almost all cases. Uppercase is reserved for special use cases where headline case is necessary, for example legal document names and references.
+-product-mozilla-accounts =
+    { $capitalization ->
+       *[lowercase] Mozilla accounts
+        [uppercase] Mozilla Accounts
+    }
 
 # "account" should be localized and lowercase, "Firefox" must be treated as a brand.
 # This is used to refer to a user's account, e.g. "update your Firefox account ..."


### PR DESCRIPTION
## Because

* We want l10n strings that are changing from Firefox account(s) to Mozilla account(s) to be localized before launch

## This pull request

* Create new copies of ftl strings that contained Firefox account/accounts and replace brand term with Mozilla account/accounts
* This ticket DOES NOT implement the new strings, that will be handled in a follow-up ticket (8321)

## Issue that this pull request solves

Closes: #FXA-7992

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Brand terms (`-product-mozilla-account` and `-product-mozilla-accounts`) are already added to fxa-shared for use by fxa-auth-server (among other packages).

Skipped updates to recovery key emails as they will be updated with account-agnostic content in JIRA 7669