### PR TITLE
feat(auth,admin): add stripe key error on startup

### DIFF
--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -9,7 +9,7 @@ import { setupFirestore } from '../firestore-db';
 import { CurrencyHelper } from '../payments/currencies';
 import { configureSentry } from '../sentry';
 import { AppConfig, AuthFirestore, AuthLogger, ProfileClient } from '../types';
-import { StripeHelper } from './stripe';
+import { StripeHelper, createStripeHelper } from './stripe';
 
 import convictConf from '../../config';
 const config = convictConf.getProperties();
@@ -74,7 +74,7 @@ export async function setupProcessingTaskObjects(processName: string) {
 
   const currencyHelper = new CurrencyHelper(config);
   Container.set(CurrencyHelper, currencyHelper);
-  const stripeHelper = new StripeHelper(log, config, statsd);
+  const stripeHelper = createStripeHelper(log, config, statsd);
   Container.set(StripeHelper, stripeHelper);
 
   return {

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -241,6 +241,31 @@ export class StripeHelper extends StripeHelperBase {
     this.initStripe();
   }
 
+  async checkStripeAPIKey() {
+    try {
+      await this.stripe.customers.list({ limit: 1 });
+    } catch (error) {
+      if (error.type === 'StripeAuthenticationError') {
+        this.log.error('checkStripeAPIKey', {
+          error,
+          rawMesage: error.raw.message,
+        });
+        if (['dev', 'development'].includes(this.config.env)) {
+          console.error(`
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!-----------------------------------!!!
+!!!-----------------------------------!!!
+!!!--- Stripe Authentication Error ---!!!
+!!!---- Check your Stripe API Key ----!!!
+!!!-----------------------------------!!!
+!!!-----------------------------------!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+`);
+        }
+      }
+    }
+  }
+
   /**
    * Validates state of stripe plan
    * @param plan
@@ -3381,5 +3406,7 @@ export class StripeHelper extends StripeHelperBase {
  * Create a Stripe Helper with built-in caching.
  */
 export function createStripeHelper(log: any, config: any, statsd: StatsD) {
-  return new StripeHelper(log, config, statsd);
+  const stripeHelper = new StripeHelper(log, config, statsd);
+  stripeHelper.checkStripeAPIKey();
+  return stripeHelper;
 }

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -79,6 +79,7 @@ export enum STRIPE_PRICE_ID_TO_IAP_ANALOG {
 }
 
 export type StripeHelperConfig = {
+  env: string;
   subscriptions: {
     stripeApiKey: string;
     stripeWebhookSecret: string;


### PR DESCRIPTION
## Because

- It is difficult to identify when a Stripe API key is no longer valid

## This pull request

- Adds an error messsage to service logs on Stripe initialization

## Issue that this pull request solves

Closes: #FXA-8552

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Error on GraphQL response
![image](https://github.com/mozilla/fxa/assets/10620585/bfc50f08-3b6a-4819-b3b4-6142ce8dea5e)

Console log error
![image](https://github.com/mozilla/fxa/assets/10620585/b6273e59-ad30-4778-848a-2daaec73637e)


## Other information (Optional)

Any other information that is important to this pull request.
