### PR TITLE
bug(settings): Create new password page blank for mobile

### DIFF
--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -121,6 +121,7 @@ test.describe('oauth reset password react', () => {
       },
       {
         action: 'emailFirst',
+        newTab: true,
         accountRecoveryKey,
       }
     );

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -559,17 +559,17 @@ export class Account implements AccountData {
     service?: string,
     redirectTo?: string
   ): Promise<PasswordForgotSendCodePayload> {
-    let serviceName;
-    if (service && service === MozServices.FirefoxSync) {
-      serviceName = 'sync';
-    } else {
-      serviceName = service;
-    }
-    const result = await this.authClient.passwordForgotSendCode(email, {
-      service: serviceName,
+    const opts: { resume: string; redirectTo?: string; service?: string } = {
       resume: 'e30=', // base64 json for {}
       redirectTo,
-    });
+    };
+
+    // Important! Only set the service option when it's sync.
+    if (service && service === MozServices.FirefoxSync) {
+      opts.service = 'sync';
+    }
+
+    const result = await this.authClient.passwordForgotSendCode(email, opts);
     return result;
   }
 


### PR DESCRIPTION
## Because

- The email link that a users click to create a new password resulted in a blank page on mobile.

## This pull request

- Makes sure that the service option is only provided to passwordForgotResentCode when the service is sync.
- Exports a type for PasswordForgotSendCodeOptions in fxa-auth-client.

## Issue that this pull request solves

Closes: FXA-8358

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that since this issue resides in mobile, it's a bit tricky to test locally. 
