### PR TITLE
feat(libs): create EligibilityManager library

### DIFF
--- a/libs/payments/capability/README.md
+++ b/libs/payments/capability/README.md
@@ -8,4 +8,4 @@ Run `nx build payments-capability` to build the library.
 
 ## Running unit tests
 
-Run `nx test payments-capability` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test-unit payments-capability` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/payments/eligibility/.eslintrc.json
+++ b/libs/payments/eligibility/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/payments/eligibility/README.md
+++ b/libs/payments/eligibility/README.md
@@ -1,0 +1,11 @@
+# payments-eligibility
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build payments-eligibility` to build the library.
+
+## Running unit tests
+
+Run `nx test-unit payments-eligibility` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/payments/eligibility/jest.config.ts
+++ b/libs/payments/eligibility/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'payments-eligibility',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/payments/eligibility',
+};

--- a/libs/payments/eligibility/package.json
+++ b/libs/payments/eligibility/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fxa/payments/eligibility",
+  "version": "0.0.1"
+}

--- a/libs/payments/eligibility/project.json
+++ b/libs/payments/eligibility/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "payments-eligibility",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/payments/eligibility/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "rootDir": ".",
+        "outputPath": "dist/libs/payments/eligibility",
+        "tsConfig": "libs/payments/eligibility/tsconfig.lib.json",
+        "packageJson": "libs/payments/eligibility/package.json",
+        "main": "libs/payments/eligibility/src/index.ts",
+        "assets": ["libs/payments/eligibility/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/payments/eligibility/**/*.ts",
+          "libs/payments/eligibility/package.json"
+        ]
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/eligibility/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": ["scope:shared:lib:payments"]
+}

--- a/libs/payments/eligibility/src/index.ts
+++ b/libs/payments/eligibility/src/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './lib/eligibility.manager';

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EligibilityManager {
+  constructor() {}
+}

--- a/libs/payments/eligibility/tsconfig.json
+++ b/libs/payments/eligibility/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/payments/eligibility/tsconfig.lib.json
+++ b/libs/payments/eligibility/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/payments/eligibility/tsconfig.spec.json
+++ b/libs/payments/eligibility/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,6 +26,7 @@
     "paths": {
       "@fxa/payments/capability": ["libs/payments/capability/src/index.ts"],
       "@fxa/payments/cart": ["libs/payments/cart/src/index.ts"],
+      "@fxa/payments/eligibility": ["libs/payments/eligibility/src/index.ts"],
       "@fxa/payments/paypal": ["libs/payments/paypal/src/index.ts"],
       "@fxa/payments/ui": ["libs/payments/ui/src/index.ts"],
       "@fxa/payments/ui/server": ["libs/payments/ui/src/server.ts"],


### PR DESCRIPTION
Because:

* Plan eligibility depends on a number of factors, including what plans the user is already subscribed to (in Stripe, Google IAP or Apple IAP) and available upgrade paths for those plans per product-specific config (in Stripe metadata currently but soon to live in Contentful).
* We want to break out eligibility checks and types into a separate library from the auth server's `CapabilityService.getPlanEligibility`, since it's not really capability-oriented.

This commit:

* Generates a new nx library in lib/payments/eligibility

Closes #FXA-7582

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
