### PR TITLE
fix(content): Avatar in Subscription Management - mobile view

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -48,17 +48,27 @@
   // remove when Payments isn't using `avatar-settings-view`
   &.avatar-settings-view {
     border: 2px solid transparent;
-    display: flex;
+    display: block;
     flex-shrink: 0;
     margin: 0;
-    align-items: center;
-    justify-content: center;
 
     &.spinner-completed {
       border: 2px solid $avatar-border-color;
       box-shadow: $card-box-low;
     }
 
+    @include respond-to('big') {
+      height: 64px;
+      width: 64px;
+    }
+
+    @include respond-to('small') {
+      height: 50px;
+      width: 50px;
+    }
+  }
+
+  .profile-image {
     @include respond-to('big') {
       height: 64px;
       width: 64px;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -545,7 +545,7 @@ const ProfileBanner = ({
 }: ProfileProps) => (
   <header id="fxa-settings-profile-header-wrapper">
     <div className="avatar-wrapper avatar-settings-view nohover">
-      <img src={avatar} alt={displayName || email} className="w-16 h-16" />
+      <img src={avatar} alt={displayName || email} className="profile-image" />
     </div>
     <div id="fxa-settings-profile-header">
       <h1 className="card-header">{displayName ? displayName : email}</h1>


### PR DESCRIPTION
## This pull request

- reverts changes previously made in #16020
- revises the size of the avatar on Subscription Management in mobile view

## Issue that this pull request solves

Closes: [FXA-8597](https://mozilla-hub.atlassian.net/browse/FXA-8597)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshot
Before
<img width="448" alt="Screenshot 2023-11-03 at 6 15 18 PM" src="https://github.com/mozilla/fxa/assets/28129806/ca25d540-5c11-4526-9973-b500423b8839">

After
<img width="405" alt="Screenshot 2023-11-08 at 11 01 22 AM" src="https://github.com/mozilla/fxa/assets/28129806/b319e465-7c82-405d-a665-b32ec7aba2b0">

[FXA-8597]: https://mozilla-hub.atlassian.net/browse/FXA-8597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ