### PR TITLE
fix(settings): skip oauth client info fetch when id is invalid

### DIFF
--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useContext, useRef, useEffect, useMemo } from 'react';
+import { isHexadecimal, length } from 'class-validator';
 import { AppContext } from './contexts/AppContext';
 import {
   INITIAL_SETTINGS_QUERY,
@@ -172,9 +173,12 @@ export function useClientInfoState() {
   const urlQueryData = new UrlQueryData(new ReachRouterWindow());
   const clientId =
     urlQueryData.get('client_id') || urlQueryData.get('service') || '';
+
   return useQuery<{ clientInfo: RelierClientInfo }>(GET_CLIENT_INFO, {
     client: apolloClient,
     variables: { input: clientId },
+    // an oauth client id is a 16 digit hex
+    skip: !isHexadecimal(clientId) || !length(clientId, 16),
   });
 }
 


### PR DESCRIPTION
Because:
 - an oauth client id needs to be a 16 digit hex

This commit:
 - skips the graphql-api query to fetch an oauth client's info that will result in an HTTP 400
