### PR TITLE
feat(metrics): add access_token_checked backend Glean event

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -155,7 +155,8 @@ export function gleanMetrics(config: ConfigType) {
     },
 
     oauth: {
-      tokenCreated: createEventFn('oauth_token_created'),
+      tokenCreated: createEventFn('access_token_created'),
+      tokenChecked: createEventFn('access_token_checked'),
     },
   };
 }

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -12,7 +12,7 @@ module.exports = (log, config, db, mailer, devices, statsd, glean) => {
     require('./jwks')(),
     require('./key_data')({ log, oauthDB, statsd }),
     require('./token')({ log, oauthDB, db, mailer, devices, statsd, glean }),
-    require('./verify')({ log }),
+    require('./verify')({ log, glean }),
   ].flat();
 
   const clientGetAlias = require('./client/get')({ log, oauthDB });

--- a/packages/fxa-auth-server/lib/routes/oauth/verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/verify.js
@@ -10,7 +10,7 @@ const validators = require('../../oauth/validators');
 const OAUTH_SERVER_DOCS =
   require('../../../docs/swagger/oauth-server-api').default;
 
-module.exports = ({ log }) => ({
+module.exports = ({ log, glean }) => ({
   method: 'POST',
   path: '/verify',
   config: {
@@ -42,6 +42,10 @@ module.exports = ({ log }) => ({
       req.emitMetricsEvent('verify.success', {
         service: info.client_id,
         uid: info.user,
+      });
+      glean.oauth.tokenChecked(req, {
+        uid: info.user,
+        oauthClientId: info.client_id,
       });
       return info;
     },

--- a/packages/fxa-auth-server/test/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/test/oauth/routes/verify.js
@@ -40,6 +40,9 @@ describe('/verify POST', () => {
           })
         ),
       },
+      glean: {
+        oauth: { tokenChecked: sandbox.stub() },
+      },
     };
 
     dependencies = {
@@ -49,7 +52,7 @@ describe('/verify POST', () => {
     route = proxyquire(
       '../../../lib/routes/oauth/verify',
       dependencies
-    )({ log: mocks.log });
+    )({ log: mocks.log, glean: mocks.glean });
   });
 
   afterEach(() => {
@@ -111,6 +114,13 @@ describe('/verify POST', () => {
           uid: 'bar',
         })
       );
+    });
+
+    it('logs an Glean event', () => {
+      sinon.assert.calledOnceWithExactly(mocks.glean.oauth.tokenChecked, req, {
+        uid: 'bar',
+        oauthClientId: 'foo',
+      });
     });
   });
 });


### PR DESCRIPTION
Because:
 - we want to replace the legacy access_token_checked events with Glean events

This commmit:
 - adds the access_token_checked backend Glean event to the verify token endpoint
