### PR TITLE
fix(nx): remove nx prject rootDir and main changes

### DIFF
--- a/libs/payments/capability/project.json
+++ b/libs/payments/capability/project.json
@@ -8,7 +8,6 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/payments/capability",
         "tsConfig": "libs/payments/capability/tsconfig.lib.json",
         "packageJson": "libs/payments/capability/package.json",

--- a/libs/payments/cart/project.json
+++ b/libs/payments/cart/project.json
@@ -8,9 +8,8 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/payments/cart",
-        "main": "libs/payments/cart/libs/payments/cart/src/index.ts",
+        "main": "libs/payments/cart/src/index.ts",
         "tsConfig": "libs/payments/cart/tsconfig.lib.json",
         "assets": ["libs/payments/cart/*.md"]
       }

--- a/libs/payments/eligibility/project.json
+++ b/libs/payments/eligibility/project.json
@@ -8,7 +8,6 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/payments/eligibility",
         "tsConfig": "libs/payments/eligibility/tsconfig.lib.json",
         "packageJson": "libs/payments/eligibility/package.json",

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -5,7 +5,7 @@
 import {
   ContentfulManager,
   EligibilityOfferingResult,
-} from '../../../../shared/contentful/src';
+} from '@fxa/shared/contentful';
 import { Injectable } from '@nestjs/common';
 
 import { OfferingComparison, OfferingOverlapResult } from './eligibility.types';

--- a/libs/payments/paypal/project.json
+++ b/libs/payments/paypal/project.json
@@ -8,11 +8,10 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/payments/paypal",
         "tsConfig": "libs/payments/paypal/tsconfig.lib.json",
         "packageJson": "libs/payments/paypal/package.json",
-        "main": "libs/payments/paypal/libs/payments/paypal/src/index.ts",
+        "main": "libs/payments/paypal/src/index.ts",
         "assets": ["libs/payments/paypal/*.md"]
       }
     },

--- a/libs/shared/account/account/project.json
+++ b/libs/shared/account/account/project.json
@@ -12,7 +12,7 @@
         "outputPath": "dist/libs/shared/account/account",
         "tsConfig": "libs/shared/account/account/tsconfig.lib.json",
         "packageJson": "libs/shared/account/account/package.json",
-        "main": "libs/shared/account/account/src/index.ts",
+        "main": "libs/shared/account/account/libs/shared/account/account/src/index.ts",
         "assets": ["libs/shared/account/account/*.md"]
       }
     },
@@ -20,9 +20,7 @@
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "libs/shared/account/account/**/*.ts"
-        ]
+        "lintFilePatterns": ["libs/shared/account/account/**/*.ts"]
       }
     },
     "test-integration": {

--- a/libs/shared/contentful/project.json
+++ b/libs/shared/contentful/project.json
@@ -14,7 +14,6 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/shared/contentful",
         "main": "libs/shared/contentful/src/index.ts",
         "tsConfig": "libs/shared/contentful/tsconfig.lib.json",

--- a/libs/shared/db/mysql/account/project.json
+++ b/libs/shared/db/mysql/account/project.json
@@ -8,11 +8,10 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/shared/db/mysql/account",
         "tsConfig": "libs/shared/db/mysql/account/tsconfig.lib.json",
         "packageJson": "libs/shared/db/mysql/account/package.json",
-        "main": "libs/shared/db/mysql/account/libs/shared/db/mysql/account/src/index.ts",
+        "main": "libs/shared/db/mysql/account/src/index.ts",
         "assets": ["libs/shared/db/mysql/account/*.md"]
       }
     },

--- a/libs/shared/db/mysql/account/src/index.ts
+++ b/libs/shared/db/mysql/account/src/index.ts
@@ -7,5 +7,6 @@ export * from './lib/keysley-types';
 export { CartFactory } from './lib/factories';
 export { setupAccountDatabase, AccountDbProvider } from './lib/setup';
 export { testAccountDatabaseSetup } from './lib/tests';
+export type { ACCOUNT_TABLES } from './lib/tests';
 export type { AccountDatabase } from './lib/setup';
 export { AccountDatabaseNestFactory } from './lib/account.provider';

--- a/libs/shared/db/mysql/account/src/lib/account.provider.ts
+++ b/libs/shared/db/mysql/account/src/lib/account.provider.ts
@@ -4,7 +4,7 @@
 
 import { Provider } from '@nestjs/common';
 
-import { MySQLConfig } from '../../../core/src';
+import { MySQLConfig } from '@fxa/shared/db/mysql/core';
 import {
   AccountDatabase,
   AccountDbProvider,

--- a/libs/shared/db/mysql/core/project.json
+++ b/libs/shared/db/mysql/core/project.json
@@ -8,11 +8,10 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/shared/db/mysql/core",
         "tsConfig": "libs/shared/db/mysql/core/tsconfig.lib.json",
         "packageJson": "libs/shared/db/mysql/core/package.json",
-        "main": "libs/shared/db/mysql/core/libs/shared/db/mysql/core/src/index.ts",
+        "main": "libs/shared/db/mysql/core/src/index.ts",
         "assets": ["libs/shared/db/mysql/core/*.md"]
       }
     },

--- a/libs/shared/db/mysql/core/src/lib/core.ts
+++ b/libs/shared/db/mysql/core/src/lib/core.ts
@@ -7,8 +7,8 @@ import { createPool } from 'mysql2';
 import { promisify } from 'util';
 import { v4 as uuidv4 } from 'uuid';
 
-import { ConsoleLogger, Logger } from '../../../../../log/src';
-import { localStatsD, StatsD } from '../../../../../metrics/statsd/src';
+import { ConsoleLogger, Logger } from '@fxa/shared/log';
+import { localStatsD, StatsD } from '@fxa/shared/metrics/statsd';
 import { MySQLConfig } from './config';
 
 const REQUIRED_SQL_MODES = ['STRICT_ALL_TABLES', 'NO_ENGINE_SUBSTITUTION'];

--- a/libs/shared/error/project.json
+++ b/libs/shared/error/project.json
@@ -8,9 +8,8 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/shared/error",
-        "main": "libs/shared/error/libs/shared/error/src/index.ts",
+        "main": "libs/shared/error/src/index.ts",
         "tsConfig": "libs/shared/error/tsconfig.lib.json",
         "assets": ["libs/shared/error/*.md"]
       }

--- a/libs/shared/l10n/project.json
+++ b/libs/shared/l10n/project.json
@@ -8,9 +8,8 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/shared/l10n",
-        "main": "libs/shared/l10n/libs/shared/l10n/src/index.ts",
+        "main": "libs/shared/l10n/src/index.ts",
         "tsConfig": "libs/shared/l10n/tsconfig.lib.json",
         "assets": ["libs/shared/l10n/*.md"]
       }

--- a/libs/shared/log/project.json
+++ b/libs/shared/log/project.json
@@ -8,11 +8,10 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
         "outputPath": "dist/libs/shared/log",
         "tsConfig": "libs/shared/log/tsconfig.lib.json",
         "packageJson": "libs/shared/log/package.json",
-        "main": "libs/shared/log/libs/shared/log/src/index.ts",
+        "main": "libs/shared/log/src/index.ts",
         "assets": ["libs/shared/log/*.md"]
       }
     },

--- a/libs/shared/metrics/statsd/project.json
+++ b/libs/shared/metrics/statsd/project.json
@@ -8,11 +8,10 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "rootDir": ".",
-        "outputPath": "dist/shared/metrics/statsd",
+        "outputPath": "dist/libs/shared/metrics/statsd",
         "tsConfig": "libs/shared/metrics/statsd/tsconfig.lib.json",
         "packageJson": "libs/shared/metrics/statsd/package.json",
-        "main": "libs/shared/metrics/statsd/libs/shared/metrics/statsd/src/index.ts",
+        "main": "libs/shared/metrics/statsd/src/index.ts",
         "assets": ["libs/shared/metrics/statsd/*.md"]
       }
     },

--- a/packages/fxa-graphql-api/tsconfig.build.json
+++ b/packages/fxa-graphql-api/tsconfig.build.json
@@ -9,7 +9,8 @@
       "@fxa/payments/cart": ["libs/payments/cart/src/index"],
       "@fxa/shared/log": ["libs/shared/log/src/index"],
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index"],
-      "@fxa/shared/db/mysql/core": ["libs/shared/db/mysql/core/src/index.ts"]
+      "@fxa/shared/db/mysql/core": ["libs/shared/db/mysql/core/src/index"],
+      "@fxa/shared/metrics/statsd": ["libs/shared/metrics/statsd/src/index"]
     }
   }
 }


### PR DESCRIPTION
## Because

- Manual changes were needed to all nx libraries to ensure expected TypeScript build and development intellisense behavior.

## This pull request

- Removes the "rootDir" build option added to all libraries, to allow for relative paths. This is no longer necessary since issues using TypeScript path aliases have been resolved.
- Removes changes to "main" build option, which ensured the built version of package.json had the correct path to the main index.js.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
