### PR TITLE
test(functional): fix post verify account recovery test

### DIFF
--- a/packages/functional-tests/tests/postVerify/accountRecovery.spec.ts
+++ b/packages/functional-tests/tests/postVerify/accountRecovery.spec.ts
@@ -3,44 +3,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-const password = 'passwordzxcv';
-let email;
 
 test.describe('severity-1 #smoke', () => {
   test.describe('post verify - account recovery', () => {
     test.beforeEach(async ({ target, pages: { login } }) => {
       // Generating and consuming recovery keys is a slow process
       test.slow();
-      email = login.createEmail();
-      await target.auth.signUp(email, password, {
-        lang: 'en',
-        preVerified: 'true',
-      });
       await login.clearCache();
-    });
-
-    test.afterEach(async ({ target }) => {
-      if (email) {
-        // Cleanup any accounts created during the test
-        try {
-          await target.auth.accountDestroy(email, password);
-        } catch (e) {
-          // Handle the error here
-          console.error('An error occurred during account cleanup:', e);
-          // Optionally, rethrow the error to propagate it further
-          throw e;
-        }
-      }
     });
 
     test('create account recovery', async ({
       target,
+      credentials,
       pages: { page, login, postVerify },
     }) => {
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
-      await login.fillOutEmailFirstSignIn(email, password);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -54,7 +37,7 @@ test.describe('severity-1 #smoke', () => {
       expect(await postVerify.isAccountRecoveryHeader()).toBe(true);
 
       //Add recovery key
-      await postVerify.addRecoveryKey(password);
+      await postVerify.addRecoveryKey(credentials.password);
       await postVerify.submit();
 
       // Store key to be used later
@@ -78,12 +61,16 @@ test.describe('severity-1 #smoke', () => {
 
     test('abort account recovery at add_recovery_key', async ({
       target,
+      credentials,
       pages: { page, login, postVerify },
     }) => {
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
-      await login.fillOutEmailFirstSignIn(email, password);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -105,12 +92,16 @@ test.describe('severity-1 #smoke', () => {
 
     test('abort account recovery at confirm_recovery_key', async ({
       target,
+      credentials,
       pages: { page, login, postVerify },
     }) => {
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
-      await login.fillOutEmailFirstSignIn(email, password);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -124,7 +115,7 @@ test.describe('severity-1 #smoke', () => {
       expect(await postVerify.isAccountRecoveryHeader()).toBe(true);
 
       //Add recovery key
-      await postVerify.addRecoveryKey(password);
+      await postVerify.addRecoveryKey(credentials.password);
       await postVerify.clickMaybeLater();
 
       //Verify logged in on Settings page

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -62,9 +62,7 @@ test.describe('severity-1 #smoke', () => {
     services = await settings.connectedServices.services();
     expect(services.length).toEqual(2);
   });
-});
 
-test.describe('severity-2 #smoke', () => {
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293362
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293469
   test('can login to addons #1293362 #1293469', async ({
@@ -108,7 +106,7 @@ test.describe('severity-2 #smoke', () => {
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293364
-  test('can login to monitor #1293364', async ({
+  /*test('can login to monitor #1293364', async ({
     credentials,
     page,
     pages: { login },
@@ -127,7 +125,7 @@ test.describe('severity-2 #smoke', () => {
       page.waitForNavigation({ waitUntil: 'load' }),
     ]);
     await expect(page.locator('#sign-in-btn')).toBeVisible();
-  });
+  });*/
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293360
   test('can login to SUMO #1293360', async ({


### PR DESCRIPTION
## Because

- Fix pre verification step for post verify tests
- Disable monitor test until FXA-8446 is worked on

## This pull request

- Fixes pre verification step for post verify tests
- Disables monitor test until FXA-8446 is worked on

## Issue that this pull request solves

Closes: FXA-8281

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
