### PR TITLE
task(settings): Coerce data types for fields with @bind

### DIFF
--- a/packages/fxa-settings/config/jest/babelTransform.js
+++ b/packages/fxa-settings/config/jest/babelTransform.js
@@ -18,6 +18,11 @@ const hasJsxRuntime = (() => {
 })();
 
 module.exports = babelJest.createTransformer({
+  plugins: [
+    'babel-plugin-transform-typescript-metadata',
+    ['@babel/plugin-proposal-decorators', { legacy: true }],
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
+  ],
   presets: [
     [
       require.resolve('babel-preset-react-app'),

--- a/packages/fxa-settings/config/jest/babelTransform.js
+++ b/packages/fxa-settings/config/jest/babelTransform.js
@@ -20,7 +20,7 @@ const hasJsxRuntime = (() => {
 module.exports = babelJest.createTransformer({
   plugins: [
     'babel-plugin-transform-typescript-metadata',
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
+    ['@babel/plugin-proposal-decorators', { version: 'legacy' }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
   ],
   presets: [

--- a/packages/fxa-settings/config/webpack.config.js
+++ b/packages/fxa-settings/config/webpack.config.js
@@ -431,6 +431,7 @@ module.exports = function (webpackEnv) {
                   ],
                 ],
                 plugins: [
+                  'babel-plugin-transform-typescript-metadata',
                   isEnvDevelopment &&
                     shouldUseReactRefresh &&
                     require.resolve('react-refresh/babel'),

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -176,6 +176,7 @@
     "react-markdown": "^8.0.5",
     "react-refresh": "^0.11.0",
     "react-webcam": "^7.0.0",
+    "reflect-metadata": "^0.1.13",
     "rehype-raw": "^6.1.1",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^4.0.0",
@@ -196,6 +197,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",
+    "@babel/preset-typescript": "^7.23.0",
     "@babel/types": "^7.22.5",
     "@sentry/browser": "^7.66.0",
     "@sentry/integrations": "^7.66.0",
@@ -229,6 +231,7 @@
     "@types/webpack": "5.28.0",
     "babel-loader": "^9.1.3",
     "babel-plugin-named-exports-order": "^0.0.2",
+    "babel-plugin-transform-typescript-metadata": "^0.3.2",
     "eslint": "^7.32.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-jest": "^27.2.1",

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.test.ts
@@ -54,7 +54,7 @@ describe('lib/integrations/integration-factory-flags', function () {
     });
 
     it('when browser is same and verification 1', () => {
-      storageData.set('oauth', { client_id: 'sync' });
+      storageData.set('oauth', JSON.stringify({ client_id: 'sync' }));
       queryData.set('service', 'sync');
       queryData.set('uid', '123');
       queryData.set('code', '123');
@@ -62,7 +62,7 @@ describe('lib/integrations/integration-factory-flags', function () {
     });
 
     it('when browser is same and verification 2', () => {
-      storageData.set('oauth', { client_id: 'sync' });
+      storageData.set('oauth', JSON.stringify({ client_id: 'sync' }));
       queryData.set('service', 'sync');
       queryData.set('token', '123');
       queryData.set('code', '123');
@@ -70,14 +70,14 @@ describe('lib/integrations/integration-factory-flags', function () {
     });
 
     it('when browser is same and verification 3', () => {
-      storageData.set('oauth', { client_id: 'sync' });
+      storageData.set('oauth', JSON.stringify({ client_id: 'sync' }));
       queryData.set('service', 'sync');
       sandbox.replaceGetter(queryData, 'pathName', () => '/report_signin/');
       expect(integrationFlags.isOAuth()).toBeTruthy();
     });
 
     it('when browser is different and verification 1', () => {
-      storageData.set('oauth', { client_id: 'foo' });
+      storageData.set('oauth', JSON.stringify({ client_id: 'foo' }));
       queryData.set('service', 'foo');
       queryData.set('uid', '123');
       queryData.set('code', '123');
@@ -85,7 +85,7 @@ describe('lib/integrations/integration-factory-flags', function () {
     });
 
     it('when browser is different and verification 2', () => {
-      storageData.set('oauth', { client_id: 'foo' });
+      storageData.set('oauth', JSON.stringify({ client_id: 'foo' }));
       queryData.set('service', 'foo');
       queryData.set('uid', '123');
       queryData.set('token', '123');
@@ -93,7 +93,7 @@ describe('lib/integrations/integration-factory-flags', function () {
     });
 
     it('when browser is different and verification 3', () => {
-      storageData.set('oauth', { client_id: 'foo' });
+      storageData.set('oauth', JSON.stringify({ client_id: 'foo' }));
       queryData.set('service', 'foo');
       sandbox.replaceGetter(queryData, 'pathName', () => '/report_signin/');
       expect(integrationFlags.isOAuth()).toBeTruthy();

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -129,7 +129,7 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
   }
 
   private _getSavedClientId() {
-    const oauth = this.storageData.get('oauth');
+    const oauth = JSON.parse(this.storageData.get('oauth') || `{}`);
     if (
       typeof oauth === 'object' &&
       oauth != null &&

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -129,7 +129,7 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
   }
 
   private _getSavedClientId() {
-    const oauth = JSON.parse(this.storageData.get('oauth') || `{}`);
+    const oauth = JSON.parse(this.storageData.get('oauth') || '{}');
     if (
       typeof oauth === 'object' &&
       oauth != null &&

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
@@ -66,7 +66,7 @@ describe('lib/integrations/integration-factory', () => {
       .returns(!!flagOverrides.isV3DesktopContext);
 
     urlQueryData.set('scope', 'profile');
-    urlQueryData.set('client_id', '123');
+    urlQueryData.set('client_id', '720bc80adfa6988d');
     urlQueryData.set('redirect_uri', 'https://redirect.to');
 
     urlHashData.set('scope', 'profile');
@@ -126,11 +126,11 @@ describe('lib/integrations/integration-factory', () => {
       },
       async getClientInfo(clientId: string) {
         return {
-          client_id: '123',
+          client_id: '720bc80adfa6988d',
           redirect_uri: 'https://redirect.to',
           name: 'foo',
           image_uri: 'https://redirect.to/foo',
-          trusted: false,
+          trusted: 'false',
         };
       },
     };
@@ -241,6 +241,7 @@ describe('lib/integrations/integration-factory', () => {
     beforeAll(async () => {
       await mockSearchParams({
         redirect_uri: 'foo',
+        clientId: '720bc80adfa6988d',
       });
       integration = await setup<PairingSupplicantIntegration>(
         { isDevicePairingAsSupplicant: true },

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.ts
@@ -20,6 +20,7 @@ import {
   StorageData,
   UrlHashData,
   UrlQueryData,
+  convertToDataStore,
 } from '../model-data';
 import { OAuthError } from '../oauth';
 import { ReachRouterWindow } from '../window';
@@ -264,7 +265,9 @@ export class IntegrationFactory {
 
     try {
       const serviceInfo = await this.delegates.getClientInfo(clientId);
-      const clientInfo = new ClientInfo(new GenericData(serviceInfo));
+      const clientInfo = new ClientInfo(
+        new GenericData(convertToDataStore(serviceInfo))
+      );
       return clientInfo;
     } catch (err) {
       if (

--- a/packages/fxa-settings/src/lib/model-data/bind-decorator.spec.ts
+++ b/packages/fxa-settings/src/lib/model-data/bind-decorator.spec.ts
@@ -5,7 +5,14 @@
 import { bind, KeyTransforms as T, getBoundKeys } from './bind-decorator';
 import { GenericData } from './data-stores';
 import { ModelDataProvider } from './model-data-provider';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 /**
  * Example model for testing bind decorators
@@ -17,13 +24,36 @@ class TestModel extends ModelDataProvider {
   testField: string | undefined;
 
   @IsOptional()
-  @IsString()
+  @IsNumber()
+  @bind(T.snakeCase)
+  testFieldNumber: number | undefined;
+
+  @IsOptional()
+  @IsBoolean()
+  @bind(T.snakeCase)
+  testFieldBoolean: boolean | undefined;
+
+  @IsOptional()
+  @IsObject()
+  @bind(T.snakeCase)
+  testFieldObject: { foo: string; bar?: string } | undefined;
+
+  @IsOptional()
   @IsNotEmpty()
+  @IsString()
   @bind(T.snakeCase)
   testValidatedField: string | undefined;
 }
 
 describe('bind-decorator', function () {
+  const defaultState = {
+    test_field: '1',
+    test_field_number: `2`,
+    test_field_boolean: `true`,
+    test_field_object: JSON.stringify({ foo: 'bar' }),
+    test_validated_field: `1`,
+  };
+
   it('creates with empty state', () => {
     const data = new GenericData({});
     const model1 = new TestModel(data);
@@ -31,26 +61,39 @@ describe('bind-decorator', function () {
   });
 
   it('creates with state', () => {
-    const data = new GenericData({ test_field: '1' });
+    const data = new GenericData(defaultState);
     const model1 = new TestModel(data);
     expect(model1.testField).toEqual('1');
+    expect(model1.testFieldBoolean).toEqual(true);
+    expect(model1.testFieldNumber).toEqual(2);
+    expect(model1.testFieldObject).toEqual({ foo: 'bar' });
   });
 
   it('initializes with valid state', () => {
-    const data = new GenericData({ test_validated_field: '1' });
+    const data = new GenericData(defaultState);
     const model1 = new TestModel(data);
     expect(model1.testValidatedField).toEqual('1');
   });
 
   it('maintains state', () => {
-    const data = new GenericData({ test_field: '1' });
+    const data = new GenericData(defaultState);
     const model1 = new TestModel(data);
     expect(model1.testField).toEqual('1');
+    expect(model1.testFieldBoolean).toEqual(true);
+    expect(model1.testFieldNumber).toEqual(2);
+    expect(model1.testFieldObject).toEqual({ foo: 'bar' });
 
     model1.testField = '2';
+    model1.testValidatedField = '3';
+    model1.testFieldBoolean = false;
+    model1.testFieldNumber = 3;
+    model1.testFieldObject = { foo: 'baz' };
 
     expect(model1.testField).toEqual('2');
-    expect(data.get('test_field')).toEqual('2');
+    expect(model1.testValidatedField).toEqual('3');
+    expect(model1.testFieldBoolean).toEqual(false);
+    expect(model1.testFieldNumber).toEqual(3);
+    expect(model1.testFieldObject).toEqual({ foo: 'baz' });
   });
 
   it('reflects data change', () => {
@@ -63,7 +106,7 @@ describe('bind-decorator', function () {
 
   it('throws on validation of invalid state', () => {
     const data = new GenericData({
-      test_validated_field: { foo: 'bar' },
+      test_validated_field: ``,
     });
     const model1 = new TestModel(data);
     expect(() => {
@@ -73,7 +116,7 @@ describe('bind-decorator', function () {
 
   it('throws on access of a invalid state', () => {
     const data = new GenericData({
-      test_validated_field: { foo: 'bar' },
+      test_validated_field: ``,
     });
     const model1 = new TestModel(data);
     expect(() => {
@@ -86,6 +129,8 @@ describe('bind-decorator', function () {
     const model1 = new TestModel(data);
     expect(() => {
       model1.testValidatedField = '';
+
+      model1.validate();
     }).toThrow();
   });
 
@@ -102,7 +147,13 @@ describe('bind-decorator', function () {
     const data = new GenericData({});
     const model1 = new TestModel(data);
 
-    expect(getBoundKeys(model1)).toEqual(['testField', 'testValidatedField']);
+    expect(getBoundKeys(model1)).toEqual([
+      'testField',
+      'testFieldNumber',
+      'testFieldBoolean',
+      'testFieldObject',
+      'testValidatedField',
+    ]);
   });
 
   it('gets data directly', () => {
@@ -126,12 +177,6 @@ describe('bind-decorator', function () {
     expect(model1.getModelData('test_field') !== null).toBeTruthy();
   });
 
-  it('will not set invalid data directly', () => {
-    const data = new GenericData({});
-    const model1 = new TestModel(data);
-    expect(() => model1.setModelData('test_field', 0)).toThrow();
-  });
-
   it('will not get invalid data directly', () => {
     const data = new GenericData({ test_validated_field: '' });
     const model1 = new TestModel(data);
@@ -141,11 +186,11 @@ describe('bind-decorator', function () {
   it('sets invalid when validate is specified as false', () => {
     const data = new GenericData({ test_field: 'foo' });
     const model1 = new TestModel(data);
-    expect(() => model1.setModelData('test_field', 0, false)).not.toThrow();
+    expect(() => model1.setModelData('test_field', '0', false)).not.toThrow();
   });
 
   it('gets invalid when validate is specified as false', () => {
-    const data = new GenericData({ test_field: 0 });
+    const data = new GenericData({ test_field: '0' });
     const model1 = new TestModel(data);
     expect(() => model1.getModelData('test_field', false)).not.toThrow();
   });

--- a/packages/fxa-settings/src/lib/model-data/bind-decorator.ts
+++ b/packages/fxa-settings/src/lib/model-data/bind-decorator.ts
@@ -1,8 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import 'reflect-metadata';
 import { ModelDataProvider, isModelDataProvider } from './model-data-provider';
+import 'reflect-metadata';
+
+export type dataType =
+  // The value should retrieved as a string
+  | 'string'
+  // The value should be retrieved as a boolean
+  | 'boolean'
+  // The value should be retrieved as a number
+  | 'number'
+  // The value should be retrieved as an object
+  | 'object';
 
 /**
  * Turns a field name into a lookup key. This can be one of three states.
@@ -107,17 +117,18 @@ export const bind = <T>(dataKey?: KeyTransform) => {
         if (!isModelDataProvider(this)) {
           throw new InvalidModelInstance();
         }
-
         const key = getKey(dataKey, memberName);
-        this.setModelData(key, value);
+        const type = getType(this, memberName);
+        this.setModelData(key, writeRawValue(value, type));
       },
       get: function () {
         if (!isModelDataProvider(this)) {
           throw new InvalidModelInstance();
         }
-
         const key = getKey(dataKey, memberName);
-        return this.getModelData(key);
+        const value = this.getModelData(key, true);
+        const type = getType(this, memberName);
+        return coerceValue(value, type);
       },
     };
     Object.defineProperty(model, memberName, property);
@@ -134,4 +145,95 @@ export class InvalidModelInstance extends Error {
       'Invalid bind! Does the model is not an an instance of ModelDataProvider. Check that the model inherits from ModelDataProvider.'
     );
   }
+}
+function writeRawValue(value: any, dataType: dataType | undefined) {
+  if (dataType !== undefined && typeof value !== dataType) {
+    throw new Error(
+      `Data type mismatch! Type safety violated! Cannot assign ${typeof value} to ${dataType}.`
+    );
+  }
+  if (dataType === 'object') {
+    return JSON.stringify(value);
+  }
+  return value.toString();
+}
+
+/**
+ * Takes a string value and tries to convert it to the specified data type.
+ * @param value - raw string value
+ * @param dataType - expected type
+ * @returns - a value of the specified type
+ */
+function coerceValue(
+  value: string | undefined,
+  dataType: dataType | undefined
+): string | boolean | number | any | null {
+  if (value == null) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (dataType === 'string') {
+      return value;
+    }
+
+    if (dataType === 'number') {
+      return parseFloat(value);
+    }
+
+    if (dataType === 'boolean') {
+      const lower = value.toLowerCase().trim();
+      if (lower !== 'true' && lower !== 'false') {
+        throw new Error('Invalid boolean value: ' + value);
+      }
+      return value === 'true';
+    }
+
+    // Value is a string with unknown data type or data type of object
+    try {
+      return JSON.parse(value);
+    } catch {
+      console.warn(`Cannot JSON parse value! ${value}`);
+    }
+
+    return value;
+  }
+
+  throw new Error(
+    `Data type mismatch! Type safety violated! Cannot coerce ${typeof value} (${value}) to ${dataType}.`
+  );
+}
+
+/**
+ * Uses reflection to determine the expected type of a class property
+ * @param target - instance
+ * @param memberName - property / member name
+ * @returns The expected data type of the property
+ */
+function getType(target: any, memberName: string): dataType {
+  const designType = Reflect.getMetadata(
+    'design:type',
+    target,
+    memberName
+  )?.toString();
+
+  // The reflect meta data package realizes these fields as functions with returns types. This mapping let us extract the underlying type.
+  if (
+    designType === 'boolean' ||
+    designType?.startsWith('function Boolean()')
+  ) {
+    return 'boolean';
+  }
+  if (designType === 'number' || designType?.startsWith('function Number()')) {
+    return 'number';
+  }
+  if (designType === 'string' || designType?.startsWith('function String()')) {
+    return 'string';
+  }
+  if (designType === 'object' || designType?.startsWith('function Object()')) {
+    return 'object';
+  }
+
+  // No design type is available, fallback to string
+  return 'string';
 }

--- a/packages/fxa-settings/src/lib/model-data/data-stores/generic-data.test.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/generic-data.test.ts
@@ -20,4 +20,10 @@ describe('generic-data', () => {
     const data = new GenericData({});
     expect(data.requiresSync()).toBeFalsy();
   });
+
+  it('will not accept nested objects', () => {
+    expect(() => {
+      new GenericData({ foo: { bar: 'baz' } } as any);
+    }).toThrowError();
+  });
 });

--- a/packages/fxa-settings/src/lib/model-data/data-stores/generic-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/generic-data.ts
@@ -2,26 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { ModelDataStore } from '../model-data-store';
+import { ModelDataStore, RawData } from '../model-data-store';
 
 /**
  * A simple generic data store. Good for testing or simple state management.
  * Stores state in record object.
  */
 export class GenericData extends ModelDataStore {
-  constructor(protected readonly state: Record<string, unknown>) {
+  constructor(protected readonly state: Record<string, RawData>) {
     super();
+    this.checkDataStore();
   }
 
-  public getKeys() {
+  public getKeys(): Iterable<string> {
     return Object.keys(this.state);
   }
 
-  public get(key: string) {
+  public get(key: string): RawData {
     return this.state[key];
   }
 
-  public set(key: string, value: unknown) {
+  public set(key: string, value: RawData): void {
     this.state[key] = value;
   }
 }

--- a/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReachRouterWindow } from '../../window';
-import { ModelDataStore } from '../model-data-store';
+import { RawData, ModelDataStore } from '../model-data-store';
 
 // TODO: Adapt to using ../../storage implementation. We need a way to migrate / deal with the namespace issue though.
 
@@ -14,7 +14,7 @@ export class StorageData extends ModelDataStore {
   private static readonly NAMESPACE = '__fxa_session';
   private static readonly PERSIST_TO_LOCAL_STORAGE = ['oauth'];
 
-  private state: Record<string, unknown>;
+  private state: Record<string, RawData>;
 
   constructor(private window: ReachRouterWindow) {
     super();
@@ -101,11 +101,11 @@ export class StorageData extends ModelDataStore {
     return Object.keys(this.state);
   }
 
-  public get(key: string) {
+  public get(key: string): RawData {
     return this.state[key];
   }
 
-  public set(key: string, value: unknown) {
+  public set(key: string, value: RawData) {
     this.state[key] = value;
   }
 }

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-data.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReachRouterWindow } from '../../window';
-import { ModelDataStore } from '../model-data-store';
+import { ModelDataStore, RawData } from '../model-data-store';
 
 /**
  * An abstract base class for persisting state in the URL.
@@ -28,50 +28,21 @@ export abstract class UrlData extends ModelDataStore {
     return this.getParams().keys();
   }
 
-  get(key: string): unknown {
+  get(key: string): RawData {
     const params = this.getParams();
     const value = params?.get(key);
-    if (value == null) {
-      return null;
-    }
-
-    if (isJson(value)) {
-      return JSON.parse(value);
-    }
-    return value;
+    return value === null ? undefined : value;
   }
 
-  set(key: string, val: unknown): void {
-    let raw = toStringOrJsonString(val);
-
-    if (raw == null) {
+  set(key: string, val: RawData): void {
+    if (val == null) {
       return;
     }
-
     // Get current state from URL
     const params = this.getParams();
-    params.set(key, raw);
+    params.set(key, val);
 
     // Write back to url.
     this.setParams(params);
   }
-}
-
-export function isJson(value: string) {
-  return /^["\\|\\{]/.test(value);
-}
-
-export function toStringOrJsonString(value: unknown) {
-  let raw: string | undefined;
-
-  if (typeof value === 'string') {
-    raw = value;
-  } else if (typeof value === 'number') {
-    raw = value.toString();
-  } else if (typeof value === 'boolean') {
-    raw = value.toString();
-  } else if (typeof value === 'object') {
-    raw = JSON.stringify(value);
-  }
-  return raw;
 }

--- a/packages/fxa-settings/src/lib/model-data/model-data-provider.ts
+++ b/packages/fxa-settings/src/lib/model-data/model-data-provider.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { validateSync, ValidationError } from 'class-validator';
-import { ModelDataStore } from './model-data-store';
+import { ModelDataStore, RawData } from './model-data-store';
 
 /**
  * Type guard for validating model
@@ -33,10 +33,15 @@ export class ModelDataProvider {
    * @param validate Whether or not to validate. Optional and defaults to true.
    * @returns underlying data
    */
-  setModelData(key: string, value: unknown, validate = true) {
+  setModelData(key: string, value: RawData, validate = true) {
     if (this.modelData == null) {
       throw new Error(
         'Invalid bind! Has the data store for the model been initialized?'
+      );
+    }
+    if (typeof value !== 'string') {
+      throw new Error(
+        'Model data not serialized! Convert to string before storing!'
       );
     }
     const currentValue = this.modelData.get(key);

--- a/packages/fxa-settings/src/lib/model-data/model-data-store.spec.ts
+++ b/packages/fxa-settings/src/lib/model-data/model-data-store.spec.ts
@@ -1,20 +1,24 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { ModelDataStore } from './model-data-store';
+import {
+  ModelDataStore,
+  RawData,
+  convertToDataStore,
+} from './model-data-store';
 
 class TestModelData extends ModelDataStore {
   getKeys(): Iterable<string> {
     return Object.keys(this.dataStore);
   }
-  get(key: string): unknown {
+  get(key: string): RawData {
     return this.dataStore[key];
   }
-  set(key: string, val: unknown): void {
+  set(key: string, val: RawData): void {
     this.dataStore[key] = val;
   }
 
-  constructor(public readonly dataStore: Record<string, unknown> = {}) {
+  constructor(public readonly dataStore: Record<string, RawData> = {}) {
     super();
   }
 }
@@ -49,5 +53,10 @@ describe('model-data', function () {
     model.fromJSON('{"foo":"bar"}');
     expect(model.get('foo')).toEqual('bar');
     expect(model.getKeys()).toEqual(['foo']);
+  });
+
+  it('converts to data store', () => {
+    const data = convertToDataStore({ foo: { bar: 'baz' } });
+    expect(data.foo).toEqual('{"bar":"baz"}');
   });
 });

--- a/packages/fxa-settings/src/lib/model-data/model-data-store.ts
+++ b/packages/fxa-settings/src/lib/model-data/model-data-store.ts
@@ -2,13 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/** Type of data allowed in store */
+export type RawData = string | undefined;
+
+/** Holds data in valid format */
+export type DataStore = Record<string, RawData>;
+
+/**
+ * Ensures that data is in correct format. Records must be of type Record<string, RawData>, however, it's possible
+ * this eludes type checking. This function ensures that the data is in the correct format.
+ * @param data
+ */
+export function convertToDataStore(data: any): DataStore {
+  const clone = JSON.parse(JSON.stringify(data));
+  for (const k in clone) {
+    if (typeof clone[k] === 'object') {
+      clone[k] = JSON.stringify(data[k]);
+    } else {
+      clone[k] = clone[k].toString();
+    }
+  }
+  return clone;
+}
+
 /**
  * Abstract base class for model data store classes
  */
 export abstract class ModelDataStore {
   abstract getKeys(): Iterable<string>;
-  abstract get(key: string): unknown;
-  abstract set(key: string, val: unknown): void;
+  abstract get(key: string): RawData;
+  abstract set(key: string, val: RawData): void;
 
   requiresSync(): boolean {
     return false;
@@ -37,7 +60,26 @@ export abstract class ModelDataStore {
     });
   }
 
+  getDataStore(): DataStore {
+    const dataStore: DataStore = {};
+    for (const key of this.getKeys()) {
+      dataStore[key] = this.get(key);
+    }
+    return dataStore;
+  }
+
   async synchronized() {
     // no-op - used for data stores that have async setters
+  }
+
+  checkDataStore() {
+    for (const key of this.getKeys()) {
+      const value = this.get(key);
+      if (value !== undefined && typeof value !== 'string') {
+        throw new Error(
+          'GenericData must of type Record<string, RawData>. Try calling convertToDataStore() on your data before passing it to GenericData.'
+        );
+      }
+    }
   }
 }

--- a/packages/fxa-settings/src/lib/model-data/model-data-store.ts
+++ b/packages/fxa-settings/src/lib/model-data/model-data-store.ts
@@ -13,7 +13,7 @@ export type DataStore = Record<string, RawData>;
  * this eludes type checking. This function ensures that the data is in the correct format.
  * @param data
  */
-export function convertToDataStore(data: any): DataStore {
+export function convertToDataStore(data: Record<string, any>): DataStore {
   const clone = JSON.parse(JSON.stringify(data));
   for (const k in clone) {
     if (typeof clone[k] === 'object') {

--- a/packages/fxa-settings/src/models/integrations/base-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/base-integration.ts
@@ -118,6 +118,19 @@ export abstract class Integration<
       }
     }
 
+    // TODO: Not 100% sure about this
+    // If the service is the same as the client info id, then use that service name
+    if (this.clientInfo) {
+      const clientInfo = await this.clientInfo;
+      if (
+        clientInfo?.clientId &&
+        clientInfo?.serviceName &&
+        clientInfo?.clientId === this.data.service
+      ) {
+        return clientInfo.serviceName;
+      }
+    }
+
     // Fallback to defacto service names
     switch (this.data.service) {
       case MozServices.FirefoxSync:

--- a/packages/fxa-settings/src/models/integrations/channel-info.test.ts
+++ b/packages/fxa-settings/src/models/integrations/channel-info.test.ts
@@ -30,7 +30,7 @@ describe('models/integrations/channel-info', function () {
   });
 
   it('validates', () => {
-    data.set('channel_id', {});
+    data.set('channel_id', '{}');
     expect(() => {
       model.validate();
     }).toThrow();

--- a/packages/fxa-settings/src/models/integrations/client-info.test.ts
+++ b/packages/fxa-settings/src/models/integrations/client-info.test.ts
@@ -23,14 +23,13 @@ describe('models/integrations/client-info', function () {
     data.set('image_uri', 'https://redirect.to/foo/profile/bar.png');
     data.set('name', 'foo');
     data.set('redirect_uri', 'https://redirect.to');
-    data.set('trusted', true);
+    data.set('trusted', 'true');
 
     expect(model.clientId).toEqual('123ABC');
     expect(model.imageUri).toEqual('https://redirect.to/foo/profile/bar.png');
     expect(model.serviceName).toEqual('foo');
     expect(model.redirectUri).toEqual('https://redirect.to');
     expect(model.trusted).toEqual(true);
-    expect(model.clientId).toEqual('123ABC');
   });
 
   it('validates', () => {

--- a/packages/fxa-settings/src/models/integrations/client-info.ts
+++ b/packages/fxa-settings/src/models/integrations/client-info.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  IsHexadecimal,
   IsOptional,
   IsString,
   IsBoolean,
+  IsHexadecimal,
 } from 'class-validator';
 import {
   bind,

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -16,12 +16,13 @@ import { IntegrationFlags } from '../../lib/integrations';
 import { BaseIntegrationData } from './web-integration';
 import {
   IsBoolean,
-  IsBooleanString,
   IsEmail,
   IsHexadecimal,
   IsIn,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
   MaxLength,
   MinLength,
@@ -107,11 +108,11 @@ export class OAuthIntegrationData extends BaseIntegrationData {
   @bind(T.snakeCase)
   idTokenHint: string | undefined;
 
-  // TODO: Validation - this should be converted to a number and then checked if it's >= 0
   @IsOptional()
-  @IsString()
+  @IsNumber()
+  @IsPositive()
   @bind(T.snakeCase)
-  maxAge: string | undefined;
+  maxAge: number | undefined;
 
   @IsOptional()
   @IsString()
@@ -142,10 +143,10 @@ export class OAuthIntegrationData extends BaseIntegrationData {
   @bind(T.snakeCase)
   redirectUri: string | undefined;
 
-  @IsBooleanString()
+  @IsBoolean()
   @IsOptional()
   @bind(T.snakeCase)
-  returnOnError: 'true' | 'false' | undefined;
+  returnOnError: boolean | undefined;
 
   // TODO - Validation - Should scope be required?
   @IsOptional()
@@ -214,11 +215,14 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
   }
 
   saveOAuthState() {
-    this.storageData.set('oauth', {
-      client_id: this.data.clientId,
-      scope: this.data.scope,
-      state: this.data.state,
-    });
+    this.storageData.set(
+      'oauth',
+      JSON.stringify({
+        client_id: this.data.clientId,
+        scope: this.data.scope,
+        state: this.data.state,
+      })
+    );
     this.storageData.persist();
   }
 
@@ -312,6 +316,11 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
   }
 
   async getPermissions() {
+    // TODO: Not 100% sure about this...
+    if (!this.data.scope) {
+      return [];
+    }
+
     // Ported from content server, search for _normalizeScopesAndPermissions
     let permissions = Array.from(scopeStrToArray(this.data.scope || ''));
     if (await this.isTrusted()) {

--- a/packages/fxa-settings/src/models/integrations/signin-signup-info.ts
+++ b/packages/fxa-settings/src/models/integrations/signin-signup-info.ts
@@ -4,12 +4,14 @@
 
 import {
   IsBase64,
-  IsBooleanString,
+  IsBoolean,
   IsEmail,
   IsHexadecimal,
   IsIn,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
 } from 'class-validator';
 import {
@@ -69,11 +71,11 @@ export class SignInSignUpInfo extends ModelDataProvider {
   @bind(T.snakeCase)
   loginHint: string | undefined;
 
-  // TODO: Validation - this should be converted to a number and then checked if it's >= 0
   @IsOptional()
-  @IsString()
+  @IsNumber()
+  @IsPositive()
   @bind(T.snakeCase)
-  maxAge: string | undefined;
+  maxAge: number | undefined;
 
   @IsOptional()
   @IsIn(['consent', 'none', 'login'])
@@ -93,9 +95,9 @@ export class SignInSignUpInfo extends ModelDataProvider {
   redirectTo: string | undefined;
 
   @IsOptional()
-  @IsBooleanString()
+  @IsBoolean()
   @bind(T.snakeCase)
-  returnOnError: 'true' | 'false' | undefined;
+  returnOnError: boolean | undefined;
 
   @IsOptional()
   @IsString()

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -99,7 +99,7 @@ export function mockStorage() {
   };
 }
 
-export function mockUrlQueryData(params: Record<string, unknown>) {
+export function mockUrlQueryData(params: Record<string, string | undefined>) {
   const window = new ReachRouterWindow();
   const data = new UrlQueryData(window);
   for (const param of Object.keys(params)) {

--- a/packages/fxa-settings/src/models/pages/signup/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signup/query-params.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsBooleanString, IsEmail, IsOptional } from 'class-validator';
+import { IsBoolean, IsEmail, IsOptional } from 'class-validator';
 import { bind, ModelDataProvider } from '../../../lib/model-data';
 
 export class SignupQueryParams extends ModelDataProvider {
@@ -14,7 +14,7 @@ export class SignupQueryParams extends ModelDataProvider {
   email: string = '';
 
   @IsOptional()
-  @IsBooleanString()
+  @IsBoolean()
   @bind()
-  emailFromContent: string = '';
+  emailFromContent: boolean = false;
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -93,7 +93,7 @@ export const Subject = ({
   params = mockCompleteResetPasswordParams,
 }: {
   integrationType?: IntegrationType;
-  params?: Record<string, unknown>;
+  params?: Record<string, string | undefined>;
 }) => {
   const urlQueryData = mockUrlQueryData(params);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5405,7 +5405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.23.2":
+"@babel/preset-typescript@npm:^7.23.0, @babel/preset-typescript@npm:^7.23.2":
   version: 7.23.2
   resolution: "@babel/preset-typescript@npm:7.23.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -24515,7 +24515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-transform-typescript-metadata@npm:^0.3.1":
+"babel-plugin-transform-typescript-metadata@npm:^0.3.1, babel-plugin-transform-typescript-metadata@npm:^0.3.2":
   version: 0.3.2
   resolution: "babel-plugin-transform-typescript-metadata@npm:0.3.2"
   dependencies:
@@ -35306,6 +35306,7 @@ fsevents@~2.1.1:
   dependencies:
     "@apollo/client": ^3.4.5
     "@babel/core": ^7.22.5
+    "@babel/preset-typescript": ^7.23.0
     "@babel/types": ^7.22.5
     "@emotion/react": ^11.11.1
     "@emotion/styled": ^11.10.4
@@ -35351,6 +35352,7 @@ fsevents@~2.1.1:
     babel-loader: ^9.1.3
     babel-plugin-named-asset-import: ^0.3.8
     babel-plugin-named-exports-order: ^0.0.2
+    babel-plugin-transform-typescript-metadata: ^0.3.2
     babel-preset-react-app: ^10.0.1
     base32-decode: ^1.0.0
     base32-encode: ^1.2.0
@@ -35409,6 +35411,7 @@ fsevents@~2.1.1:
     react-markdown: ^8.0.5
     react-refresh: ^0.11.0
     react-webcam: ^7.0.0
+    reflect-metadata: ^0.1.13
     rehype-raw: ^6.1.1
     resolve: ^1.20.0
     resolve-url-loader: ^4.0.0


### PR DESCRIPTION
## Because

- We want to be able to use a wide array of data types in our classes not just strings

## This pull request

- Updates bind decorator to reflect on property metadata and return the right type
- Switches validation from IsBooleanString to IsBoolean
- Switches IsString to IsNumber for numeric values
- Adds reflect-metadata and corresponding transforms to settings


## Issue that this pull request solves

Closes: FXA-8199

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
