### PR TITLE
task(ci): Remove redis dev password from source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,10 @@ executors:
       - image: jdlk7/firestore-emulator
       - image: memcached
       - image: redis
-        command: --requirepass fxa123
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
       CUSTOMS_SERVER_URL: none
-      REDIS_PASSWORD: fxa123
       HUSKY_SKIP_INSTALL: 1
 
   # For anything that needs a full stack to run and needs browsers available for
@@ -140,7 +138,6 @@ executors:
     docker:
       - image: mozilla/fxa-circleci:ci-functional-test-runner-nx
       - image: redis
-        command: --requirepass fxa123
       - image: memcached
       - image: pafortin/goaws
       - image: cimg/mysql:8.0.28
@@ -166,7 +163,6 @@ executors:
       REACT_CONVERSION_POST_VERIFY_OTHER_ROUTES: true
       REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES: true
       CUSTOMS_SERVER_URL: none
-      REDIS_PASSWORD: fxa123
       HUSKY_SKIP_INSTALL: 1
 
   # Contains a pre-installed fxa stack and browsers for doing ui test

--- a/_scripts/redis.sh
+++ b/_scripts/redis.sh
@@ -1,3 +1,9 @@
 #!/bin/bash -ex
 
-docker run --rm --name redis-server --net fxa -p 6379:6379 redis --requirepass fxa123
+if [ -z "$REDIS_PASSWORD" ]; then
+    REQUIREPASS_ARG="";
+else
+    REQUIREPASS_ARG="--requirepass $REDIS_PASSWORD";
+fi
+
+docker run --rm --name redis-server --net fxa -p 6379:6379 redis $REQUIREPASS_ARG

--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -12,7 +12,7 @@ const logger = morgan('short');
 
 // create a connection to the redis datastore
 let db = new Redis({
-  password: process.env.REDIS_PASSWORD || 'fxa123',
+  password: process.env.REDIS_PASSWORD || '',
 });
 
 db.on('error', function () {

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -145,7 +145,7 @@ const mockConfig = {
 const mockRedisConfig = {
   host: process.env.REDIS_HOST || 'localhost',
   port: process.env.REDIS_PORT || 6379,
-  password: process.env.REDIS_PASSWORD || 'fxa123',
+  password: process.env.REDIS_PASSWORD || '',
   maxPending: 1000,
   retryCount: 5,
   initialBackoff: '100 milliseconds',

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -171,7 +171,7 @@ const conf = (module.exports = convict({
         format: String,
       },
       password: {
-        default: 'fxa123',
+        default: '',
         doc: 'Redis password',
         env: 'REDIS_PASSWORD',
         sensitive: true,

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -288,7 +288,7 @@ const conf = convict({
         doc: 'port for redis server',
       },
       password: {
-        default: 'fxa123',
+        default: '',
         env: 'REDIS_PASSWORD',
         format: String,
         sensitive: true,

--- a/packages/fxa-shared/db/config.ts
+++ b/packages/fxa-shared/db/config.ts
@@ -77,7 +77,7 @@ export function makeRedisConfig() {
       doc: 'IP address or host name for Redis server',
     },
     password: {
-      default: 'fxa123',
+      default: '',
       env: 'REDIS_PASSWORD',
       format: String,
       sensitive: true,

--- a/packages/fxa-shared/scripts/feature-flags.js
+++ b/packages/fxa-shared/scripts/feature-flags.js
@@ -10,7 +10,7 @@ const Ajv = require('ajv');
 const ajv = new Ajv();
 const Redis = require('ioredis');
 const redis = new Redis({
-  password: process.env.REDIS_PASSWORD || 'fxa123',
+  password: process.env.REDIS_PASSWORD || '',
   host: process.env.REDIS_HOST || 'localhost',
   port: process.env.REDIS_PORT || 6379,
   keyPrefix: 'featureFlags:',

--- a/packages/fxa-shared/test/feature-flags/integration.js
+++ b/packages/fxa-shared/test/feature-flags/integration.js
@@ -15,7 +15,7 @@ describe('#integration - featureFlags integration:', () => {
       interval: 10000,
       host: process.env.REDIS_HOST || 'localhost',
       port: process.env.REDIS_PORT || 6379,
-      password: process.env.REDIS_PASSWORD || 'fxa123',
+      password: process.env.REDIS_PASSWORD || '',
     };
     log = { info() {}, warn() {}, error() {} };
     featureFlags = initialise(config, log, {});

--- a/packages/fxa-shared/test/scripts/feature-flags.js
+++ b/packages/fxa-shared/test/scripts/feature-flags.js
@@ -37,7 +37,7 @@ describe('#integration - scripts/feature-flags:', function () {
 
   before(async () => {
     redis = new Redis({
-      password: process.env.REDIS_PASSWORD || 'fxa123',
+      password: process.env.REDIS_PASSWORD || '',
       host: process.env.REDIS_HOST || 'localhost',
       port: process.env.REDIS_PORT || 6379,
       keyPrefix: 'featureFlags:',


### PR DESCRIPTION
## Because
- We are cleaning up things that are being flagged as passwords

## This pull request
- Removes the dev password, fxa123, from source

## Issue that this pull request solves

Closes: FXA-8444

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

In circleci, there was a password being applied and used, it turns this was just a POC to validate that a password could be used with our deployed code. For local development and running in CI a password isn't really necessary.
