### PR TITLE
fix(react): Fix wantsTwoStepAuthentication check in oauth signup

### DIFF
--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -75,7 +75,7 @@ export class OAuthIntegrationData extends BaseIntegrationData {
 
   @IsOptional()
   @IsString()
-  @bind()
+  @bind(T.snakeCase)
   acrValues: string | undefined;
 
   // TODO - Validation - Double check actions

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -168,10 +168,6 @@ const ConfirmSignupCode = ({
         // to explain why totp setup is required, but this does not currently
         // appear to be implemented.
 
-        // TODO enable wantsTwoStepAuthentication check
-        // Currently, does not correctly check for acr_values param
-        // and is returned as false even if search params contain acr_values=AAL2 (or higher)
-
         // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
           hardNavigateToContentServer(`oauth/signin${location.search}`);


### PR DESCRIPTION
Because:
* We want users to be taken to the inline two-step auth setup flow if acr_values query param is set

This commit:
* Allows the param to be set if coming in as snake case

fixes FXA-8648

---
This value wasn't being saved on the integration due to it being snakecase.

You can test this by adding `acr_values=AAL2` param after clicking "Email first" from 123done and see how this behaves in content-server vs Settings before, and see it takes you to the same screens in React (add `forceExperiment=generalizedReactApp&forceExperimentGroup=react` on index page before hitting signup to see React) with this fix.