### PR TITLE
feat(settings): Add reg_submit Glean Ping in React

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -14,7 +14,6 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 // import { FluentBundle } from '@fluent/bundle';
 import { usePageViewEvent } from '../../lib/metrics';
 import { viewName } from '.';
-import { MozServices } from '../../lib/types';
 import { REACT_ENTRYPOINT } from '../../constants';
 import {
   BEGIN_SIGNUP_HANDLER_FAIL_RESPONSE,
@@ -70,7 +69,7 @@ jest.mock('@reach/router', () => ({
 
 jest.mock('../../lib/glean', () => ({
   __esModule: true,
-  default: { registration: { view: jest.fn() } },
+  default: { registration: { view: jest.fn(), submit: jest.fn() } },
 }));
 
 describe('Signup page', () => {
@@ -302,6 +301,7 @@ describe('Signup page', () => {
         await waitFor(() => {
           expect(document.cookie).toBe('tooyoung=1;');
         });
+        expect(GleanMetrics.registration.submit).not.toBeCalled();
         expect(mockNavigate).toHaveBeenCalledWith('/cannot_create_account');
         expect(mockBeginSignupHandler).not.toBeCalled();
       });
@@ -349,6 +349,16 @@ describe('Signup page', () => {
             replace: true,
           }
         );
+      });
+    });
+
+    it('emits a metrics event on submit', async () => {
+      renderWithLocalizationProvider(<Subject />);
+      await fillOutForm();
+      submit();
+
+      await waitFor(() => {
+        expect(GleanMetrics.registration.submit).toBeCalledTimes(1);
       });
     });
 

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -146,6 +146,7 @@ const Signup = ({
         return;
       }
       setBeginSignupLoading(true);
+      GleanMetrics.registration.submit();
 
       const { data, error } = await beginSignupHandler(
         queryParamModel.email,


### PR DESCRIPTION
## Because

* We are adding glean pings to the react version of signup route

## This pull request

* Add reg_submit glean ping and associated tests

## Issue that this pull request solves

Closes: #FXA-8017

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
