### PR TITLE
fix(react): Prevent preemptive reset password email from sending with accountResetToken tweaks

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -507,7 +507,7 @@ export default class AuthClient {
     code: string,
     passwordForgotToken: hexstring,
     options: {
-      accountResetWithoutRecoveryKey?: boolean;
+      accountResetWithRecoveryKey?: boolean;
     } = {},
     headers: Headers = new Headers()
   ) {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -70,9 +70,7 @@ const accountWithValidResetToken = {
     recoveryData: 'mockRecoveryData',
     recoveryKeyId: MOCK_RECOVERY_KEY_ID,
   }),
-  verifyPasswordForgotToken: jest
-    .fn()
-    .mockResolvedValue({ accountResetToken: MOCK_RESET_TOKEN }),
+  passwordForgotVerifyCode: jest.fn().mockResolvedValue(MOCK_RESET_TOKEN),
 } as unknown as Account;
 
 const renderSubject = ({
@@ -127,7 +125,7 @@ describe('PageAccountRecoveryConfirmKey', () => {
   it('renders the component as expected when provided with an expired link', async () => {
     const accountWithTokenError = {
       resetPasswordStatus: jest.fn().mockResolvedValue(false),
-      verifyPasswordForgotToken: jest.fn().mockImplementation(() => {
+      passwordForgotVerifyCode: jest.fn().mockImplementation(() => {
         throw AuthUiErrors.INVALID_TOKEN;
       }),
     } as unknown as Account;
@@ -287,9 +285,7 @@ describe('PageAccountRecoveryConfirmKey', () => {
   it('submits successfully after invalid recovery key submission', async () => {
     const accountWithKeyInvalidOnce = {
       resetPasswordStatus: jest.fn().mockResolvedValue(true),
-      verifyPasswordForgotToken: jest
-        .fn()
-        .mockResolvedValue({ accountResetToken: MOCK_RESET_TOKEN }),
+      passwordForgotVerifyCode: jest.fn().mockResolvedValue(MOCK_RESET_TOKEN),
       getRecoveryKeyBundle: jest
         .fn()
         .mockImplementationOnce(() => {
@@ -316,17 +312,18 @@ describe('PageAccountRecoveryConfirmKey', () => {
       screen.getByRole('button', { name: 'Confirm account recovery key' })
     );
 
-    // only ever calls `verifyPasswordForgotToken` once despite number of submissions
+    // only ever calls `passwordForgotVerifyCode` once despite number of submissions
     await waitFor(() =>
       expect(
-        accountWithKeyInvalidOnce.verifyPasswordForgotToken
+        accountWithKeyInvalidOnce.passwordForgotVerifyCode
       ).toHaveBeenCalledTimes(1)
     );
     expect(
-      accountWithKeyInvalidOnce.verifyPasswordForgotToken
+      accountWithKeyInvalidOnce.passwordForgotVerifyCode
     ).toHaveBeenCalledWith(
       mockCompleteResetPasswordParams.token,
-      mockCompleteResetPasswordParams.code
+      mockCompleteResetPasswordParams.code,
+      true
     );
     expect(
       accountWithKeyInvalidOnce.getRecoveryKeyBundle

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -146,9 +146,10 @@ const AccountRecoveryConfirmKey = ({
       try {
         let resetToken = fetchedResetToken;
         if (!resetToken) {
-          const { accountResetToken } = await account.verifyPasswordForgotToken(
+          const accountResetToken = await account.passwordForgotVerifyCode(
             token,
-            code
+            code,
+            true
           );
           setFetchedResetToken(accountResetToken);
           resetToken = accountResetToken;
@@ -308,7 +309,10 @@ const AccountRecoveryConfirmKey = ({
           to={`/complete_reset_password${location.search}`}
           className="link-blue text-sm"
           id="lost-recovery-key"
-          state={{ lostRecoveryKey: true }}
+          state={{
+            lostRecoveryKey: true,
+            accountResetToken: fetchedResetToken,
+          }}
           onClick={() => {
             logViewEvent(
               'flow',

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -24,6 +24,7 @@ import {
   mockAppContext,
   renderWithRouter,
 } from '../../../models/mocks';
+import { MOCK_RESET_TOKEN } from '../../mocks';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
 
@@ -43,6 +44,7 @@ jest.mock('../../../lib/metrics', () => ({
 
 let account: Account;
 let lostRecoveryKey: boolean;
+let accountResetToken: string | undefined;
 const mockNavigate = jest.fn();
 
 const mockSearchParams = {
@@ -61,6 +63,7 @@ const mockLocation = () => {
     search,
     state: {
       lostRecoveryKey,
+      accountResetToken,
     },
   };
 };
@@ -355,7 +358,8 @@ describe('CompleteResetPassword page', () => {
         token,
         code,
         emailToHashWith,
-        PASSWORD
+        PASSWORD,
+        undefined
       );
     });
     it('submits with email if emailToHashWith is missing', async () => {
@@ -367,7 +371,24 @@ describe('CompleteResetPassword page', () => {
         token,
         code,
         email,
-        PASSWORD
+        PASSWORD,
+        undefined
+      );
+    });
+
+    it('submits with accountResetToken if available', async () => {
+      lostRecoveryKey = true;
+      accountResetToken = MOCK_RESET_TOKEN;
+      render(<Subject />, account);
+      const { token, emailToHashWith, code } = mockCompleteResetPasswordParams;
+
+      await enterPasswordAndSubmit();
+      expect(account.completeResetPassword).toHaveBeenCalledWith(
+        token,
+        code,
+        emailToHashWith,
+        PASSWORD,
+        MOCK_RESET_TOKEN
       );
     });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
@@ -24,6 +24,7 @@ export type CompleteResetPasswordSubmitData = {
 
 export interface CompleteResetPasswordLocationState {
   lostRecoveryKey: boolean;
+  accountResetToken: string;
 }
 
 export interface CompleteResetPasswordParams {

--- a/packages/fxa-settings/src/pages/mocks.ts
+++ b/packages/fxa-settings/src/pages/mocks.ts
@@ -12,5 +12,6 @@ export const MOCK_SERVICE = MozServices.FirefoxMonitor;
 export const MOCK_SESSION_TOKEN = 'sessionToken';
 export const MOCK_UNWRAP_BKEY = 'unwrapBKey';
 export const MOCK_KEY_FETCH_TOKEN = 'keyFetchToken';
+export const MOCK_RESET_TOKEN = 'mockResetToken';
 export const MOCK_AUTH_AT = 12345;
 export const MOCK_PASSWORD = 'notYourAveragePassW0Rd';


### PR DESCRIPTION

Because:
* Users could land in a bad state if they first try to reset with an invalid recovery key since auth-server would send out a reset successful email and users would see an expired link

This commit:
* Passes accountResetToken from AccountRecoveryConfirmKey to CompleteResetPassword for reuse to prevent the expired state
* Properly passes up the 'accountResetWithRecoveryKey' option to prevent auth-server from landing in an unexpected state

fixes FXA-8419