### PR TITLE
fix(auth): replace ts alias with relative paths

### DIFF
--- a/packages/fxa-auth-server/config/supportedLanguages.js
+++ b/packages/fxa-auth-server/config/supportedLanguages.js
@@ -7,4 +7,4 @@
 // The list below should be kept in sync with:
 // https://github.com/mozilla/fxa/blob/main/libs/shared/l10n/src/lib/supportedLanguages.json
 
-module.exports = require('@fxa/shared/l10n').supportedLanguages;
+module.exports = require('../../../libs/shared/l10n/src').supportedLanguages;

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -7,10 +7,11 @@
 const Joi = require('joi');
 const createBackendServiceAPI = require('./backendService');
 const { config } = require('../config');
-const localizeTimestamp = require('@fxa/shared/l10n').localizeTimestamp({
-  supportedLanguages: config.get('i18n').supportedLanguages,
-  defaultLanguage: config.get('i18n').defaultLanguage,
-});
+const localizeTimestamp =
+  require('../../../libs/shared/l10n/src').localizeTimestamp({
+    supportedLanguages: config.get('i18n').supportedLanguages,
+    defaultLanguage: config.get('i18n').defaultLanguage,
+  });
 const serviceName = 'customs';
 
 module.exports = function (log, error, statsd) {

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -17,7 +17,7 @@ const {
 const { productDetailsFromPlan } = require('fxa-shared').subscriptions.metadata;
 const Renderer = require('./renderer').default;
 const { NodeRendererBindings } = require('./renderer/bindings-node');
-const { determineLocale } = require('@fxa/shared/l10n');
+const { determineLocale } = require('../../../../libs/shared/l10n/src');
 
 const TEMPLATE_VERSIONS = require('./emails/templates/_versions.json');
 

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -19,7 +19,7 @@ const { HEX_STRING } = require('./routes/validators');
 const { configureSentry } = require('./sentry');
 const { swaggerOptions } = require('../docs/swagger/swagger-options');
 const { Account } = require('fxa-shared/db/models/auth');
-const { determineLocale } = require('@fxa/shared/l10n');
+const { determineLocale } = require('../../../libs/shared/l10n/src');
 const {
   reportValidationError,
 } = require('fxa-shared/sentry/report-validation-error');

--- a/packages/fxa-auth-server/scripts/bulk-mailer/normalize-user-records.js
+++ b/packages/fxa-auth-server/scripts/bulk-mailer/normalize-user-records.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const leftpad = require('leftpad');
-const { determineLocale } = require('@fxa/shared/l10n');
+const { determineLocale } = require('../../../../libs/shared/l10n/src');
 
 module.exports = class UserRecordNormalizer {
   /**


### PR DESCRIPTION
## Because

- fxa-auth-server is failing to start up in build since TypeScript path aliases are still present in JavaScript files.

## This pull request

- Replace ts path aliases in fxa-auth-server JS files, with relative paths.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).