### PR TITLE
fix(functional-test): Update service name check for oauth reset PW tests

### DIFF
--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -28,14 +28,16 @@ export class ResetPasswordPage extends BaseLayout {
     return this.page.locator(selectors.EMAIL);
   }
 
-  async resetPasswordHeader(title?: string) {
+  async resetPasswordHeader(headerTextPartial?: string) {
     if (this.react) {
-      const resetPass = await this.page.waitForSelector('#root .card-header');
+      const header = await this.page.waitForSelector('#root .card-header');
+      const headerText =
+        // clean up any special characters and line breaks
+        (await header.textContent())?.replace(/[^\x00-\x7F]/g, '') || '';
+
       return (
-        (await resetPass.textContent())
-          ?.replace(/[^\x00-\x7F]/g, '')
-          ?.startsWith(title || 'Reset password') &&
-        (await resetPass.isVisible())
+        headerText.startsWith(headerTextPartial || 'Reset password') &&
+        (await header.isVisible())
       );
     }
 

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -21,7 +21,6 @@ test.describe('oauth reset password react', () => {
     resetPassword.react = resetPasswordReactFlag;
   });
 
-  /*Disabling test in stage and prod until Fxa-8192 is worked on
   test('reset password', async ({
     target,
     page,
@@ -79,7 +78,6 @@ test.describe('oauth reset password react', () => {
       }
     );
   });
-  */
 
   test('reset password with PKCE different tab', async ({
     target,
@@ -248,10 +246,11 @@ async function passwordResetFlow(
   await checkForReactApp({ page });
 
   // Verify reset password header
+  // The service name can change based on environments and all of our test RPs have service names
+  // that begin with '123'. This test just ensures that the OAuth service name is rendered, it's
+  // OK that it does not exactly match.
   expect(
-    await resetPassword.resetPasswordHeader(
-      'Reset password to continue to 123Done'
-    )
+    await resetPassword.resetPasswordHeader('Reset password to continue to 123')
   ).toBe(true);
 
   await resetPassword.fillOutResetPassword(credentials.email);


### PR DESCRIPTION
Because:
* This test was failing in stage and prod, as the 123done service name differs slightly based on env

This commit:
* Updates relevant test flow to more loosely check the service name, as we start with the '123' service name across envs
* Adds a couple comments for clarity, re-enables the tests in question

fixes FXA-8192

---

I had made a couple other changes in `pages/resetPassword.ts` that I ended up reverting so the diff there might actually be unnecessary but I left it since I found the updates slightly more clear.

Locally our test RP is `123Done`, in staging it's `123done-stage`, and in prod it's `123done-heroku`, so this approach seemed fine to me. This didn't feel worth a regex and we could alternatively check that it _doesn't_ have "account settings" after continue to.