### PR TITLE
fix(a11y): remove alt text for decorative image

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -90,11 +90,7 @@ export const PaymentConfirmation = ({
         <header className="flex flex-col justify-center items-center row-divider-grey-200 text-center pb-8 mt-5 desktop:mt-2">
           {accountExists ? (
             <>
-              <img
-                className="max-h-12"
-                src={circledCheckbox}
-                alt="circled checkbox"
-              />
+              <img className="max-h-12" src={circledCheckbox} alt="" />
               <Localized id="payment-confirmation-thanks-heading">
                 <h2 className={h2classes}>Thank you!</h2>
               </Localized>


### PR DESCRIPTION
## Because

- Adjacent text explains the meaning, making the additional text unnecessary.

## This pull request

- Removes alt tag copy.

## Issue that this pull request solves

Closes: FXA-3047

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
