### PR TITLE
refactor(fxa-react): L10n updates for Mozilla accounts branding

### DIFF
--- a/packages/fxa-react/components/Head/en.ftl
+++ b/packages/fxa-react/components/Head/en.ftl
@@ -1,8 +1,15 @@
 ## FxA React - Strings shared between multiple FxA products for application page title
 
 app-default-title = { -product-firefox-accounts }
+# This string is used as the default title for pages, displayed in the browser tab.
+app-default-title-2 = { -product-mozilla-accounts }
 # This string is used as the title of the page.
 # Variables:
 #   $title (String) - the name of the current page
 #                      (for example: "Two-step authentication")
 app-page-title = { $title } | { -product-firefox-accounts }
+# This string is used as the title of the page, displayed in the browser tab.
+# Variables:
+#   $title (String) - the name of the current page
+#                      (for example: "Two-step authentication")
+app-page-title-2 = { $title } | { -product-mozilla-accounts }

--- a/packages/fxa-react/components/LogoLockup/en.ftl
+++ b/packages/fxa-react/components/LogoLockup/en.ftl
@@ -2,3 +2,5 @@
 
 app-logo-alt =
   .alt = { -brand-firefox } logo
+app-logo-alt-2 =
+  .alt = { -brand-mozilla } logo


### PR DESCRIPTION
Because:
* We want l10n strings that are changing from Firefox to Mozilla to be localized before launch

This commit:
* Creates new copies of FTL strings that contain Firefox branding references and replaces them with Mozilla branding

closes FXA-7990

---

[Quick reference](https://github.com/mozilla/fxa-content-server-l10n/blob/8331141fc538706639657f21097ddbfed61c5665/locale/templates/react.ftl) to help with review.

@bcolsson I feel like we're going to have some duplicate strings while doing this, even now our `app-logo-alt-2` here duplicates `app-footer-mozilla-logo-label`. Maybe we need an issue filed towards the end to combine some IDs where we can which would be nice on our end, but would this be not nice on the l10n side? I know translations can change based on context.