### PR TITLE
feat(auth): use abbrev plans for metadata

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2597,7 +2597,14 @@ export class StripeHelper extends StripeHelperBase {
       invoiceDiscountAmountInCents || discountType || discountDuration;
 
     const { id: planId, nickname: planName } = plan;
-    const productMetadata = this.mergeMetadata(plan, abbrevProduct);
+    const abbrevPlan = await this.findAbbrevPlanById(planId);
+    const productMetadata = this.mergeMetadata(
+      {
+        ...plan,
+        metadata: abbrevPlan.plan_metadata,
+      },
+      abbrevProduct
+    );
 
     // Use Firestore product configs if that exist
     const planConfig: Partial<PlanConfig> = await this.maybeGetPlanConfig(
@@ -2668,7 +2675,14 @@ export class StripeHelper extends StripeHelperBase {
     const planConfig = await this.maybeGetPlanConfig(plan.id);
     const { product_id: productId, product_name: productName } = abbrevProduct;
     const { id: planId, nickname: planName } = plan;
-    const productMetadata = this.mergeMetadata(plan, abbrevProduct);
+    const abbrevPlan = await this.findAbbrevPlanById(planId);
+    const productMetadata = this.mergeMetadata(
+      {
+        ...plan,
+        metadata: abbrevPlan.plan_metadata,
+      },
+      abbrevProduct
+    );
     const { emailIconURL: planEmailIconURL = '', successActionButtonURL } =
       productMetadata;
 
@@ -2870,7 +2884,14 @@ export class StripeHelper extends StripeHelperBase {
     } = planNew;
     const { product_id: productIdNew, product_name: productNameNew } =
       abbrevProductNew;
-    const productNewMetadata = this.mergeMetadata(planNew, abbrevProductNew);
+    const abbrevPlanNew = await this.findAbbrevPlanById(planNew.id);
+    const productNewMetadata = this.mergeMetadata(
+      {
+        ...planNew,
+        metadata: abbrevPlanNew.plan_metadata,
+      },
+      abbrevProductNew
+    );
     const {
       productOrder: productOrderNew,
       emailIconURL: productIconURLNew = '',
@@ -3139,10 +3160,17 @@ export class StripeHelper extends StripeHelperBase {
     const abbrevProductOld = await this.expandAbbrevProductForPlan(planOld);
     const { product_id: productIdOld, product_name: productNameOld } =
       abbrevProductOld;
+    const abbrevPlanOld = await this.findAbbrevPlanById(planOld.id);
     const {
       productOrder: productOrderOld,
       emailIconURL: productIconURLOld = '',
-    } = this.mergeMetadata(planOld, abbrevProductOld);
+    } = this.mergeMetadata(
+      {
+        ...planOld,
+        metadata: abbrevPlanOld.plan_metadata,
+      },
+      abbrevProductOld
+    );
 
     const updateType =
       parseInt(productOrderNew) > parseInt(productOrderOld)

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4915,8 +4915,8 @@ describe('#integration - StripeHelper', () => {
     const planName = 'Example Plan';
     const productId = 'prod_00000000000000';
     const productName = 'Example Product';
-    const planEmailIconURL = 'http://example.com/icon';
-    const successActionButtonURL = 'http://example.com/success';
+    const planEmailIconURL = 'http://example.com/icon-new';
+    const successActionButtonURL = 'http://example.com/download-new';
     const sourceId = eventCustomerSourceExpiring.data.object.id;
     const chargeId = 'ch_1GVm24BVqmGyQTMaUhRAfUmA';
     const privacyNoticeURL =
@@ -5176,6 +5176,7 @@ describe('#integration - StripeHelper', () => {
           emailIconURL: planEmailIconURL,
           'product:privacyNoticeURL': privacyNoticeURL,
           'product:termsOfServiceURL': termsOfServiceURL,
+          productOrder: '0',
         },
         showPaymentMethod: true,
         showTaxAmount: false,
@@ -5557,6 +5558,7 @@ describe('#integration - StripeHelper', () => {
               emailIconURL: planEmailIconURL,
               'product:privacyNoticeURL': privacyNoticeURL,
               'product:termsOfServiceURL': termsOfServiceURL,
+              productOrder: '0',
             },
           },
         ],
@@ -5655,6 +5657,27 @@ describe('#integration - StripeHelper', () => {
         productOrder: '0',
       },
     };
+
+    beforeEach(() => {
+      mockAllAbbrevPlans.unshift(
+        {
+          ...eventCustomerSubscriptionUpdated.data.previous_attributes.plan,
+          plan_id:
+            eventCustomerSubscriptionUpdated.data.previous_attributes.plan.id,
+          product_id: expectedBaseUpdateDetails.productId,
+          plan_metadata:
+            eventCustomerSubscriptionUpdated.data.previous_attributes.plan
+              .metadata,
+        },
+        {
+          ...eventCustomerSubscriptionUpdated.data.object.plan,
+          plan_id: eventCustomerSubscriptionUpdated.data.object.plan.id,
+          product_id: expectedBaseUpdateDetails.productIdNew,
+          plan_metadata:
+            eventCustomerSubscriptionUpdated.data.object.plan.metadata,
+        }
+      );
+    });
 
     describe('extractSubscriptionUpdateEventDetailsForEmail', () => {
       const mockReactivationDetails = 'mockReactivationDetails';
@@ -5954,11 +5977,13 @@ describe('#integration - StripeHelper', () => {
               ...event.data.previous_attributes.plan,
               plan_id: event.data.previous_attributes.plan.id,
               product_id: productIdOld,
+              plan_metadata: event.data.previous_attributes.plan.metadata,
             },
             {
               ...event.data.object.plan,
               plan_id: event.data.object.plan.id,
               product_id: productIdNew,
+              plan_metadata: event.data.object.plan.metadata,
             }
           );
 
@@ -6063,11 +6088,13 @@ describe('#integration - StripeHelper', () => {
             ...event.data.previous_attributes.plan,
             plan_id: event.data.previous_attributes.plan.id,
             product_id: productIdOld,
+            plan_metadata: event.data.previous_attributes.plan.metadata,
           },
           {
             ...event.data.object.plan,
             plan_id: event.data.object.plan.id,
             product_id: productIdNew,
+            plan_metadata: event.data.object.plan.metadata,
           }
         );
 


### PR DESCRIPTION
## Because

* Abbrev plans have their metadata updated via contentful. If we switch to using abbrev plans, we'll already have the contentful switching behavior.

## This pull request

* Calls for abbrev plan in email sending logic.

## Issue that this pull request solves

Closes FXA-8532