### PR TITLE
bug(content): Links hidden on some devices by banner

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -70,6 +70,7 @@
 
   @include respond-to('small') {
     padding-top: 3rem;
+    margin-bottom: 5rem;
   }
 }
 

--- a/packages/fxa-settings/src/styles/brand-banner.css
+++ b/packages/fxa-settings/src/styles/brand-banner.css
@@ -12,3 +12,7 @@
     #e3f6ed 102.21%
   );
 }
+
+.brand-messaging {
+  @apply mb-32;
+}


### PR DESCRIPTION
## Because

- Forgot password could not be clicked on when banner was visible on iPhone SE
- Use a different account could not be clicked on when banner was visible on iPhone SE

## This pull request

- Adds margin to body bottom when page is in brand messaging mode

## Issue that this pull request solves

Closes: FXA-8422

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
After fix page can be scrolled further down:

Content Server:
![image](https://github.com/mozilla/fxa/assets/94418270/edf13879-0953-481e-9ae5-b4eadd88721b)

React:
![image](https://github.com/mozilla/fxa/assets/94418270/7cf3645f-4134-44f9-8352-0b7ac9e0beeb)


## Other information (Optional)

Any other information that is important to this pull request.
