### PR TITLE
feat(glean): Add frontend reg submit success glean ping

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -69,7 +69,9 @@ jest.mock('@reach/router', () => ({
 
 jest.mock('../../lib/glean', () => ({
   __esModule: true,
-  default: { registration: { view: jest.fn(), submit: jest.fn() } },
+  default: {
+    registration: { view: jest.fn(), submit: jest.fn(), success: jest.fn() },
+  },
 }));
 
 describe('Signup page', () => {
@@ -301,7 +303,8 @@ describe('Signup page', () => {
         await waitFor(() => {
           expect(document.cookie).toBe('tooyoung=1;');
         });
-        expect(GleanMetrics.registration.submit).not.toBeCalled();
+        expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
+        expect(GleanMetrics.registration.success).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith('/cannot_create_account');
         expect(mockBeginSignupHandler).not.toBeCalled();
       });
@@ -383,6 +386,8 @@ describe('Signup page', () => {
 
       expect(notifyFirefoxOfLogin).not.toBeCalled();
 
+      expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
+
       expect(mockNavigate).toHaveBeenCalledWith(
         `/confirm_signup_code${mockLocation().search}`,
         {
@@ -418,6 +423,8 @@ describe('Signup page', () => {
         );
       });
 
+      expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
+
       expect(notifyFirefoxOfLogin).toBeCalledWith({
         authAt: BEGIN_SIGNUP_HANDLER_RESPONSE.data.SignUp.authAt,
         email: MOCK_EMAIL,
@@ -450,7 +457,9 @@ describe('Signup page', () => {
           MOCK_PASSWORD
         );
       });
+      expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
     });
+
     it('on fail', async () => {
       const mockBeginSignupHandler = jest
         .fn()
@@ -464,6 +473,8 @@ describe('Signup page', () => {
       submit();
 
       await screen.findByText(BEGIN_SIGNUP_HANDLER_FAIL_RESPONSE.error.message);
+      expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
+      expect(GleanMetrics.registration.success).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -132,6 +132,7 @@ const Signup = ({
   // to avoid breaking dashboards.
   const onSubmit = useCallback(
     async ({ newPassword, age }: SignupFormData) => {
+      GleanMetrics.registration.submit();
       if (Number(age) < 13) {
         // this is a session cookie. It will go away once:
         // 1. the user closes the tab
@@ -146,7 +147,6 @@ const Signup = ({
         return;
       }
       setBeginSignupLoading(true);
-      GleanMetrics.registration.submit();
 
       const { data, error } = await beginSignupHandler(
         queryParamModel.email,
@@ -154,6 +154,8 @@ const Signup = ({
       );
 
       if (data) {
+        GleanMetrics.registration.success();
+
         // Persist account data to local storage to match parity with content-server
         // this allows the recent account to be used for /signin
         const accountData: StoredAccountData = {


### PR DESCRIPTION
## Because

* We are adding Glean metrics to Signup flow in React

## This pull request

* Add signup submit success Glean ping on the frontend
* Modify signup submit glean ping to also fire for underage account creation request
* Add/modify relevant tests

## Issue that this pull request solves

Closes: #FXA-8018

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
