### PR TITLE
fix(payments): display disabled on aria-disabled

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -211,6 +211,9 @@ export const PaymentForm = ({
   const onPaypalFormSubmit = useCallback(
     async (ev: React.FormEvent<HTMLFormElement>) => {
       ev.preventDefault();
+      if (!allowSubmit) {
+        return;
+      }
       setLastSubmitNonce(submitNonce);
       (onSubmitForParent as PaypalSubmitHandler)({
         priceId: plan!.plan_id,
@@ -218,7 +221,7 @@ export const PaymentForm = ({
         promotionCode: promotionCode,
       });
     },
-    [onSubmitForParent, submitNonce, plan, promotionCode]
+    [onSubmitForParent, submitNonce, plan, promotionCode, allowSubmit]
   );
 
   const onStripeFormSubmit = useCallback(
@@ -266,6 +269,9 @@ export const PaymentForm = ({
     [PaymentProviders.stripe]: onStripeFormSubmit,
     [PaymentProviders.paypal]: onPaypalFormSubmit,
   });
+
+  const disabledStyles =
+    'payment-button-disabled after:bg-white after:opacity-50 after:z-[100] border-none';
 
   const paymentSource =
     plan && isExistingCustomer(customer) ? (
@@ -328,7 +334,9 @@ export const PaymentForm = ({
 
       <SubmitButton
         data-testid="submit"
-        className="payment-button cta-primary h-10 mobileLandscape:h-12 cursor-pointer"
+        className={`payment-button cta-primary h-10 mobileLandscape:h-12 cursor-pointer ${
+          inProgress && disabledStyles
+        }`}
         name="submit"
         aria-disabled={inProgress}
       >
@@ -349,7 +357,9 @@ export const PaymentForm = ({
   ) : (
     <SubmitButton
       data-testid="submit"
-      className="payment-button cta-primary !font-bold w-full mt-8 h-12 cursor-pointer mb-5"
+      className={`payment-button cta-primary !font-bold w-full mt-8 h-12 cursor-pointer mb-5 ${
+        !allowSubmit && disabledStyles
+      }`}
       name="submit"
       aria-disabled={!allowSubmit}
     >

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -207,6 +207,10 @@ export const Checkout = ({
             // every time.  new stub account, new customer, new invoice, etc.
             setRetryStatus(undefined);
             setSubscriptionError({ type: 'card_error', code: 'card_declined' });
+            // Only set In Progress to false on subscription error
+            // This is to prevent the Submit button from momentarily flashing as enabled
+            // before navigating to the success screen.
+            setInProgress(false);
           },
         });
         if (subscribeToNewsletter) {
@@ -220,9 +224,12 @@ export const Checkout = ({
           // an error property on error.
           const err = typeof error.error === 'string' ? error : error.error;
           setSubscriptionError(err);
+          // Only set In Progress to false on subscription error
+          // This is to prevent the Submit button from momentarily flashing as enabled
+          // before navigating to the success screen.
+          setInProgress(false);
         }
       }
-      setInProgress(false);
       refreshSubmitNonce();
     },
     [

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -173,13 +173,17 @@ export const SubscriptionCreate = ({
                 type: 'card_error',
                 code: 'card_declined',
               });
+              setInProgress(false);
             },
           });
         } catch (error) {
           console.error('handleSubscriptionPayment failed', error);
           setSubscriptionError(error);
+          // Only set In Progress to false on subscription error
+          // This is to prevent the Submit button from momentarily flashing as enabled
+          // before navigating to the success screen.
+          setInProgress(false);
         }
-        setInProgress(false);
         refreshSubmitNonce();
       },
       [
@@ -212,8 +216,11 @@ export const SubscriptionCreate = ({
           refreshSubscriptions();
         } catch (error) {
           setSubscriptionError(error);
+          // Only set In Progress to false on subscription error
+          // This is to prevent the Submit button from momentarily flashing as enabled
+          // before navigating to the success screen.
+          setInProgress(false);
         }
-        setInProgress(false);
         refreshSubmitNonce();
       },
       [

--- a/packages/fxa-react/styles/ctas.css
+++ b/packages/fxa-react/styles/ctas.css
@@ -34,12 +34,12 @@
     @apply bg-blue-500 border-blue-600 text-white;
   }
 
-  .cta-primary:active {
+  .cta-primary:active:not([aria-disabled='true']) {
     @apply bg-blue-800 border-blue-800;
   }
 
-  .cta-primary:focus,
-  .cta-primary:focus-visible {
+  .cta-primary:focus:not([aria-disabled='true']),
+  .cta-primary:focus-visible:not([aria-disabled='true']) {
     @apply outline outline-2 outline-offset-2 outline-blue-500;
   }
 
@@ -79,7 +79,7 @@
       @apply border-grey-200 bg-grey-100 text-grey-400;
     }
 
-    .cta-primary:hover:not(:disabled):not(:active) {
+    .cta-primary:hover:not(:disabled):not(:active):not([aria-disabled='true']) {
       @apply bg-blue-600 border-blue-600;
       /* TEMP HACK until all buttons are TWified in content-server */
       @apply text-white no-underline;


### PR DESCRIPTION
## Because

- aria-disabled=true doesn't disable the button, allowing the submit
  button to be pressed multiple times. Under the following scenario
  this would result in a duplicate subscription
  - Existing customer with existing PayPal payment method
  - Customer subscribes to a new product
  - Customer clicks the subscribe button multiple times

## This pull request

- When aria-disabled=true, show the submit button that appears disabled
- Exit early when submit button is pressed when using PayPal as the
  payment method
- Do not flash enabled button before navigating to success screen

## Issue that this pull request solves

Closes: #FXA-8590

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Ideally this change would not be necessary, and the PaymentForm would continue to use `aria-disabled`. However due to the difference in functionality provided by `disabled` and `aria-disabled`, additional work would be required to provide the desired user experience using `aria-disabled`.

For more information I found this page to be a good resource. [CSS Tricks - Making Disabled Buttons More Inclusive](https://css-tricks.com/making-disabled-buttons-more-inclusive/) 
