### PR TITLE
 task(content): Update privacy policy document

### DIFF
--- a/_scripts/clone-legal-docs.sh
+++ b/_scripts/clone-legal-docs.sh
@@ -161,7 +161,7 @@ case "$MODULE" in
         mkdir -p "$MODULE/public/legal-docs"
         cd "$MODULE/public/legal-docs"
         copy_json
-        copy_md "firefox_privacy_notice" # legal/privacy page
+        copy_md "mozilla_accounts_privacy_notice" # legal/privacy page
         copy_md "firefox_cloud_services_tos" # legal/terms page
         ;;
 esac

--- a/packages/fxa-settings/src/lib/file-utils-legal.tsx
+++ b/packages/fxa-settings/src/lib/file-utils-legal.tsx
@@ -6,7 +6,7 @@ import { GET_LEGAL_DOC } from '../models';
 import { ApolloClient } from '@apollo/client';
 
 export enum LegalDocFile {
-  privacy = 'firefox_privacy_notice',
+  privacy = 'mozilla_accounts_privacy_notice',
   terms = 'firefox_cloud_services_tos',
 }
 


### PR DESCRIPTION
## Because

- We now want to reference a privacy policy specific to Mozilla accounts

## This pull request

- Starts using the `Mozilla_Accounts_Privacy_Notice.md` legal doc

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://github.com/mozilla/fxa/assets/94418270/bbc4d859-7127-4ee1-ba4d-29ccccddda9c)


## Other information (Optional)

Note this is a correction to the previous [PR](https://github.com/mozilla/fxa/pull/15915) for FXA-8347. It turns out the privacy document for Mozilla accounts had not yet been written, and the wrong document was incorrectly referenced. The changes for that [PR](https://github.com/mozilla/fxa/pull/15930) were reverted. 

The legal document for Mozilla accounts privacy [landed](https://github.com/mozilla/legal-docs/pull/1942) just the other day, and this PR should now is now referencing that document.