### PR TITLE
fix(auth): Disable GET recoveryKey/hint route

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1284,16 +1284,16 @@ export default class AuthClient {
     );
   }
 
-  // TODO: Update to POST in FXA-7400
-  async getRecoveryKeyHint(
-    sessionToken: hexstring | undefined,
-    email?: string
-  ): Promise<{ hint: string | null }> {
-    if (sessionToken) {
-      return this.sessionGet('/recoveryKey/hint', sessionToken);
-    }
-    return this.request('GET', `/recoveryKey/hint?email=${email}`);
-  }
+  // TODO: Review in FXA-7400 - possibly convert to POST to pass payload instead of using param, and enforce rate limiting
+  // async getRecoveryKeyHint(
+  //   sessionToken: hexstring | undefined,
+  //   email?: string
+  // ): Promise<{ hint: string | null }> {
+  //   if (sessionToken) {
+  //     return this.sessionGet('/recoveryKey/hint', sessionToken);
+  //   }
+  //   return this.request('GET', `/recoveryKey/hint?email=${email}`);
+  // }
 
   async updateRecoveryKeyHint(
     sessionToken: hexstring,

--- a/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
@@ -54,15 +54,20 @@ const RECOVERYKEY_VERIFY_POST = {
   notes: ['🔒 Authenticated with session token'],
 };
 
-// TODO: Update to POST in FXA-7400
-const RECOVERYKEY_HINT_GET = {
-  ...TAGS_RECOVERY_KEY,
-  description: '/recoveryKey/hint',
-  notes: [
-    '🔒🔓 Optionally authenticated with session token',
-    'Retrieves the hint (if any) for a userʼs recovery key.',
-  ],
-};
+// This method is not yet in use
+// Disabled until we are ready to enable as part of FXA-6670
+// GET request for authenticated user should use the sessionToken for authentication
+// To display the hint during password reset, this method will need to be usable without authenticating,
+// but unauthenticated requests should be rate limited by IP and email to prevent checking multiple emails for hints
+// TODO: Review in FXA-7400 - possibly convert to POST to pass payload instead of using param, and enforce rate limiting
+// const RECOVERYKEY_HINT_GET = {
+//   ...TAGS_RECOVERY_KEY,
+//   description: '/recoveryKey/hint',
+//   notes: [
+//     '🔒🔓 Optionally authenticated with session token',
+//     'Retrieves the hint (if any) for a userʼs recovery key.',
+//   ],
+// };
 
 const RECOVERYKEY_HINT_POST = {
   ...TAGS_RECOVERY_KEY,
@@ -79,7 +84,7 @@ const API_DOCS = {
   RECOVERYKEY_POST,
   RECOVERYKEY_RECOVERYKEYID_GET,
   RECOVERYKEY_VERIFY_POST,
-  RECOVERYKEY_HINT_GET,
+  // RECOVERYKEY_HINT_GET,
   RECOVERYKEY_HINT_POST,
 };
 

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -336,59 +336,65 @@ module.exports = (
         return db.recoveryKeyExists(uid);
       },
     },
-    // TODO : Refactor API method to use POST and pass email as payload instead of query param in FXA-7400
-    {
-      method: 'GET',
-      path: '/recoveryKey/hint',
-      options: {
-        ...RECOVERY_KEY_DOCS.RECOVERYKEY_HINT_GET,
-        auth: {
-          mode: 'optional',
-          strategy: 'sessionToken',
-        },
-        validate: {
-          query: {
-            email: validators.email().optional(),
-          },
-        },
-      },
-      handler: async function (request) {
-        log.begin('getRecoveryKeyHint', request);
+    // This method is not yet in use
+    // Disabled until we are ready to enable as part of FXA-6670
+    // GET request for authenticated user should use the sessionToken to display the hint in /settings
+    // To display the hint during password reset, this method will need to be usable without authenticating,
+    // but unauthenticated requests should be rate limited by IP and email to prevent checking multiple emails for hints
+    // TODO : Review in FXA-7400 - possibly convert to POST to pass payload instead of using param, and enforce rate limiting
+    // {
+    //   method: 'GET',
+    //   path: '/recoveryKey/hint',
+    //   options: {
+    //     ...RECOVERY_KEY_DOCS.RECOVERYKEY_HINT_GET,
+    //     auth: {
+    //       mode: 'optional',
+    //       strategy: 'sessionToken',
+    //     },
+    //     validate: {
+    //       query: {
+    //         email: validators.email().optional(),
+    //       },
+    //     },
+    //   },
+    //   handler: async function (request) {
+    //     log.begin('getRecoveryKeyHint', request);
 
-        const { email } = request.query;
+    //     const { email } = request.query;
 
-        let uid;
-        if (request.auth.credentials) {
-          uid = request.auth.credentials.uid;
-        }
+    //     let uid;
+    //     if (request.auth.credentials) {
+    //       uid = request.auth.credentials.uid;
+    //     }
 
-        if (!uid) {
-          // If not using a sessionToken, an email is required to check
-          // for an account recovery key.
-          if (!email) {
-            throw errors.missingRequestParameter('email');
-          }
+    //     if (!uid) {
+    //       // If not using a sessionToken, an email is required to check
+    //       // for an account recovery key.
+    //       if (!email) {
+    //         throw errors.missingRequestParameter('email');
+    //       }
 
-          // When this request is unauthenticated, we rate-limit
-          await customs.check(request, email, 'recoveryKeyExists');
-          try {
-            const result = await db.accountRecord(email);
-            uid = result.uid;
-          } catch (err) {
-            throw errors.unknownAccount();
-          }
-        }
+    //       // When this request is unauthenticated, we must rate-limit by IP and email
+    //       // to review in FXA-7400, rate limiting does not seem to be working as expected
+    //       await customs.check(request, email, 'recoveryKeyExists');
+    //       try {
+    //         const result = await db.accountRecord(email);
+    //         uid = result.uid;
+    //       } catch (err) {
+    //         throw errors.unknownAccount();
+    //       }
+    //     }
 
-        const result = await db.recoveryKeyExists(uid);
-        if (!result.exists) {
-          throw errors.recoveryKeyNotFound();
-        }
+    //     const result = await db.recoveryKeyExists(uid);
+    //     if (!result.exists) {
+    //       throw errors.recoveryKeyNotFound();
+    //     }
 
-        const hint = await db.getRecoveryKeyHint(uid);
+    //     const hint = await db.getRecoveryKeyHint(uid);
 
-        return hint;
-      },
-    },
+    //     return hint;
+    //   },
+    // },
     {
       method: 'POST',
       path: '/recoveryKey/hint',

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -749,217 +749,219 @@ describe('DELETE /recoveryKey', () => {
   });
 });
 
-// TODO: Update to POST in FXA-7400
-describe('GET /recoveryKey/hint', () => {
-  describe('should fail when provided with no session token or email', () => {
-    beforeEach(() => {
-      const requestOptions = {
-        method: 'GET',
-        log,
-      };
-      return setup(
-        { db: { uid, email, recoveryData, hint } },
-        {},
-        '/recoveryKey/hint',
-        requestOptions
-      ).then(assert.fail, (err) => (response = err));
-    });
+// TODO: FXA-7400 - Enable these tests
+// describe('GET /recoveryKey/hint', () => {
+//   describe('should fail when provided with no session token or email', () => {
+//     beforeEach(() => {
+//       const requestOptions = {
+//         method: 'GET',
+//         log,
+//       };
+//       return setup(
+//         { db: { uid, email, recoveryData, hint } },
+//         {},
+//         '/recoveryKey/hint',
+//         requestOptions
+//       ).then(assert.fail, (err) => (response = err));
+//     });
 
-    it('returned the correct response', () => {
-      assert.equal(
-        response.errno,
-        errors.ERRNO.MISSING_PARAMETER,
-        'Missing parameter: email'
-      );
-    });
+//     it('returned the correct response', () => {
+//       assert.equal(
+//         response.errno,
+//         errors.ERRNO.MISSING_PARAMETER,
+//         'Missing parameter: email'
+//       );
+//     });
 
-    it('called log.begin correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        log.begin,
-        'getRecoveryKeyHint',
-        request
-      );
-    });
-  });
+//     it('called log.begin correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         log.begin,
+//         'getRecoveryKeyHint',
+//         request
+//       );
+//     });
+//   });
 
-  describe('should fail when there is no account associated with the email', () => {
-    beforeEach(() => {
-      const requestOptions = {
-        method: 'GET',
-        query: { email: email },
-        log,
-      };
-      return setup({}, {}, '/recoveryKey/hint', requestOptions).then(
-        assert.fail,
-        (err) => (response = err)
-      );
-    });
+//   describe('should fail when there is no account associated with the email', () => {
+//     beforeEach(() => {
+//       const requestOptions = {
+//         method: 'GET',
+//         query: { email: email },
+//         log,
+//       };
+//       return setup({}, {}, '/recoveryKey/hint', requestOptions).then(
+//         assert.fail,
+//         (err) => (response = err)
+//       );
+//     });
 
-    it('returned the correct response', () => {
-      assert.equal(
-        response.errno,
-        errors.ERRNO.ACCOUNT_UNKNOWN,
-        'Unknown account'
-      );
-    });
+//     it('returned the correct response', () => {
+//       assert.equal(
+//         response.errno,
+//         errors.ERRNO.ACCOUNT_UNKNOWN,
+//         'Unknown account'
+//       );
+//     });
 
-    it('called log.begin correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        log.begin,
-        'getRecoveryKeyHint',
-        request
-      );
-    });
+//     it('called log.begin correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         log.begin,
+//         'getRecoveryKeyHint',
+//         request
+//       );
+//     });
 
-    it('called customs.check correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        customs.check,
-        request,
-        email,
-        'recoveryKeyExists'
-      );
-    });
-  });
+//     it('called customs.check correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         customs.check,
+//         request,
+//         email,
+//         'recoveryKeyExists'
+//       );
+//     });
+//   });
 
-  describe('should fail for unknown recovery key when provided with a session token', () => {
-    beforeEach(() => {
-      const requestOptions = {
-        method: 'GET',
-        credentials: { uid, email },
-        log,
-      };
-      return setup(
-        { db: { uid, email } },
-        {},
-        '/recoveryKey/hint',
-        requestOptions
-      ).then(assert.fail, (err) => (response = err));
-    });
+//   describe('should fail for unknown recovery key when provided with a session token', () => {
+//     beforeEach(() => {
+//       const requestOptions = {
+//         method: 'GET',
+//         credentials: { uid, email },
+//         log,
+//       };
+//       return setup(
+//         { db: { uid, email } },
+//         {},
+//         '/recoveryKey/hint',
+//         requestOptions
+//       ).then(assert.fail, (err) => (response = err));
+//     });
 
-    it('returned the correct response', () => {
-      assert.equal(
-        response.errno,
-        errors.ERRNO.RECOVERY_KEY_NOT_FOUND,
-        'Account recovery key not found'
-      );
-    });
+//     it('returned the correct response', () => {
+//       assert.equal(
+//         response.errno,
+//         errors.ERRNO.RECOVERY_KEY_NOT_FOUND,
+//         'Account recovery key not found'
+//       );
+//     });
 
-    it('called log.begin correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        log.begin,
-        'getRecoveryKeyHint',
-        request
-      );
-    });
-  });
+//     it('called log.begin correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         log.begin,
+//         'getRecoveryKeyHint',
+//         request
+//       );
+//     });
+//   });
 
-  describe('should fail for unknown recovery key when provided with an email', () => {
-    beforeEach(() => {
-      const requestOptions = {
-        method: 'GET',
-        query: { email: email },
-        log,
-      };
-      return setup(
-        { db: { uid, email } },
-        {},
-        '/recoveryKey/hint',
-        requestOptions
-      ).then(assert.fail, (err) => (response = err));
-    });
+//   describe('should fail for unknown recovery key when provided with an email', () => {
+//     beforeEach(() => {
+//       const requestOptions = {
+//         method: 'GET',
+//         query: { email: email },
+//         log,
+//       };
+//       return setup(
+//         { db: { uid, email } },
+//         {},
+//         '/recoveryKey/hint',
+//         requestOptions
+//       ).then(assert.fail, (err) => (response = err));
+//     });
 
-    it('returned the correct response', () => {
-      assert.equal(
-        response.errno,
-        errors.ERRNO.RECOVERY_KEY_NOT_FOUND,
-        'Account recovery key not found'
-      );
-    });
+//     it('returned the correct response', () => {
+//       assert.equal(
+//         response.errno,
+//         errors.ERRNO.RECOVERY_KEY_NOT_FOUND,
+//         'Account recovery key not found'
+//       );
+//     });
 
-    it('called log.begin correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        log.begin,
-        'getRecoveryKeyHint',
-        request
-      );
-    });
+//     it('called log.begin correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         log.begin,
+//         'getRecoveryKeyHint',
+//         request
+//       );
+//     });
 
-    it('called customs.check correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        customs.check,
-        request,
-        email,
-        'recoveryKeyExists'
-      );
-    });
-  });
+//     it('called customs.check correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         customs.check,
+//         request,
+//         email,
+//         'recoveryKeyExists'
+//       );
+//     });
+//   });
 
-  describe('should retrieve the recovery key hint using sessionToken', () => {
-    beforeEach(() => {
-      const requestOptions = {
-        credentials: { uid, email },
-        log,
-      };
-      return setup(
-        { db: { recoveryData, hint } },
-        {},
-        '/recoveryKey/hint',
-        requestOptions
-      ).then((r) => (response = r));
-    });
+//   describe('should retrieve the recovery key hint using sessionToken', () => {
+//     beforeEach(() => {
+//       const requestOptions = {
+//         credentials: { uid, email },
+//         log,
+//       };
+//       return setup(
+//         { db: { recoveryData, hint } },
+//         {},
+//         '/recoveryKey/hint',
+//         requestOptions
+//       ).then((r) => (response = r));
+//     });
 
-    it('returned the correct response', () => {
-      assert.deepEqual(response.hint, hint);
-      sinon.assert.calledOnceWithExactly(db.getRecoveryKeyHint, uid);
-    });
+//     it('returned the correct response', () => {
+//       assert.deepEqual(response.hint, hint);
+//       sinon.assert.calledOnceWithExactly(db.getRecoveryKeyHint, uid);
+//     });
 
-    it('called log.begin correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        log.begin,
-        'getRecoveryKeyHint',
-        request
-      );
-    });
-  });
+//     it('called log.begin correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         log.begin,
+//         'getRecoveryKeyHint',
+//         request
+//       );
+//     });
+//   });
 
-  describe('should retrieve the recovery key hint using email', () => {
-    beforeEach(async () => {
-      const requestOptions = {
-        method: 'GET',
-        query: { email: email },
-        log,
-      };
-      response = await setup(
-        { db: { recoveryData, hint, uid, email } },
-        {},
-        '/recoveryKey/hint',
-        requestOptions
-      );
-    });
+//   describe('should retrieve the recovery key hint using email', () => {
+//     beforeEach(async () => {
+//       const requestOptions = {
+//         method: 'GET',
+//         query: { email: email },
+//         log,
+//       };
+//       response = await setup(
+//         { db: { recoveryData, hint, uid, email } },
+//         {},
+//         '/recoveryKey/hint',
+//         requestOptions
+//       );
+//     });
 
-    it('returned the correct response', () => {
-      assert.deepEqual(response.hint, hint);
-      sinon.assert.calledOnceWithExactly(db.getRecoveryKeyHint, uid);
-    });
+//     it('returned the correct response', () => {
+//       assert.deepEqual(response.hint, hint);
+//       sinon.assert.calledOnceWithExactly(db.getRecoveryKeyHint, uid);
+//     });
 
-    it('called log.begin correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        log.begin,
-        'getRecoveryKeyHint',
-        request
-      );
-    });
+//     it('called log.begin correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         log.begin,
+//         'getRecoveryKeyHint',
+//         request
+//       );
+//     });
 
-    it('called customs.check correctly', () => {
-      sinon.assert.calledOnceWithExactly(
-        customs.check,
-        request,
-        email,
-        'recoveryKeyExists'
-      );
-    });
-  });
-});
+//     // TODO - FXA-7400 verify that request throws an error and aborts the rest of the call
+//     // if the request is rate-limited
+//     it('called customs.check correctly', () => {
+//       sinon.assert.calledOnceWithExactly(
+//         customs.check,
+//         request,
+//         email,
+//         'recoveryKeyExists'
+//       );
+//     });
+//   });
+// });
 
 describe('POST /recoveryKey/hint', () => {
   describe('should fail for unverified session', () => {

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1221,14 +1221,15 @@ export class Account implements AccountData {
     return recoveryKey;
   }
 
-  async getRecoveryKeyHint() {
-    const recoveryKeyHint = await this.authClient.getRecoveryKeyHint(
-      sessionToken()!,
-      this.primaryEmail.email
-    );
+  // Not currently in use - enable in FXA-7894 after FXA-7400 is completed
+  // async getRecoveryKeyHint() {
+  //   const recoveryKeyHint = await this.authClient.getRecoveryKeyHint(
+  //     sessionToken()!,
+  //     this.primaryEmail.email
+  //   );
 
-    return recoveryKeyHint;
-  }
+  //   return recoveryKeyHint;
+  // }
 
   async updateRecoveryKeyHint(hint: string) {
     await this.withLoadingStatus(


### PR DESCRIPTION
## Because

* Rate limiting is not working as expected on this currently unused route

## This pull request

* Disable (by commenting out) the GET recoveryKey/hint route and associated tests
* Add comments about intended rate limiting on this route

## Issue that this pull request solves

Closes: #FXA-8722

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

See JIRA details for issue this is addressing. I'll be filing a follow up ticket for UX to review how this hint is displayed to users.