### PR TITLE
chore(deps): Specify 123Done client secret from a secrets.json file

### DIFF
--- a/packages/123done/README.md
+++ b/packages/123done/README.md
@@ -3,6 +3,7 @@
 ## Running locally
 
 1. Complete prerequisites for running [FxA](https://github.com/mozilla/fxa#getting-started)
+1. Create a `secrets.json` file in 123done root folder and specify the `client_secret` value.
 1. Run the server: `yarn start`
 1. Visit it in your browser: `http://localhost:8080/`
 1. Hack and reload! (web resources don't require a server restart)

--- a/packages/123done/config-local-untrusted.json
+++ b/packages/123done/config-local-untrusted.json
@@ -1,7 +1,6 @@
 {
   "cookie_name": "321done",
   "client_id": "325b4083e32fe8e7",
-  "client_secret": "a084f4c36501ea1eb2de33258421af97b2e67ffbe107d2812f4a14f3579900ef",
   "redirect_uri": "http://localhost:10139/api/oauth",
   "issuer_uri": "http://localhost:3030",
   "scopes": "profile:display_name profile:email profile:uid openid"

--- a/packages/123done/config-local.json
+++ b/packages/123done/config-local.json
@@ -1,6 +1,5 @@
 {
   "client_id": "dcdb5ae7add825d2",
-  "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
   "issuer_uri": "http://localhost:3030",
   "pkce_client_id": "38a6b9b3a65a1871",
   "pkce_redirect_uri": "http://localhost:8080/?oauth_pkce_redirect=1",

--- a/packages/123done/config-stage.json
+++ b/packages/123done/config-stage.json
@@ -1,9 +1,0 @@
-{
-  "client_id": "dcdb5ae7add825d2",
-  "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
-  "redirect_uri": "https://stage-123done.herokuapp.com/api/oauth",
-  "issuer_uri": "https://accounts.stage.mozaws.net",
-  "scopes": "profile openid",
-  "pkce_client_id": "38a6b9b3a65a1871",
-  "pkce_redirect_uri": "https://stage-123done.herokuapp.com/?oauth_pkce_redirect=1"
-}

--- a/packages/123done/config.js
+++ b/packages/123done/config.js
@@ -12,9 +12,9 @@ const conf = convict({
   },
   client_secret: {
     doc: 'Oauth client secret',
-    default: 'b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8',
+    default: '',
     format: String,
-    env: 'CLIENT_SECRET',
+    env: 'CLIENT_SECRET_123DONE',
   },
   redirect_uri: {
     doc: 'Oauth client redirect',
@@ -68,7 +68,8 @@ const conf = convict({
 
 const configTarget = process.env.CONFIG_123DONE || './config.json';
 const configFile = path.resolve(__dirname, configTarget);
-const file = [configFile].filter(fs.existsSync);
+const secretsFile = path.resolve(__dirname, './secrets.json');
+const file = [configFile, secretsFile].filter(fs.existsSync);
 conf.loadFile(file);
 
 conf.validate();

--- a/packages/123done/config.json
+++ b/packages/123done/config.json
@@ -1,6 +1,5 @@
 {
   "client_id": "dcdb5ae7add825d2",
-  "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
 
   "pkce_client_id": "38a6b9b3a65a1871",
   "pkce_redirect_uri": "http://localhost:8080/?&oauth_pkce_redirect=1",


### PR DESCRIPTION
## Because

- We want to define the client_secret via an environment value or secrets file

## This pull request

- Removes all the 123Done stage configs
- Loads the client_secret from file when running locally

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8373

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I have also updated our Heroku, CircleCI configs to specify this value from the ENV. Note, we will still need to rotate the secrets for stage.
