### PR TITLE
fix(settings): stop displaying an empty success alert bar

### DIFF
--- a/packages/fxa-settings/src/models/AlertBarInfo.ts
+++ b/packages/fxa-settings/src/models/AlertBarInfo.ts
@@ -5,7 +5,7 @@ export type AlertBarType = 'success' | 'info' | 'error';
 
 export const alertContent = makeVar(consumeAlertTextExternal() || '');
 export const alertType = makeVar<AlertBarType>('success');
-export const alertVisible = makeVar(!!alertContent);
+export const alertVisible = makeVar(!!alertContent());
 
 export class AlertBarInfo {
   get visible() {


### PR DESCRIPTION
Because:
 - converting a function to a bool will always results in true, causing an empty success alert bar to be display on initial render of settings

This commit:
 - calls the function to get the value to be eval'd to a bool
