### PR TITLE
feat(auth): add planIdsToClientCapabilities to legacy capability service

### DIFF
--- a/packages/fxa-auth-server/lib/payments/utils.ts
+++ b/packages/fxa-auth-server/lib/payments/utils.ts
@@ -40,3 +40,18 @@ export function generateIdempotencyKey(params: string[]) {
 export function roundTime(date = new Date()) {
   return Math.round(date.getTime() / (1000 * 60)).toString();
 }
+
+export function sortClientCapabilities(
+  obj: Record<string, string[]> | Record<string, readonly string[]>
+): Record<string, string[]> | Record<string, readonly string[]> {
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, string[]> | Record<string, readonly string[]>>(
+      (accumulator, key) => {
+        accumulator[key] = Array.from(obj[key]).sort();
+
+        return accumulator;
+      },
+      {}
+    );
+}

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 const assert = { ...sinon.assert, ...require('chai').assert };
 const { Container } = require('typedi');
 
-const { mockContentfulClients, mockLog, mockPlans } = require('../../mocks');
+const { mockContentfulClients, mockLog, mockPlans, mockContentfulPlanIdsToClientCapabilities } = require('../../mocks');
 const { AuthLogger } = require('../../../lib/types');
 const { StripeHelper } = require('../../../lib/payments/stripe');
 const { PlayBilling } = require('../../../lib/payments/iap/google-play');
@@ -161,6 +161,8 @@ describe('CapabilityService', () => {
     mockStripeHelper.allMergedPlanConfigs = sinon.spy(async () => {});
     mockCapabilityManager = {
       getClients: sinon.fake.resolves(mockContentfulClients),
+      planIdsToClientCapabilities: sinon.fake.resolves(mockContentfulPlanIdsToClientCapabilities),
+
     };
     log = mockLog();
     Container.set(AuthLogger, log);
@@ -944,7 +946,91 @@ describe('CapabilityService', () => {
         await assertExpectedCapabilities(clientId, expected);
       }
     });
+
+    it('returns results from Stripe when CapabilityManager is not found and logs to Sentry', async () => {
+      sinon.stub(Sentry, 'captureMessage');
+
+      Container.remove(CapabilityManager);
+
+      let mockCapabilityService = {};
+      mockCapabilityService = new CapabilityService();
+
+      const subscribedPrices = await mockCapabilityService.subscribedPriceIds(UID);
+
+      const mockStripeCapabilities =
+        await mockCapabilityService.planIdsToClientCapabilitiesFromStripe(subscribedPrices);
+
+      const mockContentfulCapabilities = await mockCapabilityService.planIdsToClientCapabilities(subscribedPrices);
+
+      assert.deepEqual(mockContentfulCapabilities, mockStripeCapabilities);
+
+      sinon.assert.calledOnceWithExactly(
+        Sentry.captureMessage,
+        `CapabilityManager not found.`,
+        'error'
+      );
+    });
+
+    it('returns results from Stripe and logs to Sentry when results do not match', async () => {
+      const sentryScope = { setContext: sinon.stub() };
+      sinon.stub(Sentry, 'withScope').callsFake((cb) => cb(sentryScope));
+      sinon.stub(Sentry, 'captureMessage');
+
+      mockCapabilityManager.planIdsToClientCapabilities = sinon.fake.resolves(
+        {
+          c1: ['capAlpha'],
+          c4: ['capBeta', 'capDelta', 'capEpsilon'],
+          c6: ['capGamma', 'capZeta'],
+          c8: ['capOmega']
+        },
+      );
+
+      const expected = {
+        c0: ['capAll'],
+        c1: ['capAll', 'cap4', 'cap5', 'capZZ', 'capAlpha'],
+        c2: ['capAll', 'cap5', 'cap6', 'capC', 'capD'],
+        c3: ['capAll', 'capD', 'capE', 'capP'],
+        null: [
+          'capAll',
+          'cap4',
+          'cap5',
+          'cap6',
+          'capC',
+          'capD',
+          'capE',
+          'capP',
+          'capZZ',
+          'capAlpha',
+        ],
+      };
+
+      for (const clientId in expected) {
+        await assertExpectedCapabilities(clientId, expected[clientId]);
+      }
+
+      sinon.assert.calledOnceWithExactly(sentryScope.setContext, 'planIdsToClientCapabilities', {
+        contentful: {
+          c1: ['capAlpha'],
+          c4: ['capBeta', 'capDelta', 'capEpsilon'],
+          c6: ['capGamma', 'capZeta'],
+          c8: ['capOmega']
+        },
+        stripe: {
+          c1: [ 'capZZ', 'cap4', 'cap5', 'capAlpha' ],
+          '*': [ 'capAll' ],
+          c2: [ 'cap5', 'cap6', 'capC', 'capD' ],
+          c3: [ 'capD', 'capE', 'capP' ]
+        }
+      });
+
+      sinon.assert.calledOnceWithExactly(
+        Sentry.captureMessage,
+        `CapabilityService.planIdsToClientCapabilities - Returned Stripe as plan ids to client capabilities did not match.`,
+        'error'
+      );
+    });
   });
+
   describe('getClients', () => {
     beforeEach(() => {
       mockStripeHelper.allAbbrevPlans = sinon.spy(async () => mockPlans);

--- a/packages/fxa-auth-server/test/local/payments/utils.js
+++ b/packages/fxa-auth-server/test/local/payments/utils.js
@@ -5,6 +5,7 @@
 const { assert } = require('chai');
 const {
   roundTime,
+  sortClientCapabilities,
 } = require('../../../lib/payments/utils');
 
 it('checks that roundTime() returns time rounded to the nearest minute', async () => {
@@ -15,4 +16,24 @@ it('checks that roundTime() returns time rounded to the nearest minute', async (
 
   assert.deepEqual(res, roundedTime);
   assert.notEqual(res, actualTime);
+});
+
+it('checks that sortClientCapabilities() returns object sorted by key and capabilities', async () => {
+  const mockCapabilities = {
+    c1: [ 'capZZ', 'cap4', 'cap5', 'capAlpha' ],
+    '*': [ 'capAll' ],
+    c2: [ 'cap5', 'cap6', 'capC', 'capD' ],
+    c3: [ 'capE', 'capD' ]
+  }
+
+  const result = sortClientCapabilities(mockCapabilities);
+
+  const expected = {
+    '*': [ 'capAll' ],
+    c1: [ 'cap4', 'cap5', 'capAlpha', 'capZZ' ],
+    c2: [ 'cap5', 'cap6', 'capC', 'capD' ],
+    c3: [ 'capD', 'capE' ]
+  }
+
+  assert.deepEqual(result, expected);
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -229,6 +229,13 @@ const MOCK_CONTENTFUL_CLIENTS = [
   },
 ];
 
+const MOCK_CONTENTFUL_CLIENT_CAPABILITIES = {
+  c1: [ 'capZZ', 'cap4', 'cap5', 'capAlpha' ],
+  '*': [ 'capAll' ],
+  c2: [ 'cap5', 'cap6', 'capC', 'capD' ],
+  c3: [ 'capD', 'capE' ]
+}
+
 const MOCK_PLANS = [
   {
     plan_id: 'firefox_pro_basic_823',
@@ -282,6 +289,7 @@ module.exports = {
   generateMetricsContext: generateMetricsContext,
   mockBounces: mockObject(['check']),
   mockContentfulClients: MOCK_CONTENTFUL_CLIENTS,
+  mockContentfulPlanIdsToClientCapabilities: MOCK_CONTENTFUL_CLIENT_CAPABILITIES,
   mockCustoms,
   mockDB,
   mockDevices,


### PR DESCRIPTION
## Because

- We want to use the new capability manager in the capability service and compare its results to the existing check, reporting any differences in the comparison.

## This pull request

- Updates `planIdsToClientCapabilities` in legacy capability service to compare data returned from Contentful and Stripe.
- If results are same, returns from Contentful, otherwise Stripe, with appropriate error messaging to Sentry.
- Adds tests to return from Stripe in the event that the results did not match and successfully logs error to Sentry.
- Adds a util function to sort data for comparison.

## Issue that this pull request solves

Closes: FXA-8274

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
