### PR TITLE
feat(auth): remove productOrder from email logic

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2892,10 +2892,7 @@ export class StripeHelper extends StripeHelperBase {
       },
       abbrevProductNew
     );
-    const {
-      productOrder: productOrderNew,
-      emailIconURL: productIconURLNew = '',
-    } = productNewMetadata;
+    const { emailIconURL: productIconURLNew = '' } = productNewMetadata;
     const planConfig = await this.maybeGetPlanConfig(planIdNew);
 
     const productPaymentCycleNew = this.stripePlanToPaymentCycle(planNew);
@@ -2971,7 +2968,6 @@ export class StripeHelper extends StripeHelperBase {
         baseDetails,
         invoice,
         upcomingInvoiceWithInvoiceItem,
-        productOrderNew,
         planOld
       );
     }
@@ -3146,7 +3142,6 @@ export class StripeHelper extends StripeHelperBase {
     baseDetails: any,
     invoice: Stripe.Invoice,
     upcomingInvoiceWithInvoiceItem: Stripe.UpcomingInvoice | undefined,
-    productOrderNew: string,
     planOld: Stripe.Plan
   ) {
     const {
@@ -3161,21 +3156,13 @@ export class StripeHelper extends StripeHelperBase {
     const { product_id: productIdOld, product_name: productNameOld } =
       abbrevProductOld;
     const abbrevPlanOld = await this.findAbbrevPlanById(planOld.id);
-    const {
-      productOrder: productOrderOld,
-      emailIconURL: productIconURLOld = '',
-    } = this.mergeMetadata(
+    const { emailIconURL: productIconURLOld = '' } = this.mergeMetadata(
       {
         ...planOld,
         metadata: abbrevPlanOld.plan_metadata,
       },
       abbrevProductOld
     );
-
-    const updateType =
-      parseInt(productOrderNew) > parseInt(productOrderOld)
-        ? SUBSCRIPTION_UPDATE_TYPES.UPGRADE
-        : SUBSCRIPTION_UPDATE_TYPES.DOWNGRADE;
 
     const productPaymentCycleOld = this.stripePlanToPaymentCycle(planOld);
 
@@ -3191,7 +3178,7 @@ export class StripeHelper extends StripeHelperBase {
 
     return {
       ...baseDetails,
-      updateType,
+      updateType: SUBSCRIPTION_UPDATE_TYPES.UPGRADE,
       productIdOld,
       productNameOld,
       productIconURLOld,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -5864,7 +5864,6 @@ describe('#integration - StripeHelper', () => {
           expectedBaseUpdateDetails,
           mockInvoice,
           undefined,
-          event.data.object.plan.metadata.productOrder,
           oldPlan
         );
       });
@@ -5890,7 +5889,6 @@ describe('#integration - StripeHelper', () => {
           expectedBaseUpdateDetails,
           mockInvoice,
           undefined,
-          event.data.object.plan.metadata.productOrder,
           oldPlan
         );
       });
@@ -5930,11 +5928,7 @@ describe('#integration - StripeHelper', () => {
 
     describe('extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail', () => {
       const commonTest =
-        (
-          isUpgrade,
-          upcomingInvoice = undefined,
-          expectedPaymentProratedInCents = 0
-        ) =>
+        (upcomingInvoice = undefined, expectedPaymentProratedInCents = 0) =>
         async () => {
           const event = deepCopy(eventCustomerSubscriptionUpdated);
           const productIdOld = event.data.previous_attributes.plan.product;
@@ -5987,26 +5981,19 @@ describe('#integration - StripeHelper', () => {
             }
           );
 
-          event.data.object.plan.metadata.productOrder = isUpgrade ? 2 : 1;
-          event.data.previous_attributes.plan.metadata.productOrder = isUpgrade
-            ? 1
-            : 2;
-
           const result =
             await stripeHelper.extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail(
               event.data.object,
               baseDetails,
               mockInvoice,
               upcomingInvoice,
-              event.data.object.plan.metadata.productOrder,
               event.data.previous_attributes.plan
             );
 
           assert.deepEqual(result, {
             ...baseDetails,
             productIdNew,
-            updateType:
-              SUBSCRIPTION_UPDATE_TYPES[isUpgrade ? 'UPGRADE' : 'DOWNGRADE'],
+            updateType: SUBSCRIPTION_UPDATE_TYPES.UPGRADE,
             productIdOld,
             productNameOld,
             productIconURLOld,
@@ -6026,15 +6013,7 @@ describe('#integration - StripeHelper', () => {
 
       it(
         'extracts expected details for a subscription upgrade',
-        commonTest(true, {
-          currency: 'usd',
-          total: 1234,
-        })
-      );
-
-      it(
-        'extracts expected details for a subscription downgrade',
-        commonTest(false, {
+        commonTest({
           currency: 'usd',
           total: 1234,
         })
@@ -6104,7 +6083,6 @@ describe('#integration - StripeHelper', () => {
             baseDetails,
             mockInvoice,
             undefined,
-            event.data.object.plan.metadata.productOrder,
             event.data.previous_attributes.plan
           );
 
@@ -6116,7 +6094,7 @@ describe('#integration - StripeHelper', () => {
 
       it(
         'extracts expected details for a subscription upgrade with pending invoice items',
-        commonTest(false, {
+        commonTest({
           currency: 'usd',
           total: 1234,
           lines: {


### PR DESCRIPTION
## Because

* We don't have the concept of productOrder in Contentful.

## This pull request

* Removes productOrder from email logic, since we do not have downgrade functionality at this time.

## Issue that this pull request solves

Closes FXA-8620