### PR TITLE
fix(build): use different tmp file name

### DIFF
--- a/_dev/docker/mono/build.sh
+++ b/_dev/docker/mono/build.sh
@@ -19,7 +19,7 @@ VERSION=$(echo "${VERSION}" | sed 's/^v//')
 function patchVersion() {
   if [ -f "package.json" ]; then
     echo "Updating version in $(pwd)/package.json to ${VERSION}"
-    jq ".version = \"$VERSION\"" package.json > tmp && mv tmp package.json
+    jq ".version = \"$VERSION\"" package.json > ver_tmp && mv ver_tmp package.json
   else
     echo "$(pwd)/package.json not found!"
   fi


### PR DESCRIPTION
Because:
 - at least one of the build processes creates a 'tmp' directory in the project root directory, which would cause the mono build script to fail
   - this is not an issue in CI since its starting state is clean but locally if the monorepo's been built before this becomes an issue

This commit:
 - renames the temporary file name slightly
