### PR TITLE
fix(react): Set isSignedIn=false for 'Must verify' state resulting in spinner

### DIFF
--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -79,6 +79,15 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
           return window.location.replace(
             `/signin_token_code?action=email&service=sync`
           );
+          // TODO: Improve in FXA-7626
+          // If the user isn't in Settings and they see this message they may hit it due to
+          // the initial metrics query - e.g. if they attempt to sign in and see the TOTP page,
+          // they'll be in this state.
+        } else {
+          cache.writeQuery({
+            query: GET_LOCAL_SIGNED_IN_STATUS,
+            data: { isSignedIn: false },
+          });
         }
       }
     }


### PR DESCRIPTION
Because:
* Users could login with 2FA enabled and then at the TOTP screen, try to reset their PW and in this state they would see an endless spinner

This commit:
* Sets the local isSignedIn state to 'false' for this case, allowing the page to render

fixes FXA-8792

---

Kind of a bandaid until we work on the related "Must verify" / session verify tickets in the architecture epic, but this seems to work for me.