### PR TITLE
fix(contentful): switch to graphql-request for contentful client

### DIFF
--- a/libs/shared/contentful/src/lib/contentful.error.ts
+++ b/libs/shared/contentful/src/lib/contentful.error.ts
@@ -39,30 +39,3 @@ export class ContentfulQueryError extends BaseError {
     super(...args);
   }
 }
-
-/**
- * https://www.contentful.com/developers/docs/references/graphql/#/reference/graphql-errors
- */
-export class ContentfulExecutionError extends ContentfulQueryError {
-  constructor(...args: ConstructorParameters<typeof ContentfulQueryError>) {
-    super(...args);
-  }
-}
-
-/**
- * https://www.contentful.com/developers/docs/references/graphql/#/reference/graphql-errors
- */
-export class ContentfulLocaleError extends ContentfulQueryError {
-  constructor(...args: ConstructorParameters<typeof ContentfulQueryError>) {
-    super(...args);
-  }
-}
-
-/**
- * https://www.contentful.com/developers/docs/references/graphql/#/reference/graphql-errors
- */
-export class ContentfulLinkError extends ContentfulQueryError {
-  constructor(...args: ConstructorParameters<typeof ContentfulQueryError>) {
-    super(...args);
-  }
-}

--- a/libs/shared/contentful/src/lib/contentful.manager.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.spec.ts
@@ -36,9 +36,7 @@ describe('ContentfulManager', () => {
   describe('getPurchaseDetailsForEligibility', () => {
     it('should return empty result', async () => {
       mockClient.query = jest.fn().mockReturnValue({
-        data: {
-          purchaseCollection: { items: [] },
-        },
+        purchaseCollection: { items: [] },
       });
       const result = await manager.getPurchaseDetailsForEligibility(['test']);
       expect(result).toBeInstanceOf(EligibilityContentByPlanIdsResultUtil);
@@ -47,7 +45,7 @@ describe('ContentfulManager', () => {
 
     it('should return successfully with subgroups and offering', async () => {
       const queryData = EligibilityContentByPlanIdsQueryFactory();
-      mockClient.query = jest.fn().mockResolvedValueOnce({ data: queryData });
+      mockClient.query = jest.fn().mockResolvedValueOnce(queryData);
       const result = await manager.getPurchaseDetailsForEligibility(['test']);
       const planId = result.purchaseCollection.items[0].stripePlanChoices[0];
       expect(result).toBeInstanceOf(EligibilityContentByPlanIdsResultUtil);
@@ -61,9 +59,7 @@ describe('ContentfulManager', () => {
   describe('getServicesWithCapabilities', () => {
     it('should return results', async () => {
       mockClient.query = jest.fn().mockReturnValue({
-        data: {
-          serviceCollection: { items: [] },
-        },
+        serviceCollection: { items: [] },
       });
       const result = await manager.getServicesWithCapabilities();
       expect(result).toBeInstanceOf(ServicesWithCapabilitiesResultUtil);
@@ -72,7 +68,7 @@ describe('ContentfulManager', () => {
 
     it('should return successfully with services and capabilities', async () => {
       const queryData = ServicesWithCapabilitiesQueryFactory();
-      mockClient.query = jest.fn().mockResolvedValueOnce({ data: queryData });
+      mockClient.query = jest.fn().mockResolvedValueOnce(queryData);
       const result = await manager.getServicesWithCapabilities();
       expect(result).toBeInstanceOf(ServicesWithCapabilitiesResultUtil);
       expect(result.serviceCollection.items).toHaveLength(1);
@@ -82,9 +78,7 @@ describe('ContentfulManager', () => {
   describe('getPurchaseWithDetailsOfferingContentByPlanIds', () => {
     it('should return empty result', async () => {
       mockClient.query = jest.fn().mockReturnValue({
-        data: {
-          purchaseCollection: { items: [] },
-        },
+        purchaseCollection: { items: [] },
       });
       mockClient.getLocale = jest.fn().mockResolvedValue('en');
       const result =
@@ -100,7 +94,7 @@ describe('ContentfulManager', () => {
       const queryData =
         PurchaseWithDetailsOfferingContentByPlanIdsResultFactory();
       const queryDataItem = queryData.purchaseCollection.items[0];
-      mockClient.query = jest.fn().mockResolvedValueOnce({ data: queryData });
+      mockClient.query = jest.fn().mockResolvedValueOnce(queryData);
       mockClient.getLocale = jest.fn().mockResolvedValue('en');
       const result =
         await manager.getPurchaseWithDetailsOfferingContentByPlanIds(

--- a/libs/shared/contentful/src/lib/contentful.manager.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.ts
@@ -49,7 +49,7 @@ export class ContentfulManager {
     );
 
     return new CapabilityServiceByPlanIdsResultUtil(
-      queryResult.data as DeepNonNullable<CapabilityServiceByPlanIdsQuery>
+      queryResult as DeepNonNullable<CapabilityServiceByPlanIdsQuery>
     );
   }
 
@@ -67,7 +67,7 @@ export class ContentfulManager {
     );
 
     return new EligibilityContentByPlanIdsResultUtil(
-      queryResult.data as DeepNonNullable<EligibilityContentByPlanIdsQuery>
+      queryResult as DeepNonNullable<EligibilityContentByPlanIdsQuery>
     );
   }
 
@@ -79,7 +79,7 @@ export class ContentfulManager {
     });
 
     return new ServicesWithCapabilitiesResultUtil(
-      queryResult.data as DeepNonNullable<ServicesWithCapabilitiesQuery>
+      queryResult as DeepNonNullable<ServicesWithCapabilitiesQuery>
     );
   }
 
@@ -99,7 +99,7 @@ export class ContentfulManager {
     );
 
     return new PurchaseWithDetailsOfferingContentUtil(
-      queryResult.data as DeepNonNullable<PurchaseWithDetailsOfferingContentQuery>
+      queryResult as DeepNonNullable<PurchaseWithDetailsOfferingContentQuery>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "class-validator": "^0.14.0",
     "diffparser": "^2.0.1",
     "graphql": "^15.6.1",
+    "graphql-request": "^6.1.0",
     "hot-shots": "^10.0.0",
     "husky": "^4.2.5",
     "knex": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35686,6 +35686,7 @@ fsevents@~2.1.1:
     eslint-plugin-react: ^7.32.2
     eslint-plugin-react-hooks: 4.6.0
     graphql: ^15.6.1
+    graphql-request: ^6.1.0
     hot-shots: ^10.0.0
     husky: ^4.2.5
     jest: ^29.5.0
@@ -36970,7 +36971,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"graphql-request@npm:^6.0.0":
+"graphql-request@npm:^6.0.0, graphql-request@npm:^6.1.0":
   version: 6.1.0
   resolution: "graphql-request@npm:6.1.0"
   dependencies:


### PR DESCRIPTION
## Because

- We've had numerous problems with Apollo Client server-side (it's intended as a frontend client, mostly for React).

## This pull request

- Replaces Apollo Client with graphql-request for server-to-server graphql requests in the Contentful lib.

## Issue that this pull request solves

Closes: FXA-8645