### PR TITLE
fix: stop throwing when an email bounces

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -434,7 +434,7 @@ module.exports = function (log, config, bounces) {
         to,
         template,
       });
-      throw err;
+      return;
     }
 
     if (this.sesConfigurationSet) {


### PR DESCRIPTION
Because:

* We have unhandled exceptions for bounced emails

This commit:

* Stops throwing them

Closes FXA-3643
