### PR TITLE
feat: add getOfferingOverlap to eligibility manager 

### DIFF
--- a/libs/payments/eligibility/src/index.ts
+++ b/libs/payments/eligibility/src/index.ts
@@ -3,3 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * from './lib/eligibility.manager';
+export * from './lib/eligibility.types';

--- a/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import {
+  ContentfulManager,
+  EligibilityContentByPlanIdsResultUtil,
+  EligibilityOfferingResultFactory,
+  EligibilitySubgroupResultFactory,
+} from '../../../../shared/contentful/src';
+import { EligibilityManager } from './eligibility.manager';
+import { OfferingComparison } from './eligibility.types';
+
+describe('EligibilityManager', () => {
+  let manager: EligibilityManager;
+  let mockContentfulManager: ContentfulManager;
+  let mockResult: EligibilityContentByPlanIdsResultUtil;
+
+  beforeEach(async () => {
+    mockResult = {} as any;
+    mockContentfulManager = {
+      getPurchaseDetailsForEligibility: jest
+        .fn()
+        .mockResolvedValueOnce(mockResult),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: ContentfulManager, useValue: mockContentfulManager },
+        EligibilityManager,
+      ],
+    }).compile();
+
+    manager = module.get<EligibilityManager>(EligibilityManager);
+  });
+
+  describe('getOfferingOverlap', () => {
+    it('should return empty result', async () => {
+      mockResult.offeringForPlanId = jest.fn().mockReturnValueOnce(undefined);
+      const result = await manager.getOfferingOverlap(['test'], [], 'test');
+      expect(result.length).toBe(0);
+    });
+
+    it('should return same offeringStripeProductIds as same comparison', async () => {
+      const offeringResult = EligibilityOfferingResultFactory({
+        stripeProductId: 'prod_test',
+      });
+      mockResult.offeringForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult);
+      const result = await manager.getOfferingOverlap(
+        [],
+        ['prod_test'],
+        'test'
+      );
+      expect(result.length).toBe(1);
+      expect(result[0].comparison).toBe(OfferingComparison.SAME);
+    });
+
+    it('should return subgroup upgrade target offeringStripeProductIds as upgrade comparison', async () => {
+      const offeringResult = EligibilityOfferingResultFactory(
+        { stripeProductId: 'prod_test2' },
+        [],
+        [
+          { stripeProductId: 'prod_test', countries: ['usa'] },
+          { stripeProductId: 'prod_test2', countries: ['usa'] },
+        ]
+      );
+      mockResult.offeringForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult);
+      const result = await manager.getOfferingOverlap(
+        [],
+        ['prod_test'],
+        'test'
+      );
+      expect(result.length).toBe(1);
+      expect(result[0].comparison).toBe(OfferingComparison.UPGRADE);
+    });
+
+    it('should return subgroup downgrade target offeringStripeProductIds as downgrade comparison', async () => {
+      const offeringResult = EligibilityOfferingResultFactory(
+        { stripeProductId: 'prod_test' },
+        [],
+        [
+          { stripeProductId: 'prod_test', countries: ['usa'] },
+          { stripeProductId: 'prod_test2', countries: ['usa'] },
+        ]
+      );
+      mockResult.offeringForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult);
+      const result = await manager.getOfferingOverlap(
+        [],
+        ['prod_test2'],
+        'test'
+      );
+      expect(result.length).toBe(1);
+      expect(result[0].comparison).toBe(OfferingComparison.DOWNGRADE);
+    });
+
+    it('should return same comparison for same planId', async () => {
+      const offeringResult = EligibilityOfferingResultFactory({
+        stripeProductId: 'prod_test',
+      });
+      const existingResult = EligibilityOfferingResultFactory({
+        stripeProductId: 'prod_test',
+      });
+      mockResult.offeringForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult)
+        .mockReturnValueOnce(existingResult);
+      const result = await manager.getOfferingOverlap(
+        ['plan_test'],
+        [],
+        'plan_test'
+      );
+      expect(result.length).toBe(1);
+      expect(result[0].comparison).toBe(OfferingComparison.SAME);
+    });
+
+    it('should return upgrade comparison for upgrade planId', async () => {
+      const offeringResult = EligibilityOfferingResultFactory(
+        {
+          stripeProductId: 'prod_test2',
+        },
+        [],
+        [
+          { stripeProductId: 'prod_test', countries: ['usa'] },
+          { stripeProductId: 'prod_test2', countries: ['usa'] },
+        ]
+      );
+      const existingResult = EligibilityOfferingResultFactory({
+        stripeProductId: 'prod_test',
+      });
+      mockResult.offeringForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult)
+        .mockReturnValueOnce(existingResult);
+      const result = await manager.getOfferingOverlap(
+        ['plan_test'],
+        [],
+        'plan_test'
+      );
+      expect(result.length).toBe(1);
+      expect(result[0].comparison).toBe(OfferingComparison.UPGRADE);
+    });
+
+    it('should return multiple comparisons in multiple subgroups', async () => {
+      const offeringResult = EligibilityOfferingResultFactory(
+        { stripeProductId: 'prod_test2' },
+        [
+          EligibilitySubgroupResultFactory({}, [
+            { stripeProductId: 'prod_test', countries: ['usa'] },
+            { stripeProductId: 'prod_test2', countries: ['usa'] },
+            { stripeProductId: 'prod_test3', countries: ['usa'] },
+          ]),
+        ],
+        [
+          { stripeProductId: 'prod_test', countries: ['usa'] },
+          { stripeProductId: 'prod_test2', countries: ['usa'] },
+        ]
+      );
+      const existingResult = EligibilityOfferingResultFactory({
+        stripeProductId: 'prod_test',
+      });
+      mockResult.offeringForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult)
+        .mockReturnValueOnce(existingResult);
+      const result = await manager.getOfferingOverlap(
+        ['plan_test'],
+        ['prod_test3'],
+        'plan_test'
+      );
+      expect(result.length).toBe(2);
+      expect(result[0]).toEqual({
+        comparison: OfferingComparison.DOWNGRADE,
+        offeringProductId: 'prod_test3',
+      });
+      expect(result[1]).toEqual({
+        comparison: OfferingComparison.UPGRADE,
+        planId: 'plan_test',
+      });
+    });
+  });
+});

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -2,9 +2,93 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  ContentfulManager,
+  EligibilityOfferingResult,
+} from '../../../../shared/contentful/src';
 import { Injectable } from '@nestjs/common';
+
+import { OfferingComparison, OfferingOverlapResult } from './eligibility.types';
 
 @Injectable()
 export class EligibilityManager {
-  constructor() {}
+  constructor(private contentfulManager: ContentfulManager) {}
+
+  /**
+   * Determine what existing planIds or Offerings a user has overlap with
+   * a desired target plan and what the comparison is to the target plan.
+   *
+   * @returns Array of overlapping planIds/offeringProductIds and their comparison
+   *          to the target plan.
+   */
+  async getOfferingOverlap(
+    planIds: string[],
+    offeringStripeProductIds: string[],
+    targetPlanId: string
+  ): Promise<OfferingOverlapResult[]> {
+    if (!planIds.length && !offeringStripeProductIds.length) return [];
+
+    const detailsResult =
+      await this.contentfulManager.getPurchaseDetailsForEligibility([
+        ...planIds,
+        targetPlanId,
+      ]);
+
+    const result: OfferingOverlapResult[] = [];
+
+    const targetOffering = detailsResult.offeringForPlanId(targetPlanId);
+    if (!targetOffering) return [];
+
+    for (const offeringProductId of offeringStripeProductIds) {
+      const comparison = offeringComparison(offeringProductId, targetOffering);
+      if (comparison) result.push({ comparison, offeringProductId });
+    }
+
+    for (const planId of planIds) {
+      const fromOffering = detailsResult.offeringForPlanId(planId);
+      if (!fromOffering) continue;
+      const comparison = offeringComparison(
+        fromOffering.stripeProductId,
+        targetOffering
+      );
+      if (comparison) result.push({ comparison, planId });
+    }
+    return result;
+  }
+}
+
+/**
+ * Returns whether the target offering overlaps, and how.
+ *
+ * @returns OfferingComparison if there's overlap, null otherwise.
+ */
+function offeringComparison(
+  fromOfferingProductId: string,
+  targetOffering: EligibilityOfferingResult
+) {
+  if (targetOffering.stripeProductId === fromOfferingProductId)
+    return OfferingComparison.SAME;
+  const commonSubgroups =
+    targetOffering.linkedFrom.subGroupCollection.items.filter(
+      (subgroup) =>
+        !!subgroup.offeringCollection.items.find(
+          (oc) => oc.stripeProductId === fromOfferingProductId
+        )
+    );
+  if (!commonSubgroups.length) return null;
+  const subgroupProductIds = commonSubgroups[0].offeringCollection.items.map(
+    (o) => o.stripeProductId
+  );
+  const existingIndex = subgroupProductIds.indexOf(fromOfferingProductId);
+  const targetIndex = subgroupProductIds.indexOf(
+    targetOffering.stripeProductId
+  );
+  switch (targetIndex - existingIndex) {
+    case 0:
+      return OfferingComparison.SAME;
+    case 1:
+      return OfferingComparison.UPGRADE;
+    default:
+      return OfferingComparison.DOWNGRADE;
+  }
 }

--- a/libs/payments/eligibility/src/lib/eligibility.types.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.types.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Used to represent offering comparison to target plan
+export enum OfferingComparison {
+  SAME = 'same',
+  UPGRADE = 'upgrade',
+  DOWNGRADE = 'downgrade',
+}
+
+export type OfferingOverlapBaseResult = {
+  comparison: OfferingComparison;
+};
+
+export type OfferingOverlapPlanResult = OfferingOverlapBaseResult & {
+  planId: string;
+};
+
+export type OfferingOverlapProductResult = OfferingOverlapBaseResult & {
+  offeringProductId: string;
+};
+
+export type OfferingOverlapResult =
+  | OfferingOverlapPlanResult
+  | OfferingOverlapProductResult;

--- a/libs/shared/contentful/src/lib/contentful.manager.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.spec.ts
@@ -49,8 +49,10 @@ describe('ContentfulManager', () => {
       const result = await manager.getPurchaseDetailsForEligibility(['test']);
       const planId = result.purchaseCollection.items[0].stripePlanChoices[0];
       expect(result).toBeDefined();
-      expect(result.getSubgroupsForPlanId(planId)).toHaveLength(1);
-      expect(result.getOfferingForPlanId(planId)).toBeDefined();
+      expect(
+        result.offeringForPlanId(planId)?.linkedFrom.subGroupCollection.items
+      ).toHaveLength(1);
+      expect(result.offeringForPlanId(planId)).toBeDefined();
     });
   });
 });

--- a/libs/shared/contentful/src/lib/factories.ts
+++ b/libs/shared/contentful/src/lib/factories.ts
@@ -2,15 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ApolloQueryResult, NetworkStatus } from '@apollo/client';
 import { faker } from '@faker-js/faker';
-import { NetworkStatus } from '@apollo/client';
-import { ApolloQueryResult } from '@apollo/client';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
 import {
+  EligibilityContentByPlanIdsQuery,
   OfferingQuery,
   PurchaseWithDetailsQuery,
-  EligibilityContentByPlanIdsQuery,
 } from '../__generated__/graphql';
+import {
+  EligibilityOfferingResult,
+  EligibilitySubgroupOfferingResult,
+  EligibilitySubgroupResult,
+} from './queries/eligibility-content-by-plan-ids';
 import { ContentfulErrorResponse } from './types';
 
 export const EligibilityContentByPlanIdsQueryFactory = (
@@ -49,6 +54,54 @@ export const EligibilityContentByPlanIdsQueryFactory = (
     ...override,
   };
 };
+
+export const EligibilityOfferingResultFactory = (
+  override?: Partial<EligibilityOfferingResult>,
+  subGroupCollectionExtension?: EligibilitySubgroupResult[],
+  subGroupOfferingCollectionExtension?: EligibilitySubgroupOfferingResult[]
+): EligibilityOfferingResult => ({
+  stripeProductId: faker.string.sample(),
+  countries: [faker.string.sample()],
+  linkedFrom: {
+    subGroupCollection: {
+      items: [
+        {
+          groupName: faker.string.sample(),
+          offeringCollection: {
+            items: [
+              {
+                stripeProductId: faker.string.sample(),
+                countries: [faker.string.sample()],
+              },
+              ...(subGroupOfferingCollectionExtension ?? []),
+            ],
+          },
+        },
+        ...(subGroupCollectionExtension ?? []),
+      ],
+    },
+  },
+  ...override,
+});
+
+export const EligibilitySubgroupResultFactory = (
+  override?: Partial<EligibilitySubgroupResult>,
+  offeringCollection?: EligibilitySubgroupOfferingResult[]
+): EligibilitySubgroupResult => ({
+  groupName: faker.string.sample(),
+  offeringCollection: {
+    items: [...(offeringCollection ?? [])],
+  },
+  ...override,
+});
+
+export const EligibilitySubgroupOfferingResultFactory = (
+  override?: Partial<EligibilitySubgroupOfferingResult>
+): EligibilitySubgroupOfferingResult => ({
+  stripeProductId: faker.string.sample(),
+  countries: [faker.string.sample()],
+  ...override,
+});
 
 export const OfferingQueryFactory = (
   override?: Partial<OfferingQuery>

--- a/libs/shared/contentful/src/lib/queries/eligibility-content-by-plan-ids/util.spec.ts
+++ b/libs/shared/contentful/src/lib/queries/eligibility-content-by-plan-ids/util.spec.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { EligibilityContentByPlanIdsQueryFactory } from '../../factories';
+import { EligibilityContentByPlanIdsResult } from './types';
+import { EligibilityContentByPlanIdsResultUtil } from './util';
+
+describe('EligibilityContentByPlanIdsResultUtil', () => {
+  it('should create a util from response', () => {
+    const result = EligibilityContentByPlanIdsQueryFactory();
+    const planId = result.purchaseCollection?.items[0]?.stripePlanChoices?.[0];
+    const util = new EligibilityContentByPlanIdsResultUtil(
+      result as EligibilityContentByPlanIdsResult
+    );
+    expect(util).toBeDefined();
+    expect(util.offeringForPlanId(planId ?? '')?.stripeProductId).toBeDefined();
+    expect(util.purchaseCollection.items.length).toBe(1);
+  });
+});

--- a/libs/shared/contentful/src/lib/queries/eligibility-content-by-plan-ids/util.ts
+++ b/libs/shared/contentful/src/lib/queries/eligibility-content-by-plan-ids/util.ts
@@ -5,24 +5,22 @@
 import {
   EligibilityContentByPlanIdsResult,
   EligibilityOfferingResult,
-  EligibilitySubgroupResult,
+  EligibilityPurchaseResult,
 } from './types';
 
 export class EligibilityContentByPlanIdsResultUtil {
-  constructor(private rawResult: EligibilityContentByPlanIdsResult) {}
+  private purchaseByPlanId: Record<string, EligibilityPurchaseResult> = {};
 
-  getOfferingForPlanId(planId: string): EligibilityOfferingResult | undefined {
-    return this.rawResult.purchaseCollection.items.find((purchase) =>
-      purchase.stripePlanChoices.includes(planId)
-    )?.offering;
+  constructor(private rawResult: EligibilityContentByPlanIdsResult) {
+    for (const purchase of rawResult.purchaseCollection.items) {
+      for (const planId of purchase.stripePlanChoices) {
+        this.purchaseByPlanId[planId] = purchase;
+      }
+    }
   }
 
-  getSubgroupsForPlanId(planId: string): EligibilitySubgroupResult[] {
-    return (
-      this.rawResult.purchaseCollection.items.find((purchase) =>
-        purchase.stripePlanChoices.includes(planId)
-      )?.offering.linkedFrom.subGroupCollection.items || []
-    );
+  offeringForPlanId(planId: string): EligibilityOfferingResult | undefined {
+    return this.purchaseByPlanId[planId]?.offering;
   }
 
   get purchaseCollection() {


### PR DESCRIPTION
## Because:
    
* We want to determine whether a customer is eligible for a plan
  offering, and if so, which offering they are eligible for.
    
## This commit:
    
* Adds the getOfferingOverlap method to the eligibility manager.
    
Closes FXA-8241

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
