### PR TITLE
bug(auth): Fail fast if email isn't present in linked account

### DIFF
--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -242,6 +242,17 @@ export class LinkedAccountHandler {
     );
 
     if (!linkedAccountRecord) {
+      // Something has gone wrong! We shouldn't hit a case where we have an unlinked without
+      // an email set in the idToken. Failing hard and fast. Logging more info
+      if (!email) {
+        this.log.error('linked_account.no_email_in_id_token', {
+          provider,
+          userid,
+          name,
+        });
+        throw error.thirdPartyAccountError();
+      }
+
       try {
         // This is a new third party account linking an existing FxA account
         accountRecord = await this.db.accountRecord(email);


### PR DESCRIPTION
## Because

- Calling db.accountRecord with an undefined email is invalid.

## This pull request

- Checks that an email is provided.

## Issue that this pull request solves

Closes: FXA-8382

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

It's odd that this case arises. We get the data from either apple or google's API. I did extensive black box testing and couldn't trip the problem. I noticed that in sentry this issue first showed up in v1.61.2. This is around the time the apple transfer of pocket user script landed. I wonder if this is somehow just impacting pocket users with transferred apple accounts. With the error log, I think we will have a better idea. 
