### PR TITLE
fix(content): Apply styling to Signin TOTP

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
@@ -20,9 +20,9 @@
 
     {{^isLinkExpired}}
         <header>
-            <h1 id="fxa-recovery-key-confirm">
+            <h1 id="fxa-recovery-key-confirm" class="card-header">
                 <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-                {{#t}}Reset password with account recovery key{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+                {{#t}}Reset password with account recovery key{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
             </h1>
         </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/inline_recovery_setup.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/inline_recovery_setup.mustache
@@ -1,9 +1,9 @@
 <div id="main-content" class="card inline-recovery-setup">
   {{^showConfirmation}}
   <header>
-    <h1 id="fxa-save-recovery-codes">
+    <h1 id="fxa-save-recovery-codes" class="card-header">
       <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-      {{#t}}Save backup authentication codes{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{#t}}Save backup authentication codes{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
     </h1>
   </header>
   <section>
@@ -55,9 +55,9 @@
   {{/showConfirmation}}
   {{#showConfirmation}}
   <header>
-    <h1 id="fxa-confirm-recovery-code">
+    <h1 id="fxa-confirm-recovery-code" class="card-header">
       <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-      {{#t}}Confirm backup authentication code{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{#t}}Confirm backup authentication code{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
     </h1>
   </header>
   <section>

--- a/packages/fxa-content-server/app/scripts/templates/inline_totp_setup.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/inline_totp_setup.mustache
@@ -1,9 +1,9 @@
 <div id="main-content" class="card inline-totp-setup">
   {{#showIntro}}
     <header>
-      <h1 id="fxa-inline-totp-setup">
+      <h1 id="fxa-inline-totp-setup" class="card-header">
         <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Enable two-step authentication{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{#t}}Enable two-step authentication{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
       </h1>
     </header>
     <section>
@@ -25,15 +25,15 @@
   {{^showIntro}}
     <header>
       {{#showQRImage}}
-        <h1 id="fxa-totp-qr-image">
+        <h1 id="fxa-totp-qr-image" class="card-header">
           <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-          {{#t}}Scan authentication code{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+          {{#t}}Scan authentication code{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
         </h1>
       {{/showQRImage}}
       {{^showQRImage}}
-        <h1 id="fxa-totp-code-text">
+        <h1 id="fxa-totp-code-text" class="card-header">
           <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-          {{#t}}Enter code manually{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+          {{#t}}Enter code manually{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
         </h1>
       {{/showQRImage}}
     </header>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/password/force_password_change.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/password/force_password_change.mustache
@@ -1,9 +1,9 @@
 <div id="main-content" class="card force-password-change">
   <header>
-    <h1 id="fxa-force-password-change-header">
+    <h1 id="fxa-force-password-change-header" class="card-header">
       {{#serviceName}}
         <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Please change your password{{/t}} <span class="service">{{#t}}to continue to %(serviceName)s{{/t}}</span>
+        {{#t}}Please change your password{{/t}} <span class="card-subheader">{{#t}}to continue to %(serviceName)s{{/t}}</span>
       {{/serviceName}}
       {{^serviceName}}
         {{#t}}Please change your password{{/t}}

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/secondary_email/add_secondary_email.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/secondary_email/add_secondary_email.mustache
@@ -1,9 +1,9 @@
 <div id="main-content" class="card add-secondary-email">
     <header>
-        <h1 id="fxa-add-secondary-email-header">
+        <h1 id="fxa-add-secondary-email-header" class="card-header">
             {{#serviceName}}
                 <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-                {{#t}}Add a secondary email address{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+                {{#t}}Add a secondary email address{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
             {{/serviceName}}
             {{^serviceName}}
                 {{#t}}Add a secondary email address{{/t}}

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/secondary_email/confirm_secondary_email.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/secondary_email/confirm_secondary_email.mustache
@@ -1,9 +1,9 @@
 <div id="main-content" class="card confirm-signup">
     <header>
-        <h1 id="fxa-confirm-secondary-email-header">
+        <h1 id="fxa-confirm-secondary-email-header" class="card-header">
             {{#serviceName}}
                 <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-                {{#t}}Enter confirmation code{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+                {{#t}}Enter confirmation code{{/t}} <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
             {{/serviceName}}
             {{^serviceName}}
                 {{#t}}Enter confirmation code{{/t}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
@@ -1,7 +1,7 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-recovery-code-header">{{#t}}Enter backup authentication code{{/t}}
-      <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+    <h1 id="fxa-recovery-code-header" class="card-header">{{#t}}Enter backup authentication code{{/t}}
+      <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
@@ -1,7 +1,7 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-totp-code-header">{{#t}}Enter security code{{/t}}
-      <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+    <h1 id="fxa-totp-code-header" class="card-header">{{#t}}Enter security code{{/t}}
+      <span class="card-subheader">{{#t}}Continue to %(serviceName)s{{/t}}</span>
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/tests/spec/views/pair/auth_totp.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/auth_totp.js
@@ -96,7 +96,7 @@ describe('views/pair/auth_totp', () => {
       return view.render().then(() => {
         $('#container').html(view.el);
         view.$('.totp-code').val(TOTP_CODE);
-        const serviceElText = view.$('.service').text();
+        const serviceElText = view.$('.card-subheader').text();
         assert.include(serviceElText, 'Continue to');
         assert.notInclude(serviceElText, '%(serviceName)');
         return view.submit().then(() => {


### PR DESCRIPTION
## Because

* Sign in with TOTP screen did not have styling applied to header and subheader

## This pull request
* Add styling to sign_in_totp_code mustache file

## Issue that this pull request solves

Closes: #FXA-8559

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://github.com/mozilla/fxa/assets/22231637/195a9542-9f15-4005-8d35-d330a1620436)

After:
![image](https://github.com/mozilla/fxa/assets/22231637/78e7228a-3ef9-4517-bf6a-f9e002bd92bd)

## Other information (Optional)

Any other information that is important to this pull request.
