### PR TITLE
fix(tests): Re-enable React signup tests in production

### DIFF
--- a/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/cannotCreateAccount.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test } from '../../lib/fixtures/standard';
 import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.beforeEach(async ({ pages: { configPage } }) => {
@@ -14,6 +14,6 @@ test.beforeEach(async ({ pages: { configPage } }) => {
 test.describe('react-conversion', () => {
   test('Cannot create account', async ({ page, target }) => {
     await page.goto(getReactFeatureFlagUrl(target, '/cannot_create_account'));
-    expect(await page.locator('#root').isEnabled()).toBeTruthy();
+    await page.waitForSelector('#root');
   });
 });

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -17,7 +17,7 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(getReactFeatureFlagUrl(target, '/legal'));
 
       // Verify react page has been loaded
-      expect(await page.locator('#root').isEnabled()).toBeTruthy();
+      await page.waitForSelector('#root');
 
       // Verify legal page is visible
       expect(
@@ -48,7 +48,7 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(getReactFeatureFlagUrl(target, '/legal/terms'));
 
       // Verify react page has been loaded
-      await page.locator('#root').isVisible();
+      await page.waitForSelector('#root');
 
       // Verify legal page is visible
       // this text is not in our codebase, it's pulled from the `legal-docs` repo
@@ -61,7 +61,7 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(getReactFeatureFlagUrl(target, '/legal/privacy'));
 
       // Verify react page has been loaded
-      await page.locator('#root').isVisible();
+      await page.waitForSelector('#root');
 
       // Verify privacy page is visible
       await page.waitForTimeout(1000);

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -298,6 +298,6 @@ test.describe('severity-1 #smoke', () => {
 
   /** Checks that the version of the app being used is the React Version. */
   async function checkForReactApp({ page }) {
-    expect(await page.locator('#root')).toBeVisible();
+    await page.waitForSelector('#root');
   }
 });


### PR DESCRIPTION
## Because

- Tests are skipped based on feature flag value, does not need a skip based on project

## This pull request

- Removes the test skip based on production environment

## Issue that this pull request solves

Closes: #FXA-8543

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Tested locally that react signup tests are skipped if showReactApp flag for signUpRoutes is set to false
