### PR TITLE
bug(settings): Make 'Create Account' button work if passwords match and are valid

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -565,5 +565,61 @@ describe('Signup page', () => {
       expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.registration.success).not.toHaveBeenCalled();
     });
+
+    describe('allows user to correct password', () => {
+      beforeEach(async () => {
+        const mockBeginSignupHandler = jest
+          .fn()
+          .mockResolvedValue(BEGIN_SIGNUP_HANDLER_FAIL_RESPONSE);
+
+        renderWithLocalizationProvider(
+          <Subject beginSignupHandler={mockBeginSignupHandler} />
+        );
+        fireEvent.input(screen.getByLabelText('How old are you?'), {
+          target: { value: 13 },
+        });
+        fireEvent.input(screen.getByLabelText('Password'), {
+          target: { value: MOCK_PASSWORD },
+        });
+        fireEvent.input(screen.getByLabelText('Repeat password'), {
+          target: { value: MOCK_PASSWORD + 'x' },
+        });
+        await waitFor(() => {
+          expect(
+            screen.getByRole('button', {
+              name: 'Create account',
+            })
+          ).toBeDisabled();
+        });
+      });
+
+      it('enables when password is corrected', async () => {
+        fireEvent.input(screen.getByLabelText('Password'), {
+          target: { value: MOCK_PASSWORD + 'x' },
+        });
+        fireEvent.blur(screen.getByLabelText('Password'));
+        await waitFor(() => {
+          expect(
+            screen.getByRole('button', {
+              name: 'Create account',
+            })
+          ).toBeEnabled();
+        });
+      });
+
+      it('enables when repeat password is corrected', async () => {
+        fireEvent.input(screen.getByLabelText('Repeat password'), {
+          target: { value: MOCK_PASSWORD },
+        });
+        fireEvent.blur(screen.getByLabelText('Repeat password'));
+        await waitFor(() => {
+          expect(
+            screen.getByRole('button', {
+              name: 'Create account',
+            })
+          ).toBeEnabled();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Because
- We could get in a state where the Create Account button was not enabled even if passwords matched
- This would happen if the first password was updated to match the second (i.e. the repeat password field)

## This pull request
- Checks if the form is invalid and then triggers on the related input to clear any potential error state.
- Adds test coverage for these checks.

## Issue that this pull request solves

Closes: FXA-8486

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
