### PR TITLE
fix(analytics): Update consent defaults for GA

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -119,7 +119,7 @@ const conf = convict({
     },
     debugMode: {
       default: false,
-      doc: 'Toggle Google Analytics gtag debug mode. (Not to be confused with librayr react-ga testMode',
+      doc: 'Toggle Google Analytics gtag debug mode. (Not to be confused with library react-ga testMode',
       env: 'GA_TEST_MODE',
       format: Boolean,
     },

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -142,7 +142,9 @@ export function useReactGA4Setup(config: Config, productId: string) {
       // https://developers.google.com/tag-platform/devguides/privacy#consent_mode_terminology
       ReactGA.gtag('consent', 'default', {
         ad_storage: 'denied',
-        analytics_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        analytics_storage: 'granted',
         functionality_storage: 'denied',
         personalization_storage: 'denied',
         security_storage: 'denied',


### PR DESCRIPTION
## Because

- Consent defaults prevented events to be logged in GA dashboard

## This pull request

- Updates consent defaults

## Issue that this pull request solves

Closes: [FXA-8624](https://mozilla-hub.atlassian.net/browse/FXA-8624)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
<img width="758" alt="Screenshot 2023-11-30 at 3 12 47 PM" src="https://github.com/mozilla/fxa/assets/28129806/3a9fbc76-f841-444a-ae0a-4e495ffa64db">