### PR TITLE
test(functional): update selectors for the failing SUMO test

### DIFF
--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -138,13 +138,10 @@ test.describe('severity-1 #smoke', () => {
 
     await page.goto('https://support.mozilla.org/en-US/');
 
+    await Promise.all([page.click('text=Sign In/Up'), page.waitForLoadState()]);
     await Promise.all([
-      page.click('text=Sign In/Up'),
-      page.waitForNavigation(),
-    ]);
-    await Promise.all([
-      page.click('text=Continue with Firefox Accounts'),
-      page.waitForNavigation(),
+      page.click('text=Sign In or Sign Up'),
+      page.waitForLoadState(),
     ]);
     await login.login(credentials.email, credentials.password);
 


### PR DESCRIPTION
## Because

- The SUMO tests were failing as the text `Sign in to Firefox Account`is no longer valid. Updated the selector so that the test passes.

## This pull request

- Updates the selector.

## Issue that this pull request solves

Closes: FXA-8595

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
