### PR TITLE
bug(settings,content): Font weight and size incorrect in postlaunch banner

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -25,7 +25,7 @@
             {{#showPostlaunch}}
             <div class="flex ms-auto"/>
                 <div>
-                    <p class="text-sm font-bold">
+                    <p class="text-start text-xs font-semibold">
                         {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
                         <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</span>
                     </p>

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -136,7 +136,7 @@ export const BrandMessaging = ({
         {mode === 'postlaunch' && (
           <div className="flex ms-auto" data-testid="brand-postlaunch">
             <div>
-              <p className="text-sm font-bold">
+              <p className="text-start text-xs font-semibold">
                 <FtlMsg id="brand-postlaunch-title">
                   We’ve renamed Firefox accounts to Mozilla accounts. You’ll
                   still sign in with the same username and password, and there


### PR DESCRIPTION


## Because

- The font weight and size were not to spec

## This pull request

- Sets font to 12px (tailwind text-xs)
- Sets weight to 600 (tailwind font-semibold)

## Issue that this pull request solves

Closes: FXA-8505

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

