### PR TITLE
bug(auth): Fix targeting of integration tests

### DIFF
--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -17,6 +17,7 @@ const db = require('../../lib/oauth/db');
 const encrypt = require('fxa-shared/auth/encrypt');
 const config = testServer.config;
 let Server;
+let Server2;
 
 const unique = require('../../lib/oauth/unique');
 const util = require('../../lib/oauth/util');
@@ -213,8 +214,9 @@ describe('#integration - /v1', function () {
     ]);
   });
 
-  after(function () {
-    return Server.close();
+  after(async function () {
+    await Server?.close();
+    await Server2?.close();
   });
 
   beforeEach(() => {
@@ -2861,7 +2863,7 @@ describe('#integration - /v1', function () {
     it('should not reject expired tokens from pocket clients', async function () {
       const clientId = '749818d3f2e7857f';
       config.set('oauthServer.expiration.accessTokenExpiryEpoch', undefined);
-      Server = await testServer.start();
+      Server2 = await testServer.start();
       let res = await newToken(
         {
           ttl: 1,
@@ -2880,7 +2882,7 @@ describe('#integration - /v1', function () {
         shouldAdvanceTime: true,
       });
 
-      res = await Server.api.post({
+      res = await Server2.api.post({
         url: '/verify',
         payload: {
           token: res.result.access_token,

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -18,7 +18,7 @@ const {
   AppStoreSubscriptions,
 } = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
-describe('remote account create', function () {
+describe('#integration - remote account create', function () {
   this.timeout(30000);
   let server;
   before(async () => {
@@ -51,7 +51,7 @@ describe('remote account create', function () {
     return server;
   });
 
-  it('#integration - unverified account fail when getting keys', () => {
+  it('unverified account fail when getting keys', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;
@@ -78,7 +78,7 @@ describe('remote account create', function () {
       );
   });
 
-  it('#integration - create and verify sync account', () => {
+  it('create and verify sync account', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;
@@ -122,7 +122,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - create account with service identifier and resume', () => {
+  it('create account with service identifier and resume', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     const options = { service: 'abcdef', resume: 'foo' };
@@ -136,7 +136,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - create account allows localization of emails', () => {
+  it('create account allows localization of emails', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;
@@ -172,7 +172,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - Unknown account should not exist', () => {
+  it('Unknown account should not exist', () => {
     const client = new Client(config.publicUrl);
     client.email = server.uniqueEmail();
     client.authPW = crypto.randomBytes(32);
@@ -186,7 +186,7 @@ describe('remote account create', function () {
     );
   });
 
-  it('#integration - /account/create works with proper data', () => {
+  it('/account/create works with proper data', () => {
     const email = server.uniqueEmail();
     const password = 'ilikepancakes';
     let client;
@@ -208,7 +208,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - /account/create returns a sessionToken', () => {
+  it('/account/create returns a sessionToken', () => {
     const email = server.uniqueEmail();
     const password = 'ilikepancakes';
     const client = new Client(config.publicUrl);
@@ -224,7 +224,7 @@ describe('remote account create', function () {
     });
   });
 
-  it('#integration - /account/create returns a keyFetchToken when keys=true', () => {
+  it('/account/create returns a keyFetchToken when keys=true', () => {
     const email = server.uniqueEmail();
     const password = 'ilikepancakes';
     const client = new Client(config.publicUrl);
@@ -238,7 +238,7 @@ describe('remote account create', function () {
     });
   });
 
-  it('#integration - signup with same email, different case', () => {
+  it('signup with same email, different case', () => {
     const email = server.uniqueEmail();
     const email2 = email.toUpperCase();
     const password = 'abcdef';
@@ -262,7 +262,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - re-signup against an unverified email', () => {
+  it('re-signup against an unverified email', () => {
     const email = server.uniqueEmail();
     const password = 'abcdef';
     return Client.create(config.publicUrl, email, password)
@@ -328,7 +328,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - valid metricsContext', () => {
+  it('valid metricsContext', () => {
     const api = new Client.Api(config.publicUrl);
     const email = server.uniqueEmail();
     const authPW =
@@ -348,7 +348,7 @@ describe('remote account create', function () {
     return api.accountCreate(email, authPW, options);
   });
 
-  it('#integration - empty metricsContext', () => {
+  it('empty metricsContext', () => {
     const api = new Client.Api(config.publicUrl);
     const email = server.uniqueEmail();
     const authPW =
@@ -535,7 +535,7 @@ describe('remote account create', function () {
       .then(assert.fail, (err) => assert.equal(err.errno, 107));
   });
 
-  it('#integration - create account with service query parameter', () => {
+  it('create account with service query parameter', () => {
     const email = server.uniqueEmail();
     return Client.create(config.publicUrl, email, 'foo', {
       serviceQuery: 'bar',
@@ -552,7 +552,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - account creation works with unicode email address', () => {
+  it('account creation works with unicode email address', () => {
     const email = server.uniqueUnicodeEmail();
     return Client.create(config.publicUrl, email, 'foo')
       .then((client) => {
@@ -599,7 +599,7 @@ describe('remote account create', function () {
     );
   });
 
-  it('#integration - account creation works with maximal metricsContext metadata', () => {
+  it('account creation works with maximal metricsContext metadata', () => {
     const email = server.uniqueEmail();
     const opts = {
       metricsContext: mocks.generateMetricsContext(),
@@ -623,7 +623,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - account creation works with empty metricsContext metadata', () => {
+  it('account creation works with empty metricsContext metadata', () => {
     const email = server.uniqueEmail();
     return Client.create(config.publicUrl, email, 'foo', {
       metricsContext: {},
@@ -665,7 +665,7 @@ describe('remote account create', function () {
     );
   });
 
-  it('#integration - create account for non-sync service, gets generic sign-up email and does not get post-verify email', () => {
+  it('create account for non-sync service, gets generic sign-up email and does not get post-verify email', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;
@@ -704,7 +704,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - create account for unspecified service does not get create sync email and no post-verify email', () => {
+  it('create account for unspecified service does not get create sync email and no post-verify email', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;
@@ -743,7 +743,7 @@ describe('remote account create', function () {
       });
   });
 
-  it('#integration - create account and subscribe to newsletters', () => {
+  it('create account and subscribe to newsletters', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;

--- a/packages/fxa-auth-server/test/remote/account_login_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_login_tests.js
@@ -11,7 +11,7 @@ const TestServer = require('../test_server');
 
 const config = require('../../config').default.getProperties();
 
-describe('remote account login', () => {
+describe('#integration - remote account login', () => {
   let server;
 
   before(function () {
@@ -23,7 +23,7 @@ describe('remote account login', () => {
     });
   });
 
-  it('#integration - the email is returned in the error on Incorrect password errors', () => {
+  it('the email is returned in the error on Incorrect password errors', () => {
     const email = server.uniqueEmail();
     const password = 'abcdef';
     return Client.createAndVerify(
@@ -45,7 +45,7 @@ describe('remote account login', () => {
       );
   });
 
-  it('#integration - the email is returned in the error on Incorrect email case errors with correct password', () => {
+  it('the email is returned in the error on Incorrect email case errors with correct password', () => {
     const signupEmail = server.uniqueEmail();
     const loginEmail = signupEmail.toUpperCase();
     const password = 'abcdef';
@@ -68,7 +68,7 @@ describe('remote account login', () => {
       );
   });
 
-  it('#integration - Unknown account should not exist', () => {
+  it('Unknown account should not exist', () => {
     const client = new Client(config.publicUrl);
     client.email = server.uniqueEmail();
     client.authPW = crypto.randomBytes(32);
@@ -82,7 +82,7 @@ describe('remote account login', () => {
     );
   });
 
-  it('#integration - No keyFetchToken without keys=true', () => {
+  it('No keyFetchToken without keys=true', () => {
     const email = server.uniqueEmail();
     const password = 'abcdef';
     return Client.createAndVerify(
@@ -99,7 +99,7 @@ describe('remote account login', () => {
       });
   });
 
-  it('#integration - login works with unicode email address', () => {
+  it('login works with unicode email address', () => {
     const email = server.uniqueUnicodeEmail();
     const password = 'wibble';
     return Client.createAndVerify(
@@ -116,7 +116,7 @@ describe('remote account login', () => {
       });
   });
 
-  it('#integration - account login works with minimal metricsContext metadata', () => {
+  it('account login works with minimal metricsContext metadata', () => {
     const email = server.uniqueEmail();
     return Client.createAndVerify(
       config.publicUrl,
@@ -192,7 +192,7 @@ describe('remote account login', () => {
       );
   });
 
-  describe('#integration - can use verificationMethod', () => {
+  describe('can use verificationMethod', () => {
     let client, email;
     const password = 'foo';
     beforeEach(() => {

--- a/packages/fxa-auth-server/test/remote/base_path_tests.js
+++ b/packages/fxa-auth-server/test/remote/base_path_tests.js
@@ -9,7 +9,7 @@ const TestServer = require('../test_server');
 const Client = require('../client')();
 const superagent = require('superagent');
 
-describe('remote base path', function () {
+describe('#integration - remote base path', function () {
   this.timeout(15000);
   let server, config;
   before(() => {
@@ -46,7 +46,7 @@ describe('remote base path', function () {
     };
   }
 
-  it('#integration - alternate base path', () => {
+  it('alternate base path', () => {
     const email = `${Math.random()}@example.com`;
     const password = 'ok';
     // if this doesn't crash, we're all good

--- a/packages/fxa-auth-server/test/remote/email_validity_tests.js
+++ b/packages/fxa-auth-server/test/remote/email_validity_tests.js
@@ -10,7 +10,7 @@ const Client = require('../client')();
 
 const config = require('../../config').default.getProperties();
 
-describe('remote email validity', function () {
+describe('#integration - remote email validity', function () {
   this.timeout(15000);
   let server;
   before(() => {
@@ -47,7 +47,7 @@ describe('remote email validity', function () {
     return Promise.all(emails);
   });
 
-  it('#integration - /account/create with a variety of unusual but valid email addresses', () => {
+  it('/account/create with a variety of unusual but valid email addresses', () => {
     const pwd = '123456';
 
     const emails = [

--- a/packages/fxa-auth-server/test/remote/misc_tests.js
+++ b/packages/fxa-auth-server/test/remote/misc_tests.js
@@ -13,7 +13,7 @@ const hawk = require('@hapi/hawk');
 
 const config = require('../../config').default.getProperties();
 
-describe('remote misc', function () {
+describe('#integration - remote misc', function () {
   this.timeout(15000);
   let server;
   before(() => {
@@ -78,7 +78,7 @@ describe('remote misc', function () {
       });
   });
 
-  it('#integration - /__heartbeat__ returns a 200 OK', () => {
+  it('/__heartbeat__ returns a 200 OK', () => {
     return superagent.get(`${config.publicUrl}/__heartbeat__`).then((res) => {
       assert.equal(res.statusCode, 200, 'http ok');
     });
@@ -136,7 +136,7 @@ describe('remote misc', function () {
       });
   });
 
-  it('#integration - timestamp header', () => {
+  it('timestamp header', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let url = null;
@@ -235,7 +235,7 @@ describe('remote misc', function () {
     });
   });
 
-  it('#integration - fail on hawk payload mismatch', () => {
+  it('fail on hawk payload mismatch', () => {
     const email = server.uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let url = null;

--- a/packages/fxa-auth-server/test/remote/sign_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/sign_key_tests.js
@@ -9,7 +9,7 @@ const superagent = require('superagent');
 const TestServer = require('../test_server');
 const path = require('path');
 
-describe('remote sign key', function () {
+describe('#integration - remote sign key', function () {
   this.timeout(15000);
   let server;
   before(() => {

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -12,7 +12,7 @@
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint .",
     "test": "mocha",
-    "test-unit": "MOCHA_FILE=../../artifacts/tests/$npm_package_name/mocha-unit.xml mocha --grep '#integration' --invert",
+    "test-unit": "MOCHA_FILE=../../artifacts/tests/$npm_package_name/mocha-unit.xml mocha --grep '^(?!.*#integration)' ",
     "test-integration": "MOCHA_FILE=../../artifacts/tests/$npm_package_name/mocha-integration.xml mocha --grep '#integration'",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   },


### PR DESCRIPTION
## Because
- We were seeing integration tests failing in unit-test suites
- This indicates that our we incorrectly targeted tests.

## This pull request
- Makes sure that any test suite requiring a server to be started are marked as integration.
- Closes one server that may have been left open.

## Issue that this pull request solves

Closes: FXA-8663

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note this doesn't necessarily solve the related issue, FXA-8664, where we get random port conflicts. There's a small chance that closing a test server that is created mid test suite will help (see oauth/api.js) , but I don't think it's a silver bullet.