### PR TITLE
bug(settings): redirectTo can be rejected by password/forgot/send_code endpoint

### DIFF
--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -559,17 +559,26 @@ export class Account implements AccountData {
     service?: string,
     redirectTo?: string
   ): Promise<PasswordForgotSendCodePayload> {
-    let serviceName;
-    if (service && service === MozServices.FirefoxSync) {
-      serviceName = 'sync';
-    } else {
-      serviceName = service;
-    }
-    const result = await this.authClient.passwordForgotSendCode(email, {
-      service: serviceName,
+    let options: {
+      service?: string;
+      resume?: string;
+      redirectTo?: string;
+    } = {
       resume: 'e30=', // base64 json for {}
-      redirectTo,
-    });
+    };
+
+    // Important! Only set service when it's Firefox Sync
+    if (service && service === MozServices.FirefoxSync) {
+      options.service = 'sync';
+    } else {
+      options.service = service;
+    }
+
+    if (redirectTo) {
+      options.redirectTo = redirectTo;
+    }
+
+    const result = await this.authClient.passwordForgotSendCode(email, options);
     return result;
   }
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -160,6 +160,7 @@ const AccountRecoveryConfirmKey = ({
           email,
         });
       } catch (error) {
+        setIsLoading(false);
         logViewEvent('flow', `${viewName}.fail`, REACT_ENTRYPOINT);
         // if the link expired or the reset was completed in another tab/browser
         // between page load and form submission
@@ -181,8 +182,6 @@ const AccountRecoveryConfirmKey = ({
             setBannerMessage(localizedBannerMessage);
           }
         }
-      } finally {
-        setIsLoading(false);
       }
     },
     [
@@ -191,6 +190,7 @@ const AccountRecoveryConfirmKey = ({
       ftlMsgResolver,
       getRecoveryBundleAndNavigate,
       setLinkStatus,
+      setIsLoading,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/container.tsx
@@ -3,40 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps } from '@reach/router';
-import { Integration, useAuthClient } from '../../../models';
-import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { Integration } from '../../../models';
 import AccountRecoveryResetPassword from '.';
-import AppLayout from '../../../components/AppLayout';
-import CardHeader from '../../../components/CardHeader';
 
 const AccountRecoveryResetPasswordContainer = ({
   integration,
 }: {
   integration: Integration;
 } & RouteComponentProps) => {
-  const authClient = useAuthClient();
-  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
-    authClient,
-    integration
-  );
-
-  // TODO: UX for this, FXA-8106
-  if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
-  }
-
-  return (
-    <AccountRecoveryResetPassword
-      {...{ integration, finishOAuthFlowHandler }}
-    />
-  );
+  return <AccountRecoveryResetPassword {...{ integration }} />;
 };
 
 export default AccountRecoveryResetPasswordContainer;

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
@@ -34,9 +34,6 @@ const storyWithProps = (ctx: AppContextValue, history?: History) => {
       <LocationProvider {...{ history }}>
         <AccountRecoveryResetPassword
           integration={createMockAccountRecoveryResetPasswordSyncDesktopIntegration()}
-          finishOAuthFlowHandler={() =>
-            Promise.resolve({ redirect: 'someUri' })
-          }
         />
       </LocationProvider>
     </AppContext.Provider>

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -100,12 +100,7 @@ const render = (ui = <Subject />, account = mockAccount()) => {
 
 const Subject = ({
   integration = createMockAccountRecoveryResetPasswordSyncDesktopIntegration(),
-}) => (
-  <AccountRecoveryResetPassword
-    {...{ integration }}
-    finishOAuthFlowHandler={() => Promise.resolve({ redirect: 'someUri' })}
-  />
-);
+}) => <AccountRecoveryResetPassword {...{ integration }} />;
 
 describe('AccountRecoveryResetPassword page', () => {
   let account = mockAccount();
@@ -261,8 +256,6 @@ describe('AccountRecoveryResetPassword page', () => {
       expect(
         (account.resetPasswordWithRecoveryKey as jest.Mock).mock.calls[0]
       ).toBeTruthy();
-      expect(account.isSessionVerifiedAuthClient).toHaveBeenCalled();
-      expect(account.hasTotpAuthClient).toHaveBeenCalled();
     });
 
     it('sets integration state', () => {
@@ -306,36 +299,6 @@ describe('AccountRecoveryResetPassword page', () => {
           MOCK_SEARCH_PARAMS
         ).toString()}`
       );
-    });
-  });
-
-  describe('successful reset with totp', () => {
-    // Window mocks not needed once this page doesn't use `hardNavigateToContentServer`
-    const originalWindow = window.location;
-    beforeAll(() => {
-      // @ts-ignore
-      delete window.location;
-      window.location = { ...originalWindow, href: '' };
-    });
-    beforeEach(async () => {
-      window.location.href = originalWindow.href;
-      account.setLastLogin = jest.fn();
-      account.resetPasswordWithRecoveryKey = jest
-        .fn()
-        .mockResolvedValue(MOCK_RESET_DATA);
-      account.isSessionVerifiedAuthClient = jest.fn();
-      account.hasTotpAuthClient = jest.fn().mockResolvedValue(true);
-      render(<Subject />, account);
-
-      await enterPassword('foo12356789!');
-      await clickResetPassword();
-    });
-    afterAll(() => {
-      window.location = originalWindow;
-    });
-
-    it('navigates as expected', async () => {
-      expect(window.location.href).toContain('/signin_totp_code');
     });
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -4,11 +4,7 @@
 
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from '@reach/router';
-import {
-  FtlMsg,
-  hardNavigate,
-  hardNavigateToContentServer,
-} from 'fxa-react/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { useForm } from 'react-hook-form';
 
 import AppLayout from '../../../components/AppLayout';
@@ -31,11 +27,6 @@ import { LinkStatus } from '../../../lib/types';
 import { IntegrationType, isOAuthIntegration } from '../../../models';
 import { notifyFirefoxOfLogin } from '../../../lib/channels/helpers';
 import {
-  clearOAuthData,
-  clearOriginalTab,
-  isOriginalTab,
-} from '../../../lib/storage-utils';
-import {
   AccountRecoveryResetPasswordBannerState,
   AccountRecoveryResetPasswordFormData,
   AccountRecoveryResetPasswordLocationState,
@@ -53,7 +44,6 @@ export const viewName = 'account-recovery-reset-password';
 
 const AccountRecoveryResetPassword = ({
   integration,
-  finishOAuthFlowHandler,
 }: AccountRecoveryResetPasswordProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -210,9 +200,6 @@ const AccountRecoveryResetPassword = ({
       const accountResetData = await account.resetPasswordWithRecoveryKey(
         options
       );
-      // must come after completeResetPassword since that receives the sessionToken
-      // required for this check
-      const sessionIsVerified = await account.isSessionVerifiedAuthClient();
 
       // TODO: do we need this? Is integration data the right place for it if so?
       integration.data.resetPasswordConfirm = true;
@@ -235,26 +222,7 @@ const AccountRecoveryResetPassword = ({
           });
           break;
         case IntegrationType.OAuth:
-          // TODO just use type guard instead of switch, FXA-8111
-          if (sessionIsVerified && isOAuthIntegration(integration)) {
-            const { redirect } = await finishOAuthFlowHandler(
-              integration.data.uid || account.uid,
-              accountResetData.sessionToken,
-              accountResetData.keyFetchToken,
-              accountResetData.unwrapBKey
-            );
-
-            // Clear session / local storage states
-            clearOAuthData();
-
-            // If the user is on a single tab throughout this process, just redirect them
-            // back to the relying party. Otherwise, show them a success message
-            if (isOriginalTab()) {
-              clearOriginalTab();
-              hardNavigate(redirect);
-              return;
-            }
-          }
+          // TODO: Considering providing a way to redirect user back to RP.
           break;
         case IntegrationType.Web:
           // no-op, don't run default
@@ -283,19 +251,9 @@ const AccountRecoveryResetPassword = ({
   }
 
   async function navigateAway() {
-    // TODO / refactor: the initial account result with useAccount() does not
-    // contain account data due to no session token. Users receive the session
-    // token on PW reset, so we can query here for it.
-    const hasTotp = await account.hasTotpAuthClient();
-
     setUserPreference('account-recovery', false);
     logViewEvent(viewName, 'recovery-key-consume.success');
-
-    if (hasTotp) {
-      hardNavigateToContentServer(`/signin_totp_code${location.search}`);
-    } else {
-      navigate(`/reset_password_with_recovery_key_verified${location.search}`);
-    }
+    navigate(`/reset_password_with_recovery_key_verified${location.search}`);
   }
 };
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/interfaces.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps } from '@reach/router';
-import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
   BaseIntegrationData,
   IntegrationType,
@@ -13,7 +12,6 @@ import {
 
 export type AccountRecoveryResetPasswordProps = {
   integration: AccountRecoveryResetPasswordIntegration;
-  finishOAuthFlowHandler: FinishOAuthFlowHandler;
 } & RouteComponentProps;
 
 export interface AccountRecoveryResetPasswordFormData {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -4,37 +4,16 @@
 
 import { RouteComponentProps } from '@reach/router';
 import CompleteResetPassword from '.';
-import { Integration, useAuthClient } from '../../../models';
+import { Integration } from '../../../models';
 import LinkValidator from '../../../components/LinkValidator';
 import { LinkType } from '../../../lib/types';
 import { CreateCompleteResetPasswordLink } from '../../../models/reset-password/verification/factory';
-import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import AppLayout from '../../../components/AppLayout';
-import { CardHeader } from '@material-ui/core';
 
 const CompleteResetPasswordContainer = ({
   integration,
 }: {
   integration: Integration;
 } & RouteComponentProps) => {
-  const authClient = useAuthClient();
-  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
-    authClient,
-    integration
-  );
-
-  // TODO: UX for this, FXA-8106
-  if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
-  }
-
   // TODO: possibly rethink LinkValidator approach as it's a lot of layers with
   // the new container approach. We want to handle validation here while still sharing
   // logic with other container components and probably rendering CompleteResetPassword
@@ -55,7 +34,6 @@ const CompleteResetPasswordContainer = ({
             setLinkStatus,
             linkModel,
             integration,
-            finishOAuthFlowHandler,
           }}
         />
       )}

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -386,19 +386,7 @@ describe('CompleteResetPassword page', () => {
         window.location = originalWindow;
       });
 
-      it('account has TOTP', async () => {
-        account = {
-          ...account,
-          hasTotpAuthClient: jest.fn().mockResolvedValue(true),
-        } as unknown as Account;
-
-        render(<Subject />, account);
-        await enterPasswordAndSubmit();
-
-        expect(window.location.href).toContain('/signin_totp_code');
-      });
-
-      it('account does not have TOTP', async () => {
+      it('navigates to reset_password_verified', async () => {
         render(<Subject />, account);
         await enterPasswordAndSubmit();
         expect(mockUseNavigateWithoutRerender).toHaveBeenCalledWith(

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { IntegrationSubsetType } from '../../../lib/integrations';
-import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { LinkStatus } from '../../../lib/types';
 import { IntegrationType, OAuthIntegrationData } from '../../../models';
 import { CompleteResetPasswordLink } from '../../../models/reset-password/verification';
@@ -47,5 +46,4 @@ export interface CompleteResetPasswordProps {
   linkModel: CompleteResetPasswordLink;
   setLinkStatus: React.Dispatch<React.SetStateAction<LinkStatus>>;
   integration: CompleteResetPasswordIntegration;
-  finishOAuthFlowHandler: FinishOAuthFlowHandler;
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -125,9 +125,6 @@ export const Subject = ({
         <CompleteResetPassword
           {...{ setLinkStatus, linkModel }}
           integration={completeResetPasswordIntegration}
-          finishOAuthFlowHandler={() =>
-            Promise.resolve({ redirect: 'someUri' })
-          }
         />
       )}
     </LinkValidator>

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
@@ -116,8 +116,7 @@ describe('ConfirmResetPassword page', () => {
 
     expect(account.resetPassword).toHaveBeenCalledWith(
       MOCK_EMAIL,
-      MOCK_SERVICE,
-      MOCK_REDIRECT_URI
+      MOCK_SERVICE
     );
     expect(logViewEvent).toHaveBeenCalledWith(
       'confirm-reset-password',

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -89,8 +89,7 @@ const ConfirmResetPassword = ({
       if (isOAuthIntegration(integration)) {
         const result = await account.resetPassword(
           email,
-          integration.getService(),
-          integration.getRedirectUri()
+          integration.getService()
         );
         setCurrentPasswordForgotToken(result.passwordForgotToken);
       } else {

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -143,8 +143,7 @@ describe('PageResetPassword', () => {
 
     expect(account.resetPassword).toHaveBeenCalledWith(
       MOCK_ACCOUNT.primaryEmail.email,
-      MOCK_SERVICE,
-      MOCK_REDIRECT_URI
+      MOCK_SERVICE
     );
 
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -276,7 +275,7 @@ describe('PageResetPassword', () => {
       target: { value: MOCK_ACCOUNT.primaryEmail.email },
     });
 
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: 'Begin reset' }));
     await screen.findByText('Unknown account');
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -106,8 +106,7 @@ const ResetPassword = ({
           integration.saveOAuthState();
           const result = await account.resetPassword(
             email,
-            integration.getService(),
-            integration.getRedirectUri()
+            integration.getService()
           );
           navigateToConfirmPwReset({
             passwordForgotToken: result.passwordForgotToken,


### PR DESCRIPTION
## Because

- The `redirectTo` URL is an optional parameter for the `password/forgot/send_code` end point
- If we don't send this, the user just won't get redirected back to the RP. Rather they will see a success message instead that acts as a dead end to their flow.
- The redirect back to the RP would if the email link was opened in the same tab, so it's unlikely many users were experience flows where they were redirected. Therefore this change resolves a bug, and has low impact on our users.

## This pull request

- Removes the `redirectTo` URL form the call to the password/forgot/send_code endpoint.

## Issue that this pull request solves

Closes: FXA-8363, FXA-8358

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

These flows are being revisited in [FXA-6670](https://mozilla-hub.atlassian.net/browse/FXA-6670). For the time being we are choosing to reduce complexity, by simply showing the success message after password resets and keep password reset flow isolated. 

The reason the absence of the `redirectTo` parameter in email links is unlikely to impact end users also deserves further explanation. At the moment, when we supply the `redirectTo` parameter and a user opens the link sent to their email in the **same** tab that they initiated the reset from, then and only then, do we honor the `redirectTo` parameter and send the user back to the RP. The reality is that most users will open their email and click the reset password link, and this will open in a new tab. Very few if any users will copy this link, and then paste it in their original tab, therefore this edge case of redirecting users back to the RP is probably not encountered often.

Note that we are also in the process of improving these flows, and so it probably isn't worth the effort of mimicking the legacy behavior in backbone. Furthermore in backbone, there was some trickiness that users probably didn't even notice, where the originating tab would be notified of the reset, and that tab would then kick out to the signin page, upon which a subsequent sign in would redirect back the RP.

It was decided that the intertab communication would be dropped in the port of the backbone app to the react app because intertab communication isn't terribly common and is therefore not anticipated by most users, i.e. a tab changing state behind a user’s back isn’t typical. There were also other asymmetries that arose in the old code as a result of trying to share state between tabs.





[FXA-6670]: https://mozilla-hub.atlassian.net/browse/FXA-6670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ