### PR TITLE
chore(build): split the fxa-settings js bundle

### DIFF
--- a/packages/fxa-settings/config/webpack.config.js
+++ b/packages/fxa-settings/config/webpack.config.js
@@ -322,6 +322,9 @@ module.exports = function (webpackEnv) {
           'react-dom$': 'react-dom/profiling',
           'scheduler/tracing': 'scheduler/tracing-profiling',
         }),
+        fxaCryptoDeriver: require.resolve(
+          'fxa-crypto-relier/dist/fxa-crypto-relier/fxa-crypto-deriver'
+        ),
         ...(modules.webpackAliases || {}),
       },
       plugins: [

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps, Router } from '@reach/router';
 import { ScrollToTop } from '../Settings/ScrollToTop';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+
 import { currentAccount, sessionToken } from '../../lib/cache';
 import {
   useAccount,
@@ -17,7 +19,6 @@ import * as Metrics from '../../lib/metrics';
 import sentryMetrics from 'fxa-shared/lib/sentry';
 
 import { PageWithLoggedInStatusState } from '../PageWithLoggedInStatusState';
-import Settings from '../Settings';
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
 import Clear from '../../pages/Clear';
 import CookiesDisabled from '../../pages/CookiesDisabled';
@@ -55,6 +56,8 @@ import AccountRecoveryResetPasswordContainer from '../../pages/ResetPassword/Acc
 import { QueryParams } from '../..';
 import SignupContainer from '../../pages/Signup/container';
 import GleanMetrics from '../../lib/glean';
+
+const Settings = lazy(() => import('../Settings'));
 
 // TODO: FXA-8098
 // export const INITIAL_METRICS_QUERY = gql`
@@ -160,7 +163,9 @@ const SettingsRoutes = (_: RouteComponentProps) => {
   return (
     <SettingsContext.Provider value={settingsContext}>
       <ScrollToTop default>
-        <Settings path="/settings/*" />
+        <Suspense fallback={<LoadingSpinner />}>
+          <Settings path="/settings/*" />
+        </Suspense>
       </ScrollToTop>
     </SettingsContext.Provider>
   );

--- a/packages/fxa-settings/src/lib/crypto/deriver.ts
+++ b/packages/fxa-settings/src/lib/crypto/deriver.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// `fxaCryptoDeriver` is used in device pairing, so it's not something we
+// always need to load in the main js bundle.
+export default function importFxaCryptoDeriver() {
+  // @ts-ignore
+  return import(/* webpackChunkName: "fxaCryptoDeriver" */ 'fxaCryptoDeriver');
+}


### PR DESCRIPTION
Because:
 - we should split the fxa-settings js bundle into smaller chunks

This commit:
 - splits Settings and non-Settings routes by lazy loading the Settings component

I did try Webpack's `splitChunks` but that did not make sense as the main js file will always load the "shared" code; we really have just one entrypoint.  All that would get us is an extra request to get the shared js.  

Any further lazy loading of components are very small incremental gains.  But more importantly, attempts in doing so resulted in `Error: The <Localized /> component was not properly wrapped in a <LocalizationProvider />.`  That's the reason there aren't any more lazy loaded components in this PR.

So this is the first attempt at code-splitting with the low hanging fruit.  If we want to reduce the file sizes, I think investing effort in tree shaking is more worthwhile since the main js file is still pretty large after the split.