### PR TITLE
fix(react): Allow redirect back to SubPlat after Signup

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -74,6 +74,7 @@ const settingsConfig = {
   appleAuthConfig: config.get('appleAuthConfig'),
   brandMessagingMode: config.get('brandMessagingMode'),
   glean: { ...config.get('glean'), appDisplayVersion: config.get('version') },
+  redirectAllowlist: config.get('redirect_check.allow_list'),
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -22,3 +22,4 @@ auth-error-999 = Unexpected error
 auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different
 auth-error-1011 = Valid email required
+auth-error-1062 = Invalid redirect

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -76,6 +76,7 @@ export interface Config {
     logPings: boolean;
     debugViewTag: string;
   };
+  redirectAllowlist: string[];
 }
 
 export function getDefault() {
@@ -142,6 +143,7 @@ export function getDefault() {
       logPings: false,
       debugViewTag: '',
     },
+    redirectAllowlist: ['localhost'],
   } as Config;
 }
 

--- a/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { isAllowed } from 'fxa-shared/configuration/convict-format-allow-list';
+import {
+  BaseIntegrationData,
+  useConfig,
+  useFtlMsgResolver,
+} from '../../../models';
+import { useLocation } from '@reach/router';
+import {
+  AuthUiErrors,
+  composeAuthUiErrorTranslationId,
+} from '../../auth-errors/auth-errors';
+
+/*
+ * Check if the integration contains a valid `redirectTo` based on
+ * a whitelist maintained in the config.
+ *
+ * At the time of writing, this is only valid for web integrations.
+ * OAuth integrations must derive keys before redirecting.
+ */
+export function useWebRedirect(redirectTo: BaseIntegrationData['redirectTo']) {
+  const config = useConfig();
+  const location = useLocation();
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const isValid = () =>
+    redirectTo
+      ? isAllowed(redirectTo, location.href, config.redirectAllowlist)
+      : false;
+
+  const getLocalizedErrorMessage = () =>
+    ftlMsgResolver.getMsg(
+      composeAuthUiErrorTranslationId(AuthUiErrors.INVALID_REDIRECT_TO),
+      AuthUiErrors.INVALID_REDIRECT_TO.message
+    );
+
+  return {
+    isValid,
+    getLocalizedErrorMessage,
+  };
+}

--- a/packages/fxa-settings/src/models/integrations/web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/web-integration.ts
@@ -53,6 +53,13 @@ export class BaseIntegrationData extends ModelDataProvider {
   @bind(T.snakeCase)
   entrypointVariation: string | undefined;
 
+  // This is for SubPlat redirects which use the web integration
+  // TODO - Validation, this should be `IsUrl` but `localhost` fails
+  @IsOptional()
+  @IsString()
+  @bind(T.snakeCase)
+  redirectTo: string | undefined;
+
   @IsOptional()
   @IsIn(['true', 'false', true, false])
   @bind(T.snakeCase)

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -42,6 +42,7 @@ export interface ConfirmSignupCodeBaseIntegration {
   type: IntegrationType;
   data: {
     uid: BaseIntegrationData['uid'];
+    redirectTo: BaseIntegrationData['redirectTo'];
   };
 }
 
@@ -49,6 +50,7 @@ export interface ConfirmSignupCodeOAuthIntegration {
   type: IntegrationType.OAuth;
   data: {
     uid: OAuthIntegrationData['uid'];
+    redirectTo: OAuthIntegrationData['redirectTo'];
   };
   getService: () => ReturnType<OAuthIntegration['getService']>;
   getRedirectUri: () => ReturnType<OAuthIntegration['getService']>;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -23,17 +23,19 @@ export const MOCK_AUTH_ERROR = {
   message: 'Something broke',
 };
 
-function createMockWebIntegration(): ConfirmSignupCodeBaseIntegration {
+export const MOCK_SIGNUP_CODE = '123456';
+
+export function createMockWebIntegration({
+  redirectTo = undefined,
+}: { redirectTo?: string } = {}): ConfirmSignupCodeBaseIntegration {
   return {
     type: IntegrationType.Web,
-    data: { uid: MOCK_UID },
+    data: { uid: MOCK_UID, redirectTo },
   };
 }
 
-const MOCK_WEB_INTEGRATION = createMockWebIntegration();
-
 export const Subject = ({
-  integration = MOCK_WEB_INTEGRATION,
+  integration = createMockWebIntegration(),
   newsletterSlugs,
 }: {
   integration?: ConfirmSignupCodeIntegration;


### PR DESCRIPTION
Because:
* Users that click the "Sign in" link from a subscription and choose to create a new account were not being redirected back to that subscription page on account verification

This commit:
* Makes the existing REDIRECT_CHECK_ALLOW_LIST config in fxa-content-server available in fxa-settings
* Creates a hook for web integration integration.data.redirectTo validity (OAuth integration redirects are handled differently)
* Accounts for this condition on ConfirmSignupCode submission

fixes FXA-8468

---

### Testing
Go to 123done with a fresh stack (or hit `/clear`) and pick a subscription. Click "Sign in", add the force React experiment params. Enter an email to see React signup. Sign up, verify the account, and see the redirect back to the SubPlat page you were on.

### Notes

This SubPlat link initially hits content-server at `localhost:3030`. We store that value [here](http://github.com/mozilla/fxa/blob/f66607fa6557b240de28c0625995eda6c2afa3bd/packages/fxa-content-server/app/scripts/views/base.js#L406), which loads even before the index page does, but `redirect_to` in the URL gets set to `localhost:3031`. Our "whitelist check" for this simply [compares the origin](http://github.com/mozilla/fxa/blob/f66607fa6557b240de28c0625995eda6c2afa3bd/packages/fxa-content-server/app/scripts/views/behaviors/navigate-or-redirect.js#L18) of the current URL against the one set on the relier, which works for content-server since it was stored as `localhost:3030`. When trying this in React, I can only reference the `redirect_to` param, which is `localhost:3031` and so this kind of check fails since the port differs.

I originally started overwriting the `redirect_to` param with the one stored on content-server's relier since the origins would then match, but I'm not confident this is what we want and for what pages across signup/signin. I then remembered we had this allow list that is set up to handle our different environments already which made this a lot cleaner. You may notice when going through the flow that there's an awkward redirect to `localhost:3031` that goes back to `:3030` and then `:3031` when the flow completes - I'm pretty sure this is a local-only thing. I'm happy to address any feedback on the approach, though since that `base.js` file loads before the index page, the sunset content-server epic may be the place to do it.

Also in Backbone, I noticed we send up `metricsContext` and `redirectTo` with the `account/create` request that we are not sending in React. However if I change `redirectTo` to something invalid I'm not seeing it in the request, and I don't see us doing much with `metricsContext` (see [auth-server handler](http://github.com/mozilla/fxa/blob/f66607fa6557b240de28c0625995eda6c2afa3bd/packages/fxa-auth-server/lib/routes/account.ts#L446-L447)). I think this might've been a remnant of account verification links, but LMK if you think otherwise since we can these in the request if we want to.

Follow up I noticed (double/triple flow params): [FXA-8687](https://mozilla-hub.atlassian.net/browse/FXA-8687)

[FXA-8687]: https://mozilla-hub.atlassian.net/browse/FXA-8687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ