### PR TITLE
fix(branding): Minor UI tweaks for Mozilla banner in Backbone & React

### DIFF
--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -25,8 +25,8 @@ body {
     justify-content: flex-start;
     padding-top: 0;
 
-    & #mozilla-header {
-      display:none;
+    & .mozilla-header {
+      display: none;
     }
   }
 

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -31,24 +31,24 @@
   }
 }
 
-#mozilla-header {
+.mozilla-header {
   width: 100%;
-  padding: 0 2rem;
-  margin-bottom: 2rem;
+  padding: 0 1.5rem;
+  margin-bottom: 1.5rem;
 
   @include respond-to('small') {
     width: auto;
     margin: auto 0;
-    padding-top: 24px;
+    padding-top: 1.5rem;
   }
 }
 #about-mozilla {
   background: image-url('mozilla.svg') no-repeat center center;
   cursor: pointer;
   display: block;
-  height: 32px;
+  height: 2rem;
   transition: opacity $short-transition;
-  width: 128px;
+  width: 7rem;
 
   // Links to external sites cannot be opened when signing in
   // to Sync on Firefox for iOS
@@ -64,9 +64,9 @@
     padding-top: 3rem;
     margin-bottom: 5rem;
   }
-                                #mozilla-header {
-                                  padding-top: 2rem;
-                                }
+  .mozilla-header {
+    padding-top: 1.5rem;
+  }
 }
 
 .banner-brand-message {

--- a/packages/fxa-content-server/server/templates/pages/src/404.html
+++ b/packages/fxa-content-server/server/templates/pages/src/404.html
@@ -20,14 +20,15 @@
       <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
-    <div id="mozilla-header">
+    <header class="mozilla-header">
       <a
       id="about-mozilla"
       rel="author"
       target="_blank"
       href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+      aria-label="{{#t}}Mozilla logo{{/t}}"
       ></a>
-    </div>
+    </header>
     <div id="stage">
       <div id="main-content" class="card">
         <header>

--- a/packages/fxa-content-server/server/templates/pages/src/500.html
+++ b/packages/fxa-content-server/server/templates/pages/src/500.html
@@ -20,14 +20,15 @@
     <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
-    <div id="mozilla-header">
+    <header class="mozilla-header">
       <a
       id="about-mozilla"
       rel="author"
       target="_blank"
       href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+      aria-label="{{#t}}Mozilla logo{{/t}}"
       ></a>
-    </div>
+    </header>
     <div id="stage">
       <div id="main-content" class="card">
         <header>

--- a/packages/fxa-content-server/server/templates/pages/src/502.html
+++ b/packages/fxa-content-server/server/templates/pages/src/502.html
@@ -20,14 +20,15 @@
     <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
-    <div id="mozilla-header">
+    <header class="mozilla-header">
       <a
       id="about-mozilla"
       rel="author"
       target="_blank"
       href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+      aria-label="{{#t}}Mozilla logo{{/t}}"
       ></a>
-    </div>
+    </header>
     <div id="stage">
       <div id="main-content" class="card">
         <header>

--- a/packages/fxa-content-server/server/templates/pages/src/503.html
+++ b/packages/fxa-content-server/server/templates/pages/src/503.html
@@ -20,14 +20,15 @@
      <!-- endbuild -->
   </head>
   <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
-    <div id="mozilla-header">
+    <header class="mozilla-header">
       <a
       id="about-mozilla"
       rel="author"
       target="_blank"
       href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+      aria-label="{{#t}}Mozilla logo{{/t}}"
       ></a>
-    </div>
+    </header>
     <div id="stage">
       <div id="main-content" class="card">
         <header>

--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -37,14 +37,15 @@
             />
         </div>
 
-        <div id="mozilla-header">
+        <header class="mozilla-header">
             <a
             id="about-mozilla"
             rel="author"
             target="_blank"
             href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+            aria-label="{{#t}}Mozilla logo{{/t}}"
             ></a>
-        </div>
+        </header>
 
         <div id="stage">
             <div id="main-content" class="card"></div>

--- a/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
+++ b/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
@@ -25,14 +25,15 @@
         <script type="text/javascript" src="{{ bundlePath }}/head.bundle.js"></script>
     </head>
     <body class="static">
-        <div id="mozilla-header">
+        <header class="mozilla-header">
             <a
             id="about-mozilla"
             rel="author"
             target="_blank"
             href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+            aria-label="{{#t}}Mozilla logo{{/t}}"
             ></a>
-          </div>
+        </header>
         <div id="stage">
             <div id="main-content" class="card">
                 <header>

--- a/packages/fxa-react/styles/flows.css
+++ b/packages/fxa-react/styles/flows.css
@@ -6,7 +6,7 @@
  * applied after content-server no longer needs it */
 /* Transparent border around card is for Windows HCM mode */
 .card {
-  @apply relative text-center w-full border border-transparent mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 pb-12 pt-9 mobileLandscape:shadow-card-grey-drop;
+  @apply relative text-center w-full border border-transparent mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 pb-12 pt-9 mobileLandscape:shadow-card-grey-drop mb-6;
 
   /* HACK until content-server no longer needs .card, otherwise component classes take precedence */
   &.card-xl {

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -27,10 +27,11 @@ export const AppLayout = ({ title, children, widthClass }: AppLayoutProps) => {
         data-testid="app"
       >
         <div id="body-top" className="w-full hidden mobileLandscape:block" />
-        <div className="w-full">
+        <header className="w-full px-6 pt-16 pb-0 mobileLandscape:py-6">
           <LinkExternal
             rel="author"
             href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+            className="mobileLandscape:inline-block"
           >
             <img
               src={mozLogo}
@@ -39,10 +40,10 @@ export const AppLayout = ({ title, children, widthClass }: AppLayoutProps) => {
                 null,
                 'Mozilla logo'
               )}
-              className="h-20 p-6 mx-auto mobileLandscape:mx-0"
+              className="h-auto w-28 mx-auto mobileLandscape:mx-0"
             />
           </LinkExternal>
-        </div>
+        </header>
         <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1">
           <section>
             <div className={classNames('card', widthClass)}>{children}</div>


### PR DESCRIPTION
Because:
* There were some minor UI inconsistencies between the two versions

This commit:
* Fixes that in React, the banner link was expanding the full width
* Addresses in Backbone, extra horizontal space when tabbing, using px values instead of rem, and a reused style was referenced by ID instead of class
* There was some inconsistent margin/padding across breakpoints when comparing the two versions which this fixes, and adds a small margin-bottom on the card so the box shadow no longer cuts off
* Adds minor a11y improvements

fixes FXA-8539

**Note**: I realized after the `<header>` change that while this definitely makes sense in desktop IMO, it could probably go either way in mobile. I'm OK with reverting that back to a `div` if we want, but I also think it's fine the way it is. It's also pretty easy to create a component for this in React and conditionally render a `header` or `div`, but the less easy part is updating it on window width change.

---

Ignore the banner difference in the two, I didn't change the mode locally.

## Backbone

### Before
<img width="601" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/7f9356c9-b63b-425f-9a97-19b18bda5932">


### After

(less padding to match React + rems, horizontal width fix)
<img width="506" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/42c809a2-4932-4b54-9bd5-16c2c50557f1">



## React

### Before
<img width="413" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/d3e6e807-b554-4bfe-81f8-b00296e4fcec">

### After
In mobile, we really need more space at the top. It gets cut off when viewing in-browser if not. Also, this link was extending full width of the div which we don't want.
<img width="438" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/d99bd803-a476-4852-b30d-46b45b6316aa">


## Both

### Before
<img width="524" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/61481ca8-1777-42ef-ac7a-c04940f3cf62">

### After
<img width="532" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/89a0477c-f9b9-4120-8a0d-64e6076477ff">

