### PR TITLE
fix(react): Signup submit can be enabled if password autofilled

### DIFF
--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -35,7 +35,6 @@ export class SignupReactPage extends BaseLayout {
   async setAge(value: string) {
     const ageInput = await this.page.getByLabel('How old are you?');
     await ageInput.fill(value);
-    await ageInput.blur();
   }
 
   async setCode(value: string) {

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -239,15 +239,12 @@ describe('Signup page', () => {
       fireEvent.input(screen.getByLabelText('Password'), {
         target: { value: MOCK_PASSWORD },
       });
-      fireEvent.blur(passwordInput);
       fireEvent.input(screen.getByLabelText('Repeat password'), {
         target: { value: MOCK_PASSWORD },
       });
-      fireEvent.blur(repeatPasswordInput);
       fireEvent.input(ageInput, {
         target: { value: age },
       });
-      fireEvent.blur(ageInput);
 
       await waitFor(() => {
         expect(

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -99,7 +99,7 @@ const Signup = ({
 
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<SignupFormData>({
-      mode: 'onBlur',
+      mode: 'onChange',
       criteriaMode: 'all',
       defaultValues: {
         email: queryParamModel.email,


### PR DESCRIPTION
## Because

* Submit button was not enabled if password field was autofilled by password manager, even if all form requirements met
* Validation was only happening if all inputs blurred

## This pull request

* Change onBlur form validation mode to onChange
* Update related tests

## Issue that this pull request solves

Closes: #FXA-8331

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

✅  Checked that form submission is disabled if password requirements are not met, passwords do not match, or any field is empty.
✅ Checked that form submission is enabled if all requirements above met and password field was autofilled and we don't manually touch/change/blur it