### PR TITLE
feat(auth): add sample rate to capability sentry

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -678,6 +678,13 @@ describe('DirectStripeRoutes', () => {
         `CapabilityManager not found.`,
         'error'
       );
+
+      // Test logToSentry logic. Remove if no longer necessary
+      await directStripeRoutes.getClients();
+
+      sinon.assert.calledOnceWithExactly(sentryScope.setContext, 'getClients', {
+        msg: `CapabilityManager not found.`,
+      });
     });
 
     it('returns results from Contentful when it matches Stripe', async () => {
@@ -736,6 +743,14 @@ describe('DirectStripeRoutes', () => {
         `Returned Stripe as clients did not match.`,
         'error'
       );
+
+      // Test logToSentry logic. Remove if no longer necessary
+      await directStripeRoutesInstance.getClients();
+
+      sinon.assert.calledOnceWithExactly(sentryScope.setContext, 'getClients', {
+        contentful: mockClientsFromContentful,
+        stripe: mockClientsFromStripe,
+      });
     });
   });
 


### PR DESCRIPTION
## Because

- Capability APIs and related functions have high usage, and certain Sentry events do not need to be logged for every event.

## This pull request

- Adds a function to wrap calls to Sentry, to only send events for a specified sample rate.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

