### PR TITLE
fix(react): Tweak integration clientInfo check for reset PW sync mobile

### DIFF
--- a/packages/fxa-settings/src/lib/integrations/integration-factory.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.ts
@@ -231,7 +231,21 @@ export class IntegrationFactory {
   }
 
   initClientInfo(integration: OAuthIntegration) {
-    integration.clientInfo = this.createClientInfo(integration.data.clientId);
+    /* TODO: Possibly create SyncMobile integration if we need more special cases
+     * for sync mobile, or, probably remove 'isOAuthVerificationDifferentBrowser'
+     * 'isOAuthVerificationSameBrowser' checks when reset PW no longer uses links.
+     *
+     * `service=sync` is passed when `context` is `fx_desktop_v3` (Sync desktop) or
+     * when context is `fx_ios_v1` (which we don't support, iOS 1.0 ... < 2.0). See:
+     * https://mozilla.github.io/ecosystem-platform/relying-parties/reference/query-parameters#service
+     *
+     * However, mobile Sync reset PW can pass a 'service' param without a 'clientId' that
+     * acts as a clientId, and we currently consider this an OAuth flow (in Backbone as well)
+     * that does not want to redirect. In this case, createClientInfo with 'service'.
+     */
+    integration.clientInfo = this.createClientInfo(
+      integration.data.clientId || integration.data.service
+    );
   }
 
   initSubscriptionInfo(integration: Integration) {

--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -185,8 +185,23 @@ export function useFinishOAuthFlowHandler(
     [authClient, integration]
   );
 
-  // We can't return early because `useCallback` can't be set conditionally
-  if (isOAuthIntegration(integration)) {
+  /* TODO: Possibly create SyncMobile integration if we need more special cases
+   * for sync mobile, or, probably remove 'isOAuthVerificationDifferentBrowser'
+   * 'isOAuthVerificationSameBrowser' checks when reset PW no longer uses links.
+   *
+   * `service=sync` is passed when `context` is `fx_desktop_v3` (Sync desktop) or
+   * when context is `fx_ios_v1` (which we don't support, iOS 1.0 ... < 2.0). See:
+   * https://mozilla.github.io/ecosystem-platform/relying-parties/reference/query-parameters#service
+   *
+   * However, mobile Sync reset PW can pass a 'service' param without a 'clientId' that
+   * acts as a clientId, and we currently consider this an OAuth flow (in Backbone as well)
+   * that does not want to redirect. For this case, ensure `integration.data.service`
+   * does not exist, because we otherwise do not want to check other OAuth data
+   * are present and do not want to provide back `finishOAuthFlowHandler`.
+   *
+   * P.S. we can't return early regardless because `useCallback` can't be set conditionally.
+   */
+  if (isOAuthIntegration(integration) && !integration.data.service) {
     const oAuthDataError = checkOAuthData(integration);
     return { oAuthDataError, finishOAuthFlowHandler };
   }


### PR DESCRIPTION
Because:
* When resetting through mobile sync, a blank page was rendered on complete reset PW attempt

This commit:
* Passes `integration.data.service` into the get client info call if it's present, since this can sometimes contain the client ID

closes FXA-8358

---

See [comment here](https://github.com/mozilla/fxa/pull/15820/files#r1333442428) where I started to track down the problem. The reason it's loading a blank page is because we were accidentally trying to use material-ui's `CardHeader` instead of our own.

In prod / Backbone, we are hitting the OAuth broker for this flow, which can be verified by checking the network request and seeing `broker: redirect`. Testing locally, I'm able to see our `isOAuthVerificationDifferentBrowser` check return true for this same case (e.g. in the OAuth flow). Also in production, we are passing `service={clientId}` in this flow (not service=sync). Since locally it correctly passes for desktop sync, I don't think modifying `Account.ts` is necessarily right here. See my comments in-code, I think we can simplify this further when we use codes instead of links for reset PW, but this should work to fix the issue for now.

One way to help test this is to confirm [this on staging](https://accounts.stage.mozaws.net/complete_reset_password?uid=0030f7adf6d843aabad2798b6231396a&token=35bdb0a433d29129d350b41d4800e5fb88f55bdefcb1a103d74f6de83efaa329&code=288f0a5d36e5acb7008d9c3cdb6a2257&email=test%40gmail.com&service=1b1a3e44c54fbb58&resume=e30%3D&emailToHashWith=test%40gmail.com&utm_medium=email&utm_campaign=fx-forgot-password&utm_content=fx-reset-password) is a blank page, then if you load it locally on main you'll see a blank page, and then in my branch you should get an "expired link" page.

**Note**, I started adding a unit test for this but it was awkward with the partial container component bits and decided it was better as a functional test anyway. I started writing this in `oauthResetPassword` (which feels kinda awkward but relates to comments in-code) but needed more time to get it right. I'd like to not block on this to double check the fix works in staging.