### PR TITLE
bug(shared): Amplitude crashes on startup with unhandled error

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -14,6 +14,8 @@
 
 const { Container } = require('typedi');
 const { StatsD } = require('hot-shots');
+const config = require('../../config').default.getProperties();
+const logger = require('../log')(config.log.level, 'amplitude');
 
 const { GROUPS, initialize } =
   require('fxa-shared/metrics/amplitude').amplitude;
@@ -183,7 +185,9 @@ module.exports = (log, config) => {
   const transformEvent = initialize(
     config.oauth.clientIds,
     EVENTS,
-    FUZZY_EVENTS
+    FUZZY_EVENTS,
+    logger,
+    Container.has(StatsD) ? Container.get(StatsD) : undefined
   );
 
   return receiveEvent;

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -916,7 +916,7 @@ const FUZZY_EVENTS = new Map([
   ],
 ]);
 
-const transform = initialize(SERVICES, EVENTS, FUZZY_EVENTS);
+const transform = initialize(SERVICES, EVENTS, FUZZY_EVENTS, logger, statsd);
 
 module.exports = receiveEvent;
 

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -47,7 +47,9 @@ const FUZZY_EVENTS = new Map([
 const transform = initialize(
   config.get('oauth_client_id_map'),
   {},
-  FUZZY_EVENTS
+  FUZZY_EVENTS,
+  log,
+  Container.has(StatsD) ? Container.get(StatsD) : undefined
 );
 
 // TODO: remove eslint ignore in FXA-6950

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -40,7 +40,7 @@ describe('metrics/amplitude:', () => {
 
   it('exports an initialize method', () => {
     assert.isFunction(amplitude.initialize);
-    assert.lengthOf(amplitude.initialize, 3);
+    assert.lengthOf(amplitude.initialize, 5);
   });
 
   describe('initialize:', () => {


### PR DESCRIPTION
## Because

- Content server was restarting due to unknown event group

## This pull request

- Wraps the mapping function with try catch to ensure it cannot result in an unhandled error
- Adds optional statsd and logger parameters so that we can track potential problems outside of sentry.
- Updates initialization to provide statsd and logger parameters to amplitude's initialization routine.

## Issue that this pull request solves

Closes: FXA-7683

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

It appears the code that currently calls this mapper function always checks to see if the event returned is empty and will log an amplitude dropped event if it is. Therefore the try catch isn't especially risky since we monitor these dropped events. Adding the optional internal logging and metrics is just icing on the cake to future proof it and help us pinpoint the issue in the event of an expected error.
