### PR TITLE
chore(script): Rework config-fxios script for iOS testing, remove replace-in-file

### DIFF
--- a/_scripts/config-fxios.js
+++ b/_scripts/config-fxios.js
@@ -1,53 +1,48 @@
 #!/usr/bin/env node
 
-var path = require("path");
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var r = require("replace-in-file");
+const path = require('path');
+const fs = require('fs');
 
-var ios_path = process.env.FIREFOX_IOS_HOME;
-
-if (!ios_path) {
-  throw new Error("FIREFOX_IOS_HOME is not set");
+const iosPath = process.env.FIREFOX_IOS_HOME;
+if (!iosPath) {
+  throw new Error('FIREFOX_IOS_HOME is not set');
 }
 
-var config_path = path.join(
-  ios_path,
-  "Account",
-  "FirefoxAccountConfiguration.swift"
-);
+// This matches lines containing `FxAConfig(` with a `server: server` param.
+// We want to change this so `FxAConfig` is called with our `contentUrl`.
+const regex = /FxAConfig\([^)]*server: server[^)]*\)/g;
+const replaceFrom = /\bserver: server\b/;
+const replaceTo = 'contentUrl: "http://localhost:3030"';
 
-function replace(options) {
-  return new Promise(function(resolve, reject) {
-    r(options, function(err) {
-      if (err) reject(err);
-      resolve();
+function replace() {
+  const filePath = path.join(iosPath, 'RustFxA', 'RustFirefoxAccounts.swift');
+  let fileContent = fs.readFileSync(filePath, 'utf8');
+  const matches = fileContent.match(regex);
+
+  if (matches) {
+    matches.forEach((match) => {
+      const replaced = match.replace(replaceFrom, replaceTo);
+      fileContent = fileContent.replace(match, replaced);
     });
-  });
+    fs.writeFileSync(filePath, fileContent, 'utf8');
+    console.log(
+      '✅ Successfully updated the firefox-ios FxAConfig to use localhost.'
+    );
+  } else {
+    if (fileContent.includes(replaceTo)) {
+      console.log(
+        'The firefox-ios FxAConfig was already updated to use localhost.'
+      );
+    } else {
+      throw new Error(
+        `Did not find the \`server\` parameter in any \`FxAConfig\` call to replace. Check ${filePath} - the code on the firefox-ios side may have changed.`
+      );
+    }
+  }
 }
 
-return replace({
-  files: config_path,
-  replace: /https:\/\/accounts.firefox.com/g,
-  with: "http://localhost:3030"
-})
-  .then(function() {
-    return replace({
-      files: config_path,
-      replace: "https://api.accounts.firefox.com/v1",
-      with: "http://localhost:9000/v1"
-    });
-  })
-  .then(function() {
-    return replace({
-      files: config_path,
-      replace: "https://oauth.accounts.firefox.com/v1",
-      with: "http://localhost:9010/v1"
-    });
-  })
-  .then(function() {
-    return replace({
-      files: config_path,
-      replace: "https://profile.accounts.firefox.com/v1",
-      with: "http://localhost:1111/v1"
-    });
-  });
+replace();

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",
-    "replace-in-file": "^7.0.1",
     "rxjs": "^7.8.1",
     "semver": "^7.5.2",
     "tslib": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35850,7 +35850,6 @@ fsevents@~2.1.1:
     react-ga4: ^2.1.0
     react-test-renderer: ^18.2.0
     reflect-metadata: ^0.1.13
-    replace-in-file: ^7.0.1
     rxjs: ^7.8.1
     semver: ^7.5.2
     stylelint: ^15.10.1
@@ -54562,19 +54561,6 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"replace-in-file@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "replace-in-file@npm:7.0.1"
-  dependencies:
-    chalk: ^4.1.2
-    glob: ^8.1.0
-    yargs: ^17.7.2
-  bin:
-    replace-in-file: bin/cli.js
-  checksum: da6115387bf79ac7fb2057a4212da4159cc85889e34212df62d86cc3b5ceb23167a7c22ce0dc0cebfe55c01a08ccd99fd496398375dfa29e30f173013c81579a
-  languageName: node
-  linkType: hard
-
 "request-progress@npm:^3.0.0":
   version: 3.0.0
   resolution: "request-progress@npm:3.0.0"
@@ -63361,7 +63347,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+"yargs@npm:^17.0.0, yargs@npm:^17.6.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
Because:
* The script has been broken since firefox-ios moved to Rust components and we want to do local iOS testing

This commit:
* Reworks the script that replaced several strings containing our endpoints to change a parameter used to call FxAConfig in the firefox-ios directory instead. On the Rust side we're now checking against the well-known file for these endpoints instead of using hard-coded values
* Removes replace-in-file in favor of fs since while this approach is still not robust, the new regex checks for a FxAConfig function call and replaces a specific parameter and replace-in-file does not seem to support regex/partial replacements like this

Closes FXA-2195

---

To see this broken on `main` and then working in this branch, you'll have to clone or pull latest from [firefox-ios](https://github.com/mozilla-mobile/firefox-ios) and follow the setup instructions. If the repo is adjacent to `fxa` you can run `FIREFOX_IOS_HOME=../firefox-ios yarn run config-fxios` inside FxA and see it borked on `main`. When you run the script in this branch and then build the client in XCode, you'll see that when you try to create an account or sign into Sync you'll be pointed to local servers.

(Yes, I've filed a bug for the empty alert bar, I see that through web content as well.)
<img src="https://github.com/mozilla/fxa/assets/13018240/e127133a-07af-480c-bf45-cd1e4459c415" width="300">


Two things broke this script:
* `replace-in-file` at some point had changed `replace` to `from` and `replaceWith` to `to`
* `firefox-ios` moved to Rust components so 1) the referenced file with endpoints easily replaced no longer existed and 2) on the Rust side ([link 1](https://github.com/mozilla/application-services/blob/8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1/components/fxa-client/src/lib.rs#L128), [link 2](https://github.com/mozilla/application-services/blob/8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1/components/fxa-client/src/internal/config.rs#L55-L56), [link 3](https://github.com/mozilla/application-services/blob/8ded4cb602aed89fd22c0dd7fdbfc6fa063c5ef1/components/fxa-client/src/internal/config.rs#L88-L89)) we check against content-server's `.well-known/fxa-client-configuration` for endpoints

`localhost` well-known:
<img width="400" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/a07e75a8-bb05-4f8c-9513-f2efb0c18665">

With the changes here, this script replaces `server: server` [on this line](https://github.com/mozilla-mobile/firefox-ios/blob/7e7aebb8166428b3b3635f59f63964ba7bc6aeee/RustFxA/RustFirefoxAccounts.swift#L137). We could have kept `replace-in-file` and simply replaced `server: server`, but that feels even more fragile than what's in this PR. (Plus, one less dependency to manage.)

A more robust solution would be to override config values somewhere in `firefox-ios` so we aren't directly modifying this file that can break again if the approach changes. There are [relevant keys here](https://github.com/mozilla-mobile/firefox-ios/blob/4bcdbdc4b06e1fd48b21106a136f8f8daf0e914f/Shared/Prefs.swift#L107-L108) (also see [this default value](github.com/mozilla-mobile/firefox-ios/blob/4bcdbdc4b06e1fd48b21106a136f8f8daf0e914f/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift#L16)), but I couldn't seem to find a way to set these values. I think these keys are tied to some underlying store that connects to the user's browser prefs. I _think_ we want something like this:

```
prefs.setBool(true, forKey: PrefsKeys.KeyUseCustomFxAContentServer)
prefs.setString("http://localhost:3030/", forKey: PrefsKeys.KeyCustomFxAContentServer)
```

... but I could not get that to work and don't see how to override these. This works for now, and we now have the above notes if this breaks again.