### PR TITLE
fix(react): Fix various React signup OAuth/Sync bugs

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -167,12 +167,10 @@ test.describe('severity-1 #smoke', () => {
 
       await signupReact.fillOutCodeForm(code);
 
-      // TODO code verification is currently throwing an UNAUTHORIZED error
-      // remove the following line once this error is no longer thrown
-      // expect(await page.getByText(/Invalid token/).isVisible()).toBeFalsy();
-      // TODO uncomment these lines once line above is passing (no token error)
-      // await page.waitForURL(/connect_another_device/);
-      // expect(await page.getByText('Youʼre signed into Firefox').isVisible()).toBeTruthy();
+      // See note in `firefox.ts` about an event listener hack needed for this test
+      expect(await page.getByText(/Invalid token/).isVisible()).toBeFalsy();
+      await page.waitForURL(/connect_another_device/);
+      await expect(page.getByText('You’re signed into Firefox')).toBeVisible();
 
       await syncBrowserPages.browser?.close();
     });

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -58,6 +58,7 @@ const settingsConfig = {
   oauth: {
     clientId: config.get('oauth_client_id'),
     scopedKeysEnabled: config.get('scopedKeys.enabled'),
+    scopedKeysValidation: config.get('scopedKeys.validation'),
     isPromptNoneEnabled: config.get('oauth.prompt_none.enabled'),
     isPromptNoneEnabledClientIds: config.get(
       'oauth.prompt_none.enabled_client_ids'

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -112,7 +112,8 @@ export function getDefault() {
     },
     oauth: {
       clientId: '',
-      scopedKeysEnabled: false,
+      scopedKeysEnabled: true,
+      scopedKeysValidation: {},
       isPromptNoneEnabled: false,
       isPromptNoneEnabledClientIds: new Array<string>(),
       reactClientIdsEnabled: new Array<string>(),

--- a/packages/fxa-settings/src/lib/crypto/scoped-keys.ts
+++ b/packages/fxa-settings/src/lib/crypto/scoped-keys.ts
@@ -46,7 +46,7 @@ export async function createEncryptedBundle(
  */
 async function encryptBundle(bundleObject: any, keysJwk: any) {
   const cryptoDeriver = await fxaCryptoDeriver();
-  const fxaDeriverUtils = new cryptoDeriver.deriverutils();
+  const fxaDeriverUtils = new cryptoDeriver.DeriverUtils();
   return fxaDeriverUtils.encryptBundle(keysJwk, JSON.stringify(bundleObject));
 }
 

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
@@ -178,6 +178,10 @@ describe('lib/integrations/integration-factory', () => {
       );
     });
 
+    afterAll(() => {
+      urlQueryData.set('service', '');
+    });
+
     it('has correct state', () => {
       expect(integration.type).toEqual(IntegrationType.SyncDesktop);
       expect(integration.isOAuth()).toBeFalsy();
@@ -206,27 +210,48 @@ describe('lib/integrations/integration-factory', () => {
   describe('OAuthIntegration creation', () => {
     let integration: OAuthIntegration;
 
-    beforeAll(async () => {
-      integration = await setup<OAuthIntegration>(
-        { isOAuth: true },
-        { initIntegration: 1, initOAuthIntegration: 1, initClientInfo: 1 },
-        (i: Integration) => i instanceof OAuthIntegration
-      );
+    describe('OAuth redirect', () => {
+      beforeEach(async () => {
+        integration = await setup<OAuthIntegration>(
+          { isOAuth: true },
+          { initIntegration: 1, initOAuthIntegration: 1, initClientInfo: 1 },
+          (i: Integration) => i instanceof OAuthIntegration
+        );
 
-      sandbox.stub(integration, 'clientInfo').returns(
-        Promise.resolve({
-          trusted: true,
-        })
-      );
+        sandbox
+          .stub(integration, 'clientInfo')
+          .get(() => ({ ...clientInfo, trusted: true }));
+      });
+
+      it('has correct state', async () => {
+        expect(integration.type).toEqual(IntegrationType.OAuth);
+        expect(integration.isOAuth()).toBeTruthy();
+        expect(integration.isSync()).toBeFalsy();
+        expect(integration.wantsKeys()).toBeFalsy();
+        expect(integration.isTrusted()).toBeTruthy();
+      });
     });
 
-    it('has correct state', async () => {
-      expect(integration.type).toEqual(IntegrationType.OAuth);
-      expect(integration.isOAuth()).toBeTruthy();
-      expect(integration.isSync()).toBeFalsy();
-      expect(integration.wantsKeys()).toBeFalsy();
-      expect(integration.isTrusted()).toBeFalsy();
-    });
+    // TODO in FXA-8657
+    // describe('Sync mobile', () => {
+    // beforeEach(async () => {
+    // set scope to oauth_oldsync_scope
+    //   integration = await setup<OAuthIntegration>(
+    //     { isOAuth: true },
+    //     { initIntegration: 1, initOAuthIntegration: 1, initClientInfo: 1 },
+    //     (i: Integration) => i instanceof OAuthIntegration
+    //   );
+
+    // });
+    // it('has correct state', async () => {
+    //   expect(integration.type).toEqual(IntegrationType.OAuth);
+    //   expect(integration.isOAuth()).toBeTruthy();
+    //   expect(integration.isSync()).toBeTruthy();
+    //   expect(integration.wantsKeys()).toBeFalsy();
+    //   expect(integration.isTrusted()).toBeTruthy();
+    // });
+    // });
+
     // TODO: Port remaining tests from content-server
   });
 
@@ -243,6 +268,10 @@ describe('lib/integrations/integration-factory', () => {
         { initIntegration: 1, initClientInfo: 1 },
         (i: Integration) => i instanceof PairingSupplicantIntegration
       );
+
+      sandbox
+        .stub(integration, 'clientInfo')
+        .get(() => ({ ...clientInfo, trusted: true }));
     });
 
     it('has correct state', () => {
@@ -250,7 +279,7 @@ describe('lib/integrations/integration-factory', () => {
       expect(integration.isOAuth()).toBeTruthy();
       expect(integration.isSync()).toBeFalsy();
       expect(integration.wantsKeys()).toBeFalsy();
-      expect(integration.isTrusted()).toBeFalsy();
+      expect(integration.isTrusted()).toBeTruthy();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -173,7 +173,7 @@ const ConfirmSignupCode = ({
           return;
         } else {
           const { redirect, code, state } = await finishOAuthFlowHandler(
-            integration.data.uid,
+            uid,
             sessionToken,
             // yes, non-null operator is gross, but it's temporary.
             // see note in container component / router.js for this page, once

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -225,7 +225,7 @@ export const Signup = ({
         sessionToken(data.SignUp.sessionToken);
 
         if (isSyncDesktopIntegration(integration)) {
-          firefox.fxaLogin({
+          await firefox.fxaLogin({
             email: queryParamModel.email,
             keyFetchToken: data.SignUp.keyFetchToken,
             sessionToken: data.SignUp.sessionToken,


### PR DESCRIPTION
Because:
* We want to fix all Signup React bugs before rolling out to prod

This commit:
* Fixes AMO signup where client_id, scope, state, and access type are given params - we should only hit the 'account/keys' endpoint if integration.wantsKeys() is true
* Passes missing scopedKeysValidation config to React, as 'validation' was undefined when checking integration.wantsKeys() and sets scopedKeysEnabled to 'true' by default to match content-server's config
* Adds an event listener for fxaLogin in Playwright that resolves when a response is received from the browser and enables test, tweaks a couple of others
* Includes Sync mobile fixes:
  1) Tweaks integration.isSync() to account for 'oldsync' scope to ensure sync mobile is considered 'sync'
  2) passes back the correct state and redirect from the useFinishOAuthFlowHandler hook
  3) properly sets and checks for clientInfo.redirectUri
  4) calls the OAuth handler hook with account uid from signup data (local storage) instead of integration.data.uid
  5) correctly calls a method in cryptoDeriver that had a capitalization mismatch

fixes FXA-8743
fixes FXA-8763

---

### How to Test

You can verify regular OAuth Signup works from `localhost:8080` and appending the React params (`forceExperiment=generalizedReactApp&forceExperimentGroup=react`) from the index screen. You can also verify desktop Firefox sync works by running `FXA_DESKTOP_CONTEXT=fx_desktop_v3 npm start` inside of `fxa-dev-launcher`, clicking "Looking for Firefox Sync?" and then appending the React params (or doing this from the browser menu) and going through the flow and seeing the chosen options synced up to the browser. 

Since this contains Sync mobile fixes, the _best_ way to test this is to [follow our instructions to run `firefox-ios`](https://mozilla.github.io/ecosystem-platform/reference/mobile-specifics#tag/OAuth-Server-API-Overview/operation/postAuthorizedclientsDestroy), change `oauth/signup` in `router.js` from `createReactOrBackboneViewHandler` to `createReactViewHandler` to guarantee a React flow, and go through the Sync signup flow in XCode's simulator to see this allows the user to go through the flow, create an account, verify the account, and see that the user is logged into Sync, and Sync options are saved.

Another way to test the Sync mobile fixes, though you won't see the sync to browser but you'll see the account is created and verified without error, is to run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 npm start` and then [go to this URL in the new FF](http://localhost:3030/authorization?action=email&response_type=code&entrypoint=email_browser-menu&client_id=1b1a3e44c54fbb58&scope=profile+https%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync+https%3A%2F%2Fidentity.mozilla.com%2Ftokens%2Fsession&state=QYCng5JjZLtZr6HWAHbtpA&code_challenge_method=S256&code_challenge=2oc_C4v1qHeefWAGu5LI5oDG1oX4FV_Itc148D8_oQI&access_type=offline&keys_jwk=eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6ImdUejVIWFJfa2pxSFRtMG43ZjhxcDMybVZFaHZ1cGo1dXNUV1h5TWZsb1kiLCJ5IjoiVER5TlhkalhibHZld1pWLVc5MXNDZU9fRWd0NU9WYXhpblBzOEFTQ3owZyJ9&context=oauth_webchannel_v1), which I got by printing the URL from `firefox-ios` code. You'll also want to append those React params (or, make a change in `router.js` described in the previous paragraph). Nothing happens when you verify the code since in iOS the window closes but you can go through without error.

Here's a screen recording of this working in iOS. (The automatically selected "Credit cards" sync option will be fixed on the `firefox-ios` side soon)
https://github.com/mozilla/fxa/assets/13018240/dc79b2ae-d3d4-43ef-9cdc-1b65756e61cb


