### PR TITLE
chore(libs): Create getClients method in CapabilityManager

### DIFF
--- a/libs/payments/capability/src/lib/capability.manager.spec.ts
+++ b/libs/payments/capability/src/lib/capability.manager.spec.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import {
+  ContentfulManager,
+  ServiceResultFactory,
+  ServicesWithCapabilitiesResultUtil,
+} from '@fxa/shared/contentful';
+import { CapabilityManager } from './capability.manager';
+
+describe('CapabilityManager', () => {
+  let manager: CapabilityManager;
+  let mockContentfulManager: ContentfulManager;
+  let mockResult: ServicesWithCapabilitiesResultUtil;
+
+  beforeEach(async () => {
+    mockResult = {} as any;
+    mockContentfulManager = {
+      getServicesWithCapabilities: jest.fn().mockResolvedValueOnce(mockResult),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: ContentfulManager, useValue: mockContentfulManager },
+        CapabilityManager,
+      ],
+    }).compile();
+
+    manager = module.get<CapabilityManager>(CapabilityManager);
+  });
+
+  it('should be defined', async () => {
+    expect(manager).toBeDefined();
+    expect(manager).toBeInstanceOf(CapabilityManager);
+  });
+
+  describe('getClients', () => {
+    it('should return empty results', async () => {
+      mockResult.getServices = jest.fn().mockReturnValueOnce(undefined);
+      const result = await manager.getClients();
+      expect(result.length).toBe(0);
+    });
+
+    it('should return services with capabilities', async () => {
+      const clientResults = ServiceResultFactory({
+        oauthClientId: 'client1',
+        capabilitiesCollection: {
+          items: [
+            { slug: 'exampleCap0' },
+            { slug: 'exampleCap2' },
+            { slug: 'exampleCap4' },
+            { slug: 'exampleCap5' },
+            { slug: 'exampleCap6' },
+            { slug: 'exampleCap8' },
+          ],
+        },
+      });
+      mockResult.getServices = jest.fn().mockReturnValue(clientResults);
+      const result = await manager.getClients();
+      expect(result.length).toBe(1);
+      expect(result[0].clientId).toBe('client1');
+
+      const actualCapabilities = [
+        'exampleCap0',
+        'exampleCap2',
+        'exampleCap4',
+        'exampleCap5',
+        'exampleCap6',
+        'exampleCap8',
+      ];
+      expect(result[0].capabilities).toHaveLength(6);
+      expect(result[0].capabilities).toStrictEqual(actualCapabilities);
+    });
+  });
+});

--- a/libs/payments/capability/src/lib/capability.manager.ts
+++ b/libs/payments/capability/src/lib/capability.manager.ts
@@ -2,9 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  CapabilitiesResult,
+  ContentfulManager,
+  ServiceResult,
+} from '@fxa/shared/contentful';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class CapabilityManager {
-  constructor() {}
+  constructor(private contentfulManager: ContentfulManager) {}
+
+  async getClients() {
+    const clients: ServiceResult[] = (
+      await this.contentfulManager.getServicesWithCapabilities()
+    ).getServices();
+
+    if (!clients) return [];
+
+    return clients.map((client: ServiceResult) => ({
+      clientId: client.oauthClientId,
+      capabilities: client.capabilitiesCollection.items.map(
+        (capability: CapabilitiesResult) => capability.slug
+      ),
+    }));
+  }
 }

--- a/libs/shared/contentful/src/index.ts
+++ b/libs/shared/contentful/src/index.ts
@@ -8,3 +8,4 @@ export * from './lib/contentful.error';
 export * from './lib/contentful.manager';
 export * from './lib/factories';
 export * from './lib/queries/eligibility-content-by-plan-ids';
+export * from './lib/queries/services-with-capabilities';

--- a/libs/shared/contentful/src/lib/__mocks__/contentful.client.ts
+++ b/libs/shared/contentful/src/lib/__mocks__/contentful.client.ts
@@ -1,9 +1,0 @@
-export const mockQuery = jest
-  .fn()
-  .mockResolvedValue({ data: { purchaseCollection: { items: [] } } });
-const mock = jest.fn().mockImplementation(() => {
-  return {
-    query: mockQuery,
-  };
-});
-export const ContentfulClient = mock;

--- a/libs/shared/contentful/src/lib/contentful.manager.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.ts
@@ -4,12 +4,19 @@
 
 import { Injectable } from '@nestjs/common';
 
-import { EligibilityContentByPlanIdsQuery } from '../__generated__/graphql';
+import {
+  EligibilityContentByPlanIdsQuery,
+  ServicesWithCapabilitiesQuery,
+} from '../__generated__/graphql';
 import { ContentfulClient } from './contentful.client';
 import {
   eligibilityContentByPlanIdsQuery,
   EligibilityContentByPlanIdsResultUtil,
 } from './queries/eligibility-content-by-plan-ids';
+import {
+  servicesWithCapabilitiesQuery,
+  ServicesWithCapabilitiesResultUtil,
+} from './queries/services-with-capabilities';
 import { DeepNonNullable } from './types';
 
 @Injectable()
@@ -24,13 +31,25 @@ export class ContentfulManager {
       {
         skip: 0,
         limit: 100,
-        locale: 'en-US',
+        locale: 'en',
         stripePlanIds,
       }
     );
 
     return new EligibilityContentByPlanIdsResultUtil(
       queryResult.data as DeepNonNullable<EligibilityContentByPlanIdsQuery>
+    );
+  }
+
+  async getServicesWithCapabilities(): Promise<ServicesWithCapabilitiesResultUtil> {
+    const queryResult = await this.client.query(servicesWithCapabilitiesQuery, {
+      skip: 0,
+      limit: 100,
+      locale: 'en',
+    });
+
+    return new ServicesWithCapabilitiesResultUtil(
+      queryResult.data as DeepNonNullable<ServicesWithCapabilitiesQuery>
     );
   }
 }

--- a/libs/shared/contentful/src/lib/factories.ts
+++ b/libs/shared/contentful/src/lib/factories.ts
@@ -10,12 +10,17 @@ import {
   EligibilityContentByPlanIdsQuery,
   OfferingQuery,
   PurchaseWithDetailsQuery,
+  ServicesWithCapabilitiesQuery,
 } from '../__generated__/graphql';
 import {
   EligibilityOfferingResult,
   EligibilitySubgroupOfferingResult,
   EligibilitySubgroupResult,
 } from './queries/eligibility-content-by-plan-ids';
+import {
+  CapabilitiesResult,
+  ServiceResult,
+} from './queries/services-with-capabilities';
 import { ContentfulErrorResponse } from './types';
 
 export const EligibilityContentByPlanIdsQueryFactory = (
@@ -135,6 +140,39 @@ export const PurchaseWithDetailsQueryFactory = (
   },
   ...override,
 });
+
+export const ServicesWithCapabilitiesQueryFactory = (
+  override?: Partial<ServicesWithCapabilitiesQuery>
+): ServicesWithCapabilitiesQuery => ({
+  serviceCollection: {
+    items: [
+      {
+        oauthClientId: faker.string.sample(),
+        capabilitiesCollection: {
+          items: [
+            {
+              slug: faker.string.sample(),
+            },
+          ],
+        },
+      },
+    ],
+  },
+  ...override,
+});
+
+export const ServiceResultFactory = (
+  override?: Partial<ServiceResult>,
+  capabilitiesCollection?: CapabilitiesResult[]
+): ServiceResult[] => [
+  {
+    oauthClientId: faker.string.sample(),
+    capabilitiesCollection: {
+      items: [...(capabilitiesCollection ?? [])],
+    },
+    ...override,
+  },
+];
 
 /**
  * Generates a graphql response from the contentful client based on the passed query.

--- a/libs/shared/contentful/src/lib/queries/services-with-capabilities/index.ts
+++ b/libs/shared/contentful/src/lib/queries/services-with-capabilities/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './query';
+export * from './types';
+export * from './util';

--- a/libs/shared/contentful/src/lib/queries/services-with-capabilities/query.ts
+++ b/libs/shared/contentful/src/lib/queries/services-with-capabilities/query.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { graphql } from '../../__generated__/gql';
+import { graphql } from '../../../__generated__/gql';
 
 export const servicesWithCapabilitiesQuery = graphql(`
   query ServicesWithCapabilities($skip: Int!, $limit: Int!, $locale: String!) {

--- a/libs/shared/contentful/src/lib/queries/services-with-capabilities/types.ts
+++ b/libs/shared/contentful/src/lib/queries/services-with-capabilities/types.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export interface CapabilitiesResult {
+  slug: string;
+}
+
+export interface ServiceResult {
+  oauthClientId: string;
+  capabilitiesCollection: {
+    items: CapabilitiesResult[];
+  };
+}
+
+export interface ServicesWithCapabilitiesResult {
+  serviceCollection: {
+    items: ServiceResult[];
+  };
+}

--- a/libs/shared/contentful/src/lib/queries/services-with-capabilities/util.spec.ts
+++ b/libs/shared/contentful/src/lib/queries/services-with-capabilities/util.spec.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ServicesWithCapabilitiesQueryFactory } from '../../factories';
+import { ServicesWithCapabilitiesResult } from './types';
+import { ServicesWithCapabilitiesResultUtil } from './util';
+
+describe('ServicesWithCapabilitiesResultUtil', () => {
+  it('should create a util from response', () => {
+    const result = ServicesWithCapabilitiesQueryFactory();
+    const util = new ServicesWithCapabilitiesResultUtil(
+      result as ServicesWithCapabilitiesResult
+    );
+    expect(util).toBeDefined();
+    expect(util.serviceCollection.items.length).toBe(1);
+  });
+
+  it('getServices - should return services and capabilities', () => {
+    const result = ServicesWithCapabilitiesQueryFactory();
+    const util = new ServicesWithCapabilitiesResultUtil(
+      result as ServicesWithCapabilitiesResult
+    );
+    expect(util.getServices()[0].oauthClientId).toBeDefined();
+    expect(util.getServices()[0].oauthClientId).toEqual(
+      result.serviceCollection?.items[0]?.oauthClientId
+    );
+    expect(util.getServices()[0].capabilitiesCollection).toBeDefined();
+    expect(util.getServices()[0].capabilitiesCollection.items[0].slug).toEqual(
+      result.serviceCollection?.items[0]?.capabilitiesCollection?.items[0]?.slug
+    );
+  });
+});

--- a/libs/shared/contentful/src/lib/queries/services-with-capabilities/util.ts
+++ b/libs/shared/contentful/src/lib/queries/services-with-capabilities/util.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ServiceResult, ServicesWithCapabilitiesResult } from './types';
+
+export class ServicesWithCapabilitiesResultUtil {
+  constructor(private rawResult: ServicesWithCapabilitiesResult) {}
+
+  getServices(): ServiceResult[] {
+    return this.serviceCollection.items;
+  }
+  get serviceCollection() {
+    return this.rawResult.serviceCollection;
+  }
+}

--- a/libs/shared/contentful/tsconfig.lib.json
+++ b/libs/shared/contentful/tsconfig.lib.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
-    "types": ["jest", "node"]
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/libs/shared/contentful/tsconfig.spec.json
+++ b/libs/shared/contentful/tsconfig.spec.json
@@ -9,7 +9,6 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts",
-    "src/**/__mocks__/*.ts"
+    "src/**/*.d.ts"
   ]
 }

--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -16,7 +16,6 @@ import {
 import Stripe from 'stripe';
 import Container from 'typedi';
 
-import { commaSeparatedListToArray } from 'fxa-shared/lib/utils';
 import error from '../error';
 import { AppleIAP } from './iap/apple-app-store/apple-iap';
 import { authEvents } from '../events';
@@ -27,6 +26,7 @@ import { PlayStoreSubscriptionPurchase } from './iap/google-play/subscription-pu
 import { PurchaseQueryError } from './iap/google-play/types';
 import { StripeHelper } from './stripe';
 import { PaymentConfigManager } from './configuration/manager';
+import { clientIdCapabilityMapFromMetadata } from './utils';
 import { ALL_RPS_CAPABILITIES_KEY } from 'fxa-shared/subscriptions/configuration/base';
 import { productUpgradeFromProductConfig } from 'fxa-shared/subscriptions/configuration/utils';
 
@@ -593,25 +593,4 @@ export class CapabilityService {
 
     return result;
   }
-}
-
-function clientIdFromMetadataKey(key: string): string {
-  return key === 'capabilities'
-    ? ALL_RPS_CAPABILITIES_KEY
-    : key.split(':')[1].trim();
-}
-
-function capabilitiesFromMetadataValue(value: string): string[] {
-  return commaSeparatedListToArray(value);
-}
-
-function clientIdCapabilityMapFromMetadata(
-  metadata?: Record<string, string>
-): ClientIdCapabilityMap {
-  return Object.entries(metadata || {})
-    .filter(([key]) => key.startsWith('capabilities'))
-    .reduce((acc, [key, value]) => {
-      acc[clientIdFromMetadataKey(key)] = capabilitiesFromMetadataValue(value);
-      return acc;
-    }, {} as ClientIdCapabilityMap);
 }

--- a/packages/fxa-auth-server/lib/payments/utils.ts
+++ b/packages/fxa-auth-server/lib/payments/utils.ts
@@ -2,6 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { createHash } from 'crypto';
+import { commaSeparatedListToArray } from 'fxa-shared/lib/utils';
+import { ALL_RPS_CAPABILITIES_KEY } from 'fxa-shared/subscriptions/configuration/base';
+import {
+  ClientIdCapabilityMap,
+  ProductMetadata,
+} from 'fxa-shared/subscriptions/types';
+
+export function clientIdFromMetadataKey(key: string): string {
+  return key === 'capabilities'
+    ? ALL_RPS_CAPABILITIES_KEY
+    : key.split(':')[1].trim();
+}
+
+export function capabilitiesFromMetadataValue(value: string): string[] {
+  return commaSeparatedListToArray(value);
+}
+
+export function clientIdCapabilityMapFromMetadata(
+  metadata?: Record<string, string> | ProductMetadata,
+  filterBy?: string
+): ClientIdCapabilityMap {
+  return Object.entries(metadata || {})
+    .filter(([key]) => key.startsWith(filterBy || 'capabilities'))
+    .reduce((acc, [key, value]) => {
+      acc[clientIdFromMetadataKey(key)] = capabilitiesFromMetadataValue(value);
+      return acc;
+    }, {} as ClientIdCapabilityMap);
+}
 
 export function generateIdempotencyKey(params: string[]) {
   const sha = createHash('sha256');

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -23,6 +23,8 @@ const {
   AppStoreSubscriptions,
 } = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
+const { CapabilityManager } = require('@fxa/payments/capability');
+
 const validClients = config.oauthServer.clients.filter(
   (client) => client.trusted && client.canGrant && client.publicClient
 );
@@ -50,6 +52,7 @@ describe('#integration - remote subscriptions:', function () {
     const mockStripeHelper = {};
     const mockPlaySubscriptions = {};
     const mockAppStoreSubscriptions = {};
+    const mockCapabilityManager = {};
     const mockProfileClient = {};
 
     before(async () => {
@@ -104,6 +107,8 @@ describe('#integration - remote subscriptions:', function () {
       Container.set(ProfileClient, mockProfileClient);
       Container.remove(CapabilityService);
       Container.set(CapabilityService, new CapabilityService());
+      mockCapabilityManager.getClients = () => {};
+      Container.set(CapabilityManager, mockCapabilityManager);
 
       server = await testServerFactory.start(config, false, {
         authServerMockDependencies: {


### PR DESCRIPTION
## Because

- we want to add getClients method in the CapabilityManager library

## This pull request

- [x] Refactor existing CapabilityService.getClients before adding CapabilityManager.getClients
- [x] Add getServicesWithCapabilities to ContentfulManager class
   - [x] Update `contentful.manager.spec.ts` to include `getServicesWithCapabilities`
- [x] Add CapabilityManager.getClients
   - [x] Add `capability.manager.spec.ts` 
- [x] Set up CapabilityManager in auth-server
- [x] Update the existing CapabilityService.getClients to use the CapabilityManager.getClients, following the Merge approach discussed below
   - [x] Add two tests in `stripe.js`
        - [x] Returns results from Contentful if they match results in Stripe
        - [x] Returns results from Stripe and logs to Sentry if Contentful results do not match

## Issue that this pull request solves

Closes: [FXA-8242](https://mozilla-hub.atlassian.net/browse/FXA-8242)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.


[FXA-8242]: https://mozilla-hub.atlassian.net/browse/FXA-8242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ