### PR TITLE
fix(contentful): Added help texts to fields and updated default locale

### DIFF
--- a/libs/shared/contentful/src/lib/constants.ts
+++ b/libs/shared/contentful/src/lib/constants.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const DEFAULT_LOCALE = 'en-US';

--- a/libs/shared/contentful/src/lib/contentful.client.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.spec.ts
@@ -4,6 +4,7 @@
 
 import { faker } from '@faker-js/faker';
 import { ApolloQueryResult } from '@apollo/client';
+import { DEFAULT_LOCALE } from './constants';
 import { ContentfulClient } from './contentful.client';
 import { offeringQuery } from './queries/offering';
 import { OfferingQuery } from '../__generated__/graphql';
@@ -180,7 +181,6 @@ describe('ContentfulClient', () => {
   });
 
   describe('getLocale', () => {
-    const DEFAULT_LOCALE = 'en';
     const ACCEPT_LANGUAGE = 'en-US,fr-FR;q=0.7,de-DE;q=0.3';
     const MOCK_DATA = {
       items: [{ code: 'en' }, { code: 'fr-FR' }],

--- a/libs/shared/contentful/src/lib/contentful.client.ts
+++ b/libs/shared/contentful/src/lib/contentful.client.ts
@@ -12,6 +12,7 @@ import { BaseError } from '@fxa/shared/error';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { Injectable } from '@nestjs/common';
 import { determineLocale } from '@fxa/shared/l10n';
+import { DEFAULT_LOCALE } from './constants';
 import { ContentfulClientConfig } from './contentful.client.config';
 import {
   ContentfulCDNError,
@@ -39,7 +40,11 @@ export class ContentfulClient {
 
   async getLocale(acceptLanguage: string): Promise<string> {
     const contentfulLocales = await this.getLocales();
-    return determineLocale(acceptLanguage, contentfulLocales);
+    const result = determineLocale(acceptLanguage, contentfulLocales);
+    if (result === 'en') {
+      return DEFAULT_LOCALE;
+    }
+    return result;
   }
 
   async query<Result, Variables>(

--- a/libs/shared/contentful/src/lib/contentful.manager.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.ts
@@ -10,6 +10,7 @@ import {
   ServicesWithCapabilitiesQuery,
   CapabilityServiceByPlanIdsQuery,
 } from '../__generated__/graphql';
+import { DEFAULT_LOCALE } from './constants';
 import { ContentfulClient } from './contentful.client';
 
 import {
@@ -42,7 +43,7 @@ export class ContentfulManager {
       {
         skip: 0,
         limit: 100,
-        locale: 'en',
+        locale: DEFAULT_LOCALE,
         stripePlanIds,
       }
     );
@@ -60,7 +61,7 @@ export class ContentfulManager {
       {
         skip: 0,
         limit: 100,
-        locale: 'en',
+        locale: DEFAULT_LOCALE,
         stripePlanIds,
       }
     );
@@ -74,7 +75,7 @@ export class ContentfulManager {
     const queryResult = await this.client.query(servicesWithCapabilitiesQuery, {
       skip: 0,
       limit: 100,
-      locale: 'en',
+      locale: DEFAULT_LOCALE,
     });
 
     return new ServicesWithCapabilitiesResultUtil(

--- a/packages/db-migrations/contentful/1699394072129_fxa-8502.js
+++ b/packages/db-migrations/contentful/1699394072129_fxa-8502.js
@@ -1,0 +1,195 @@
+function migrationFunction(migration, context) {
+  const purchase = migration.editContentType('purchase');
+  const purchaseStripePlanChoices = purchase.editField('stripePlanChoices');
+  purchaseStripePlanChoices.required(false);
+  purchase.changeFieldControl('stripePlanChoices', 'builtin', 'tagEditor', {
+    helpText:
+      'All active Stripe Plan IDs from Stripe associated to the Stripe Product ID of the product offering.',
+  });
+  purchase.changeFieldControl('purchaseDetails', 'builtin', 'entryLinkEditor', {
+    helpText: 'Purchase details for this purchase entry.',
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+  purchase.changeFieldControl('offering', 'builtin', 'entryLinkEditor', {
+    helpText: 'Associated offering for this purchase entry.',
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+
+  const offering = migration.editContentType('offering');
+  const offeringCountries = offering.editField('countries');
+  offeringCountries.items({
+    type: 'Symbol',
+    validations: [
+      {
+        in: [
+          'CA - Canada',
+          'FR - France',
+          'DE - Germany',
+          'GB - Great Britain',
+          'IT - Italy',
+          'ES - Spain',
+          'US - United States',
+        ],
+      },
+    ],
+  });
+
+  const offeringStripeLegacyPlans = offering.createField('stripeLegacyPlans');
+  offeringStripeLegacyPlans
+    .name('Stripe Legacy Plans')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({ type: 'Symbol', validations: [] });
+  offering.moveField('iap').beforeField('stripeLegacyPlans');
+  offering.moveField('couponConfig').beforeField('stripeLegacyPlans');
+  offering.moveField('commonContent').beforeField('stripeLegacyPlans');
+  offering.moveField('capabilities').beforeField('stripeLegacyPlans');
+  offering.changeFieldControl('internalName', 'builtin', 'singleLine', {
+    helpText: 'e.g. 123Done Pro Plus',
+  });
+  offering.changeFieldControl('apiIdentifier', 'builtin', 'singleLine', {
+    helpText:
+      'Identifier used in the URL path to uniquely identify this Offering. (e.g. 123doneproplus)',
+  });
+  offering.changeFieldControl('stripeProductId', 'builtin', 'singleLine', {
+    helpText: 'The Stripe Product ID of this product offering found in Stripe.',
+  });
+  offering.changeFieldControl('countries', 'builtin', 'checkbox', {
+    helpText: 'The countries in which this product offering is available.',
+  });
+  offering.changeFieldControl('couponConfig', 'builtin', 'entryLinksEditor', {
+    helpText: 'Coupons offered for this product offering.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+  offering.changeFieldControl('iap', 'builtin', 'entryLinksEditor', {
+    helpText: 'IAP configuration for this product offering.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+  offering.changeFieldControl('commonContent', 'builtin', 'entryLinkEditor', {
+    helpText: 'Common content for this product offering.',
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+  offering.changeFieldControl('stripeLegacyPlans', 'builtin', 'tagEditor', {
+    helpText:
+      'All archived Stripe Plan IDs from Stripe associated to the Stripe Product ID of the product offering.',
+  });
+
+  const couponConfig = migration.editContentType('couponConfig');
+  const couponConfigCountries = couponConfig.editField('countries');
+  couponConfigCountries.items({
+    type: 'Symbol',
+    validations: [
+      {
+        in: [
+          'CA - Canada',
+          'FR - France',
+          'DE - Germany',
+          'GB - Great Britain',
+          'IT - Italy',
+          'ES - Spain',
+          'US - United States',
+        ],
+      },
+    ],
+  });
+  couponConfig.changeFieldControl(
+    'stripePromotionCodes',
+    'builtin',
+    'tagEditor',
+    {
+      helpText:
+        'All of the Stripe promotion codes valid for the product offering.',
+    }
+  );
+  couponConfig.changeFieldControl('countries', 'builtin', 'checkbox', {
+    helpText: 'The countries in which the promotion codes can be applied.',
+  });
+
+  const capability = migration.editContentType('capability');
+  capability.changeFieldControl('services', 'builtin', 'entryLinksEditor', {
+    helpText: 'Services associated with this Capability.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+
+  const commonContent = migration.editContentType('commonContent');
+  commonContent.changeFieldControl(
+    'privacyNoticeDownloadUrl',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'The URL for a downloadable version of the Privacy Notice for the product offering, used in emails. This must be a URL to the FxA CDN. It can be either a) full, direct URL to a PDF b) a URL without the language and file extension.',
+    }
+  );
+  commonContent.changeFieldControl(
+    'termsOfServiceDownloadUrl',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'The URL for a downloadable version of the Terms of Service for the product offering, used in emails. This must be a URL to the FxA CDN. It can be either a) full, direct URL to a PDF b) a URL without the language and file extension.',
+    }
+  );
+  commonContent.changeFieldControl('cancellationUrl', 'builtin', 'singleLine', {
+    helpText:
+      'Override URL for the Cancellation Survey for the product offering. This parameter is used as a hyperlink in emails sent to the customer when their subscription is cancelled due, manual cancellation, Mozilla account deletion, or failed payment.',
+  });
+  commonContent.changeFieldControl(
+    'newsletterLabelTextCode',
+    'builtin',
+    'radio',
+    {
+      helpText:
+        'A code used to determine which pre-defined labels to add to the newsletter checkbox. If no code is selected, the default label text of "I’d like to receive product news and updates from ⁨Mozilla⁩" will be displayed.',
+    }
+  );
+  commonContent.changeFieldControl('newsletterSlug', 'builtin', 'checkbox', {
+    helpText:
+      'Slugs that represent the available newsletters to send if a customer opts to sign up for them. Defaults to `mozilla-accounts`.',
+  });
+
+  const iap = migration.editContentType('iap');
+  iap.changeFieldControl('internalName', 'builtin', 'singleLine');
+  iap.changeFieldControl('appleProductIDs', 'builtin', 'tagEditor', {
+    helpText:
+      'All of the Apple App Store productIds that map to this product offering. There must only be one Stripe plan per App Store productId per environment (development/stage/production). ',
+  });
+  iap.changeFieldControl('googleSKUs', 'builtin', 'tagEditor', {
+    helpText:
+      'All of the Google Play product SKUs (now called product IDs) that map to this product offering. There must only be one Stripe plan per Google Play product SKU per environment (development/stage/production).',
+  });
+
+  const service = migration.editContentType('service');
+  service.changeFieldControl('capabilities', 'builtin', 'entryLinksEditor', {
+    helpText: 'Capabilities associated with this service.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+
+  const subGroup = migration.editContentType('subGroup');
+  subGroup.changeFieldControl('groupName', 'builtin', 'singleLine', {
+    helpText: 'Name of the subscription group.',
+  });
+  subGroup.changeFieldControl('offering', 'builtin', 'entryLinksEditor', {
+    helpText:
+      'All offerings included in this subscription group. The order of the offerings is the order in which a customer can upgrade from and to within the sub group.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+}
+module.exports = migrationFunction;


### PR DESCRIPTION
## This pull request

- adds help texts to fields in Contentful

## Issue that this pull request solves

Closes: [FXA-8502](https://mozilla-hub.atlassian.net/browse/FXA-8502)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Other information (Optional)

Changes to the updated codegen files were included in #15957

[FXA-8502]: https://mozilla-hub.atlassian.net/browse/FXA-8502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ