### PR TITLE
feat(metrics): add more signin frontend events

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -178,6 +178,12 @@ export const GleanMetrics = {
     error: createEventFn('login_submit_frontend_error'),
   },
 
+  cachedLogin: {
+    view: createEventFn('cached_login_view'),
+    submit: createEventFn('cached_login_submit'),
+    success: createEventFn('cached_login_success_view'),
+  },
+
   loginConfirmation: {
     view: createEventFn('login_email_confirmation_view'),
     submit: createEventFn('login_email_confirmation_submit'),

--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -6,6 +6,7 @@ import AuthErrors from '../../lib/auth-errors';
 import FormPrefillMixin from './form-prefill-mixin';
 import SigninMixin from './signin-mixin';
 import VerificationMethods from '../../lib/verification-methods';
+import GleanMetrics from '../../lib/glean';
 
 export default {
   dependsOn: [FormPrefillMixin, SigninMixin],
@@ -107,7 +108,10 @@ export default {
         return this.signIn(account, null, {
           // When using a cached credential, the auth-server routes do not get hit,
           // This event will cause the content-server to emit the complete event.
-          onSuccess: () => this.logEvent('cached.signin.success'),
+          onSuccess: () => {
+            this.logEvent('cached.signin.success');
+            GleanMetrics.cachedLogin.success();
+          },
         });
       })
       .catch((err) => {

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -78,7 +78,14 @@ const SignInPasswordView = FormView.extend({
   },
 
   logView() {
-    GleanMetrics.login.view();
+    const context = this.getContext();
+
+    if (!context.isPasswordNeeded) {
+      GleanMetrics.cachedLogin.view();
+    } else {
+      GleanMetrics.login.view();
+    }
+
     return FormView.prototype.logView.call(this);
   },
 
@@ -108,6 +115,7 @@ const SignInPasswordView = FormView.extend({
         this.onSignInError(account, password, error)
       );
     } else {
+      GleanMetrics.cachedLogin.submit();
       return this.useLoggedInAccount(account);
     }
   },

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/cached-credentials-mixin.js
@@ -14,6 +14,7 @@ import OAuthRelier from 'models/reliers/oauth';
 import User from 'models/user';
 import sinon from 'sinon';
 import VerificationMethods from 'lib/verification-methods';
+import GleanMetrics from '../../../../scripts/lib/glean';
 
 describe('views/mixins/cached-credentials-mixin', () => {
   let account;
@@ -205,6 +206,11 @@ describe('views/mixins/cached-credentials-mixin', () => {
       sinon
         .stub(account, 'accountProfile')
         .callsFake(() => Promise.resolve({}));
+      sinon.stub(GleanMetrics.cachedLogin, 'success');
+    });
+
+    afterEach(() => {
+      GleanMetrics.cachedLogin.success.restore();
     });
 
     it('delegates to signIn, logs cached.signin.success event', () => {
@@ -226,6 +232,7 @@ describe('views/mixins/cached-credentials-mixin', () => {
         onSuccess();
         assert.equal(view.logEvent.callCount, 1);
         assert.deepEqual(view.logEvent.args[0], ['cached.signin.success']);
+        sinon.assert.calledOnce(GleanMetrics.cachedLogin.success);
       });
     });
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { usePageViewEvent } from '../../lib/metrics';
 import { useFtlMsgResolver } from '../../models';
 import { MozServices } from '../../lib/types';
@@ -45,14 +45,34 @@ const Signin = ({
     'Password'
   );
 
+  useEffect(() => {
+    if (!isPasswordNeeded) {
+      GleanMetrics.cachedLogin.view();
+    } else {
+      GleanMetrics.login.view();
+    }
+  }, [isPasswordNeeded]);
+
   const signInUsingLoggedInAccount = useCallback(() => {
+    GleanMetrics.cachedLogin.submit();
+
     // TODO: add in functionality to sign in using the logged in account
     // return an error to be displayed if anythign goes wrong.
+
+    // Move this event if necessary.  The branching logic for a successful or
+    // failed login has not been implemented when the event was added.
+    GleanMetrics.cachedLogin.success();
   }, []);
 
   const signInWithPassword = useCallback((email: string, password: string) => {
+    GleanMetrics.login.submit();
+
     // TODO: add in the functionality to actually sign a user in using their password
     // return an error to be displayed if anything goes wrong.
+
+    // Move this event if necessary.  The branching logic for a successful or
+    // failed login has not been implemented when the event was added.
+    GleanMetrics.login.success();
   }, []);
 
   // TODO: This page is also supposed to render the user card, complete with avatar.

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -46,6 +46,12 @@ export const eventsMap = {
     forgotPassword: 'login_forgot_pwd_submit',
   },
 
+  cachedLogin: {
+    view: 'cached_login_view',
+    submit: 'cached_login_submit',
+    success: 'cached_login_success_view',
+  },
+
   loginConfirmation: {
     view: 'login_email_confirmation_view',
     submit: 'login_email_confirmation_submit',


### PR DESCRIPTION
Because:
 - some signin events were missing in content-server or not yet implemented in fxa-settings

This commit:
 - add the missing "cached" signin events in content-server
 - add signin events to fxa-settings there were already in content-server as well as the "cached" signin events
