### PR TITLE
bug(content): Page would not render properly in some cases

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -3,7 +3,7 @@
     <div class="banner-brand-message w-full">
         <div class="flex justify-center p-2 brand-banner-bg">
             {{#showPrelaunch}}
-            <div class="flex"/>
+            <div class="flex">
                 <div class="flex-none relative">
                     <img
                         class="w-8 h-8 bg-black m-4 mt-1"
@@ -17,17 +17,17 @@
                     </p>
                     <p class="text-start text-xs">
                         {{#t}}You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
+                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</span>
                     </p>
                 </div>
             </div>
             {{/showPrelaunch}}
             {{#showPostlaunch}}
-            <div className="flex"/>
+            <div class="flex"/>
                 <div>
                     <p class="text-sm font-bold">
                         {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</a>
+                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</span>
                     </p>
                 </div>
             </div>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
@@ -1,4 +1,4 @@
-{{ brandMessagingHTML }}
+{{{ brandMessagingHTML }}}
 <div class="card">
   <header class="mb-2">
     <h1 id="fxa-signup-password-header" class="card-header">


### PR DESCRIPTION
## Because
- There was invalid HTML

## This pull request

- Fixes the mismatched `<span>Learn more</a>` HTML
- Adds extra curly brace to the include

## Issue that this pull request solves

Closes: FXA-8423

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

The defect looked like this with HTML being output to the page:
![image](https://github.com/mozilla/fxa/assets/94418270/6f15e6f7-5d75-4b0f-93e8-e73b632bd27d)



