### PR TITLE
fix(bug): Update reset password to use authPW

### DIFF
--- a/packages/fxa-auth-client/browser.ts
+++ b/packages/fxa-auth-client/browser.ts
@@ -1,4 +1,5 @@
 import AuthClient from './lib/client';
+export * from './lib/crypto';
 export * from './lib/client';
 export * from './lib/recoveryKey';
 export default AuthClient;

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -534,6 +534,8 @@ export default class AuthClient {
     );
   }
 
+  // TODO: Once password reset react is 100% and stable in production
+  // we can remove this.
   async accountReset(
     email: string,
     newPassword: string,
@@ -562,6 +564,30 @@ export default class AuthClient {
       accountData.unwrapBKey = credentials.unwrapBKey;
     }
     return accountData;
+  }
+
+  async accountResetAuthPW(
+    newPasswordAuthPW: string,
+    accountResetToken: hexstring,
+    options: {
+      keys?: boolean;
+      sessionToken?: boolean;
+    } = {},
+    headers: Headers = new Headers()
+  ) {
+    const payloadOptions = ({ keys, ...rest }: any) => rest;
+    const payload = {
+      authPW: newPasswordAuthPW,
+      ...payloadOptions(options),
+    };
+    return await this.hawkRequest(
+      'POST',
+      pathWithKeys('/account/reset', options.keys),
+      accountResetToken,
+      tokenType.accountResetToken,
+      payload,
+      headers
+    );
   }
 
   async finishSetup(

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -524,7 +524,7 @@ describe('#integration - AccountResolver', () => {
           'x-forwarded-for': '123.123.123.123',
         });
         const now = Date.now();
-        authClient.accountReset = jest.fn().mockResolvedValue({
+        authClient.accountResetAuthPW = jest.fn().mockResolvedValue({
           clientMutationId: 'testid',
           uid: 'uid',
           verified: true,
@@ -533,12 +533,11 @@ describe('#integration - AccountResolver', () => {
           keyFetchToken: 'keyFetchToken',
         });
         const result = await resolver.accountReset(headers, {
-          email: 'up@dog.com',
-          newPassword: 'password',
+          newPasswordAuthPW: 'passwordAuthPW',
           accountResetToken: 'token',
           options: {},
         });
-        expect(authClient.accountReset).toBeCalledTimes(1);
+        expect(authClient.accountResetAuthPW).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
           uid: 'uid',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -503,9 +503,8 @@ export class AccountResolver {
     @Args('input', { type: () => AccountResetInput })
     input: AccountResetInput
   ): Promise<AccountResetPayload> {
-    const result = await this.authAPI.accountReset(
-      input.email,
-      input.newPassword,
+    const result = await this.authAPI.accountResetAuthPW(
+      input.newPasswordAuthPW,
       input.accountResetToken,
       input.options,
       headers

--- a/packages/fxa-graphql-api/src/gql/dto/input/password-forgot.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/password-forgot.ts
@@ -79,10 +79,7 @@ export class AccountResetInput {
   public accountResetToken!: string;
 
   @Field()
-  public email!: string;
-
-  @Field()
-  public newPassword!: string;
+  public newPasswordAuthPW!: string;
 
   @Field({ nullable: true })
   public options?: AccountResetInputOptions;


### PR DESCRIPTION
## Because

- We should be using the authPW value in react routes

## This pull request

- Updates the reset password react to use authPW

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8471

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="856" alt="Screenshot 2023-10-13 at 12 47 50 PM" src="https://github.com/mozilla/fxa/assets/1295288/76019ac9-5484-4b43-84bc-8b26c8e531e2">
enshots


