### PR TITLE
feat(contentful): add contentful get locale

### DIFF
--- a/libs/shared/contentful/src/index.ts
+++ b/libs/shared/contentful/src/index.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * from './lib/contentful.client';
-export * from './lib/contentful.manager';
+export * from './lib/contentful.client.config';
 export * from './lib/contentful.error';
+export * from './lib/contentful.manager';
 export * from './lib/factories';
 export * from './lib/queries/eligibility-content-by-plan-ids';

--- a/libs/shared/contentful/src/lib/contentful.client.config.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.config.ts
@@ -6,6 +6,9 @@ import { IsString, IsUrl } from 'class-validator';
 
 export class ContentfulClientConfig {
   @IsUrl()
+  public readonly cdnApiUri!: string;
+
+  @IsUrl()
   public readonly graphqlApiUri!: string;
 
   @IsString()

--- a/libs/shared/contentful/src/lib/contentful.client.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.spec.ts
@@ -8,10 +8,13 @@ import { ContentfulClient } from './contentful.client';
 import { offeringQuery } from './queries/offering';
 import { OfferingQuery } from '../__generated__/graphql';
 import {
+  ContentfulCDNError,
+  ContentfulCDNExecutionError,
   ContentfulError,
   ContentfulLinkError,
   ContentfulLocaleError,
 } from './contentful.error';
+import { ContentfulCDNErrorFactory } from './factories';
 
 const ApolloError = jest.requireActual('@apollo/client').ApolloError;
 
@@ -30,6 +33,7 @@ describe('ContentfulClient', () => {
 
   beforeEach(() => {
     contentfulClient = new ContentfulClient({
+      cdnApiUri: faker.string.uuid(),
       graphqlApiKey: faker.string.uuid(),
       graphqlApiUri: faker.string.uuid(),
       graphqlSpaceId: faker.string.uuid(),
@@ -170,6 +174,83 @@ describe('ContentfulClient', () => {
               'Contentful: Unexpected Linked Content Type'
             ),
           ])
+        );
+      });
+    });
+  });
+
+  describe('getLocale', () => {
+    const DEFAULT_LOCALE = 'en';
+    const ACCEPT_LANGUAGE = 'en-US,fr-FR;q=0.7,de-DE;q=0.3';
+    const MOCK_DATA = {
+      items: [{ code: 'en' }, { code: 'fr-FR' }],
+    };
+
+    beforeEach(() => {
+      (global.fetch as jest.Mock) = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_DATA),
+        })
+      );
+    });
+
+    afterEach(() => {
+      (global.fetch as jest.Mock).mockClear();
+    });
+    describe('success', () => {
+      it('Returns prefered locale', async () => {
+        const result = await contentfulClient.getLocale(ACCEPT_LANGUAGE);
+        expect(result).toBe(DEFAULT_LOCALE);
+      });
+
+      it('Returns 2nd prefered locale, if prefered locale is not in configured', async () => {
+        const acceptLanguage = 'de-DE,fr-FR;q=0.7,en-US;q=0.3';
+        const result = await contentfulClient.getLocale(acceptLanguage);
+        expect(result).toBe('fr-FR');
+      });
+
+      it('Returns the default locale, if no matching locale in Contentful', async () => {
+        const acceptLanguage = 'de-DE';
+        const result = await contentfulClient.getLocale(acceptLanguage);
+        expect(result).toBe(DEFAULT_LOCALE);
+      });
+
+      it('Returns prefered locale from cache instead of fetching from Contentful', async () => {
+        await contentfulClient.getLocale(ACCEPT_LANGUAGE);
+        await contentfulClient.getLocale(ACCEPT_LANGUAGE);
+        expect(global.fetch).toBeCalledTimes(1);
+      });
+    });
+
+    describe('errors', () => {
+      const cdnErrorResult = ContentfulCDNErrorFactory();
+      it('throws a cdn error when contentful returns an error', async () => {
+        (global.fetch as jest.Mock) = jest.fn(() =>
+          Promise.resolve({
+            ok: false,
+            json: () => Promise.resolve(cdnErrorResult),
+          })
+        );
+
+        await expect(() =>
+          contentfulClient.getLocale(ACCEPT_LANGUAGE)
+        ).rejects.toThrow(
+          new ContentfulCDNError(
+            { info: cdnErrorResult },
+            cdnErrorResult.message
+          )
+        );
+      });
+
+      it('throws a cdn execution error when contentful cant be reached', async () => {
+        const error = new Error('failure');
+        (global.fetch as jest.Mock) = jest.fn(() => Promise.reject(error));
+
+        await expect(() =>
+          contentfulClient.getLocale(ACCEPT_LANGUAGE)
+        ).rejects.toThrow(
+          new ContentfulCDNExecutionError(error, 'Contentful: Execution Error')
         );
       });
     });

--- a/libs/shared/contentful/src/lib/contentful.client.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable } from '@nestjs/common';
 import {
   ApolloClient,
-  InMemoryCache,
-  ApolloQueryResult,
   ApolloError,
+  ApolloQueryResult,
+  InMemoryCache,
 } from '@apollo/client';
+import { BaseError } from '@fxa/shared/error';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { Injectable } from '@nestjs/common';
+import { determineLocale } from '@fxa/shared/l10n';
+import { ContentfulClientConfig } from './contentful.client.config';
 import {
+  ContentfulCDNError,
+  ContentfulCDNExecutionError,
   ContentfulError,
   ContentfulExecutionError,
   ContentfulLinkError,
   ContentfulLocaleError,
 } from './contentful.error';
-import { BaseError } from '@fxa/shared/error';
-import { ContentfulClientConfig } from './contentful.client.config';
+import { ContentfulErrorResponse } from './types';
 
 @Injectable()
 export class ContentfulClient {
@@ -25,8 +29,14 @@ export class ContentfulClient {
     uri: `${this.contentfulClientConfig.graphqlApiUri}/spaces/${this.contentfulClientConfig.graphqlSpaceId}/environments/${this.contentfulClientConfig.graphqlEnvironment}?access_token=${this.contentfulClientConfig.graphqlApiKey}`,
     cache: new InMemoryCache(),
   });
+  private locales: string[] = [];
 
   constructor(private contentfulClientConfig: ContentfulClientConfig) {}
+
+  async getLocale(acceptLanguage: string): Promise<string> {
+    const contentfulLocales = await this.getLocales();
+    return determineLocale(acceptLanguage, contentfulLocales);
+  }
 
   async query<Result, Variables>(
     query: TypedDocumentNode<Result, Variables>,
@@ -47,6 +57,40 @@ export class ContentfulClient {
         throw new ContentfulError([e]);
       }
       throw new ContentfulError([new BaseError(e, e.message)]);
+    }
+  }
+
+  private async getLocales(): Promise<string[]> {
+    if (!!this.locales?.length) {
+      return this.locales;
+    }
+
+    try {
+      const localesUrl = `${this.contentfulClientConfig.cdnApiUri}/spaces/${this.contentfulClientConfig.graphqlSpaceId}/environments/${this.contentfulClientConfig.graphqlEnvironment}/locales?access_token=${this.contentfulClientConfig.graphqlApiKey}`;
+      const response = await fetch(localesUrl);
+      const results = await response.json();
+
+      if (!response.ok) {
+        const errorResult = results as ContentfulErrorResponse;
+        throw new ContentfulCDNError(
+          { info: errorResult },
+          errorResult.message
+        );
+      }
+
+      // Assign value to locale "cache"
+      this.locales = results.items.map((locale: any) => locale.code);
+
+      return this.locales;
+    } catch (error) {
+      if (error instanceof ContentfulCDNError) {
+        throw error;
+      } else {
+        throw new ContentfulCDNExecutionError(
+          error,
+          'Contentful: Execution Error'
+        );
+      }
     }
   }
 

--- a/libs/shared/contentful/src/lib/contentful.error.ts
+++ b/libs/shared/contentful/src/lib/contentful.error.ts
@@ -14,6 +14,24 @@ export class ContentfulError extends BaseMultiError {
 }
 
 /**
+ * Thrown when errors are returned in the Contentful CDN response
+ */
+export class ContentfulCDNError extends BaseError {
+  constructor(...args: ConstructorParameters<typeof BaseError>) {
+    super(...args);
+  }
+}
+
+/**
+ * https://www.contentful.com/developers/docs/references/graphql/#/reference/graphql-errors
+ */
+export class ContentfulCDNExecutionError extends ContentfulCDNError {
+  constructor(...args: ConstructorParameters<typeof ContentfulQueryError>) {
+    super(...args);
+  }
+}
+
+/**
  * Thrown when errors are returned in the Contentful GraphQL response
  */
 export class ContentfulQueryError extends BaseError {

--- a/libs/shared/contentful/src/lib/contentful.manager.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.spec.ts
@@ -16,6 +16,7 @@ describe('ContentfulManager', () => {
   beforeEach(async () => {
     (ContentfulClient as jest.Mock).mockClear();
     mockClient = new ContentfulClient({
+      cdnApiUri: 'test',
       graphqlApiKey: 'test',
       graphqlApiUri: 'test',
       graphqlEnvironment: 'test',

--- a/libs/shared/contentful/src/lib/factories.ts
+++ b/libs/shared/contentful/src/lib/factories.ts
@@ -11,6 +11,7 @@ import {
   PurchaseWithDetailsQuery,
   EligibilityContentByPlanIdsQuery,
 } from '../__generated__/graphql';
+import { ContentfulErrorResponse } from './types';
 
 export const EligibilityContentByPlanIdsQueryFactory = (
   override?: Partial<EligibilityContentByPlanIdsQuery>
@@ -97,5 +98,14 @@ export const ContentfulClientQueryFactory = <Result, Variables>(
   data: data, // Must be used to negotiate the type inference for Result
   loading: false,
   networkStatus: NetworkStatus.ready,
+  ...override,
+});
+
+export const ContentfulCDNErrorFactory = (
+  override?: ContentfulErrorResponse
+): ContentfulErrorResponse => ({
+  sys: { type: 'Error', id: faker.string.sample() },
+  message: faker.string.sample(),
+  requestId: faker.string.uuid(),
   ...override,
 });

--- a/libs/shared/contentful/src/lib/types.ts
+++ b/libs/shared/contentful/src/lib/types.ts
@@ -1,3 +1,16 @@
 export type DeepNonNullable<T> = {
   [K in keyof T]: Exclude<DeepNonNullable<T[K]>, null | undefined>;
 };
+
+/*
+https://www.contentful.com/developers/docs/references/errors/
+*/
+export type ContentfulErrorResponse = {
+  sys: {
+    type: 'Error';
+    id: string;
+  };
+  message: string;
+  requestId: string;
+  details?: NonNullable<unknown>;
+};

--- a/libs/shared/l10n/package.json
+++ b/libs/shared/l10n/package.json
@@ -5,6 +5,5 @@
     "tslib": "^2.3.0"
   },
   "type": "commonjs",
-  "main": "./src/index.js",
-  "typings": "./src/index.d.ts"
+  "main": "./src/index.js"
 }

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1981,7 +1981,13 @@ const convictConf = convict({
   },
 
   contentful: {
-    apiUrl: {
+    cdnUrl: {
+      doc: 'Base URL for Content Delivery API (https://www.contentful.com/developers/docs/references/content-delivery-api/)',
+      format: String,
+      env: 'CONTENTFUL_CDN_API_URL',
+      default: '',
+    },
+    graphqlUrl: {
       default: '',
       doc: 'Base URL for GraphQL Content API (https://www.contentful.com/developers/docs/references/graphql/)',
       env: 'CONTENTFUL_GRAPHQL_API_URL',

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -42,7 +42,13 @@ const conf = convict({
     },
   },
   contentful: {
-    apiUrl: {
+    cdnUrl: {
+      doc: 'Base URL for Content Delivery API (https://www.contentful.com/developers/docs/references/content-delivery-api//)',
+      format: String,
+      env: 'CONTENTFUL_CDN_API_URL',
+      default: '',
+    },
+    graphqlUrl: {
       doc: 'Base URL for GraphQL Content API (https://www.contentful.com/developers/docs/references/graphql/)',
       format: String,
       env: 'CONTENTFUL_GRAPHQL_API_URL',
@@ -273,5 +279,5 @@ conf.loadFile(files);
 conf.validate({ allowed: 'strict' });
 const Config = conf;
 
-export type AppConfig = ReturnType<typeof Config['getProperties']>;
+export type AppConfig = ReturnType<(typeof Config)['getProperties']>;
 export default Config;


### PR DESCRIPTION
## Because

- Need to determine a valid locale configured in Contentful.

## This pull request

- Add getLocale method to ContentfulClient to determine locale using locales available in Contentful and defaulting to 'en' as a fallback.

## Issue that this pull request solves

Closes: #FXA-8225

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Keeping in draft until #15798 is merged.
