### PR TITLE
task(content): Add l10n strings for Mozilla account

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
@@ -50,3 +50,7 @@
         </section>
     {{/isLinkExpired}}
 </div>
+
+<!-- New L10N Strings
+{{#t}}Please enter the one time use account recovery key you stored in a safe place to regain access to your Mozilla account.{{/t}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -29,3 +29,7 @@
         </form>
     </section>
 </div>
+
+<!-- New L10N Strings
+{{#unsafeTranslate}}Enter confirmation code <span class="card-subheader" id="subheader"> for your Mozilla account</span>{{/unsafeTranslate}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -46,3 +46,7 @@
     {{/fatalError}}
   </section>
 </div>
+
+<!-- New L10N Strings
+{{#unsafeTranslate}}Enter your password <span class="card-subheader" id="subheader">for your Mozilla account</span>{{/unsafeTranslate}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -64,3 +64,8 @@
     {{/isInThirdPartyAuthExperiment}}
   </section>
 </div>
+
+<!-- New L10N Strings
+{{#t}}Continue to your Mozilla account{{/t}}
+{{#t}}A Mozilla account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
@@ -60,3 +60,7 @@
     </section>
     {{/isLinkValid}}
 </div>
+
+<!-- New L10N Strings
+{{#t}}Create a Mozilla account{{/t}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/password/force_password_change.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/password/force_password_change.mustache
@@ -48,3 +48,7 @@
     </form>
   </section>
 </div>
+
+<!-- New L10N Strings
+{{#t}}We detected suspicious behavior on your Mozilla account. To protect your account, please create a new password. You’ll use this password to sign back in to all of your Mozilla account services.{{/t}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -93,3 +93,8 @@
       </div>
   </section>
 </div>
+
+
+<!-- New L10N Strings
+{{#unsafeTranslate}}Enter your password <span class="card-subheader" id="subheader">for your Mozilla account</span>{{/unsafeTranslate}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -30,3 +30,7 @@
     </div>
   </section>
 </div>
+
+<!-- New L10N Strings
+{{#unsafeTranslate}}Enter confirmation code <span class="card-subheader">for your Mozilla account</span>{{/unsafeTranslate}}
+-->

--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -103,3 +103,7 @@
 </div>
 
 <footer id="legal-footer"><a class="terms text-blue-500" href="/legal/terms">{{#t}}Terms of Service{{/t}}</a><a class="privacy text-blue-500" href="/legal/privacy">{{#t}}Privacy Notice{{/t}}</a></footer>
+
+<!-- New L10N Strings
+{{#t}}Mozilla account{{/t}}
+-->

--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -62,4 +62,7 @@
         <script type="text/javascript" src="{{ bundlePath }}/appDependencies.bundle.js"></script>
         <script type="text/javascript" src="{{ bundlePath }}/app.bundle.js"></script>
     </body>
+<!-- New L10N Strings
+{{#t}}Mozilla accounts require JavaScript.{{/t}}
+-->
 </html>

--- a/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
+++ b/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
@@ -60,4 +60,11 @@
             ></a>
         </div>
     </body>
+<!-- New L10N Strings
+{{#t}}Mozilla account{{/t}}
+{{#t}}Your Mozilla account makes use of features that are
+not supported in your version of Firefox. Please
+download and install the latest version of Firefox to
+continue.{{/t}}
+-->
 </html>


### PR DESCRIPTION
## Because

- We are introducing new strings for Mozilla account

## This pull request

- Adds new strings in comment blocks

## Issue that this pull request solves

Closes: FXA-7989

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Example of updated pot file
<img width="534" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/030d3ab7-2d97-40cd-9fd0-3103c8144bf9">


## Other information (Optional)

I validated locally that `{{#t}} {{/t}}` tags in comment blocks get extracted.
