### PR TITLE
task(auth): Add brand messaging to subplat emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -137,6 +137,7 @@ tr > td:first-child {
 }
 
 %banner-common {
+  max-width: 640px !important;
   width: 100% !important;
   background: linear-gradient(88.76deg, #E4EAF6 3.37%, #DBEEF8 39.93%, #DAF3F4 65.09%, #E3F6ED 102.21%);
   background-color: #DBEEF8;

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -12,118 +12,123 @@
     <%- include('/partials/metadata.mjml') %>
   </mj-head>
 
-  <mj-body css-class="body">
+  <mj-body>
     <mj-include path="<%- locals.cssPath %>/global.css" type="css" css-inline="inline" />
     <mj-include path="<%- locals.cssPath %>/subscription/index.css" type="css" css-inline="inline" />
     <mj-include path="<%- locals.cssPath %>/locale-dir.css" type="css" />
+    <%- include('/partials/brandMessaging/index.mjml') %>
 
-    <% if (locals.preHeader) { %>
-      <mj-section>
+    <mj-wrapper css-class="body">
+      <% if (locals.preHeader) { %>
+        <mj-section>
+          <mj-column>
+            <mj-text css-class="hidden">
+              <%- preHeader %>
+              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
+            </mj-text>
+          </mj-column>
+        </mj-section>
+      <% } %>
+
+      <mj-section css-class="header-container">
         <mj-column>
-          <mj-text css-class="hidden">
-            <%- preHeader %>
-            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-            ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
-          </mj-text>
+          <mj-image css-class="fxa-logo-firefox"
+            width="171px"
+            align="left"
+            href="https://www.mozilla.org/firefox/new"
+            src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo-email.png"
+            alt="Firefox logo"
+            title="Firefox">
+          </mj-image>
         </mj-column>
       </mj-section>
-    <% } %>
+    </mj-wrapper>
 
-    <mj-section css-class="header-container">
-      <mj-column>
-        <mj-image css-class="fxa-logo-firefox"
-          width="171px"
-          align="left"
-          href="https://www.mozilla.org/firefox/new"
-          src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo-email.png"
-          alt="Firefox logo"
-          title="Firefox">
-        </mj-image>
-      </mj-column>
-    </mj-section>
-
-    <mj-wrapper css-class="px-6">
+    <mj-wrapper css-class="body px-6">
       <%- body %>
     </mj-wrapper>
 
-    <mj-section css-class="footer-container">
-      <mj-column>
-        <mj-text css-class="footer-text-bottom-margin">
-          <% if (locals.productName) { %>
-            <span data-l10n-id="subplat-explainer-specific" data-l10n-args="<%= JSON.stringify({ email, productName }) %>">
-              You’re receiving this email because <%- email %> has a Firefox account and you signed up for <%- productName %>.
-            </span>
-          <% } else if (locals.reminderShortForm) { %>
-            <span data-l10n-id="subplat-explainer-reminder-form" data-l10n-args="<%= JSON.stringify({ email }) %>">
-              You’re receiving this email because <%- email %> has a Firefox account.
-            </span>
-          <% } else if (locals.wasDeleted) { %>
-            <span data-l10n-id="subplat-explainer-was-deleted" data-l10n-args="<%= JSON.stringify({ email }) %>">
-              You’re receiving this email because <%- email %> was registered for a Firefox account.
-            </span>
-          <% } else { %>
-            <span data-l10n-id="subplat-explainer-multiple" data-l10n-args="<%= JSON.stringify({ email }) %>">
-              You’re receiving this email because <%- email %> has a Firefox account and you have subscribed to multiple products.
-            </span>
-          <% } %>
-        </mj-text>
-
-        <% if (!locals.reminderShortForm && !locals.wasDeleted) { %>
+    <mj-wrapper css-class="body">
+      <mj-section css-class="footer-container">
+        <mj-column>
           <mj-text css-class="footer-text-bottom-margin">
-            <span data-l10n-id="subplat-manage-account">
-              Manage your Firefox account settings by visiting your <a href="<%- accountSettingsUrl %>" class="footer-link" data-l10n-name="subplat-account-page">account page</a>.
-            </span>
+            <% if (locals.productName) { %>
+              <span data-l10n-id="subplat-explainer-specific" data-l10n-args="<%= JSON.stringify({ email, productName }) %>">
+                You’re receiving this email because <%- email %> has a Firefox account and you signed up for <%- productName %>.
+              </span>
+            <% } else if (locals.reminderShortForm) { %>
+              <span data-l10n-id="subplat-explainer-reminder-form" data-l10n-args="<%= JSON.stringify({ email }) %>">
+                You’re receiving this email because <%- email %> has a Firefox account.
+              </span>
+            <% } else if (locals.wasDeleted) { %>
+              <span data-l10n-id="subplat-explainer-was-deleted" data-l10n-args="<%= JSON.stringify({ email }) %>">
+                You’re receiving this email because <%- email %> was registered for a Firefox account.
+              </span>
+            <% } else { %>
+              <span data-l10n-id="subplat-explainer-multiple" data-l10n-args="<%= JSON.stringify({ email }) %>">
+                You’re receiving this email because <%- email %> has a Firefox account and you have subscribed to multiple products.
+              </span>
+            <% } %>
           </mj-text>
 
-          <mj-text css-class="footer-text">
-            <% if (locals.productName || locals.subscriptions?.length > 0) { %>
-              <a href="<%- subscriptionTermsUrl %>" class="footer-link" data-l10n-id="subplat-terms-policy">Terms and cancellation policy</a>
-              &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+          <% if (!locals.reminderShortForm && !locals.wasDeleted) { %>
+            <mj-text css-class="footer-text-bottom-margin">
+              <span data-l10n-id="subplat-manage-account">
+                Manage your Firefox account settings by visiting your <a href="<%- accountSettingsUrl %>" class="footer-link" data-l10n-name="subplat-account-page">account page</a>.
+              </span>
+            </mj-text>
 
-              <a href="<%- subscriptionPrivacyUrl %>" class="footer-link" data-l10n-id="subplat-privacy-notice">Privacy notice</a>
-            <% } %>
+            <mj-text css-class="footer-text">
+              <% if (locals.productName || locals.subscriptions?.length > 0) { %>
+                <a href="<%- subscriptionTermsUrl %>" class="footer-link" data-l10n-id="subplat-terms-policy">Terms and cancellation policy</a>
+                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
 
-            <% if (!locals.isFinishSetup) { %>
-              &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-              <% if (locals.isCancellationEmail) { %>
-                <a href="<%- reactivateSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-reactivate">Reactivate subscription</a>
-                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-              <% } else { %>
-                <a href="<%- cancelSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-cancel">Cancel subscription</a>
-                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+                <a href="<%- subscriptionPrivacyUrl %>" class="footer-link" data-l10n-id="subplat-privacy-notice">Privacy notice</a>
               <% } %>
 
-              <a href="<%- updateBillingUrl %>" class="footer-link" data-l10n-id="subplat-update-billing">Update billing information</a>
-            <% } %>
-          </mj-text>
-        <% } else { %>
+              <% if (!locals.isFinishSetup) { %>
+                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+                <% if (locals.isCancellationEmail) { %>
+                  <a href="<%- reactivateSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-reactivate">Reactivate subscription</a>
+                  &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+                <% } else { %>
+                  <a href="<%- cancelSubscriptionUrl %>" class="footer-link" data-l10n-id="subplat-cancel">Cancel subscription</a>
+                  &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+                <% } %>
+
+                <a href="<%- updateBillingUrl %>" class="footer-link" data-l10n-id="subplat-update-billing">Update billing information</a>
+              <% } %>
+            </mj-text>
+          <% } else { %>
+            <mj-text css-class="footer-text">
+              <a href="<%- privacyUrl %>" class="footer-link" data-l10n-id="subplat-privacy-policy">Mozilla Privacy Policy</a>
+                &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+
+              <a href="<%- subscriptionTermsUrl %>" class="footer-link" data-l10n-id="subplat-cloud-terms">Firefox Cloud Terms of Service</a>
+            </mj-text>
+          <% } %>
+
+          <mj-image css-class="mozilla-logo"
+            width="120px"
+            href="https://www.mozilla.org"
+            src="https://accounts-static.cdn.mozilla.net/product-icons/mozilla-logo.png"
+            alt="Mozilla logo"
+            title="Mozilla">
+          </mj-image>
+
+          <mj-text css-class="footer-text-bottom-margin">149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
+
           <mj-text css-class="footer-text">
-            <a href="<%- privacyUrl %>" class="footer-link" data-l10n-id="subplat-privacy-policy">Mozilla Privacy Policy</a>
-              &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-
-            <a href="<%- subscriptionTermsUrl %>" class="footer-link" data-l10n-id="subplat-cloud-terms">Firefox Cloud Terms of Service</a>
+            <a href="https://www.mozilla.org/about/legal/terms/services/" class="footer-link" data-l10n-id="subplat-legal">Legal</a>
+            &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+            <a href="https://www.mozilla.org/privacy/websites/" class="footer-link" data-l10n-id="subplat-privacy">Privacy</a>
           </mj-text>
-        <% } %>
-
-        <mj-image css-class="mozilla-logo"
-          width="120px"
-          href="https://www.mozilla.org"
-          src="https://accounts-static.cdn.mozilla.net/product-icons/mozilla-logo.png"
-          alt="Mozilla logo"
-          title="Mozilla">
-        </mj-image>
-
-        <mj-text css-class="footer-text-bottom-margin">149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
-
-        <mj-text css-class="footer-text">
-          <a href="https://www.mozilla.org/about/legal/terms/services/" class="footer-link" data-l10n-id="subplat-legal">Legal</a>
-          &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-          <a href="https://www.mozilla.org/privacy/websites/" class="footer-link" data-l10n-id="subplat-privacy">Privacy</a>
-        </mj-text>
-      </mj-column>
-    </mj-section>
+        </mj-column>
+      </mj-section>
+    </mg-wrapper>
   </mj-body>
 </mjml>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.stories.ts
@@ -14,6 +14,7 @@ const createStory = subplatStoryWithProps(
   'The Subscription Platform email base layout.',
   {
     subject: 'N/A',
+    brandMessagingMode: 'none',
   }
 );
 
@@ -35,8 +36,20 @@ export const LayoutMultipleProducts = createStory(
       },
     ],
   },
-  'Multiple products'
+  'Default - With brand messaging'
 );
+
+export const LayoutMultipleProductsWithBrandMessaging = createStory({
+  subscriptions: [
+    {
+      productName: 'Firefox Fortress',
+    },
+    {
+      productName: 'Mozilla VPN',
+    },
+  ],
+  brandMessagingMode: 'postlaunch',
+});
 
 export const LayoutWithProduct = createStory(
   {

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -1,3 +1,10 @@
+<% if (locals.brandMessagingMode == 'postlaunch') { %>
+brand-banner-message = "Did you know we changed our name from Firefox accounts to Mozilla accounts? Learn more"
+
+https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts
+
+<% } %>
+
 <%- body %>
 
 <% if (!locals.wasDeleted) { %>


### PR DESCRIPTION
## Because

- We want the brand messaging notice on subscription emails too

## This pull request

- Adds the brand messaging.
- Increase max width on the message container to 640px to be inline with subscription email's max width.

## Issue that this pull request solves

Closes: FXA-8465

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/mozilla/fxa/assets/94418270/a8d89808-d744-4924-9bcf-6a1c605a6f1f)

## Other information (Optional)

Any other information that is important to this pull request.
