### PR TITLE
chore(auth): remove unused and invalid test Stripe API key

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -129,7 +129,7 @@ const mockConfig = {
   subscriptions: {
     cacheTtlSeconds: 10,
     productConfigsFirestore: { enabled: true },
-    stripeApiKey: 'sk_test_4eC39HqLyjWDarjtT1zdp7dc',
+    stripeApiKey: 'blah',
   },
   subhub: {
     enabled: true,


### PR DESCRIPTION
Because:

* The value of this key doesn't matter for the purpose of this test.
* This key isn't valid.
* Using a key that looks like a valid key is causing us to get security alerts.

This commit:

* Replaces the key value in the test with a dummy string.

Relates to #FXA-8371

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
