### PR TITLE
fix(react-signup): Fix endless CWTS spinner on iOS + mobile unexpected error

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -97,12 +97,29 @@ export type FxAOAuthLogin = {
   code: string;
   redirect: string;
   state: string;
+  // For sync mobile
+  declinedSyncEngines?: string[];
+  offeredSyncEngines?: string[];
 };
 
 // ref: https://searchfox.org/mozilla-central/rev/82828dba9e290914eddd294a0871533875b3a0b5/services/fxaccounts/FxAccountsWebChannel.sys.mjs#230
 export type FxACanLinkAccount = {
   email: string;
 };
+
+let messageIdSuffix = 0;
+/**
+ * Create a messageId for a given command/data combination.
+ *
+ * messageId is sent to the relier who is expected to respond
+ * with the same messageId. Used to keep track of outstanding requests
+ * and is required in at least Firefox iOS to send back a response.
+ * */
+function createMessageId() {
+  // If two messages are created within the same millisecond, Date.now()
+  // returns the same value. Append a suffix that ensures uniqueness.
+  return `${Date.now()}${++messageIdSuffix}`;
+}
 
 export class Firefox extends EventTarget {
   private broadcastChannel?: BroadcastChannel;
@@ -163,7 +180,7 @@ export class Firefox extends EventTarget {
   private formatEventDetail(
     command: FirefoxCommand,
     data: any,
-    messageId: string = ''
+    messageId: string = createMessageId()
   ) {
     const detail = {
       id: this.id,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -30,6 +30,8 @@ const SignupConfirmCodeContainer = ({
   };
   const {
     selectedNewsletterSlugs: newsletterSlugs,
+    offeredSyncEngines,
+    declinedSyncEngines,
     keyFetchToken,
     unwrapBKey,
   } = location.state || {};
@@ -117,6 +119,8 @@ const SignupConfirmCodeContainer = ({
         integration,
         finishOAuthFlowHandler,
         newsletterSlugs,
+        offeredSyncEngines,
+        declinedSyncEngines,
         keyFetchToken,
         unwrapBKey,
       }}

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -55,6 +55,8 @@ const ConfirmSignupCode = ({
   integration,
   finishOAuthFlowHandler,
   newsletterSlugs: newsletters,
+  offeredSyncEngines,
+  declinedSyncEngines,
   keyFetchToken,
   unwrapBKey,
 }: ConfirmSignupCodeProps & RouteComponentProps) => {
@@ -68,9 +70,6 @@ const ConfirmSignupCode = ({
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
   );
-  // TODO: Sync mobile cleanup, see note in oauth-integration isSync
-  const isSyncMobileWebChannel =
-    isOAuthIntegration(integration) && integration.isSync();
 
   const navigate = useNavigate();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
@@ -183,9 +182,15 @@ const ConfirmSignupCode = ({
             unwrapBKey!
           );
 
+          // TODO: Sync mobile cleanup, see note in oauth-integration isSync, FXA-8671
+          const isSyncMobileWebChannel =
+            isOAuthIntegration(integration) &&
+            integration.isSync() &&
+            integration.features.webChannelSupport === true;
           if (isSyncMobileWebChannel) {
             firefox.fxaOAuthLogin({
-              // TODO: is this 'action' correct?
+              declinedSyncEngines,
+              offeredSyncEngines,
               action: 'signup',
               code,
               redirect,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -17,6 +17,8 @@ export type LocationState = {
   selectedNewsletterSlugs?: string[];
   keyFetchToken?: string;
   unwrapBKey?: string;
+  offeredSyncEngines?: string[];
+  declinedSyncEngines?: string[];
 };
 
 export type ConfirmSignupCodeContainerProps = {
@@ -31,6 +33,8 @@ export type ConfirmSignupCodeProps = {
   integration: ConfirmSignupCodeIntegration;
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   newsletterSlugs?: string[];
+  offeredSyncEngines?: string[];
+  declinedSyncEngines?: string[];
 } & Pick<LocationState, 'keyFetchToken' | 'unwrapBKey'> &
   RouteComponentProps;
 

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -86,7 +86,7 @@ const SignupContainer = ({
 
   const isOAuth = isOAuthIntegration(integration);
   const hasWebChannelSupport = integration.features.webChannelSupport === true;
-  // TODO: Sync mobile cleanup, see note in oauth-integration isSync
+  // TODO: Sync mobile cleanup, see note in oauth-integration isSync, FXA-8671
   const isSyncMobile = isOAuth && serviceName === MozServices.FirefoxSync;
   const isSyncMobileWebChannel = isSyncMobile && hasWebChannelSupport;
   const isSyncDesktop = isSyncDesktopIntegration(integration);

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -217,14 +217,14 @@ export const Signup = ({
           metricsEnabled: true,
         };
 
+        const getOfferedSyncEngines = () =>
+          getSyncEngineIds(offeredSyncEngineConfigs || []);
+
         persistAccount(accountData);
         setCurrentAccount(data.SignUp.uid);
         sessionToken(data.SignUp.sessionToken);
 
         if (isSyncDesktopIntegration(integration)) {
-          const offeredSyncEngines = getSyncEngineIds(
-            offeredSyncEngineConfigs || []
-          );
           firefox.fxaLogin({
             email: queryParamModel.email,
             keyFetchToken: data.SignUp.keyFetchToken,
@@ -234,7 +234,7 @@ export const Signup = ({
             verified: false,
             services: {
               sync: {
-                offeredEngines: offeredSyncEngines,
+                offeredEngines: getOfferedSyncEngines(),
                 declinedEngines: declinedSyncEngines,
               },
             },
@@ -246,6 +246,12 @@ export const Signup = ({
             selectedNewsletterSlugs,
             keyFetchToken: data.SignUp.keyFetchToken,
             unwrapBKey: data.unwrapBKey,
+            // Sync desktop sends a web channel message up on Signup
+            // while Sync mobile does on confirm signup
+            ...(isSyncMobileWebChannel && {
+              offeredSyncEngines: getOfferedSyncEngines(),
+              declinedSyncEngines,
+            }),
           },
           replace: true,
         });
@@ -262,11 +268,12 @@ export const Signup = ({
       ftlMsgResolver,
       navigate,
       selectedNewsletterSlugs,
-      offeredSyncEngineConfigs,
       declinedSyncEngines,
       queryParamModel.email,
       location.search,
       integration,
+      offeredSyncEngineConfigs,
+      isSyncMobileWebChannel,
     ]
   );
 


### PR DESCRIPTION
Because:
* We want to fix all teh bugs

This commit:
* Creates a web channel message ID if one does not exist, as we require this on the firefox-ios side before responding with a web channel message containing Sync engine capabilities
* Adjusts our finishOAuthFlowHandler to account for the existing oauth-webchannel-v1 sendOAuthResultToRelier functionality

fixes FXA-8676
fixes FXA-8677

---

For testing, you'll want the changes in #16139 and to run `FIREFOX_IOS_HOME=../firefox-ios yarn run config-fxios` if `firefox-ios` is adjacent to `fxa`. Then you'll build the client.

To ensure you'll see the React version of the Signup page, you can change the `router.js` `oauth/signup` from `createReactOrBackboneViewHandler` to `createReactViewHandler`.

Tests will be added in FXA-8657.

<img src="https://github.com/mozilla/fxa/assets/13018240/52b594d0-1512-4388-96a9-46ea0cdb3c3c" width="200">

Forgot to show the account logged in and synced items showing (I think I remember there being an issue around credit cards a while back, I'm confident that's existing). Also went to mozilla.org so the webpage wasn't as confusing:
<img src="https://github.com/mozilla/fxa/assets/13018240/130c8be2-61cd-4d9e-b75f-9fc54821496e" width="200">

