### PR TITLE
fix(content): Fix unreadable button text when active

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/auth_complete.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/auth_complete.mustache
@@ -18,10 +18,10 @@
 
     <div class="flex">
       {{#hasFirefoxViewSupport}}
-        <a id="open-firefox-view" class="cta-primary cta-xl">{{#t}}See tabs from synced devices{{/t}}</a>
+        <button id="open-firefox-view" class="cta-primary cta-xl">{{#t}}See tabs from synced devices{{/t}}</button>
       {{/hasFirefoxViewSupport}}
       {{^hasFirefoxViewSupport}}
-        <a href="/settings#connected-services" class="cta-primary cta-xl">{{#t}}Manage devices{{/t}}</a>
+        <button id="open-connected-services" class="cta-primary cta-xl">{{#t}}Manage devices{{/t}}</button>
       {{/hasFirefoxViewSupport}}
     </div>
   </section>

--- a/packages/fxa-content-server/app/scripts/views/pair/auth_complete.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/auth_complete.js
@@ -17,6 +17,9 @@ class PairAuthCompleteView extends FormView {
 
   events = assign(this.events, {
     'click #open-firefox-view': preventDefaultThen('openFirefoxView'),
+    'click #open-connected-services': preventDefaultThen(
+      'openConnectedServices'
+    ),
   });
 
   initialize(options) {
@@ -57,6 +60,10 @@ class PairAuthCompleteView extends FormView {
       // TODO: What is the correct entrypoint value?
       entryPoint: 'preferences',
     });
+  }
+
+  openConnectedServices() {
+    this.navigateAway('/settings#connected-services');
   }
 
   _hasFirefoxViewSupport() {


### PR DESCRIPTION
## Because

* On the pair complete page, link text becomes unreadable on click due to insufficient contrast.

## This pull request

* Change link to button element

## Issue that this pull request solves

Closes: #FXA-8483

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

The two possible CTAs for the pair/auth/complete page, with updated focus active and not active states:

![image](https://github.com/mozilla/fxa/assets/22231637/82755fab-552f-4759-90cc-b9063de589b7)

## Other information (Optional)

The `pair/auth/complete` page is difficult to reach locally. To validate that the change from links to buttons resolves the UI/a11y issue, I temporarily copied the buttons to the index page (_change not included in this PR_)