### PR TITLE
task(auth): Update totp service name

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1669,7 +1669,7 @@ const convictConf = convict({
   totp: {
     serviceName: {
       doc: 'Default service name to appear in authenticator',
-      default: 'Firefox',
+      default: 'Mozilla',
       format: 'String',
       env: 'TOTP_SERVICE_NAME',
     },


### PR DESCRIPTION
## Because

- We were encoding Firefox as the service name used when setting up a 2FA authenticator

## This pull request

- Changes the totp service name to Mozilla

## Issue that this pull request solves

Closes: FXA-8509

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

From authy:
![image](https://github.com/mozilla/fxa/assets/94418270/9156682b-c4a1-4bf3-9bdb-fb1ddddc0b55)


## Other information (Optional)

Note that authenticator apps, like Authy, automatically try to look up a logo based on service name. By changing the service name we also change the logo in the authenticator app.

Also note that this name has no bearing the authenticity of totp codes.
