### PR TITLE
bug(auth): Random email non-delivery

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -295,19 +295,25 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
         }
       }
 
-      function sendEmail() {
+      async function sendEmail() {
+        log.info('account.signin.sendEmail', {
+          uid: accountRecord.uid,
+          isUnverifiedAccount,
+          mustVerifySession,
+        });
+
         // For unverified accounts, we always re-send the account verification email.
         if (isUnverifiedAccount) {
-          return sendVerifyAccountEmail();
+          return await sendVerifyAccountEmail();
         }
         // If the session needs to be verified, send the sign-in confirmation email.
         if (mustVerifySession) {
-          return sendVerifySessionEmail();
+          return await sendVerifySessionEmail();
         }
         // Otherwise, no email is necessary.
       }
 
-      function sendVerifyAccountEmail() {
+      async function sendVerifyAccountEmail() {
         if (verificationMethod === 'email-otp') {
           return sendVerifyLoginCodeEmail();
         }
@@ -316,8 +322,8 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
         const emailCode =
           sessionToken.tokenVerificationId ||
           accountRecord.primaryEmail.emailCode;
-        return mailer
-          .sendVerifyEmail([], accountRecord, {
+        try {
+          await mailer.sendVerifyEmail([], accountRecord, {
             code: emailCode,
             service,
             redirectTo,
@@ -335,21 +341,27 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
             uaOSVersion: request.app.ua.osVersion,
             uaDeviceType: request.app.ua.deviceType,
             uid: sessionToken.uid,
-          })
-          .then(() => request.emitMetricsEvent('email.verification.sent'));
+          });
+          await request.emitMetricsEvent('email.verification.sent');
+        } catch (err) {
+          log.error('mailer.verification.error', {
+            err,
+          });
+          throw err;
+        }
       }
 
-      function sendVerifySessionEmail() {
+      async function sendVerifySessionEmail() {
         // If this login requires a confirmation, check to see if a specific method was specified in
         // the request. If none was specified, use the `email` verificationMethod.
         switch (verificationMethod) {
           case 'email':
             // Sends an email containing a link to verify login
-            return sendVerifyLoginEmail();
+            return await sendVerifyLoginEmail();
           case 'email-2fa':
           case 'email-otp':
             // Sends an email containing a code that can verify a login
-            return sendVerifyLoginCodeEmail();
+            return await sendVerifyLoginCodeEmail();
           case 'email-captcha':
             // `email-captcha` is a custom verification method used only for
             // unblock codes. We do not need to send a verification email
@@ -360,7 +372,7 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
             // application.
             break;
           default:
-            return sendVerifyLoginEmail();
+            return await sendVerifyLoginEmail();
         }
       }
 
@@ -397,7 +409,9 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
           );
           await request.emitMetricsEvent('email.confirmation.sent');
         } catch (err) {
-          log.error('mailer.confirmation.error', { err });
+          log.error('mailer.confirmation.error', {
+            err,
+          });
           throw emailUtils.sendError(err, isUnverifiedAccount);
         }
       }
@@ -410,32 +424,40 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
         const secret = accountRecord.primaryEmail.emailCode;
         const code = otpUtils.generateOtpCode(secret, otpOptions);
         const { location, timeZone } = request.app.geo;
-        await mailer.sendVerifyLoginCodeEmail(
-          accountRecord.emails,
-          accountRecord,
-          {
-            acceptLanguage: request.app.acceptLanguage,
-            code,
-            deviceId,
-            flowId,
-            flowBeginTime,
-            ip,
-            location,
-            redirectTo,
-            resume,
-            service,
-            timeZone,
-            uaBrowser: request.app.ua.browser,
-            uaBrowserVersion: request.app.ua.browserVersion,
-            uaOS: request.app.ua.os,
-            uaOSVersion: request.app.ua.osVersion,
-            uaDeviceType: request.app.ua.deviceType,
-            uid: sessionToken.uid,
-          }
-        );
 
-        request.emitMetricsEvent('email.tokencode.sent');
-        glean.login.verifyCodeEmailSent(request, { uid: sessionToken.uid });
+        try {
+          await mailer.sendVerifyLoginCodeEmail(
+            accountRecord.emails,
+            accountRecord,
+            {
+              acceptLanguage: request.app.acceptLanguage,
+              code,
+              deviceId,
+              flowId,
+              flowBeginTime,
+              ip,
+              location,
+              redirectTo,
+              resume,
+              service,
+              timeZone,
+              uaBrowser: request.app.ua.browser,
+              uaBrowserVersion: request.app.ua.browserVersion,
+              uaOS: request.app.ua.os,
+              uaOSVersion: request.app.ua.osVersion,
+              uaDeviceType: request.app.ua.deviceType,
+              uid: sessionToken.uid,
+            }
+          );
+
+          await request.emitMetricsEvent('email.tokencode.sent');
+          await glean.login.verifyCodeEmailSent(request, {
+            uid: sessionToken.uid,
+          });
+        } catch (err) {
+          log.error('mailer.tokencode.error', { err });
+          throw err;
+        }
       }
 
       function recordSecurityEvent() {


### PR DESCRIPTION
## Because

- We want to pin down reports of occasionally unsent emails.
- sendVerifyAccountEmail was written with promise chains, where as other similar functions were async/await

## This pull request

- Adds info log prior to email send, so we know if the email will send code will be triggered
- Adds try catch around sendEmail code so we can monitor any issues
- Converts sendVerifyAccountEmail to an async function to be consistent with rest of code in `signin.js` and prevent mixing of patterns and improve error handling/logging.

## Issue that this pull request solves

Closes: FXA-8376

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

An example log letting us gain more insight into the flow:
![image](https://github.com/mozilla/fxa/assets/94418270/9ce5eb48-8980-406a-8616-308426cb19b9)


## Other information (Optional)

This won't fix the issue reported in FXA-8376, however, it will allow us to reopen it with more info. To validate this changeset locally:
- Add `SIGNIN_CONFIRMATION_FORCE_GLOBALLY=true` to your .env file
- Run `dotenv -- yarn start`
- Create a new account, login, logout
- Sign back in, you should be prompted for a code
- Check auth error logs for `account.signin.sendEmail`
