### PR TITLE
bug(settings,content): Follow up for in brand messaging

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -1,20 +1,22 @@
 {{#showBanner}}
-<div id="banner-brand-message" class="absolute w-full top-0 left-0">
+<div id="banner-brand-message" class="w-full relative mobileLandscape:absolute mobileLandscape:top-0 mobileLandscape:left-0">
     <div class="flex justify-center p-2 brand-banner-bg">
         {{#showPrelaunch}}
         <div class="flex"/>
-            <div class="flex-none m-logo relative mt-1 mr-4 mb-2 bg-black">
-                <div>
-                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAQCAYAAAAFzx/vAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAEKSURBVHgB7ZThDYIwEIWLcQBHYAPdQDfQEdxAR9AJdAN0AnECYAOYoGwAG5yv4UiacrX9ofGPL3kEel/v2tI2IaKFUmqnpiqTJGk5voHXsHnv4SdipQ2DSznPkpkGzG2S1YAkaw9vYO2JX6wcBw+jeSBRBTMK68QDeydNwyoFC47q4AdceGKa3wvmtMAd7YILHuVRAB/26Mg/m5Uzgc6JZ7H/MhU4HUqGtqvD5GNspvyqzS4V2t22RurrfHcxBXsVp1guWPAr+hf8uObmgW17UsM9aSvldqMeO/bqybHl45ODqT3MinMNcQpLjz1JvnGM9hbjuyCy3ywpdA5w9lm7w5XA2MvZwjeBqV7FRzhNrCW4kwAAAABJRU5ErkJggg==" alt="{{#t}}mozilla m logo{{/t}}" />
-                </div>
+            <div class="flex-none relative">
+                <img
+                    class="w-8 h-8 bg-black m-4 mt-1"
+                    src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3QgeD0iMC43NjkyMjYiIHk9IjAuNzY5MjI2IiB3aWR0aD0iMzAuNDYxNSIgaGVpZ2h0PSIzMC40NjE1IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMjcuNzMxNCAyMC41MDg0SDI5LjY0NDFWMjMuNjE1NEgyMy42MTIxVjE1LjI3NDVDMjMuNjEyMSAxMi42NTY3IDIyLjc3ODEgMTEuNjcyOCAyMS4xNTkyIDExLjY3MjhDMTkuMTk3MiAxMS42NzI4IDE4LjQxMjQgMTMuMTYwOSAxOC40MTI0IDE1LjIxMzlWMjAuNDQ5NkgyMC4zMjUxVjIzLjU2MDRIMTQuMzAwOFYxNS4yNjg5QzE0LjMwMDggMTIuNjUxIDEzLjQ2NjcgMTEuNjY3MSAxMS44NDc4IDExLjY2NzFDOS44ODU4MyAxMS42NjcxIDguNzg4MjUgMTMuMTU1MiA4Ljc4ODI1IDE1LjIwODJWMjAuNDQzOUgxMS44MzY0VjIzLjU2MDRIMy4wMTQxNFYyMC40NTM0SDQuODIyNThWMTIuMzU3MkgyLjkyNjk0VjguNjU0OThIOC4zNzY5VjEwLjk5NDJDOS41MDExOSA5LjMyNDQ0IDExLjM5OTMgOC4zNDMyMiAxMy40MTE3IDguMzkxNDlDMTUuNTIxNCA4LjI3NjQ3IDE3LjQzOTkgOS42MDg1NCAxOC4wNjkzIDExLjYyNTRDMTguNzQ2NyA5LjY0MzQ2IDIwLjYzNSA4LjMzMjg3IDIyLjcyODggOC4zOTE0OUMyNC4xMDE5IDguMzI4NzkgMjUuNDM1MSA4Ljg2MzI2IDI2LjM4NDYgOS44NTcxNkMyNy4zMzQyIDEwLjg1MTEgMjcuODA3MyAxMi4yMDcyIDI3LjY4MjEgMTMuNTc2MVYyMC41MDg0SDI3LjczMTRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K"
+                    alt="{{#t}}Mozilla m logo{{/t}}"
+                />
             </div>
-            <div class="flex-initial max-w-md pr-2">
-                <p class="text-left text-sm font-bold">
+            <div class="flex-initial max-w-md">
+                <p class="text-start text-sm font-bold">
                     {{#t}}Firefox accounts will be renamed Mozilla accounts on Nov 1{{/t}}
                 </p>
-                <p class="text-left text-xs">
+                <p class="text-start text-xs">
                     {{#t}}You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                    <span class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
+                    <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
                 </p>
             </div>
         </div>
@@ -24,14 +26,24 @@
             <div>
                 <p class="text-sm font-bold">
                     {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                    <span role="link" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
+                    <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
                 </p>
             </div>
         </div>
         {{/showPostlaunch}}
-    </div>
-    <div class="absolute w-10 right-0 top-0 pt-3 start-0">
-        <img id="close-brand-banner" class="cursor-pointer" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+CiAgPGc+CiAgICA8cGF0aCBmaWxsPSJyZ2JhKDEyLCAxMiwgMTMsIC44KSIgZD0iTTkuNDE0IDhsNS4yOTMtNS4yOTNhMSAxIDAgMDAtMS40MTQtMS40MTRMOCA2LjU4NiAyLjcwNyAxLjI5M2ExIDEgMCAwMC0xLjQxNCAxLjQxNEw2LjU4NiA4bC01LjI5MyA1LjI5M2ExIDEgMCAxMDEuNDE0IDEuNDE0TDggOS40MTRsNS4yOTMgNS4yOTNhMSAxIDAgMDAxLjQxNC0xLjQxNHoiLz4KICA8L2c+Cjwvc3ZnPgo=" alt="{{#t}}Close Banner{{/t}}" />
+        <div class="flex justify-right order-last rtl:justify-left m-4 mt-1 mb-1">
+            <button
+                id="close-brand-banner"
+                class="w-4 h-4"
+                aria-label="{{#t}}Close Banner{{/t}}"
+                >
+                <img
+                    src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+CiAgPGc+CiAgICA8cGF0aCBmaWxsPSJyZ2JhKDEyLCAxMiwgMTMsIC44KSIgZD0iTTkuNDE0IDhsNS4yOTMtNS4yOTNhMSAxIDAgMDAtMS40MTQtMS40MTRMOCA2LjU4NiAyLjcwNyAxLjI5M2ExIDEgMCAwMC0xLjQxNCAxLjQxNEw2LjU4NiA4bC01LjI5MyA1LjI5M2ExIDEgMCAxMDEuNDE0IDEuNDE0TDggOS40MTRsNS4yOTMgNS4yOTNhMSAxIDAgMDAxLjQxNC0xLjQxNHoiLz4KICA8L2c+Cjwvc3ZnPgo="
+                    class="cursor-pointer h-4 w-4"
+                    alt="{{#t}}Close Banner{{/t}}"
+                />
+            </button>
+        </div>
     </div>
 </div>
 {{/showBanner}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -45,8 +45,8 @@
         <div class="flex">
           <button
             id="{{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}{{#isPasswordNeeded}}submit-btn{{/isPasswordNeeded}}"
-            class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}" type="submit">{{#t}}
-            Sign in{{/t}}</button>
+            class="cta-primary cta-xl {{^isPasswordNeeded}}use-logged-in{{/isPasswordNeeded}}"
+            type="submit">{{#t}}Sign in{{/t}}</button>
         </div>
       </form>
     {{/hasLinkedAccountAndNoPassword}}
@@ -56,7 +56,7 @@
       {{^isSync}}
         {{{ unsafeThirdPartyAuthHTML }}}
       {{/isSync}}
-    
+
       <!-- Case where Sync user has a linked account but doesn't have a password set, show third party auth -->
       {{#isSync}}
         {{^hasPassword}}
@@ -64,7 +64,7 @@
         {{/hasPassword}}
       {{/isSync}}
     {{/hasLinkedAccount}}
-    
+
     {{^hasLinkedAccount}}
       <!-- Don't show third party login options for Sync user -->
       {{^isSync}}

--- a/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
@@ -24,11 +24,6 @@ const Mixin = {
     }
   },
 
-  events: {
-    [`click #close-brand-banner`]: 'onBrandBannerClose',
-    [`click .brand-learn-more`]: 'onBrandLearnMoreClick',
-  },
-
   beforeRender() {
     // Check to see if the user has cleared the brand messaging banner. If so,
     // we don't want to keep showing them this messaging
@@ -41,13 +36,29 @@ const Mixin = {
       (this.mode === 'prelaunch' || this.mode === 'postlaunch')
     ) {
       this.logFlowEvent(`brand-messaging-${this.mode}-view`, this.viewName);
-
-      // hack add some padding to prevent overlap
-      setTimeout(() => {
-        console.log('!!! adding padding2');
-        document.body.classList.add('brand-messaging');
-      }, 300);
+      document.body.classList.add('brand-messaging');
     }
+  },
+
+  afterRender() {
+    setTimeout(() => {
+      /**
+       * Move element up to body, so that it can be sticky header or inline footer.
+       *
+       * Note, we can't use backbone's event object, because moving the elements
+       * unbinds it's events. Instead, directly bind events here.
+       */
+      const el = document.querySelector('#banner-brand-message');
+      if (el) {
+        document.body.append(el);
+        document.querySelector('#close-brand-banner').onclick = () => {
+          this.onBrandBannerClose();
+        };
+        document.querySelector('.brand-learn-more').onclick = () => {
+          this.onBrandLearnMoreClick();
+        };
+      }
+    }, 0);
   },
 
   setInitialContext(context) {
@@ -70,8 +81,8 @@ const Mixin = {
       `${bannerClosedLocalStorageKey}_${this.mode}`,
       this.disableBanner
     );
-    this.$('#banner-brand-message').remove();
-    this.$('body').removeClass('brand-messaging');
+    document.querySelector('#banner-brand-message').remove();
+    document.body.classList.remove('brand-messaging');
     this.logFlowEvent(
       `brand-messaging-${this.mode}-banner-close`,
       this.viewName

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -65,40 +65,10 @@
   }
 }
 
-#banner-brand-message {
-  .brand-banner-bg {
-    background: linear-gradient(88.76deg, #E4EAF6 3.37%, #DBEEF8 39.93%, #DAF3F4 65.09%, #E3F6ED 102.21%);
-  }
-
-  .m-logo {
-    width: 30px;
-    height: 30px;
-    top: 5px;
-    background-color: #000;
-
-    >div:first-child {
-      position: absolute;
-      width: 30px;
-      height: 30px;
-      left: calc(50% - 15px + 0.25px);
-        top: calc(50% - 15px - 0px);
-
-      >img:first-child {
-        position: absolute;
-        width: 27px;
-        height: 16px;
-        left: calc(50% - 13.5px);
-          top: calc(50% - 8px);
-        background: #000;
-      }
-    }
-  }
-
-  @include respond-to('small') {
-    top: initial;
-    bottom: 0;
-  }
+.brand-banner-bg {
+  background: linear-gradient(88.76deg, #E4EAF6 3.37%, #DBEEF8 39.93%, #DAF3F4 65.09%, #E3F6ED 102.21%);
 }
+
 /** Work around for sticky fixed banner */
 body.brand-messaging {
   padding-top: 9rem;
@@ -109,6 +79,7 @@ body.brand-messaging {
   body.brand-messaging {
     padding-top: inherit;
   }
+
 }
 .choose-what-to-sync {
   .success-email-created {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -279,7 +279,7 @@ const conf = (module.exports = convict({
     },
   },
   brandMessagingMode: {
-    default: 'prelaunch',
+    default: 'none',
     doc: 'The type of messaging to show. Options are prelaunch, postlaunch, or none',
     env: 'BRAND_MESSAGING_MODE',
     format: String,

--- a/packages/fxa-settings/Gruntfile.js
+++ b/packages/fxa-settings/Gruntfile.js
@@ -3,7 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = function (grunt) {
-  const srcPaths = ['.license.header', 'src/**/*.ftl'];
+  const srcPaths = [
+    '../fxa-shared/l10n/branding.ftl',
+    '.license.header',
+    '../fxa-react/components/**/*.ftl',
+    'src/**/*.ftl',
+  ];
   const testPaths = [
     '../fxa-shared/l10n/branding.ftl',
     '../fxa-react/components/**/*.ftl',

--- a/packages/fxa-settings/src/components/BrandMessaging/en.ftl
+++ b/packages/fxa-settings/src/components/BrandMessaging/en.ftl
@@ -20,7 +20,9 @@ brand-postlaunch-title = We’ve renamed { -product-firefox-accounts } to { -pro
 brand-learn-more = Learn more
 
 # Alt text for close banner image
-brand-close-banner = Close Banner
+brand-close-banner =
+  .alt = Close Banner
 
 # Alt text for 'm' logo in banner header
-brand-m-logo = Mozilla m logo
+brand-m-logo =
+  .alt = { -brand-mozilla } m logo

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -68,37 +68,41 @@ const BrandMessaging = ({
   }
 
   return (
-    <div id="banner-brand-message" className="fixed w-full top-0 left-0">
+    <div
+      id="banner-brand-message"
+      className="w-full relative mobileLandscape:absolute mobileLandscape:top-0 mobileLandscape:left-0"
+    >
       <div className="flex relative justify-center p-2 brand-banner-bg">
         {mode === 'prelaunch' && (
           <div className="flex" data-testid="brand-prelaunch">
-            <div className="m-logo flex-none relative mt-1 mr-4 mb-2">
-              <div className="bg-black">
-                <Localized id="brand-m-logo" attrs={{ alt: true }}>
-                  <img
-                    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAQCAYAAAAFzx/vAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAEKSURBVHgB7ZThDYIwEIWLcQBHYAPdQDfQEdxAR9AJdAN0AnECYAOYoGwAG5yv4UiacrX9ofGPL3kEel/v2tI2IaKFUmqnpiqTJGk5voHXsHnv4SdipQ2DSznPkpkGzG2S1YAkaw9vYO2JX6wcBw+jeSBRBTMK68QDeydNwyoFC47q4AdceGKa3wvmtMAd7YILHuVRAB/26Mg/m5Uzgc6JZ7H/MhU4HUqGtqvD5GNspvyqzS4V2t22RurrfHcxBXsVp1guWPAr+hf8uObmgW17UsM9aSvldqMeO/bqybHl45ODqT3MinMNcQpLjz1JvnGM9hbjuyCy3ywpdA5w9lm7w5XA2MvZwjeBqV7FRzhNrCW4kwAAAABJRU5ErkJggg=="
-                    alt="Mozilla m logo"
-                  />
-                </Localized>
-              </div>
+            <div className="flex-none relative">
+              <Localized id="brand-m-logo" attrs={{ alt: true }}>
+                <img
+                  className="w-8 h-8 bg-black m-4 mt-1"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3QgeD0iMC43NjkyMjYiIHk9IjAuNzY5MjI2IiB3aWR0aD0iMzAuNDYxNSIgaGVpZ2h0PSIzMC40NjE1IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMjcuNzMxNCAyMC41MDg0SDI5LjY0NDFWMjMuNjE1NEgyMy42MTIxVjE1LjI3NDVDMjMuNjEyMSAxMi42NTY3IDIyLjc3ODEgMTEuNjcyOCAyMS4xNTkyIDExLjY3MjhDMTkuMTk3MiAxMS42NzI4IDE4LjQxMjQgMTMuMTYwOSAxOC40MTI0IDE1LjIxMzlWMjAuNDQ5NkgyMC4zMjUxVjIzLjU2MDRIMTQuMzAwOFYxNS4yNjg5QzE0LjMwMDggMTIuNjUxIDEzLjQ2NjcgMTEuNjY3MSAxMS44NDc4IDExLjY2NzFDOS44ODU4MyAxMS42NjcxIDguNzg4MjUgMTMuMTU1MiA4Ljc4ODI1IDE1LjIwODJWMjAuNDQzOUgxMS44MzY0VjIzLjU2MDRIMy4wMTQxNFYyMC40NTM0SDQuODIyNThWMTIuMzU3MkgyLjkyNjk0VjguNjU0OThIOC4zNzY5VjEwLjk5NDJDOS41MDExOSA5LjMyNDQ0IDExLjM5OTMgOC4zNDMyMiAxMy40MTE3IDguMzkxNDlDMTUuNTIxNCA4LjI3NjQ3IDE3LjQzOTkgOS42MDg1NCAxOC4wNjkzIDExLjYyNTRDMTguNzQ2NyA5LjY0MzQ2IDIwLjYzNSA4LjMzMjg3IDIyLjcyODggOC4zOTE0OUMyNC4xMDE5IDguMzI4NzkgMjUuNDM1MSA4Ljg2MzI2IDI2LjM4NDYgOS44NTcxNkMyNy4zMzQyIDEwLjg1MTEgMjcuODA3MyAxMi4yMDcyIDI3LjY4MjEgMTMuNTc2MVYyMC41MDg0SDI3LjczMTRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K"
+                  alt="Mozilla m logo"
+                />
+              </Localized>
             </div>
-            <div className="flex-initial max-w-md pr-2">
-              <p className="text-left text-sm font-bold">
+            <div className="flex-initial max-w-md">
+              <p className="text-start text-sm font-bold">
                 <FtlMsg id="brand-prelaunch-title">
                   Firefox accounts will be renamed Mozilla accounts on Nov 1
                 </FtlMsg>
               </p>
-              <p className="text-left text-xs">
+              <p className="text-start text-xs">
                 <FtlMsg id="brand-prelaunch-subtitle">
                   You’ll still sign in with the same username and password, and
                   there are no other changes to the products that you use.
                 </FtlMsg>
+                &nbsp;
                 <span
                   role="link"
+                  tabIndex={0}
                   className="brand-learn-more underline cursor-pointer"
                   onClick={onClickLearnMore}
                 >
-                  &nbsp;<FtlMsg id="brand-learn-more">Learn more</FtlMsg>
+                  <FtlMsg id="brand-learn-more">Learn more</FtlMsg>
                 </span>
               </p>
             </div>
@@ -107,37 +111,39 @@ const BrandMessaging = ({
 
         {mode === 'postlaunch' && (
           <div className="flex" data-testid="brand-postlaunch">
-            <div className="flex-initial max-w-md pr-2">
+            <div>
               <p className="text-sm font-bold">
                 <FtlMsg id="brand-postlaunch-title">
                   We’ve renamed Firefox accounts to Mozilla accounts. You’ll
                   still sign in with the same username and password, and there
                   are no other changes to the products that you use.
                 </FtlMsg>
+                &nbsp;
                 <span
                   role="link"
+                  tabIndex={0}
                   className="brand-learn-more underline cursor-pointer"
                   onClick={onClickLearnMore}
                 >
-                  &nbsp;<FtlMsg id="brand-learn-more">Learn more</FtlMsg>
+                  <FtlMsg id="brand-learn-more">Learn more</FtlMsg>
                 </span>
               </p>
             </div>
           </div>
         )}
-        <div className="absolute w-1/12 right-0 top-0 pt-3 start-0">
+        <div className="flex justify-right order-last rtl:justify-left m-4 mt-1 mb-1">
           <FtlMsg id="brand-banner-dismiss-button" attrs={{ ariaLabel: true }}>
             <button
-              id="close-brand-banner"
-              className="cursor-pointer"
+              className="w-4 h-4"
               data-testid="close-brand-messaging"
               type="button"
               aria-label="Close Banner"
               onClick={onClickCloseBanner}
             >
-              <Localized id="branding-close-banner" attrs={{ alt: true }}>
+              <Localized id="brand-close-banner" attrs={{ alt: true }}>
                 <img
                   src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+CiAgPGc+CiAgICA8cGF0aCBmaWxsPSJyZ2JhKDEyLCAxMiwgMTMsIC44KSIgZD0iTTkuNDE0IDhsNS4yOTMtNS4yOTNhMSAxIDAgMDAtMS40MTQtMS40MTRMOCA2LjU4NiAyLjcwNyAxLjI5M2ExIDEgMCAwMC0xLjQxNCAxLjQxNEw2LjU4NiA4bC01LjI5MyA1LjI5M2ExIDEgMCAxMDEuNDE0IDEuNDE0TDggOS40MTRsNS4yOTMgNS4yOTNhMSAxIDAgMDAxLjQxNC0xLjQxNHoiLz4KICA8L2c+Cjwvc3ZnPgo="
+                  className="cursor-pointer h-4 w-4"
                   alt="Close Banner"
                 />
               </Localized>

--- a/packages/fxa-settings/src/styles/brand-banner.css
+++ b/packages/fxa-settings/src/styles/brand-banner.css
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/** Custom gradient taken from design spec */
 .brand-banner-bg {
   background: linear-gradient(
     88.76deg,
@@ -12,42 +13,21 @@
   );
 }
 
-.m-logo {
-  width: 30px;
-  height: 30px;
-
-  div:first-child {
-    @apply absolute;
-    width: 30px;
-    height: 30px;
-    left: calc(50% - 30px / 2 + 0.25px);
-    top: calc(50% - 30px / 2 - 0px);
-
-    img:first-child {
-      @apply absolute;
-      width: 27px;
-      height: 16px;
-      left: calc(50% - 27px / 2 + 0px);
-      top: calc(50% - 16px / 2 - 0px);
-    }
+/** At widths less than 540, text starts wrapping, and more padding is needing */
+@media only screen and (max-width: 540px) {
+  body.brand-messaging {
+    @apply pt-28;
   }
 }
 
-/*  This class ensures that the top banner which holds in product messaging
-    doesn't obstruct the main card. It also handles the mobile edge cases
-    where we want the banner to stick to the bottom of the screen. The class
-    will be added by the brand messaging control when applicable. */
+/** By default a bit of padding is needed to offset the banner at top of page. */
 body.brand-messaging {
-  @apply pt-24 !important;
+  @apply pt-18;
 }
 
+/** On screens smaller than 480, footer drops to bottom, so no padding is needed */
 @media only screen and (max-width: 480px) {
   body.brand-messaging {
-    @apply mt-0;
-  }
-
-  #banner-brand-message {
-    top: initial;
-    @apply bottom-0;
+    @apply pt-0;
   }
 }


### PR DESCRIPTION
## Because:
- A couple defects were noticed.
  - The X icon was always on the left side.
  - role="Link" was missing in one spot, so screen readers wouldn't work for Learn more link.
  - The link could not be tabbed to.
  - In mobile view some pages would overlap the messaging
  - In mobile view the 'X' icon would over overlap the text on some devices
  - Noticed an existing issue with signup text due to line break in {{\t}} wrapper
  - Branding ftl strings in [fxa-shared](https://mozilla-hub.atlassian.net/browse/FXA-shared) not coming through
  - Mozilla hard coded in alt text


## This pull request
- Adds `rtl:` and `ltr:` prefix to ensure x is on the right side
- switched to using flex to ensure X icon doesn't overlap
- some tricks to ensure banner is fixed and sticky when render at top, and appended / inline rendered at bottom of page in mobile view.
- Moves away from pixel based css for m-logo and uses tailwind styles instead.
- Removes a stray console.log
- Sets timeout to 0 for adding the brand-messaging class. A long timeout is not necessary.
- Default BRAND_MESSAGING_MODE to none, to avoid accidental rollout.
- Fixes bug in grunt file, where latest changes form [fxa-shared](https://mozilla-hub.atlassian.net/browse/FXA-shared) branding.ftl (or [fxa-react](https://mozilla-hub.atlassian.net/browse/FXA-react) *.ftl files) weren't picked up.
- Replaces hard code 'Mozilla' string with { -brand-mozilla }


## Issue that this pull request solves

Closes: FXA-7993

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Icon now in correct spot for ltr and rtl languages:
![image](https://github.com/mozilla/fxa/assets/94418270/91b1c69b-395f-4eed-9143-b588f7b95245)
![image](https://github.com/mozilla/fxa/assets/94418270/9a1d9718-9611-4fc8-b210-4042a0893f43)

No more overlap for sticky footer
![image](https://github.com/mozilla/fxa/assets/94418270/4180c3f1-2c00-4f8c-b1f5-02a4260bee1f)


## Other information (Optional)

This is a follow up to #15788 
