### PR TITLE
bug(content): Fix font style on signup with passwordless flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/400.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/400.mustache
@@ -1,10 +1,9 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-400-header">{{#t}}Bad Request{{/t}}</h1>
+    <h1 id="fxa-400-header" class="card-header">{{#t}}Bad Request{{/t}}</h1>
   </header>
 
   <section>
     <div class="error visible">{{message}}</div>
   </section>
 </div>
-

--- a/packages/fxa-content-server/app/scripts/templates/500.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/500.mustache
@@ -1,6 +1,6 @@
 <div id="main-content" class="card error-500-page">
   <header>
-    <h1 id="fxa-500-header">{{#t}}500 Error{{/t}}</h1>
+    <h1 id="fxa-500-header" class="card-header">{{#t}}500 Error{{/t}}</h1>
   </header>
 
   <section>
@@ -10,4 +10,3 @@
     </details>
   </section>
 </div>
-

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
@@ -1,7 +1,7 @@
 <div id="main-content" class="card account-setup-set-password">
     {{^isLinkValid}}
         <header>
-            <h1 id="fxa-account-setup-set-damaged-header">{{#t}}Link damaged{{/t}}</h1>
+            <h1 id="fxa-account-setup-set-damaged-header" class="card-header">{{#t}}Link damaged{{/t}}</h1>
         </header>
 
         <section>
@@ -13,10 +13,10 @@
 
     {{#isLinkValid}}
     <header>
-        <h1 id="fxa-account-setup-set-password-header">
+        <h1 id="fxa-account-setup-set-password-header" class="card-header">
         {{#productName}}
             <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(productName)s" -->
-            {{#t}}Create a Mozilla account{{/t}} <span class="service">{{#t}}Continue to %(productName)s{{/t}}</span>
+            {{#t}}Create a Mozilla account{{/t}} <span id="subheader" class="card-subheader">{{#t}}Continue to %(productName)s{{/t}}</span>
         {{/productName}}
         {{^productName}}
             {{#t}}Create a Mozilla account{{/t}}
@@ -28,7 +28,7 @@
         <div class="error"></div>
 
         <form novalidate>
-            <p id="email">{{ email }}</p>
+            <p id="email" class="my-5 text-base break-all">{{ email }}</p>
 
             <!-- hidden email field is to allow Fx password manager
                  to correctly save the updated password. Without it,

--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -46,7 +46,6 @@
   header {
     margin-bottom: 15px;
 
-    h1,
     h2,
     h3 {
       @include header-font();
@@ -54,8 +53,7 @@
       margin: 0;
     }
 
-    h1 {
-      @include title30();
+        h1 {
       color: $header-color;
       line-height: 26px;
 

--- a/packages/fxa-content-server/server/templates/pages/src/404.html
+++ b/packages/fxa-content-server/server/templates/pages/src/404.html
@@ -12,9 +12,12 @@
     <meta name="referrer" content="origin" />
     <meta name="robots" content="noindex,nofollow" />
 
-    <!-- build:css(.tmp) /styles/main.css -->
-    <link rel="stylesheet" href="/styles/main.css" />
-    <!-- endbuild -->
+      <!-- build:css(.tmp) /styles/main.css -->
+      <link rel="stylesheet" href="/styles/main.css" />
+      <!-- endbuild -->
+      <!-- build:css(.tmp) /styles/tailwind.out.css -->
+      <link rel="stylesheet" href="/styles/tailwind.out.css" />
+      <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
     <div id="mozilla-header">
@@ -28,7 +31,7 @@
     <div id="stage">
       <div id="main-content" class="card">
         <header>
-          <h1 id="fxa-404-header">{{#t}}Page not found{{/t}}</h1>
+          <h1 id="fxa-404-header" class="card-header">{{#t}}Page not found{{/t}}</h1>
         </header>
 
         <p class="fxa-404-p" >

--- a/packages/fxa-content-server/server/templates/pages/src/500.html
+++ b/packages/fxa-content-server/server/templates/pages/src/500.html
@@ -15,6 +15,9 @@
     <!-- build:css(.tmp) /styles/main.css -->
     <link rel="stylesheet" href="/styles/main.css" />
     <!-- endbuild -->
+    <!-- build:css(.tmp) /styles/tailwind.out.css -->
+    <link rel="stylesheet" href="/styles/tailwind.out.css" />
+    <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
     <div id="mozilla-header">
@@ -28,12 +31,14 @@
     <div id="stage">
       <div id="main-content" class="card">
         <header>
-          <h1 id="fxa-500-header">{{#t}}500 Error{{/t}}</h1>
+          <h1 id="fxa-500-header" class="card-header">{{#t}}500 Error{{/t}}</h1>
         </header>
 
         <section>
+          <p>
           {{#t}}Oh dear, something went wrong there. We've been notified and
           will get working on a fix.{{/t}}
+          </p>
         </section>
 
         <div class="button-row">

--- a/packages/fxa-content-server/server/templates/pages/src/502.html
+++ b/packages/fxa-content-server/server/templates/pages/src/502.html
@@ -15,6 +15,9 @@
     <!-- build:css(.tmp) /styles/main.css -->
     <link rel="stylesheet" href="/styles/main.css" />
     <!-- endbuild -->
+    <!-- build:css(.tmp) /styles/tailwind.out.css -->
+    <link rel="stylesheet" href="/styles/tailwind.out.css" />
+    <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
     <div id="mozilla-header">
@@ -28,12 +31,14 @@
     <div id="stage">
       <div id="main-content" class="card">
         <header>
-          <h1 id="fxa-502-header">{{#t}}502 Error{{/t}}</h1>
+          <h1 id="fxa-502-header" class="card-header">{{#t}}502 Error{{/t}}</h1>
         </header>
 
         <section>
+          <p>
           {{#t}}Oh dear, something went wrong there. We've been notified and
           will get working on a fix.{{/t}}
+          </p>
         </section>
 
         <div class="button-row">

--- a/packages/fxa-content-server/server/templates/pages/src/503.html
+++ b/packages/fxa-content-server/server/templates/pages/src/503.html
@@ -12,9 +12,12 @@
     <meta name="referrer" content="origin" />
     <meta name="robots" content="noindex,nofollow" />
 
-    <!-- build:css(.tmp) /styles/main.css -->
-    <link rel="stylesheet" href="/styles/main.css" />
-    <!-- endbuild -->
+     <!-- build:css(.tmp) /styles/main.css -->
+     <link rel="stylesheet" href="/styles/main.css" />
+     <!-- endbuild -->
+     <!-- build:css(.tmp) /styles/tailwind.out.css -->
+     <link rel="stylesheet" href="/styles/tailwind.out.css" />
+     <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
     <div id="mozilla-header">
@@ -28,14 +31,16 @@
     <div id="stage">
       <div id="main-content" class="card">
         <header>
-          <h1 id="fxa-503-header">
+          <h1 id="fxa-503-header" class="card-header">
             {{#t}}Server busy, try again soon{{/t}}
           </h1>
         </header>
 
         <section>
-          {{#t}}We are currently under heavy strain and are working to return
-          the system to normal as soon as possible.{{/t}}
+          <p>
+            {{#t}}We are currently under heavy strain and are working to return
+            the system to normal as soon as possible.{{/t}}
+          </p>
         </section>
 
         <div class="button-row">


### PR DESCRIPTION
## Because

- This view didn't look like others

## This pull request

- Adds appropriate classes
- Removes some legacy hacks in _layout.scss

## Issue that this pull request solves

Closes: FXA-8515

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/mozilla/fxa/assets/94418270/6194f1a6-c3f4-4e3b-bcd3-cc5fb5a7a7c3)
![image](https://github.com/mozilla/fxa/assets/94418270/5121fdf2-b5f5-4248-a473-59632aa98611)
![image](https://github.com/mozilla/fxa/assets/94418270/fe6842b1-2cb8-4342-b9cc-67fdbe646c29)
![image](https://github.com/mozilla/fxa/assets/94418270/3c8cff6e-372e-4444-99aa-ab4e8a01e828)
![image](https://github.com/mozilla/fxa/assets/94418270/d958156d-4a1b-4e97-b089-0e9f3953a01c)


## Other information (Optional)

Note this could probably use a follow up due to the comment here. It's largely outside the scope of account branding work, so the minimum fix will be applied here.
