### PR TITLE
task(nx): Remove accessToken

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,8 +16,7 @@
           "test-e2e",
           "test-integration",
           "test-unit"
-        ],
-        "accessToken": "YWYzOTViMDQtNDE4Ny00MGU5LWFlMWItZTBiODA2YTIwYzMzfHJlYWQ="
+        ]
       }
     }
   },


### PR DESCRIPTION
## Because

- We are removing tokens from our source
- Even those that are just for dev purposes


## This pull request

- Removes the accessToken from the default nx tasksRunnerOptions.

## Issue that this pull request solves

Closes: FXA-8392

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

Note: Some instructions will be added for developers who want to an access token to speed up builds locally.
