### PR TITLE
chore(all): Move gql dependencies to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",
   "dependencies": {
+    "@apollo/client": "^3.8.3",
     "@apollo/server": "^4.9.3",
     "@faker-js/faker": "^8.1.0",
     "@fluent/bundle": "^0.18.0",

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -36,7 +36,6 @@
     ]
   },
   "dependencies": {
-    "@apollo/client": "^3.8.3",
     "@sentry/browser": "^7.66.0",
     "@sentry/node": "^7.66.0",
     "body-parser": "^1.20.1",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -51,7 +51,6 @@
     "fxa-auth-client": "workspace:*",
     "fxa-shared": "workspace:*",
     "googleapis": "^109.0.1",
-    "graphql": "^16.8.0",
     "helmet": "^7.1.0",
     "hot-shots": "^10.0.0",
     "knex": "^2.4.2",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -51,7 +51,6 @@
     "fxa-jwtool": "^0.7.2",
     "fxa-shared": "workspace:*",
     "google-auth-library": "^9.2.0",
-    "graphql": "^16.8.0",
     "hot-shots": "^10.0.0",
     "joi": "^17.8.3",
     "jwks-rsa": "^3.0.0",

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -54,7 +54,6 @@
     "fxa-profile-server": "workspace:*",
     "fxa-shared": "workspace:*",
     "get-stream": "^6.0.1",
-    "graphql": "^16.8.0",
     "graphql-parse-resolve-info": "^4.13.0",
     "graphql-query-complexity": "^0.12.0",
     "helmet": "^7.1.0",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -115,7 +115,6 @@
     ]
   },
   "dependencies": {
-    "@apollo/client": "^3.8.3",
     "@babel/core": "^7.16.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
@@ -154,7 +153,6 @@
     "fxa-crypto-relier": "^2.7.0",
     "fxa-react": "workspace:*",
     "get-orientation": "^1.1.2",
-    "graphql": "^16.8.0",
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -299,7 +299,6 @@
     "@nestjs/common": "^10.2.4",
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.2.4",
-    "@nestjs/graphql": "^12.0.8",
     "@nestjs/mapped-types": "^2.0.2",
     "@opentelemetry/api": "~1.4.0",
     "@opentelemetry/auto-instrumentations-node": "~0.39.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,16 +244,15 @@ __metadata:
   linkType: hard
 
 "@apollo/client@npm:^3.8.3":
-  version: 3.8.3
-  resolution: "@apollo/client@npm:3.8.3"
+  version: 3.8.8
+  resolution: "@apollo/client@npm:3.8.8"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
-    "@wry/context": ^0.7.3
     "@wry/equality": ^0.5.6
-    "@wry/trie": ^0.4.3
+    "@wry/trie": ^0.5.0
     graphql-tag: ^2.12.6
     hoist-non-react-statics: ^3.3.2
-    optimism: ^0.17.5
+    optimism: ^0.18.0
     prop-types: ^15.7.2
     response-iterator: ^0.2.6
     symbol-observable: ^4.0.0
@@ -275,7 +274,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: cdecd5d613c0f941d00fc1904b9ecdeb502fc157c10400430231adb47d8f67727c78eed1b7489aed91cce6e20e32fc44e16b6c2d5424a42d7c100dcef65b942b
+  checksum: df01412424b61f0b102b8453dfc611d7a2bdae6921fed31700196939076f1c6774eb942dc52bf6dc3f7212280dc0748998b243e09f60b889d989d9a1f08f30b3
   languageName: node
   linkType: hard
 
@@ -21871,21 +21870,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/context@npm:^0.7.0, @wry/context@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "@wry/context@npm:0.7.3"
+"@wry/caches@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@wry/caches@npm:1.0.1"
   dependencies:
     tslib: ^2.3.0
-  checksum: 91c1e9eee9046c48ff857d60dcbb59f22246ce0f9bb2d9b190e0555227e7ba3f86024032cc057f3f5141d3bee93fc6b2a15ce2c79fa512569d3432eb8e1af02b
+  checksum: 9e89aa8e9e08577b2e4acbe805f406b141ae49c2ac4a2e22acf21fbee68339fa0550e0dee28cf2158799f35bb812326e80212e49e2afd169f39f02ad56ae4ef4
+  languageName: node
+  linkType: hard
+
+"@wry/context@npm:^0.7.0":
+  version: 0.7.4
+  resolution: "@wry/context@npm:0.7.4"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 9bc8c30a31f9c7d36b616e89daa9280c03d196576a4f9fef800e9bd5de9434ba70216322faeeacc7ef1ab95f59185599d702538114045df729a5ceea50aef4e2
   languageName: node
   linkType: hard
 
 "@wry/equality@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "@wry/equality@npm:0.5.6"
+  version: 0.5.7
+  resolution: "@wry/equality@npm:0.5.7"
   dependencies:
     tslib: ^2.3.0
-  checksum: 9addf8891bdff5e23eecff03641846e7a56c1de3c9362c25e69c0b2ee3303e74b22e9a0376920283cd9d3bdd1bada12df54be5eaa29c2d801d33d94992672e14
+  checksum: 892f262fae362df80f199b12658ea6966949539d4a3a50c1acf00d94a367d673a38f8efa1abcb726ae9e5cc5e62fce50c540c70f797b7c8a2c4308b401dfd903
   languageName: node
   linkType: hard
 
@@ -21895,6 +21903,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.0
   checksum: 106e021125cfafd22250a6631a0438a6a3debae7bd73f6db87fe42aa0757fe67693db0dfbe200ae1f60ba608c3e09ddb8a4e2b3527d56ed0a7e02aa0ee4c94e1
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wry/trie@npm:0.5.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 92aeea34152bd8485184236fe328d3d05fc98ee3b431d82ee60cf3584dbf68155419c3d65d0ff3731b204ee79c149440a9b7672784a545afddc8d4342fbf21c9
   languageName: node
   linkType: hard
 
@@ -34551,7 +34568,6 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa-admin-panel@workspace:packages/fxa-admin-panel"
   dependencies:
-    "@apollo/client": ^3.8.3
     "@babel/core": ^7.15.0
     "@rescripts/cli": 0.0.16
     "@sentry/browser": ^7.66.0
@@ -34633,7 +34649,6 @@ fsevents@~2.1.1:
     fxa-auth-client: "workspace:*"
     fxa-shared: "workspace:*"
     googleapis: ^109.0.1
-    graphql: ^16.8.0
     helmet: ^7.1.0
     hot-shots: ^10.0.0
     jest: 29.3.1
@@ -35125,7 +35140,6 @@ fsevents@~2.1.1:
     fxa-jwtool: ^0.7.2
     fxa-shared: "workspace:*"
     google-auth-library: ^9.2.0
-    graphql: ^16.8.0
     hot-shots: ^10.0.0
     jest: 27.5.1
     joi: ^17.8.3
@@ -35211,7 +35225,6 @@ fsevents@~2.1.1:
     fxa-profile-server: "workspace:*"
     fxa-shared: "workspace:*"
     get-stream: ^6.0.1
-    graphql: ^16.8.0
     graphql-parse-resolve-info: ^4.13.0
     graphql-query-complexity: ^0.12.0
     helmet: ^7.1.0
@@ -35492,7 +35505,6 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa-settings@workspace:packages/fxa-settings"
   dependencies:
-    "@apollo/client": ^3.8.3
     "@babel/core": ^7.22.5
     "@babel/preset-typescript": ^7.23.0
     "@babel/types": ^7.22.5
@@ -35568,7 +35580,6 @@ fsevents@~2.1.1:
     fxa-react: "workspace:*"
     fxa-shared: "workspace:*"
     get-orientation: ^1.1.2
-    graphql: ^16.8.0
     grunt: ^1.6.1
     grunt-cli: ^1.4.3
     grunt-contrib-concat: ^2.1.0
@@ -35633,7 +35644,6 @@ fsevents@~2.1.1:
     "@nestjs/common": ^10.2.4
     "@nestjs/config": ^3.0.0
     "@nestjs/core": ^10.2.4
-    "@nestjs/graphql": ^12.0.8
     "@nestjs/mapped-types": ^2.0.2
     "@opentelemetry/api": ~1.4.0
     "@opentelemetry/auto-instrumentations-node": ~0.39.2
@@ -35739,6 +35749,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa@workspace:."
   dependencies:
+    "@apollo/client": ^3.8.3
     "@apollo/server": ^4.9.3
     "@babel/core": ^7.22.20
     "@babel/preset-react": ^7.14.5
@@ -48979,14 +48990,15 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.17.5":
-  version: 0.17.5
-  resolution: "optimism@npm:0.17.5"
+"optimism@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "optimism@npm:0.18.0"
   dependencies:
+    "@wry/caches": ^1.0.0
     "@wry/context": ^0.7.0
     "@wry/trie": ^0.4.3
     tslib: ^2.3.0
-  checksum: 5990217d989e9857dc523a64cb6e5a9205eae68c7acac78f7dde8fbe50045d0f11ca8068cdbb51b1eae15510d96ad593a99cf98c6f86c41d1b6f90e54956ff11
+  checksum: d6ed6a90b05ee886dadfe556c7a30227c66843f51278e51eb843977a6a9368b6c50297fcc63fa514f53d8a5a58f8ddc8049c2356bd4ffac32f8961bcb806254d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
* We want to move shared deps to the root package.json

This commit:
* Removes packages from several package.jsons as they are already present in root.json
* Moves @apollo/client to root package.json

---

follow up to #16130

Happy to make any other changes if I missed one, I assume we only want deps shared by more than one package to go in the root.