### PR TITLE
fix(auth): skip contentful if manager not set

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -232,7 +232,9 @@ export class StripeHelper extends StripeHelperBase {
     this.webhookSecret = config.subscriptions.stripeWebhookSecret;
     this.taxIds = config.subscriptions.taxIds;
     this.currencyHelper = Container.get(CurrencyHelper);
-    this.contentfulManager = Container.get(ContentfulManager);
+    if (Container.has(ContentfulManager)) {
+      this.contentfulManager = Container.get(ContentfulManager);
+    }
 
     // Initializes caching
     this.initRedis();


### PR DESCRIPTION
## Because

- Only get ContentfulManager from container if it is set

## This pull request

- Checks for ContentfulManager in container before getting

## Issue that this pull request solves

Closes: #FXA-8762

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).