### PR TITLE
bug(auth): Fix email subjects when signing in directly from browser

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -808,11 +808,19 @@ module.exports = function (log, config, bounces) {
     };
 
     return oauthClientInfo.fetch(message.service).then((clientInfo) => {
-      const clientName = clientInfo.name;
+      let clientName = clientInfo.name;
       const [time, date] = this._constructLocalTimeString(
         message.timeZone,
         message.acceptLanguage
       );
+
+      /**
+       * Edge case. We assume the service is firefox, which is true when the service is sync. However, if
+       * the service is not sync we must be more general. A user could be signing directly into settings.
+       */
+      if (clientName === 'Firefox' && message.service !== 'sync') {
+        clientName = 'Mozilla';
+      }
 
       return this.send({
         ...message,
@@ -875,7 +883,15 @@ module.exports = function (log, config, bounces) {
       'X-Signin-Verify-Code': message.code,
     };
 
-    const { name: serviceName } = await oauthClientInfo.fetch(message.service);
+    let { name: serviceName } = await oauthClientInfo.fetch(message.service);
+
+    /**
+     * Edge case. We assume the service is firefox, which is true when the service is sync. However, if
+     * the service is not sync we must be more general. A user could be signing directly into settings.
+     */
+    if (serviceName === 'Firefox' && message.service !== 'sync') {
+      serviceName = 'Mozilla';
+    }
 
     return this.send({
       ...message,
@@ -1201,11 +1217,19 @@ module.exports = function (log, config, bounces) {
     };
 
     return oauthClientInfo.fetch(message.service).then((clientInfo) => {
-      const clientName = clientInfo.name;
+      let clientName = clientInfo.name;
       const [time, date] = this._constructLocalTimeString(
         message.timeZone,
         message.acceptLanguage
       );
+
+      /**
+       * Edge case. We assume the service is firefox, which is true when the service is sync. However, if
+       * the service is not sync we must be more general. A user could be signing directly into settings.
+       */
+      if (clientName === 'Firefox' && message.service !== 'sync') {
+        clientName = 'Mozilla';
+      }
 
       return this.send({
         ...message,


### PR DESCRIPTION
## Because

- We don't want users to see 'New sign-in to Firefox' in the email subject if they are signing directly into Mozilla accounts
- We don't want users to see 'Approve sign-in to Firefox' in the email subject if they are signing directly into Mozilla accounts

## This pull request

- Replaces the term Firefox with Mozilla for clientName/serviceName when the signin occurs directly from the web (ie not through sync)

## Issue that this pull request solves

Closes: FXA-8530

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that because our email templates are expecting a product name for `New sign-in to <% -clientName %>` or `Approve sign-in to <%- serviceName ->`. I have opted to simply use the term Mozilla in this case so as to be consistent. This needs to be cleared with product. If this is not okay, we will need to come up with a different term, e.g. 'account settings' or 'Mozilla account settings', and this term will need to be translated.
