### PR TITLE
bug(settings): Fix link on data collection privacy notice

### DIFF
--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
@@ -35,7 +35,7 @@ describe('DataCollection', () => {
       screen.getByTestId('link-external-telemetry-opt-out')
     ).toHaveAttribute(
       'href',
-      'https://www.mozilla.org/privacy/firefox/#firefox-accounts'
+      'https://www.mozilla.org/privacy/mozilla-accounts/'
     );
   });
 

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.tsx
@@ -73,7 +73,7 @@ export const DataCollection = () => {
                 Mozilla.
               </Localized>{' '}
               <LinkExternal
-                href="https://www.mozilla.org/privacy/firefox/#firefox-accounts"
+                href="https://www.mozilla.org/privacy/mozilla-accounts/"
                 className="link-blue"
                 data-testid="link-external-telemetry-opt-out"
               >


### PR DESCRIPTION
## Because

- The link pointed at the previous Firefox Accounts privacy notice

## This pull request

- Updates the link to point at the Mozilla accounts privacy notice

## Issue that this pull request solves

Closes: FXA-8608

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

