### PR TITLE
fix(auth): Show third party options when signing up for non-sync

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -537,11 +537,9 @@ export class LoginPage extends BaseLayout {
   }
 
   async clearCache() {
-    await this.page.goto(`${this.target.contentServerUrl}/clear`, {
-      waitUntil: 'load',
-    });
+    await this.page.goto(`${this.target.contentServerUrl}/clear`);
     await this.page.context().clearCookies();
-    return this.page.waitForTimeout(1000);
+    return this.page.waitForTimeout(2000);
   }
 
   async getErrorMessage() {

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -73,6 +73,10 @@
         <button id="submit-btn" class="cta-primary cta-xl" type="submit">{{#t}}Create account{{/t}}</button>
       </div>
 
+      {{^isSync}}
+        {{{ unsafeThirdPartyAuthHTML }}}
+      {{/isSync}}
+
       <div id="tos-pp" class="text-grey-500 mt-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -23,6 +23,8 @@ import SignUpMixin from './mixins/signup-mixin';
 import GleanMetrics from '../lib/glean';
 import BrandMessagingMixin from './mixins/brand-messaging-mixin';
 import MonitorClientMixin from './mixins/monitor-client-mixin';
+import ThirdPartyAuth from '../templates/partial/third-party-auth.mustache';
+import ThirdPartyAuthMixin from './mixins/third-party-auth-mixin';
 
 const t = (msg) => msg;
 
@@ -71,6 +73,9 @@ const SignUpPasswordView = FormView.extend({
     context.set({
       canChangeAccount: !this.model.get('forceEmail'),
       email: this.getAccount().get('email'),
+      unsafeThirdPartyAuthHTML: this.renderTemplate(ThirdPartyAuth, {
+        showSeparator: true,
+      }),
     });
 
     // We debounce the password check function to give the password input
@@ -164,6 +169,7 @@ Cocktail.mixin(
   }),
   ServiceMixin,
   SignedInNotificationMixin,
+  ThirdPartyAuthMixin,
   SignUpMixin,
   PocketMigrationMixin,
   AccountSuggestionMixin,

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
@@ -12,11 +12,14 @@ import GleanMetrics from '../../../scripts/lib/glean';
 import Notifier from 'lib/channels/notifier';
 import Relier from 'models/reliers/relier';
 import sinon from 'sinon';
-import { SIGNUP_PASSWORD } from '../../../../tests/functional/lib/selectors';
+import {
+  SIGNUP_PASSWORD,
+  THIRD_PARTY_AUTH,
+} from '../../../../tests/functional/lib/selectors';
 import View from 'views/sign_up_password';
 import WindowMock from '../../mocks/window';
 
-const Selectors = SIGNUP_PASSWORD;
+const Selectors = { ...SIGNUP_PASSWORD, THIRD_PARTY_AUTH };
 
 const EMAIL = 'testuser@testuser.com';
 
@@ -112,7 +115,9 @@ describe('views/sign_up_password', () => {
       assert.lengthOf(view.$(Selectors.LINK_USE_DIFFERENT), 1);
       assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
       assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
-      assert.isTrue(notifier.trigger.calledOnce);
+      assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 1);
+      assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 1);
+      assert.isTrue(notifier.trigger.calledTwice);
       assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
     });
 
@@ -132,6 +137,19 @@ describe('views/sign_up_password', () => {
           view.$(Selectors.ERROR).text().toLowerCase(),
           'recreate'
         );
+      });
+    });
+
+    it('does not show third party options for sync', () => {
+      sinon.stub(relier, 'isSync').callsFake(() => true);
+      return view.render().then(() => {
+        assert.include(view.$(Selectors.HEADER).text(), 'Set your password');
+        assert.lengthOf(view.$(Selectors.EMAIL), 1);
+        assert.equal(view.$(Selectors.EMAIL).val(), EMAIL);
+        assert.lengthOf(view.$(Selectors.PASSWORD), 1);
+        assert.lengthOf(view.$(Selectors.VPASSWORD), 1);
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 0);
+        assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 0);
       });
     });
   });


### PR DESCRIPTION
## Because

- We want to give users the option to use a third party account when signing up

## This pull request

- Adds third party auth options in the signup screen

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8293

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2023-11-13 at 12 35 53 PM](https://github.com/mozilla/fxa/assets/1295288/f923e5b5-b0cb-47c8-bd78-89253d33d631)


## Other information (Optional)

Note this is only for the backbone version. I tried adding for React we needed to do some extra work integrating third party auth options.
