### PR TITLE
fix(content): Styling of device details

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/auth_wait_for_supp.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/auth_wait_for_supp.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card pair-auth">
+<div class="card">
   <header>
     <h1 id="fxa-pair-auth-wait-for-supp-header" class="card-header">
       {{#unsafeTranslate}}Approval now required <small class="card-subheader">from your other device</small>{{/unsafeTranslate}}

--- a/packages/fxa-content-server/app/scripts/templates/pair/supp_wait_for_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/supp_wait_for_auth.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card">
+<div class="card">
   <header>
     <h1 id="fxa-pair-supp-wait-for-auth-header" class="card-header">
       {{#unsafeTranslate}}Approval now required <small class="card-subheader">from your other device</small>{{/unsafeTranslate}}

--- a/packages/fxa-content-server/app/scripts/templates/push/completed.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/push/completed.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card pair-auth push-auth-complete">
+<div class="card">
   <header>
     <h1 id="push-auth-complete-header" class="card-header">{{#t}}Sign-in confirmed{{/t}}</h1>
   </header>

--- a/packages/fxa-content-server/app/scripts/templates/push/confirm_login.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/push/confirm_login.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card push-confirm-login">
+<div class="card push-confirm-login">
   <header>
     <h1 id="fxa-push-confirm-login-header">{{#t}}New sign-in to Firefox{{/t}}</h1>
   </header>

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -146,14 +146,6 @@
   }
 }
 
-.pair-auth {
-  h1 {
-    > small {
-      display: block;
-    }
-  }
-}
-
 .qr-code-container {
   margin: 40px 0;
 }


### PR DESCRIPTION
## Because

* Header styling had been fixed for the pair pages, but margins were still too big on device details

## This pull request

* Remove unused `main-content` id that was pulling in styles we didn't want

## Issue that this pull request solves

Issue: #FXA-8585

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://github.com/mozilla/fxa/assets/22231637/1a5b3c8b-65ec-4bc6-9482-5cd6637a2555)

After:
![image](https://github.com/mozilla/fxa/assets/22231637/6aa629e8-a067-4ab1-87d1-9bce453d013c)

## Other information (Optional)

Reference: main-content only served stylistic purposes and is no longer needed according to [this Tailwind README](https://github.com/mozilla/fxa/blob/0323bb5ae74cb717fdc6336f4c9824812a7939b9/packages/fxa-content-server/app/styles/tailwind/README.md?plain=1#L13C3-L13C3)
