### PR TITLE
refactor(l10n): Remove old fxa-react FF account strings

### DIFF
--- a/packages/fxa-react/components/Head/en.ftl
+++ b/packages/fxa-react/components/Head/en.ftl
@@ -1,13 +1,7 @@
 ## FxA React - Strings shared between multiple FxA products for application page title
 
-app-default-title = { -product-firefox-accounts }
 # This string is used as the default title for pages, displayed in the browser tab.
 app-default-title-2 = { -product-mozilla-accounts }
-# This string is used as the title of the page.
-# Variables:
-#   $title (String) - the name of the current page
-#                      (for example: "Two-step authentication")
-app-page-title = { $title } | { -product-firefox-accounts }
 # This string is used as the title of the page, displayed in the browser tab.
 # Variables:
 #   $title (String) - the name of the current page

--- a/packages/fxa-react/components/LogoLockup/en.ftl
+++ b/packages/fxa-react/components/LogoLockup/en.ftl
@@ -1,8 +1,4 @@
 ## FxA React - Strings shared between multiple FxA products for logo lockup
 
-app-logo-alt =
-  .alt = { -brand-firefox } logo
-app-logo-alt-2 =
-  .alt = { -brand-mozilla } logo
 app-logo-alt-3 =
   .alt = { -brand-mozilla } m logo

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
@@ -4,6 +4,5 @@ header-menu-open = Close menu
 header-menu-closed = Site navigation menu
 header-back-to-top-link =
   .title = Back to top
-header-title = Firefox Account
 header-title-2 = { -product-mozilla-account }
 header-help = Help


### PR DESCRIPTION
Because:
* We are no longer using these strings

This commit:
* Removes old strings

---

**Do not merge until new strings are in production**.

This was originally part of #15911, but Bryan asked me in review if the string removal could cause any problems and I realized it would if we make any dot releases; English fallback text would show since the IDs wouldn't be found.