### PR TITLE
feat(settings): Automatically show third party auth modal from create password

### DIFF
--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -29,7 +29,7 @@ test.describe('severity-1 #smoke', () => {
 
     test('can remove TOTP from account and skip confirmation', async ({
       credentials,
-      pages: { login, relier, settings, totp },
+      pages: { login, relier, settings, totp, page },
     }) => {
       await settings.goto();
       await settings.totp.clickAdd();
@@ -37,8 +37,9 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.totp.clickDisable();
       await settings.clickModalConfirm();
-      await settings.waitForAlertBar();
-      let status = await settings.totp.statusText();
+      // wait for alert bar message
+      await page.getByText('Two-step authentication disabled').waitFor();
+      const status = await settings.totp.statusText();
       expect(status).toEqual('Not Set');
 
       await relier.goto();

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -16,7 +16,7 @@ test.describe('severity-1 #smoke', () => {
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1293452
     test('add and remove totp', async ({
       credentials,
-      pages: { settings, totp, login },
+      pages: { settings, totp, login, page },
     }) => {
       await settings.goto();
       let status = await settings.totp.statusText();
@@ -28,7 +28,8 @@ test.describe('severity-1 #smoke', () => {
       expect(status).toEqual('Enabled');
       await settings.totp.clickDisable();
       await settings.clickModalConfirm();
-      await settings.waitForAlertBar();
+      // wait for alert bar message
+      await page.getByText('Two-step authentication disabled').waitFor();
       status = await settings.totp.statusText();
       expect(status).toEqual('Not Set');
 

--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
@@ -19,9 +19,19 @@ export const typeClasses = {
 export const AlertBar = () => {
   const { l10n } = useLocalization();
   const visible = useReactiveVar(alertVisible);
-  const insideRef = useClickOutsideEffect<HTMLDivElement>(() =>
-    alertVisible(false)
-  );
+  const insideRef = useClickOutsideEffect<HTMLDivElement>(() => {
+    // TODO: cleanup Portal component and references, FXA-2463
+    // We don't want to automatically close the alert bar if a modal
+    // is also open. There's at least one case where a modal could be
+    // opened at the same time as the alert bar, and because the modal
+    // takes precedence, we want to allow the user to see and read the
+    // alert bar instead of closing them at the same time. We have to check
+    // for `innerHTML` because when a modal is closed it is still in the DOM.
+    if (!document.getElementById('modal')?.innerHTML) {
+      alertVisible(false);
+    }
+  });
+
   // Although `role="alert" is usually sufficient to trigger a screenreader
   // without having to reset focus, if this component is rerendered before
   // it's removed from the DOM, the message won't be read. Setting focus

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.test.tsx
@@ -4,19 +4,35 @@
 
 import React from 'react';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';
-import { Account, AppContext } from '../../../models';
+import { Account, AppContext, LinkedAccount } from '../../../models';
 import LinkedAccounts from '../LinkedAccounts';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
+import { LinkedAccountProviderIds } from '../../../lib/types';
+import { withLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 
-const account = {
+const MOCK_ACCOUNT = {
   hasPassword: true,
   linkedAccounts: MOCK_LINKED_ACCOUNTS,
 } as unknown as Account;
 
+const mockNavigate = jest.fn();
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation(),
+}));
+
+let mockLocationState = {};
+const mockLocation = () => {
+  return {
+    state: mockLocationState,
+  };
+};
+
 const clickUnlinkButton = async () => {
   await act(async () => {
-    const unlinkButtons = await screen.findAllByTestId('linked-account-unlink');
+    const unlinkButtons = await screen.findAllByTestId(/linked-account-unlink/);
     fireEvent.click(unlinkButtons[0]);
   });
 };
@@ -26,14 +42,33 @@ const clickConfirmUnlinkButton = async () => {
     fireEvent.click(confirmButton);
   });
 };
+
+// This directly modifies `account.linkedAccounts` for the account object
+// passed in to simulate a state update. Because it is mutable, be sure to
+// spread a new `linkedAccounts` array if referencing a constant. We also
+// have to force a re-render after account.unlinkThirdParty is called
+// because manual state updates to account.linkedAccounts from our mock
+// are not detected by React.
+const mockUnlinkThirdParty = (
+  providerId: LinkedAccountProviderIds,
+  account: Account
+) => {
+  const index = account.linkedAccounts.findIndex(
+    (linkedAcc: LinkedAccount) => linkedAcc.providerId === providerId
+  );
+  if (index !== -1) {
+    account.linkedAccounts.splice(index, 1);
+  }
+};
+
 describe('#integration - Linked Accounts', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
+  beforeEach(() => {
+    mockLocationState = {};
   });
 
   it('renders "fresh load" <LinkedAccounts/> with correct content', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account: MOCK_ACCOUNT })}>
         <LinkedAccounts />
       </AppContext.Provider>
     );
@@ -52,12 +87,15 @@ describe('#integration - Linked Accounts', () => {
       </AppContext.Provider>
     );
 
-    expect(screen.queryByTestId('linked-account')).toBeNull();
+    expect(
+      screen.queryByRole('heading', { name: 'Linked Accounts' })
+    ).toBeNull();
+    expect(screen.queryByTestId('settings-linked-account')).toBeNull();
   });
 
   it('renders proper modal when "unlink" is clicked', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account: MOCK_ACCOUNT })}>
         <LinkedAccounts />
       </AppContext.Provider>
     );
@@ -69,18 +107,23 @@ describe('#integration - Linked Accounts', () => {
   });
 
   it('on unlink, removes linked account', async () => {
-    const linkedAccounts = MOCK_LINKED_ACCOUNTS;
-
     const account = {
-      linkedAccounts,
-      unlinkThirdParty: () => account.linkedAccounts.shift(),
+      hasPassword: true,
+      linkedAccounts: [...MOCK_LINKED_ACCOUNTS],
+      unlinkThirdParty: (providerId: LinkedAccountProviderIds) =>
+        mockUnlinkThirdParty(providerId, account),
     } as unknown as Account;
 
-    renderWithRouter(
+    const ui = (
       <AppContext.Provider value={mockAppContext({ account })}>
         <LinkedAccounts />
       </AppContext.Provider>
     );
+    const { rerender } = renderWithRouter(ui);
+
+    const initialCount = (
+      await screen.findAllByTestId('settings-linked-account')
+    ).length;
 
     await clickUnlinkButton();
 
@@ -89,37 +132,49 @@ describe('#integration - Linked Accounts', () => {
     ).toBeInTheDocument();
 
     await clickConfirmUnlinkButton();
+    rerender(withLocalizationProvider(ui));
 
-    expect(screen.queryAllByTestId('linked-account')).toHaveLength(0);
+    expect(
+      await screen.findAllByTestId('settings-linked-account')
+    ).toHaveLength(initialCount - 1);
+  });
+
+  it('automatically opens corresponding provider ID modal if router state has wantsUnlinkProviderId', async () => {
+    mockLocationState = {
+      wantsUnlinkProviderId: LinkedAccountProviderIds.Apple,
+    };
+    const account = {
+      hasPassword: true,
+      linkedAccounts: [...MOCK_LINKED_ACCOUNTS],
+      unlinkThirdParty: (providerId: LinkedAccountProviderIds) =>
+        mockUnlinkThirdParty(providerId, account),
+    } as unknown as Account;
+
+    const ui = (
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <LinkedAccounts />
+      </AppContext.Provider>
+    );
+    const { rerender } = renderWithRouter(ui);
+
+    await waitFor(() => {
+      screen.getByText('Are you sure you want to unlink your account?', {
+        exact: false,
+      });
+    });
+    await clickConfirmUnlinkButton();
+    rerender(withLocalizationProvider(ui));
+
+    expect(screen.queryByLabelText('Apple')).not.toBeInTheDocument();
+    // Apple should be unlinked and Google auth should still be present
+    screen.getByLabelText('Google');
   });
 
   describe('account without password', () => {
     const accountWithoutPassword = {
       hasPassword: false,
-      linkedAccounts: MOCK_LINKED_ACCOUNTS,
+      linkedAccounts: [...MOCK_LINKED_ACCOUNTS],
     } as unknown as Account;
-
-    let mockHref = jest.fn();
-    let originalLocation = window.location;
-
-    beforeEach(() => {
-      mockHref = jest.fn();
-      Object.defineProperty(window, 'location', {
-        value: {
-          set href(val: string) {
-            mockHref(val);
-          },
-          get href() {
-            return mockHref();
-          },
-          search: '',
-        },
-      });
-    });
-
-    afterEach(() => {
-      Object.defineProperty(window, 'location', originalLocation);
-    });
 
     it('on unlink, directs user to create password flow', async () => {
       renderWithRouter(
@@ -132,7 +187,12 @@ describe('#integration - Linked Accounts', () => {
         </AppContext.Provider>
       );
 
-      await clickUnlinkButton();
+      fireEvent.click(
+        await screen.findByTestId(
+          `linked-account-unlink-${LinkedAccountProviderIds.Google}`
+        )
+      );
+
       expect(
         screen.queryByText(
           'Before unlinking your account, you must set a password. Without a password, there is no way for you to log in after unlinking your account.'
@@ -140,7 +200,10 @@ describe('#integration - Linked Accounts', () => {
       ).toBeInTheDocument();
 
       await clickConfirmUnlinkButton();
-      expect(mockHref).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/settings/create_password', {
+        replace: true,
+        state: { wantsUnlinkProviderId: LinkedAccountProviderIds.Google },
+      });
     });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { useAccount } from '../../../models';
 import { Localized } from '@fluent/react';
-import { LinkedAccount as LinkedAccountSection } from './LinkedAccount';
+import { LinkedAccount } from './LinkedAccount';
 
 export const LinkedAccounts = () => {
   const account = useAccount();
@@ -30,7 +30,7 @@ export const LinkedAccounts = () => {
             </div>
 
             {linkedAccounts.map((linkedAccount) => (
-              <LinkedAccountSection
+              <LinkedAccount
                 {...{
                   key: linkedAccount.providerId,
                   providerId: linkedAccount.providerId,

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/mocks.ts
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/mocks.ts
@@ -8,4 +8,9 @@ export const MOCK_LINKED_ACCOUNTS = [
     authAt: Date.now(),
     enabled: true,
   },
+  {
+    providerId: 2,
+    authAt: Date.now(),
+    enabled: true,
+  },
 ];

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.test.tsx
@@ -22,6 +22,7 @@ import {
 import { act, fireEvent, screen } from '@testing-library/react';
 import { HomePath } from '../../../constants';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
+import { LinkedAccountProviderIds } from '../../../lib/types';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -32,7 +33,15 @@ const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation(),
 }));
+
+let mockLocationState = {};
+const mockLocation = () => {
+  return {
+    state: mockLocationState,
+  };
+};
 
 const account = {
   primaryEmail: {
@@ -157,5 +166,23 @@ describe('PageCreatePassword', () => {
     });
     expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
     expect(alertBarInfo.success).toHaveBeenCalledWith('Password set');
+  });
+
+  describe('location state', () => {
+    afterEach(() => {
+      mockLocationState = {};
+    });
+    it('redirects with linked account state if present', async () => {
+      mockLocationState = {
+        wantsUnlinkProviderId: LinkedAccountProviderIds.Google,
+      };
+      await createPassword();
+      expect(mockNavigate).toHaveBeenCalledWith(HomePath + '#password', {
+        replace: true,
+        state: {
+          wantsUnlinkProviderId: LinkedAccountProviderIds.Google,
+        },
+      });
+    });
   });
 });

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -39,3 +39,11 @@ export enum ResendStatus {
   'sent',
   'error',
 }
+
+export enum LinkedAccountProviderIds {
+  Google = 1,
+  Apple = 2,
+}
+export type UnlinkAccountLocationState = {
+  wantsUnlinkProviderId?: LinkedAccountProviderIds;
+};

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -21,7 +21,7 @@ import Storage from '../lib/storage';
 import random from '../lib/random';
 import { AuthUiErrorNos, AuthUiErrors } from '../lib/auth-errors/auth-errors';
 import { GET_SESSION_VERIFIED } from './Session';
-import { MozServices } from '../lib/types';
+import { LinkedAccountProviderIds, MozServices } from '../lib/types';
 import { GET_LOCAL_SIGNED_IN_STATUS } from '../components/App/gql';
 
 export interface DeviceLocation {
@@ -38,7 +38,7 @@ export interface Email {
 }
 
 export interface LinkedAccount {
-  providerId: number;
+  providerId: LinkedAccountProviderIds;
   authAt: number;
   enabled: boolean;
 }


### PR DESCRIPTION
Because:
* We want to take users back to actions they attempted to perform. If a user wants to unlink their third party account but do not have a password set, we should not only link them to the create password page, but on successful password creation we should also take them back to Settings with the third party auth modal automatically open

This commit:
* Adds router/location state containing the third party provider ID to the create password page if a user opts to "Set password" from the initial modal
* Accounts for this new state in create password by sending it back to Settings only if the password is successfully created
* Checks for this location state in the LinkedAccount component to automatically open it
* Removes the hard navigate from LinkedAccount
* Adds tests and refactors LinkedAccount tests, as some were not testing what we intended and causing test pollution

closes FXA-8297