### PR TITLE
feat: Accept new RP names

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
@@ -49,6 +49,7 @@ export function Service({
       Icon = <PocketIcon data-testid="pocket-icon" />;
       break;
     case 'Firefox Monitor':
+    case 'Mozilla Monitor':
       serviceLink = 'https://monitor.firefox.com/';
       Icon = <MonitorIcon data-testid="monitor-icon" />;
       break;
@@ -61,6 +62,7 @@ export function Service({
       Icon = <FPNIcon data-testid="fpn-icon" />;
       break;
     case 'Firefox Relay':
+    case 'Mozilla Relay':
       serviceLink = 'https://relay.firefox.com/';
       Icon = <RelayIcon data-testid="relay-icon" />;
       break;


### PR DESCRIPTION
Because:

* RP names will change Dec 5 and we should continue to show the right icons

This commit:

* accepts the new names

Closes FXA-8506