### PR TITLE
bug(settings,content): UX defects with brand messaging banner

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -1,48 +1,49 @@
 {{#showBanner}}
-<div id="banner-brand-message" class="w-full relative mobileLandscape:absolute mobileLandscape:top-0 mobileLandscape:left-0">
-    <div class="flex justify-center p-2 brand-banner-bg">
-        {{#showPrelaunch}}
-        <div class="flex"/>
-            <div class="flex-none relative">
-                <img
-                    class="w-8 h-8 bg-black m-4 mt-1"
-                    src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3QgeD0iMC43NjkyMjYiIHk9IjAuNzY5MjI2IiB3aWR0aD0iMzAuNDYxNSIgaGVpZ2h0PSIzMC40NjE1IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMjcuNzMxNCAyMC41MDg0SDI5LjY0NDFWMjMuNjE1NEgyMy42MTIxVjE1LjI3NDVDMjMuNjEyMSAxMi42NTY3IDIyLjc3ODEgMTEuNjcyOCAyMS4xNTkyIDExLjY3MjhDMTkuMTk3MiAxMS42NzI4IDE4LjQxMjQgMTMuMTYwOSAxOC40MTI0IDE1LjIxMzlWMjAuNDQ5NkgyMC4zMjUxVjIzLjU2MDRIMTQuMzAwOFYxNS4yNjg5QzE0LjMwMDggMTIuNjUxIDEzLjQ2NjcgMTEuNjY3MSAxMS44NDc4IDExLjY2NzFDOS44ODU4MyAxMS42NjcxIDguNzg4MjUgMTMuMTU1MiA4Ljc4ODI1IDE1LjIwODJWMjAuNDQzOUgxMS44MzY0VjIzLjU2MDRIMy4wMTQxNFYyMC40NTM0SDQuODIyNThWMTIuMzU3MkgyLjkyNjk0VjguNjU0OThIOC4zNzY5VjEwLjk5NDJDOS41MDExOSA5LjMyNDQ0IDExLjM5OTMgOC4zNDMyMiAxMy40MTE3IDguMzkxNDlDMTUuNTIxNCA4LjI3NjQ3IDE3LjQzOTkgOS42MDg1NCAxOC4wNjkzIDExLjYyNTRDMTguNzQ2NyA5LjY0MzQ2IDIwLjYzNSA4LjMzMjg3IDIyLjcyODggOC4zOTE0OUMyNC4xMDE5IDguMzI4NzkgMjUuNDM1MSA4Ljg2MzI2IDI2LjM4NDYgOS44NTcxNkMyNy4zMzQyIDEwLjg1MTEgMjcuODA3MyAxMi4yMDcyIDI3LjY4MjEgMTMuNTc2MVYyMC41MDg0SDI3LjczMTRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K"
-                    alt="{{#t}}Mozilla m logo{{/t}}"
-                />
+<div class="hidden">
+    <div class="banner-brand-message w-full">
+        <div class="flex justify-center p-2 brand-banner-bg">
+            {{#showPrelaunch}}
+            <div class="flex"/>
+                <div class="flex-none relative">
+                    <img
+                        class="w-8 h-8 bg-black m-4 mt-1"
+                        src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3QgeD0iMC43NjkyMjYiIHk9IjAuNzY5MjI2IiB3aWR0aD0iMzAuNDYxNSIgaGVpZ2h0PSIzMC40NjE1IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMjcuNzMxNCAyMC41MDg0SDI5LjY0NDFWMjMuNjE1NEgyMy42MTIxVjE1LjI3NDVDMjMuNjEyMSAxMi42NTY3IDIyLjc3ODEgMTEuNjcyOCAyMS4xNTkyIDExLjY3MjhDMTkuMTk3MiAxMS42NzI4IDE4LjQxMjQgMTMuMTYwOSAxOC40MTI0IDE1LjIxMzlWMjAuNDQ5NkgyMC4zMjUxVjIzLjU2MDRIMTQuMzAwOFYxNS4yNjg5QzE0LjMwMDggMTIuNjUxIDEzLjQ2NjcgMTEuNjY3MSAxMS44NDc4IDExLjY2NzFDOS44ODU4MyAxMS42NjcxIDguNzg4MjUgMTMuMTU1MiA4Ljc4ODI1IDE1LjIwODJWMjAuNDQzOUgxMS44MzY0VjIzLjU2MDRIMy4wMTQxNFYyMC40NTM0SDQuODIyNThWMTIuMzU3MkgyLjkyNjk0VjguNjU0OThIOC4zNzY5VjEwLjk5NDJDOS41MDExOSA5LjMyNDQ0IDExLjM5OTMgOC4zNDMyMiAxMy40MTE3IDguMzkxNDlDMTUuNTIxNCA4LjI3NjQ3IDE3LjQzOTkgOS42MDg1NCAxOC4wNjkzIDExLjYyNTRDMTguNzQ2NyA5LjY0MzQ2IDIwLjYzNSA4LjMzMjg3IDIyLjcyODggOC4zOTE0OUMyNC4xMDE5IDguMzI4NzkgMjUuNDM1MSA4Ljg2MzI2IDI2LjM4NDYgOS44NTcxNkMyNy4zMzQyIDEwLjg1MTEgMjcuODA3MyAxMi4yMDcyIDI3LjY4MjEgMTMuNTc2MVYyMC41MDg0SDI3LjczMTRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K"
+                        alt="{{#t}}Mozilla m logo{{/t}}"
+                    />
+                </div>
+                <div class="flex-initial max-w-md">
+                    <p class="text-start text-sm font-bold">
+                        {{#t}}Firefox accounts will be renamed Mozilla accounts on Nov 1{{/t}}
+                    </p>
+                    <p class="text-start text-xs">
+                        {{#t}}You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
+                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
+                    </p>
+                </div>
             </div>
-            <div class="flex-initial max-w-md">
-                <p class="text-start text-sm font-bold">
-                    {{#t}}Firefox accounts will be renamed Mozilla accounts on Nov 1{{/t}}
-                </p>
-                <p class="text-start text-xs">
-                    {{#t}}You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                    <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
-                </p>
+            {{/showPrelaunch}}
+            {{#showPostlaunch}}
+            <div className="flex"/>
+                <div>
+                    <p class="text-sm font-bold">
+                        {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
+                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
+                    </p>
+                </div>
             </div>
-        </div>
-        {{/showPrelaunch}}
-        {{#showPostlaunch}}
-        <div className="flex"/>
-            <div>
-                <p class="text-sm font-bold">
-                    {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                    <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
-                </p>
+            {{/showPostlaunch}}
+            <div class="flex justify-right order-last rtl:justify-left m-4 mt-1 mb-1">
+                <button
+                    class="close-brand-banner w-4 h-4"
+                    aria-label="{{#t}}Close Banner{{/t}}"
+                    >
+                    <img
+                        src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+CiAgPGc+CiAgICA8cGF0aCBmaWxsPSJyZ2JhKDEyLCAxMiwgMTMsIC44KSIgZD0iTTkuNDE0IDhsNS4yOTMtNS4yOTNhMSAxIDAgMDAtMS40MTQtMS40MTRMOCA2LjU4NiAyLjcwNyAxLjI5M2ExIDEgMCAwMC0xLjQxNCAxLjQxNEw2LjU4NiA4bC01LjI5MyA1LjI5M2ExIDEgMCAxMDEuNDE0IDEuNDE0TDggOS40MTRsNS4yOTMgNS4yOTNhMSAxIDAgMDAxLjQxNC0xLjQxNHoiLz4KICA8L2c+Cjwvc3ZnPgo="
+                        class="cursor-pointer h-4 w-4"
+                        alt="{{#t}}Close Banner{{/t}}"
+                    />
+                </button>
             </div>
-        </div>
-        {{/showPostlaunch}}
-        <div class="flex justify-right order-last rtl:justify-left m-4 mt-1 mb-1">
-            <button
-                id="close-brand-banner"
-                class="w-4 h-4"
-                aria-label="{{#t}}Close Banner{{/t}}"
-                >
-                <img
-                    src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+CiAgPGc+CiAgICA8cGF0aCBmaWxsPSJyZ2JhKDEyLCAxMiwgMTMsIC44KSIgZD0iTTkuNDE0IDhsNS4yOTMtNS4yOTNhMSAxIDAgMDAtMS40MTQtMS40MTRMOCA2LjU4NiAyLjcwNyAxLjI5M2ExIDEgMCAwMC0xLjQxNCAxLjQxNEw2LjU4NiA4bC01LjI5MyA1LjI5M2ExIDEgMCAxMDEuNDE0IDEuNDE0TDggOS40MTRsNS4yOTMgNS4yOTNhMSAxIDAgMDAxLjQxNC0xLjQxNHoiLz4KICA8L2c+Cjwvc3ZnPgo="
-                    class="cursor-pointer h-4 w-4"
-                    alt="{{#t}}Close Banner{{/t}}"
-                />
-            </button>
         </div>
     </div>
 </div>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
@@ -1,4 +1,4 @@
-{{{ brandMessagingHTML }}}
+{{ brandMessagingHTML }}
 <div class="card">
   <header class="mb-2">
     <h1 id="fxa-signup-password-header" class="card-header">

--- a/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
@@ -31,34 +31,64 @@ const Mixin = {
       `${bannerClosedLocalStorageKey}_${this.mode}`
     );
 
-    if (
+    this.enabled =
       this.disableBanner == null &&
-      (this.mode === 'prelaunch' || this.mode === 'postlaunch')
-    ) {
+      (this.mode === 'prelaunch' || this.mode === 'postlaunch');
+
+    if (this.enabled) {
       this.logFlowEvent(`brand-messaging-${this.mode}-view`, this.viewName);
       document.body.classList.add('brand-messaging');
     }
   },
 
   afterRender() {
+    if (!this.enabled) {
+      return;
+    }
+
     setTimeout(() => {
-      /**
-       * Move element up to body, so that it can be sticky header or inline footer.
-       *
-       * Note, we can't use backbone's event object, because moving the elements
-       * unbinds it's events. Instead, directly bind events here.
-       */
-      const el = document.querySelector('#banner-brand-message');
-      if (el) {
-        document.body.append(el);
-        document.querySelector('#close-brand-banner').onclick = () => {
-          this.onBrandBannerClose();
-        };
-        document.querySelector('.brand-learn-more').onclick = () => {
-          this.onBrandLearnMoreClick();
-        };
+      const brandMessageNode = document.querySelector('.banner-brand-message');
+      const insertBanner = (selector) => {
+        const container = document.querySelector(selector);
+
+        // Clears out text incase of double render scenario...
+        container.innerText = '';
+        const clone = brandMessageNode.cloneNode(true);
+        container.append(clone);
+      };
+
+      const bindClickHandlers = () => {
+        /**
+         * Note, we can't use backbone's event object, because moving the elements
+         * unbinds its events. Instead, directly bind events here.
+         */
+        document.querySelectorAll('.close-brand-banner').forEach((x) => {
+          x.onclick = () => {
+            this.onBrandBannerClose();
+          };
+        });
+        document.querySelectorAll('.brand-learn-more').forEach((x) => {
+          x.onclick = () => {
+            this.onBrandLearnMoreClick();
+          };
+        });
+      };
+
+      if (brandMessageNode) {
+        /**
+         * Inject the brand message into the top and bottom of the page.
+         */
+        insertBanner('#body-top');
+        insertBanner('#body-bottom');
+        bindClickHandlers();
+      } else {
+        /**
+         * Recursive call. If the node doesn't exist, try again. There appear to be
+         * some race condition in backbones 'afterRender' method.
+         */
+        this.afterRender();
       }
-    }, 0);
+    }, 100);
   },
 
   setInitialContext(context) {
@@ -81,8 +111,9 @@ const Mixin = {
       `${bannerClosedLocalStorageKey}_${this.mode}`,
       this.disableBanner
     );
-    document.querySelector('#banner-brand-message').remove();
-    document.body.classList.remove('brand-messaging');
+    document
+      .querySelectorAll('.banner-brand-message')
+      .forEach((x) => x.remove());
     this.logFlowEvent(
       `brand-messaging-${this.mode}-banner-close`,
       this.viewName

--- a/packages/fxa-content-server/app/scripts/views/post_verify/third_party_auth/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/third_party_auth/set_password.js
@@ -13,6 +13,7 @@ import CWTSOnSignupPasswordMixin from '../../mixins/cwts-on-signup-password';
 import ServiceMixin from '../../mixins/service-mixin';
 import AccountSuggestionMixin from '../../mixins/account-suggestion-mixin';
 import SigninMixin from '../../mixins/signin-mixin';
+import BrandMessagingMixin from '../../mixins/brand-messaging-mixin';
 
 const PASSWORD_INPUT_SELECTOR = '#password';
 const VPASSWORD_INPUT_SELECTOR = '#vpassword';
@@ -80,7 +81,8 @@ Cocktail.mixin(
   }),
   ServiceMixin,
   AccountSuggestionMixin,
-  SigninMixin
+  SigninMixin,
+  BrandMessagingMixin
 );
 
 export default SetPassword;

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -65,22 +65,50 @@
   }
 }
 
+.brand-messaging {
+  padding-top: 0;
+
+  @include respond-to('small') {
+    padding-top: 3rem;
+  }
+}
+
+.banner-brand-message {
+
+  @include respond-to('big') {
+    position: relative;
+  }
+
+    /** Make it fixed to keep the banner sticky on mobile and ensure
+      it doesn't get cut off by the folding line. */
+  @include respond-to('small') {
+    position: fixed;
+      bottom: 0;
+  }
+}
+
+#body-top {
+  @include respond-to('small') {
+    display: none;
+  }
+}
+
+#body-top .brand-messaging {
+  @include respond-to('small') {
+    padding-top: initial;
+  }
+}
+
+#body-bottom {
+  @include respond-to('big') {
+    display: none;
+  }
+}
+
 .brand-banner-bg {
   background: linear-gradient(88.76deg, #E4EAF6 3.37%, #DBEEF8 39.93%, #DAF3F4 65.09%, #E3F6ED 102.21%);
 }
 
-/** Work around for sticky fixed banner */
-body.brand-messaging {
-  padding-top: 9rem;
-}
-
-/** On mobile banner moves to bottom, so we can undo padding hack above */
-@media screen and (max-width:480px) {
-  body.brand-messaging {
-    padding-top: inherit;
-  }
-
-}
 .choose-what-to-sync {
   .success-email-created {
     margin-bottom: 26px;

--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -28,14 +28,13 @@
         data-flow-begin="{{flowBeginTime}}"
         data-static-resource-host="{{{staticResourceUrl}}}"
     >
+        <div id="body-top" role="banner" class="w-full mb-12"></div>
+
         <div id="loading-spinner">
             <img
                 alt="{{#t}}Loading{{/t}}"
                 src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI3M3B4IiBoZWlnaHQ9IjczcHgiIHZpZXdCb3g9IjAgMCA3MyA3MyIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDxkZWZzPiAgICAgICAgPGxpbmVhckdyYWRpZW50IHgxPSI5My4wOTI4MDk2JSIgeTE9IjUyLjc3MzQzNzUlIiB4Mj0iNjguNTEzMzM5OCUiIHkyPSIxMTkuMzI2MDA3JSIgaWQ9ImxpbmVhckdyYWRpZW50LTEiPiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMwQTg0RkYiIHN0b3Atb3BhY2l0eT0iMCIgb2Zmc2V0PSIwJSI+PC9zdG9wPiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMwQTg0RkYiIG9mZnNldD0iNjkuMzY5ODE4MiUiPjwvc3RvcD4gICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMEE4NEZGIiBvZmZzZXQ9IjEwMCUiPjwvc3RvcD4gICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMjQ4NEM2IiBzdG9wLW9wYWNpdHk9IjAuMDA0Nzc3NjY5NTEiIG9mZnNldD0iMTAwJSI+PC9zdG9wPiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMyNDg0QzYiIHN0b3Atb3BhY2l0eT0iMCIgb2Zmc2V0PSIxMDAlIj48L3N0b3A+ICAgICAgICAgICAgPHN0b3Agc3RvcC1jb2xvcj0iIzI0ODRDNiIgc3RvcC1vcGFjaXR5PSIwIiBvZmZzZXQ9IjEwMCUiPjwvc3RvcD4gICAgICAgIDwvbGluZWFyR3JhZGllbnQ+ICAgICAgICA8cmVjdCBpZD0icGF0aC0yIiB4PSIwIiB5PSIwIiB3aWR0aD0iNDgiIGhlaWdodD0iNjAiPjwvcmVjdD4gICAgPC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4gICAgICAgIDxnIGlkPSJTaGFwZSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTUuMDAwMDAwLCAtMS4wMDAwMDApIj4gICAgICAgICAgICA8cGF0aCBkPSJNNDEuOCw3My44IEMyMS45LDczLjggNS44LDU3LjcgNS44LDM3LjggQzUuOCwxOC4xIDIxLjYsMi4yIDQxLjEsMS44IEM0MS4zLDEuOCA0MS40LDEuOCA0MS40LDEuOCBDNDEuNSwxLjggNDEuNywxLjggNDEuOCwxLjggQzQ0LjYsMi4yIDQ2LjgsNC41IDQ2LjgsNy4zIEM0Ni44LDEwLjEgNDQuNiwxMi41IDQxLjgsMTIuNyBDMjgsMTIuOCAxNi44LDI0IDE2LjgsMzcuOCBDMTYuOCw1MS42IDI4LDYyLjggNDEuOCw2Mi44IEM1NS42LDYyLjggNjYuOCw1MS42IDY2LjgsMzcuOCBMNzcuOCwzNy44IEM3Ny44LDU3LjcgNjEuNyw3My44IDQxLjgsNzMuOCBaIiBmaWxsPSJ1cmwoI2xpbmVhckdyYWRpZW50LTEpIj48L3BhdGg+ICAgICAgICAgICAgPG1hc2sgaWQ9Im1hc2stMyIgZmlsbD0id2hpdGUiPiAgICAgICAgICAgICAgICA8dXNlIHhsaW5rOmhyZWY9IiNwYXRoLTIiPjwvdXNlPiAgICAgICAgICAgIDwvbWFzaz4gICAgICAgICAgICA8ZyBpZD0iTWFzayI+PC9nPiAgICAgICAgICAgIDxwYXRoIGQ9Ik00MS44LDczLjggQzIxLjksNzMuOCA1LjgsNTcuNyA1LjgsMzcuOCBDNS44LDE4LjEgMjEuNiwyLjIgNDEuMSwxLjggQzQxLjMsMS44IDQxLjQsMS44IDQxLjQsMS44IEM0MS41LDEuOCA0MS43LDEuOCA0MS44LDEuOCBDNDQuNiwyLjIgNDYuOCw0LjUgNDYuOCw3LjMgQzQ2LjgsMTAuMSA0NC42LDEyLjUgNDEuOCwxMi43IEMyOCwxMi44IDE2LjgsMjQgMTYuOCwzNy44IEMxNi44LDUxLjYgMjgsNjIuOCA0MS44LDYyLjggQzU1LjYsNjIuOCA2Ni44LDUxLjYgNjYuOCwzNy44IEw3Ny44LDM3LjggQzc3LjgsNTcuNyA2MS43LDczLjggNDEuOCw3My44IFoiIGZpbGw9IiMwQTg0RkYiIG1hc2s9InVybCgjbWFzay0zKSI+PC9wYXRoPiAgICAgICAgPC9nPiAgICA8L2c+PC9zdmc+"
             />
-        </div>
-
-        <div class="hidden mobileLandscape:block">
         </div>
 
 
@@ -52,8 +51,8 @@
             ></a>
         </div>
 
-        <div class="block mobileLandscape:hidden">
-        </div>
+
+        <div id="body-bottom" role="banner" class="w-full mt-12"></div>
 
         <noscript>
             {{#t}}Firefox Accounts requires JavaScript.{{/t}}

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -21,6 +21,7 @@ export const AppLayout = ({ title, children, widthClass }: AppLayoutProps) => {
   const { l10n } = useLocalization();
   return (
     <>
+      <div id="body-top" className="w-full hidden mobileLandscape:block"></div>
       <Head {...{ title }} />
       <div
         className="flex min-h-screen flex-col items-center"
@@ -49,6 +50,10 @@ export const AppLayout = ({ title, children, widthClass }: AppLayoutProps) => {
           </LinkExternal>
         </footer>
       </div>
+      <div
+        id="body-bottom"
+        className="w-full block mobileLandscape:hidden"
+      ></div>
     </>
   );
 };

--- a/packages/fxa-settings/src/components/BrandMessaging/index.stories.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.stories.tsx
@@ -6,28 +6,28 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import BrandMessaging from '.';
+import { BrandMessagingPortal } from '.';
 
 export default {
   title: 'Components/BrandMessaging',
-  component: BrandMessaging,
+  component: BrandMessagingPortal,
   decorators: [withLocalization],
 } as Meta;
 
 export const NoLaunch = () => (
   <AppLayout>
-    <BrandMessaging viewName="storybook" />
+    <BrandMessagingPortal viewName="storybook" />
   </AppLayout>
 );
 
 export const PreLaunch = () => (
   <AppLayout>
-    <BrandMessaging mode="prelaunch" viewName="storybook" />
+    <BrandMessagingPortal mode="prelaunch" viewName="storybook" />
   </AppLayout>
 );
 
 export const PostLaunch = () => (
   <AppLayout>
-    <BrandMessaging mode="postlaunch" viewName="storybook" />
+    <BrandMessagingPortal mode="postlaunch" viewName="storybook" />
   </AppLayout>
 );

--- a/packages/fxa-settings/src/components/BrandMessaging/index.test.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { act, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import BrandMessaging, { bannerClosedLocalStorageKey } from '.';
+import { BrandMessaging, bannerClosedLocalStorageKey } from '.';
 
 describe('BrandMessaging', () => {
   const preLaunchMessageTestId = 'brand-prelaunch';

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -7,11 +7,33 @@ import { useConfig } from '../../models';
 import { useMetrics } from '../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { Localized } from '@fluent/react';
+import { createPortal } from 'react-dom';
 
 export const bannerClosedLocalStorageKey =
   '__fxa_storage.fxa_disable_brand_banner';
 
-const BrandMessaging = ({
+export type BrandMessagingProps = {
+  mode?: string;
+  viewName: string;
+};
+
+export const BrandMessagingPortal = (props: BrandMessagingProps) => {
+  const bodyTop = document.querySelector('#body-top');
+  const bodyBottom = document.querySelector('#body-bottom');
+
+  if (bodyTop == null || bodyBottom == null) {
+    return <></>;
+  }
+
+  return (
+    <>
+      {createPortal(<BrandMessaging {...props} />, bodyTop)}
+      {createPortal(<BrandMessaging {...props} />, bodyBottom)}
+    </>
+  );
+};
+
+export const BrandMessaging = ({
   mode,
   viewName,
 }: {
@@ -69,8 +91,8 @@ const BrandMessaging = ({
 
   return (
     <div
-      id="banner-brand-message"
-      className="w-full relative mobileLandscape:absolute mobileLandscape:top-0 mobileLandscape:left-0"
+      className="banner-brand-message w-full fixed bottom-0 mobileLandscape:top-0 mobileLandscape:relative"
+      role="banner"
     >
       <div className="flex relative justify-center p-2 brand-banner-bg">
         {mode === 'prelaunch' && (
@@ -154,4 +176,3 @@ const BrandMessaging = ({
     </div>
   );
 };
-export default BrandMessaging;

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.tsx
@@ -7,8 +7,7 @@ import HeaderLockup from '../HeaderLockup';
 import ContentSkip from '../ContentSkip';
 import Footer from 'fxa-react/components/Footer';
 import { AlertBar } from '../AlertBar';
-import BrandMessaging from '../../BrandMessaging';
-import { createPortal } from 'react-dom';
+import { BrandMessagingPortal } from '../../BrandMessaging';
 
 type AppLayoutProps = {
   children: React.ReactNode;
@@ -20,8 +19,9 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
       className="flex flex-col justify-between min-h-screen"
       data-testid="app"
     >
-      {createPortal(<BrandMessaging viewName="settings" />, document.body)}
       <ContentSkip />
+      <div id="body-top" className="hidden mobileLandscape:block" />
+      <BrandMessagingPortal viewName="settings" />
       <HeaderLockup />
       <div className="max-w-screen-desktopXl flex-1 w-full mx-auto tablet:px-20 desktop:px-12">
         <main id="main" data-testid="main" className="w-full">
@@ -30,6 +30,7 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
         </main>
       </div>
       <Footer />
+      <div id="body-bottom" className="block mobileLandscape:hidden" />
     </div>
   );
 };

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -276,7 +276,7 @@ describe('PageResetPassword', () => {
       target: { value: MOCK_ACCOUNT.primaryEmail.email },
     });
 
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: 'Begin reset' }));
     await screen.findByText('Unknown account');
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -27,6 +27,7 @@ import { isEmailValid } from 'fxa-shared/email/helpers';
 import { setOriginalTabMarker } from '../../lib/storage-utils';
 import { ResetPasswordFormData, ResetPasswordProps } from './interfaces';
 import { ConfirmResetPasswordLocationState } from './ConfirmResetPassword/interfaces';
+import { BrandMessagingPortal } from '../../components/BrandMessaging';
 
 export const viewName = 'reset-password';
 
@@ -162,6 +163,7 @@ const ResetPassword = ({
 
   return (
     <AppLayout>
+      <BrandMessagingPortal {...{ viewName }} />
       <CardHeader
         headingWithDefaultServiceFtlId="reset-password-heading-w-default-service"
         headingWithCustomServiceFtlId="reset-password-heading-w-custom-service"

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { usePageViewEvent } from '../../lib/metrics';
 import { useFtlMsgResolver } from '../../models';
 import { MozServices } from '../../lib/types';
@@ -14,7 +13,7 @@ import TermsPrivacyAgreement from '../../components/TermsPrivacyAgreement';
 import { REACT_ENTRYPOINT } from '../../constants';
 import CardHeader from '../../components/CardHeader';
 import ThirdPartyAuth from '../../components/ThirdPartyAuth';
-import BrandMessaging from '../../components/BrandMessaging';
+import { BrandMessagingPortal } from '../../components/BrandMessaging';
 
 export type SigninProps = {
   email: string;
@@ -81,7 +80,7 @@ const Signin = ({
 
   return (
     <>
-      {createPortal(<BrandMessaging {...{ viewName }} />, document.body)}
+      <BrandMessagingPortal {...{ viewName }} />,
       {isPasswordNeeded ? (
         <CardHeader
           headingText="Enter your password"

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -16,6 +16,12 @@ import { LocationProvider } from '@reach/router';
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
+  logViewEventOnce: jest.fn(),
+  useMetrics: () => ({
+    usePageViewEvent: jest.fn(),
+    logViewEvent: jest.fn(),
+    logViewEventOnce: jest.fn(),
+  }),
 }));
 
 // TODO test for email received from params (if arriving from content-server) in FXA-8303

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -36,6 +36,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { ResendStatus } from 'fxa-settings/src/lib/types';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { ConfirmSignupCodeQueryParams } from '../../../models/pages/confirm-signup-code';
+import { BrandMessagingPortal } from '../../../components/BrandMessaging';
 
 export const viewName = 'confirm-signup-code';
 
@@ -213,6 +214,7 @@ const ConfirmSignupCode = (_: RouteComponentProps) => {
 
   return (
     <AppLayout title={localizedPageTitle}>
+      <BrandMessagingPortal {...{ viewName }} />
       <CardHeader
         headingText="Enter confirmation code"
         headingAndSubheadingFtlId="confirm-signup-code-heading"

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -33,9 +33,8 @@ import {
   setCurrentAccount,
 } from '../../lib/storage-utils';
 import { sessionToken } from '../../lib/cache';
-import BrandMessaging from '../../components/BrandMessaging';
-import { createPortal } from 'react-dom';
 import GleanMetrics from '../../lib/glean';
+import { BrandMessagingPortal } from '../../components/BrandMessaging';
 
 export const viewName = 'signup';
 
@@ -216,7 +215,7 @@ const Signup = ({
     // TODO: FXA-8268, if force_auth && AuthErrors.is(error, 'DELETED_ACCOUNT'):
     //       - forceMessage('Account no longer exists. Recreate it?')
     <AppLayout>
-      {createPortal(<BrandMessaging {...{ viewName }} />, document.body)}
+      <BrandMessagingPortal {...{ viewName }} />
       <CardHeader
         headingText="Set your password"
         headingTextFtlId="signup-heading"

--- a/packages/fxa-settings/src/styles/brand-banner.css
+++ b/packages/fxa-settings/src/styles/brand-banner.css
@@ -12,22 +12,3 @@
     #e3f6ed 102.21%
   );
 }
-
-/** At widths less than 540, text starts wrapping, and more padding is needing */
-@media only screen and (max-width: 540px) {
-  body.brand-messaging {
-    @apply pt-28;
-  }
-}
-
-/** By default a bit of padding is needed to offset the banner at top of page. */
-body.brand-messaging {
-  @apply pt-18;
-}
-
-/** On screens smaller than 480, footer drops to bottom, so no padding is needed */
-@media only screen and (max-width: 480px) {
-  body.brand-messaging {
-    @apply pt-0;
-  }
-}


### PR DESCRIPTION
## Because

- More than one banner could show up on mobile
- Tab order was wrong
- Settings header could overlap brand header

## This pull request

- Takes a different approach to injecting the banner
- Two banners are now rendered in a static matter at the top & bottom of page
- Responsive CSS is used to control the visibility of these headers
- Adds the banner to the confirm signup page for the react conversion

## Issue that this pull request solves

Closes: FXA-8352, FXA-8357, FXA-8359, FXA-8332

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
