### PR TITLE
bug(settings,content): Switch 'Learn more' branding link to a native link

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/brand-messaging.mustache
@@ -17,7 +17,7 @@
                     </p>
                     <p class="text-start text-xs">
                         {{#t}}You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</span>
+                        <a href="https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts" target="_blank" class="brand-learn-more cursor-pointer underline hover:text-blue-900">{{#t}}Learn more{{/t}}</a>
                     </p>
                 </div>
             </div>
@@ -27,7 +27,7 @@
                 <div>
                     <p class="text-start text-xs font-semibold">
                         {{#t}}We’ve renamed Firefox accounts to Mozilla accounts. You’ll still sign in with the same username and password, and there are no other changes to the products that you use.{{/t}}
-                        <span role="link" tabindex="0" class="brand-learn-more cursor-pointer underline">{{#t}}Learn more{{/t}}</span>
+                        <a target="_blank" href="https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts" class="brand-learn-more cursor-pointer underline hover:text-blue-900">{{#t}}Learn more{{/t}}</a>
                     </p>
                 </div>
             </div>

--- a/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/brand-messaging-mixin.js
@@ -122,10 +122,6 @@ const Mixin = {
 
   onBrandLearnMoreClick() {
     this.logFlowEvent(`brand-messaging-${this.mode}-learn-more`, this.viewName);
-    window.open(
-      'https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts',
-      '_blank'
-    );
   },
 };
 

--- a/packages/fxa-react/components/LinkExternal/index.tsx
+++ b/packages/fxa-react/components/LinkExternal/index.tsx
@@ -13,6 +13,7 @@ type LinkExternalProps = {
   'data-testid'?: string;
   rel?: 'noopener noreferrer' | 'author';
   tabIndex?: number;
+  onClick?: () => void;
 };
 
 export const LinkExternal = ({
@@ -23,6 +24,7 @@ export const LinkExternal = ({
   'data-testid': testid = 'link-external',
   rel = 'noopener noreferrer',
   tabIndex,
+  onClick,
 }: LinkExternalProps) => (
   <a
     data-testid={testid}
@@ -33,6 +35,7 @@ export const LinkExternal = ({
       title,
       rel,
       tabIndex,
+      onClick,
     }}
   >
     {children}

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
 import { Localized } from '@fluent/react';
 import { createPortal } from 'react-dom';
 import logo from 'fxa-react/images/moz-m-logo.svg';
+import LinkExternal from 'fxa-react/components/LinkExternal';
 
 export const bannerClosedLocalStorageKey =
   '__fxa_storage.fxa_disable_brand_banner';
@@ -75,10 +76,6 @@ export const BrandMessaging = ({
 
   function onClickLearnMore() {
     logViewEventOnce(`flow.${viewName}`, `brand-messaging-${mode}-learn-more`);
-    window.open(
-      'https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts',
-      '_blank'
-    );
   }
 
   function onClickCloseBanner() {
@@ -90,6 +87,16 @@ export const BrandMessaging = ({
     localStorage.setItem(`${bannerClosedLocalStorageKey}_${mode}`, 'true');
     setBannerClosed('true');
   }
+
+  const learnMoreLink = (
+    <LinkExternal
+      href="https://support.mozilla.org/kb/firefox-accounts-renamed-mozilla-accounts"
+      onClick={onClickLearnMore}
+      className="underline cursor-pointer hover:text-blue-900"
+    >
+      <FtlMsg id="brand-learn-more">Learn more</FtlMsg>
+    </LinkExternal>
+  );
 
   return (
     <div
@@ -120,14 +127,7 @@ export const BrandMessaging = ({
                   there are no other changes to the products that you use.
                 </FtlMsg>
                 &nbsp;
-                <span
-                  role="link"
-                  tabIndex={0}
-                  className="brand-learn-more underline cursor-pointer"
-                  onClick={onClickLearnMore}
-                >
-                  <FtlMsg id="brand-learn-more">Learn more</FtlMsg>
-                </span>
+                {learnMoreLink}
               </p>
             </div>
           </div>
@@ -143,14 +143,7 @@ export const BrandMessaging = ({
                   are no other changes to the products that you use.
                 </FtlMsg>
                 &nbsp;
-                <span
-                  role="link"
-                  tabIndex={0}
-                  className="brand-learn-more underline cursor-pointer"
-                  onClick={onClickLearnMore}
-                >
-                  <FtlMsg id="brand-learn-more">Learn more</FtlMsg>
-                </span>
+                {learnMoreLink}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Because

- The learn more link would not respond to an Enter key press

## This pull request

- Uses LinkExternal in React for this link instead of a span with role=link
- Modifies content-server to use an anchor instead of a span with role=link

## Issue that this pull request solves

Closes: FXA-8586

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
