### PR TITLE
bug(profile): Fix server crash on unexpected response.

### DIFF
--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -202,6 +202,10 @@ exports.create = async function createServer() {
                   logger.error('oauth.error', err);
                   return reject(AppError.oauthError(err));
                 }
+                if (body == null) {
+                  logger.error('oauth.error', 'no response body');
+                  return reject(AppError.oauthError('no response body'));
+                }
                 if (body.code >= 400) {
                   logger.debug('unauthorized', body);
                   return reject(AppError.unauthorized(body.message));


### PR DESCRIPTION
## Because

- If the response from the auth server contained no body. The profile server would crash and restart.

## This pull request

- Gracefully handles the scenario where the body is missing.

## Issue that this pull request solves

Closes: FXA-8375

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

It's a bit odd the body isn't being provided. Not sure if other think so. If so, I can file a follow up for this.