### PR TITLE
refactor(fxa-settings): L10n updates for Mozilla accounts branding

### DIFF
--- a/packages/fxa-react/components/LogoLockup/en.ftl
+++ b/packages/fxa-react/components/LogoLockup/en.ftl
@@ -4,3 +4,5 @@ app-logo-alt =
   .alt = { -brand-firefox } logo
 app-logo-alt-2 =
   .alt = { -brand-mozilla } logo
+app-logo-alt-3 =
+  .alt = { -brand-mozilla } m logo

--- a/packages/fxa-settings/src/components/GetDataTrio/en.ftl
+++ b/packages/fxa-settings/src/components/GetDataTrio/en.ftl
@@ -3,6 +3,7 @@
 get-data-trio-title-firefox = { -brand-firefox }
 get-data-trio-title-firefox-recovery-key = { -brand-firefox } account recovery key
 get-data-trio-title-firefox-backup-verification-codes = { -brand-firefox } backup authentication codes
+get-data-trio-title-backup-verification-codes = Backup authentication codes
 get-data-trio-download-2 =
   .title = Download
   .aria-label = Download

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/en.ftl
@@ -1,7 +1,9 @@
 # BentoMenu component
 
 bento-menu-title = { -brand-firefox } Bento Menu
+bento-menu-title-2 = { -brand-mozilla } Bento Menu
 bento-menu-firefox-title = { -brand-firefox } is tech that fights for your online privacy.
+bento-menu-mozilla-title = { -brand-mozilla } is tech that fights for your online privacy.
 
 bento-menu-vpn-2 = { -product-mozilla-vpn }
 bento-menu-monitor-2 = { -product-firefox-monitor }

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -47,11 +47,13 @@ cs-disconnect-lost-advice-content-2 = Since your device was lost or stolen, to
   keep your information safe, you should change your { -product-firefox-account } password
   in your account settings. You should also look for information from your
   device manufacturer about erasing your data remotely.
+cs-disconnect-lost-advice-content-3 = Since your device was lost or stolen, to keep your information safe, you should change your { -product-mozilla-account } password in your account settings. You should also look for information from your device manufacturer about erasing your data remotely.
 cs-disconnect-suspicious-advice-heading = Suspicious device disconnected
 cs-disconnect-suspicious-advice-content = If the disconnected device is indeed
   suspicious, to keep your information safe, you should change your { -product-firefox-account }
   password in your account settings. You should also change any other
   passwords you saved in { -brand-firefox } by typing about:logins into the address bar.
+cs-disconnect-suspicious-advice-content-2 = If the disconnected device is indeed suspicious, to keep your information safe, you should change your { -product-mozilla-account } password in your account settings. You should also change any other passwords you saved in { -brand-firefox } by typing about:logins into the address bar.
 
 cs-sign-out-button = Sign out
 

--- a/packages/fxa-settings/src/components/Settings/DataCollection/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/en.ftl
@@ -2,8 +2,12 @@
 
 dc-heading = Data Collection and Use
 dc-subheader = Help improve { -product-firefox-accounts }
+dc-subheader-2 = Help improve { -product-mozilla-accounts }
 dc-subheader-content = Allow { -product-firefox-accounts } to send technical and interaction data to { -brand-mozilla }.
+dc-subheader-content-2 = Allow { -product-mozilla-accounts } to send technical and interaction data to { -brand-mozilla }.
 dc-opt-out-success = Opt out successful. { -product-firefox-accounts } won’t send technical or interaction data to { -brand-mozilla }.
+dc-opt-out-success-2 = Opt out successful. { -product-mozilla-accounts } won’t send technical or interaction data to { -brand-mozilla }.
 dc-opt-in-success = Thanks! Sharing this data helps us improve { -product-firefox-accounts }.
+dc-opt-in-success-2 = Thanks! Sharing this data helps us improve { -product-mozilla-accounts }.
 dc-opt-in-out-error-2 = Sorry, there was a problem changing your data collection preference
 dc-learn-more = Learn more

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/en.ftl
@@ -1,6 +1,7 @@
 # DropDownAvatarMenu component
 
 drop-down-menu-title = { -product-firefox-account } menu
+drop-down-menu-title-2 = { -product-mozilla-account } menu
 # This string is used to show the current user's name or email in the settings page menu.
 # Variables:
 #   $user (String) - the user's name (or email address, if they haven't added their name to their account)

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
@@ -1,8 +1,9 @@
-# HeaderLockup component
+## HeaderLockup component, the header in account settings
 
 header-menu-open = Close menu
 header-menu-closed = Site navigation menu
 header-back-to-top-link =
   .title = Back to top
 header-title = Firefox Account
+header-title-2 = { -product-mozilla-account }
 header-help = Help

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
@@ -7,8 +7,10 @@ delete-account-step-1-2 = Step 1 of 2
 delete-account-step-2-2 = Step 2 of 2
 
 delete-account-confirm-title-3 = You may have connected your { -product-firefox-account } to one or more of the following { -brand-mozilla } products or services that keep you secure and productive on the web:
+delete-account-confirm-title-4 = You may have connected your { -product-mozilla-account } to one or more of the following { -brand-mozilla } products or services that keep you secure and productive on the web:
 
 delete-account-product-firefox-account = { -product-firefox-account }
+delete-account-product-mozilla-account = { -product-mozilla-account }
 delete-account-product-mozilla-vpn = { -product-mozilla-vpn }
 delete-account-product-mdn-plus = { -product-mdn-plus }
 delete-account-product-mozilla-hubs = { -product-mozilla-hubs }
@@ -34,7 +36,6 @@ delete-account-continue-button = Continue
 
 delete-account-password-input =
  .label = Enter password
- 
 pocket-delete-notice = If you subscribe to Pocket Premium, please make sure that you <a>cancel your subscription</a> before deleting your account.
 
 delete-account-cancel-button = Cancel

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
@@ -3,9 +3,17 @@
 
 # This message is followed by a bulleted list
 terms-privacy-agreement-intro = By proceeding, you agree to:
+# This message is followed by a bulleted list
+terms-privacy-agreement-intro-2 = By proceeding, you agree to the:
 # links to Pocket's Terms of Service and Privacy Notice
 terms-privacy-agreement-pocket = { -product-pocket }’s <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
+# links to Pocket's Terms of Service and Privacy Notice, part of a bulleted list
+terms-privacy-agreement-pocket-2 = { -product-pocket } <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
 # links to Firefox's Terms of Service and Privacy Notice
 terms-privacy-agreement-firefox = { -brand-firefox }’s <firefoxTos>Terms of Service</firefoxTos> and <firefoxPrivacy>Privacy Notice</firefoxPrivacy>
+# links to Mozilla Accounts Terms of Service and Privacy Notice, part of a bulleted list
+terms-privacy-agreement-mozilla = { -product-mozilla-accounts(capitalization:"uppercase") } <mozillaAccountsTos>Terms of Service</mozillaAccountsTos> and <mozillaAccountsPrivacy>Privacy Notice</mozillaAccountsPrivacy>
 # links to Firefox's Terms of Service and Privacy Notice
 terms-privacy-agreement-default = By proceeding, you agree to the <firefoxTos>Terms of Service</firefoxTos> and <firefoxPrivacy>Privacy Notice</firefoxPrivacy>.
+# links to Mozilla Account's Terms of Service and Privacy Notice
+terms-privacy-agreement-default-2 = By proceeding, you agree to the <mozillaAccountsTos>Terms of Service</mozillaAccountsTos> and <mozillaAccountsPrivacy>Privacy Notice</mozillaAccountsPrivacy>.

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/en.ftl
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/en.ftl
@@ -3,5 +3,6 @@
 
 cannot-create-account-header = Cannot create account
 cannot-create-account-requirements = You must meet certain age requirements to create a { -product-firefox-account }.
+cannot-create-account-requirements-2 = You must meet certain age requirements to create a { -product-mozilla-account }.
 # For an external link: https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy
 cannot-create-account-learn-more-link = Learn more

--- a/packages/fxa-settings/src/pages/CookiesDisabled/en.ftl
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/en.ftl
@@ -3,6 +3,7 @@
 
 cookies-disabled-header = Local storage and cookies are required
 cookies-disabled-enable-prompt = Please enable cookies and local storage in your browser to access { -product-firefox-accounts }. Doing so will enable functionality such as remembering you between sessions.
+cookies-disabled-enable-prompt-2 = Please enable cookies and local storage in your browser to access your { -product-mozilla-account }. Doing so will enable functionality such as remembering you between sessions.
 # A button users may click to check if cookies and local storage are enabled and be directed to the previous page if so.
 cookies-disabled-button-try-again = Try again
 # An external link going to: https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/en.ftl
@@ -9,6 +9,7 @@ account-recovery-confirm-key-heading-w-default-service = Reset password with acc
 account-recovery-confirm-key-heading-w-custom-service = Reset password with account recovery key <span>to continue to { $serviceName }</span>
 
 account-recovery-confirm-key-instructions = Please enter the one time use account recovery key you stored in a safe place to regain access to your { -product-firefox-account }.
+account-recovery-confirm-key-instructions-2 = Please enter the one time use account recovery key you stored in a safe place to regain access to your { -product-mozilla-account }.
 
 account-recovery-confirm-key-warning-message = <span>Note:</span> If you reset your password and don’t have your account recovery key saved, some of your data will be erased (including synced server data like history and bookmarks).
 # Prompts the user to enter their account recovery code

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
@@ -6,6 +6,10 @@
 # If more appropriate in a locale, the string within the <span>, "for your { -product-firefox-account }"
 # can stand alone as "{ -product-firefox-account }"
 signin-token-code-heading = Enter confirmation code<span> for your { -product-firefox-account }</span>
+# String within the <span> element appears on a separate line
+# If more appropriate in a locale, the string within the <span>, "for your { -product-mozilla-account }"
+# can stand alone as "{ -product-mozilla-account }"
+signin-token-code-heading-2 = Enter confirmation code<span> for your { -product-mozilla-account }</span>
 # { $email } represents the email that the user entered to sign in
 signin-token-code-instruction = Enter the code that was sent to { $email } within 5 minutes.
 signin-token-code-input-label-v2 = Enter 6-digit code

--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -2,6 +2,8 @@
 
 # Strings within the <span> elements appear as a subheading.
 signin-password-needed-header = Enter your password <span>for your { -product-firefox-account }</span>
+# Strings within the <span> elements appear as a subheading.
+signin-password-needed-header-2 = Enter your password <span>for your { -product-mozilla-account }</span>
 
 # $serviceLogo - an image of the logo of the service which the user is authenticating for.
 # For languages structured like English, the phrase can read "to continue to"

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
@@ -9,6 +9,10 @@ confirm-signup-code-page-title = Enter confirmation code
 # If more appropriate in a locale, the string within the <span>, "for your { -product-firefox-account }"
 # can stand alone as "{ -product-firefox-account }"
 confirm-signup-code-heading = Enter confirmation code <span>for your { -product-firefox-account }</span>
+# String within the <span> element appears on a separate line
+# If more appropriate in a locale, the string within the <span>, "for your { -product-mozilla-account }"
+# can stand alone as "{ -product-mozilla-account }"
+confirm-signup-code-heading-2 = Enter confirmation code <span>for your { -product-mozilla-account }</span>
 # { $email } represents the email that the user entered to sign in
 confirm-signup-code-instruction = Enter the code that was sent to { $email } within 5 minutes.
 confirm-signup-code-input-label = Enter 6-digit code


### PR DESCRIPTION
Because:
* We want l10n strings that are changing from Firefox to Mozilla to be localized before launch

This commit:
* Creates new copies of FTL strings that contain Firefox branding references and replaces them with Mozilla branding

closes FXA-7988

--

There were less string updates here than I figured there would be, so feel free to double check me. Here's [a handy link](https://github.com/mozilla/fxa-content-server-l10n/blob/main/locale/templates/settings.ftl) to see the full list.