### PR TITLE
bug(settings): Firefox Accounts requires JavaScript

### DIFF
--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -18,7 +18,7 @@
 </head>
 
 <body>
-  <noscript>Firefox Accounts requires JavaScript.</noscript>
+  <noscript>Mozilla accounts requires JavaScript.</noscript>
   <div id="root"></div>
 </body>
 


### PR DESCRIPTION
## Because

- We are updating <Mozilla branding

## This pull request

- Changes text to Mozilla accounts requires JavaScript

## Issue that this pull request solves

Closes: FXA-8517

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


