### PR TITLE
feat(contentful): Add query to get all clients (services with capabilities)

### DIFF
--- a/libs/shared/contentful/src/__generated__/gql.ts
+++ b/libs/shared/contentful/src/__generated__/gql.ts
@@ -21,6 +21,8 @@ const documents = {
     types.PurchaseWithDetailsDocument,
   '\n  query PurchaseWithDetailsOfferingContent(\n    $skip: Int!\n    $limit: Int!\n    $locale: String!\n    $stripePlanIds: [String]!\n  ) {\n    purchaseCollection(\n      skip: $skip\n      limit: $limit\n      locale: $locale\n      where: { stripePlanChoices_contains_some: $stripePlanIds }\n    ) {\n      items {\n        stripePlanChoices\n        purchaseDetails {\n          details\n          productName\n          subtitle\n          webIcon\n        }\n        offering {\n          stripeProductId\n          commonContent {\n            privacyNoticeUrl\n            privacyNoticeDownloadUrl\n            termsOfServiceUrl\n            termsOfServiceDownloadUrl\n            cancellationUrl\n            emailIcon\n            successActionButtonUrl\n            successActionButtonLabel\n          }\n        }\n      }\n    }\n  }\n':
     types.PurchaseWithDetailsOfferingContentDocument,
+  '\n  query ServicesWithCapabilities($skip: Int!, $limit: Int!, $locale: String!) {\n    serviceCollection(skip: $skip, limit: $limit, locale: $locale) {\n      items {\n        oauthClientId\n        capabilitiesCollection(skip: $skip, limit: $limit) {\n          items {\n            slug\n          }\n        }\n      }\n    }\n  }\n':
+    types.ServicesWithCapabilitiesDocument,
 };
 
 /**
@@ -61,6 +63,12 @@ export function graphql(
 export function graphql(
   source: '\n  query PurchaseWithDetailsOfferingContent(\n    $skip: Int!\n    $limit: Int!\n    $locale: String!\n    $stripePlanIds: [String]!\n  ) {\n    purchaseCollection(\n      skip: $skip\n      limit: $limit\n      locale: $locale\n      where: { stripePlanChoices_contains_some: $stripePlanIds }\n    ) {\n      items {\n        stripePlanChoices\n        purchaseDetails {\n          details\n          productName\n          subtitle\n          webIcon\n        }\n        offering {\n          stripeProductId\n          commonContent {\n            privacyNoticeUrl\n            privacyNoticeDownloadUrl\n            termsOfServiceUrl\n            termsOfServiceDownloadUrl\n            cancellationUrl\n            emailIcon\n            successActionButtonUrl\n            successActionButtonLabel\n          }\n        }\n      }\n    }\n  }\n'
 ): (typeof documents)['\n  query PurchaseWithDetailsOfferingContent(\n    $skip: Int!\n    $limit: Int!\n    $locale: String!\n    $stripePlanIds: [String]!\n  ) {\n    purchaseCollection(\n      skip: $skip\n      limit: $limit\n      locale: $locale\n      where: { stripePlanChoices_contains_some: $stripePlanIds }\n    ) {\n      items {\n        stripePlanChoices\n        purchaseDetails {\n          details\n          productName\n          subtitle\n          webIcon\n        }\n        offering {\n          stripeProductId\n          commonContent {\n            privacyNoticeUrl\n            privacyNoticeDownloadUrl\n            termsOfServiceUrl\n            termsOfServiceDownloadUrl\n            cancellationUrl\n            emailIcon\n            successActionButtonUrl\n            successActionButtonLabel\n          }\n        }\n      }\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query ServicesWithCapabilities($skip: Int!, $limit: Int!, $locale: String!) {\n    serviceCollection(skip: $skip, limit: $limit, locale: $locale) {\n      items {\n        oauthClientId\n        capabilitiesCollection(skip: $skip, limit: $limit) {\n          items {\n            slug\n          }\n        }\n      }\n    }\n  }\n'
+): (typeof documents)['\n  query ServicesWithCapabilities($skip: Int!, $limit: Int!, $locale: String!) {\n    serviceCollection(skip: $skip, limit: $limit, locale: $locale) {\n      items {\n        oauthClientId\n        capabilitiesCollection(skip: $skip, limit: $limit) {\n          items {\n            slug\n          }\n        }\n      }\n    }\n  }\n'];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/libs/shared/contentful/src/__generated__/graphql.ts
+++ b/libs/shared/contentful/src/__generated__/graphql.ts
@@ -2783,6 +2783,30 @@ export type PurchaseWithDetailsOfferingContentQuery = {
   } | null;
 };
 
+export type ServicesWithCapabilitiesQueryVariables = Exact<{
+  skip: Scalars['Int']['input'];
+  limit: Scalars['Int']['input'];
+  locale: Scalars['String']['input'];
+}>;
+
+export type ServicesWithCapabilitiesQuery = {
+  __typename?: 'Query';
+  serviceCollection?: {
+    __typename?: 'ServiceCollection';
+    items: Array<{
+      __typename?: 'Service';
+      oauthClientId?: string | null;
+      capabilitiesCollection?: {
+        __typename?: 'ServiceCapabilitiesCollection';
+        items: Array<{
+          __typename?: 'Capability';
+          slug?: string | null;
+        } | null>;
+      } | null;
+    } | null>;
+  } | null;
+};
+
 export const CapabilityServiceByPriceIdsDocument = {
   kind: 'Document',
   definitions: [
@@ -3477,4 +3501,145 @@ export const PurchaseWithDetailsOfferingContentDocument = {
 } as unknown as DocumentNode<
   PurchaseWithDetailsOfferingContentQuery,
   PurchaseWithDetailsOfferingContentQueryVariables
+>;
+export const ServicesWithCapabilitiesDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'ServicesWithCapabilities' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'skip' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'limit' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'locale' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'String' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'serviceCollection' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'skip' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'skip' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'limit' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'limit' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'locale' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'locale' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'items' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'oauthClientId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'capabilitiesCollection' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'skip' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'skip' },
+                            },
+                          },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'limit' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'limit' },
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'items' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'slug' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  ServicesWithCapabilitiesQuery,
+  ServicesWithCapabilitiesQueryVariables
 >;

--- a/libs/shared/contentful/src/lib/queries/servicesWithCapabilities.ts
+++ b/libs/shared/contentful/src/lib/queries/servicesWithCapabilities.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { graphql } from '../../__generated__/gql';
+
+export const servicesWithCapabilitiesQuery = graphql(`
+  query ServicesWithCapabilities($skip: Int!, $limit: Int!, $locale: String!) {
+    serviceCollection(skip: $skip, limit: $limit, locale: $locale) {
+      items {
+        oauthClientId
+        capabilitiesCollection(skip: $skip, limit: $limit) {
+          items {
+            slug
+          }
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION
## Because

- we need to be able to fetch all Services and Capabilities

## This pull request

- Adds a query to fetch that information from Contentful via a GraphQL query, along with updated typings.

## Issue that this pull request solves

Closes: [FXA-8334](https://mozilla-hub.atlassian.net/browse/FXA-8334)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

[FXA-8334]: https://mozilla-hub.atlassian.net/browse/FXA-8334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ