### PR TITLE
fix(payments): update Mozilla logo on Set up your subscription page

### DIFF
--- a/packages/fxa-payments-server/src/components/Header/index.tsx
+++ b/packages/fxa-payments-server/src/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Profile } from '../../store/types';
-import mozillaLogo from 'fxa-react/images/moz-m-logo.svg';
+import mozillaLogo from 'fxa-react/images/moz-logo-bw-rgb.svg';
 import { useLocalization } from '@fluent/react';
 
 export type HeaderProps = {


### PR DESCRIPTION
## Because

- Mozilla `m` logo should be full logo on Set up your subscription page.

## This pull request

- Replaces Mozilla `m` logo with full logo on Set up your subscription page.

## Issue that this pull request solves

Closes FXA-8803

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).