### PR TITLE
fix(settings): Ensure "delete recovery key" modal can be dismissed

### DIFF
--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.tsx
@@ -18,15 +18,13 @@ export const UnitRowRecoveryKey = () => {
 
   const recoveryKey = account.recoveryKey;
   const alertBar = useAlertBar();
-  const [deleteModalVisible, setDeleteModalVisible] = useState<boolean>(false);
-  const [modalRevealed, hideModal] = useBooleanState();
+  const [modalRevealed, revealModal, hideModal] = useBooleanState();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const ftlMsgResolver = useFtlMsgResolver();
 
   const deleteRecoveryKey = useCallback(async () => {
     try {
       await account.deleteRecoveryKey();
-      setDeleteModalVisible(false);
       hideModal();
       alertBar.success(
         ftlMsgResolver.getMsg(
@@ -37,7 +35,6 @@ export const UnitRowRecoveryKey = () => {
       logViewEvent('flow.settings.account-recovery', 'confirm-revoke.success');
     } catch (e) {
       hideModal();
-      setDeleteModalVisible(false);
       alertBar.error(
         ftlMsgResolver.getMsg(
           'rk-remove-error-2',
@@ -84,7 +81,7 @@ export const UnitRowRecoveryKey = () => {
             title={localizedDeleteRKIconButton}
             classNames="inline-block mobileLandscape:hidden ms-1"
             disabled={!recoveryKey || account.loading}
-            onClick={() => setDeleteModalVisible(true)}
+            onClick={revealModal}
           />
         )
       }
@@ -95,7 +92,7 @@ export const UnitRowRecoveryKey = () => {
             title={localizedDeleteRKIconButton}
             classNames="hidden mobileLandscape:inline-block ms-1"
             disabled={!recoveryKey || account.loading}
-            onClick={() => setDeleteModalVisible(true)}
+            onClick={revealModal}
           />
         )
       }
@@ -105,7 +102,7 @@ export const UnitRowRecoveryKey = () => {
           Restore your information when you forget your password.
         </p>
       </FtlMsg>
-      {(deleteModalVisible || modalRevealed) && (
+      {modalRevealed && (
         <VerifiedSessionGuard
           onDismiss={hideModal}
           onError={(error) => {
@@ -122,7 +119,6 @@ export const UnitRowRecoveryKey = () => {
           <Modal
             onDismiss={() => {
               hideModal();
-              setDeleteModalVisible(false);
             }}
             onConfirm={() => {
               setIsLoading(true);


### PR DESCRIPTION
## Because

* "Delete recovery key" modal is staying on screen after clicking "delete" or dismiss button
## This pull request

* Fix the modal dismiss

## Issue that this pull request solves

Closes: #FXA-8550

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
