### PR TITLE
task(payments): Update strings referencing 'Firefox accounts'

### DIFF
--- a/packages/fxa-payments-server/src/components/Header/en.ftl
+++ b/packages/fxa-payments-server/src/components/Header/en.ftl
@@ -1,3 +1,4 @@
 ## Component - Header
 
 brand-name-firefox-logo = { -brand-name-firefox } logo
+brand-name-mozilla-logo = { -brand-mozilla } logo

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/en.ftl
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/en.ftl
@@ -1,6 +1,7 @@
 ## Component - NewUserEmailForm
 
 new-user-sign-in-link = Already have a { -brand-name-firefox } account? <a>Sign in</a>
+new-user-sign-in-link-2 = Already have a { -product-mozilla-account }? <a>Sign in</a>
 # "Required" to indicate that the user must use the checkbox below this text to
 # agree to a payment method's terms of service and privacy notice in order to
 # continue.

--- a/packages/fxa-payments-server/src/routes/Checkout/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Checkout/en.ftl
@@ -1,5 +1,6 @@
 ## Routes - Checkout - New user
 
 new-user-step-1 = 1. Create a { -brand-name-firefox } account
+new-user-step-1-2 = 1. Create a { -product-mozilla-account }
 new-user-card-title = Enter your card information
 new-user-submit = Subscribe Now


### PR DESCRIPTION
## Because

- We want to start the localization effort of updating strings from Firefox to Mozilla

## This pull request

- Creates new l10n strings / ids using the Mozilla branding

## Issue that this pull request solves

Closes: FXA-7991

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
