### PR TITLE
fix(fxa-settings): Remove outline from tab fence for alertBar and modal

### DIFF
--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
@@ -41,7 +41,12 @@ export const AlertBar = () => {
         role="alert"
         data-testid="alert-bar"
       >
-        <div tabIndex={0} ref={tabFenceRef} data-testid="alert-bar-tab-fence">
+        <div
+          tabIndex={0}
+          ref={tabFenceRef}
+          data-testid="alert-bar-tab-fence"
+          className="outline-none"
+        >
           <div
             data-testid="alert-bar-inner"
             // Transparent border is for Windows HCM - to ensure there is a border around the alert when background color is removed

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -68,7 +68,12 @@ export const Modal = ({
           )}
           ref={modalInsideRef}
         >
-          <div tabIndex={0} ref={tabFenceRef} data-testid="modal-tab-fence">
+          <div
+            tabIndex={0}
+            ref={tabFenceRef}
+            data-testid="modal-tab-fence"
+            className="outline-none"
+          >
             <div className="flex justify-end pe-2 py-2">
               <button
                 data-testid="modal-dismiss"


### PR DESCRIPTION
## Because

* Changes for Windows HCM caused a focus outline to be displayed around alertBar and modal

## This pull request

* Add 'outline-none' to the tabFence, focus outline is only shown for interactive elements like buttons, links, inputs

## Issue that this pull request solves

Closes: #FXA-8477

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

With (undesirable) focus outline:
![image](https://github.com/mozilla/fxa/assets/22231637/22643b1a-6bb9-477a-859e-d7c6c9e36bdc)

No focus outline:
![image](https://github.com/mozilla/fxa/assets/22231637/148958d3-34ff-4361-80e2-679e5d652fc7)

## Other information (Optional)

Any other information that is important to this pull request.
