### PR TITLE
bug(settings,content): Make banner x aligned right

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -3,7 +3,7 @@
     <div class="banner-brand-message w-full">
         <div class="flex justify-center p-2 brand-banner-bg">
             {{#showPrelaunch}}
-            <div class="flex">
+            <div class="flex ltr:ml-auto rtl:mr-auto">
                 <div class="flex-none relative">
                     <img
                         class="w-8 h-8 bg-black m-4 mt-1"
@@ -23,7 +23,7 @@
             </div>
             {{/showPrelaunch}}
             {{#showPostlaunch}}
-            <div class="flex"/>
+            <div class="flex ltr:ml-auto rtl:mr-auto"/>
                 <div>
                     <p class="text-sm font-bold">
                         {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
@@ -32,7 +32,7 @@
                 </div>
             </div>
             {{/showPostlaunch}}
-            <div class="flex justify-right order-last rtl:justify-left m-4 mt-1 mb-1">
+            <div class="flex justify-right order-last m-4 mt-1 mb-1 ml-auto rtl:justify-left rtl:ml-4 rtl:mr-auto">
                 <button
                     class="close-brand-banner w-4 h-4"
                     aria-label="{{#t}}Close Banner{{/t}}"

--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -3,7 +3,7 @@
     <div class="banner-brand-message w-full">
         <div class="flex justify-center p-2 brand-banner-bg">
             {{#showPrelaunch}}
-            <div class="flex ltr:ml-auto rtl:mr-auto">
+            <div class="flex ms-auto">
                 <div class="flex-none relative">
                     <img
                         class="w-8 h-8 bg-black m-4 mt-1"
@@ -23,7 +23,7 @@
             </div>
             {{/showPrelaunch}}
             {{#showPostlaunch}}
-            <div class="flex ltr:ml-auto rtl:mr-auto"/>
+            <div class="flex ms-auto"/>
                 <div>
                     <p class="text-sm font-bold">
                         {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
@@ -32,7 +32,7 @@
                 </div>
             </div>
             {{/showPostlaunch}}
-            <div class="flex justify-right order-last m-4 mt-1 mb-1 ml-auto rtl:justify-left rtl:ml-4 rtl:mr-auto">
+            <div class="flex order-last m-4 mt-1 mb-1 ml-auto ms-auto">
                 <button
                     class="close-brand-banner w-4 h-4"
                     aria-label="{{#t}}Close Banner{{/t}}"

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -98,7 +98,10 @@ export const BrandMessaging = ({
     >
       <div className="flex relative justify-center p-2 brand-banner-bg border border-transparent">
         {mode === 'prelaunch' && (
-          <div className="flex" data-testid="brand-prelaunch">
+          <div
+            className="flex ltr:ml-auto rtl:mr-auto"
+            data-testid="brand-prelaunch"
+          >
             <div className="flex-none relative">
               <Localized id="brand-m-logo" attrs={{ alt: true }}>
                 <img
@@ -134,7 +137,10 @@ export const BrandMessaging = ({
         )}
 
         {mode === 'postlaunch' && (
-          <div className="flex" data-testid="brand-postlaunch">
+          <div
+            className="flex ltr:ml-auto rtl:mr-auto"
+            data-testid="brand-postlaunch"
+          >
             <div>
               <p className="text-sm font-bold">
                 <FtlMsg id="brand-postlaunch-title">
@@ -155,7 +161,7 @@ export const BrandMessaging = ({
             </div>
           </div>
         )}
-        <div className="flex justify-end mx-2 my-1">
+        <div className="flex justify-end mx-2 my-1 ml-auto rtl:justify-left rtl:ml-4 rtl:mr-auto">
           <FtlMsg
             id="brand-banner-dismiss-button-2"
             attrs={{ ariaLabel: true }}

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -98,10 +98,7 @@ export const BrandMessaging = ({
     >
       <div className="flex relative justify-center p-2 brand-banner-bg border border-transparent">
         {mode === 'prelaunch' && (
-          <div
-            className="flex ltr:ml-auto rtl:mr-auto"
-            data-testid="brand-prelaunch"
-          >
+          <div className="flex ms-auto" data-testid="brand-prelaunch">
             <div className="flex-none relative">
               <Localized id="brand-m-logo" attrs={{ alt: true }}>
                 <img
@@ -137,10 +134,7 @@ export const BrandMessaging = ({
         )}
 
         {mode === 'postlaunch' && (
-          <div
-            className="flex ltr:ml-auto rtl:mr-auto"
-            data-testid="brand-postlaunch"
-          >
+          <div className="flex ms-auto" data-testid="brand-postlaunch">
             <div>
               <p className="text-sm font-bold">
                 <FtlMsg id="brand-postlaunch-title">
@@ -161,7 +155,7 @@ export const BrandMessaging = ({
             </div>
           </div>
         )}
-        <div className="flex justify-end mx-2 my-1 ml-auto rtl:justify-left rtl:ml-4 rtl:mr-auto">
+        <div className="flex justify-end mx-2 my-1 ms-auto">
           <FtlMsg
             id="brand-banner-dismiss-button-2"
             attrs={{ ariaLabel: true }}


### PR DESCRIPTION
## Because

- We want the banner close icon to be aligned right

## This pull request

- Aligns the X icon by using mr-auto (ml-auto for rtl) for flex

## Issue that this pull request solves

Closes: FXA-8455

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Backbone:
![image](https://github.com/mozilla/fxa/assets/94418270/d4bcb9d2-b81f-429b-b72e-ae3c82562298)
![image](https://github.com/mozilla/fxa/assets/94418270/34abc1cf-35f7-4c65-bf88-503f123f6e53)
![image](https://github.com/mozilla/fxa/assets/94418270/e12d21a6-e2dc-4449-a26d-b76f986b1576)
![image](https://github.com/mozilla/fxa/assets/94418270/3ef436b7-0f95-4d4a-b151-b1b19b4a0f29)

React:
![image](https://github.com/mozilla/fxa/assets/94418270/c84cb6b8-3043-47fe-89d7-a3932ddbf1b7)
![image](https://github.com/mozilla/fxa/assets/94418270/cb6f002a-212a-4948-8706-48f1075f9b5c)
![image](https://github.com/mozilla/fxa/assets/94418270/60596e0c-77de-49ee-a2dd-df77ad63653e)
![image](https://github.com/mozilla/fxa/assets/94418270/bcdbc60a-5986-439c-b5cf-4dfa5f30cee7)
![image](https://github.com/mozilla/fxa/assets/94418270/13ccba8c-e11f-4497-9a50-a5f2f612f78a)
![image](https://github.com/mozilla/fxa/assets/94418270/728e09bc-2e6c-41f0-b59d-6060cfab8702)


## Other information (Optional)

Note, that when testing the React version in Hebrew, the text direction wasn't swapping properly, where as for backbone it was. To get around this, I manually changed the `dir` attribute on the document, and you can see that once this is changed the layout renders correctly. I will be filing a follow up issue for the fact that Hebrew is not triggering a RTL direction in our react app. This defect is also observable on production.
