### PR TITLE
fix(contentful): do not reset contentful cache

### DIFF
--- a/libs/shared/contentful/src/lib/contentful.client.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.ts
@@ -134,7 +134,6 @@ export class ContentfulClient {
 
     setInterval(() => {
       this.locales = [];
-      this.client.clearStore();
     }, cacheTTL);
   }
 }


### PR DESCRIPTION
Contentful cache reset is causing "Store reset while query was in flight (not completed in link chain)".

We'd like to replace apollo client with graphql-request server-side in #16008 but this is a fix for now.