### PR TITLE
feat(events): Add support for handling Google RISC events, add cli to test

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/third-party-auth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/third-party-auth-api.ts
@@ -19,9 +19,15 @@ const LINKED_ACCOUNT_UNLINK_POST = {
   notes: ['🔒 Authenticated with session token'],
 };
 
+const LINKED_ACCOUNT_WEBHOOK_GOOGLE_EVENT_RECEIVER_POST = {
+  ...TAGS_THIRD_PARTY_AUTH,
+  description: '/linked_account/webhook/google_event_receiver',
+};
+
 const API_DOCS = {
   LINKED_ACCOUNT_LOGIN_POST,
   LINKED_ACCOUNT_UNLINK_POST,
+  LINKED_ACCOUNT_WEBHOOK_GOOGLE_EVENT_RECEIVER_POST,
 };
 
 export default API_DOCS;

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -181,7 +181,14 @@ module.exports = function (
   const util = require('./util')(log, config, config.smtp.redirectDomain);
 
   const { linkedAccountRoutes } = require('./linked-accounts');
-  const linkedAccounts = linkedAccountRoutes(log, db, config, mailer, profile);
+  const linkedAccounts = linkedAccountRoutes(
+    log,
+    db,
+    config,
+    mailer,
+    profile,
+    statsd
+  );
 
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {

--- a/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import jwt from 'jsonwebtoken';
+import { jwk2pem } from 'pem-jwk';
+import axios from 'axios';
+
+const RISC_CONFIG_URI =
+  'https://accounts.google.com/.well-known/risc-configuration';
+
+export type SETEvent = {
+  subject: {
+    subject_type: string;
+    iss: string;
+    sub: string;
+  };
+  reason?: string;
+  state?: string; // Only present for test events
+};
+
+export type SETEvents = {
+  [key: string]: SETEvent;
+};
+
+export type JWTSETPayload = {
+  iss: string;
+  aud: string;
+  iat: number;
+  jti: string;
+  events: SETEvents;
+};
+
+// See events at https://developers.google.com/identity/protocols/risc#supported_event_types
+export const eventHandlers = {
+  'https://schemas.openid.net/secevent/risc/event-type/verification':
+    handleTestEvent,
+};
+
+function handleTestEvent(eventDetails: SETEvent, log: any) {
+  log.debug(`Received test event: ${eventDetails.state}`);
+}
+
+export function handleOtherEventType(eventType: string, log: any) {
+  log.debug(`Received unknown event: ${eventType}`);
+}
+
+/**
+ * Get Google's public key from their RISC configuration.
+ *
+ * @param token
+ * @returns {Promise<{pem: string, issuer: string}>}
+ */
+export async function getGooglePublicKey(token: string) {
+  const riscConfig = await axios.get(RISC_CONFIG_URI);
+  const { jwks_uri: jwksUri, issuer } = riscConfig.data;
+
+  const googleCerts = await axios.get(jwksUri);
+  const jwtHeader = jwt.decode(token, { complete: true })?.header;
+  const keyId = jwtHeader.kid;
+  if (!keyId) {
+    throw new Error('No valid keyId found.');
+  }
+
+  const publicKey = googleCerts.data.keys.find(
+    (key: { kid: string }) => key.kid === keyId
+  );
+
+  if (!publicKey) {
+    throw new Error('Public key certificate not found.');
+  }
+
+  return {
+    pem: jwk2pem(publicKey),
+    issuer,
+  };
+}
+
+/**
+ * Validate a JWT security token against Google's public key.
+ *
+ * @param token
+ * @param clientId
+ * @param publicKey
+ * @returns {Promise<JWTSETPayload>}
+ */
+export async function validateSecurityToken(
+  token: string,
+  clientId: string,
+  publicKey: { pem: any; issuer: string }
+): Promise<JWTSETPayload> {
+  // Decode the token, validating its signature, audience, and issuer
+  return jwt.verify(token, publicKey.pem, {
+    algorithms: ['RS256'],
+    audience: [clientId],
+    issuer: publicKey.issuer,
+  }) as JWTSETPayload;
+}
+
+/**
+ * Check to see if the JWT token aud value matches the client ID. We
+ * should ignore events from other clients.
+ *
+ * @param token
+ * @param clientId
+ */
+export function isValidClientId(token: string, clientId: string) {
+  const decoded = jwt.decode(token, { complete: true }) as {
+    payload: JWTSETPayload;
+  };
+  return decoded && decoded.payload.aud.includes(clientId);
+}

--- a/packages/fxa-auth-server/scripts/google-events-cli.js
+++ b/packages/fxa-auth-server/scripts/google-events-cli.js
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This script is used to configure the Google RISC Event Stream. It
+ * assumes that your project is configured to send events
+ * ref: https://developers.google.com/identity/protocols/risc#set_up_a_project_in_the
+ *
+ * The code examples here were taken from the Google documentation and modified.
+ */
+const fs = require('fs');
+const jwt = require('jsonwebtoken');
+const axios = require('axios');
+
+const { Command } = require('commander');
+const program = new Command();
+
+program
+  .command('token <file>')
+  .description('Make authentication token')
+  .action((file) => {
+    const authToken = makeBearerToken(file);
+    console.log(authToken);
+  });
+
+program
+  .command('config <token>')
+  .description('Get event stream config')
+  .action(async (token) => {
+    await getEventStreamConfig(token);
+  });
+
+program
+  .command('setup <token> <endpoint>')
+  .description('Configure event stream')
+  .option('-e, --events <events...>', 'Events requested')
+  .action(async (token, endpoint, cmdObj) => {
+    const events = cmdObj.events.split(',');
+    await configureEventStream(token, endpoint, events).catch((error) => {
+      console.error(`Failed: ${error}`);
+    });
+  });
+
+program
+  .command('test <token>')
+  .description('Test event stream')
+  .option(
+    '-n, --nonce <nonce>',
+    'Nonce for the test',
+    `Test token requested at ${new Date().toUTCString()}`
+  )
+  .action(async (token, cmdObj) => {
+    await testEventStream(token, cmdObj.nonce).catch((error) => {
+      console.error(`Failed to test event stream: ${error.message}`);
+    });
+  });
+
+program.parse(process.argv);
+function makeBearerToken(credentialsFile) {
+  const serviceAccount = JSON.parse(fs.readFileSync(credentialsFile, 'utf8'));
+  const issuer = serviceAccount.client_email;
+  const subject = serviceAccount.client_email;
+  const privateKeyId = serviceAccount.private_key_id;
+  const privateKey = serviceAccount.private_key;
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresAt = issuedAt + 3600;
+
+  const payload = {
+    iss: issuer,
+    sub: subject,
+    aud: 'https://risc.googleapis.com/google.identity.risc.v1beta.RiscManagementService',
+    iat: issuedAt,
+    exp: expiresAt,
+  };
+
+  return jwt.sign(payload, privateKey, {
+    algorithm: 'RS256',
+    header: { kid: privateKeyId },
+  });
+}
+
+async function getEventStreamConfig(authToken) {
+  const streamUpdateEndpoint = 'https://risc.googleapis.com/v1beta/stream';
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+  };
+
+  try {
+    const response = await axios.get(streamUpdateEndpoint, {
+      headers: headers,
+    });
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    console.log('getEventStreamConfig response', response.data);
+    return response.data;
+  } catch (error) {
+    console.error(`Error configuring the event stream: ${error}`);
+    throw error;
+  }
+}
+async function configureEventStream(
+  authToken,
+  receiverEndpoint,
+  eventsRequested
+) {
+  const streamUpdateEndpoint =
+    'https://risc.googleapis.com/v1beta/stream:update';
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+  };
+  const streamCfg = {
+    delivery: {
+      delivery_method:
+        'https://schemas.openid.net/secevent/risc/delivery-method/push',
+      url: receiverEndpoint,
+    },
+    events_requested: eventsRequested,
+  };
+
+  try {
+    const currentConfig = await getEventStreamConfig(authToken);
+    const newConfig = {
+      ...currentConfig,
+      ...streamCfg,
+    };
+
+    const response = await axios.post(streamUpdateEndpoint, newConfig, {
+      headers: headers,
+    });
+    console.log('configureEventStream response', response.data);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+  } catch (error) {
+    console.log(`Error configuring the event stream: ${error}`);
+    throw error;
+  }
+}
+
+async function testEventStream(authToken, nonce) {
+  const streamVerifyEndpoint =
+    'https://risc.googleapis.com/v1beta/stream:verify';
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+  };
+  const state = {
+    state: nonce,
+  };
+
+  try {
+    const response = await axios.post(streamVerifyEndpoint, state, {
+      headers: headers,
+    });
+    console.log('testEventStream response', response.data);
+    if (response.status !== 200) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+  } catch (error) {
+    console.error(`Error testing the event stream: ${error.message}`);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Because

- We need to be to handle Google RISC events, these are security events for the account

## This pull request

- Adds a reciever endpoint
- Adds a cli to setup, configure RISC stream from Google

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7963

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
