### PR TITLE
Revert grunt change

### DIFF
--- a/packages/fxa-settings/Gruntfile.js
+++ b/packages/fxa-settings/Gruntfile.js
@@ -3,12 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = function (grunt) {
-  const srcPaths = [
-    '../fxa-shared/l10n/branding.ftl',
-    '.license.header',
-    '../fxa-react/components/**/*.ftl',
-    'src/**/*.ftl',
-  ];
+  const srcPaths = ['.license.header', 'src/**/*.ftl'];
   const testPaths = [
     '../fxa-shared/l10n/branding.ftl',
     '../fxa-react/components/**/*.ftl',

--- a/packages/fxa-settings/Gruntfile.js
+++ b/packages/fxa-settings/Gruntfile.js
@@ -12,6 +12,16 @@ module.exports = function (grunt) {
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    // make a copy of the local branding terms available for local development
+    // before they are extracted to the l10n repo
+    // this file will not be included in the string extraction process, so should not lead to duplication
+    copy: {
+      'branding-ftl': {
+        nonull: true,
+        src: '../fxa-shared/l10n/branding.ftl',
+        dest: 'public/locales/en/branding.ftl',
+      },
+    },
     concat: {
       ftl: {
         src: srcPaths,
@@ -38,10 +48,11 @@ module.exports = function (grunt) {
     },
   });
 
+  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-concat');
 
-  grunt.registerTask('merge-ftl', ['concat:ftl']);
+  grunt.registerTask('merge-ftl', ['copy:branding-ftl', 'concat:ftl']);
   grunt.registerTask('merge-ftl:test', ['concat:ftl-test']);
   grunt.registerTask('watch-ftl', ['watch:ftl']);
 };


### PR DESCRIPTION
## Because

* Merging the branding.ftl and react.ftl files into the settings.ftl file (to allow new brand terms to be visible in local development) was resulting in string duplication during l10n extract

## This pull request

* Reverts the changes to fxa-settings gruntfile
* Adds a copy step to the grunt file to make the branding file available for local development without duplicating strings for extraction (only the `settings.ftl` file will be extracted from the settings package)

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

After running `nx start fxa-settings` on this branch, the new Mozilla account brand terms are added to branding.ftl AND main.ftl in `fxa-settings/public/locales/en` but are no longer included in the settings.ftl file:

![Screenshot 2023-09-14 at 5 55 28 PM](https://github.com/mozilla/fxa/assets/22231637/9392fcf6-4ad0-4d5d-bb53-f4164490185f)