### PR TITLE
fix(l10n): Remove en-us from external links

### DIFF
--- a/packages/fxa-react/components/Footer/index.test.tsx
+++ b/packages/fxa-react/components/Footer/index.test.tsx
@@ -23,11 +23,11 @@ describe('Footer', () => {
     );
     expect(screen.getByTestId('link-privacy')).toHaveAttribute(
       'href',
-      'https://www.mozilla.org/en-US/privacy/websites/'
+      'https://www.mozilla.org/privacy/websites/'
     );
     expect(screen.getByTestId('link-terms')).toHaveAttribute(
       'href',
-      'https://www.mozilla.org/en-US/about/legal/terms/services/'
+      'https://www.mozilla.org/about/legal/terms/services/'
     );
   });
 });

--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -32,7 +32,7 @@ export const Footer = () => {
         <Localized id="app-footer-privacy-notice">
           <LinkExternal
             data-testid="link-privacy"
-            href="https://www.mozilla.org/en-US/privacy/websites/"
+            href="https://www.mozilla.org/privacy/websites/"
             className="transition-standard text-xs hover:text-grey-500 hover:underline mobileLandscape:self-end"
           >
             Website Privacy Notice
@@ -43,7 +43,7 @@ export const Footer = () => {
         <Localized id="app-footer-terms-of-service">
           <LinkExternal
             data-testid="link-terms"
-            href="https://www.mozilla.org/en-US/about/legal/terms/services/"
+            href="https://www.mozilla.org/about/legal/terms/services/"
             className="transition-standard text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline"
           >
             Terms of Service

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
@@ -17,7 +17,7 @@ describe('Connect another device Promo', () => {
     ).toBeTruthy();
     expect(await screen.findByTestId('download-link')).toHaveAttribute(
       'href',
-      'https://www.mozilla.org/en-US/firefox/mobile/'
+      'https://www.mozilla.org/firefox/mobile/'
     );
     expect(screen.getByTestId('play-store-link')).toHaveAttribute(
       'href',

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -34,7 +34,7 @@ export function ConnectAnotherDevicePromo() {
             br: <br />,
             linkExternal: (
               <LinkExternal
-                href="https://www.mozilla.org/en-US/firefox/mobile/"
+                href="https://www.mozilla.org/firefox/mobile/"
                 className="link-blue"
                 data-testid="download-link"
               >
@@ -47,7 +47,7 @@ export function ConnectAnotherDevicePromo() {
             Find Firefox in the Google Play and App Store or
             <br />
             <LinkExternal
-              href="https://www.mozilla.org/en-US/firefox/mobile/"
+              href="https://www.mozilla.org/firefox/mobile/"
               className="link-blue"
               data-testid="download-link"
             >

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
@@ -54,7 +54,7 @@ export function Service({
       Icon = <MonitorIcon data-testid="monitor-icon" />;
       break;
     case 'Firefox Lockwise':
-      serviceLink = 'https://www.mozilla.org/en-US/firefox/lockwise/';
+      serviceLink = 'https://www.mozilla.org/firefox/lockwise/';
       Icon = <LockwiseIcon data-testid="lockwise-icon" />;
       break;
     case 'Firefox Private Network':
@@ -68,7 +68,7 @@ export function Service({
       break;
     case 'Firefox Sync':
       serviceLink =
-        'https://support.mozilla.org/en-US/kb/how-do-i-set-sync-my-computer';
+        'https://support.mozilla.org/kb/how-do-i-set-sync-my-computer';
       Icon = <SyncIcon data-testid="sync-icon" />;
       break;
     case 'MDN Plus':

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -149,7 +149,7 @@ describe('Connected Services', () => {
         expect(result.icon).toBeTruthy();
         expect(result.link).toHaveAttribute(
           'href',
-          'https://www.mozilla.org/en-US/firefox/lockwise/'
+          'https://www.mozilla.org/firefox/lockwise/'
         );
       }
     );
@@ -231,7 +231,7 @@ describe('Connected Services', () => {
       expect(result.icon).toBeTruthy();
       expect(result.link).toHaveAttribute(
         'href',
-        'https://support.mozilla.org/en-US/kb/how-do-i-set-sync-my-computer'
+        'https://support.mozilla.org/kb/how-do-i-set-sync-my-computer'
       );
     });
   });

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
@@ -35,7 +35,7 @@ describe('DataCollection', () => {
       screen.getByTestId('link-external-telemetry-opt-out')
     ).toHaveAttribute(
       'href',
-      'https://www.mozilla.org/en-US/privacy/firefox/#firefox-accounts'
+      'https://www.mozilla.org/privacy/firefox/#firefox-accounts'
     );
   });
 

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.tsx
@@ -73,7 +73,7 @@ export const DataCollection = () => {
                 Mozilla.
               </Localized>{' '}
               <LinkExternal
-                href="https://www.mozilla.org/en-US/privacy/firefox/#firefox-accounts"
+                href="https://www.mozilla.org/privacy/firefox/#firefox-accounts"
                 className="link-blue"
                 data-testid="link-external-telemetry-opt-out"
               >

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -153,7 +153,7 @@ export const UnitRowTwoStepAuth = () => {
                 linkExternal: (
                   <LinkExternal
                     className="link-blue"
-                    href="https://support.mozilla.org/en-US/kb/changing-your-two-step-authentication-device-firefox-account"
+                    href="https://support.mozilla.org/kb/changing-your-two-step-authentication-device-firefox-account"
                   >
                     {' '}
                   </LinkExternal>
@@ -165,7 +165,7 @@ export const UnitRowTwoStepAuth = () => {
                 of{' '}
                 <LinkExternal
                   className="link-blue"
-                  href="https://support.mozilla.org/en-US/kb/reset-your-firefox-account-password-recovery-keys"
+                  href="https://support.mozilla.org/kb/reset-your-firefox-account-password-recovery-keys"
                 >
                   replacing your backup authentication codes
                 </LinkExternal>


### PR DESCRIPTION
## Because

* Some links to terms, support articles were forcing en-us version
* We want to show the user's preferred language

## This pull request

* Remove en-US from links

## Issue that this pull request solves

Closes: #FXA-8556

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
