### PR TITLE
fix(functional): fix oauth permission tests in prod for the pre verificaton

### DIFF
--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '../../lib/fixtures/standard';
 let email;
 const password = 'passwordzxcv';
 
-test.describe('oauth permissions for trusted reliers', () => {
+test.describe('oauth permissions for trusted reliers - sign up', () => {
   test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     email = login.createEmail();
@@ -58,20 +58,25 @@ test.describe('oauth permissions for trusted reliers', () => {
 
     //Verify sign up code header
     await login.waitForSignUpCodeHeader();
+  });
+});
 
+test.describe('oauth permissions for trusted reliers - sign in', () => {
+  test.beforeEach(async ({ pages: { login } }) => {
+    test.slow();
+    await login.clearCache();
   });
 
   test('signin without `prompt=consent`', async ({
-    target,
+    credentials,
     pages: { login, relier },
   }) => {
-    await target.auth.signUp(email, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
     await relier.goto();
     await relier.clickEmailFirst();
-    await login.fillOutEmailFirstSignIn(email, password);
+    await login.fillOutEmailFirstSignIn(
+      credentials.email,
+      credentials.password
+    );
 
     //Verify logged in to relier
     expect(await relier.isLoggedIn()).toBe(true);
@@ -80,19 +85,19 @@ test.describe('oauth permissions for trusted reliers', () => {
   test('signin with `prompt=consent`', async ({
     target,
     page,
+    credentials,
     pages: { login, relier },
   }) => {
-    await target.auth.signUp(email, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
     const query = { prompt: 'consent' };
     const queryParam = new URLSearchParams(query);
     await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
       waitUntil: 'load',
     });
     await relier.clickEmailFirst();
-    await login.fillOutEmailFirstSignIn(email, password);
+    await login.fillOutEmailFirstSignIn(
+      credentials.email,
+      credentials.password
+    );
 
     //Verify permissions header
     expect(await login.permissionsHeader()).toBe(true);
@@ -105,15 +110,15 @@ test.describe('oauth permissions for trusted reliers', () => {
   test('signin without `prompt=consent`, then re-signin with `prompt=consent`', async ({
     target,
     page,
+    credentials,
     pages: { login, relier },
   }) => {
-    await target.auth.signUp(email, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
     await relier.goto();
     await relier.clickEmailFirst();
-    await login.fillOutEmailFirstSignIn(email, password);
+    await login.fillOutEmailFirstSignIn(
+      credentials.email,
+      credentials.password
+    );
 
     //Verify logged in to relier
     expect(await relier.isLoggedIn()).toBe(true);
@@ -135,16 +140,12 @@ test.describe('oauth permissions for trusted reliers', () => {
   });
 
   test('force_auth without `prompt=consent`', async ({
-    target,
+    credentials,
     pages: { login, relier },
   }) => {
-    await target.auth.signUp(email, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
-    await relier.goto(`email=${email}`);
+    await relier.goto(`email=${credentials.email}`);
     await relier.clickForceAuth();
-    await login.setPassword(password);
+    await login.setPassword(credentials.password);
     await login.submit();
 
     //Verify logged in to relier
@@ -154,19 +155,16 @@ test.describe('oauth permissions for trusted reliers', () => {
   test('force_auth with `prompt=consent`', async ({
     target,
     page,
+    credentials,
     pages: { login, relier },
   }) => {
-    await target.auth.signUp(email, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
     const query = new URLSearchParams({
       prompt: 'consent',
-      email: email,
+      email: credentials.email,
     });
     await page.goto(`${target.relierUrl}/?${query.toString()}`);
     await relier.clickForceAuth();
-    await login.setPassword(password);
+    await login.setPassword(credentials.password);
     await login.submit();
 
     //Verify permissions header

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -8,8 +8,14 @@ let email;
 const password = 'passwordzxcv';
 
 test.describe('oauth prompt none', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
+  test.beforeEach(async ({ pages: { login } }, { project }) => {
     test.slow();
+
+    //Epic Fxa-7861 filed for the work to add plans in prod
+    test.skip(
+      project.name === 'production',
+      'test plan not yet available in prod'
+    );
     email = login.createEmail();
     await login.clearCache();
   });
@@ -140,8 +146,14 @@ test.describe('oauth prompt none', () => {
 });
 
 test.describe('oauth prompt none with emails', () => {
-  test.beforeEach(async ({ pages: { login } }) => {
+  test.beforeEach(async ({ pages: { login } }, { project }) => {
     test.slow();
+
+    //Epic Fxa-7861 filed for the work to add plans in prod
+    test.skip(
+      project.name === 'production',
+      'test plan not yet available in prod'
+    );
     email = login.createEmail();
     await login.clearCache();
   });


### PR DESCRIPTION
## Because

- The oauth permission test were failing in Prod because the pre-verification flow doesn't work in prod
- The oauth prompt none tests were failing in Prod because there is no test plan setup in prod yet.

## This pull request

- Fixes the pre-verification flow by using `credentials` id and password in Prod
- Skips the prompt none test until test plans are setup in prod

## Issue that this pull request solves

Closes: #FXA-8279 FXA-8280

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
