### PR TITLE
bug(fxa-settings): Protect against legacy state in local storage

### DIFF
--- a/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.test.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReachRouterWindow } from '../../window';
+import { RawData } from '../model-data-store';
 import { StorageData } from './storage-data';
 
 describe('storage-data', () => {
@@ -40,5 +41,17 @@ describe('storage-data', () => {
     // Load by default
     const data3 = new StorageData(window);
     expect(data3.get('foo')).toEqual('bar');
+  });
+
+  it('protects against legacy state', () => {
+    const data1 = new StorageData(window);
+
+    // Side step type safety to mimic legacy state. Content server may
+    // have written data akin to this.
+    data1.set('foo', { x: { bar: 'baz' } } as unknown as RawData);
+
+    const value = data1.get('foo');
+
+    expect(value).toEqual(JSON.stringify({ x: { bar: 'baz' } }));
   });
 });

--- a/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/storage-data.ts
@@ -102,7 +102,17 @@ export class StorageData extends ModelDataStore {
   }
 
   public get(key: string): RawData {
-    return this.state[key];
+    const value = this.state[key];
+
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    // Protects against legacy state in local storage. It's possible that
+    // content server wrote a complex object into a key value pair held in
+    // local storage. Since we now assume that all objects are stored as
+    // strings, if we encounter an object, convert it to a string value.
+    return JSON.stringify(value);
   }
 
   public set(key: string, value: RawData) {


### PR DESCRIPTION
## Because

- We could run into type safety issues in the storage-data.ts data store implementation.
- There were scenarios where content server would write complex objects to local storage

## This pull request

- Ensures that the RawData type, which is used as the input output format for all model data, is upheld.
- Checks that data being accessed from local storage is returned as a string value, so that it can later be coerced into the expected type.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is related to https://github.com/mozilla/fxa/pull/16066. It's a similar issue, but the reverse scenario. In this case `fxa-settings` needs to be able handle legacy values created by the content server. If you want to test this manually, do the following:
- On localhost, create an account.
- Navigate back to the sign in page.
- Go to local storage and find the `fxa-session`.
- In the `fxa-session`, convert the value for 'oauth' into a object instead of json blob, which is legacy state. (You can do this manually through dev tools > storage.)
- Start a reset password flow. Without this change set, you'll eventually hit an error. With this changes in the PR you will not. 

Note that unit tests have also been added to cover this edge case.
