### PR TITLE
fix(payments): config file missing in build

### DIFF
--- a/apps/payments/next/.env.production.json
+++ b/apps/payments/next/.env.production.json
@@ -1,0 +1,10 @@
+{
+  "mysqlConfig": {
+    "database": "fxa",
+    "port": 3306,
+    "host": "",
+    "user": "",
+    "password": "",
+    "connectionLimitMax": 20
+  }
+}

--- a/apps/payments/next/app/_nestapp/app.module.ts
+++ b/apps/payments/next/app/_nestapp/app.module.ts
@@ -15,9 +15,20 @@ import { RootConfig } from './config';
     TypedConfigModule.forRoot({
       schema: RootConfig,
       load: [
-        dotenvLoader({ separator: '__', ignoreEnvFile: true }),
         fileLoader(),
+        dotenvLoader({
+          separator: '__',
+          ignoreEnvFile: true,
+        }),
       ],
+      normalize(config) {
+        config.mysqlConfig.port = parseInt(config.mysqlConfig.port, 10);
+        config.mysqlConfig.connectionLimitMax = parseInt(
+          config.mysqlConfig.connectionLimitMax,
+          10
+        );
+        return config;
+      },
     }),
   ],
   controllers: [],

--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -16,7 +16,15 @@
         "development": {
           "outputPath": "apps/payments/next"
         },
-        "production": {}
+        "production": {
+          "assets": [
+            {
+              "input": "apps/payments/next",
+              "glob": ".env.production.json",
+              "output": "./../"
+            }
+          ]
+        }
       }
     },
     "serve": {


### PR DESCRIPTION
## Because

- payments-next heartbeat api returns 500 due to missing config file.

## This pull request

- Reorders nest-typed-config loaders so that fileLoader is first, which results in an empty .env.json file to be included in the payments-next build.
- Adds normalization step to config loader, for non-string values.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

