### PR TITLE
fix(l10n): Ensure Settings and Payments are displayed RTL for RTL locales

### DIFF
--- a/libs/shared/l10n/README.md
+++ b/libs/shared/l10n/README.md
@@ -8,4 +8,4 @@ Run `nx build shared-l10n` to build the library.
 
 ## Running unit tests
 
-Run `nx test shared-l10n` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run shared-l10n:test-unit` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/shared/l10n/src/index.ts
+++ b/libs/shared/l10n/src/index.ts
@@ -5,6 +5,7 @@ export {
   getLocalizedDateString,
 } from './lib/formatters';
 export { getBundle, getFormattedMsg } from './lib/l10n';
+export * from './lib/determine-direction';
 export * from './lib/determine-locale';
 export * from './lib/localize-timestamp';
 export * from './lib/other-languages';

--- a/libs/shared/l10n/src/lib/determine-direction.spec.ts
+++ b/libs/shared/l10n/src/lib/determine-direction.spec.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { determineDirection } from './determine-direction';
+
+describe('l10n/determineDirection:', () => {
+  it('defaults to ltr for undefined locale', () => {
+    const s: any = undefined;
+    expect(determineDirection(s)).toEqual('ltr');
+  });
+
+  it('defaults to ltr for non-sense langauge', () => {
+    expect(determineDirection('wibble')).toEqual('ltr');
+  });
+
+  it('resolves to ltr for a selection of ltr languages', () => {
+    expect(determineDirection('fr')).toEqual('ltr');
+    expect(determineDirection('de')).toEqual('ltr');
+    expect(determineDirection('zh')).toEqual('ltr');
+  });
+
+  // arabic is not currently supported, and strings will be displayed in English
+  // direction must be LTR for English even if requested locale is arabic
+  it('resolves to ltr for unspported ltr language', () => {
+    expect(determineDirection('ar')).toEqual('ltr');
+  });
+
+  it('resolves to rtl for hebrew', () => {
+    expect(determineDirection('he')).toEqual('rtl');
+  });
+
+  it('it ignores case and resovles to rtl for hebrew', () => {
+    expect(determineDirection('he-il')).toEqual('rtl');
+    expect(determineDirection('he-IL')).toEqual('rtl');
+  });
+});

--- a/libs/shared/l10n/src/lib/determine-direction.ts
+++ b/libs/shared/l10n/src/lib/determine-direction.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { determineLocale } from './determine-locale';
+import rtlLocales from './rtl-locales.json';
+
+/**
+ * Given a set of supported languages and an accept-language http header value, this resolves the direction of the language that fits best.
+ * @param acceptLanguage - The accept-language http header value
+ * @param supportedLanguages - optional set of supported languages. Defaults to main list held in ./supportedLanguages.json
+ * @returns The best fitting locale
+ */
+export function determineDirection(
+  acceptLanguage: string,
+  supportedLanguages?: string[]
+) {
+  const locale = determineLocale(acceptLanguage, supportedLanguages);
+  if (rtlLocales.includes(locale)) {
+    return 'rtl';
+  }
+  return 'ltr';
+}

--- a/libs/shared/l10n/src/lib/rtl-locales.json
+++ b/libs/shared/l10n/src/lib/rtl-locales.json
@@ -1,0 +1,17 @@
+[
+  "ar",
+  "arc",
+  "ckb",
+  "dv",
+  "fa",
+  "he",
+  "he-IL",
+  "ks",
+  "pa-PK",
+  "ps",
+  "skr",
+  "syr",
+  "ug",
+  "ur",
+  "yi"
+]

--- a/packages/fxa-auth-server/lib/senders/renderer/index.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/index.ts
@@ -17,6 +17,7 @@ const RTL_LOCALES = [
   'syr',
   'ur',
   'ug',
+  'pa',
 ];
 
 export interface GlobalTemplateValues {

--- a/packages/fxa-react/components/Head/index.tsx
+++ b/packages/fxa-react/components/Head/index.tsx
@@ -5,11 +5,20 @@
 import { useLocalization } from '@fluent/react';
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { determineLocale } from 'fxa-shared/l10n/determineLocale';
+import { determineDirection } from 'fxa-shared/l10n/determineDirection';
+
+const supportedUserLocale = determineLocale(
+  window.navigator.languages.join(', ')
+);
+const localeDirection = determineDirection(supportedUserLocale);
 
 const Head = ({ title }: { title?: string }) => {
   const { l10n } = useLocalization();
   return (
-    <Helmet>
+    <Helmet
+      htmlAttributes={{ lang: supportedUserLocale, dir: localeDirection }}
+    >
       <title>
         {title
           ? l10n.getString(

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/VectorImagesForPdf.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/VectorImagesForPdf.tsx
@@ -158,8 +158,12 @@ export const KeySvg = (props: { direction: 'rtl' | 'ltr' }) => {
 
 export const MozillaLogoSvg = () => {
   return (
-    <Svg viewBox="0 0 2000 571.9" height="22" preserveAspectRatio="true">
-      <Rect y="0" width="2000" height="571.9" style={{ fill: 'black' }} />
+    <Svg
+      viewBox="0 0 2000 571.9"
+      style={{ height: '22', width: '77' }}
+      preserveAspectRatio="true"
+    >
+      <Rect width="2000" height="571.9" style={{ fill: 'black' }} />
       <Path
         d="M1910.2,410.5c-3.9,1.1-7.2,1.7-10.5,1.7c-11.7,0-17.2-5-17.2-19.4V284.1c0-57.1-45.5-84.9-99.3-84.9
 		c-41.1,0-63.2,5-107.1,22.7l-9.8,57.6l57.1,6.1l8.1-28.2c11.7-6.1,23.3-7.2,38.3-7.2c40.5,0,41.1,30.5,41.1,56v8.3

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../lib/metrics';
 import { FontData, getRequiredFont } from './requiredFont';
+import { determineLocale } from 'fxa-shared/l10n/determineLocale';
 
 export interface LocalizedRecoveryKeyPdfContent {
   heading: string;
@@ -52,7 +53,9 @@ export const ButtonDownloadRecoveryKeyPDF = ({
   const account = useAccount();
   const email = account.primaryEmail.email;
   const keyCreated = Date.now();
-  const currentLanguage = navigator.language;
+  const currentLanguage = determineLocale(
+    window.navigator.languages.join(', ')
+  );
   const ftlMsgResolver = useFtlMsgResolver();
 
   const alertBar = useAlertBar();

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/requiredFont.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/requiredFont.test.tsx
@@ -54,10 +54,12 @@ describe('getRequiredFont', () => {
     expect(requiredFont.direction).toEqual('ltr');
   });
 
+  // Punjabi (India) uses Gurmukhi script and is written left-to-right
+  // Punjabi (Pakistan) - pa-PK - is currently unsupported and uses Shahmukhi script and is written right-to-left
   it('returns the expected font data when the language is Punjabi', async () => {
     const requiredFont = getRequiredFont('pa');
     expect(requiredFont.family).toEqual('Noto Serif Gurmukhi');
-    expect(requiredFont.direction).toEqual('rtl');
+    expect(requiredFont.direction).toEqual('ltr');
   });
 
   it('returns the expected font data when the language is Thai', async () => {

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/requiredFont.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/requiredFont.tsx
@@ -164,12 +164,13 @@ export const getRequiredFont = (language: string) => {
         breakwords: false,
       };
       break;
-    // Punjabi
+    // Punjabi (India)
     // Noto Sans variant of this font was not working as expected and was preventing PDF generation
     // Replaced with Noto Serif version
+    // NOTE: Punjabi (Pakistan) - pa-PK - is not currently supported and falls back to Punjabi (India)
+    // If Punjabi (Pakistan) becomes supported, and will need its own script (Shamukhi) and direction (RTL)
     case 'pa':
     case 'pa-in':
-    case 'pa-pk':
       requiredFont = {
         family: 'Noto Serif Gurmukhi',
         sources: [
@@ -189,7 +190,7 @@ export const getRequiredFont = (language: string) => {
             weight: 'bold',
           },
         ],
-        direction: 'rtl',
+        direction: 'ltr',
         breakwords: false,
       };
       break;

--- a/packages/fxa-shared/l10n/determineDirection.ts
+++ b/packages/fxa-shared/l10n/determineDirection.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// TODO - FXA-8413 - Delete file. Replaced by @fxa/shared/l10n
+
+import { determineLocale } from './determineLocale';
+import rtlLocales from './rtl-locales.json';
+
+/**
+ * Given a set of supported languages and an accept-language http header value, this resolves the direction of the language that fits best.
+ * @param acceptLanguage - The accept-language http header value
+ * @param supportedLanguages - optional set of supported languages. Defaults to main list held in ./supportedLanguages.json
+ * @returns The best fitting locale
+ */
+export function determineDirection(
+  acceptLanguage: string,
+  supportedLanguages?: string[]
+) {
+  const locale = determineLocale(acceptLanguage, supportedLanguages);
+  if (rtlLocales.includes(locale)) {
+    return 'rtl';
+  }
+  return 'ltr';
+}

--- a/packages/fxa-shared/l10n/rtl-locales.json
+++ b/packages/fxa-shared/l10n/rtl-locales.json
@@ -1,0 +1,17 @@
+[
+  "ar",
+  "arc",
+  "ckb",
+  "dv",
+  "fa",
+  "he",
+  "he-IL",
+  "ks",
+  "pa-PK",
+  "ps",
+  "skr",
+  "syr",
+  "ug",
+  "ur",
+  "yi"
+]


### PR DESCRIPTION
## Because

* Settings and payments were not automatically displayed in RTL for languages such as Hebrew
* dir and lang html attributes were defaulting to en, ltr

## This pull request

* Set lang and dir with react helmet
* Add method to determine locale direction

## Issue that this pull request solves

Closes: #FXA-6234

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This fix does not apply to Storybook - storybook has a LTR/RTL toggle to manual control directionality. I'm not sure if we want to keep this manual control (only) or use the browser locale+ locale direction as a starting point for storybook.

To test this flow for the account settings:
- set the browser's preferred page display language to a supported RTL language (e.g., Hebew)
- go to `localhost:3030` and sign up/sign in to an account to view account settings
- the page should be displayed in RTL Hebrew
- change the browser language back to an LTR language (e.g., english) and refresh the account settings page to verify the direction is now set to LTR
