### PR TITLE
Allow broader input for CSP document-uri

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/post-csp.js
+++ b/packages/fxa-content-server/server/lib/routes/post-csp.js
@@ -18,7 +18,6 @@ const {
 
 const INTEGER_TYPE = validation.TYPES.INTEGER;
 const STRING_TYPE = validation.TYPES.LONG_STRING;
-const LONG_URI_TYPE = validation.TYPES.LONG_URI;
 
 const BODY_SCHEMA = {
   'csp-report': joi
@@ -33,7 +32,7 @@ const BODY_SCHEMA = {
       disposition: STRING_TYPE.optional(),
       // CSP 2, 3 required
       // Allow 'about:srcdoc', see https://bugzilla.mozilla.org/show_bug.cgi?id=1073952#c22
-      'document-uri': LONG_URI_TYPE.required().allow('about:srcdoc'),
+      'document-uri': STRING_TYPE.allow('').optional(),
       // CSP 2 required, but not always sent
       'effective-directive': STRING_TYPE.optional(),
       // CSP 2 optional


### PR DESCRIPTION
## Because

- Our CSP has a lot of failures.  See https://mozilla.sentry.io/issues/3551750499/?project=6231069&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=6 .  Also FXA-7556

## This pull request

- Loosens restrictions

