### PR TITLE
bug(content/settings): Fix issue where redirect to react app would fail for complete_reset_password

### DIFF
--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -39,13 +39,11 @@ test.describe('severity-1 #smoke', () => {
       // Verify confirm password reset page rendered
       await resetPasswordReact.confirmResetPasswordHeadingVisible();
 
-      // We need to append `&showReactApp=true` to reset link in order to enroll in reset password experiment
-      let link = await target.email.waitForEmail(
+      const link = await target.email.waitForEmail(
         credentials.email,
         EmailType.recovery,
         EmailHeader.link
       );
-      link = `${link}&showReactApp=true`;
 
       // Open link in a new window
       const diffPage = await context.newPage();
@@ -115,12 +113,11 @@ test.describe('severity-1 #smoke', () => {
       await resetPasswordReact.confirmResetPasswordHeadingVisible();
 
       // We need to append `&showReactApp=true` to reset link in order to enroll in reset password experiment
-      let link = await target.email.waitForEmail(
+      const link = await target.email.waitForEmail(
         credentials.email,
         EmailType.recovery,
         EmailHeader.link
       );
-      link = `${link}&showReactApp=true`;
 
       // Open link in a new window
       const diffPage = await context.newPage();

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -191,6 +191,8 @@ var OAuthRelier = Relier.extend({
         client_id: this.getSearchParam('service'), //eslint-disable-line camelcase
         service: this.getSearchParam('service'),
       };
+    } else if (typeof resumeObj === 'string') {
+      resumeObj = JSON.parse(resumeObj);
     }
 
     var result = Transform.transformUsingSchema(


### PR DESCRIPTION

## Because:
- We detected that on stage signing into firefox monitor and then visiting the forgot reset password link would result in an error stating, 'Bad Request - Missing Oauth parameter: 0'
- React now holds all data-store data as strings and then coverts it to the proper type. Content, sever doesn't understand this however. As a result, react would write the fxa session to local storage as: `__fxa_session: "{"oauth":"{\"client_id\":\"REDACTED\",\"scope\":\"profile openid\",\"state\":\"REDACTED-REDACTED\"}"}"` Where as content server was expecting the oauth field to be an object, not a json encoded string. This would result in model validation failing, and an error being generated.

## This PR:
- Addresses the issue head on and makes sure that the resume object is converted to an object if its data type is string.

- Removes the hack in functional tests that would add showReactApp=true to the reset password link. The router should handle this, and this hack is the reason this issue wasn't caught sooner.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Example of error message:
<img width="758" alt="image" src="https://github.com/mozilla/fxa/assets/94418270/b680fbf3-c5f4-4a7a-9d7e-a92a6e37753a">


## Other information (Optional)

I double checked for other places in content server where something like this could happen and this appears to be the only instance of this issue where a complex object is held. If more problems crop up, we might have to change how the local storage data store in fxa-settings works.
