### PR TITLE
chore(sonoma): always set `no-referrer` header test for sonoma

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -120,6 +120,11 @@ function makeApp() {
     })
   );
 
+  app.use(
+    helmet.referrerPolicy({
+      policy: 'no-referrer',
+    })
+  );
   app.use(helmet.xssFilter());
   app.use(
     helmet.hsts({


### PR DESCRIPTION
## Because

- Investigating Sonoma issues, seems to imply some setting in content-server is impacting this bug
- When navigating from `getpocket.com`, the `window.location.search` params are empty after the request `https://accounts.firefox.com/signup?hello=123` is loaded. Content-server at this point is not aware of the params and fails to load the correct OAuth clients
- When navigating from `getpocket.com` to `https://accounts.firefox.com/signup?hello=123`, the query params persist and the page is loaded correctly. So our React settings page do not have any issues and work as expected

## This pull request

- Adds the helmet referrer policy `no-referrer` to requests, this should simulate the `rel="no-referrer"` tag in <a> elements

## Issue that this pull request solves

Closes:

## Checklist

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is something to try, I'm not sure exactly the impact on metrics by enabling this. I'm going to target a point release with our unoptmized builds.
