### PR TITLE
chore(payments): remove additional alt text for decorative images

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -105,8 +105,8 @@ export const PaymentConfirmation = ({
             </>
           ) : (
             <>
-              <img src={checkmarkIcon} alt="checkmark icon" />
-              <img src={emailSentIcon} alt="email sent icon" />
+              <img src={checkmarkIcon} alt="" />
+              <img src={emailSentIcon} alt="" />
               <Localized id="payment-confirmation-thanks-heading-account-exists">
                 <h2 className={h2classes}>Thanks, now check your email!</h2>
               </Localized>


### PR DESCRIPTION
## Because

- Adjacent text explains the meaning, making the additional text unnecessary.

## This pull request

- Removes alt tag copy in two additional places.

## Issue that this pull request solves

Closes: FXA-3047

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (optional)

Follow up to #16098 and https://github.com/mozilla/fxa/pull/16098#discussion_r1398339749 .
