### PR TITLE
fix(content): Fix avatar on sign in page

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -68,7 +68,7 @@
     }
   }
 
-  .profile-image {
+  .avatar-image {
     @include respond-to('big') {
       height: 64px;
       width: 64px;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -545,7 +545,7 @@ const ProfileBanner = ({
 }: ProfileProps) => (
   <header id="fxa-settings-profile-header-wrapper">
     <div className="avatar-wrapper avatar-settings-view nohover">
-      <img src={avatar} alt={displayName || email} className="profile-image" />
+      <img src={avatar} alt={displayName || email} className="avatar-image" />
     </div>
     <div id="fxa-settings-profile-header">
       <h1 className="card-header">{displayName ? displayName : email}</h1>


### PR DESCRIPTION
## This pull request

- updates the classname from `profile-image` to `avatar-image`

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Before - /signin (mobile)
<img width="425" alt="Screenshot 2023-11-08 at 8 34 25 PM" src="https://github.com/mozilla/fxa/assets/28129806/7fb1fa50-ac5d-44a3-a429-0658bb6c27b7">

After - /signin (mobile)
<img width="424" alt="Screenshot 2023-11-08 at 8 34 34 PM" src="https://github.com/mozilla/fxa/assets/28129806/9c17abeb-08b4-4a19-938f-440f9582c708">

Settings homepage 
Mobile
<img width="425" alt="Screenshot 2023-11-08 at 8 45 55 PM" src="https://github.com/mozilla/fxa/assets/28129806/acd4ab76-0c17-4f93-97fa-601bfb468e12">

Desktop
<img width="855" alt="Screenshot 2023-11-08 at 8 46 17 PM" src="https://github.com/mozilla/fxa/assets/28129806/5ba533d4-e30b-4b3b-a159-6abc38830360">

Subscription Management
Mobile
<img width="422" alt="Screenshot 2023-11-08 at 8 47 25 PM" src="https://github.com/mozilla/fxa/assets/28129806/5b1d7f76-2b39-49fd-9324-1bed32c0e1f8">

Desktop
<img width="871" alt="Screenshot 2023-11-08 at 8 47 06 PM" src="https://github.com/mozilla/fxa/assets/28129806/4bd52303-97cd-4226-9d5a-2f6eb0bf8333">

