### PR TITLE
task(scripts): Return firestore back to latest image version

### DIFF
--- a/_scripts/firestore.sh
+++ b/_scripts/firestore.sh
@@ -5,4 +5,4 @@ cd "$DIR/../_dev/firebase"
 
 # the "demo-" prefix for --project is special
 # see https://firebase.google.com/docs/emulator-suite/connect_firestore#choose_a_firebase_project
-docker run --rm --net fxa -p 4400:4400 -p 4500:4500 -p 8085:8085 -p 9090:9090 -p 9299:9299 -v "$(pwd)":/home/node --name firebase-tools andreysenov/firebase-tools:10.9.1 firebase emulators:start --project demo-fxa
+docker run --rm --net fxa -p 4400:4400 -p 4500:4500 -p 8085:8085 -p 9090:9090 -p 9299:9299 -v "$(pwd)":/home/node --name firebase-tools andreysenov/firebase-tools:latest firebase emulators:start --project demo-fxa


### PR DESCRIPTION
## Because

- Firestore is flaky to start up

## This pull request

- Sets it back to latest. Hopefully this helps :crossed_fingers: 

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

IIRC, we hard set the image version because 'latest' was causing problems at one point. There's been many more versions released since then, however, so it's worth giving this another shot.
