### PR TITLE
fix(auth): add contentful to plans api

### DIFF
--- a/libs/payments/legacy/.eslintrc.json
+++ b/libs/payments/legacy/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/payments/legacy/README.md
+++ b/libs/payments/legacy/README.md
@@ -1,0 +1,11 @@
+# payments-legacy
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build payments-legacy` to build the library.
+
+## Running unit tests
+
+Run `nx test payments-legacy` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/payments/legacy/jest.config.ts
+++ b/libs/payments/legacy/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'payments-legacy',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/payments/legacy',
+};

--- a/libs/payments/legacy/package.json
+++ b/libs/payments/legacy/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fxa/payments/legacy",
+  "version": "0.0.1"
+}

--- a/libs/payments/legacy/project.json
+++ b/libs/payments/legacy/project.json
@@ -1,0 +1,44 @@
+{
+  "name": "payments-legacy",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/payments/legacy/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/payments/legacy",
+        "tsConfig": "libs/payments/legacy/tsconfig.lib.json",
+        "packageJson": "libs/payments/legacy/package.json",
+        "main": "libs/payments/legacy/src/index.ts",
+        "assets": ["libs/payments/legacy/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/payments/legacy/**/*.ts",
+          "libs/payments/legacy/package.json"
+        ]
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/legacy/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/payments/legacy/src/index.ts
+++ b/libs/payments/legacy/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/stripe-mapper.service';

--- a/libs/payments/legacy/src/lib/factories.ts
+++ b/libs/payments/legacy/src/lib/factories.ts
@@ -1,0 +1,7 @@
+import { StripeMetadataWithContentful } from './types';
+
+export const StripeMetadataWithContentfulFactory = (
+  override?: Partial<StripeMetadataWithContentful>
+): StripeMetadataWithContentful => ({
+  ...override,
+});

--- a/libs/payments/legacy/src/lib/plan-mapper.util.spec.ts
+++ b/libs/payments/legacy/src/lib/plan-mapper.util.spec.ts
@@ -1,0 +1,171 @@
+import {
+  OfferingCommonContentResult,
+  PurchaseDetailsTransformed,
+  OfferingCommonContentResultFactory,
+  PurchaseDetailsTransformedFactory,
+} from '@fxa/shared/contentful';
+import { PlanMapperUtil } from './plan-mapper.util';
+import { StripeMetadataWithContentfulFactory } from './factories';
+import { StripeMetadataKeysForContentful } from './types';
+
+describe('PlanMapperUtil', () => {
+  const defaultCommonContent: OfferingCommonContentResult =
+    OfferingCommonContentResultFactory();
+  const defaultPurchaseDetails: PurchaseDetailsTransformed =
+    PurchaseDetailsTransformedFactory();
+  const stripeMetadata = StripeMetadataWithContentfulFactory({
+    emailIconURL: `${defaultCommonContent.emailIcon}/random/addition`,
+    webIconURL: defaultPurchaseDetails.webIcon,
+  });
+
+  describe('mapField', () => {
+    let defaultMapper: PlanMapperUtil;
+    beforeEach(() => {
+      defaultMapper = new PlanMapperUtil(
+        defaultCommonContent,
+        defaultPurchaseDetails,
+        stripeMetadata
+      );
+    });
+
+    it('should return stripeValue if neither is set', () => {
+      const expected = undefined;
+      const actual = defaultMapper.mapField(
+        StripeMetadataKeysForContentful.DetailsLine1,
+        undefined,
+        null
+      );
+      expect(actual).toBe(expected);
+      expect(defaultMapper.errorFields.length).toBe(0);
+    });
+
+    it('should return stripeValue and log error fieldname', () => {
+      const testFieldName = StripeMetadataKeysForContentful.EmailIcon;
+      const expected = stripeMetadata[testFieldName];
+      const actual = defaultMapper.mapField(
+        testFieldName,
+        stripeMetadata[testFieldName],
+        defaultCommonContent.emailIcon
+      );
+      expect(actual).toBe(expected);
+      expect(defaultMapper.errorFields.length).toBe(1);
+      expect(defaultMapper.errorFields[0]).toBe(testFieldName);
+    });
+
+    it('should return contentfulValue if no stripeValue and contentful is available', () => {
+      const testFieldName = StripeMetadataKeysForContentful.ToS;
+      const expected = defaultCommonContent.termsOfServiceUrl;
+      const actual = defaultMapper.mapField(
+        testFieldName,
+        stripeMetadata[testFieldName],
+        defaultCommonContent.termsOfServiceUrl
+      );
+      expect(actual).toBe(expected);
+      expect(defaultMapper.errorFields.length).toBe(0);
+    });
+
+    it('should return stripeValue as default', () => {
+      const testFieldName = StripeMetadataKeysForContentful.WebIcon;
+      const expected = stripeMetadata[testFieldName];
+      const actual = defaultMapper.mapField(
+        testFieldName,
+        stripeMetadata[testFieldName],
+        defaultPurchaseDetails.webIcon
+      );
+      expect(actual).toBe(expected);
+      expect(defaultMapper.errorFields.length).toBe(0);
+    });
+  });
+
+  describe('getStripeForMetadataKey', () => {
+    const commonContent = {
+      ...defaultCommonContent,
+      newsletterSlug: ['snp', 'mdnplus', 'hubs'],
+    };
+    const defaultMapper = new PlanMapperUtil(
+      commonContent,
+      defaultPurchaseDetails,
+      stripeMetadata
+    );
+    // Instead of having a test for each Stripe Metadata Key, only test
+    // for keys with mapping logic, e.g. newsletterSlug
+    it('should return newsletterSlug in expected format', () => {
+      const expected = 'hubs,mdnplus,snp';
+      const actual = defaultMapper.getContentfulForMetadataKey(
+        StripeMetadataKeysForContentful.NewsletterSlug
+      );
+      expect(actual).toBe(expected);
+    });
+
+    it('should return newsletterSlug in expected format', () => {
+      const commonContent = {
+        ...defaultCommonContent,
+        newsletterSlug: null,
+      };
+      const mapper = new PlanMapperUtil(
+        commonContent,
+        defaultPurchaseDetails,
+        stripeMetadata
+      );
+      const expected = null;
+      const actual = mapper.getContentfulForMetadataKey(
+        StripeMetadataKeysForContentful.NewsletterSlug
+      );
+      expect(actual).toBe(expected);
+    });
+
+    it('should return undefined as default', () => {
+      const expected = undefined;
+      const actual = defaultMapper.getContentfulForMetadataKey(
+        'doesnotexist' as StripeMetadataKeysForContentful
+      );
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('getContentfulForMetadataKey', () => {
+    it('should return newsletterSlug in expected format', () => {
+      const metadata = {
+        newsletterSlug: 'snp,mdnplus,hubs',
+      };
+      const mapper = new PlanMapperUtil(
+        defaultCommonContent,
+        defaultPurchaseDetails,
+        metadata
+      );
+      const expected = 'hubs,mdnplus,snp';
+      const actual = mapper.getStripeForMetadataKey(
+        StripeMetadataKeysForContentful.NewsletterSlug
+      );
+      expect(actual).toBe(expected);
+    });
+
+    it('should return undefined for undefined newsletterSlug', () => {
+      const metadata = {};
+      const mapper = new PlanMapperUtil(
+        defaultCommonContent,
+        defaultPurchaseDetails,
+        metadata
+      );
+      const expected = undefined;
+      const actual = mapper.getStripeForMetadataKey(
+        StripeMetadataKeysForContentful.NewsletterSlug
+      );
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('mergeStripeAndContentful', () => {
+    it('successfully maps contentful and stripe data', () => {
+      const defaultMapper = new PlanMapperUtil(
+        defaultCommonContent,
+        defaultPurchaseDetails,
+        stripeMetadata
+      );
+      const result = defaultMapper.mergeStripeAndContentful();
+      expect(result.errorFields.length).toBe(1);
+      expect(result.errorFields[0]).toBe('emailIconURL');
+      expect(result.metadata.webIconURL).toBe(defaultPurchaseDetails.webIcon);
+    });
+  });
+});

--- a/libs/payments/legacy/src/lib/plan-mapper.util.ts
+++ b/libs/payments/legacy/src/lib/plan-mapper.util.ts
@@ -1,0 +1,139 @@
+import { Stripe } from 'stripe';
+import {
+  OfferingCommonContentResult,
+  PurchaseDetailsTransformed,
+} from '@fxa/shared/contentful';
+import { StripeMetadataKeysForContentful } from './types';
+
+/**
+ *  Class that maps Contentful Config onto a single Stripe Plan's metadata
+ */
+export class PlanMapperUtil {
+  errorFields: string[] = [];
+  constructor(
+    private commonContent: OfferingCommonContentResult,
+    private purchaseDetails: PurchaseDetailsTransformed,
+    private stripeMetadata: Stripe.Metadata | null
+  ) {}
+
+  /**
+   * For a specific Metadata key, determine whether to use the Stripe metadata value
+   * or Contentful value
+   */
+  mapField(
+    stripeFieldName: StripeMetadataKeysForContentful,
+    stripeValue?: string,
+    contentfulValue?: string | null
+  ) {
+    // Return undefined if stripe and contentful aren't provided
+    if (stripeValue === undefined && contentfulValue === null) {
+      return undefined;
+    }
+
+    // Return contentful if no stripe value is available
+    if (!stripeValue && !!contentfulValue) {
+      return contentfulValue;
+    }
+
+    // If stripe does not match contentful, return stripe and log error
+    if (stripeValue !== contentfulValue) {
+      this.errorFields.push(stripeFieldName);
+      return stripeValue;
+    }
+
+    return stripeValue;
+  }
+
+  /**
+   * Return the Stripe metadata value for the provided key
+   */
+  getStripeForMetadataKey(stripeMetadataKey: StripeMetadataKeysForContentful) {
+    if (!this.stripeMetadata) {
+      return undefined;
+    }
+
+    switch (stripeMetadataKey) {
+      case StripeMetadataKeysForContentful.NewsletterSlug:
+        return (
+          this.stripeMetadata[StripeMetadataKeysForContentful.NewsletterSlug] &&
+          this.stripeMetadata[StripeMetadataKeysForContentful.NewsletterSlug]
+            .split(',')
+            .sort()
+            .join(',')
+        );
+      default:
+        return this.stripeMetadata[stripeMetadataKey];
+    }
+  }
+
+  /**
+   * Return the Contentful config value for the provided Stripe metadata key,
+   * in the format expected by Stripe metadata
+   */
+  getContentfulForMetadataKey(
+    stripeMetadataKey: StripeMetadataKeysForContentful
+  ) {
+    switch (stripeMetadataKey) {
+      case StripeMetadataKeysForContentful.DetailsLine1:
+        return this.purchaseDetails.details[0];
+      case StripeMetadataKeysForContentful.DetailsLine2:
+        return this.purchaseDetails.details[1];
+      case StripeMetadataKeysForContentful.DetailsLine3:
+        return this.purchaseDetails.details[2];
+      case StripeMetadataKeysForContentful.DetailsLine4:
+        return this.purchaseDetails.details[3];
+      case StripeMetadataKeysForContentful.Subtitle:
+        return this.purchaseDetails.subtitle;
+      case StripeMetadataKeysForContentful.WebIcon:
+        return this.purchaseDetails.webIcon;
+      case StripeMetadataKeysForContentful.PrivacyNotice:
+        return this.commonContent.privacyNoticeUrl;
+      case StripeMetadataKeysForContentful.PrivacyNoticeDownload:
+        return this.commonContent.privacyNoticeDownloadUrl;
+      case StripeMetadataKeysForContentful.ToS:
+        return this.commonContent.termsOfServiceUrl;
+      case StripeMetadataKeysForContentful.ToSDownload:
+        return this.commonContent.termsOfServiceDownloadUrl;
+      case StripeMetadataKeysForContentful.CancellationURL:
+        return this.commonContent.cancellationUrl;
+      case StripeMetadataKeysForContentful.EmailIcon:
+        return this.commonContent.emailIcon;
+      case StripeMetadataKeysForContentful.SuccessAction:
+        return this.commonContent.successActionButtonUrl;
+      case StripeMetadataKeysForContentful.SuccessActionLabel:
+        return this.commonContent.successActionButtonLabel;
+      case StripeMetadataKeysForContentful.NewsletterLabel:
+        return this.commonContent.newsletterLabelTextCode;
+      case StripeMetadataKeysForContentful.NewsletterSlug: {
+        return (
+          this.commonContent.newsletterSlug &&
+          [...this.commonContent.newsletterSlug].sort().join(',')
+        );
+      }
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Merges Stripe and Contentful values where appropriate, and logs fields where
+   * Contentful does not match Stripe metadata values
+   */
+  mergeStripeAndContentful() {
+    const mappedMetadata: {
+      [key in StripeMetadataKeysForContentful]?: string;
+    } = {};
+    Object.values(StripeMetadataKeysForContentful).forEach((key) => {
+      mappedMetadata[key] = this.mapField(
+        key,
+        this.getStripeForMetadataKey(key),
+        this.getContentfulForMetadataKey(key)
+      );
+    });
+
+    return {
+      metadata: mappedMetadata,
+      errorFields: this.errorFields,
+    };
+  }
+}

--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -1,0 +1,155 @@
+import { Stripe } from 'stripe';
+import {
+  ContentfulClient,
+  PurchaseWithDetailsOfferingContentUtil,
+  ContentfulManager,
+  PurchaseWithDetailsOfferingContentTransformedFactory,
+} from '@fxa/shared/contentful';
+import { StripeMapperService } from './stripe-mapper.service';
+import { ProductFactory, PlanFactory } from '@fxa/payments/stripe';
+import { StripeMetadataWithContentfulFactory } from './factories';
+
+describe('StripeMapperService', () => {
+  describe('mapContentfulToStripePlans', () => {
+    let stripeMapper: StripeMapperService;
+    const mockContentfulConfigUtil = {
+      transformedPurchaseWithCommonContentForPlanId: jest.fn(),
+    };
+
+    beforeEach(() => {
+      jest
+        .spyOn(
+          ContentfulManager.prototype,
+          'getPurchaseWithDetailsOfferingContentByPlanIds'
+        )
+        .mockResolvedValue(
+          mockContentfulConfigUtil as unknown as PurchaseWithDetailsOfferingContentUtil
+        );
+      const contentfulClient = {} as ContentfulClient;
+      stripeMapper = new StripeMapperService(
+        new ContentfulManager(contentfulClient)
+      );
+    });
+
+    it('should return stripe metadata with error due to plan.product not being an object', async () => {
+      const validMetadata = StripeMetadataWithContentfulFactory({
+        webIconURL: 'https://example.com/webIconURL',
+      });
+      const stripePlan = PlanFactory({
+        product: 'stringvalue',
+        metadata: validMetadata,
+      });
+      const { mappedPlans, nonMatchingPlans } =
+        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+      expect(mappedPlans[0].metadata?.['webIconURL']).toBe(
+        validMetadata.webIconURL
+      );
+      expect(nonMatchingPlans[0].split(' - ')[1]).toBe(
+        'Plan product not expanded'
+      );
+    });
+
+    it('should return stripe metadata with error due to missing contentful data', async () => {
+      mockContentfulConfigUtil.transformedPurchaseWithCommonContentForPlanId =
+        jest.fn().mockReturnValueOnce(undefined);
+      const validMetadata = StripeMetadataWithContentfulFactory({
+        webIconURL: 'https://example.com/webIconURL',
+      });
+      const stripePlan = PlanFactory({
+        product: ProductFactory({
+          metadata: validMetadata,
+        }),
+      });
+      const { mappedPlans, nonMatchingPlans } =
+        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+      const actualProduct = mappedPlans[0].product as Stripe.Product;
+      expect(actualProduct.metadata?.['webIconURL']).toBe(
+        validMetadata.webIconURL
+      );
+      expect(nonMatchingPlans[0].split(' - ')[1]).toBe('No Contentful config');
+    });
+
+    it('should return stripe metadata with error due to invalid fields in product.metadata', async () => {
+      mockContentfulConfigUtil.transformedPurchaseWithCommonContentForPlanId =
+        jest
+          .fn()
+          .mockReturnValueOnce(
+            PurchaseWithDetailsOfferingContentTransformedFactory()
+          );
+      const validMetadata = StripeMetadataWithContentfulFactory({
+        webIconURL: 'https://example.com/webIconURL',
+      });
+      const stripePlan = PlanFactory({
+        product: ProductFactory({
+          metadata: validMetadata,
+        }),
+      });
+      const { mappedPlans, nonMatchingPlans } =
+        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+      const actualProduct = mappedPlans[0].product as Stripe.Product;
+      expect(actualProduct.metadata?.['webIconURL']).toBe(
+        validMetadata.webIconURL
+      );
+      expect(nonMatchingPlans[0].split(' - ')[1]).toBe('webIconURL');
+    });
+
+    it('should return stripe metadata with error due to invalid fields in plan.metadata', async () => {
+      mockContentfulConfigUtil.transformedPurchaseWithCommonContentForPlanId =
+        jest
+          .fn()
+          .mockReturnValueOnce(
+            PurchaseWithDetailsOfferingContentTransformedFactory()
+          );
+      const validMetadata = StripeMetadataWithContentfulFactory({
+        webIconURL: 'https://example.com/webIconURL',
+      });
+      const planOverrideMetadata = StripeMetadataWithContentfulFactory({
+        webIconURL: 'https://plan.override/emailIcon',
+      });
+      const stripePlan = PlanFactory({
+        product: ProductFactory({
+          metadata: validMetadata,
+        }),
+        metadata: planOverrideMetadata,
+      });
+      const { mappedPlans, nonMatchingPlans } =
+        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+      const actualProduct = mappedPlans[0].product as Stripe.Product;
+      expect(actualProduct.metadata?.['webIconURL']).toBe(
+        planOverrideMetadata.webIconURL
+      );
+      expect(nonMatchingPlans[0].split(' - ')[1]).toBe('webIconURL');
+    });
+
+    it('should return data from contentful', async () => {
+      const expected = PurchaseWithDetailsOfferingContentTransformedFactory();
+      mockContentfulConfigUtil.transformedPurchaseWithCommonContentForPlanId =
+        jest.fn().mockReturnValueOnce(expected);
+      const productMetadata = {
+        productSet: 'set',
+        productOrder: 'order',
+      };
+      const stripePlan = PlanFactory({
+        product: ProductFactory({
+          metadata: productMetadata,
+        }),
+      });
+      const { mappedPlans, nonMatchingPlans } =
+        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+      const actualProduct = mappedPlans[0].product as Stripe.Product;
+      expect(mappedPlans[0].metadata?.['webIconURL']).toBe(
+        expected.purchaseDetails.webIcon
+      );
+      expect(actualProduct.metadata?.['webIconURL']).toBe(
+        expected.purchaseDetails.webIcon
+      );
+      expect(actualProduct.metadata?.['productSet']).toBe(
+        productMetadata.productSet
+      );
+      expect(actualProduct.metadata?.['productOrder']).toBe(
+        productMetadata.productOrder
+      );
+      expect(nonMatchingPlans.length).toBe(0);
+    });
+  });
+});

--- a/libs/payments/legacy/src/lib/stripe-mapper.service.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.ts
@@ -1,0 +1,104 @@
+import { Stripe } from 'stripe';
+import { ContentfulManager } from '@fxa/shared/contentful';
+import { PlanMapperUtil } from './plan-mapper.util';
+
+/**
+ * Class to fetch Contentful config and map Contentful config to
+ * Stripe metadata for an array of Stripe Plans.
+ */
+export class StripeMapperService {
+  private nonMatchingPlans: string[] = [];
+  constructor(private contentfulManager: ContentfulManager) {}
+
+  /**
+   *  TypeGuard to ensure product on plan is a Product Object
+   */
+  private isProductObject(
+    product: Stripe.Plan['product']
+  ): product is Stripe.Product {
+    if (typeof product !== 'string' && product && !product.deleted) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Merge Contentful config and Stripe metadata and assign to
+   * plan and product metadata fields
+   */
+  async mapContentfulToStripePlans(
+    plans: Stripe.Plan[],
+    acceptLanguage: string
+  ) {
+    const mappedPlans: Stripe.Plan[] = [];
+    const validPlanIds = plans.map((plan) => plan.id);
+
+    const contentfulConfigUtil =
+      await this.contentfulManager.getPurchaseWithDetailsOfferingContentByPlanIds(
+        validPlanIds,
+        acceptLanguage
+      );
+
+    for (const plan of plans) {
+      if (!this.isProductObject(plan.product)) {
+        mappedPlans.push(plan);
+        this.nonMatchingPlans.push(`${plan.id} - Plan product not expanded`);
+        continue;
+      }
+
+      const mergedStripeMetadata = {
+        ...plan.product.metadata,
+        ...plan.metadata,
+      };
+
+      const contentfulConfigData =
+        contentfulConfigUtil.transformedPurchaseWithCommonContentForPlanId(
+          plan.id
+        );
+
+      if (!contentfulConfigData) {
+        mappedPlans.push(plan);
+        this.nonMatchingPlans.push(`${plan.id} - No Contentful config`);
+        continue;
+      }
+
+      const {
+        offering: { commonContent },
+        purchaseDetails,
+      } = contentfulConfigData;
+
+      const planMapper = new PlanMapperUtil(
+        commonContent,
+        purchaseDetails,
+        mergedStripeMetadata
+      );
+
+      const { metadata, errorFields } = planMapper.mergeStripeAndContentful();
+
+      mappedPlans.push({
+        ...plan,
+        metadata: {
+          ...plan.metadata,
+          ...metadata,
+        },
+        product: {
+          ...plan.product,
+          metadata: {
+            ...plan.product.metadata,
+            ...metadata,
+          },
+        },
+      });
+
+      if (errorFields.length) {
+        this.nonMatchingPlans.push(`${plan.id} - ${errorFields.join(', ')}`);
+      }
+    }
+
+    return {
+      mappedPlans,
+      nonMatchingPlans: this.nonMatchingPlans,
+    };
+  }
+}

--- a/libs/payments/legacy/src/lib/types.ts
+++ b/libs/payments/legacy/src/lib/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Stripe metadata keys with Contentful config
+ */
+export enum StripeMetadataKeysForContentful {
+  DetailsLine1 = 'product:details:1',
+  DetailsLine2 = 'product:details:2',
+  DetailsLine3 = 'product:details:3',
+  DetailsLine4 = 'product:details:4',
+  Subtitle = 'product:subtitle',
+  WebIcon = 'webIconURL',
+  PrivacyNotice = 'product:privacyNoticeURL',
+  PrivacyNoticeDownload = 'product:privacyNoticeDownloadURL',
+  ToS = 'product:termsOfServiceURL',
+  ToSDownload = 'product:termsOfServiceDownloadURL',
+  CancellationURL = 'product:cancellationSurveyURL',
+  EmailIcon = 'emailIconURL',
+  SuccessAction = 'successActionButtonURL',
+  SuccessActionLabel = 'product:successActionButtonLabel',
+  NewsletterLabel = 'newsletterLabelTextCode',
+  NewsletterSlug = 'newsletterSlug',
+}
+
+export type StripeMetadataWithContentful = Partial<
+  Record<StripeMetadataKeysForContentful, string>
+>;

--- a/libs/payments/legacy/tsconfig.json
+++ b/libs/payments/legacy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/payments/legacy/tsconfig.lib.json
+++ b/libs/payments/legacy/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/payments/legacy/tsconfig.spec.json
+++ b/libs/payments/legacy/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -3,6 +3,7 @@ export { CustomerFactory } from './lib/factories/customer.factory';
 export { InvoiceLineItemFactory } from './lib/factories/invoice-line-item.factory';
 export { InvoiceFactory } from './lib/factories/invoice.factory';
 export { PriceFactory } from './lib/factories/price.factory';
+export { PlanFactory } from './lib/factories/plan.factory';
 export { ProductFactory } from './lib/factories/product.factory';
 export { SubscriptionItemFactory } from './lib/factories/subscription-item.factory';
 export { SubscriptionFactory } from './lib/factories/subscription.factory';

--- a/libs/payments/stripe/src/lib/factories/plan.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/plan.factory.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { Stripe } from 'stripe';
+
+export const PlanFactory = (override?: Partial<Stripe.Plan>): Stripe.Plan => ({
+  id: `plan_${faker.string.alphanumeric({ length: 24 })}`,
+  object: 'plan',
+  active: true,
+  billing_scheme: 'per_unit',
+  created: faker.number.int(),
+  currency: faker.finance.currencyCode(),
+  livemode: false,
+  metadata: {},
+  nickname: null,
+  product: `prod_${faker.string.alphanumeric({ length: 14 })}`,
+  tiers_mode: null,
+  aggregate_usage: null,
+  amount: faker.number.int({ max: 1000 }),
+  amount_decimal: faker.commerce.price({ min: 1000 }),
+  interval: 'month',
+  interval_count: 1,
+  transform_usage: null,
+  trial_period_days: null,
+  usage_type: 'licensed',
+  ...override,
+});

--- a/libs/shared/contentful/src/index.ts
+++ b/libs/shared/contentful/src/index.ts
@@ -9,4 +9,6 @@ export * from './lib/contentful.manager';
 export * from './lib/factories';
 export * from './lib/queries/capability-service-by-plan-ids';
 export * from './lib/queries/eligibility-content-by-plan-ids';
+export * from './lib/queries/purchase-with-details-offering-content';
 export * from './lib/queries/services-with-capabilities';
+export * from './lib/types';

--- a/libs/shared/contentful/src/lib/queries/purchase-with-details-offering-content/index.ts
+++ b/libs/shared/contentful/src/lib/queries/purchase-with-details-offering-content/index.ts
@@ -4,3 +4,4 @@
 export * from './query';
 export * from './types';
 export * from './util';
+export * from './factories';

--- a/libs/shared/contentful/src/lib/queries/purchase-with-details-offering-content/types.ts
+++ b/libs/shared/contentful/src/lib/queries/purchase-with-details-offering-content/types.ts
@@ -22,8 +22,8 @@ export interface OfferingCommonContentResult {
   emailIcon: string | null;
   successActionButtonUrl: string;
   successActionButtonLabel: string;
-  newsletterLabelTextCode: string;
-  newsletterSlug: string[];
+  newsletterLabelTextCode: string | null;
+  newsletterSlug: string[] | null;
 }
 
 export interface PurchaseOfferingResult {

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -26,6 +26,7 @@ import { StatsD } from 'hot-shots';
 import Stripe from 'stripe';
 import { AppConfig } from '../config';
 import { FirestoreService } from '../backend/firestore.service';
+import { ContentfulManager } from '@fxa/shared/contentful';
 
 export const StripeFactory: Provider<Stripe> = {
   provide: 'STRIPE',
@@ -96,6 +97,7 @@ export class StripeService extends StripeHelper {
   protected override readonly paymentConfigManager?:
     | PaymentConfigManager
     | undefined;
+  protected contentfulManager?: ContentfulManager | undefined;
 
   constructor(
     configService: ConfigService<AppConfig>,

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -125,6 +125,7 @@ async function run(config) {
         graphqlEnvironment: config.contentful.environment,
       });
       const contentfulManager = new ContentfulManager(contentfulClient);
+      Container.set(ContentfulManager, contentfulManager);
       const capabilityManager = new CapabilityManager(contentfulManager);
       Container.set(CapabilityManager, capabilityManager);
     }

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -77,6 +77,7 @@ import { PlayStoreSubscriptionPurchase } from './iap/google-play/subscription-pu
 import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
 import { stripeInvoiceToLatestInvoiceItemsDTO } from './stripe-formatter';
 import { generateIdempotencyKey, roundTime } from './utils';
+import { ContentfulManager } from '@fxa/shared/contentful';
 
 // Maintains backwards compatibility. Some type defs hoisted to fxa-shared/payments/stripe
 export * from 'fxa-shared/payments/stripe';
@@ -164,6 +165,7 @@ export class StripeHelper extends StripeHelperBase {
   protected override readonly stripeFirestore: StripeFirestore;
   protected override readonly paymentConfigManager?: PaymentConfigManager;
   protected override readonly redis?: ioredis.Redis;
+  protected override readonly contentfulManager?: ContentfulManager | undefined;
 
   // Note that this isn't quite accurate, as the auth-server logger has some extras
   // attached to it in Hapi.
@@ -230,6 +232,7 @@ export class StripeHelper extends StripeHelperBase {
     this.webhookSecret = config.subscriptions.stripeWebhookSecret;
     this.taxIds = config.subscriptions.taxIds;
     this.currencyHelper = Container.get(CurrencyHelper);
+    this.contentfulManager = Container.get(ContentfulManager);
 
     // Initializes caching
     this.initRedis();

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -251,7 +251,9 @@ export class StripeHandler {
 
   async listPlans(request: AuthRequest) {
     this.log.begin('subscriptions.listPlans', request);
-    const plans = await this.stripeHelper.allAbbrevPlans();
+    const plans = await this.stripeHelper.allAbbrevPlans(
+      request?.headers?.['accept-language']
+    );
     return sanitizePlans(plans);
   }
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -226,6 +226,9 @@ describe('subscriptions stripeRoutes', () => {
         email: `${TEST_EMAIL}`,
       },
     },
+    headers: {
+      'accept-language': 'en',
+    },
   };
 
   describe('Plans', () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,11 +24,12 @@
     "useUnknownInCatchVariables": false,
     "baseUrl": ".",
     "paths": {
-      "@fxa/payments/stripe": ["libs/payments/stripe/src/index.ts"],
       "@fxa/payments/capability": ["libs/payments/capability/src/index.ts"],
       "@fxa/payments/cart": ["libs/payments/cart/src/index.ts"],
       "@fxa/payments/eligibility": ["libs/payments/eligibility/src/index.ts"],
+      "@fxa/payments/legacy": ["libs/payments/legacy/src/index.ts"],
       "@fxa/payments/paypal": ["libs/payments/paypal/src/index.ts"],
+      "@fxa/payments/stripe": ["libs/payments/stripe/src/index.ts"],
       "@fxa/payments/ui": ["libs/payments/ui/src/index.ts"],
       "@fxa/payments/ui/server": ["libs/payments/ui/src/server.ts"],
       "@fxa/shared/account/account": [


### PR DESCRIPTION
## Because

- The GET /plans API is used in multiple places to retrieve the relying party configuration data currently configured in Stripe.metadata

## This pull request

- Updates the logic used by the GET /plans API to retrieve the relying party configuration data from Contentful, with Stripe.metadata as a fallback
- Reports a Sentry error when the Contentful configuration data does not match the Stripe.metadata

## Issue that this pull request solves

Closes: #FXA-8538

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
