### PR TITLE
fxa(metrics): Add glean metrics for reset password with recovery key

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -145,6 +145,10 @@ export function gleanMetrics(config: ConfigType) {
       createNewSuccess: createEventFn('password_reset_create_new_success'),
       accountReset: createEventFn('account_password_reset'),
       recoveryKeySuccess: createEventFn('password_reset_recovery_key_success'),
+
+      recoveryKeyCreatePasswordSuccess: createEventFn(
+        'password_reset_recovery_key_create_success'
+      ),
     },
   };
 }

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1361,6 +1361,11 @@ export class AccountHandler {
         this.glean.resetPassword.createNewSuccess(request, {
           uid: account.uid,
         }),
+        recoveryKeyId
+          ? this.glean.resetPassword.recoveryKeyCreatePasswordSuccess(request, {
+              uid: account.uid,
+            })
+          : Promise.resolve(),
         this.log.notifyAttachedServices('reset', request, {
           uid: account.uid,
           generation: account.verifierSetAt,

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -311,6 +311,13 @@ describe('/account/reset', () => {
       assert.equal(mockMetricsContext.validate.callCount, 0);
       assert.equal(mockMetricsContext.setFlowCompleteSignal.callCount, 0);
       assert.equal(mockMetricsContext.propagate.callCount, 2);
+      sinon.assert.calledOnceWithExactly(
+        glean.resetPassword.recoveryKeyCreatePasswordSuccess,
+        mockRequest,
+        {
+          uid,
+        }
+      );
     });
 
     it('should have created session', () => {

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -116,10 +116,10 @@ describe('lib/glean', () => {
 
     it('does not submit a ping on an event', async () => {
       GleanMetrics.registration.view();
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           sinon.assert.notCalled(submitPingStub);
-          resovle(undefined);
+          resolve(undefined);
         }, 80)
       );
     });
@@ -127,7 +127,7 @@ describe('lib/glean', () => {
     it('does not set the metrics values', async () => {
       GleanMetrics.registration.view();
 
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           sinon.assert.notCalled(setOauthClientIdStub);
           sinon.assert.notCalled(setServiceStub);
@@ -141,7 +141,7 @@ describe('lib/glean', () => {
           sinon.assert.notCalled(setUtmMediumStub);
           sinon.assert.notCalled(setUtmSourceStub);
           sinon.assert.notCalled(setUtmTermStub);
-          resovle(undefined);
+          resolve(undefined);
         }, 80)
       );
     });
@@ -156,10 +156,10 @@ describe('lib/glean', () => {
       expect(config.enabled).toBe(false);
       GleanMetrics.registration.view();
 
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           sinon.assert.notCalled(setuserIdSha256Stub);
-          resovle(undefined);
+          resolve(undefined);
         }, 20)
       );
     });
@@ -194,10 +194,10 @@ describe('lib/glean', () => {
 
     it('submits a ping on an event', async () => {
       GleanMetrics.registration.view();
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           sinon.assert.calledOnce(submitPingStub);
-          resovle(undefined);
+          resolve(undefined);
         }, 20)
       );
     });
@@ -213,7 +213,7 @@ describe('lib/glean', () => {
       );
       GleanMetrics.registration.view();
 
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           sinon.assert.calledWith(setuserIdSha256Stub, '');
 
@@ -229,7 +229,7 @@ describe('lib/glean', () => {
           sinon.assert.calledWith(setUtmMediumStub, '');
           sinon.assert.calledWith(setUtmSourceStub, '');
           sinon.assert.calledWith(setUtmTermStub, '');
-          resovle(undefined);
+          resolve(undefined);
         }, 20)
       );
     });
@@ -242,7 +242,7 @@ describe('lib/glean', () => {
 
       GleanMetrics.registration.view();
 
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           sinon.assert.calledWith(
             setOauthClientIdStub,
@@ -274,7 +274,7 @@ describe('lib/glean', () => {
             mockIntegration.data.utmSource
           );
           sinon.assert.calledWith(setUtmTermStub, mockIntegration.data.utmTerm);
-          resovle(undefined);
+          resolve(undefined);
         }, 20)
       );
     });
@@ -286,7 +286,7 @@ describe('lib/glean', () => {
       GleanMetrics.registration.success();
 
       // the ping submissions are await'd internally in GleanMetrics...
-      await new Promise((resovle) =>
+      await new Promise((resolve) =>
         setTimeout(() => {
           // the set name call is after the await of the ping ahead of it...
           expect(
@@ -301,7 +301,7 @@ describe('lib/glean', () => {
               .calledBefore(setEventNameStub.getCall(2))
           ).toBeTruthy();
 
-          resovle(true);
+          resolve(true);
         }, 80)
       );
     });
@@ -313,7 +313,7 @@ describe('lib/glean', () => {
         >;
         GleanMetrics.login.success();
         // the ping submissions are await'd internally in GleanMetrics...
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledTwice(setuserIdSha256Stub);
             // it sets a default of '' first
@@ -322,7 +322,7 @@ describe('lib/glean', () => {
               setuserIdSha256Stub,
               '7ca0172850c53065046beeac3cdec3fe921532dbfebdf7efeb5c33d019cd7798'
             );
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
@@ -331,11 +331,11 @@ describe('lib/glean', () => {
     describe('email first', () => {
       it('submits a ping with the email_first_view event name', async () => {
         GleanMetrics.emailFirst.view();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'email_first_view');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
@@ -345,33 +345,33 @@ describe('lib/glean', () => {
       it('submits a ping with the reg_view event name', async () => {
         GleanMetrics.registration.view();
 
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'reg_view');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the reg_submit event name', async () => {
         GleanMetrics.registration.submit();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'reg_submit');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the reg_submit_success event name', async () => {
         GleanMetrics.registration.success();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'reg_submit_success');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
@@ -380,22 +380,22 @@ describe('lib/glean', () => {
     describe('signup confirmation code', () => {
       it('submits a ping with the reg_signup_code_view event name', async () => {
         GleanMetrics.signupConfirmation.view();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'reg_signup_code_view');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the reg_signup_code_submit event name', async () => {
         GleanMetrics.signupConfirmation.submit();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'reg_signup_code_submit');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
@@ -404,28 +404,28 @@ describe('lib/glean', () => {
     describe('loginConfirmation', () => {
       it('submits a ping with the login_email_confirmation_view event name', async () => {
         GleanMetrics.loginConfirmation.view();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(
               setEventNameStub,
               'login_email_confirmation_view'
             );
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the reg_submit event name', async () => {
         GleanMetrics.loginConfirmation.submit();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(
               setEventNameStub,
               'login_email_confirmation_submit'
             );
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
@@ -434,36 +434,36 @@ describe('lib/glean', () => {
     describe('totpForm', () => {
       it('submits a ping with the login_totp_form_view event name', async () => {
         GleanMetrics.totpForm.view();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'login_totp_form_view');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the login_totp_code_submit event name', async () => {
         GleanMetrics.totpForm.submit();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'login_totp_code_submit');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the login_totp_code_success_view event name', async () => {
         GleanMetrics.totpForm.success();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(
               setEventNameStub,
               'login_totp_code_success_view'
             );
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
@@ -472,40 +472,40 @@ describe('lib/glean', () => {
     describe('login', () => {
       it('submits a ping with the login_view event name', async () => {
         GleanMetrics.login.view();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'login_view');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the login_submit event name', async () => {
         GleanMetrics.login.submit();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'login_submit');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the login_submit_success event name', async () => {
         GleanMetrics.login.success();
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(setEventNameStub, 'login_submit_success');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });
 
       it('submits a ping with the login_submit_frontend_error event name and a reason', async () => {
         GleanMetrics.login.error({ reason: 'quux' });
-        await new Promise((resovle) =>
+        await new Promise((resolve) =>
           setTimeout(() => {
             sinon.assert.calledOnce(setEventNameStub);
             sinon.assert.calledWith(
@@ -514,7 +514,7 @@ describe('lib/glean', () => {
             );
             sinon.assert.calledOnce(setEventReasonStub);
             sinon.assert.calledWith(setEventReasonStub, 'quux');
-            resovle(undefined);
+            resolve(undefined);
           }, 20)
         );
       });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -30,6 +30,17 @@ import {
 } from './mocks';
 import { AccountRecoveryResetPasswordBaseIntegration } from './interfaces';
 
+import GleanMetrics from '../../../lib/glean';
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    resetPassword: {
+      recoveryKeyCreatePasswordView: jest.fn(),
+      recoveryKeyCreatePasswordSubmit: jest.fn(),
+    },
+  },
+}));
+
 const mockUseNavigateWithoutRerender = jest.fn();
 
 jest.mock('../../../lib/hooks/useNavigateWithoutRerender', () => ({
@@ -207,6 +218,9 @@ describe('AccountRecoveryResetPassword page', () => {
         'account-recovery-reset-password',
         REACT_ENTRYPOINT
       );
+      expect(
+        GleanMetrics.resetPassword.recoveryKeyCreatePasswordView
+      ).toHaveBeenCalled();
     });
 
     it('displays password requirements when the new password field is in focus', async () => {
@@ -242,6 +256,9 @@ describe('AccountRecoveryResetPassword page', () => {
         viewName,
         'verification.success'
       );
+      expect(
+        GleanMetrics.resetPassword.recoveryKeyCreatePasswordSubmit
+      ).toHaveBeenCalled();
     });
 
     it('calls account API methods', () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -34,6 +34,7 @@ import {
 } from './interfaces';
 import { CreateVerificationInfo } from '../../../models/verification';
 import firefox from '../../../lib/channels/firefox';
+import GleanMetrics from '../../../lib/glean';
 
 // This page is based on complete_reset_password but has been separated to align with the routes.
 
@@ -47,6 +48,7 @@ const AccountRecoveryResetPassword = ({
   integration,
 }: AccountRecoveryResetPasswordProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  GleanMetrics.resetPassword.recoveryKeyCreatePasswordView();
 
   const account = useAccount();
   const navigate = useNavigate();
@@ -192,6 +194,7 @@ const AccountRecoveryResetPassword = ({
   async function onSubmit(data: AccountRecoveryResetPasswordFormData) {
     const password = data.newPassword;
     const email = verificationInfo.email;
+    GleanMetrics.resetPassword.recoveryKeyCreatePasswordSubmit();
 
     try {
       const options = {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -17,10 +17,20 @@ import {
   createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopIntegration,
   createMockResetPasswordWithRecoveryKeyVerifiedWebIntegration,
 } from './mocks';
+import GleanMetrics from '../../../lib/glean';
 
 jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
   usePageViewEvent: jest.fn(),
+}));
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    resetPassword: {
+      recoveryKeyResetSuccessView: jest.fn(),
+    },
+  },
 }));
 
 afterEach(() => {
@@ -122,5 +132,8 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
       'continue-to-account',
       REACT_ENTRYPOINT
     );
+    expect(
+      GleanMetrics.resetPassword.recoveryKeyResetSuccessView
+    ).toHaveBeenCalled();
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -5,12 +5,13 @@
 import React from 'react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { logViewEvent } from '../../../lib/metrics';
+import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import Ready from '../../../components/Ready';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import AppLayout from '../../../components/AppLayout';
 import { useFtlMsgResolver } from '../../../models';
 import { ResetPasswordWithRecoveryKeyVerifiedProps } from './interfaces';
+import GleanMetrics from '../../../lib/glean';
 
 export const viewName = 'reset-password-with-recovery-key-verified';
 
@@ -23,6 +24,9 @@ const ResetPasswordWithRecoveryKeyVerified = ({
   isSignedIn,
   integration,
 }: ResetPasswordWithRecoveryKeyVerifiedProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  GleanMetrics.resetPassword.recoveryKeyResetSuccessView();
+
   const navigate = useNavigate();
 
   const ftlMsgResolver = useFtlMsgResolver();

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -72,5 +72,13 @@ export const eventsMap = {
     createNewSuccess: 'password_reset_create_new_success_view',
     recoveryKeyView: 'password_reset_recovery_key_view',
     recoveryKeySubmit: 'password_reset_recovery_key_submit',
+
+    recoveryKeyCreatePasswordView:
+      'password_reset_recovery_key_create_new_view',
+    recoveryKeyCreatePasswordSubmit:
+      'password_reset_recovery_key_create_new_submit',
+
+    recoveryKeyResetSuccessView:
+      'password_reset_recovery_key_create_success_view',
   },
 };


### PR DESCRIPTION
## Because

- We need to instrutment our reset password with recovery key React pages

## This pull request

- Adds Glean metrics for reset password with recovery key
  - Views the change password screen with valid recovery key `password_reset_recovery_key_create_new_view`
  - Submits for on the change password screen after entering valid recovery key `password_reset_recovery_key_create_new_submit`
  - Views the successful password changed with valid recovery key `password_reset_recovery_key_create_success_view`
- Backend Glean metric when user completes reset password with recovery key `password_reset_recovery_key_create_success`

## Issue that this pull request solves


Closes: https://mozilla-hub.atlassian.net/browse/FXA-8574
Closes: https://mozilla-hub.atlassian.net/browse/FXA-8575
Closes: https://mozilla-hub.atlassian.net/browse/FXA-8576
Closes: https://mozilla-hub.atlassian.net/browse/FXA-8577

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
