### PR TITLE
feat(contentful): setup cachebusting

### DIFF
--- a/libs/shared/contentful/src/lib/contentful.client.config.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.config.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsString, IsUrl } from 'class-validator';
+import { IsNumber, IsString, IsUrl } from 'class-validator';
 
 export class ContentfulClientConfig {
   @IsUrl()
@@ -19,4 +19,7 @@ export class ContentfulClientConfig {
 
   @IsString()
   public readonly graphqlEnvironment!: string;
+
+  @IsNumber()
+  public readonly cacheTTL?: number;
 }

--- a/libs/shared/contentful/src/lib/contentful.client.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.ts
@@ -23,6 +23,8 @@ import {
 } from './contentful.error';
 import { ContentfulErrorResponse } from './types';
 
+const DEFAULT_CACHE_TTL = 300000; // Milliseconds
+
 @Injectable()
 export class ContentfulClient {
   client = new ApolloClient({
@@ -31,7 +33,9 @@ export class ContentfulClient {
   });
   private locales: string[] = [];
 
-  constructor(private contentfulClientConfig: ContentfulClientConfig) {}
+  constructor(private contentfulClientConfig: ContentfulClientConfig) {
+    this.setupCacheBust();
+  }
 
   async getLocale(acceptLanguage: string): Promise<string> {
     const contentfulLocales = await this.getLocales();
@@ -123,5 +127,14 @@ export class ContentfulClient {
         );
       })
     );
+  }
+
+  private setupCacheBust() {
+    const cacheTTL = this.contentfulClientConfig.cacheTTL || DEFAULT_CACHE_TTL;
+
+    setInterval(() => {
+      this.locales = [];
+      this.client.clearStore();
+    }, cacheTTL);
   }
 }


### PR DESCRIPTION
## Because

* Apollo client provides no means of setting a cache TTL

## This pull request

* Sets up cache busting on a 5 minute interval by default, configurable via optional Nestjs config option.

## Issue that this pull request solves

Closes: FXA-8224