### PR TITLE
fix(content): Avatar not centered on SubMan

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -48,9 +48,11 @@
   // remove when Payments isn't using `avatar-settings-view`
   &.avatar-settings-view {
     border: 2px solid transparent;
-    display: block;
+    display: flex;
     flex-shrink: 0;
     margin: 0;
+    align-items: center;
+    justify-content: center;
 
     &.spinner-completed {
       border: 2px solid $avatar-border-color;


### PR DESCRIPTION
## This pull request

- Centers avatar on Subscription Management

## Issue that this pull request solves

Closes: [FXA-8597](https://mozilla-hub.atlassian.net/browse/FXA-8597)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Before
<img width="645" alt="Screenshot 2023-11-02 at 10 04 20 AM" src="https://github.com/mozilla/fxa/assets/28129806/7dae080e-d97b-4528-ac42-c138bf966ec3">

After
<img width="645" alt="Screenshot 2023-11-02 at 10 03 51 AM" src="https://github.com/mozilla/fxa/assets/28129806/9137242a-c40b-44c2-80c1-c2c1b6564288">


[FXA-8597]: https://mozilla-hub.atlassian.net/browse/FXA-8597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ