### PR TITLE
fix(functional-tests): Update react reset password playwright test to reflect background nav

### DIFF
--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -61,7 +61,9 @@ test.describe('severity-1 #smoke', () => {
       await diffPage.waitForURL(/reset_password_verified/);
 
       // Wait for initial page to automatically redirect once password is reset
-      await page.waitForURL(`${target.contentServerUrl}/signin`);
+      // without an account in local storage (state in this test), the initial navigation
+      // to /signin is expected to redirect to the root
+      await page.waitForURL(target.contentServerUrl);
 
       // Verify password reset confirmation page is rendered
       await resetPasswordReact.resetPwdConfirmedHeadingVisible(diffPage);


### PR DESCRIPTION
## Because

* The confirm reset password page redirects to email-first even if URL is set to /signin because the account is not in local storage
* The test was failing in stage smoke test because it was waiting for /signin to load

## This pull request

* Update polling on ConfirmResetPassword to navigate to email-first page if reset password is completed in another tab (instead of sign in)
* Update test to expect navigation to email-first

## Issue that this pull request solves

Closes: #FXA-8801

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
