### PR TITLE
feat(metrics): emit oauth_token_created backend Glean event

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -21,6 +21,7 @@ interface MetricsRequest extends Omit<AuthRequest, 'auth'> {
 type MetricsData = {
   uid?: string;
   reason?: string;
+  oauthClientId?: string;
 };
 
 type ErrorLoggerFnParams = {
@@ -44,8 +45,14 @@ const findUid = (request: MetricsRequest, metricsData?: MetricsData): string =>
 const sha256HashUid = (uid: string) =>
   createHash('sha256').update(uid).digest('hex');
 
-const findOauthClientId = (request: MetricsRequest): string =>
-  request.auth.credentials?.client_id || request.payload?.client_id || '';
+const findOauthClientId = (
+  request: MetricsRequest,
+  metricsData?: MetricsData
+): string =>
+  metricsData?.oauthClientId ||
+  request.auth.credentials?.client_id ||
+  request.payload?.client_id ||
+  '';
 
 const findServiceName = async (request: MetricsRequest) => {
   const metricsContext = await request.app.metricsContext;
@@ -90,7 +97,7 @@ const createEventFn =
         account_user_id_sha256: '',
         event_name: eventName,
         event_reason: metricsData?.reason || '',
-        relying_party_oauth_client_id: findOauthClientId(request),
+        relying_party_oauth_client_id: findOauthClientId(request, metricsData),
         relying_party_service: await findServiceName(request),
         session_device_type: request.app.ua.deviceType || '',
         session_entrypoint: metricsContext.entrypoint || '',
@@ -144,6 +151,10 @@ export function gleanMetrics(config: ConfigType) {
       createNewSuccess: createEventFn('password_reset_create_new_success'),
       accountReset: createEventFn('account_password_reset'),
       recoveryKeySuccess: createEventFn('password_reset_recovery_key_success'),
+    },
+
+    oauth: {
+      tokenCreated: createEventFn('oauth_token_created'),
     },
   };
 }

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -83,7 +83,8 @@ module.exports = function (
     db,
     mailer,
     devicesImpl,
-    statsd
+    statsd,
+    glean
   );
   const devicesSessions = require('./devices-and-sessions')(
     log,

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -1,6 +1,6 @@
 const oauthDB = require('../../oauth/db');
 
-module.exports = (log, config, db, mailer, devices, statsd) => {
+module.exports = (log, config, db, mailer, devices, statsd, glean) => {
   const routes = [
     require('./authorization')({ log, oauthDB, config }),
     require('./authorized-clients/destroy')({ oauthDB }),
@@ -11,7 +11,7 @@ module.exports = (log, config, db, mailer, devices, statsd) => {
     require('./introspect')({ oauthDB }),
     require('./jwks')(),
     require('./key_data')({ log, oauthDB, statsd }),
-    require('./token')({ log, oauthDB, db, mailer, devices, statsd }),
+    require('./token')({ log, oauthDB, db, mailer, devices, statsd, glean }),
     require('./verify')({ log }),
   ].flat();
 

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -178,6 +178,12 @@ describe('Glean server side events', () => {
         assert.equal(metrics['relying_party_oauth_client_id'], 'corny_jokes');
       });
 
+      it('uses the client id from the event data', async () => {
+        await glean.login.success(request, { oauthClientId: 'runny_eggs' });
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['relying_party_oauth_client_id'], 'runny_eggs');
+      });
+
       it('uses the service name from the metrics context', async () => {
         const req = {
           ...request,


### PR DESCRIPTION
Because:
 - we want to replace the legacy metrics events around oauth token creation

This commit:
 - emit a Glean event after generating tokens on the token endpoints
