### PR TITLE
fix(capability): handle capability manager errors

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -667,15 +667,10 @@ export class CapabilityService {
 
     if (!this.capabilityManager) {
       if (this.logToSentry('getClients.CapabilityManagerNotFound')) {
-        Sentry.withScope((scope) => {
-          scope.setContext('getClients', {
-            msg: `CapabilityManager not found.`,
-          });
-          Sentry.captureMessage(
-            `CapabilityManager not found.`,
-            'error' as SeverityLevel
-          );
-        });
+        Sentry.captureMessage(
+          `CapabilityManager not found.`,
+          'error' as SeverityLevel
+        );
       }
 
       return clientsFromStripe;
@@ -691,20 +686,25 @@ export class CapabilityService {
       if (this.logToSentry('getClients.NoMatch')) {
         Sentry.withScope((scope) => {
           scope.setContext('getClients', {
-            contentful: clientsFromContentful,
-            stripe: clientsFromStripe,
+            contentful: clientsFromContentful.map((service) => ({
+              ...service,
+              capabilities: service.capabilities.length,
+            })),
+            stripe: clientsFromStripe.map((service) => ({
+              ...service,
+              capabilities: service.capabilities.length,
+            })),
           });
           Sentry.captureMessage(
-            `Returned Stripe as clients did not match.`,
+            `CapabilityService.getClients - Returned Stripe as clients did not match.`,
             'error' as SeverityLevel
           );
         });
       }
-
-      return clientsFromStripe;
     } catch (error) {
       this.log.error('subscriptions.getClients', { error: error });
-      throw error;
+      Sentry.captureException(error);
     }
+    return clientsFromStripe;
   }
 }


### PR DESCRIPTION
## Because

- Errors originating from the capability manager caused the GET */subscriptions/clients API to throw an error.

## This pull request

- Report capability manager errors to Sentry and return results from Stripe metadata
- Sanitizes capabilities info sent to Sentry

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
