### PR TITLE
feat(react): Allow Signup 'Change email' to behave as expected

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/relier.js
@@ -67,6 +67,8 @@ const QUERY_PARAMETER_SCHEMA = {
   flow_id: Vat.string().renameTo('flowId'),
   flow_begin_time: Vat.string().renameTo('flowBeginTime'),
   device_id: Vat.string().renameTo('deviceId'),
+  // Temporary parameter for React app -> Backbone app communication
+  prefillEmail: Vat.string(),
 };
 
 const EMAIL_FIRST_EMAIL_SCHEMA = {

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -58,10 +58,13 @@ class IndexView extends FormView {
   beforeRender() {
     const account = this.getAccount();
     const relierEmail = this.relier.get('email');
+    const prefillEmailFromReact = this.relier.get('prefillEmail');
     if (account) {
       this.formPrefill.set(account.pick('email'));
     } else if (relierEmail) {
       this.formPrefill.set('email', relierEmail);
+    } else if (prefillEmailFromReact) {
+      this.formPrefill.set('email', prefillEmailFromReact);
     }
   }
 
@@ -142,7 +145,13 @@ class IndexView extends FormView {
         // The relier email set used as the prefill email in beforeRender.
         this.showValidationErrors();
       }
-    } else if (this.allowSuggestedAccount(suggestedAccount)) {
+      // Don't redirect to `/signin` if the React query param `prefillEmail`
+      // exists. This signals to content-server we want to stay on the index
+      // screen with that email prefilled.
+    } else if (
+      this.allowSuggestedAccount(suggestedAccount) &&
+      !this.relier.get('prefillEmail')
+    ) {
       this.replaceCurrentPage('signin', {
         account: suggestedAccount,
       });

--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -24,6 +24,8 @@ export default {
 
   /**
    * Get the prefill email.
+   * Note this does not account for our temporary React `prefillEmail` query
+   * parameter for clarity - let this function deal with Backbone concerns.
    *
    * @returns {String}
    */

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -97,6 +97,19 @@ describe('views/index', () => {
       });
     });
 
+    it('prefills the email with React prefillEmail=email and does not navigate', () => {
+      const prefillEmail = 'mycoolemail@gmail.com';
+      relier.set('prefillEmail', prefillEmail);
+
+      return view
+        .render()
+        .then(() => view.afterVisible())
+        .then(() => {
+          assert.isFalse(view.navigate.called);
+          assert.equal(view.$(Selectors.EMAIL).val(), prefillEmail);
+        });
+    });
+
     describe('account has bounced', () => {
       it('prefills the email, shows a tooltip', () => {
         const bouncedAccount = user.initAccount({

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -34,6 +34,7 @@ import {
 import { newsletters } from '../../components/ChooseNewsletters/newsletters';
 import { notifyFirefoxOfLogin } from '../../lib/channels/helpers';
 import GleanMetrics from '../../lib/glean';
+import * as utils from 'fxa-react/lib/utils';
 
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -105,6 +106,34 @@ describe('Signup page', () => {
     // Checkboxes have their own test
     expect(firefoxTermsLink).toHaveAttribute('href', '/legal/terms');
     expect(firefoxPrivacyLink).toHaveAttribute('href', '/legal/privacy');
+  });
+
+  describe('hardNavigateToContentServer', () => {
+    let hardNavigateToContentServerSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      hardNavigateToContentServerSpy = jest
+        .spyOn(utils, 'hardNavigateToContentServer')
+        .mockImplementation(() => {});
+    });
+    afterEach(() => {
+      hardNavigateToContentServerSpy.mockRestore();
+    });
+
+    it('allows users to change their email', async () => {
+      renderWithLocalizationProvider(<Subject />);
+
+      await waitFor(() => {
+        fireEvent.click(
+          screen.getByRole('link', {
+            name: 'Change email',
+          })
+        );
+      });
+      expect(hardNavigateToContentServerSpy).toHaveBeenCalledWith(
+        `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
+      );
+    });
   });
 
   it('allows users to show and hide password input', async () => {

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -271,11 +271,17 @@ const Signup = ({
               className="link-blue text-sm"
               onClick={(e) => {
                 e.preventDefault();
-                // TODO in FXA-8307: this takes users to /signin if they've got an email in
-                // localStorage. Hopefully there's another workaround but might
-                // need to send a param back over to content-server to force load /
-                // and give the option to enter another email address
-                hardNavigateToContentServer('/');
+                const params = new URLSearchParams(location.search);
+                // Tell content-server to stay on index and prefill the email
+                params.set('prefillEmail', queryParamModel.email);
+                // Passing back the 'email' param causes various behaviors in
+                // content-server since it marks the email as "coming from a RP".
+                // Also remove `emailFromContent` since we pass that when coming
+                // from content-server to Backbone, see Signup container component
+                // for more info.
+                params.delete('emailFromContent');
+                params.delete('email');
+                hardNavigateToContentServer(`/?${params.toString()}`);
               }}
             >
               Change email


### PR DESCRIPTION
Because:
* Taking the user back to the Backbone index page on click of React "Change email"  when they had an account in local storage would force a redirect to /signin

This commit:
* Adds a new 'prefillEmail' parameter for the React app to pass back to the Backbone app to signify to Backbone that 'Change email' was clicked
* On the React side, remove existing 'emailFromContent' and 'email' params from link since 'email' alters behavior on the Backbone side and 'emailFromContent' alters behavior on the React side
* On the Backbone side, set this field as a new relier field (typical of how we handle/validate external params), and if it exists on the index page, don't redirect and instead, prefill the email to match parity

fixes FXA-8307