### PR TITLE
feat(monitor): Add monitor terms of service to signin/signup

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -35,9 +35,28 @@
       </div>
     </form>
 
-    <div id="tos-pp" class="text-grey-500 my-5 text-xs">
-      {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
-    </div>
+      <div id="tos-pp" class="text-grey-500 mt-5 text-xs">
+        {{#isPocketClient}}
+          {{#unsafeTranslate}}
+            By proceeding, you agree to:<br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+          {{/unsafeTranslate}}
+        {{/isPocketClient}}
+        {{^isPocketClient}}
+          {{#isMonitorClient}}
+            {{#unsafeTranslate}}
+              By proceeding, you agree to:<br />
+              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            {{/unsafeTranslate}}
+          {{/isMonitorClient}}
+          {{^isMonitorClient}}
+            {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+          {{/isMonitorClient}}
+        {{/isPocketClient}}
+      </div>
+
 
     <div class="flex justify-between">
       <a href="/" id="use-different" class="link-blue" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a>

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -46,26 +46,60 @@
     {{#isInThirdPartyAuthExperiment}}
       {{^isSync}}
         {{{ unsafeThirdPartyAuthHTML }}}
-        <div id="tos-pp" class="text-grey-500 -mb-2 mt-5 text-xs">
-            {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
-        </div>
-      {{/isSync}}
-      {{#isSync}}
-        <p class="text-xs text-grey-500 mb-0 mt-5" id="firefox-family-services">
-          {{#t}}A Firefox account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
-        </p>
       {{/isSync}}
     {{/isInThirdPartyAuthExperiment}}
 
     {{^isInThirdPartyAuthExperiment}}
-      <p class="text-xs text-grey-500 mb-0 mt-5" id="firefox-family-services">
-        {{#t}}A Firefox account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
-      </p>
+      {{^isSync}}
+        <div class="text-xs text-grey-500 mb-0 mt-5">
+          <p id="firefox-family-services">
+            {{#t}}A Firefox account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
+          </p>
+        </div>
+      {{/isSync}}
     {{/isInThirdPartyAuthExperiment}}
+
+    <div class="text-xs text-grey-500 mb-0 mt-5">
+      {{#isSync}}
+        <p id="firefox-family-services" class="mb-2">
+          {{#t}}A Firefox account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
+        </p>
+      {{/isSync}}
+      {{#isPocketClient}}
+        {{#unsafeTranslate}}
+          By proceeding, you agree to:<br />
+          Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+          Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+        {{/unsafeTranslate}}
+      {{/isPocketClient}}
+      {{^isPocketClient}}
+        {{#isMonitorClient}}
+          {{#unsafeTranslate}}
+            By proceeding, you agree to:<br />
+            Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+          {{/unsafeTranslate}}
+        {{/isMonitorClient}}
+        {{^isMonitorClient}}
+          {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+        {{/isMonitorClient}}
+      {{/isPocketClient}}
+    </div>
+
   </section>
 </div>
 
 <!-- New L10N Strings
 {{#t}}Continue to your Mozilla account{{/t}}
 {{#t}}A Mozilla account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
+{{#unsafeTranslate}}
+  By proceeding, you agree to:<br />
+  Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+  Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+{{/unsafeTranslate}}
+{{#unsafeTranslate}}
+  By proceeding, you agree to:<br />
+  Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+  Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+{{/unsafeTranslate}}
 -->

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
@@ -1,5 +1,5 @@
 <div id="main-content" class="card account-setup-set-password">
-    {{#isLinkValid}}
+    {{^isLinkValid}}
         <header>
             <h1 id="fxa-account-setup-set-damaged-header">{{#t}}Link damaged{{/t}}</h1>
         </header>
@@ -11,7 +11,7 @@
         </section>
     {{/isLinkValid}}
 
-    {{^isLinkValid}}
+    {{#isLinkValid}}
     <header>
         <h1 id="fxa-account-setup-set-password-header">
         {{#productName}}
@@ -49,10 +49,9 @@
                        placeholder="{{#t}}Confirm password{{/t}}" required pattern=".{8,}" data-synchronize-show="true"/>
             </div>
 
-            <div class="button-row ">
-                <button type="submit">{{#t}}Create Password{{/t}}</button>
+            <div class="button-row">
+                <button type="submit">{{#t}}Create password{{/t}}</button>
             </div>
-
             <div id="tos-pp" class="text-grey-500 my-5 text-xs">
                 {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
             </div>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/third_party_auth/set_password.mustache
@@ -48,7 +48,10 @@
       </div>
 
       <div class="flex">
-        <button id="submit-btn" class="cta-primary cta-xl" type="submit">{{#t}}Create Password{{/t}}</button>
+        <button id="submit-btn" class="cta-primary cta-xl" type="submit">{{#t}}Create password{{/t}}</button>
+      </div>
+      <div id="tos-pp" class="text-grey-500 my-5 text-xs">
+        {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
       </div>
     </form>
   </section>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -77,11 +77,20 @@
           {{#unsafeTranslate}}
             By proceeding, you agree to:<br />
             Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
-          {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+          {{#isMonitorClient}}
+            {{#unsafeTranslate}}
+              By proceeding, you agree to:<br />
+              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            {{/unsafeTranslate}}
+          {{/isMonitorClient}}
+          {{^isMonitorClient}}
+            {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+          {{/isMonitorClient}}
         {{/isPocketClient}}
       </div>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -77,12 +77,21 @@
         {{#isPocketClient}}
           {{#unsafeTranslate}}
             By proceeding, you agree to:<br />
-            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a class="link-grey" id="pocket-pp" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
             Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
-          {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+          {{#isMonitorClient}}
+            {{#unsafeTranslate}}
+              By proceeding, you agree to:<br />
+              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            {{/unsafeTranslate}}
+          {{/isMonitorClient}}
+          {{^isMonitorClient}}
+            {{#unsafeTranslate}}By proceeding, you agree to the <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+          {{/isMonitorClient}}
         {{/isPocketClient}}
       </div>
     </form>

--- a/packages/fxa-content-server/app/scripts/views/force_auth.js
+++ b/packages/fxa-content-server/app/scripts/views/force_auth.js
@@ -22,6 +22,8 @@ import Transform from '../lib/transform';
 import UserCardMixin from './mixins/user-card-mixin';
 import Vat from '../lib/vat';
 import BrandMessagingMixin from './mixins/brand-messaging-mixin';
+import PocketMigrationMixin from './mixins/pocket-migration-mixin';
+import MonitorClientMixin from './mixins/monitor-client-mixin';
 
 const t = (msg) => msg;
 
@@ -252,7 +254,9 @@ Cocktail.mixin(
   SignInMixin,
   SignedInNotificationMixin,
   UserCardMixin,
-  BrandMessagingMixin
+  BrandMessagingMixin,
+  PocketMigrationMixin,
+  MonitorClientMixin
 );
 
 export default View;

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -26,6 +26,7 @@ import Template from 'templates/index.mustache';
 import checkEmailDomain from '../lib/email-domain-validator';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 import BrandMessagingMixin from './mixins/brand-messaging-mixin';
+import MonitorClientMixin from './mixins/monitor-client-mixin';
 
 const EMAIL_SELECTOR = 'input[type=email]';
 
@@ -298,7 +299,8 @@ Cocktail.mixin(
     entrypoint: 'fxa:enter_email',
     flowEvent: 'link.signin',
   }),
-  PocketMigrationMixin
+  PocketMigrationMixin,
+  MonitorClientMixin
 );
 
 export default IndexView;

--- a/packages/fxa-content-server/app/scripts/views/mixins/monitor-client-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/monitor-client-mixin.js
@@ -2,26 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const POCKET_CLIENTIDS = [
-  '7377719276ad44ee', // pocket-mobile
-  '749818d3f2e7857f', // pocket-web
+export const MONITOR_CLIENTIDS = [
+  '802d56ef2a9af9fa', // Firefox Monitor
+  '946bfd23df91404c', // Firefox Monitor stage
+  'edd29a80019d61a1', // Firefox Monitor local dev
   // enable for testing on 123Done locally
   // only enable for either pocket-migration-mixin or monitor-client-mixin
-  // but not both at the same time
+  // but not both
   // 'dcdb5ae7add825d2',
 ];
 
 export default {
   setInitialContext(context) {
-    const isPocketClient = POCKET_CLIENTIDS.includes(
+    const isMonitorClient = MONITOR_CLIENTIDS.includes(
       this.relier.get('clientId')
     );
 
-    if (isPocketClient) {
+    if (isMonitorClient) {
       context.set({
-        newsletters: [], // Disables newsletters
-        isAnyNewsletterEnabled: false,
-        isPocketClient, // In signup pages we add more terms and conditions for Pocket
+        // in signin and signup pages we add terms of service and privacy notice for Monitor
+        isMonitorClient,
       });
     }
   },

--- a/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
@@ -57,7 +57,7 @@ class SetPassword extends FormView {
       productName: decodeURIComponent(
         this._verificationInfo.get('product_name').replace(/\+/g, ' ')
       ),
-      isLinkValid: !this._verificationInfo.isValid(),
+      isLinkValid: this._verificationInfo.isValid(),
     });
   }
 

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -22,6 +22,7 @@ import ThirdPartyAuth from '../templates/partial/third-party-auth.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 import BrandMessagingMixin from './mixins/brand-messaging-mixin';
+import MonitorClientMixin from './mixins/monitor-client-mixin';
 
 const SignInPasswordView = FormView.extend({
   template: Template,
@@ -147,7 +148,8 @@ Cocktail.mixin(
   ThirdPartyAuthMixin,
   UserCardMixin,
   PocketMigrationMixin,
-  BrandMessagingMixin
+  BrandMessagingMixin,
+  MonitorClientMixin
 );
 
 export default SignInPasswordView;

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -22,6 +22,7 @@ import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignUpMixin from './mixins/signup-mixin';
 import GleanMetrics from '../lib/glean';
 import BrandMessagingMixin from './mixins/brand-messaging-mixin';
+import MonitorClientMixin from './mixins/monitor-client-mixin';
 
 const t = (msg) => msg;
 
@@ -166,7 +167,8 @@ Cocktail.mixin(
   SignUpMixin,
   PocketMigrationMixin,
   AccountSuggestionMixin,
-  BrandMessagingMixin
+  BrandMessagingMixin,
+  MonitorClientMixin
 );
 
 export default SignUpPasswordView;

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -174,6 +174,8 @@ describe('views/sign_in_password', () => {
         // only renders if service is pocket
         assert.lengthOf(view.$('#pocket-pp'), 0);
         assert.lengthOf(view.$('#pocket-tos'), 0);
+        // only renders if service is monitor
+        assert.lengthOf(view.$('#monitor-tos'), 0);
       });
     });
 
@@ -220,7 +222,7 @@ describe('views/sign_in_password', () => {
         hasLinkedAccount: false,
         hasPassword: true,
       });
-      
+
       return view.render().then(() => {
         assert.include(view.$(Selectors.HEADER).text(), 'Enter your password');
         assert.lengthOf(view.$('input[type=password]'), 1);
@@ -246,6 +248,27 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#fxa-tos'), 1);
         assert.lengthOf(view.$('#pocket-pp'), 1);
         assert.lengthOf(view.$('#pocket-tos'), 1);
+        assert.lengthOf(view.$('#monitor-tos'), 0);
+      });
+    });
+
+    it('renders TOS as expected when service is monitor', () => {
+      relier.set({
+        clientId: '802d56ef2a9af9fa',
+      });
+      // Monitor TOS should always show for monitor clients despite
+      // linked account / password state
+      account.set({
+        hasLinkedAccount: true,
+        hasPassword: false,
+      });
+
+      return view.render().then(() => {
+        assert.lengthOf(view.$('#fxa-pp'), 1);
+        assert.lengthOf(view.$('#fxa-tos'), 1);
+        assert.lengthOf(view.$('#pocket-pp'), 0);
+        assert.lengthOf(view.$('#pocket-tos'), 0);
+        assert.lengthOf(view.$('#monitor-tos'), 1);
       });
     });
   });

--- a/packages/fxa-settings/src/components/CardHeader/index.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.tsx
@@ -125,8 +125,13 @@ const serviceLogos: {
 // export const POCKET_CLIENTIDS = [
 //   '7377719276ad44ee', // pocket-mobile
 //   '749818d3f2e7857f', // pocket-web
-//   'dcdb5ae7add825d2', // pocket-web
 // ];
+// This also applies to Monitor
+// export const MONITOR_CLIENTIDS = [
+// '802d56ef2a9af9fa', // Firefox Monitor
+// '946bfd23df91404c', // Firefox Monitor stage
+// 'edd29a80019d61a1', // Firefox Monitor local dev
+// };
 
 const CardHeader = (props: CardHeaderProps) => {
   const { headingText } = props;

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
@@ -9,6 +9,10 @@ terms-privacy-agreement-intro-2 = By proceeding, you agree to the:
 terms-privacy-agreement-pocket = { -product-pocket }’s <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
 # links to Pocket's Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-pocket-2 = { -product-pocket } <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
+# link to Firefox Monitor's Terms of Service and Privacy Notice
+terms-privacy-agreement-monitor = { -product-firefox-monitor }'s <monitorTos>Terms of Service and Privacy Notice</monitorTos>
+# link to Firefox Monitor's Terms of Service and Privacy Notice, part of a bulleted list
+terms-privacy-agreement-monitor-2 = { -product-firefox-monitor } <monitorTos>Terms of Service and Privacy Notice</monitorTos>
 # links to Firefox's Terms of Service and Privacy Notice
 terms-privacy-agreement-firefox = { -brand-firefox }’s <firefoxTos>Terms of Service</firefoxTos> and <firefoxPrivacy>Privacy Notice</firefoxPrivacy>
 # links to Mozilla Accounts Terms of Service and Privacy Notice, part of a bulleted list

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
@@ -25,3 +25,9 @@ export const PocketClient = () => (
     <TermsPrivacyAgreement isPocketClient />
   </AppLayout>
 );
+
+export const MonitorClient = () => (
+  <AppLayout>
+    <TermsPrivacyAgreement isMonitorClient />
+  </AppLayout>
+);

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
@@ -33,6 +33,7 @@ describe('TermsPrivacyAgreement', () => {
 
     const linkElements: HTMLElement[] = screen.getAllByRole('link');
 
+    expect(linkElements).toHaveLength(4);
     expect(linkElements[0]).toHaveAttribute(
       'href',
       'https://getpocket.com/tos/'
@@ -44,4 +45,19 @@ describe('TermsPrivacyAgreement', () => {
     expect(linkElements[2]).toHaveAttribute('href', '/legal/terms');
     expect(linkElements[3]).toHaveAttribute('href', '/legal/privacy');
   });
+});
+
+it('renders component as expected for Monitor clients', () => {
+  renderWithLocalizationProvider(<TermsPrivacyAgreement isMonitorClient />);
+  // testAllL10n(screen, bundle);
+
+  const linkElements: HTMLElement[] = screen.getAllByRole('link');
+
+  expect(linkElements).toHaveLength(3);
+  expect(linkElements[0]).toHaveAttribute(
+    'href',
+    'https://www.mozilla.org/privacy/firefox-monitor/'
+  );
+  expect(linkElements[1]).toHaveAttribute('href', '/legal/terms');
+  expect(linkElements[2]).toHaveAttribute('href', '/legal/privacy');
 });

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
@@ -9,19 +9,21 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 
 export type TermsPrivacyAgreementProps = {
   isPocketClient?: boolean;
+  isMonitorClient?: boolean;
 };
 
 const TermsPrivacyAgreement = ({
   isPocketClient = false,
+  isMonitorClient = false,
 }: TermsPrivacyAgreementProps) => {
-  return (
-    <div className="text-grey-500 mt-5 text-xs">
-      {isPocketClient ? (
-        <>
-          <FtlMsg id="terms-privacy-agreement-intro">
-            <p>By proceeding, you agree to:</p>
-          </FtlMsg>
-          <ul>
+  if (isPocketClient || isMonitorClient) {
+    return (
+      <div className="text-grey-500 mt-5 text-xs">
+        <FtlMsg id="terms-privacy-agreement-intro">
+          <p>By proceeding, you agree to:</p>
+        </FtlMsg>
+        <ul>
+          {isPocketClient && (
             <FtlMsg
               id="terms-privacy-agreement-pocket"
               elems={{
@@ -60,35 +62,65 @@ const TermsPrivacyAgreement = ({
                 </LinkExternal>
               </li>
             </FtlMsg>
+          )}
+          {isMonitorClient && (
             <FtlMsg
-              id="terms-privacy-agreement-firefox"
+              id="terms-privacy-agreement-monitor"
               elems={{
-                firefoxTos: (
-                  <Link className="link-grey" to="/legal/terms">
-                    Terms of Service
-                  </Link>
-                ),
-                firefoxPrivacy: (
-                  <Link className="link-grey" to="/legal/privacy">
-                    Privacy Notice
-                  </Link>
+                monitorTos: (
+                  <LinkExternal
+                    className="link-grey"
+                    href="https://www.mozilla.org/privacy/firefox-monitor/"
+                  >
+                    Terms of Service and Privacy Notice
+                  </LinkExternal>
                 ),
               }}
             >
               <li>
-                Firefox’s{' '}
+                Firefox Monitor's{' '}
+                <LinkExternal
+                  className="link-grey"
+                  href="https://www.mozilla.org/privacy/firefox-monitor/"
+                >
+                  Terms of Service and Privacy Notice
+                </LinkExternal>
+              </li>
+            </FtlMsg>
+          )}
+          {/* Included for both Pocket and Monitor */}
+          <FtlMsg
+            id="terms-privacy-agreement-firefox"
+            elems={{
+              firefoxTos: (
                 <Link className="link-grey" to="/legal/terms">
                   Terms of Service
-                </Link>{' '}
-                and{' '}
+                </Link>
+              ),
+              firefoxPrivacy: (
                 <Link className="link-grey" to="/legal/privacy">
                   Privacy Notice
                 </Link>
-              </li>
-            </FtlMsg>
-          </ul>
-        </>
-      ) : (
+              ),
+            }}
+          >
+            <li>
+              Firefox’s{' '}
+              <Link className="link-grey" to="/legal/terms">
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link className="link-grey" to="/legal/privacy">
+                Privacy Notice
+              </Link>
+            </li>
+          </FtlMsg>
+        </ul>
+      </div>
+    );
+  } else {
+    return (
+      <div className="text-grey-500 mt-5 text-xs">
         <FtlMsg
           id="terms-privacy-agreement-default"
           elems={{
@@ -116,9 +148,9 @@ const TermsPrivacyAgreement = ({
             .
           </p>
         </FtlMsg>
-      )}
-    </div>
-  );
+      </div>
+    );
+  }
 };
 
 export default TermsPrivacyAgreement;

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -63,3 +63,11 @@ export const IsPocketClient = () => (
     serviceName={MozServices.Pocket}
   />
 );
+
+export const IsMonitorClient = () => (
+  <SigninWithProvider
+    email={MOCK_EMAIL}
+    isPasswordNeeded={false}
+    serviceName={MozServices.FirefoxMonitor}
+  />
+);

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -31,6 +31,7 @@ const Signin = ({
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const isPocketClient = serviceName === MozServices.Pocket;
+  const isMonitorClient = serviceName === MozServices.FirefoxMonitor;
   const [error, setError] = useState('');
   const [password, setPassword] = useState('');
   const ftlMsgResolver = useFtlMsgResolver();
@@ -140,7 +141,7 @@ const Signin = ({
          */}
         <ThirdPartyAuth {...{ enabled: false }} />
 
-        <TermsPrivacyAgreement {...{ isPocketClient }} />
+        <TermsPrivacyAgreement {...{ isPocketClient, isMonitorClient }} />
 
         <div className="flex justify-between">
           <FtlMsg id="signin-use-a-different-account">

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -54,6 +54,10 @@ export const ClientIsPocket = storyWithProps({
   integration: createMockSignupOAuthIntegration(MozServices.Pocket),
 });
 
+export const ClientIsMonitor = storyWithProps({
+  integration: createMockSignupOAuthIntegration(MozServices.FirefoxMonitor),
+});
+
 export const ChooseWhatToSyncIsEnabled = storyWithProps({
   integration: createMockSignupSyncDesktopIntegration(),
 });

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -38,10 +38,13 @@ import { BrandMessagingPortal } from '../../components/BrandMessaging';
 
 export const viewName = 'signup';
 
-// TODO, confirm this is how we want to check for Pocket
+// TODO, confirm this is how we want to check for Relying Parties (Monitor/Pocket)
 // There's a similar TODO in CardHeader. FXA-8290
 const isPocketClient = (serviceName: string) =>
   serviceName.includes(MozServices.Pocket);
+
+const isMonitorClient = (serviceName: string) =>
+  serviceName.includes(MozServices.FirefoxMonitor);
 
 const Signup = ({
   integration,
@@ -357,7 +360,10 @@ const Signup = ({
         )}
       </FormPasswordWithBalloons>
 
-      <TermsPrivacyAgreement isPocketClient={isPocketClient(serviceName)} />
+      <TermsPrivacyAgreement
+        isPocketClient={isPocketClient(serviceName)}
+        isMonitorClient={isMonitorClient(serviceName)}
+      />
     </AppLayout>
   );
 };


### PR DESCRIPTION
## Because

* We want to show links to Monitor's terms of service and privacy notice when users are signing in/signing up from that relying party

## This pull request

* Add MoniterClientMixin to conditionally display Monitor terms
* Add monitor terms of service to index, sign_in_password, sign_up_password, set_password, force_auth when the oauth client id corresponds to Monitor's
* Add same terms to React version of the same pages
* Add l10n strings for rebrand to Mozilla account
* Update tests
* Disable 123Done client id from pocket-migration-mixin (intended for testing)

## Issue that this pull request solves

Closes: #FXA-8370

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Signin/signup with Monitor terms
![image](https://github.com/mozilla/fxa/assets/22231637/b9a9bbfe-c1d0-4347-9896-614989876eb5)

## Other information (Optional)

To simulate login to Monitor with 123Done (localhost:8080):
1) Uncomment 123Done client ID on line 12 of `monitor-client-mixin.js`
2) With stack running locally, go to localhost:8080 and click `Email first`

Monitor terms should not be shown:
- when navigating directly to localhost:3030 (non-oauth)
- with 123Done client ID uncommented in `pocket-migration-mixin.js` - this should show Pocket terms (make sure to only uncomment in either Monitor or Pocket mixin when testing with 123Done)
- when signing in with sync (`yarn firefox`, sign in from Firefox hamburger menu)