### PR TITLE
fix(metrics): Send service value when using the linked account login route

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -603,6 +603,7 @@ export default class AuthClient {
   async verifyAccountThirdParty(
     code: string,
     provider: AUTH_PROVIDER = AUTH_PROVIDER.GOOGLE,
+    service?: string,
     metricsContext: MetricsContext = {}
   ): Promise<{
     uid: hexstring;
@@ -612,6 +613,7 @@ export default class AuthClient {
     const payload = {
       code,
       provider,
+      service,
       metricsContext,
     };
     return await this.request('POST', '/linked_account/login', payload);

--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -69,6 +69,7 @@ describe('/linked_account', () => {
           payload: {
             provider: 'google',
             code: '123',
+            service: 'sync',
           },
         });
 
@@ -259,7 +260,7 @@ describe('/linked_account', () => {
         );
 
         const result = await runTest(route, mockRequest);
-        
+
         assert.isTrue(mockDB.totpToken.calledOnce);
         assert.isTrue(mockDB.createSessionToken.calledOnce);
         assert.ok(mockDB.createSessionToken.args[0][0].tokenVerificationId);

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1384,19 +1384,21 @@ FxaClientWrapper.prototype = {
   verifyAccountThirdParty: withClient(
     (client, relier, token, provider, metricsContext) => {
       return client
-        .verifyAccountThirdParty(token, provider, metricsContext)
+        .verifyAccountThirdParty(
+          token,
+          provider,
+          relier.get('service'),
+          metricsContext
+        )
         .then((accountData) => {
           return getUpdatedSessionData(accountData.email, relier, accountData);
         });
     }
   ),
 
-  createPassword: withClient(
-    (client, token, email, password) => {
-      return client
-        .createPassword(token, email, password)
-    }
-  ),
+  createPassword: withClient((client, token, email, password) => {
+    return client.createPassword(token, email, password);
+  }),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/scripts/views/post_verify/third_party_auth/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/third_party_auth/set_password.js
@@ -19,7 +19,7 @@ const VPASSWORD_INPUT_SELECTOR = '#vpassword';
 
 class SetPassword extends FormView {
   template = Template;
-  
+
   _getPassword() {
     return this.$(PASSWORD_INPUT_SELECTOR).val();
   }
@@ -38,7 +38,7 @@ class SetPassword extends FormView {
       this.showValidationError(this.$(PASSWORD_INPUT_SELECTOR), err, true);
     }
   }
-  
+
   getAccount() {
     return this.getSignedInAccount();
   }
@@ -61,17 +61,17 @@ class SetPassword extends FormView {
     const account = this.getAccount();
     const password = this._getPassword();
 
-    return account.createPassword(account.get('email'), password)
-      .then(() => {
-        // After the user has set a password, initiated the standard Sync
-        // login flow with the password they set.
-        return this.signIn(account, password);
-      });
+    return account.createPassword(account.get('email'), password).then(() => {
+      // After the user has set a password, initiated the standard Sync
+      // login flow with the password they set.
+      return this.signIn(account, password);
+    });
   }
 }
 
 Cocktail.mixin(
   SetPassword,
+  FlowEventsMixin,
   PasswordMixin,
   CWTSOnSignupPasswordMixin,
   PasswordStrengthMixin({
@@ -80,7 +80,6 @@ Cocktail.mixin(
   }),
   ServiceMixin,
   AccountSuggestionMixin,
-  FlowEventsMixin,
   SigninMixin
 );
 


### PR DESCRIPTION
## Because

- The service param was not being populated in our dashboards

## This pull request

- Sends the service value into the route directly

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8003

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Here are the metrics logs for different flows

### New account
```
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_third_party_auth - view","time":1694713313434,"device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_branding - enter_email_brand_messaging_prelaunch_view","time":1694713313434,"device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_email_first - view","time":1694713313449,"device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_third_party_auth - google_oauth_start","time":1694713315601,"device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
28|auth  | 2023-09-14T13:42:34: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_reg - email_confirmed","time":1694713354304,"user_id":"4d91cba05f9b40f4935d401d024867a5","device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"undefined_oauth"}}}
28|auth  | 2023-09-14T13:42:34: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_reg - complete","time":1694713354304,"user_id":"4d91cba05f9b40f4935d401d024867a5","device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"undefined_oauth"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_branding - enter_email_brand_messaging_prelaunch_view","time":1694713353293,"device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_third_party_auth - google_signin_complete","time":1694713354414,"device_id":"b6d6300cbe65413dac97a7ac15bc8a56","session_id":1694713292657,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"604ddf6ead726b47fdf3bfea5e5c53677efb5796e2d17b2d97290f68057b4766","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
28|auth  | 2023-09-14T13:42:34: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_created","time":1694713354594,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
28|auth  | 2023-09-14T13:42:34: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1694713354634,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_rp_button - view","time":1694713354952,"device_id":"7a4aba61be9d4adba16920e44749c157","app_version":"0.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","utm_campaign":"123done"}}
```
### Existing account
```
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_third_party_auth - view","time":1694713384272,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_branding - enter_email_brand_messaging_prelaunch_view","time":1694713384272,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_branding - signin_brand_messaging_prelaunch_view","time":1694713384285,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - view","time":1694713384310,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
28|auth  | 2023-09-14T13:43:04: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_created","time":1694713384387,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","event_properties":{"service":"undefined_oauth","oauth_client_id":"98e6508e88680e1a"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
28|auth  | 2023-09-14T13:43:04: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - oauth_access_token_created","time":1694713384347,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"98e6508e88680e1a"},"user_properties":{"ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"undefined_oauth"},"sync_device_count":0,"sync_active_devices_day":0,"sync_active_devices_week":0,"sync_active_devices_month":0}}
28|auth  | 2023-09-14T13:43:04: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1694713384398,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","event_properties":{"service":"undefined_oauth","oauth_client_id":"98e6508e88680e1a"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_third_party_auth - google_oauth_start","time":1694713386442,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
28|auth  | 2023-09-14T13:43:13: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - success","time":1694713393820,"user_id":"4d91cba05f9b40f4935d401d024867a5","device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"undefined_oauth"}}}
28|auth  | 2023-09-14T13:43:13: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1694713393820,"user_id":"4d91cba05f9b40f4935d401d024867a5","device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"undefined_oauth"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_branding - signin_brand_messaging_prelaunch_view","time":1694713393375,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_branding - enter_email_brand_messaging_prelaunch_view","time":1694713393383,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_third_party_auth - google_signin_complete","time":1694713393844,"device_id":"7a4aba61be9d4adba16920e44749c157","session_id":1694713354952,"app_version":"0.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"72aaa0c8b78a85fce6870ae7b99c1daf374fb5348f55bbb11607a78fed2a76ce","ua_browser":"Firefox","ua_version":"109.0","$append":{"fxa_services_used":"123done"}}}
28|auth  | 2023-09-14T13:43:13: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_created","time":1694713393936,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
28|auth  | 2023-09-14T13:43:13: INFO fxa-auth-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_activity - access_token_checked","time":1694713393947,"user_id":"4d91cba05f9b40f4935d401d024867a5","app_version":"0.0","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"$append":{"fxa_services_used":"undefined_oauth"}}}
37|content  | INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_rp_button - view","time":1694713394121,"device_id":"b7a1e88b859f484188ed6d11570fafce","app_version":"0.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{},"user_properties":{"flow_id":"18c14ac080485d3744f8968cbbb3448e6a00b7c2ce28bccd7128251c6b2a57b2","ua_browser":"Firefox","ua_version":"109.0","utm_campaign":"123done"}}
```

Notice that the `oauth_client_id` is correctly populated with 123Done client id.
