### PR TITLE
feat(metrics): add glean pings for setting new password during reset

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import GleanMetrics from '../../../lib/glean';
 import { Account, IntegrationType } from '../../../models';
 import { logPageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
@@ -40,6 +41,11 @@ const PASSWORD = 'passwordzxcv';
 jest.mock('../../../lib/metrics', () => ({
   logPageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
+}));
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: { resetPassword: { createNewView: jest.fn() } },
 }));
 
 let account: Account;
@@ -114,6 +120,8 @@ describe('CompleteResetPassword page', () => {
       hasTotpAuthClient: jest.fn().mockResolvedValue(false),
       isSessionVerifiedAuthClient: jest.fn().mockResolvedValue(true),
     } as unknown as Account;
+
+    (GleanMetrics.resetPassword.createNewView as jest.Mock).mockReset();
   });
 
   afterEach(() => {
@@ -225,6 +233,7 @@ describe('CompleteResetPassword page', () => {
       'complete-reset-password',
       REACT_ENTRYPOINT
     );
+    expect(GleanMetrics.resetPassword.createNewView).toBeCalledTimes(1);
   });
 
   describe('errors', () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -34,6 +34,7 @@ import {
   AuthUiErrors,
   getLocalizedErrorMessage,
 } from '../../../lib/auth-errors/auth-errors';
+import GleanMetrics from '../../../lib/glean';
 
 // The equivalent complete_reset_password mustache file included account_recovery_reset_password
 // For React, we have opted to separate these into two pages to align with the routes.
@@ -68,6 +69,10 @@ const CompleteResetPassword = ({
     state: CompleteResetPasswordLocationState;
   };
   const ftlMsgResolver = useFtlMsgResolver();
+
+  useEffect(() => {
+    GleanMetrics.resetPassword.createNewView();
+  }, []);
 
   const { handleSubmit, register, getValues, errors, formState, trigger } =
     useForm<CompleteResetPasswordFormData>({

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import GleanMetrics from '../../../lib/glean';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import ResetPasswordConfirmed, { viewName } from '.';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
@@ -15,7 +16,16 @@ jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
 }));
 
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: { resetPassword: { createNewSuccess: jest.fn() } },
+}));
+
 describe('ResetPasswordConfirmed', () => {
+  beforeEach(() => {
+    (GleanMetrics.resetPassword.createNewSuccess as jest.Mock).mockReset();
+  });
+
   async function renderResetPasswordConfirmed(params: {
     isSignedIn: boolean;
     continueHandler?: Function;
@@ -44,6 +54,7 @@ describe('ResetPasswordConfirmed', () => {
   it('emits the expected metrics on render', async () => {
     await renderResetPasswordConfirmed({ isSignedIn: false });
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+    expect(GleanMetrics.resetPassword.createNewSuccess).toBeCalledTimes(1);
   });
 
   it('emits the expected metrics when a user clicks `Continue`', async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
@@ -7,6 +7,7 @@ import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
 import AppLayout from '../../../components/AppLayout';
 import { ResetPasswordConfirmedProps } from './interfaces';
+import GleanMetrics from '../../../lib/glean';
 
 export const viewName = 'reset-password-confirmed';
 
@@ -17,6 +18,10 @@ const ResetPasswordConfirmed = ({
 }: ResetPasswordConfirmedProps & RouteComponentProps) => {
   const [serviceName, setServiceName] = useState<string>();
   const [isSync, setIsSync] = useState<boolean>();
+
+  useEffect(() => {
+    GleanMetrics.resetPassword.createNewSuccess();
+  }, []);
 
   useEffect(() => {
     (async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -28,6 +28,7 @@ import { setOriginalTabMarker } from '../../lib/storage-utils';
 import { ResetPasswordFormData, ResetPasswordProps } from './interfaces';
 import { ConfirmResetPasswordLocationState } from './ConfirmResetPassword/interfaces';
 import { BrandMessagingPortal } from '../../components/BrandMessaging';
+import GleanMetrics from '../../lib/glean';
 
 export const viewName = 'reset-password';
 
@@ -55,6 +56,10 @@ const ResetPassword = ({
       setServiceName(name);
     })();
   }, [integration]);
+
+  useEffect(() => {
+    GleanMetrics.resetPassword.view();
+  }, []);
 
   const { control, getValues, handleSubmit, register } =
     useForm<ResetPasswordFormData>({
@@ -143,6 +148,7 @@ const ResetPassword = ({
         ftlMsgResolver.getMsg('auth-error-1011', 'Valid email required')
       );
     } else {
+      GleanMetrics.resetPassword.submit();
       submitEmail(sanitizedEmail);
     }
   }, [ftlMsgResolver, getValues, submitEmail]);

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -58,5 +58,7 @@ export const eventsMap = {
   resetPassword: {
     view: 'password_reset_view',
     submit: 'password_reset_submit',
+    createNewView: 'password_reset_create_new_view',
+    createNewSuccess: 'password_reset_create_new_success',
   },
 };

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -54,4 +54,9 @@ export const eventsMap = {
     submit: 'login_totp_code_submit',
     success: 'login_totp_code_success_view',
   },
+
+  resetPassword: {
+    view: 'password_reset_view',
+    submit: 'password_reset_submit',
+  },
 };


### PR DESCRIPTION
This PR follows, and includes the commit from, https://github.com/mozilla/fxa/pull/15969.  Please review that first.