### PR TITLE
chore: remove unused jwt-decode dep

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -113,7 +113,6 @@
     "jsdom": "^22.1.0",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.0.0",
-    "jwt-decode": "^3.1.2",
     "keyv": "4.5.0",
     "lodash": "^4.17.21",
     "luxon": "^2.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34655,7 +34655,6 @@ fsevents@~2.1.1:
     jsxgettext-recursive-next: 1.1.0
     jwks-rsa: ^3.0.0
     jws: 4.0.0
-    jwt-decode: ^3.1.2
     keypair: 1.0.4
     keyv: 4.5.0
     leftpad: 0.0.1
@@ -43746,13 +43745,6 @@ fsevents@~2.1.1:
     jwa: ^1.4.1
     safe-buffer: ^5.0.1
   checksum: f0213fe5b79344c56cd443428d8f65c16bf842dc8cb8f5aed693e1e91d79c20741663ad6eff07a6d2c433d1831acc9814e8d7bada6a0471fbb91d09ceb2bf5c2
-  languageName: node
-  linkType: hard
-
-"jwt-decode@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "jwt-decode@npm:3.1.2"
-  checksum: 20a4b072d44ce3479f42d0d2c8d3dabeb353081ba4982e40b83a779f2459a70be26441be6c160bfc8c3c6eadf9f6380a036fbb06ac5406b5674e35d8c4205eeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* We stopped using jwt-decode and forgot to remove the dependency.

This commit:

* Removes the unused jwt-decode dependency.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
