### PR TITLE
fix(osx): Fix an issue in Sonoma where oauth query params were being stripped

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/authorization.js
+++ b/packages/fxa-content-server/app/scripts/views/authorization.js
@@ -30,7 +30,14 @@ class AuthorizationView extends BaseView {
     } else {
       // if no action is specified, let oauth-index decide based on
       // current user signed in state.
-      this.replaceCurrentPage('/oauth/');
+      // this.replaceCurrentPage('/oauth/');
+
+      // This is an attempt to fix an issue in OSX Sonoma & Safari private mode with `Advanced Fringerprinting Protection` enabled.
+      // Previously oauth query params were lost after redirecting to `/oauth/` page.
+      const searchParams = new URLSearchParams(this.window.location.search);
+      this.navigateAway(
+        this.window.origin + '/oauth/?' + searchParams.toString()
+      );
     }
   }
 

--- a/packages/fxa-content-server/app/tests/spec/views/authorization.js
+++ b/packages/fxa-content-server/app/tests/spec/views/authorization.js
@@ -69,6 +69,7 @@ describe('views/authorization', function () {
     });
 
     sinon.spy(view, 'replaceCurrentPage');
+    sinon.spy(view, 'navigateAway');
   }
 
   describe('beforeRender', () => {
@@ -84,10 +85,7 @@ describe('views/authorization', function () {
 
     it('handles default action', () => {
       return view.render().then(() => {
-        assert.ok(
-          view.replaceCurrentPage.calledOnceWith('/oauth/'),
-          'called with proper action'
-        );
+        assert.ok(view.navigateAway.calledOnce, 'called with proper action');
       });
     });
 


### PR DESCRIPTION
## Because

- In upcoming Safari Sonoma, FxA OAuth query params would be stripped from the url. This would cause FxA to default to sending the user to settings page and not complete the OAuth flow
- This doesn't happen to all RPs, for example https://production-123done.herokuapp.com/ fails but https://stage-123done.herokuapp.com/ works properly

## This pull request

- Skips using the `replaceCurrentPage` Backbone navigate function and uses `window.location.href` directly
- Doing this also skips a few query validation and checks we perform

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I can't say for certain if this works but it should hopefully narrow down the issue. Getting Safari to load FxA locally is a pain since it forces urls to https.

Note, I would like to try this on stage since we can reproduce the issue with certain RPs.
