### PR TITLE
bug(settings): Fix stray Firefox branding reference in static pages t…

### DIFF
--- a/packages/fxa-content-server/server/templates/pages/src/500.html
+++ b/packages/fxa-content-server/server/templates/pages/src/500.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>{{#t}}Firefox Accounts{{/t}}</title>
+    <title>{{#t}}Mozilla accounts{{/t}}</title>
     <meta name="description" content="" />
     <meta
       name="viewport"

--- a/packages/fxa-content-server/server/templates/pages/src/503.html
+++ b/packages/fxa-content-server/server/templates/pages/src/503.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>{{#t}}Firefox Accounts{{/t}}</title>
+    <title>{{#t}}Mozilla accounts{{/t}}</title>
     <meta name="description" content="" />
     <meta
       name="viewport"

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <title>Firefox Accounts</title>
+  <title>Mozilla accounts</title>
   <meta name="description" content="" />
   <meta name="referrer" content="origin" />
   <meta name="robots" content="noindex,nofollow" />


### PR DESCRIPTION
## Because
- We noticed a couple page titles were still referencing Firefox

## This pull request
- Updates page titles to reference Mozilla branding

## Issue that this pull request solves

Closes:  FXA-8599
## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


