### PR TITLE
task(all): Ignore all .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ external
 .env.development.local
 .env.test.local
 .env.production.local
+*.env
+
 .keys
 public-key.json
 secret-key.json

--- a/_dev/docker/ci/Dockerfile.dockerignore
+++ b/_dev/docker/ci/Dockerfile.dockerignore
@@ -8,6 +8,8 @@
 **/Library
 **/_dev/docker
 **/.circleci
+**/.env
+**/*.env
 **/.npm
 **/artifacts
 **/configs


### PR DESCRIPTION
## Because

- We want all files ending in .env to be ignored

## This pull request

- gitignores files ending with .env
- dockeringores files ending with .env

## Issue that this pull request solves

Closes: 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
