### PR TITLE
fix(auth): allow baggage header in request

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -131,7 +131,7 @@ async function create(log, error, config, routes, db, statsd, glean) {
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        additionalHeaders: ['sentry-trace'],
+        additionalHeaders: ['sentry-trace', 'baggage'],
         // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
         // which is more forgiving of missing Origin header.
         origin: config.corsOrigin[0] === '*' ? 'ignore' : config.corsOrigin,


### PR DESCRIPTION
## Because

- `fxa-content-server` was receiving CORS errors from auth-server, due to some headers not being allowed.

## This pull request

- Update auth cors settings to allow baggage header.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Necessary to resolve CORS issues, discussed in [Sentry docs here](https://docs.sentry.io/platforms/node/usage/distributed-tracing/dealing-with-cors-issues/), after adding [browser tracing in this PR](https://github.com/mozilla/fxa/pull/15778).
