### PR TITLE
fix(react): Pass query parameters on 'Remember your password' link

### DIFF
--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.test.tsx
@@ -9,6 +9,28 @@ import LinkRememberPassword from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
+import { MOCK_CLIENT_ID } from '../../pages/mocks';
+import { LocationProvider } from '@reach/router';
+
+const mockLocation = () => {
+  return {
+    search: '?' + new URLSearchParams({ client_id: MOCK_CLIENT_ID }),
+  };
+};
+
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useLocation: () => mockLocation(),
+}));
+
+const Subject = ({
+  email = MOCK_ACCOUNT.primaryEmail.email,
+  forceAuth = false,
+}) => (
+  <LocationProvider>
+    <LinkRememberPassword {...{ email, forceAuth }} />
+  </LocationProvider>
+);
 
 describe('LinkRememberPassword', () => {
   let bundle: FluentBundle;
@@ -17,9 +39,7 @@ describe('LinkRememberPassword', () => {
   });
 
   it('renders', () => {
-    renderWithLocalizationProvider(
-      <LinkRememberPassword email={MOCK_ACCOUNT.primaryEmail.email} />
-    );
+    renderWithLocalizationProvider(<Subject />);
     testAllL10n(screen, bundle);
 
     expect(
@@ -27,10 +47,8 @@ describe('LinkRememberPassword', () => {
     ).toBeInTheDocument();
   });
 
-  it('links to signin if not forceAuth', () => {
-    renderWithLocalizationProvider(
-      <LinkRememberPassword email={MOCK_ACCOUNT.primaryEmail.email} />
-    );
+  it('links to signin if not forceAuth, appends parameters', () => {
+    renderWithLocalizationProvider(<Subject />);
 
     const rememberPasswordLink = screen.getByRole('link', {
       name: 'Remember your password? Sign in',
@@ -39,21 +57,19 @@ describe('LinkRememberPassword', () => {
 
     expect(rememberPasswordLink).toHaveAttribute(
       'href',
-      '/signin?email=johndope%40example.com'
+      '/signin?client_id=123&email=johndope%40example.com'
     );
   });
 
-  it('links to force_auth if forceAuth is true', () => {
-    renderWithLocalizationProvider(
-      <LinkRememberPassword email={MOCK_ACCOUNT.primaryEmail.email} forceAuth />
-    );
+  it('links to force_auth if forceAuth is true, appends parameters', () => {
+    renderWithLocalizationProvider(<Subject forceAuth={true} />);
 
     const rememberPasswordLink = screen.getByRole('link', {
       name: 'Remember your password? Sign in',
     });
     expect(rememberPasswordLink).toHaveAttribute(
       'href',
-      '/force_auth?email=johndope%40example.com'
+      '/force_auth?client_id=123&email=johndope%40example.com'
     );
   });
 });

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
+import { useLocation } from '@reach/router';
 
 export type LinkRememberPasswordProps = {
   email?: string;
@@ -14,15 +15,20 @@ const LinkRememberPassword = ({
   email,
   forceAuth = false,
 }: LinkRememberPasswordProps) => {
-  const linkTarget = `${forceAuth ? '/force_auth' : '/signin'}`;
-  let target = linkTarget;
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
   if (email) {
-    target = `${linkTarget}?email=${encodeURIComponent(email)}`;
+    params.set('email', email);
   }
+  const linkHref = `${
+    forceAuth ? '/force_auth' : '/signin'
+  }?${params.toString()}`;
+
   return (
     <div className="text-sm mt-6">
       <FtlMsg id="remember-pw-link">
-        <a href={target} className="link-blue text-sm" id="remember-password">
+        {/* TODO: use Link component once signin is Reactified */}
+        <a href={linkHref} className="link-blue text-sm" id="remember-password">
           Remember your password? Sign in
         </a>
       </FtlMsg>

--- a/packages/fxa-settings/src/pages/mocks.ts
+++ b/packages/fxa-settings/src/pages/mocks.ts
@@ -8,6 +8,7 @@ import { MOCK_ACCOUNT } from '../models/mocks';
 export const MOCK_EMAIL = MOCK_ACCOUNT.primaryEmail.email;
 export const MOCK_UID = 'abc123';
 export const MOCK_REDIRECT_URI = 'http://localhost:8080/123Done';
+export const MOCK_CLIENT_ID = '123';
 export const MOCK_SERVICE = MozServices.FirefoxMonitor;
 export const MOCK_SESSION_TOKEN = 'sessionToken';
 export const MOCK_UNWRAP_BKEY = 'unwrapBKey';


### PR DESCRIPTION
Because:
* Not passing query parameters causes OAuth and Sync flows to lose their query params (and context) on signin

This commit:
* Passes params and email param if present back to /signin or /force_auth

fixes FXA-8427