### PR TITLE
task(settings,auth,react,payments): Clean up deprecated l10n strings

### DIFF
--- a/packages/fxa-auth-server/lib/l10n/server.ftl
+++ b/packages/fxa-auth-server/lib/l10n/server.ftl
@@ -1,5 +1,4 @@
 ## Non-email strings
 
-session-verify-send-push-title = Logging in to { -product-firefox-accounts }?
 session-verify-send-push-title-2 = Logging in to your { -product-mozilla-account }?
 session-verify-send-push-body-2 = Click here to confirm it’s you

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
@@ -3,11 +3,9 @@
 ## Emails do not contain buttons, only links. Emails have a rich HTML version and a plaintext
 ## version. The strings are usually identical but sometimes they differ slightly.
 
-fxa-header-firefox-logo = <img data-l10n-name="fxa-logo" alt="{ -brand-firefox } logo">
 fxa-header-mozilla-logo = <img data-l10n-name="mozilla-logo" alt="{ -brand-mozilla } logo">
 fxa-header-sync-devices-image = <img data-l10n-name="sync-devices-image" alt="Sync devices">
 body-devices-image = <img data-l10n-name="devices-image" alt="Devices">
 fxa-privacy-url = { -brand-mozilla } Privacy Policy
 moz-accounts-privacy-url-2 = { -product-mozilla-accounts(capitalization:"uppercase") } Privacy Notice
-fxa-service-url = { -product-firefox-cloud } Terms of Service
 moz-accounts-terms-url = { -product-mozilla-accounts(capitalization:"uppercase") } Terms of Service

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
@@ -1,7 +1,4 @@
-subplat-header-firefox-logo = <img data-l10n-name="fxa-logo-firefox" alt="{ -brand-firefox } logo">
-subplat-header-mozilla-logo = <img data-l10n-name="mozilla-logo" alt="{ -brand-mozilla } logo">
 subplat-header-mozilla-logo-2 = <img data-l10n-name="subplat-mozilla-logo" alt="{ -brand-mozilla } logo">
-subplat-footer-mozilla-logo = <img data-l10n-name="mozilla-logo" alt="{ -brand-mozilla } logo">
 subplat-footer-mozilla-logo-2 = <img data-l10n-name="mozilla-logo-footer" alt="{ -brand-mozilla } logo">
 subplat-automated-email = This is an automated email; if you received it in error, no action is required.
 subplat-privacy-notice = Privacy notice
@@ -10,26 +7,13 @@ subplat-update-billing-plaintext = { subplat-update-billing }:
 # Variables:
 #  $email (String) - A user's primary email address
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subplat-explainer-specific = You’re receiving this email because { $email } has a { -product-firefox-account } and you signed up for { $productName }.
-# Variables:
-#  $email (String) - A user's primary email address
-#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subplat-explainer-specific-2 = You’re receiving this email because { $email } has a { -product-mozilla-account } and you signed up for { $productName }.
 # Variables:
 #  $email (String) - A user's primary email address
-subplat-explainer-reminder-form = You’re receiving this email because { $email } has a { -product-firefox-account }.
-# Variables:
-#  $email (String) - A user's primary email address
 subplat-explainer-reminder-form-2 = You’re receiving this email because { $email } has a { -product-mozilla-account }.
-subplat-explainer-multiple = You’re receiving this email because { $email } has a { -product-firefox-account } and you have subscribed to multiple products.
 subplat-explainer-multiple-2 = You’re receiving this email because { $email } has a { -product-mozilla-account } and you have subscribed to multiple products.
-subplat-explainer-was-deleted = You’re receiving this email because { $email } was registered for a { -product-firefox-account }.
 subplat-explainer-was-deleted-2 = You’re receiving this email because { $email } was registered for a { -product-mozilla-account }.
-subplat-manage-account = Manage your { -product-firefox-account } settings by visiting your <a data-l10n-name="subplat-account-page">account page</a>.
 subplat-manage-account-2 = Manage your { -product-mozilla-account } settings by visiting your <a data-l10n-name="subplat-account-page">account page</a>.
-# Variables:
-#  $accountSettingsUrl (String) - URL to Account Settings
-subplat-manage-account-plaintext = Manage your { -product-firefox-account } settings by visiting your account page: { $accountSettingsUrl }
 # Variables:
 #  $accountSettingsUrl (String) - URL to Account Settings
 subplat-manage-account-plaintext-2 = Manage your { -product-mozilla-account } settings by visiting your account page: { $accountSettingsUrl }
@@ -44,8 +28,6 @@ subplat-privacy-policy = { -brand-mozilla } Privacy Policy
 subplat-privacy-policy-2 = { -product-mozilla-accounts(capitalization:"uppercase") } Privacy Notice
 subplat-privacy-policy-plaintext = { subplat-privacy-policy }:
 subplat-privacy-policy-plaintext-2 = { subplat-privacy-policy-2 }:
-subplat-cloud-terms = { -product-firefox-cloud } Terms of Service
-subplat-cloud-terms-plaintext = { subplat-cloud-terms }:
 subplat-moz-terms = { -product-mozilla-accounts(capitalization:"uppercase") } Terms of Service
 subplat-moz-terms-plaintext = { subplat-moz-terms }:
 subplat-legal = Legal

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en.ftl
@@ -3,5 +3,4 @@ cadReminderFirst-action = Sync another device
 cadReminderFirst-action-plaintext = { cadReminderFirst-action }:
 # In the title of the email, "It takes two to sync", "two" refers to syncing two devices
 cadReminderFirst-title-1 = It takes two to sync
-cadReminderFirst-description-1 = Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use { -brand-firefox }. It’s like having magic in your { -brand-firefox } account!
 cadReminderFirst-description-v2 = Take your tabs across all your devices. Get your bookmarks, passwords, and other data everywhere you use { -brand-firefox }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/fraudulentAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/fraudulentAccountDeletion/en.ftl
@@ -1,9 +1,6 @@
-fraudulentAccountDeletion-subject = Your { -product-firefox-account } was deleted
 fraudulentAccountDeletion-subject-2 = Your { -product-mozilla-account } was deleted
 fraudulentAccountDeletion-title = Your account was deleted
-fraudulentAccountDeletion-content = Recently, a { -product-firefox-account } was created and a subscription was charged using this email address. As we do with all new accounts, we asked that you confirm your account by first validating this email address.
 fraudulentAccountDeletion-content-part1-v2 = Recently, a { -product-mozilla-account } was created and a subscription was charged using this email address. As we do with all new accounts, we asked that you confirm your account by first validating this email address.
-fraudulentAccountDeletion-content-2 = At present, we see that the account was never confirmed. Since this step was not completed, we are not sure if this was an authorized subscription. As a result, the { -product-firefox-account } registered to this email address was deleted and your subscription was canceled with all charges reimbursed.
 fraudulentAccountDeletion-content-part2-v2 = At present, we see that the account was never confirmed. Since this step was not completed, we are not sure if this was an authorized subscription. As a result, the { -product-mozilla-account } registered to this email address was deleted and your subscription was canceled with all charges reimbursed.
 fraudulentAccountDeletion-contact = If you have any questions, please contact our <a data-l10n-name="mozillaSupportUrl">support team</a>.
 # Variables:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
@@ -1,7 +1,6 @@
 # Variables:
 # $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
 newDeviceLogin-subject = New sign-in to { $clientName }
-newDeviceLogin-title-2 = Your { -product-firefox-account } was used to sign in
 newDeviceLogin-title-3 = Your { -product-mozilla-account } was used to sign in
 # The "Not you?" question is asking whether the recipient of the email is the
 # person who performed the action that triggered the email.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/en.ftl
@@ -1,8 +1,6 @@
 passwordChangeRequired-subject = Suspicious activity detected
 passwordChangeRequired-title = Password Change Required
-passwordChangeRequired-suspicious-activity = We detected suspicious behavior on your { -product-firefox-account }. To prevent unauthorized access to your { -product-firefox-account }, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution.
 passwordChangeRequired-suspicious-activity-2 = We detected suspicious behavior on your { -product-mozilla-account }. To prevent unauthorized access to your { -product-mozilla-account }, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution.
-passwordChangeRequired-sign-in = Sign back into any device or service where you use your { -product-firefox-account } and follow the steps that will be presented to you.
 passwordChangeRequired-sign-in-2 = Sign back into any device or service where you use your { -product-mozilla-account } and follow the steps that will be presented to you.
 passwordChangeRequired-different-password = <b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account.
 passwordChangeRequired-different-password-plaintext = Important: Pick a different password than what you were previously using and make sure that it is different from your email account.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/en.ftl
@@ -1,4 +1,3 @@
 passwordChanged-subject = Password updated
 passwordChanged-title = Password changed successfully
-passwordChanged-description = Your { -product-firefox-account } password was successfully changed from the following device:
 passwordChanged-description-2 = Your { -product-mozilla-account } password was successfully changed from the following device:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/en.ftl
@@ -3,8 +3,6 @@ passwordResetAccountRecovery-title-2 = Password reset successfully
 # Details of the device and date/time that used account recovery key follow.
 passwordResetAccountRecovery-description-2 = You used your account recovery key to update your password from:
 # Text for button action to initiate creating new account recovery key
-passwordResetAccountRecovery-action-2 = Create a new account recovery key
-# Text for button action to initiate creating new account recovery key
 passwordResetAccountRecovery-action-3 = Create account recovery key
 passwordResetAccountRecovery-regen-required-mjml-1 = You’ll need to sign in again on all of your synced devices. Remember to create a new account recovery key to replace the one you used.
 # After the colon, there's a link to https://accounts.firefox.com/settings/account_recovery

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddLinkedAccount/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddLinkedAccount/en.ftl
@@ -1,8 +1,4 @@
-postAddLinkedAccount-subject = New account linked to { -brand-firefox }
 postAddLinkedAccount-subject-2 = New account linked to your { -product-mozilla-account }
-#  Variables:
-#  $providerName (String) - The name of the provider, e.g. Apple, Google
-postAddLinkedAccount-title = Your { $providerName } account has been linked to your { -product-firefox-account }
 #  Variables:
 #  $providerName (String) - The name of the provider, e.g. Apple, Google
 postAddLinkedAccount-title-2 = Your { $providerName } account has been linked to your { -product-mozilla-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en.ftl
@@ -2,8 +2,5 @@ postChangePrimary-subject = Primary email updated
 postChangePrimary-title = New primary email
 # Variables:
 #  $email (String) - A user's email address
-postChangePrimary-description = You have successfully changed your primary email to { $email }. This address is now your username for signing in to your { -product-firefox-account }, as well as receiving security notifications and sign-in confirmations.
-# Variables:
-#  $email (String) - A user's email address
 postChangePrimary-description-2 = You have successfully changed your primary email to { $email }. This address is now your username for signing in to your { -product-mozilla-account }, as well as receiving security notifications and sign-in confirmations.
 postChangePrimary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en.ftl
@@ -2,8 +2,5 @@ postRemoveSecondary-subject = Secondary email removed
 postRemoveSecondary-title = Secondary email removed
 # Variables:
 #  $secondaryEmail (String) - A user's email address
-postRemoveSecondary-description = You have successfully removed { $secondaryEmail } as a secondary email from your { -product-firefox-account }. Security notifications and sign-in confirmations will no longer be delivered to this address.
-# Variables:
-#  $secondaryEmail (String) - A user's email address
 postRemoveSecondary-description-2 = You have successfully removed { $secondaryEmail } as a secondary email from your { -product-mozilla-account }. Security notifications and sign-in confirmations will no longer be delivered to this address.
 postRemoveSecondary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en.ftl
@@ -2,7 +2,6 @@ postVerify-sub-title-3 = We’re delighted to see you!
 postVerify-title-2 = Want to see the same tab on two devices?
 postVerify-description-2 = It’s easy! Just install { -brand-firefox } on another device and log in to sync. It’s like magic!
 postVerify-sub-description = (Psst… It also means you can get your bookmarks, passwords, and other { -brand-firefox } data everywhere you’re signed in.)
-postVerify-subject-3 = Welcome to { -brand-firefox }!
 postVerify-subject-4 = Welcome to { -brand-mozilla }!
 postVerify-setup-2 = Connect another device:
 postVerify-action-2 = Connect another device

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en.ftl
@@ -2,8 +2,5 @@ postVerifySecondary-subject = Secondary email added
 postVerifySecondary-title = Secondary email added
 # Variables:
 #  $secondaryEmail (String) - A user's secondary email address
-postVerifySecondary-content-2 = You have successfully confirmed { $secondaryEmail } as a secondary email for your { -product-firefox-account }. Security notifications and sign-in confirmations will now be delivered to both email addresses.
-# Variables:
-#  $secondaryEmail (String) - A user's secondary email address
 postVerifySecondary-content-3 = You have successfully confirmed { $secondaryEmail } as a secondary email for your { -product-mozilla-account }. Security notifications and sign-in confirmations will now be delivered to both email addresses.
 postVerifySecondary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/en.ftl
@@ -1,8 +1,6 @@
 recovery-subject = Reset your password
 recovery-title-2 = Forgot your password?
 # Information on the device, date and time of the request that triggered the email follows.
-recovery-request-origin = We received a request for a password change on your { -product-firefox-account } from:
-# Information on the device, date and time of the request that triggered the email follows.
 recovery-request-origin-2 = We received a request for a password change on your { -product-mozilla-account } from:
 recovery-new-password-button = Create a new password by clicking the button below. This link will expire within the next hour.
 recovery-copy-paste = Create a new password by copying and pasting the URL below into your browser. This link will expire within the next hour.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -6,9 +6,4 @@ subscriptionAccountDeletion-title = Sorry to see you go
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
-subscriptionAccountDeletion-content-cancelled = You recently deleted your { -product-firefox-account }. As a result, we’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.
-#  Variables:
-#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
-#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
 subscriptionAccountDeletion-content-cancelled-2 = You recently deleted your { -product-mozilla-account }. As a result, we’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountFinishSetup/en.ftl
@@ -5,6 +5,5 @@ subscriptionAccountFinishSetup-subject = Welcome to { $productName }: Please set
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionAccountFinishSetup-title = Welcome to { $productName }
 subscriptionAccountFinishSetup-content-processing = Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel.
-subscriptionAccountFinishSetup-content-create-2 = Next, you’ll create a { -product-firefox-account } password to start using your new subscription.
 subscriptionAccountFinishSetup-content-create-3 = Next, you’ll create a { -product-mozilla-account } password to start using your new subscription.
 subscriptionAccountFinishSetup-action-2 = Get started

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderFirst/en.ftl
@@ -1,6 +1,5 @@
 subscriptionAccountReminderFirst-subject = Reminder: Finish setting up your account
 subscriptionAccountReminderFirst-title = You can’t access your subscription yet
-subscriptionAccountReminderFirst-content-info-2 = A few days ago you created a { -product-firefox-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
 subscriptionAccountReminderFirst-content-info-3 = A few days ago you created a { -product-mozilla-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
 subscriptionAccountReminderFirst-content-select-2 = Select “Create Password” to set up a new password and finish confirming your account.
 subscriptionAccountReminderFirst-action = Create Password

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountReminderSecond/en.ftl
@@ -1,7 +1,5 @@
 subscriptionAccountReminderSecond-subject = Final reminder: Setup your account
-subscriptionAccountReminderSecond-title = Welcome to { -brand-firefox }!
 subscriptionAccountReminderSecond-title-2 = Welcome to { -brand-mozilla }!
-subscriptionAccountReminderSecond-content-info-2 = A few days ago you created a { -product-firefox-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
 subscriptionAccountReminderSecond-content-info-3 = A few days ago you created a { -product-mozilla-account } but never confirmed it. We hope you’ll finish setting up your account, so you can use your new subscription.
 subscriptionAccountReminderSecond-content-select-2 = Select “Create Password” to set up a new password and finish confirming your account.
 subscriptionAccountReminderSecond-action = Create Password

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFinal/en.ftl
@@ -1,5 +1,4 @@
 verificationReminderFinal-subject = Final reminder to confirm your account
-verificationReminderFinal-description = A couple of weeks ago you created a { -product-firefox-account }, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours.
 verificationReminderFinal-description-2 = A couple of weeks ago you created a { -product-mozilla-account }, but never confirmed it. For your security, we will delete the account if not verified in the next 24 hours.
 confirm-account = Confirm account
 confirm-account-plaintext = { confirm-account }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en.ftl
@@ -1,7 +1,5 @@
 verificationReminderFirst-subject-2 = Remember to confirm your account
-verificationReminderFirst-title-2 = Welcome to { -brand-firefox }!
 verificationReminderFirst-title-3 = Welcome to { -brand-mozilla }!
-verificationReminderFirst-description-2 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.
 verificationReminderFirst-description-3 = A few days ago you created a { -product-mozilla-account }, but never confirmed it. Please confirm your account in the next 15 days or it will be automatically deleted.
 verificationReminderFirst-sub-description-3 = Don’t miss out on the browser that puts you and your privacy first.
 confirm-email-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en.ftl
@@ -1,9 +1,6 @@
 verificationReminderSecond-subject-2 = Remember to confirm your account
-verificationReminderSecond-title-2 = Don’t miss out on { -brand-firefox }!
 verificationReminderSecond-title-3 = Don’t miss out on { -brand-mozilla }!
-verificationReminderSecond-description-3 = A few days ago you created a { -product-firefox-account }, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.
 verificationReminderSecond-description-4 = A few days ago you created a { -product-mozilla-account }, but never confirmed it. Please confirm your account in the next 10 days or it will be automatically deleted.
-verificationReminderSecond-second-description = Your { -product-firefox-account } lets you sync your info across devices and unlocks access to more privacy-protecting products from { -brand-mozilla }.
 verificationReminderSecond-second-description-3 = Your { -product-mozilla-account } lets you sync your { -brand-firefox } experience across devices and unlocks access to more privacy-protecting products from { -brand-mozilla }.
 verificationReminderSecond-sub-description-2 = Be part of our mission to transform the internet into a place that’s open for everyone.
 verificationReminderSecond-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/en.ftl
@@ -1,6 +1,4 @@
-verify-title-2 = Open the internet with { -brand-firefox }
 verify-title-3 = Open the internet with { -brand-mozilla }
-verify-description = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in starting with:
 verify-description-2 = Confirm your account and get the most out of { -brand-mozilla } everywhere you sign in starting with:
 verify-subject = Finish creating your account
 verify-action-2 = Confirm account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/en.ftl
@@ -3,9 +3,6 @@ verifySecondaryCode-title-2 = Confirm secondary email
 verifySecondaryCode-action-2 = Confirm email
 # Variables:
 #  $email (string) A user's unverified secondary email address
-verifySecondaryCode-explainer = A request to use { $email } as a secondary email address has been made from the following { -product-firefox-account }:
-# Variables:
-#  $email (string) A user's unverified secondary email address
 verifySecondaryCode-explainer-2 = A request to use { $email } as a secondary email address has been made from the following { -product-mozilla-account }:
 verifySecondaryCode-prompt-2 = Use this confirmation code:
 verifySecondaryCode-expiry-notice-2 = It expires in 5 minutes. Once confirmed, this address will begin receiving security notifications and confirmations.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
@@ -1,10 +1,7 @@
 # Variables:
 #  $code (Number) - e.g. 123456
 verifyShortCode-subject-3 = Confirm your account
-verifyShortCode-title-2 = Open the internet with { -brand-firefox }
 verifyShortCode-title-3 = Open the internet with { -brand-mozilla }
-# Information on the browser and device triggering this confirmation email follows below this string.
-verifyShortCode-title-subtext = Confirm your account and get the most out of { -brand-firefox } everywhere you sign in starting with:
 # Information on the browser and device triggering this confirmation email follows below this string.
 verifyShortCode-title-subtext-2 = Confirm your account and get the most out of { -brand-mozilla } everywhere you sign in starting with:
 verifyShortCode-prompt-3 = Use this confirmation code:

--- a/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
@@ -50,7 +50,3 @@
         </section>
     {{/isLinkExpired}}
 </div>
-
-<!-- Old L10N Strings - TBR
-{{#t}}Please enter the one time use account recovery key you stored in a safe place to regain access to your Firefox Account.{{/t}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -26,8 +26,3 @@
         </form>
     </section>
 </div>
-
-<!-- Old L10N Strings - TBR
-{{#t}}Enter confirmation code{{/t}}
-{{#t}}for your Firefox account{{/t}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -63,7 +63,3 @@
     {{/fatalError}}
   </section>
 </div>
-
-<!-- Old L10N Strings - TBR
-{{#unsafeTranslate}}Enter your password <span class="card-subheader" id="subheader">for your Firefox account</span>{{/unsafeTranslate}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -88,17 +88,3 @@
 
   </section>
 </div>
-<!-- Old L10N Strings - TBR
-{{#t}}Continue to Firefox accounts{{/t}}
-{{#t}}A Firefox account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}
-{{#unsafeTranslate}}
-  By proceeding, you agree to:<br />
-  Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-  Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
-{{/unsafeTranslate}}
-{{#unsafeTranslate}}
-  By proceeding, you agree to:<br />
-  Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
-  Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
-{{/unsafeTranslate}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
@@ -59,7 +59,3 @@
     </section>
     {{/isLinkValid}}
 </div>
-
-<!-- Old L10N Strings - TBR
-{{#t}}Create a Firefox Account{{/t}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/password/force_password_change.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/password/force_password_change.mustache
@@ -48,7 +48,3 @@
     </form>
   </section>
 </div>
-
-<!-- Old L10N Strings - TBR
-{{#t}}We detected suspicious behavior on your Firefox account. To protect your account, please create a new password. You’ll use this password to sign back in to all of your Firefox account services.{{/t}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -100,8 +100,3 @@
       </div>
   </section>
 </div>
-
-
-<!-- Old L10N Strings - TBR
-{{#unsafeTranslate}}Enter your password <span class="card-subheader" id="subheader">for your Firefox account</span>{{/unsafeTranslate}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -30,7 +30,3 @@
     </div>
   </section>
 </div>
-
-<!-- Old L10N Strings - TBR
-{{#unsafeTranslate}}Enter confirmation code <span class="card-subheader">for your Firefox account</span>{{/unsafeTranslate}}
--->

--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -108,7 +108,3 @@
 </div>
 
 <footer id="legal-footer"><a class="terms text-blue-500" href="/legal/terms">{{#t}}Terms of Service{{/t}}</a><a class="privacy text-blue-500" href="/legal/privacy">{{#t}}Privacy Notice{{/t}}</a></footer>
-
-<!-- Old L10N Strings - TBR
-{{#t}}Firefox Accounts{{/t}}
--->

--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -60,7 +60,4 @@
         <script type="text/javascript" src="{{ bundlePath }}/appDependencies.bundle.js"></script>
         <script type="text/javascript" src="{{ bundlePath }}/app.bundle.js"></script>
     </body>
-<!-- Old L10N Strings - TBR
-{{#t}}Firefox Accounts requires JavaScript.{{/t}}
--->
 </html>

--- a/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
+++ b/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
@@ -60,11 +60,4 @@
             </div>
         </div>
     </body>
-<!-- Old L10N Strings - TBR
-{{#t}}Firefox Accounts{{/t}}
-{{#t}}Firefox Accounts makes use of features that are
-not supported in your version of Firefox. Please
-download and install the latest version of Firefox to
-continue.{{/t}}
--->
 </html>

--- a/packages/fxa-payments-server/src/components/Header/en.ftl
+++ b/packages/fxa-payments-server/src/components/Header/en.ftl
@@ -1,5 +1,3 @@
 ## Component - Header
 
-# TODO: Remove once new branding sticks
-brand-name-firefox-logo = { -brand-name-firefox } logo
 brand-name-mozilla-logo = { -brand-mozilla } logo

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/en.ftl
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/en.ftl
@@ -1,7 +1,5 @@
 ## Component - NewUserEmailForm
 
-# TODO: Remove once new branding sticks
-new-user-sign-in-link = Already have a { -brand-name-firefox } account? <a>Sign in</a>
 new-user-sign-in-link-2 = Already have a { -product-mozilla-account }? <a>Sign in</a>
 # "Required" to indicate that the user must use the checkbox below this text to
 # agree to a payment method's terms of service and privacy notice in order to

--- a/packages/fxa-payments-server/src/routes/Checkout/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Checkout/en.ftl
@@ -1,7 +1,5 @@
 ## Routes - Checkout - New user
 
-# TODO - Remove once branding sticks
-new-user-step-1 = 1. Create a { -brand-name-firefox } account
 new-user-step-1-2 = 1. Create a { -product-mozilla-account }
 new-user-card-title = Enter your card information
 new-user-submit = Subscribe Now

--- a/packages/fxa-react/components/Head/en.ftl
+++ b/packages/fxa-react/components/Head/en.ftl
@@ -1,13 +1,8 @@
 ## FxA React - Strings shared between multiple FxA products for application page title
 
-app-default-title = { -product-firefox-accounts }
 # This string is used as the default title for pages, displayed in the browser tab.
 app-default-title-2 = { -product-mozilla-accounts }
-# This string is used as the title of the page.
-# Variables:
-#   $title (String) - the name of the current page
-#                      (for example: "Two-step authentication")
-app-page-title = { $title } | { -product-firefox-accounts }
+
 # This string is used as the title of the page, displayed in the browser tab.
 # Variables:
 #   $title (String) - the name of the current page

--- a/packages/fxa-react/components/LogoLockup/en.ftl
+++ b/packages/fxa-react/components/LogoLockup/en.ftl
@@ -1,8 +1,4 @@
 ## FxA React - Strings shared between multiple FxA products for logo lockup
 
-app-logo-alt =
-  .alt = { -brand-firefox } logo
-app-logo-alt-2 =
-  .alt = { -brand-mozilla } logo
 app-logo-alt-3 =
   .alt = { -brand-mozilla } m logo

--- a/packages/fxa-settings/src/components/GetDataTrio/en.ftl
+++ b/packages/fxa-settings/src/components/GetDataTrio/en.ftl
@@ -2,7 +2,6 @@
 
 get-data-trio-title-firefox = { -brand-firefox }
 get-data-trio-title-firefox-recovery-key = { -brand-firefox } account recovery key
-get-data-trio-title-firefox-backup-verification-codes = { -brand-firefox } backup authentication codes
 get-data-trio-title-backup-verification-codes = Backup authentication codes
 get-data-trio-download-2 =
   .title = Download

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/en.ftl
@@ -1,9 +1,6 @@
 # BentoMenu component
 
-bento-menu-title = { -brand-firefox } Bento Menu
-bento-menu-title-2 = { -brand-mozilla } Bento Menu
 bento-menu-title-3 = { -brand-mozilla } products
-bento-menu-firefox-title = { -brand-firefox } is tech that fights for your online privacy.
 bento-menu-tagline = More products from { -brand-mozilla } that protect your privacy
 
 bento-menu-vpn-2 = { -product-mozilla-vpn }

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -43,16 +43,8 @@ cs-disconnect-sync-opt-not-say = Rather not say
 
 cs-disconnect-advice-confirm = Okay, got it
 cs-disconnect-lost-advice-heading = Lost or stolen device disconnected
-cs-disconnect-lost-advice-content-2 = Since your device was lost or stolen, to
-  keep your information safe, you should change your { -product-firefox-account } password
-  in your account settings. You should also look for information from your
-  device manufacturer about erasing your data remotely.
 cs-disconnect-lost-advice-content-3 = Since your device was lost or stolen, to keep your information safe, you should change your { -product-mozilla-account } password in your account settings. You should also look for information from your device manufacturer about erasing your data remotely.
 cs-disconnect-suspicious-advice-heading = Suspicious device disconnected
-cs-disconnect-suspicious-advice-content = If the disconnected device is indeed
-  suspicious, to keep your information safe, you should change your { -product-firefox-account }
-  password in your account settings. You should also change any other
-  passwords you saved in { -brand-firefox } by typing about:logins into the address bar.
 cs-disconnect-suspicious-advice-content-2 = If the disconnected device is indeed suspicious, to keep your information safe, you should change your { -product-mozilla-account } password in your account settings. You should also change any other passwords you saved in { -brand-firefox } by typing about:logins into the address bar.
 
 cs-sign-out-button = Sign out

--- a/packages/fxa-settings/src/components/Settings/DataCollection/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/en.ftl
@@ -1,13 +1,9 @@
 ## Data collection section
 
 dc-heading = Data Collection and Use
-dc-subheader = Help improve { -product-firefox-accounts }
 dc-subheader-2 = Help improve { -product-mozilla-accounts }
-dc-subheader-content = Allow { -product-firefox-accounts } to send technical and interaction data to { -brand-mozilla }.
 dc-subheader-content-2 = Allow { -product-mozilla-accounts } to send technical and interaction data to { -brand-mozilla }.
-dc-opt-out-success = Opt out successful. { -product-firefox-accounts } won’t send technical or interaction data to { -brand-mozilla }.
 dc-opt-out-success-2 = Opt out successful. { -product-mozilla-accounts } won’t send technical or interaction data to { -brand-mozilla }.
-dc-opt-in-success = Thanks! Sharing this data helps us improve { -product-firefox-accounts }.
 dc-opt-in-success-2 = Thanks! Sharing this data helps us improve { -product-mozilla-accounts }.
 dc-opt-in-out-error-2 = Sorry, there was a problem changing your data collection preference
 dc-learn-more = Learn more

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/en.ftl
@@ -1,6 +1,5 @@
 # DropDownAvatarMenu component
 
-drop-down-menu-title = { -product-firefox-account } menu
 drop-down-menu-title-2 = { -product-mozilla-account } menu
 # This string is used to show the current user's name or email in the settings page menu.
 # Variables:

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
@@ -4,6 +4,5 @@ header-menu-open = Close menu
 header-menu-closed = Site navigation menu
 header-back-to-top-link =
   .title = Back to top
-header-title = Firefox Account
 header-title-2 = { -product-mozilla-account }
 header-help = Help

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
@@ -6,10 +6,8 @@ delete-account-header =
 delete-account-step-1-2 = Step 1 of 2
 delete-account-step-2-2 = Step 2 of 2
 
-delete-account-confirm-title-3 = You may have connected your { -product-firefox-account } to one or more of the following { -brand-mozilla } products or services that keep you secure and productive on the web:
 delete-account-confirm-title-4 = You may have connected your { -product-mozilla-account } to one or more of the following { -brand-mozilla } products or services that keep you secure and productive on the web:
 
-delete-account-product-firefox-account = { -product-firefox-account }
 delete-account-product-mozilla-account = { -product-mozilla-account }
 delete-account-product-mozilla-vpn = { -product-mozilla-vpn }
 delete-account-product-mdn-plus = { -product-mdn-plus }

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
@@ -2,22 +2,15 @@
 ## These terms are used in signin and signup for Firefox account
 
 # This message is followed by a bulleted list
-terms-privacy-agreement-intro = By proceeding, you agree to:
-# This message is followed by a bulleted list
 terms-privacy-agreement-intro-2 = By proceeding, you agree to the:
 # links to Pocket's Terms of Service and Privacy Notice
-terms-privacy-agreement-pocket = { -product-pocket }’s <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
 # links to Pocket's Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-pocket-2 = { -product-pocket } <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
 # link to Firefox Monitor's Terms of Service and Privacy Notice
 terms-privacy-agreement-monitor = { -product-firefox-monitor }'s <monitorTos>Terms of Service and Privacy Notice</monitorTos>
 # link to Firefox Monitor's Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-monitor-2 = { -product-firefox-monitor } <monitorTos>Terms of Service and Privacy Notice</monitorTos>
-# links to Firefox's Terms of Service and Privacy Notice
-terms-privacy-agreement-firefox = { -brand-firefox }’s <firefoxTos>Terms of Service</firefoxTos> and <firefoxPrivacy>Privacy Notice</firefoxPrivacy>
 # links to Mozilla Accounts Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-mozilla = { -product-mozilla-accounts(capitalization:"uppercase") } <mozillaAccountsTos>Terms of Service</mozillaAccountsTos> and <mozillaAccountsPrivacy>Privacy Notice</mozillaAccountsPrivacy>
-# links to Firefox's Terms of Service and Privacy Notice
-terms-privacy-agreement-default = By proceeding, you agree to the <firefoxTos>Terms of Service</firefoxTos> and <firefoxPrivacy>Privacy Notice</firefoxPrivacy>.
 # links to Mozilla Account's Terms of Service and Privacy Notice
 terms-privacy-agreement-default-2 = By proceeding, you agree to the <mozillaAccountsTos>Terms of Service</mozillaAccountsTos> and <mozillaAccountsPrivacy>Privacy Notice</mozillaAccountsPrivacy>.

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/en.ftl
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/en.ftl
@@ -2,7 +2,6 @@
 ## Users are redirected to this page if they attempt to create an account that does not meet age requirements.
 
 cannot-create-account-header = Cannot create account
-cannot-create-account-requirements = You must meet certain age requirements to create a { -product-firefox-account }.
 cannot-create-account-requirements-2 = You must meet certain age requirements to create a { -product-mozilla-account }.
 # For an external link: https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy
 cannot-create-account-learn-more-link = Learn more

--- a/packages/fxa-settings/src/pages/CookiesDisabled/en.ftl
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/en.ftl
@@ -2,7 +2,6 @@
 ## Users will see this page if they have local storage or cookies disabled.
 
 cookies-disabled-header = Local storage and cookies are required
-cookies-disabled-enable-prompt = Please enable cookies and local storage in your browser to access { -product-firefox-accounts }. Doing so will enable functionality such as remembering you between sessions.
 cookies-disabled-enable-prompt-2 = Please enable cookies and local storage in your browser to access your { -product-mozilla-account }. Doing so will enable functionality such as remembering you between sessions.
 # A button users may click to check if cookies and local storage are enabled and be directed to the previous page if so.
 cookies-disabled-button-try-again = Try again

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/en.ftl
@@ -8,7 +8,6 @@ account-recovery-confirm-key-heading-w-default-service = Reset password with acc
 # { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable
 account-recovery-confirm-key-heading-w-custom-service = Reset password with account recovery key <span>to continue to { $serviceName }</span>
 
-account-recovery-confirm-key-instructions = Please enter the one time use account recovery key you stored in a safe place to regain access to your { -product-firefox-account }.
 account-recovery-confirm-key-instructions-2 = Please enter the one time use account recovery key you stored in a safe place to regain access to your { -product-mozilla-account }.
 
 account-recovery-confirm-key-warning-message = <span>Note:</span> If you reset your password and don’t have your account recovery key saved, some of your data will be erased (including synced server data like history and bookmarks).

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
@@ -3,10 +3,6 @@
 ## a 6-digit code that is sent to the user's email address.
 
 # String within the <span> element appears on a separate line
-# If more appropriate in a locale, the string within the <span>, "for your { -product-firefox-account }"
-# can stand alone as "{ -product-firefox-account }"
-signin-token-code-heading = Enter confirmation code<span> for your { -product-firefox-account }</span>
-# String within the <span> element appears on a separate line
 # If more appropriate in a locale, the string within the <span>, "for your { -product-mozilla-account }"
 # can stand alone as "{ -product-mozilla-account }"
 signin-token-code-heading-2 = Enter confirmation code<span> for your { -product-mozilla-account }</span>

--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -1,8 +1,6 @@
 ## Signin page
 
 # Strings within the <span> elements appear as a subheading.
-signin-password-needed-header = Enter your password <span>for your { -product-firefox-account }</span>
-# Strings within the <span> elements appear as a subheading.
 signin-password-needed-header-2 = Enter your password <span>for your { -product-mozilla-account }</span>
 
 # $serviceLogo - an image of the logo of the service which the user is authenticating for.

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
@@ -6,10 +6,6 @@
 confirm-signup-code-page-title = Enter confirmation code
 
 # String within the <span> element appears on a separate line
-# If more appropriate in a locale, the string within the <span>, "for your { -product-firefox-account }"
-# can stand alone as "{ -product-firefox-account }"
-confirm-signup-code-heading = Enter confirmation code <span>for your { -product-firefox-account }</span>
-# String within the <span> element appears on a separate line
 # If more appropriate in a locale, the string within the <span>, "for your { -product-mozilla-account }"
 # can stand alone as "{ -product-mozilla-account }"
 confirm-signup-code-heading-2 = Enter confirmation code <span>for your { -product-mozilla-account }</span>


### PR DESCRIPTION
## Because

- Now that branding has landed we can safely remove old l10n strings

## This pull request

- Removes old l10n strings referencing firefox branding

## Issue that this pull request solves

Closes: FXA-8474

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

Strings were located by looking at the following PRs which modified l10n strings for the rebrand:
- https://github.com/mozilla/fxa/pull/15792
- https://github.com/mozilla/fxa/pull/15838
- https://github.com/mozilla/fxa/pull/15810
- https://github.com/mozilla/fxa/pull/15812
- https://github.com/mozilla/fxa/pull/15800
- https://github.com/mozilla/fxa/pull/15909
- https://github.com/mozilla/fxa/pull/15908
- https://github.com/mozilla/fxa/pull/15907
- https://github.com/mozilla/fxa/pull/15911
- https://github.com/mozilla/fxa/pull/15914
- https://github.com/mozilla/fxa/pull/15948
