### PR TITLE
fix(metrics): try-catch Glean initialization error

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -123,23 +123,32 @@ const createEventFn =
 
 export const GleanMetrics = {
   initialize: (config: GleanMetricsConfig, context: GleanMetricsContext) => {
-    if (config.enabled) {
-      Glean.initialize(config.applicationId, config.uploadEnabled, {
-        appDisplayVersion: config.appDisplayVersion,
-        channel: config.channel,
-        serverEndpoint: config.serverEndpoint,
-        // Glean does not offer direct control over when metrics are uploaded;
-        // this ensures that events are uploaded.
-        maxEvents: 1,
-      });
-      Glean.setLogPings(config.logPings);
-      if (config.debugViewTag) {
-        Glean.setDebugViewTag(config.debugViewTag);
-      }
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1859629
+    // Starting with glean.js v2, accessing localStorage during
+    // initialization could cause an error
+    try {
+      if (config.enabled) {
+        Glean.initialize(config.applicationId, config.uploadEnabled, {
+          appDisplayVersion: config.appDisplayVersion,
+          channel: config.channel,
+          serverEndpoint: config.serverEndpoint,
+          // Glean does not offer direct control over when metrics are uploaded;
+          // this ensures that events are uploaded.
+          maxEvents: 1,
+        });
+        Glean.setLogPings(config.logPings);
+        if (config.debugViewTag) {
+          Glean.setDebugViewTag(config.debugViewTag);
+        }
 
-      gleanMetricsContext = context;
+        gleanMetricsContext = context;
+      }
+      GleanMetrics.setEnabled(config.enabled);
+    } catch (_) {
+      // set some states so we won't try to do anything with glean.js later
+      config.enabled = false;
+      gleanEnabled = false;
     }
-    GleanMetrics.setEnabled(config.enabled);
   },
 
   setEnabled: (enabled) => {

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -129,6 +129,19 @@ describe('lib/glean', () => {
     });
   });
 
+  describe('initialization error', () => {
+    it('disables Glean', async () => {
+      const config = { ...mockConfig, enabled: true };
+      const initStub = sandbox.stub(Glean, 'initialize').throws();
+      GleanMetrics.initialize(config, { metrics, relier, user, userAgent });
+      await GleanMetrics.registration.view();
+      sinon.assert.calledOnce(initStub);
+      assert.isFalse(config.enabled);
+      // does not try to set a value since internal enabled state is false
+      sinon.assert.notCalled(setuserIdSha256Stub);
+    });
+  });
+
   describe('enabled', () => {
     it('calls Glean.initialize when enabled', () => {
       const initStub = sandbox.stub(Glean, 'initialize');

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -147,6 +147,24 @@ describe('lib/glean', () => {
     });
   });
 
+  describe('initialization error', () => {
+    it('disables Glean', async () => {
+      const config = { ...mockConfig, enabled: true };
+      const initStub = sandbox.stub(Glean, 'initialize').throws();
+      GleanMetrics.initialize(config, mockMetricsContext);
+      sinon.assert.calledOnce(initStub);
+      expect(config.enabled).toBe(false);
+      GleanMetrics.registration.view();
+
+      await new Promise((resovle) =>
+        setTimeout(() => {
+          sinon.assert.notCalled(setuserIdSha256Stub);
+          resovle(undefined);
+        }, 20)
+      );
+    });
+  });
+
   describe('enabled', () => {
     it('calls Glean.initialize when enabled', () => {
       const initStub = sandbox.stub(Glean, 'initialize');

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -151,20 +151,29 @@ const createEventFn =
 
 export const GleanMetrics: Pick<GleanMetricsT, 'initialize' | 'setEnabled'> = {
   initialize: (config: GleanMetricsConfig, context: GleanMetricsContext) => {
-    if (config.enabled) {
-      Glean.initialize(config.applicationId, config.uploadEnabled, {
-        appDisplayVersion: config.appDisplayVersion,
-        channel: config.channel,
-        serverEndpoint: config.serverEndpoint,
-      });
-      Glean.setLogPings(config.logPings);
-      if (config.debugViewTag) {
-        Glean.setDebugViewTag(config.debugViewTag);
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1859629
+    // Starting with glean.js v2, accessing localStorage during
+    // initialization could cause an error
+    try {
+      if (config.enabled) {
+        Glean.initialize(config.applicationId, config.uploadEnabled, {
+          appDisplayVersion: config.appDisplayVersion,
+          channel: config.channel,
+          serverEndpoint: config.serverEndpoint,
+        });
+        Glean.setLogPings(config.logPings);
+        if (config.debugViewTag) {
+          Glean.setDebugViewTag(config.debugViewTag);
+        }
       }
+      GleanMetrics.setEnabled(config.enabled);
+      metricsContext = context;
+      ua = null;
+    } catch (_) {
+      // set some states so we won't try to do anything with glean.js later
+      config.enabled = false;
+      gleanEnabled = false;
     }
-    GleanMetrics.setEnabled(config.enabled);
-    metricsContext = context;
-    ua = null;
   },
 
   setEnabled: (enabled: boolean) => {


### PR DESCRIPTION
Because:
 - glean.js/web v2 tries to access localStorage during initialization and that could cause an error in a small number of a browsers

This commit:
 - catches errors from glean.js initialization and disable the feature

