### PR TITLE
bug(settings): Margin bottom should only be applied to mobile

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -21,12 +21,12 @@ export const AppLayout = ({ title, children, widthClass }: AppLayoutProps) => {
   const { l10n } = useLocalization();
   return (
     <>
-      <div id="body-top" className="w-full hidden mobileLandscape:block"></div>
       <Head {...{ title }} />
       <div
         className="flex min-h-screen flex-col items-center"
         data-testid="app"
       >
+        <div id="body-top" className="w-full hidden mobileLandscape:block" />
         <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1 pt-14">
           <section>
             <div className={classNames('card', widthClass)}>{children}</div>
@@ -50,10 +50,7 @@ export const AppLayout = ({ title, children, widthClass }: AppLayoutProps) => {
           </LinkExternal>
         </footer>
       </div>
-      <div
-        id="body-bottom"
-        className="w-full block mobileLandscape:hidden"
-      ></div>
+      <div id="body-bottom" className="w-full block mobileLandscape:hidden" />
     </>
   );
 };

--- a/packages/fxa-settings/src/styles/brand-banner.css
+++ b/packages/fxa-settings/src/styles/brand-banner.css
@@ -14,5 +14,5 @@
 }
 
 .brand-messaging {
-  @apply mb-32;
+  @apply mb-32 mobileLandscape:mb-0;
 }


### PR DESCRIPTION
## Because

- When the brand messaging banner is enabled, there's  extra white space at the bottom of the doc in the react flows.

## This pull request

- Only applies the extra margin for mobile flows with a sticky banner in the footer.
## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

After fix:
![image](https://github.com/mozilla/fxa/assets/94418270/26770096-665e-4b6a-8f35-725c200b2572)
![image](https://github.com/mozilla/fxa/assets/94418270/476c1977-1382-47f4-b177-fd835b6244ce)


## Other information (Optional)

This is a small follow up to https://github.com/mozilla/fxa/pull/15865. 
