### PR TITLE
feat(contentful): Add Stripe Legacy Plans field to Offering

### DIFF
--- a/packages/db-migrations/contentful/1698948888495_fxa-8534.js
+++ b/packages/db-migrations/contentful/1698948888495_fxa-8534.js
@@ -1,0 +1,18 @@
+function migrationFunction(migration, context) {
+  const offering = migration.editContentType('offering');
+  const offeringStripeLegacyPlans = offering.createField('stripeLegacyPlans');
+  offeringStripeLegacyPlans
+    .name('Stripe Legacy Plans')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({ type: 'Symbol', validations: [] });
+  offering.changeFieldControl('stripeLegacyPlans', 'builtin', 'tagEditor', {
+    helpText:
+      'All archived Stripe Plan IDs from Stripe associated to the Stripe Product ID of the product offering.',
+  });
+}
+module.exports = migrationFunction;


### PR DESCRIPTION
## This pull request

- adds `Stripe Legacy Plans` field to Offering

## Issue that this pull request solves

Closes: [FXA-8534](https://mozilla-hub.atlassian.net/browse/FXA-8534)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Other information (Optional)

Changes to the updated codegen files will be included in the PR for FXA-8502


[FXA-8534]: https://mozilla-hub.atlassian.net/browse/FXA-8534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ