### PR TITLE
feat(sentry): Remove 16 char sentry filter

### DIFF
--- a/packages/fxa-shared/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/sentry/pii-filter-actions.ts
@@ -325,6 +325,6 @@ export const CommonPiiActions = {
    * Matches uid, session, oauth and other common tokens which we would prefer not to include in Sentry reports.
    */
   tokenValues: new PiiRegexFilter(
-    /[a-fA-F0-9]{16,}|[a-fA-F0-9]{32,}|[a-fA-F0-9]{64,}/gim
+    /[a-fA-F0-9]{32,}|[a-fA-F0-9]{64,}/gim
   ),
 };

--- a/packages/fxa-shared/test/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/test/sentry/pii-filter-actions.ts
@@ -338,17 +338,6 @@ describe('pii-filter-actions', () => {
       });
     });
 
-    it('filters 16 byte token values', () => {
-      const token1 = uuid.v4().replace(/-/g, '');
-      const { val: result } = CommonPiiActions.tokenValues.execute({
-        foo: `X'${token1.substring(0, 16)}'`,
-      });
-
-      expect(result).to.deep.equal({
-        foo: `X'${FILTERED}'`,
-      });
-    });
-
     it('filters 64 byte token values', () => {
       const token1 = uuid.v4().replace(/-/g, '');
       const { val: result } = CommonPiiActions.tokenValues.execute({


### PR DESCRIPTION
Because:

* It can be hard to debug error in Sentry

This commit:

* Removes the 16 char token filter

Fix FXA-8675