### PR TITLE
bug(shared,admin-sever): Fix broken email-bounce script

### DIFF
--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -25,7 +25,7 @@
     "test-cov": "jest --coverage",
     "test-debug": "node --inspect-brk -r tsconfig-paths/register -r esbuild-register node_modules/.bin/jest --runInBand",
     "test-e2e": "jest --runInBand --config ./test/jest-e2e.json --forceExit",
-    "email-bounce": "node -r esbuild-register ./scripts/email-bounce.ts"
+    "email-bounce": "node -r esbuild-register ./src/scripts/email-bounce.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -200,6 +200,10 @@
     "./tracing/*": {
       "import": "./dist/esm/packages/fxa-shared/tracing/*.js",
       "require": "./dist/cjs/packages/fxa-shared/tracing/*.js"
+    },
+    "./test/db/models/auth/*": {
+      "import": "./dist/esm/packages/fxa-shared/test/db/models/auth/*.js",
+      "require": "./dist/cjs/packages/fxa-shared/test/db/models/auth/*.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Because

- The script would not run with `nx email-bounce admin-server`

## This pull request

- Fixes the path to the script.
- Applies the necessary changes to `package.json` to expose `fxa-shared/test/db/models/auth/helper.ts`

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
