### PR TITLE
test(functional): Re-enable test upon Stripe update of test card

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -40,7 +40,6 @@ test.describe('severity-2 #smoke', () => {
     test('subscribe with credit card after initial failed subscription & verify existing user checkout funnel metrics', async ({
       pages: { relier, login, subscribe },
     }, { project }) => {
-      test.skip(); //FXA-8717
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'


### PR DESCRIPTION
## Because

- we skipped this test as the Stripe test card caused the test to stall since the postal code field was not activated

## This pull request

- re-instates test upon Stripe update

## Issue that this pull request solves

Closes: FXA-8717

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

