### PR TITLE
task(auth): Add branding banner to emails

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -354,6 +354,12 @@ const convictConf = convict({
         env: 'MAILER_PORT',
       },
     },
+    brandMessagingMode: {
+      doc: 'The type of messaging to show. Options are prelaunch, postlaunch, or none',
+      format: String,
+      default: 'none',
+      env: 'BRAND_MESSAGING_MODE',
+    },
     host: {
       doc: 'SMTP host for sending email',
       default: 'localhost',

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -390,6 +390,13 @@ module.exports = function (log, config, bounces) {
   };
 
   Mailer.prototype.send = async function (message) {
+    // Make sure brandMessagingMode always reflects the current config state.
+
+    if (message && message.templateValues) {
+      message.templateValues.brandMessagingMode =
+        config.smtp.brandMessagingMode;
+    }
+
     log.trace(`mailer.${message.template}`, {
       email: message.email,
       uid: message.uid,

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -110,6 +110,11 @@ $s-10: 40px;
   }
 }
 
+.p {
+  &-4 {
+    padding: $s-4 !important;
+  }
+}
 // Global styles
 tbody > td:first-child,
 tr > td:first-child {
@@ -131,6 +136,24 @@ tr > td:first-child {
   @extend .font-sans;
 }
 
+%banner-common {
+  width: 100% !important;
+  background: linear-gradient(88.76deg, #E4EAF6 3.37%, #DBEEF8 39.93%, #DAF3F4 65.09%, #E3F6ED 102.21%);
+  background-color: #DBEEF8;
+}
+
+%text-banner-common {
+  @extend %text-header-common;
+  @extend .text-xs;
+  @extend .p-4;
+  color: $black !important;
+  font-weight: 700 !important;
+}
+
+%link-banner-common {
+  color: $black !important;
+  text-decoration: underline !important;
+}
 .align-left div {
   text-align: left !important;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -12,53 +12,58 @@
     <%- include('/partials/metadata.mjml') %>
   </mj-head>
 
-  <mj-body css-class="body">
+  <mj-body>
     <mj-include path="<%- locals.cssPath %>/global.css" type="css" css-inline="inline" />
     <mj-include path="<%- locals.cssPath %>/fxa/index.css" type="css" css-inline="inline" />
     <mj-include path="<%- locals.cssPath %>/locale-dir.css" type="css" />
+    <%- include('/partials/brandMessaging/index.mjml') %>
 
-    <mj-section>
-      <mj-column>
-        <% if (locals.preHeader) { %>
-          <mj-text css-class="hidden">
-            <%- preHeader %>
-            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
+    <mj-wrapper css-class="body">
+      <mj-section>
+        <mj-column>
+          <% if (locals.preHeader) { %>
+            <mj-text css-class="hidden">
+              <%- preHeader %>
+              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
+            </mj-text>
+          <% } %>
+          <% if (!locals.sync) { %>
+            <mj-image css-class="fxa-logo"
+              width="60px"
+              src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo.png"
+              alt="Firefox logo"
+              title="Firefox logo">
+            </mj-image>
+          <% } else { %>
+            <mj-image css-class="sync-img"
+              width="300px"
+              src="https://accounts-static.cdn.mozilla.net/other/sync-devices.png"
+              alt="Sync devices"
+              title="Sync devices">
+            </mj-image>
+          <% } %>
+        </mj-column>
+      </mj-section>
+
+      <%- body %>
+
+
+      <mj-section>
+        <mj-column>
+          <mj-text css-class="text-footer">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
+          <mj-text css-class="text-footer">
+            <a class="link-blue" data-l10n-id="fxa-privacy-url" href="<%- privacyUrl %>">Mozilla Privacy Policy</a>
           </mj-text>
-        <% } %>
-        <% if (!locals.sync) { %>
-          <mj-image css-class="fxa-logo"
-            width="60px"
-            src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo.png"
-            alt="Firefox logo"
-            title="Firefox logo">
-          </mj-image>
-        <% } else { %>
-          <mj-image css-class="sync-img"
-            width="300px"
-            src="https://accounts-static.cdn.mozilla.net/other/sync-devices.png"
-            alt="Sync devices"
-            title="Sync devices">
-          </mj-image>
-        <% } %>
-      </mj-column>
-    </mj-section>
+          <mj-text css-class="text-footer">
+            <a class="link-blue" data-l10n-id="fxa-service-url" href="https://www.mozilla.org/about/legal/terms/services/">Firefox Cloud Terms of Service</a>
+          </mj-text>
+        </mj-column>
+      </mj-section>
 
-    <%- body %>
-
-    <mj-section>
-      <mj-column>
-        <mj-text css-class="text-footer">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
-        <mj-text css-class="text-footer">
-          <a class="link-blue" data-l10n-id="fxa-privacy-url" href="<%- privacyUrl %>">Mozilla Privacy Policy</a>
-        </mj-text>
-        <mj-text css-class="text-footer">
-          <a class="link-blue" data-l10n-id="fxa-service-url" href="https://www.mozilla.org/about/legal/terms/services/">Firefox Cloud Terms of Service</a>
-        </mj-text>
-      </mj-column>
-    </mj-section>
+    </mj-wrapper>
   </mj-body>
 </mjml>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.stories.ts
@@ -24,3 +24,17 @@ export const ThroughSyncFlow = createStory(
   },
   'Email triggered through sync flow'
 );
+
+export const MessagingNotThroughSyncFlowWithBrandMessaging = createStory(
+  {
+    brandMessagingMode: 'postlaunch',
+  },
+  'Email not triggered through sync flow with brand messaging'
+);
+
+export const MessagingThroughSyncFlowWithBrandMessaging = createStory(
+  {
+    brandMessagingMode: 'postlaunch',
+  },
+  'Email triggered through sync flow with brand messaging'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
@@ -1,3 +1,6 @@
+<%- include('/partials/brandMessaging/index.txt') %>
+
+
 <%- body %>
 Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105
 

--- a/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/en.ftl
@@ -1,0 +1,1 @@
+brand-banner-message = Did you know we changed our name from { -product-firefox-accounts } to { -product-mozilla-accounts }? <a data-l10n-name="learnMore">Learn more</a>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/index.mjml
@@ -1,0 +1,19 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<% if (locals.brandMessagingMode == 'postlaunch') { %>
+<mj-include path="<%- locals.cssPath %>/brandMessaging/index.css" type="css" css-inline="inline" />
+
+<mj-section css-class="brand-message-container">
+  <mj-column>
+    <mj-text css-class="brand-message-text">
+      <span data-l10n-id="brand-banner-message">
+        Did you know we changed our name from Firefox accounts to Mozilla accounts?
+        <a href="https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts" class="link-blue" data-l10n-name="learnMore">Learn more</a>
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/index.scss
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@use '../../global.scss';
+
+.brand-message-container {
+  @extend %banner-common;
+}
+
+.brand-message-text>div {
+  @extend %text-banner-common;
+}
+
+.brand-message-text div span a {
+  @extend %link-banner-common;
+}

--- a/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/brandMessaging/index.txt
@@ -1,0 +1,6 @@
+<% if (locals.brandMessagingMode == 'postlaunch') { %>
+brand-banner-message = "Did you know we changed our name from Firefox accounts to Mozilla accounts? Learn more"
+
+https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts
+
+<% } %>


### PR DESCRIPTION
## Because

- We want to add in email product messaging about the Mozilla account brand

## This pull request

- Adds a banner to all fxa emails with intended messaging

## Issue that this pull request solves

Closes: FXA-7994
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

From mail dev:
![image](https://github.com/mozilla/fxa/assets/94418270/d1136864-afb0-4538-b964-761e7f14cc38)

## Other information (Optional)

In order to test set the add `BRAND_MESSAGING_MODE=postlaunch` in the `.dotenv` file in the root of fxa, and then run `dotenv -- yarn start`. To validate emails manually, run use [maildev](https://mozilla.github.io/ecosystem-platform/how-tos/local-emails-with-maildev).  We can also view the changes in storybook. `nx storybook fxa-auth-server`, then checkout the layouts which have branding and non branding versions.

One other thing to possibly test... I ended up using a background gradient with fallback solid background color. As far as I can tell this works even legacy clients. However, it might be nice to validate in a really old email client or a windows client.
