### PR TITLE
feat: add eligibility manager to capability service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ secrets.json
 **/version.json
 **/storybook-static
 *.sass-cache
+.nx/cache
 **/schema.gql
 *.map
 *.swp

--- a/libs/payments/eligibility/src/index.ts
+++ b/libs/payments/eligibility/src/index.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/eligibility.manager';
 export * from './lib/eligibility.types';
+export { intervalComparison } from './lib/utils';

--- a/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
@@ -178,10 +178,12 @@ describe('EligibilityManager', () => {
       expect(result[0]).toEqual({
         comparison: OfferingComparison.DOWNGRADE,
         offeringProductId: 'prod_test3',
+        type: 'offering',
       });
       expect(result[1]).toEqual({
         comparison: OfferingComparison.UPGRADE,
         planId: 'plan_test',
+        type: 'plan',
       });
     });
   });

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  ContentfulManager,
-  EligibilityOfferingResult,
-} from '@fxa/shared/contentful';
+import { ContentfulManager } from '@fxa/shared/contentful';
 import { Injectable } from '@nestjs/common';
 
-import { OfferingComparison, OfferingOverlapResult } from './eligibility.types';
+import { OfferingOverlapResult } from './eligibility.types';
+import { offeringComparison } from './utils';
 
 @Injectable()
 export class EligibilityManager {
@@ -41,7 +39,8 @@ export class EligibilityManager {
 
     for (const offeringProductId of offeringStripeProductIds) {
       const comparison = offeringComparison(offeringProductId, targetOffering);
-      if (comparison) result.push({ comparison, offeringProductId });
+      if (comparison)
+        result.push({ comparison, offeringProductId, type: 'offering' });
     }
 
     for (const planId of planIds) {
@@ -51,44 +50,8 @@ export class EligibilityManager {
         fromOffering.stripeProductId,
         targetOffering
       );
-      if (comparison) result.push({ comparison, planId });
+      if (comparison) result.push({ comparison, planId, type: 'plan' });
     }
     return result;
-  }
-}
-
-/**
- * Returns whether the target offering overlaps, and how.
- *
- * @returns OfferingComparison if there's overlap, null otherwise.
- */
-function offeringComparison(
-  fromOfferingProductId: string,
-  targetOffering: EligibilityOfferingResult
-) {
-  if (targetOffering.stripeProductId === fromOfferingProductId)
-    return OfferingComparison.SAME;
-  const commonSubgroups =
-    targetOffering.linkedFrom.subGroupCollection.items.filter(
-      (subgroup) =>
-        !!subgroup.offeringCollection.items.find(
-          (oc) => oc.stripeProductId === fromOfferingProductId
-        )
-    );
-  if (!commonSubgroups.length) return null;
-  const subgroupProductIds = commonSubgroups[0].offeringCollection.items.map(
-    (o) => o.stripeProductId
-  );
-  const existingIndex = subgroupProductIds.indexOf(fromOfferingProductId);
-  const targetIndex = subgroupProductIds.indexOf(
-    targetOffering.stripeProductId
-  );
-  switch (targetIndex - existingIndex) {
-    case 0:
-      return OfferingComparison.SAME;
-    case 1:
-      return OfferingComparison.UPGRADE;
-    default:
-      return OfferingComparison.DOWNGRADE;
   }
 }

--- a/libs/payments/eligibility/src/lib/eligibility.types.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.types.ts
@@ -9,18 +9,33 @@ export enum OfferingComparison {
   DOWNGRADE = 'downgrade',
 }
 
+// Used to represent an interval comparison to another interval
+export enum IntervalComparison {
+  SAME = 'same',
+  LONGER = 'longer',
+  SHORTER = 'shorter',
+}
+
 export type OfferingOverlapBaseResult = {
   comparison: OfferingComparison;
+  type: string;
 };
 
 export type OfferingOverlapPlanResult = OfferingOverlapBaseResult & {
   planId: string;
+  type: 'plan';
 };
 
 export type OfferingOverlapProductResult = OfferingOverlapBaseResult & {
   offeringProductId: string;
+  type: 'offering';
 };
 
 export type OfferingOverlapResult =
   | OfferingOverlapPlanResult
   | OfferingOverlapProductResult;
+
+export type Interval = {
+  unit: 'day' | 'week' | 'month' | 'year';
+  count: number;
+};

--- a/libs/payments/eligibility/src/lib/utils.ts
+++ b/libs/payments/eligibility/src/lib/utils.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { EligibilityOfferingResult } from '@fxa/shared/contentful';
+
+import {
+  Interval,
+  IntervalComparison,
+  OfferingComparison,
+} from './eligibility.types';
+
+/**
+ * Returns whether the target offering overlaps, and how.
+ *
+ * @returns OfferingComparison if there's overlap, null otherwise.
+ */
+export const offeringComparison = (
+  fromOfferingProductId: string,
+  targetOffering: EligibilityOfferingResult
+) => {
+  if (targetOffering.stripeProductId === fromOfferingProductId)
+    return OfferingComparison.SAME;
+  const commonSubgroups =
+    targetOffering.linkedFrom.subGroupCollection.items.filter(
+      (subgroup) =>
+        !!subgroup.offeringCollection.items.find(
+          (oc) => oc.stripeProductId === fromOfferingProductId
+        )
+    );
+  if (!commonSubgroups.length) return null;
+  const subgroupProductIds = commonSubgroups[0].offeringCollection.items.map(
+    (o) => o.stripeProductId
+  );
+  const existingIndex = subgroupProductIds.indexOf(fromOfferingProductId);
+  const targetIndex = subgroupProductIds.indexOf(
+    targetOffering.stripeProductId
+  );
+  switch (targetIndex - existingIndex) {
+    case 0:
+      return OfferingComparison.SAME;
+    case 1:
+      return OfferingComparison.UPGRADE;
+    default:
+      return OfferingComparison.DOWNGRADE;
+  }
+};
+
+/**
+ * Compare two intervals and return whether the target interval is longer,
+ * shorter, or the same as the existing interval.
+ *
+ * Note that due to months and years having varying quantities of days, this
+ * is an approximationbut should be sufficient for calculations in this
+ * context. An example is that 4 weeks will not be considered equivilant to
+ * 1 month, and 12 months will not be considered equivilant to 1 year.
+ */
+export const intervalComparison = (
+  fromInterval: Interval,
+  toInterval: Interval
+): IntervalComparison => {
+  const difference =
+    unitToDays(toInterval.unit) * toInterval.count -
+    unitToDays(fromInterval.unit) * fromInterval.count;
+  if (difference === 0) return IntervalComparison.SAME;
+  if (difference > 0) return IntervalComparison.LONGER;
+  return IntervalComparison.SHORTER;
+};
+
+/**
+ * Convert an interval unit to days.
+ */
+const unitToDays = (unit: Interval['unit']) => {
+  switch (unit) {
+    case 'day':
+      return 1;
+    case 'week':
+      return 7;
+    case 'month':
+      return 30;
+    case 'year':
+      return 365;
+    default:
+      return 0;
+  }
+};

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -7,6 +7,7 @@
 const { config } = require('../config');
 
 const { CapabilityManager } = require('@fxa/payments/capability');
+const { EligibilityManager } = require('@fxa/payments/eligibility');
 const {
   ContentfulClient,
   ContentfulManager,
@@ -126,7 +127,9 @@ async function run(config) {
       });
       const contentfulManager = new ContentfulManager(contentfulClient);
       const capabilityManager = new CapabilityManager(contentfulManager);
+      const eligibilityManager = new EligibilityManager(contentfulManager);
       Container.set(CapabilityManager, capabilityManager);
+      Container.set(EligibilityManager, eligibilityManager);
     }
 
     const { createStripeHelper } = require('../lib/payments/stripe');


### PR DESCRIPTION
Because:

* We want to use the new eligibilitymanager in the capability service and compare its results to the existing check, reporting any differences in the eligibility comparison.

This commit:

* Adds the eligibility manager to the capability service.
* Adds a wrapper to the results of the elgibility call to verify it matches the existing comparison, and report to Sentry if it doesn't.

Closes FXA-8273

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
