### PR TITLE
fix(payments): Remove remaining mentions of Firefox accounts

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/en.ftl
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/en.ftl
@@ -1,5 +1,6 @@
 ## Component - PaymentConsentCheckbox
 
 payment-confirm-with-legal-links-static = I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method for the amount shown, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+payment-confirm-with-legal-links-static-2 = I authorize { -brand-name-mozilla } to charge my payment method for the amount shown, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 
 payment-confirm-checkbox-error = You need to complete this before moving forward

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
@@ -83,7 +83,7 @@ describe('components/PaymentConsentCheckbox', () => {
         const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
 
         expect(legalCheckbox.props.children.props.children[0]).toBe(
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to'
+          'I authorize Mozilla to charge my payment method for the amount shown, according to'
         );
         expect(legalCheckbox.props.children.props.children[1]).toBe(' ');
         expect(legalCheckbox.props.children.props.children[2].props.href).toBe(
@@ -108,7 +108,7 @@ describe('components/PaymentConsentCheckbox', () => {
       it('renders Localized for a plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_daily';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'payment-confirm-with-legal-links-static';
+        const expectedMsgId = 'payment-confirm-with-legal-links-static-2';
 
         runTests(plan, expectedMsgId);
       });

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.tsx
@@ -65,7 +65,7 @@ export const PaymentConsentCheckbox = ({
 
   return (
     <Localized
-      id="payment-confirm-with-legal-links-static"
+      id="payment-confirm-with-legal-links-static-2"
       elems={{
         termsOfServiceLink: (
           <LinkExternal href={termsOfService}>Terms of Service</LinkExternal>
@@ -86,8 +86,8 @@ export const PaymentConsentCheckbox = ({
           validateCheckbox(value, focused, props)
         }
       >
-        I authorize Mozilla, maker of Firefox products, to charge my payment
-        method for the amount shown, according to{' '}
+        I authorize Mozilla to charge my payment method for the amount shown,
+        according to{' '}
         <LinkExternal href={termsOfService}>Terms of Service</LinkExternal> and{' '}
         <LinkExternal href={privacyNotice}>Privacy Notice</LinkExternal>, until
         I cancel my subscription.

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -109,7 +109,7 @@ describe('components/PaymentMethodHeader', () => {
         MOCK_PLANS.find((p) => p.plan_id === 'plan_daily') || MOCK_PLANS[0];
       const props = { plan, onClick: () => {} };
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method for the amount shown, according to Terms of ServiceOpens in new window and Privacy NoticeOpens in new window, until I cancel my subscription.';
+        'I authorize Mozilla to charge my payment method for the amount shown, according to Terms of ServiceOpens in new window and Privacy NoticeOpens in new window, until I cancel my subscription.';
 
       const { findByTestId } = renderWithLocalizationProvider(
         <PaymentMethodHeader {...props} />

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/en.ftl
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/en.ftl
@@ -1,5 +1,8 @@
 ## Component - TermsAndPrivacy
 
+# "Mozilla Accounts" is capitalized in this instance for title case in English
+# This heading is followed by links to Terms of Service and Privacy Notice
+subplat-mozilla-accounts-legal-heading = { -product-mozilla-accounts(capitalization:"uppercase") }
 terms = Terms of Service
 privacy = Privacy Notice
 terms-download = Download Terms

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -60,7 +60,9 @@ export const TermsAndPrivacy = ({
 
   const FXALegal = showFXALinks ? (
     <>
-      <p className="legal-heading">Firefox Accounts</p>
+      <Localized id="subplat-mozilla-accounts-legal-heading">
+        <p className="legal-heading">Mozilla Accounts</p>
+      </Localized>
       <p data-testid="fxa-legal-links">
         <Localized id="terms">
           <LinkExternal


### PR DESCRIPTION
## Because

* We are rebranding to Mozilla accounts

## This pull request

* Removes "make of Firefox products" from checkout page
* Replace Firefox Accounts with Mozilla Accounts in footer

## Issue that this pull request solves

Closes: #FXA-8510, FXA-8511

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Previous:
![image](https://github.com/mozilla/fxa/assets/22231637/c8ae4a97-7a48-4e4e-ae9c-4b257831a6e6)

Updated:
![image](https://github.com/mozilla/fxa/assets/22231637/2863a323-c151-4a40-ad8a-a876428fd36d)

Previous:
![image](https://github.com/mozilla/fxa/assets/22231637/129b619c-0fcb-4bc1-a294-361b20b559e1)

Updated:
![image](https://github.com/mozilla/fxa/assets/22231637/7f82006f-a05e-4409-bace-9faadb05638b)

## Other information (Optional)

The ftl file served for payments include both the payments branding terms and general branding terms, so the payments app is able to access the new branding terms in fxa-shared.
