### PR TITLE
chore(build): Add env to override the webpack build mode

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -778,6 +778,12 @@ const conf = (module.exports = convict({
     env: 'SOURCE_MAP_TYPE',
     format: String,
   },
+  webpackModeOverride: {
+    default: undefined,
+    doc: 'Tells webpack how to optimize build. See https://webpack.js.org/configuration/mode/',
+    env: 'WEBPACK_MODE_OVERRIDE',
+    format: String,
+  },
   statsd: {
     enabled: {
       doc: 'Enable StatsD',

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -9,8 +9,9 @@ const config = require('./server/lib/configuration').getProperties();
 const CopyPlugin = require('copy-webpack-plugin');
 
 const ENV = config.env;
+const WEBPACK_MODE_OVERRIDE = config.webpackModeOverride;
 const webpackConfig = {
-  mode: ENV,
+  mode: WEBPACK_MODE_OVERRIDE || ENV,
   context: path.resolve(__dirname, 'app/scripts'),
   entry: {
     app: './app.js',


### PR DESCRIPTION
## Because

- It is hard to debug webpack bundle in production because of the optimizations that webpack does

## This pull request

- Add config to build an unoptmized build that is easier to debug

## Issue that this pull request solves

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is to help debug https://mozilla-hub.atlassian.net/browse/FXA-8354. We will need a cloud ops PR to add override value.

In my local testing, the gzip unoptmized bundle was 1.2MB and ~6MB extracted. In production, the optmized bundle is 500kB and 1.2MB extracted.
