### PR TITLE
refactor(payments): Utilize new plan-eligibility endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -376,7 +376,9 @@ export class CapabilityService {
     targetPlan: AbbrevPlan
   ): Promise<SubscriptionChangeEligibility> {
     if (!this.eligibilityManager)
-      return [SubscriptionEligibilityResult.INVALID];
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+      };
     const iapProductIds = iapSubscribedPlans.map((p) => p.product_id);
     const planIds = [
       ...stripeSubscribedPlans.map((p) => p.plan_id),
@@ -389,20 +391,32 @@ export class CapabilityService {
     );
 
     // No overlap, we can create a new subscription
-    if (!overlaps.length) return [SubscriptionEligibilityResult.CREATE];
+    if (!overlaps.length)
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+      };
 
     // Users with IAP Offering overlaps should not be allowed to proceed
-    if (
-      overlaps.some(
+    const iapRoadblockPlan = iapSubscribedPlans.find((plan) => {
+      return overlaps?.some(
         (overlap) =>
           overlap.type === 'offering' &&
           iapProductIds.includes(overlap.offeringProductId)
-      )
-    )
-      return [SubscriptionEligibilityResult.BLOCKED_IAP];
+      );
+    });
+
+    if (iapRoadblockPlan)
+      return {
+        subscriptionEligibilityResult:
+          SubscriptionEligibilityResult.BLOCKED_IAP,
+        eligibleSourcePlan: iapRoadblockPlan,
+      };
 
     // Multiple existing overlapping plans, we can't merge them
-    if (overlaps.length > 1) return [SubscriptionEligibilityResult.INVALID];
+    if (overlaps.length > 1)
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+      };
 
     const overlap = overlaps[0];
     assert(
@@ -414,10 +428,15 @@ export class CapabilityService {
     );
 
     if (overlap.comparison === OfferingComparison.DOWNGRADE)
-      return [SubscriptionEligibilityResult.DOWNGRADE, overlapAbbrev];
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.DOWNGRADE,
+        eligibleSourcePlan: overlapAbbrev,
+      };
 
     if (!overlapAbbrev || overlapAbbrev.plan_id === targetPlan.plan_id)
-      return [SubscriptionEligibilityResult.INVALID];
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+      };
 
     // Any interval change that is lower than the existing plans interval is
     // a downgrade. Otherwise its considered an upgrade.
@@ -427,9 +446,15 @@ export class CapabilityService {
         { unit: targetPlan.interval, count: targetPlan.interval_count }
       ) === IntervalComparison.SHORTER
     )
-      return [SubscriptionEligibilityResult.DOWNGRADE, overlapAbbrev];
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.DOWNGRADE,
+        eligibleSourcePlan: overlapAbbrev,
+      };
 
-    return [SubscriptionEligibilityResult.UPGRADE, overlapAbbrev];
+    return {
+      subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+      eligibleSourcePlan: overlapAbbrev,
+    };
   }
 
   /**
@@ -447,10 +472,13 @@ export class CapabilityService {
       useFirestoreProductConfigs
     );
 
-    if (!targetProductSet) return [SubscriptionEligibilityResult.INVALID];
+    if (!targetProductSet)
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+      };
 
     // Lookup whether user holds an IAP subscription with a shared productSet to the target
-    const iapRoadblock = iapSubscribedPlans.some((abbrevPlan) => {
+    const iapRoadblockPlan = iapSubscribedPlans.find((abbrevPlan) => {
       const { productSet } = productUpgradeFromProductConfig(
         abbrevPlan,
         useFirestoreProductConfigs
@@ -461,7 +489,12 @@ export class CapabilityService {
 
     // Users with an IAP subscription to the productSet that we're trying to subscribe
     // to should not be allowed to proceed
-    if (iapRoadblock) return [SubscriptionEligibilityResult.BLOCKED_IAP];
+    if (iapRoadblockPlan)
+      return {
+        subscriptionEligibilityResult:
+          SubscriptionEligibilityResult.BLOCKED_IAP,
+        eligibleSourcePlan: iapRoadblockPlan,
+      };
 
     const isSubscribedToProductSet = stripeSubscribedPlans.some(
       (abbrevPlan) => {
@@ -475,7 +508,9 @@ export class CapabilityService {
     );
 
     if (!isSubscribedToProductSet)
-      return [SubscriptionEligibilityResult.CREATE];
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+      };
 
     // Use the upgradeEligibility helper to check if any of our existing plans are
     // elegible for an upgrade and if so the user can upgrade that existing plan to the desired plan
@@ -487,12 +522,21 @@ export class CapabilityService {
       );
 
       if (eligibility === SubscriptionUpdateEligibility.UPGRADE)
-        return [SubscriptionEligibilityResult.UPGRADE, abbrevPlan];
+        return {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+          eligibleSourcePlan: abbrevPlan,
+        };
 
       if (eligibility === SubscriptionUpdateEligibility.DOWNGRADE)
-        return [SubscriptionEligibilityResult.DOWNGRADE, abbrevPlan];
+        return {
+          subscriptionEligibilityResult:
+            SubscriptionEligibilityResult.DOWNGRADE,
+          eligibleSourcePlan: abbrevPlan,
+        };
     }
-    return [SubscriptionEligibilityResult.INVALID];
+    return {
+      subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+    };
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -92,12 +92,14 @@ export class MozillaSubscriptionHandler {
 
     const targetPlanId = request.params.planId;
 
-    const eligibility = (
-      await this.capabilityService.getPlanEligibility(uid, targetPlanId)
-    )[0];
+    const result = await this.capabilityService.getPlanEligibility(
+      uid,
+      targetPlanId
+    );
 
     return {
-      eligibility,
+      eligibility: result.subscriptionEligibilityResult,
+      currentPlan: result.eligibleSourcePlan,
     };
   }
 }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -108,13 +108,14 @@ export class PayPalHandler extends StripeWebhookHandler {
       }
 
       // Validate that the user doesn't have conflicting subscriptions, for instance via IAP
-      const eligibility = (
-        await this.capabilityService.getPlanEligibility(
-          customer.metadata.userid,
-          priceId
-        )
-      )[0];
-      if (eligibility !== SubscriptionEligibilityResult.CREATE) {
+      const result = await this.capabilityService.getPlanEligibility(
+        customer.metadata.userid,
+        priceId
+      );
+      if (
+        result.subscriptionEligibilityResult !==
+        SubscriptionEligibilityResult.CREATE
+      ) {
         throw error.userAlreadySubscribedToProduct();
       }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -9,6 +9,7 @@ import { SeverityLevel } from '@sentry/types';
 import { getAccountCustomerByUid } from 'fxa-shared/db/models/auth';
 import {
   AbbrevPlan,
+  SubscriptionChangeEligibility,
   SubscriptionEligibilityResult,
   SubscriptionUpdateEligibility,
 } from 'fxa-shared/subscriptions/types';
@@ -219,14 +220,14 @@ export class StripeHandler {
       );
     }
 
-    const eligibility = await this.capabilityService.getPlanEligibility(
-      uid,
-      planId
-    );
+    const result: SubscriptionChangeEligibility =
+      await this.capabilityService.getPlanEligibility(uid, planId);
 
     const eligibleForUpgrade =
-      eligibility[0] === SubscriptionEligibilityResult.UPGRADE;
-    const isUpgradeForCurrentPlan = eligibility[1]?.plan_id === currentPlan.id;
+      result.subscriptionEligibilityResult ===
+      SubscriptionEligibilityResult.UPGRADE;
+    const isUpgradeForCurrentPlan =
+      result.eligibleSourcePlan?.plan_id === currentPlan.id;
     if (!eligibleForUpgrade || !isUpgradeForCurrentPlan) {
       throw error.invalidPlanUpdate();
     }
@@ -403,13 +404,15 @@ export class StripeHandler {
       let isUpgrade = false,
         sourcePlan;
       if (customer) {
-        const upgradeResult = await this.capabilityService.getPlanEligibility(
+        const result = await this.capabilityService.getPlanEligibility(
           customer.metadata.userid,
           priceId
         );
 
-        isUpgrade = upgradeResult[0] === SubscriptionUpdateEligibility.UPGRADE;
-        sourcePlan = upgradeResult[1];
+        isUpgrade =
+          result.subscriptionEligibilityResult ===
+          SubscriptionUpdateEligibility.UPGRADE;
+        sourcePlan = result.eligibleSourcePlan;
       }
 
       const previewInvoice = await this.stripeHelper.previewInvoice({
@@ -551,13 +554,14 @@ export class StripeHandler {
       }
 
       // Validate that the user doesn't have conflicting subscriptions, for instance via IAP
-      const eligibility = (
+      const { subscriptionEligibilityResult } =
         await this.capabilityService.getPlanEligibility(
           customer.metadata.userid,
           priceId
-        )
-      )[0];
-      if (eligibility !== SubscriptionEligibilityResult.CREATE) {
+        );
+      if (
+        subscriptionEligibilityResult !== SubscriptionEligibilityResult.CREATE
+      ) {
         throw error.userAlreadySubscribedToProduct();
       }
 

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -544,7 +544,7 @@ describe('CapabilityService', () => {
     });
   });
 
-  describe('elibility', () => {
+  describe('eligibility', () => {
     const mockPlanTier1ShortInterval = {
       plan_id: 'plan_123456',
       product_id: 'prod_123456',
@@ -610,26 +610,30 @@ describe('CapabilityService', () => {
             type: 'offering',
           },
         ]);
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [],
             [mockPlanTier1ShortInterval],
             mockPlanTier1LongInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.BLOCKED_IAP);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult:
+            SubscriptionEligibilityResult.BLOCKED_IAP,
+          eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
       });
 
       it('returns create for targetPlan with offering user is not subscribed to', async () => {
         mockEligibilityManager.getOfferingOverlap = sinon.fake.resolves([]);
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [],
             [],
             mockPlanTier1ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.CREATE);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+        });
       });
 
       it('returns upgrade for targetPlan with offering user is subscribed to a lower tier of', async () => {
@@ -640,14 +644,16 @@ describe('CapabilityService', () => {
             type: 'plan',
           },
         ]);
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [mockPlanTier1ShortInterval],
             [],
             mockPlanTier2LongInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.UPGRADE);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+          eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
       });
 
       it('returns downgrade for targetPlan with offering user is subscribed to a higher tier of', async () => {
@@ -658,14 +664,17 @@ describe('CapabilityService', () => {
             type: 'plan',
           },
         ]);
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [mockPlanTier2LongInterval],
             [],
             mockPlanTier1ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.DOWNGRADE);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult:
+            SubscriptionEligibilityResult.DOWNGRADE,
+          eligibleSourcePlan: undefined,
+        });
       });
 
       it('returns upgrade for targetPlan with offering user is subscribed to a higher interval of', async () => {
@@ -676,14 +685,16 @@ describe('CapabilityService', () => {
             type: 'plan',
           },
         ]);
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [mockPlanTier1ShortInterval],
             [],
             mockPlanTier1LongInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.UPGRADE);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+          eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
       });
 
       it('returns downgrade for targetPlan with shorter interval but higher tier than user is subscribed to', async () => {
@@ -696,14 +707,17 @@ describe('CapabilityService', () => {
         ]);
         Container.set(EligibilityManager, mockEligibilityManager);
         capabilityService = new CapabilityService();
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [mockPlanTier1LongInterval],
             [],
             mockPlanTier2ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.DOWNGRADE);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult:
+            SubscriptionEligibilityResult.DOWNGRADE,
+          eligibleSourcePlan: mockPlanTier1LongInterval,
+        });
       });
 
       it('returns invalid for targetPlan with same offering user is subscribed to', async () => {
@@ -714,14 +728,15 @@ describe('CapabilityService', () => {
             type: 'plan',
           },
         ]);
-        const actual = (
+        const actual =
           await capabilityService.eligibilityFromEligibilityManager(
             [mockPlanTier1ShortInterval],
             [],
             mockPlanTier1ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.INVALID);
+          );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+        });
       });
     });
 
@@ -729,67 +744,72 @@ describe('CapabilityService', () => {
       it('returns blocked_iap for targetPlan with productSet the user is subscribed to with IAP', async () => {
         capabilityService.fetchSubscribedPricesFromAppStore =
           sinon.fake.resolves(['plan_123456']);
-        const actual = (
-          await capabilityService.eligibilityFromStripeMetadata(
-            [],
-            [mockPlanTier2LongInterval],
-            mockPlanTier1ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.BLOCKED_IAP);
+        const actual = await capabilityService.eligibilityFromStripeMetadata(
+          [],
+          [mockPlanTier2LongInterval],
+          mockPlanTier1ShortInterval
+        );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult:
+            SubscriptionEligibilityResult.BLOCKED_IAP,
+          eligibleSourcePlan: mockPlanTier2LongInterval,
+        });
       });
 
       it('returns create for targetPlan with productSet user is not subscribed to', async () => {
-        const actual = (
-          await capabilityService.eligibilityFromStripeMetadata(
-            [],
-            [],
-            mockPlanTier1ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.CREATE);
+        const actual = await capabilityService.eligibilityFromStripeMetadata(
+          [],
+          [],
+          mockPlanTier1ShortInterval
+        );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+        });
       });
 
       it('returns upgrade for targetPlan with productSet user is subscribed to a lower tier of', async () => {
         capabilityService.fetchSubscribedPricesFromStripe = sinon.fake.resolves(
           [mockPlanTier1ShortInterval.plan_id]
         );
-        const actual = (
-          await capabilityService.eligibilityFromStripeMetadata(
-            [mockPlanTier1ShortInterval],
-            [],
-            mockPlanTier2LongInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.UPGRADE);
+        const actual = await capabilityService.eligibilityFromStripeMetadata(
+          [mockPlanTier1ShortInterval],
+          [],
+          mockPlanTier2LongInterval
+        );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+          eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
       });
 
       it('returns downgrade for targetPlan with productSet user is subscribed to a higher tier of', async () => {
         capabilityService.fetchSubscribedPricesFromStripe = sinon.fake.resolves(
           [mockPlanTier2LongInterval.plan_id]
         );
-        const actual = (
-          await capabilityService.eligibilityFromStripeMetadata(
-            [mockPlanTier2LongInterval],
-            [],
-            mockPlanTier1ShortInterval
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.DOWNGRADE);
+        const actual = await capabilityService.eligibilityFromStripeMetadata(
+          [mockPlanTier2LongInterval],
+          [],
+          mockPlanTier1ShortInterval
+        );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult:
+            SubscriptionEligibilityResult.DOWNGRADE,
+          eligibleSourcePlan: mockPlanTier2LongInterval,
+        });
       });
 
       it('returns invalid for targetPlan with no product order', async () => {
         capabilityService.fetchSubscribedPricesFromStripe = sinon.fake.resolves(
           [mockPlanTier2LongInterval.plan_id]
         );
-        const actual = (
-          await capabilityService.eligibilityFromStripeMetadata(
-            [mockPlanTier2LongInterval],
-            [],
-            mockPlanNoProductOrder
-          )
-        )[0];
-        assert.equal(actual, SubscriptionEligibilityResult.INVALID);
+        const actual = await capabilityService.eligibilityFromStripeMetadata(
+          [mockPlanTier2LongInterval],
+          [],
+          mockPlanNoProductOrder
+        );
+        assert.deepEqual(actual, {
+          subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+        });
       });
     });
   });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
@@ -319,7 +319,9 @@ describe('mozilla-subscriptions', () => {
 describe('plan-eligibility', () => {
   beforeEach(() => {
     capabilityService = {
-      getPlanEligibility: sandbox.stub().resolves(['eligibility', undefined]),
+      getPlanEligibility: sandbox.stub().resolves({
+        subscriptionEligibilityResult: 'eligibility',
+      }),
     };
   });
 
@@ -334,6 +336,7 @@ describe('plan-eligibility', () => {
       );
       assert.deepEqual(resp, {
         eligibility: 'eligibility',
+        currentPlan: undefined,
       });
     });
   });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -204,10 +204,9 @@ describe('subscriptions payPalRoutes', () => {
     beforeEach(() => {
       stripeHelper.findCustomerSubscriptionByPlanId =
         sinon.fake.returns(undefined);
-      capabilityService.getPlanEligibility = sinon.fake.resolves([
-        SubscriptionEligibilityResult.CREATE,
-        undefined,
-      ]);
+      capabilityService.getPlanEligibility = sinon.fake.resolves({
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+      });
       stripeHelper.cancelSubscription = sinon.fake.resolves({});
       payPalHelper.cancelBillingAgreement = sinon.fake.resolves({});
       profile.deleteCache = sinon.fake.resolves({});

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -415,10 +415,9 @@ describe('DirectStripeRoutes', () => {
       },
     };
     mockCapabilityService.getPlanEligibility = sinon.stub();
-    mockCapabilityService.getPlanEligibility.resolves([
-      SubscriptionEligibilityResult.CREATE,
-      undefined,
-    ]);
+    mockCapabilityService.getPlanEligibility.resolves({
+      subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+    });
     mockCapabilityService.getClients = sinon.stub();
     mockCapabilityService.getClients.resolves(mockContentfulClients);
     Container.set(CapabilityService, mockCapabilityService);
@@ -1971,10 +1970,10 @@ describe('DirectStripeRoutes', () => {
       VALID_REQUEST.params = { subscriptionId: subscriptionId };
 
       mockCapabilityService.getPlanEligibility = sinon.stub();
-      mockCapabilityService.getPlanEligibility.resolves([
-        SubscriptionEligibilityResult.UPGRADE,
-        plan.id,
-      ]);
+      mockCapabilityService.getPlanEligibility.resolves({
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+        eligibleSourcePlan: subscription2,
+      });
 
       directStripeRoutesInstance.stripeHelper.changeSubscriptionPlan.resolves();
 
@@ -2010,10 +2009,9 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.findAbbrevPlanById.resolves(plan);
 
       mockCapabilityService.getPlanEligibility = sinon.stub();
-      mockCapabilityService.getPlanEligibility.resolves([
-        SubscriptionEligibilityResult.UPGRADE,
-        plan.id,
-      ]);
+      mockCapabilityService.getPlanEligibility.resolves({
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+      });
 
       try {
         await directStripeRoutesInstance.updateSubscription(VALID_REQUEST);

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -6,6 +6,7 @@ import {
   LatestInvoiceItems,
 } from 'fxa-shared/dto/auth/payments/invoice';
 import {
+  AbbrevPlan,
   IapSubscription,
   MozillaSubscriptionTypes,
   WebSubscription,
@@ -129,7 +130,7 @@ export const SELECTED_PLAN: Plan = {
   },
 };
 
-export const UPGRADE_FROM_PLAN: Plan = {
+export const UPGRADE_FROM_PLAN: AbbrevPlan = {
   plan_id: 'plan_abc',
   product_id: PRODUCT_ID,
   product_name: 'Example Product',
@@ -139,6 +140,7 @@ export const UPGRADE_FROM_PLAN: Plan = {
   interval_count: 1,
   active: true,
   plan_metadata: null,
+  plan_name: 'Example Product Monthly',
   product_metadata: {
     webIconURL: 'http://placekitten.com/49/49?image=9',
     webIconBackground: 'lime',
@@ -156,7 +158,7 @@ export const UPGRADE_FROM_PLAN: Plan = {
   },
 };
 
-export const UPGRADE_FROM_PLAN_ARCHIVED: Plan = {
+export const UPGRADE_FROM_PLAN_ARCHIVED: AbbrevPlan = {
   ...UPGRADE_FROM_PLAN,
   product_metadata: {
     ...UPGRADE_FROM_PLAN.product_metadata,

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -30,14 +30,14 @@ import './index.scss';
 import { ProductProps } from '../index';
 import { PaymentConsentCheckbox } from '../../../components/PaymentConsentCheckbox';
 import { PaymentProviderDetails } from '../../../components/PaymentProviderDetails';
-import { WebSubscription } from 'fxa-shared/subscriptions/types';
+import { AbbrevPlan, WebSubscription } from 'fxa-shared/subscriptions/types';
 import { FirstInvoicePreview } from 'fxa-shared/dto/auth/payments/invoice';
 
 export type SubscriptionUpgradeProps = {
   profile: Profile;
   customer: Customer;
   selectedPlan: Plan;
-  upgradeFromPlan: Plan;
+  upgradeFromPlan: AbbrevPlan;
   upgradeFromSubscription: WebSubscription;
   invoicePreview: FirstInvoicePreview;
   discount?: number;

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -1,4 +1,5 @@
 import {
+  AbbrevPlan,
   MozillaSubscription,
   PaypalPaymentError,
   SubscriptionEligibilityResult,
@@ -94,6 +95,7 @@ export type Customer = {
 
 export type PlanEligibility = {
   eligibility: SubscriptionEligibilityResult;
+  currentPlan?: AbbrevPlan;
 };
 
 export interface CreateSubscriptionResult {

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -220,7 +220,7 @@ export type InvoicePreview = [
   proratedInvoice?: Stripe.UpcomingInvoice
 ];
 
-export type SubscriptionChangeEligibility = [
-  subscriptionEligibilityResult: SubscriptionEligibilityResult,
-  eligibleSourcePlan?: AbbrevPlan
-];
+export type SubscriptionChangeEligibility = {
+  subscriptionEligibilityResult: SubscriptionEligibilityResult;
+  eligibleSourcePlan?: AbbrevPlan;
+};


### PR DESCRIPTION
## Because

- we want to move logic from frontend and utilize the new endpoint

## This pull request

- [x] Updates CapabilityService and the new endpoint to include the current plan in its result to replace `subscriptionUpdateEligibilityResult` and `currentPlan()`
- [x] Removes `subscriptionUpdateEligibilityResult` to use `subscriptionChangeEligibility`
- [x] Removes `currentPlan()` to use `subscriptionChangeEligibility`
- [x] Added comment to ticket for QA

## Issue that this pull request solves

Closes: [FXA-6166](https://mozilla-hub.atlassian.net/browse/FXA-6166)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.


[FXA-6166]: https://mozilla-hub.atlassian.net/browse/FXA-6166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ