### PR TITLE
task(CI): Disable nx cache in docker build

### DIFF
--- a/_dev/docker/mono/build.sh
+++ b/_dev/docker/mono/build.sh
@@ -32,7 +32,7 @@ done
 # `npx yarn` because `npm i -g yarn` needs sudo
 npx yarn install
 npx yarn gql:allowlist
-NODE_OPTIONS="--max-old-space-size=7168" SKIP_PREFLIGHT_CHECK=true npx nx run-many -t build --all --verbose
+NODE_OPTIONS="--max-old-space-size=7168" SKIP_PREFLIGHT_CHECK=true npx nx run-many -t build --all --verbose --skip-nx-cache
 
 # This will reduce packages to only production dependencies
 npx yarn workspaces focus --production --all


### PR DESCRIPTION
## Because

- We were receiving what seemed like a nondeterministic cache hit

## This pull request

- Disables nx cache for now in docker build

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

This appeared to be working previously, but currently the cache hit doesn't seem to be getting restored despite circle ci out put indicating the file was restored. 

<img width="781" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/fa74e530-23f5-4e4d-922f-5280b5969bf2">

But the docker image doesn't appear to have the file:
<img width="671" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/fa7febb2-b99f-4aaa-8ef3-50bad149d3a2">


More investigation into this behavior is needed, but for now, this small change should mitigate the issue.
