### PR TITLE
fix(content): Add header and subheader styling where missing

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/auth_wait_for_supp.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/auth_wait_for_supp.mustache
@@ -1,7 +1,7 @@
 <div id="main-content" class="card pair-auth">
   <header>
-    <h1 id="fxa-pair-auth-wait-for-supp-header">
-      {{#unsafeTranslate}}Approval now required <small>from your other device</small>{{/unsafeTranslate}}
+    <h1 id="fxa-pair-auth-wait-for-supp-header" class="card-header">
+      {{#unsafeTranslate}}Approval now required <small class="card-subheader">from your other device</small>{{/unsafeTranslate}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/pair/supp_wait_for_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/supp_wait_for_auth.mustache
@@ -1,7 +1,7 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-pair-supp-wait-for-auth-header">
-      {{#unsafeTranslate}}Approval now required <small>from your other device</small>{{/unsafeTranslate}}
+    <h1 id="fxa-pair-supp-wait-for-auth-header" class="card-header">
+      {{#unsafeTranslate}}Approval now required <small class="card-subheader">from your other device</small>{{/unsafeTranslate}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/push/completed.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/push/completed.mustache
@@ -1,6 +1,6 @@
 <div id="main-content" class="card pair-auth push-auth-complete">
   <header>
-    <h1 id="push-auth-complete-header">{{#t}}Sign-in confirmed{{/t}}</h1>
+    <h1 id="push-auth-complete-header" class="card-header">{{#t}}Sign-in confirmed{{/t}}</h1>
   </header>
 
   <section>
@@ -11,4 +11,3 @@
       <p class="verification-message">{{#t}}Please close this page and continue on the other device.{{/t}}</p>
   </section>
 </div>
-

--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -1,6 +1,6 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="{{headerId}}">{{{escapedHeaderTitle}}}</h1>
+    <h1 id="{{headerId}}" class="card-header">{{{escapedHeaderTitle}}}</h1>
   </header>
 
   <section>


### PR DESCRIPTION
## Because

* Some headings were not styled on backbone pages

## This pull request

* Add `card-header` and `card-subheader` styles where missing in `ready`, `supp_wait_for_auth`, `auth_wait_for_supp`, `completed` mustache templates

## Issue that this pull request solves

Closes: #FXA-8585

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
![image](https://github.com/mozilla/fxa/assets/22231637/66b7ae46-e1d6-4746-9ee1-acdaeedcbb68)
![image](https://github.com/mozilla/fxa/assets/22231637/cd12419f-ecfe-4cee-849a-e82f435c088c)
![image](https://github.com/mozilla/fxa/assets/22231637/c6215238-c325-49a9-97c6-019e6db22e43)

After:
![image](https://github.com/mozilla/fxa/assets/22231637/a618960c-0ad8-405b-bf82-34da8759d52e)
![image](https://github.com/mozilla/fxa/assets/22231637/7c262cc7-20aa-4826-ac40-f75e230d4246)
![image](https://github.com/mozilla/fxa/assets/22231637/4f1958ca-8d8d-4e3b-b4d1-c097c02c099b)

## Other information (Optional)

Any other information that is important to this pull request.
