### PR TITLE
bug(content): Missing & duplicate brand metrics

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -13,6 +13,7 @@ import Template from 'templates/confirm_signup_code.mustache';
 import ResendMixin from './mixins/resend-mixin';
 import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
+import BrandMessagingMixin from './mixins/brand-messaging-mixin';
 
 const CODE_INPUT_SELECTOR = '#otp-code';
 
@@ -114,7 +115,8 @@ Cocktail.mixin(
   ResendMixin(),
   ServiceMixin,
   SessionVerificationPollMixin,
-  PocketMigrationMixin
+  PocketMigrationMixin,
+  BrandMessagingMixin
 );
 
 export default ConfirmSignupCodeView;

--- a/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
@@ -36,7 +36,7 @@ const Mixin = {
       (this.mode === 'prelaunch' || this.mode === 'postlaunch');
 
     if (this.enabled) {
-      this.logFlowEvent(`brand-messaging-${this.mode}-view`, this.viewName);
+      this.logFlowEventOnce(`brand-messaging-${this.mode}-view`, this.viewName);
       document.body.classList.add('brand-messaging');
     }
   },


### PR DESCRIPTION
## Because

- We weren't seeing a `flow.confirm_sign_up.brand-messaging-prelaunch-view` metric on the confirm sign up page
- The signin page would double emit `flow.signin.brand-messaging-prelaunch-view`

## This pull request

- Registers the brand-messaging-mixin on the `confirm_signup_code view`.
- Uses `logFowEventOnce` instead of `logFlowEvent` method to emit metric.

## Issue that this pull request solves

Closes: FXA-8429

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
Double metrics:
![image](https://github.com/mozilla/fxa/assets/94418270/3d9660c3-c06e-402a-84b8-6826a1cdc7c6)

Missing confirm `flow.confirm_sign_up.brand-messaging-prelaunch-view`:
<img width="297" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/25e30d7d-777c-4839-8442-29910e6636f5">

After:
Single metric:
![image](https://github.com/mozilla/fxa/assets/94418270/94e1cb6b-cfe1-40f8-ae04-7b467a8238a6)

Emitting `flow.confirm_sign_up.brand-messaging-prelaunch-view`:
![image](https://github.com/mozilla/fxa/assets/94418270/965c709c-fdf1-4e7c-8158-258e285c8e74)

_(Note testing with postlaunch view, but it works just like prelaunch view. Pre vs post is just a string in the config file.)_


