### PR TITLE
feat(auth): update subscriptions to new plan script

### DIFF
--- a/packages/fxa-auth-server/scripts/update-subscriptions-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/update-subscriptions-to-new-plan.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+
+import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+import { SubscriptionUpdater } from './update-subscriptions-to-new-plan/update-subscriptions-to-new-plan';
+import Stripe from 'stripe';
+import fs from 'fs';
+
+const pckg = require('../package.json');
+
+const parseBatchSize = (batchSize: string | number) => {
+  return parseInt(batchSize.toString(), 10);
+};
+
+const parseRateLimit = (rateLimit: string | number) => {
+  return parseInt(rateLimit.toString(), 10);
+};
+
+const parseProrationBehavior = (
+  prorationBehavior: string
+): Stripe.SubscriptionUpdateParams.ProrationBehavior => {
+  if (
+    prorationBehavior === 'none' ||
+    prorationBehavior === 'always_invoice' ||
+    prorationBehavior === 'create_prorations'
+  ) {
+    return prorationBehavior;
+  }
+
+  throw new Error('Invalid proration behavior');
+};
+
+const parsePlanIdMapPath = (planIdMapPath: string): Record<string, string> => {
+  const planIdMap = JSON.parse(fs.readFileSync(planIdMapPath, 'utf-8'));
+
+  const isObjectWithKeys = Object.keys(planIdMap).length;
+  const isMapToString = Object.keys(planIdMap).every(
+    (key) => typeof planIdMap[key] === 'string'
+  );
+
+  if (isObjectWithKeys && isMapToString) {
+    return planIdMap;
+  }
+
+  throw new Error('Invalid planIdMap');
+};
+
+async function init() {
+  program
+    .version(pckg.version)
+    .option(
+      '-b, --batch-size [number]',
+      'Number of subscriptions to query from firestore at a time.  Defaults to 100.',
+      100
+    )
+    .option(
+      '-o, --output-file [string]',
+      'Output file to write report to. Will be output in CSV format.  Defaults to update-subscriptions-to-new-plan-output.csv.',
+      'update-subscriptions-to-new-plan-output.csv'
+    )
+    .option(
+      '-r, --rate-limit [number]',
+      'Rate limit for Stripe. Defaults to 70',
+      70
+    )
+    .option(
+      '-s, --plan-id-map-path [string]',
+      'A file containing a JSON map where keys are strings representing source plan IDs, and values are the corresponding target plan ID'
+    )
+    .option(
+      '-d, --destination [string]',
+      'Destination Stripe plan ID. All customers on the source price ID will be moved to this price ID'
+    )
+    .option(
+      '-p, --proration-behavior [string]',
+      'The Stripe proration behavior to use. Can be one of "none", "always_invoice", or "create_prorations"',
+      ''
+    )
+    .option(
+      '--dry-run',
+      'List the customers that would be deleted without actually deleting'
+    )
+    .parse(process.argv);
+
+  const { stripeHelper, database } = await setupProcessingTaskObjects(
+    'move-customers-to-new-plan'
+  );
+
+  const batchSize = parseBatchSize(program.batchSize);
+  const rateLimit = parseRateLimit(program.rateLimit);
+  const prorationBehavior = parseProrationBehavior(program.prorationBehavior);
+  const planIdMap = parsePlanIdMapPath(program.planIdMapPath);
+  const dryRun = !!program.dryRun;
+  if (!program.destination) throw new Error('--destination must be provided');
+
+  const subscriptionPlanMover = new SubscriptionUpdater(
+    planIdMap,
+    prorationBehavior,
+    batchSize,
+    program.destination,
+    stripeHelper,
+    database,
+    dryRun,
+    rateLimit
+  );
+
+  await subscriptionPlanMover.update();
+
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/scripts/update-subscriptions-to-new-plan/update-subscriptions-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/update-subscriptions-to-new-plan/update-subscriptions-to-new-plan.ts
@@ -1,0 +1,246 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Stripe from 'stripe';
+import { Firestore } from '@google-cloud/firestore';
+import Container from 'typedi';
+import fs from 'fs';
+import PQueue from 'p-queue';
+
+import { AppConfig, AuthFirestore } from '../../lib/types';
+import { ConfigType } from '../../config';
+import { StripeHelper } from '../../lib/payments/stripe';
+import { ACTIVE_SUBSCRIPTION_STATUSES } from 'fxa-shared/subscriptions/stripe';
+
+/**
+ * Firestore subscriptions contain additional expanded information
+ * on top of the base Stripe.Subscription type
+ */
+export interface FirestoreSubscription extends Stripe.Subscription {
+  customer: string;
+  plan: Stripe.Plan;
+  price: Stripe.Price;
+}
+
+export class SubscriptionUpdater {
+  private config: ConfigType;
+  private firestore: Firestore;
+  private stripeQueue: PQueue;
+  private stripe: Stripe;
+
+  /**
+   * A converter to move customers from one plan to another
+   * @param planIdMap A mapping where keys are source plan IDs and values are destination plan IDs, subscriptions with a matching source plan IDs will be moved to the destination plan ID
+   * @param prorationBehavior Stripe proration behavior for the move
+   * @param batchSize Number of subscriptions to fetch from Firestore at a time
+   * @param outputFile A CSV file to output a report of affected subscriptions to
+   * @param stripeHelper An instance of StripeHelper
+   * @param database A reference to the FXA database
+   * @param dryRun If true, does not change anything only outputs what would have been done
+   * @param rateLimit A limit for number of stripe requests within the period of 1 second
+   */
+  constructor(
+    private planIdMap: Record<string, string>,
+    private prorationBehavior: Stripe.SubscriptionUpdateParams['proration_behavior'],
+    private batchSize: number,
+    private outputFile: string,
+    private stripeHelper: StripeHelper,
+    private database: any,
+    public dryRun: boolean,
+    rateLimit: number
+  ) {
+    this.stripe = stripeHelper.stripe;
+
+    const config = Container.get<ConfigType>(AppConfig);
+    this.config = config;
+
+    const firestore = Container.get<Firestore>(AuthFirestore);
+    this.firestore = firestore;
+
+    this.stripeQueue = new PQueue({
+      intervalCap: rateLimit,
+      interval: 1000, // Stripe measures it's rate limit per second
+    });
+  }
+
+  /**
+   * Update all subscriptions from any plan listed in the map to the destination plans in batches
+   */
+  async update() {
+    let startAfter: string | null = null;
+    let hasMore = true;
+
+    while (hasMore) {
+      const subscriptions = await this.fetchSubsBatch(startAfter);
+
+      startAfter = subscriptions.at(-1)?.id as string;
+      if (!startAfter) hasMore = false;
+
+      await Promise.all(
+        subscriptions.map((sub) => this.processSubscription(sub))
+      );
+    }
+  }
+
+  /**
+   * Fetches subscriptions from Firestore paginated by batchSize
+   * @param startAfter ID of the last element of the previous batch for pagination
+   * @returns A list of subscriptions from firestore
+   */
+  async fetchSubsBatch(startAfter: string | null) {
+    const collectionPrefix = `${this.config.authFirestore.prefix}stripe-`;
+    const subscriptionCollection = `${collectionPrefix}subscriptions`;
+
+    const subscriptionSnap = await this.firestore
+      .collectionGroup(subscriptionCollection)
+      .where('plan.id', 'in', Object.keys(this.planIdMap))
+      .orderBy('id')
+      .startAfter(startAfter)
+      .limit(this.batchSize)
+      .get();
+
+    const subscriptions = subscriptionSnap.docs.map(
+      (doc) => doc.data() as FirestoreSubscription
+    );
+
+    return subscriptions;
+  }
+
+  /**
+   * Checks and attempts to move a subscription off of a plan listed in the plan map
+   * @param firestoreSubscription The subscription to convert
+   */
+  async processSubscription(firestoreSubscription: FirestoreSubscription) {
+    const {
+      id: subscriptionId,
+      customer: customerId,
+      status,
+    } = firestoreSubscription;
+
+    try {
+      const customer = await this.fetchCustomer(customerId);
+      if (!customer?.subscriptions?.data) {
+        console.error(`Customer not found: ${customerId}`);
+        return;
+      }
+
+      const account = await this.database.account(customer.metadata.userid);
+      if (!account) {
+        console.error(`Account not found: ${customer.metadata.userid}`);
+        return;
+      }
+
+      if (!ACTIVE_SUBSCRIPTION_STATUSES.includes(status)) {
+        console.log(`Sub is not in active state: ${status},${subscriptionId}`);
+        return;
+      }
+
+      if (!this.dryRun) {
+        await this.updateSubscription(firestoreSubscription);
+      }
+
+      const report = this.buildReport(customer, account);
+
+      await this.writeReport(report);
+
+      console.log(subscriptionId);
+    } catch (e) {
+      console.error(subscriptionId, e);
+    }
+  }
+
+  /**
+   * Retrieves a customer record directly from Stripe
+   * @param customerId The Stripe customer ID of the customer to fetch
+   * @returns The customer record for the customerId provided, or null if not found or deleted
+   */
+  async fetchCustomer(customerId: string) {
+    const customer = await this.enqueueRequest(() =>
+      this.stripe.customers.retrieve(customerId, {
+        expand: ['subscriptions'],
+      })
+    );
+
+    if (customer.deleted) return null;
+
+    return customer;
+  }
+
+  /**
+   * Update a subscription from any plan listed in the plan ID map to the corresponding destination plan
+   * @param subscription The subscription to convert
+   */
+  async updateSubscription(_subscription: Stripe.Subscription) {
+    const subscription = await this.enqueueRequest(() =>
+      this.stripe.subscriptions.retrieve(_subscription.id)
+    );
+
+    const updatedItems = subscription.items.data
+      .map((item): Stripe.SubscriptionUpdateParams.Item | null => {
+        if (this.planIdMap[item.plan.id]) {
+          return {
+            id: item.id,
+            plan: this.planIdMap[item.plan.id],
+          };
+        }
+
+        return null;
+      })
+      .filter((item): item is Stripe.SubscriptionUpdateParams.Item => !!item);
+
+    const firstUpdatedItem = updatedItems.at(0);
+    if (!firstUpdatedItem) {
+      console.log(
+        `Warning: Initially, but did not subsequently match subscription item for ${subscription.id}`
+      );
+      return;
+    }
+
+    await this.enqueueRequest(() =>
+      this.stripe.subscriptions.update(subscription.id, {
+        proration_behavior: this.prorationBehavior,
+        items: updatedItems,
+        metadata: {
+          previous_plan_id: subscription.items.data[0].plan.id,
+          plan_change_date: Math.round(new Date().getTime() / 1000), // Expected to be in seconds since epoch
+        },
+      })
+    );
+  }
+
+  /**
+   * Creates an ordered array of fields destined for CSV format
+   * @returns An array representing the fields to be output to CSV
+   */
+  buildReport(customer: Stripe.Customer, account: any) {
+    // We build a temporary object first for readability & maintainability purposes
+    const report = {
+      uid: customer.metadata.userid,
+      email: customer.email,
+
+      locale: account.locale,
+    };
+
+    return [report.uid, `"${report.email}"`, `"${report.locale}"`];
+  }
+
+  /**
+   * Appends the report to the output file
+   * @param report an array representing the report CSV
+   */
+  async writeReport(report: (string | number | null)[]) {
+    const reportCSV = report.join(',') + '\n';
+
+    await fs.promises.writeFile(this.outputFile, reportCSV, {
+      flag: 'a+',
+      encoding: 'utf-8',
+    });
+  }
+
+  async enqueueRequest<T>(callback: () => T): Promise<T> {
+    return this.stripeQueue.add(callback, {
+      throwOnTimeout: true,
+    });
+  }
+}

--- a/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.ts
@@ -1,0 +1,365 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+import cp from 'child_process';
+import util from 'util';
+import path from 'path';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import Container from 'typedi';
+
+import { ConfigType } from '../../config';
+import { AppConfig, AuthFirestore } from '../../lib/types';
+
+import {
+  SubscriptionUpdater,
+  FirestoreSubscription,
+} from '../../scripts/update-subscriptions-to-new-plan/update-subscriptions-to-new-plan';
+import Stripe from 'stripe';
+import { StripeHelper } from '../../lib/payments/stripe';
+
+import product1 from '../local/payments/fixtures/stripe/product1.json';
+import customer1 from '../local/payments/fixtures/stripe/customer1.json';
+import subscription1 from '../local/payments/fixtures/stripe/subscription1.json';
+
+const mockProduct = product1 as unknown as Stripe.Product;
+const mockCustomer = customer1 as unknown as Stripe.Customer;
+const mockSubscription = subscription1 as unknown as FirestoreSubscription;
+
+const mockAccount = {
+  locale: 'en-US',
+};
+
+const ROOT_DIR = '../..';
+const execAsync = util.promisify(cp.exec);
+const cwd = path.resolve(__dirname, ROOT_DIR);
+const execOptions = {
+  cwd,
+  env: {
+    ...process.env,
+    NODE_ENV: 'dev',
+    LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
+  },
+};
+
+describe('starting script', () => {
+  it('does not fail', function () {
+    this.timeout(20000);
+    return execAsync(
+      'node -r esbuild-register scripts/remove-unverified-accounts.ts',
+      execOptions
+    );
+  });
+});
+
+const mockConfig = {
+  authFirestore: {
+    prefix: 'mock-fxa-',
+  },
+  subscriptions: {
+    playApiServiceAccount: {
+      credentials: {
+        clientEmail: 'mock-client-email',
+      },
+      keyFile: 'mock-private-keyfile',
+    },
+    productConfigsFirestore: {
+      schemaValidation: {
+        cdnUrlRegex: '^http',
+      },
+    },
+  },
+} as unknown as ConfigType;
+
+describe('CustomerPlanMover', () => {
+  let subscriptionUpdater: SubscriptionUpdater;
+  let stripeStub: Stripe;
+  let stripeHelperStub: StripeHelper;
+  let dbStub: any;
+  let firestoreGetStub: sinon.SinonStub;
+  const planIdMap = {
+    [mockSubscription.items.data[0].plan.id]: 'updated',
+  };
+  const prorationBehavior = 'none';
+
+  beforeEach(() => {
+    firestoreGetStub = sinon.stub();
+    Container.set(AuthFirestore, {
+      collectionGroup: sinon.stub().returns({
+        where: sinon.stub().returnsThis(),
+        orderBy: sinon.stub().returnsThis(),
+        startAfter: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
+        get: firestoreGetStub,
+      }),
+    });
+
+    Container.set(AppConfig, mockConfig);
+
+    stripeStub = {
+      on: sinon.stub(),
+      products: {},
+      customers: {},
+      subscriptions: {},
+      invoices: {},
+    } as unknown as Stripe;
+
+    stripeHelperStub = {
+      stripe: stripeStub,
+      currencyHelper: {
+        isCurrencyCompatibleWithCountry: sinon.stub(),
+      },
+    } as unknown as StripeHelper;
+
+    dbStub = {
+      account: sinon.stub(),
+    };
+
+    subscriptionUpdater = new SubscriptionUpdater(
+      planIdMap,
+      'none',
+      100,
+      './update-subscriptions-to-new-plan.tmp.csv',
+      stripeHelperStub,
+      dbStub,
+      false,
+      20
+    );
+  });
+
+  describe('update', () => {
+    let fetchSubsBatchStub: sinon.SinonStub;
+    let processSubscriptionStub: sinon.SinonStub;
+    const mockSubs = [mockSubscription];
+
+    beforeEach(async () => {
+      fetchSubsBatchStub = sinon
+        .stub()
+        .onFirstCall()
+        .returns(mockSubs)
+        .onSecondCall()
+        .returns([]);
+      subscriptionUpdater.fetchSubsBatch = fetchSubsBatchStub;
+
+      processSubscriptionStub = sinon.stub();
+      subscriptionUpdater.processSubscription = processSubscriptionStub;
+
+      await subscriptionUpdater.update();
+    });
+
+    it('fetches subscriptions until no results', () => {
+      expect(fetchSubsBatchStub.callCount).eq(2);
+    });
+
+    it('generates a report for each applicable subscription', () => {
+      expect(processSubscriptionStub.callCount).eq(1);
+    });
+  });
+
+  describe('fetchSubsBatch', () => {
+    const mockSubscriptionId = 'mock-id';
+    let result: FirestoreSubscription[];
+
+    beforeEach(async () => {
+      firestoreGetStub.resolves({
+        docs: [
+          {
+            data: sinon.stub().returns(mockSubscription),
+          },
+        ],
+      });
+
+      result = await subscriptionUpdater.fetchSubsBatch(mockSubscriptionId);
+    });
+
+    it('returns a list of subscriptions from Firestore', () => {
+      sinon.assert.match(result, [mockSubscription]);
+    });
+  });
+
+  describe('processSubscription', () => {
+    const mockFirestoreSub = {
+      id: 'test',
+      customer: 'test',
+      plan: {
+        product: 'example-product',
+      },
+      status: 'active',
+    } as FirestoreSubscription;
+    const mockReport = ['mock-report'];
+    let logStub: sinon.SinonStub;
+    let updateSubscriptionStub: sinon.SinonStub;
+    let buildReport: sinon.SinonStub;
+    let writeReportStub: sinon.SinonStub;
+
+    beforeEach(async () => {
+      stripeStub.products.retrieve = sinon.stub().resolves(mockProduct);
+      subscriptionUpdater.fetchCustomer = sinon.stub().resolves(mockCustomer);
+      dbStub.account.resolves({
+        locale: 'en-US',
+      });
+      updateSubscriptionStub = sinon.stub().resolves();
+      subscriptionUpdater.updateSubscription = updateSubscriptionStub;
+      buildReport = sinon.stub().returns(mockReport);
+      subscriptionUpdater.buildReport = buildReport;
+      writeReportStub = sinon.stub().resolves();
+      subscriptionUpdater.writeReport = writeReportStub;
+      logStub = sinon.stub(console, 'log');
+    });
+
+    afterEach(() => {
+      logStub.restore();
+    });
+
+    describe('success', () => {
+      beforeEach(async () => {
+        await subscriptionUpdater.processSubscription(mockFirestoreSub);
+      });
+
+      it('updates subscription', () => {
+        expect(updateSubscriptionStub.calledWith(mockFirestoreSub)).true;
+      });
+
+      it('writes the report to disk', () => {
+        expect(writeReportStub.calledWith(mockReport)).true;
+      });
+    });
+
+    describe('dry run', () => {
+      beforeEach(async () => {
+        subscriptionUpdater.dryRun = true;
+        await subscriptionUpdater.processSubscription(mockFirestoreSub);
+      });
+
+      it('does not update subscription', () => {
+        expect(updateSubscriptionStub.calledWith(mockFirestoreSub)).false;
+      });
+
+      it('writes the report to disk', () => {
+        expect(writeReportStub.calledWith(mockReport)).true;
+      });
+    });
+
+    describe('invalid', () => {
+      it('aborts if customer does not exist', async () => {
+        subscriptionUpdater.fetchCustomer = sinon.stub().resolves(null);
+        await subscriptionUpdater.processSubscription(mockFirestoreSub);
+
+        expect(writeReportStub.notCalled).true;
+      });
+
+      it('aborts if account for customer does not exist', async () => {
+        dbStub.account.resolves(null);
+        await subscriptionUpdater.processSubscription(mockFirestoreSub);
+
+        expect(writeReportStub.notCalled).true;
+      });
+
+      it('does not move subscription if subscription is not in active state', async () => {
+        await subscriptionUpdater.processSubscription({
+          ...mockFirestoreSub,
+          status: 'canceled',
+        });
+
+        expect(updateSubscriptionStub.notCalled).true;
+        expect(writeReportStub.notCalled).true;
+      });
+    });
+  });
+
+  describe('fetchCustomer', () => {
+    let customerRetrieveStub: sinon.SinonStub;
+    let result: Stripe.Customer | Stripe.DeletedCustomer | null;
+
+    describe('customer exists', () => {
+      beforeEach(async () => {
+        customerRetrieveStub = sinon.stub().resolves(mockCustomer);
+        stripeStub.customers.retrieve = customerRetrieveStub;
+
+        result = await subscriptionUpdater.fetchCustomer(mockCustomer.id);
+      });
+
+      it('fetches customer from Stripe', () => {
+        expect(
+          customerRetrieveStub.calledWith(mockCustomer.id, {
+            expand: ['subscriptions'],
+          })
+        ).true;
+      });
+
+      it('returns customer', () => {
+        sinon.assert.match(result, mockCustomer);
+      });
+    });
+
+    describe('customer deleted', () => {
+      beforeEach(async () => {
+        const deletedCustomer = {
+          ...mockCustomer,
+          deleted: true,
+        };
+        customerRetrieveStub = sinon.stub().resolves(deletedCustomer);
+        stripeStub.customers.retrieve = customerRetrieveStub;
+
+        result = await subscriptionUpdater.fetchCustomer(mockCustomer.id);
+      });
+
+      it('returns null', () => {
+        sinon.assert.match(result, null);
+      });
+    });
+  });
+
+  describe('updateSubscription', () => {
+    let retrieveStub: sinon.SinonStub;
+    let updateStub: sinon.SinonStub;
+
+    beforeEach(async () => {
+      retrieveStub = sinon.stub().resolves(mockSubscription);
+      stripeStub.subscriptions.retrieve = retrieveStub;
+
+      updateStub = sinon.stub().resolves();
+      stripeStub.subscriptions.update = updateStub;
+
+      await subscriptionUpdater.updateSubscription(mockSubscription);
+    });
+
+    it('retrieves the subscription', () => {
+      expect(retrieveStub.calledWith(mockSubscription.id)).true;
+    });
+
+    it('updates the subscription', () => {
+      expect(
+        updateStub.calledWith(mockSubscription.id, {
+          proration_behavior: prorationBehavior,
+          items: [
+            {
+              id: mockSubscription.items.data[0].id,
+              plan: 'updated',
+            },
+          ],
+          metadata: {
+            previous_plan_id: mockSubscription.items.data[0].plan.id,
+            plan_change_date: sinon.match.number,
+          },
+        })
+      ).true;
+    });
+  });
+
+  describe('buildReport', () => {
+    it('returns a report', () => {
+      const result = subscriptionUpdater.buildReport(mockCustomer, mockAccount);
+
+      sinon.assert.match(result, [
+        mockCustomer.metadata.userid,
+        `"${mockCustomer.email}"`,
+        `"${mockAccount.locale}"`,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Because

* We need a way to migrate users to SP3 plan scheme.

## This pull request

* Adds a script that facilitates the migration of users from one plan to another given a mapping of plan IDs.

## Issue that this pull request solves

Closes FXA-8662