### PR TITLE
feat(settings): Update bento menu

### DIFF
--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
@@ -11,6 +11,6 @@ export default {
 
 export const Basic = () => (
   <AppLayout>
-    <p>App contents go here</p>
+    <p>App content goes here</p>
   </AppLayout>
 );

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/en.ftl
@@ -2,8 +2,9 @@
 
 bento-menu-title = { -brand-firefox } Bento Menu
 bento-menu-title-2 = { -brand-mozilla } Bento Menu
+bento-menu-title-3 = { -brand-mozilla } products
 bento-menu-firefox-title = { -brand-firefox } is tech that fights for your online privacy.
-bento-menu-mozilla-title = { -brand-mozilla } is tech that fights for your online privacy.
+bento-menu-tagline = More products from { -brand-mozilla } that protect your privacy
 
 bento-menu-vpn-2 = { -product-mozilla-vpn }
 bento-menu-monitor-2 = { -product-firefox-monitor }

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
@@ -21,8 +21,8 @@ describe('BentoMenu', () => {
 
     const toggleButton = screen.getByTestId('drop-down-bento-menu-toggle');
 
-    expect(toggleButton).toHaveAttribute('title', 'Mozilla Bento Menu');
-    expect(toggleButton).toHaveAttribute('aria-label', 'Mozilla Bento Menu');
+    expect(toggleButton).toHaveAttribute('title', 'Mozilla products');
+    expect(toggleButton).toHaveAttribute('aria-label', 'Mozilla products');
     expect(toggleButton).toHaveAttribute('aria-haspopup', 'menu');
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
@@ -7,7 +7,6 @@ import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useEscKeydownEffect } from '../../../lib/hooks';
 
-import firefoxIcon from 'fxa-react/images/ff-logo.svg';
 import monitorIcon from './monitor.svg';
 import pocketIcon from 'fxa-react/images/pocket.svg';
 import desktopIcon from './desktop.svg';
@@ -16,7 +15,6 @@ import relayIcon from './relay.svg';
 import vpnIcon from './vpn-logo.svg';
 import { ReactComponent as BentoIcon } from './bento.svg';
 import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
-import { Localized } from '@fluent/react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
 
@@ -27,12 +25,12 @@ export const BentoMenu = () => {
   const bentoMenuInsideRef = useClickOutsideEffect<HTMLDivElement>(setRevealed);
   useEscKeydownEffect(setRevealed);
   const dropDownId = 'drop-down-bento-menu';
-  const iconClassNames = 'inline-block w-5 -mb-1 ltr:pr-1 rtl:pl-1';
+  const iconClassNames = 'inline-block w-5 -mb-1 me-1';
   const ftlMsgResolver = useFtlMsgResolver();
 
   const bentoMenuTitle = ftlMsgResolver.getMsg(
-    'bento-menu-title-2',
-    'Mozilla Bento Menu'
+    'bento-menu-title-3',
+    'Mozilla products'
   );
 
   return (
@@ -46,112 +44,109 @@ export const BentoMenu = () => {
         aria-haspopup="menu"
         className="rounded p-2 mx-2 border-transparent hover:bg-grey-100 transition-standard desktop:mx-8"
       >
-        <BentoIcon className="w-5 text-purple-900" />
+        <BentoIcon className="w-5 text-violet-900" />
       </button>
 
       {isRevealed && (
         <div
           id={dropDownId}
           data-testid={dropDownId}
-          className={`w-full h-full fixed top-0 ltr:left-0 rtl:right-0 bg-white z-10
-                      mobileLandscape:h-auto mobileLandscape:drop-down-menu mobileLandscape:top-10 mobileLandscape:ltr:-left-52 mobileLandscape:rtl:-right-52 desktop:ltr:-left-50 desktop:rtl:-right-50`}
+          className={`w-full h-full fixed top-0 start-0 bg-white z-10
+                      mobileLandscape:h-auto mobileLandscape:drop-down-menu mobileLandscape:top-10 mobileLandscape:-start-52 desktop:-start-50`}
           role="menu"
         >
           <div className="flex flex-wrap">
-            <div className="flex w-full pt-4 items-center flex-col tablet:w-auto tablet:relative">
+            <div className="flex w-full py-4 gap-2 items-center flex-col tablet:w-auto tablet:relative">
               <button onClick={closeFn} title="Close">
                 <CloseIcon
                   width="16"
                   height="16"
-                  className="absolute top-5 right-5 mobileLandscape:hidden fill-current"
+                  className="absolute top-5 end-5 mobileLandscape:hidden fill-current"
                 />
               </button>
-              <div className="mt-12 text-center p-8 pt-2 pb-2 mobileLandscape:mt-0">
-                <img src={firefoxIcon} alt="" className="my-2 mx-auto w-10" />
-                <Localized id="bento-menu-firefox-title">
-                  <h2>Firefox is tech that fights for your online privacy.</h2>
-                </Localized>
+              <div className="mt-12 px-8 text-center mobileLandscape:mt-0">
+                <FtlMsg id="bento-menu-tagline">
+                  <h2>More products from Mozilla that protect your privacy</h2>
+                </FtlMsg>
               </div>
-              <div className="w-full text-xs mt-2">
+              <div className="w-full text-xs">
                 <ul className="list-none">
-                  <li>
-                    <LinkExternal
-                      data-testid="monitor-link"
-                      href="https://monitor.firefox.com"
-                      className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
-                    >
-                      <div className={iconClassNames}>
-                        <img src={monitorIcon} alt="" />
-                      </div>
-                      <Localized id="bento-menu-monitor-2">
-                        Firefox Monitor
-                      </Localized>
-                    </LinkExternal>
-                  </li>
-                  <li>
-                    <LinkExternal
-                      data-testid="pocket-link"
-                      href="https://app.adjust.com/hr2n0yz?redirect_macos=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&redirect_windows=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
-                      className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
-                    >
-                      <div className={iconClassNames}>
-                        <img src={pocketIcon} alt="" />
-                      </div>
-                      <Localized id="bento-menu-pocket-2">Pocket</Localized>
-                    </LinkExternal>
-                  </li>
                   <li>
                     <LinkExternal
                       data-testid="desktop-link"
                       href="https://www.mozilla.org/firefox/new/?utm_source=firefox-accounts&utm_medium=referral&utm_campaign=bento&utm_content=desktop"
-                      className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
+                      className="block p-2 ps-6 hover:bg-grey-100"
                     >
                       <div className={iconClassNames}>
                         <img src={desktopIcon} alt="" />
                       </div>
-                      <Localized id="bento-menu-firefox-desktop">
+                      <FtlMsg id="bento-menu-firefox-desktop">
                         Firefox Browser for Desktop
-                      </Localized>
+                      </FtlMsg>
                     </LinkExternal>
                   </li>
                   <li>
                     <LinkExternal
                       data-testid="mobile-link"
                       href="http://mozilla.org/firefox/mobile?utm_source=firefox-accounts&utm_medium=referral&utm_campaign=bento&utm_content=desktop"
-                      className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
+                      className="block p-2 ps-6 hover:bg-grey-100"
                     >
                       <div className={iconClassNames}>
                         <img src={mobileIcon} alt="" />
                       </div>
-                      <Localized id="bento-menu-firefox-mobile">
+                      <FtlMsg id="bento-menu-firefox-mobile">
                         Firefox Browser for Mobile
-                      </Localized>
+                      </FtlMsg>
                     </LinkExternal>
                   </li>
                   <li>
                     <LinkExternal
-                      data-testid="vpn-link"
-                      href="https://vpn.mozilla.org/?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-settings&utm_content=bento-promo"
-                      className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
+                      data-testid="monitor-link"
+                      href="https://monitor.firefox.com"
+                      className="block p-2 ps-6 hover:bg-grey-100"
                     >
                       <div className={iconClassNames}>
-                        <img src={vpnIcon} alt="" />
+                        <img src={monitorIcon} alt="" />
                       </div>
-                      <Localized id="bento-menu-vpn-2">Mozilla VPN</Localized>
+                      <FtlMsg id="bento-menu-monitor-2">Firefox Monitor</FtlMsg>
                     </LinkExternal>
                   </li>
                   <li>
                     <LinkExternal
                       data-testid="relay-link"
                       href="https://relay.firefox.com/"
-                      className="block p-2 ltr:pl-6 rtl:pr-6 hover:bg-grey-100"
+                      className="block p-2 ps-6 hover:bg-grey-100"
                     >
                       <div className={iconClassNames}>
                         <img src={relayIcon} alt="" />
                       </div>
-                      <Localized id="bento-menu-firefox-relay-2">
+                      <FtlMsg id="bento-menu-firefox-relay-2">
                         Firefox Relay
-                      </Localized>
+                      </FtlMsg>
+                    </LinkExternal>
+                  </li>
+                  <li>
+                    <LinkExternal
+                      data-testid="vpn-link"
+                      href="https://vpn.mozilla.org/?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-settings&utm_content=bento-promo"
+                      className="block p-2 ps-6 hover:bg-grey-100"
+                    >
+                      <div className={iconClassNames}>
+                        <img src={vpnIcon} alt="" />
+                      </div>
+                      <FtlMsg id="bento-menu-vpn-2">Mozilla VPN</FtlMsg>
+                    </LinkExternal>
+                  </li>
+                  <li>
+                    <LinkExternal
+                      data-testid="pocket-link"
+                      href="https://app.adjust.com/hr2n0yz?redirect_macos=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&redirect_windows=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
+                      className="block p-2 ps-6 hover:bg-grey-100"
+                    >
+                      <div className={iconClassNames}>
+                        <img src={pocketIcon} alt="" />
+                      </div>
+                      <FtlMsg id="bento-menu-pocket-2">Pocket</FtlMsg>
                     </LinkExternal>
                   </li>
                 </ul>
@@ -159,7 +154,7 @@ export const BentoMenu = () => {
               <FtlMsg id="bento-menu-made-by-mozilla">
                 <LinkExternal
                   data-testid="mozilla-link"
-                  className="link-blue text-xs w-full text-center block m-2 p-2 hover:bg-grey-100"
+                  className="link-blue text-xs underline-offset-4 w-full text-center p-2 block hover:bg-grey-100"
                   href="https://www.mozilla.org/"
                 >
                   Made by Mozilla

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.tsx
@@ -34,9 +34,9 @@ export const HeaderLockup = () => {
         onClick={() => setNavState(!navRevealedState)}
       >
         {navRevealedState ? (
-          <Close className="text-purple-900 w-8" />
+          <Close className="text-violet-900 w-8" />
         ) : (
-          <Menu className="text-purple-900 w-8" />
+          <Menu className="text-violet-900 w-8" />
         )}
         {navRevealedState && <Nav />}
       </button>
@@ -73,7 +73,7 @@ export const HeaderLockup = () => {
           aria-label={localizedHelpText}
           title={localizedHelpText}
           role="img"
-          className="w-5 text-purple-900"
+          className="w-5 text-violet-900"
           data-testid="header-help"
         />
       </LinkExternal>

--- a/packages/fxa-settings/src/components/Settings/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.tsx
@@ -24,15 +24,15 @@ export const Nav = () => {
   const activeClasses = 'font-bold text-blue-500 rounded-sm bg-grey-50';
   return (
     <nav
-      className="font-header fixed bg-white w-full inset-0 mt-18 ltr:mr-24 rtl:ml-24 desktop:mt-11 desktop:static desktop:bg-transparent text-xl desktop:text-base"
+      className="font-header fixed bg-white w-full inset-0 mt-24 me-24 desktop:mt-11 desktop:static desktop:bg-transparent text-xl desktop:text-base"
       data-testid="nav"
     >
-      <ul className="px-6 py-7 tablet:px-8 desktop:p-0 mobileLandscape:mt-8 text-start">
+      <ul className="px-6 py-8 tablet:px-8 desktop:p-0 text-start">
         <li className="mb-5">
           <Localized id="nav-settings">
             <h2 className="font-bold">Settings</h2>
           </Localized>
-          <ul className="ltr:ml-4 rtl:mr-4">
+          <ul className="ms-4">
             <li className="mt-3">
               <Localized id="nav-profile">
                 <a
@@ -121,7 +121,7 @@ export const Nav = () => {
             >
               <Localized id="nav-email-comm">Email Communications</Localized>
               <OpenExternal
-                className="inline-block w-3 h-3 ltr:ml-1 rtl:mr-1 transform rtl:-scale-x-1"
+                className="inline-block w-3 h-3 ms-1 transform rtl:-scale-x-1"
                 aria-hidden="true"
               />
             </LinkExternal>


### PR DESCRIPTION
## Because

* With the rename to Mozilla accounts, we are removing the Firefox logo from prominent position

## This pull request

* Remove the Firefox logo from the bento menu header
* Update copy in the bento menu and add new l1on
* Update styling
* Fixes a styling issue with the nav bar, where the bar partially overlapped the page header in mobile view

## Issue that this pull request solves

Closes: #FXA-8594

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Bento Menu - Desktop (before):
![image](https://github.com/mozilla/fxa/assets/22231637/fd8da122-ca26-404d-a3b8-fce2a25b7d28)

Bento Menu - Desktop (after):
![image](https://github.com/mozilla/fxa/assets/22231637/f1c825a7-7b88-4053-b3ba-269503094024)

Bento Menu - Mobile (before):
![image](https://github.com/mozilla/fxa/assets/22231637/b9600d62-3f58-4d4a-92f5-f12c47cb6e20)

Bento Menu - Mobile (after):
![image](https://github.com/mozilla/fxa/assets/22231637/f0e50341-d3b8-49b3-a4f3-d6ab3fa72528)

Bento Menu Tooltip (before):
![image](https://github.com/mozilla/fxa/assets/22231637/bb1b0c1a-8512-4d13-8535-16c2f71673ed)

Bento Menu Tooltip (after):
![image](https://github.com/mozilla/fxa/assets/22231637/76d2da6b-e821-44c4-b73b-cd7eac587a3a)

Nav Menu - Mobile (before):
![image](https://github.com/mozilla/fxa/assets/22231637/48b06ad7-14c5-47e2-9a23-cc4a83e22e54)

Nav Menu - Mobile (after):
![image](https://github.com/mozilla/fxa/assets/22231637/f002245e-2063-445d-9918-8f1638717e9e)

## Other information (Optional)

Any other information that is important to this pull request.
