### PR TITLE
fix(contentful): Update Contentful schema of the Subgroup model

### DIFF
--- a/packages/db-migrations/contentful/1694798435403_fxa-8294.js
+++ b/packages/db-migrations/contentful/1694798435403_fxa-8294.js
@@ -1,0 +1,10 @@
+function migrationFunction(migration, context) {
+  const subGroup = migration.editContentType('subGroup');
+  const subGroupOffering = subGroup.editField('offering');
+  subGroupOffering.items({
+    type: 'Link',
+    validations: [{ linkContentType: ['offering'] }],
+    linkType: 'Entry',
+  });
+}
+module.exports = migrationFunction;


### PR DESCRIPTION
## Because

- we should only be able to add an existing Offering or create a new Offering in a Subgroup

## This pull request

- [x] adds the migration script for the revised Subgroup schema
- [x] ran `nx codegen shared-contentful` - no additional files were generated

## Issue that this pull request solves

Closes: [FXA-8294](https://mozilla-hub.atlassian.net/browse/FXA-8294)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)
<img width="753" alt="Screenshot 2023-09-15 at 1 33 16 PM" src="https://github.com/mozilla/fxa/assets/28129806/df1b439d-81b7-4802-bc5a-66bd03b40791">

## Other information (Optional)
- [x] Schema for Subgroup in Contentful has been updated in `dev` and `stage` envs
- [x] Documentation has been updated in Ecosystem Platform


[FXA-8294]: https://mozilla-hub.atlassian.net/browse/FXA-8294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ