### PR TITLE
fix(metrics): add workaround for uid check in fxa-settings

### DIFF
--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -297,7 +297,9 @@ describe('lib/glean', () => {
         // the ping submissions are await'd internally in GleanMetrics...
         await new Promise((resovle) =>
           setTimeout(() => {
-            sinon.assert.calledOnce(setuserIdSha256Stub);
+            sinon.assert.calledTwice(setuserIdSha256Stub);
+            // it sets a default of '' first
+            sinon.assert.calledWith(setuserIdSha256Stub, '');
             sinon.assert.calledWith(
               setuserIdSha256Stub,
               '7ca0172850c53065046beeac3cdec3fe921532dbfebdf7efeb5c33d019cd7798'

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -109,11 +109,14 @@ const populateMetrics = async (properties: EventProperties) => {
     event[n].set(properties[n] || '');
   }
 
-  if (metricsContext.account?.uid) {
-    const hashedUid = await hashUid(metricsContext.account.uid);
-    userIdSha256.set(hashedUid);
-  } else {
-    userIdSha256.set('');
+  userIdSha256.set('');
+  try {
+    if (metricsContext.account?.uid) {
+      const hashedUid = await hashUid(metricsContext.account.uid);
+      userIdSha256.set(hashedUid);
+    }
+  } catch (e) {
+    // noop
   }
 
   oauthClientId.set(metricsContext.integration.data.clientId || '');


### PR DESCRIPTION
Because:
 - the uid getter in fxa-settings could cause an error to be thrown (at least when the user has not signed in yet)

This commit:
 - adds a workaround to ignore the error for now
