### PR TITLE
feat(glean): And frontend glean pings to ConfirmSignupCode React

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -14,6 +14,7 @@ import { mockAppContext } from '../../../models/mocks';
 import { MOCK_AUTH_ERROR, Subject } from './mocks';
 import { StoredAccountData } from '../../../lib/storage-utils';
 import { MOCK_EMAIL, MOCK_SESSION_TOKEN, MOCK_UID } from '../../mocks';
+import GleanMetrics from '../../../lib/glean';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -30,6 +31,11 @@ const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: { signupConfirmation: { view: jest.fn(), submit: jest.fn() } },
 }));
 
 const MOCK_STORED_ACCOUNT: StoredAccountData = {
@@ -96,6 +102,7 @@ describe('ConfirmSignupCode page', () => {
   it('emits a metrics event on render', async () => {
     renderWithAccount(account);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+    expect(GleanMetrics.signupConfirmation.view).toHaveBeenCalledTimes(1);
 
     //  Input field is autofocused on render and should emit an 'engage' event metric
     await waitFor(() => {
@@ -123,6 +130,7 @@ describe('ConfirmSignupCode page', () => {
         'verification.success',
         REACT_ENTRYPOINT
       );
+      expect(GleanMetrics.signupConfirmation.submit).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -146,6 +154,7 @@ describe('ConfirmSignupCode page', () => {
           entrypoint_variation: 'react',
         }
       );
+      expect(GleanMetrics.signupConfirmation.submit).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith('/settings', { replace: true });
     });
   });
@@ -176,6 +185,7 @@ describe('ConfirmSignupCode page', () => {
           entrypoint_variation: 'react',
         }
       );
+      expect(GleanMetrics.signupConfirmation.submit).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith('/settings', { replace: true });
     });
   });
@@ -206,6 +216,7 @@ describe('ConfirmSignupCode page with error states', () => {
       expect(screen.getByTestId('tooltip')).toHaveTextContent(
         'Confirmation code is required'
       );
+      expect(GleanMetrics.signupConfirmation.submit).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import {
@@ -39,6 +39,7 @@ import firefox from '../../../lib/channels/firefox';
 import { StoredAccountData, persistAccount } from '../../../lib/storage-utils';
 import { BrandMessagingPortal } from '../../../components/BrandMessaging';
 import { currentAccount } from '../../../lib/cache';
+import GleanMetrics from '../../../lib/glean';
 
 export const viewName = 'confirm-signup-code';
 
@@ -63,6 +64,10 @@ const ConfirmSignupCode = ({
   );
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    GleanMetrics.signupConfirmation.view();
+  }, []);
 
   const [banner, setBanner] = useState<Partial<BannerProps>>({
     type: undefined,
@@ -109,6 +114,7 @@ const ConfirmSignupCode = ({
 
   async function verifySession(code: string) {
     logViewEvent(`flow.${viewName}`, 'submit', REACT_ENTRYPOINT);
+    GleanMetrics.signupConfirmation.submit();
     try {
       const hasSelectedNewsletters = newsletters && newsletters.length > 0;
 


### PR DESCRIPTION
## Because

* We are adding Glean metrics to the React pages

## This pull request

* Add view and submit glean pings to the ConfirmSignupCode page in React
* Add associated unit tests

## Issue that this pull request solves

Closes: #FXA-8019, FXA-8074

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
