### PR TITLE
fix(signup): Enable sync success message from React

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -14,7 +14,7 @@ test.describe('severity-1 #smoke', () => {
 
     test.beforeEach(async ({ pages: { configPage, login } }) => {
       test.slow();
-      // Ensure that the feature flag is enabled
+      // Ensure that the feature flag is enabled else skip react tests
       const config = await configPage.getConfig();
       if (config.showReactApp.signUpRoutes !== true) {
         test.skip();
@@ -167,11 +167,12 @@ test.describe('severity-1 #smoke', () => {
 
       await signupReact.fillOutCodeForm(code);
 
-      // TODO this test is currently failing - remove this line once fixed
+      // TODO code verification is currently throwing an UNAUTHORIZED error
+      // remove the following line once this error is no longer thrown
       // expect(await page.getByText(/Invalid token/).isVisible()).toBeFalsy();
       // TODO uncomment these lines once line above is passing (no token error)
+      // await page.waitForURL(/connect_another_device/);
       // expect(await page.getByText('Youʼre signed into Firefox').isVisible()).toBeTruthy();
-      // expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
 
       await syncBrowserPages.browser?.close();
     });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -155,9 +155,9 @@ const ConfirmSignupCode = ({
 
       if (isSyncDesktopIntegration(integration)) {
         // Connect another device tells Sync the user is signed in
-        hardNavigateToContentServer(
-          `/connect_another_device${location.search}`
-        );
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('showSuccessMessage', 'true');
+        hardNavigateToContentServer(`/connect_another_device?${searchParams}`);
       } else if (isOAuthIntegration(integration)) {
         // Check to see if the relier wants TOTP.
         // Newly created accounts wouldn't have this so lets redirect them to signin.


### PR DESCRIPTION
## Because

- Success message was not displayed on connect_another_device when arriving from React

## This pull request

- Pass required search param to enable message

## Issue that this pull request solves

Closes: #FXA-8669

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Follow up filed for failing Playwright sync test: https://mozilla-hub.atlassian.net/browse/FXA-8763
