### PR TITLE
fix(content): Prevent infinite loop when showReactApp set to false

### DIFF
--- a/packages/fxa-content-server/app/tests/mocks/view.js
+++ b/packages/fxa-content-server/app/tests/mocks/view.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mocks a Backbone view file for router testing
+ */
+
+import BaseView from '../../scripts/views/base';
+import Template from './template.mustache';
+
+const View = BaseView.extend(
+  {
+    template: Template,
+    initialize(options = {}) {},
+
+    events: {},
+
+    setInitialContext(context) {
+      context.set({});
+    },
+
+    afterRender() {},
+  },
+  {}
+);
+
+export default View;

--- a/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
@@ -15,13 +15,17 @@ function addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n) {
    * use the default routing middleware from `fxa-shared/express/routing.ts`.
    * @param {import("./types").ReactRouteGroup}
    */
-  function addReactRoutesConditionally({ featureFlagOn, routes }) {
+  function addReactRoutesConditionally({
+    featureFlagOn,
+    routes,
+    fullProdRollout,
+  }) {
     if (featureFlagOn === true) {
       routes.forEach(({ definition }) => {
         // possible TODO - `definition.method`s will either be 'get' or 'post'. Not sure if we need
         // this for any 'post' requests but shouldn't hurt anything; 'get' alone may suffice.
         app[definition.method](definition.path, (req, res, next) => {
-          if (req.query.showReactApp === 'true') {
+          if (req.query.showReactApp === 'true' || fullProdRollout === true) {
             return middleware(req, res, next);
           } else {
             next('route');

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -9,6 +9,14 @@ const { TERMS_PRIVACY_REGEX } = require('./content-server-routes');
  * group object it should go in and add a new object in `routes` by calling `.getRoute`
  * or setting `routes` with `.getRoutes` on the react route object.
  *
+ * If a routeGroup should always be rendered with React in production, set `fullProdRollout` to true.
+ * These routes can still be turned off on SRE side by switching featureFlagOn to false
+ * on stage or prod for the relevant route if needed. React will ALWAYS be off for the routeGroup
+ * if featureFlagOn is set to false.
+ *
+ * NOTE however that routes that have been sunset in content-server (i.e, simple routes) can no longer
+ * fall back to backbone.
+ *
  * When setting a regex, the corresponding matches for `router.js` must be set in
  * `react-route-client.js`.
  *  @type {import("./types").GetReactRouteGroups}
@@ -29,6 +37,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         // * /<locale>/legal/privacy
         TERMS_PRIVACY_REGEX,
       ]),
+      fullProdRollout: true,
     },
 
     resetPasswordRoutes: {
@@ -42,11 +51,13 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'account_recovery_confirm_key',
         'account_recovery_reset_password',
       ]),
+      fullProdRollout: true,
     },
 
     oauthRoutes: {
       featureFlagOn: showReactApp.oauthRoutes,
       routes: [],
+      fullProdRollout: false,
     },
 
     signInRoutes: {
@@ -57,6 +68,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signin_verified',
         'signin_bounced',
       ]),
+      fullProdRollout: false,
     },
 
     signUpRoutes: {
@@ -70,31 +82,37 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signup_verified',
         'oauth/signup',
       ]),
+      fullProdRollout: false,
     },
 
     pairRoutes: {
       featureFlagOn: showReactApp.pairRoutes,
       routes: [],
+      fullProdRollout: false,
     },
 
     postVerifyOtherRoutes: {
       featureFlagOn: showReactApp.postVerifyOtherRoutes,
       routes: [],
+      fullProdRollout: false,
     },
 
     postVerifyCADViaQRRoutes: {
       featureFlagOn: showReactApp.postVerifyCADViaQRRoutes,
       routes: [],
+      fullProdRollout: false,
     },
 
     postVerifyThirdPartyAuthRoutes: {
       featureFlagOn: showReactApp.postVerifyThirdPartyAuthRoutes,
       routes: reactRoute.getRoutes(['post_verify/third_party_auth/callback']),
+      fullProdRollout: false,
     },
 
     webChannelExampleRoutes: {
       featureFlagOn: showReactApp.webChannelExampleRoutes,
       routes: reactRoute.getRoutes(['web_channel_example']),
+      fullProdRollout: false,
     },
   };
 };

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -21,6 +21,7 @@ export interface ReactRouteGroup {
     // only server-side react route groups contain the route definition
     definition?: RouteDefinition;
   }[];
+  fullProdRollout: boolean;
 }
 
 export interface GetRouteDefinition {


### PR DESCRIPTION
## Because

* Changing `showReactApp` query param to false in the URL was resulting in an infinite loop preventing rendering

## This pull request

* Always render React app for routes fully turned on in prod and disregard `showReactApp` param in request
* Update tests

## Issue that this pull request solves

Closes: #FXA-8666

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
