### PR TITLE
fix(tests): Skip react signup tests in production

### DIFF
--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -80,10 +80,11 @@ test.describe('severity-1 #smoke', () => {
       target,
       page,
       pages: { relier },
-    }) => {
-      await page.goto(
-        `${target.contentServerUrl}/oauth/success/dcdb5ae7add825d2`
-      );
+    }, { project }) => {
+      // Our production clientId for 123Done is different from localhost and stage
+      const clientId =
+        project.name === 'production' ? '3c32bf6654542211' : 'dcdb5ae7add825d2';
+      await page.goto(`${target.contentServerUrl}/oauth/success/${clientId}`);
 
       //Verify oauth success header
       expect(await relier.isOauthSuccessHeader()).toBe(true);

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -12,7 +12,7 @@ test.describe('severity-1 #smoke', () => {
   test.describe('signup react', () => {
     let email;
 
-    test.beforeEach(async ({ pages: { configPage, login } }) => {
+    test.beforeEach(async ({ pages: { configPage, login } }, { project }) => {
       test.slow();
       // Ensure that the feature flag is enabled
       const config = await configPage.getConfig();
@@ -22,6 +22,8 @@ test.describe('severity-1 #smoke', () => {
       } else {
         email = login.createEmail('signup_react{id}');
       }
+
+      test.skip(project.name === 'production', 'skip for production');
     });
 
     test.afterEach(async ({ target }) => {


### PR DESCRIPTION
## Because

- We shouldn't run these tests in prod

## This pull request

- Disables them in production

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8540

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
