### PR TITLE
fix(settings): Fix fluent ID errors causing errors in Sentry

### DIFF
--- a/packages/fxa-settings/src/components/FormPassword/index.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.tsx
@@ -84,7 +84,7 @@ export const FormPassword = ({
 
   return (
     <form {...{ onSubmit }}>
-      <Localized id="pw-requirements">
+      <Localized id="password-strength-balloon-heading">
         <h2>Password requirements</h2>
       </Localized>
       <ul

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -78,7 +78,7 @@ export const FlowRecoveryKeyHint = ({
     navigateForward();
     alertBar.success(
       ftlMsgResolver.getMsg(
-        'flow-recovery-key-success-alert-v2',
+        'flow-recovery-key-success-alert',
         'Account recovery key created'
       )
     );

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
@@ -43,7 +43,7 @@ const renderWithContext = (
 };
 
 describe('UnitRowRecoveryKey', () => {
-  it('renders version 2 as expected when account recovery key is set', () => {
+  it('renders as expected when account recovery key is set', () => {
     renderWithContext(accountHasRecoveryKey);
     screen.getByRole('heading', { name: 'Account recovery key' });
     expect(
@@ -60,7 +60,7 @@ describe('UnitRowRecoveryKey', () => {
     });
   });
 
-  it('renders version 2 as expected when account recovery key is not set', () => {
+  it('renders as expected when account recovery key is not set', () => {
     renderWithContext(accountWithoutRecoveryKey);
     screen.getByRole('heading', { name: 'Account recovery key' });
     expect(
@@ -71,7 +71,7 @@ describe('UnitRowRecoveryKey', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('disables key creation in version 2 when account has no password', () => {
+  it('disables key creation when account has no password', () => {
     renderWithContext(accountWithoutPassword);
     screen.getByRole('heading', { name: 'Account recovery key' });
     expect(
@@ -89,7 +89,7 @@ describe('UnitRowRecoveryKey', () => {
     });
   });
 
-  describe('delete account recovery key in version 2', () => {
+  describe('delete account recovery key', () => {
     const expectRevokeEvent = (event: string) => {
       expect(Metrics.logViewEvent).toHaveBeenCalledWith(
         'flow.settings.account-recovery',


### PR DESCRIPTION
## Because

* We are seeing errors in Sentry where '<Localized /> component was not properly wrapped in a <LocalizationProvider />'
* The breadcrumbs indicate this might be caused by missing Fluent IDs in the bundle

## This pull request

* Fix mismatched l10n ids
* Fix test descriptions (remove stray mentions of old recovery key flow)

## Issue that this pull request solves

Closes: # FXA-8557

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This might not completely resolve the Sentry errors - another avenue to investigate is the construction of localized error messages, particularly for the CompleteResetPassword page.