### PR TITLE
feat(react): Handle email bounces in react signup

### DIFF
--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -81,6 +81,10 @@ export class SignupReactPage extends BaseLayout {
     await this.page.getByRole('button', { name: label }).click();
   }
 
+  async confirmCodeHeading() {
+    await this.page.getByRole('heading', { name: /Enter confirmation code/ });
+  }
+
   async visitTermsOfServiceLink() {
     const link = await this.page.getByText('Terms of Service');
     link.click();

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -618,6 +618,21 @@ Router = Router.extend({
       url = url.split('?')[0];
     }
 
+    // With the conversion to react, we needed to pass bounced email address as a param
+    // when redirecting to backbone email-first sign in/sign up
+    // however, we don't want this param to follow like a bad smell
+    // when the user enters a valid email and successfully navigates away
+    const params = new URLSearchParams(url.split('?')[1]);
+    if (params.get('bouncedEmail')) {
+      const path = url.split('?')[0];
+      params.delete('bouncedEmail');
+      if (params.size) {
+        url = path + '?' + params.toString();
+      } else {
+        url = path;
+      }
+    }
+
     if (this.window.location.hash) {
       url += this.window.location.hash;
     }

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -151,7 +151,8 @@ class IndexView extends FormView {
       // screen with that email prefilled.
     } else if (
       this.allowSuggestedAccount(suggestedAccount) &&
-      !this.relier.get('prefillEmail')
+      !this.relier.get('prefillEmail') &&
+      !this._hasEmailBounced()
     ) {
       this.replaceCurrentPage('signin', {
         account: suggestedAccount,
@@ -204,7 +205,11 @@ class IndexView extends FormView {
 
   _hasEmailBounced() {
     const account = this.getAccount('account');
-    return account && account.get('hasBounced');
+
+    return (
+      this.getSearchParam('bouncedEmail') ||
+      (account && account.get('hasBounced'))
+    );
   }
 
   _isEmailSameAsBouncedEmail() {
@@ -212,7 +217,9 @@ class IndexView extends FormView {
       return false;
     }
 
-    const bouncedEmail = this.getAccount('account').get('email');
+    const bouncedEmail =
+      this.getSearchParam('bouncedEmail') ||
+      this.getAccount('account').get('email');
 
     return (
       bouncedEmail && bouncedEmail === this.getElementValue('input[type=email]')
@@ -258,6 +265,7 @@ class IndexView extends FormView {
       .then(() => this.user.checkAccountStatus(account))
       .then(({ exists, hasPassword, hasLinkedAccount }) => {
         const nextEndpoint = exists ? 'signin' : 'signup';
+
         if (exists) {
           // If the account exists, use the stored account
           // so that any stored avatars are displayed on

--- a/packages/fxa-content-server/app/scripts/views/sign_in_bounced.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_bounced.js
@@ -25,7 +25,7 @@ const SignInBouncedView = BaseView.extend({
   },
 
   beforeRender() {
-    if (!this.model.has('email')) {
+    if (!this.model.has('email') && !this.getSearchParam('bouncedEmail')) {
       // This may occur if the user has refreshed the page. In that case,
       // we have no context for properly rendering the view, so kick them
       // out to /signin where they can start again.
@@ -35,7 +35,7 @@ const SignInBouncedView = BaseView.extend({
 
   setInitialContext(context) {
     context.set({
-      email: this.model.get('email'),
+      email: this.model.get('email') || this.getSearchParam('bouncedEmail'),
       escapedSupportLinkAttrs:
         'id="support" href="https://support.mozilla.org/" target="_blank" data-flow-event="link.support"',
     });

--- a/packages/fxa-graphql-api/src/gql/dto/payload/email-bounce.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/email-bounce.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class EmailBounceStatusPayload {
+  @Field({
+    description:
+      'Whether or not there is a hard bounce recorded for the provided email',
+  })
+  public hasHardBounce!: boolean;
+}

--- a/packages/fxa-react/components/LoadingSpinner/index.tsx
+++ b/packages/fxa-react/components/LoadingSpinner/index.tsx
@@ -1,5 +1,6 @@
 import { useLocalization } from '@fluent/react';
 import React from 'react';
+import classNames from 'classnames';
 import { ReactComponent as Spinner } from './spinner.svg';
 import { ReactComponent as SpinnerWhite } from './spinnerwhite.svg';
 
@@ -12,12 +13,14 @@ export type LoadingSpinnerProps = {
   className?: string;
   imageClassName?: string;
   spinnerType?: SpinnerType;
+  fullScreen?: boolean;
 };
 
 export const LoadingSpinner = ({
   className,
   imageClassName = 'w-10 h-10 animate-spin',
   spinnerType = SpinnerType.Blue,
+  fullScreen = false,
 }: LoadingSpinnerProps) => {
   const { l10n } = useLocalization();
   const loadingAriaLabel = l10n.getString(
@@ -50,7 +53,14 @@ export const LoadingSpinner = ({
   }
 
   return (
-    <div {...{ className }} data-testid="loading-spinner">
+    <div
+      className={classNames(
+        className,
+        fullScreen &&
+          'bg-grey-20 flex items-center flex-col justify-center h-screen select-none'
+      )}
+      data-testid="loading-spinner"
+    >
       {spinnerImage}
     </div>
   );

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -58,11 +58,6 @@ import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 
 const Settings = lazy(() => import('../Settings'));
 
-// TODO: FXA-8305, DRY this up in the codebase
-const fullPageLoadingSpinner = (
-  <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-);
-
 export const App = ({
   flowQueryParams,
 }: { flowQueryParams: QueryParams } & RouteComponentProps) => {
@@ -158,7 +153,7 @@ export const App = ({
 
   // Wait until metrics is done loading, integration has been created, and isSignedIn has been determined.
   if (metricsLoading || !integration || isSignedIn === undefined) {
-    return fullPageLoadingSpinner;
+    return <LoadingSpinner fullScreen />;
   }
 
   // TODO: Do we like passing `isSignedIn` here, or query in page components instead?
@@ -181,14 +176,14 @@ const SettingsRoutes = ({
     hardNavigateToContentServer(
       `/signin?redirect_to=${encodeURIComponent(location.pathname)}`
     );
-    return fullPageLoadingSpinner;
+    return <LoadingSpinner fullScreen />;
   }
 
   const settingsContext = initializeSettingsContext();
   return (
     <SettingsContext.Provider value={settingsContext}>
       <ScrollToTop default>
-        <Suspense fallback={fullPageLoadingSpinner}>
+        <Suspense fallback={<LoadingSpinner fullScreen />}>
           <Settings path="/settings/*" {...{ isSignedIn }} />
         </Suspense>
       </ScrollToTop>
@@ -216,9 +211,7 @@ const AuthAndAccountSetupRoutes = ({
 
   // Show loading spinner until integration is ready and service name has been determined.
   if (!integration || serviceName === undefined) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
 
   return (

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -42,9 +42,7 @@ export const Settings = (_: RouteComponentProps) => {
   const { loading, error } = useInitialSettingsState();
 
   if (loading) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
 
   // This error check includes a network error

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
@@ -31,7 +31,7 @@ const Supp = ({ error }: SuppProps & RouteComponentProps) => {
           <p>{error}</p>
         </Banner>
       ) : (
-        <LoadingSpinner className="flex flex-col justify-center items-center select-none" />
+        <LoadingSpinner fullScreen />
       )}
     </AppLayout>
   );

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -211,9 +211,7 @@ const AccountRecoveryConfirmKey = ({
     }
   };
   if (showLoadingSpinner) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
   return (
     <AppLayout>

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -287,9 +287,7 @@ const CompleteResetPassword = ({
   );
 
   if (showLoadingSpinner) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
   return (
     <AppLayout>

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
@@ -76,7 +76,7 @@ const CompleteSignin = ({
               <FtlMsg id="validating-signin">
                 <p className="text-base">Validating sign-in…</p>
               </FtlMsg>
-              <LoadingSpinner className="flex items-center flex-col justify-center mt-4 select-none" />
+              <LoadingSpinner fullScreen />
             </>
           )}
         </div>

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -130,7 +130,7 @@ const SigninBounced = ({
           </section>
         </>
       ) : (
-        <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center select-none" />
+        <LoadingSpinner fullScreen />
       )}
     </AppLayout>
   );

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
@@ -183,9 +183,7 @@ export const Confirm = ({
   };
 
   if (showLoadingSpinner) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { RouteComponentProps, useLocation } from '@reach/router';
+import React, { useCallback, useEffect } from 'react';
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import { currentAccount } from '../../../lib/cache';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
@@ -15,9 +15,14 @@ import AppLayout from '../../../components/AppLayout';
 import CardHeader from '../../../components/CardHeader';
 import ConfirmSignupCode from '.';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
-import { LoadingSpinner } from 'fxa-react/components/LoadingSpinner';
-import { LocationState } from './interfaces';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { GetEmailBounceStatusResponse, LocationState } from './interfaces';
 import sentryMetrics from 'fxa-shared/sentry/browser';
+import { StoredAccountData } from '../../../lib/storage-utils';
+import { useQuery } from '@apollo/client';
+import { EMAIL_BOUNCE_STATUS_QUERY } from './gql';
+
+export const POLL_INTERVAL = 5000;
 
 const SignupConfirmCodeContainer = ({
   integration,
@@ -29,22 +34,93 @@ const SignupConfirmCodeContainer = ({
     state: LocationState;
   };
   const {
+    origin,
     selectedNewsletterSlugs: newsletterSlugs,
     offeredSyncEngines,
     declinedSyncEngines,
     keyFetchToken,
     unwrapBKey,
   } = location.state || {};
+  const navigate = useNavigate();
+
+  const storedLocalAccount: StoredAccountData | undefined = currentAccount();
+  const { email, sessionToken, uid } = storedLocalAccount || {};
 
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
     integration
   );
 
+  const navigateToContentServer = useCallback(
+    (path: string, hasBounced?: boolean) => {
+      const params = new URLSearchParams(location.search);
+
+      // If the user reached this page from React signup,
+      // 'email' and 'emailFromContent' will be set as params
+      // when the user was navigated from Backbone to React.
+      // This is temporary until index is converted to React.
+      // Passing back the 'email' param causes various behaviors in
+      // content-server since it marks the email as "coming from a RP".
+      params.delete('emailFromContent');
+      params.delete('email');
+      // passing the 'bouncedEmail' param will display an error tooltip
+      // on the email-first signin/signup page and allow to check
+      // if the entered email matches the bounced email
+      hasBounced && params.set('bouncedEmail', email);
+      if (Array.from(params).length > 0) {
+        path += `?${params.toString()}`;
+      }
+      hardNavigateToContentServer(path);
+    },
+    [email, location.search]
+  );
+
+  // Poll for hard bounces registered in database for the entered email.
+  // Previously, we checked if the account was deleted, and assumed
+  // that implied the email bounced/was invalid.
+  const { data } = useQuery<GetEmailBounceStatusResponse>(
+    EMAIL_BOUNCE_STATUS_QUERY,
+    {
+      variables: { input: email },
+      pollInterval: POLL_INTERVAL,
+    }
+  );
+
+  // Handle email bounces
+  useEffect(() => {
+    if (data?.emailBounceStatus.hasHardBounce) {
+      const hasBounced = true;
+      // if arriving from signup, return to '/' and allow user to signup with another email
+      if (origin === 'signup') {
+        navigateToContentServer('/', hasBounced);
+      } else {
+        // if not arriving from signup, redirect to signin_bounced for support info
+        navigateToContentServer('/signin_bounced', hasBounced);
+      }
+    }
+  }, [data, origin, navigate, navigateToContentServer]);
+
+  // TODO: This check and related test can be moved up the tree to the App component,
+  // where a missing integration should be caught and handled.
   if (!integration) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
+  }
+
+  if (!sessionToken) {
+    /* Users who reach this page should have account data set in localStorage.
+   * Account data is persisted local storage after creating an (unverified) account
+   * and after sign in. Users may also have localStorage set by the browser if
+   * they are logged in.
+
+   * The session token from local storage is required to verify the signup code.
+   * If this page is reached without an account in localStorage (e.g., directly from
+   * URL) or if the local storage is invalidated/cleared, redirect to `/`.
+
+   * TOOD: when we pull the account.verifySession call into the container component,
+   * ensure we're only reading from localStorage once. `sessionToken()` also reads from
+   * localStorage. */
+    navigateToContentServer('/');
+    return <LoadingSpinner fullScreen />;
   }
 
   // TODO: UX for this, FXA-8106
@@ -59,21 +135,6 @@ const SignupConfirmCodeContainer = ({
     );
   }
 
-  /* Users who reach this page should have account data set in localStorage.
-   * Account data is persisted local storage after creating an (unverified) account
-   * and after sign in. Users may also have localStorage set by the browser if
-   * they are logged in.
-
-   * The session token from local storage is required to verify the signup code.
-   * If this page is reached without an account in localStorage (e.g., directly from
-   * URL), redirect to `/`.
-
-   * TOOD: when we pull the account.verifySession call into the container component,
-   * ensure we're only reading from localStorage once. `sessionToken()` also reads from
-   * localStorage. */
-  const storedLocalAccount = currentAccount();
-  const { email, sessionToken, uid } = storedLocalAccount;
-
   // Users in this state should never reach this as they should see the Backbone version
   // of this page until we convert signin to React, but guard against anyway. See
   // comment in `router.js` for this route for more info.
@@ -84,30 +145,8 @@ const SignupConfirmCodeContainer = ({
         'WARNING: User should not have reached ConfirmSignupCode in React without required state for OAuth integration. Redirecting to Backbone signin page.'
       )
     );
-    const params = new URLSearchParams(location.search);
-    // Remove `emailFromContent` since we pass that when coming
-    // from content-server to Backbone, see Signup container component
-    // for more info.
-    params.delete('emailFromContent');
-    hardNavigateToContentServer(`/signin?${params.toString()}`);
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
-  }
-
-  if (!storedLocalAccount || !email || !sessionToken || !uid) {
-    const params = new URLSearchParams(location.search);
-    // Passing back the 'email' param causes various behaviors in
-    // content-server since it marks the email as "coming from a RP".
-    // Also remove `emailFromContent` since we pass that when coming
-    // from content-server to Backbone, see Signup container component
-    // for more info.
-    params.delete('emailFromContent');
-    params.delete('email');
-    hardNavigateToContentServer(`/?${params.toString()}`);
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    navigateToContentServer('/');
+    return <LoadingSpinner fullScreen />;
   }
 
   return (
@@ -127,5 +166,4 @@ const SignupConfirmCodeContainer = ({
     />
   );
 };
-
 export default SignupConfirmCodeContainer;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/gql.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/gql.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const EMAIL_BOUNCE_STATUS_QUERY = gql`
+  query GetEmailBounceStatus($input: String!) {
+    emailBounceStatus(input: $input) {
+      hasHardBounce
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -50,8 +50,8 @@ export const viewName = 'confirm-signup-code';
 
 const ConfirmSignupCode = ({
   email,
-  sessionToken,
   uid,
+  sessionToken,
   integration,
   finishOAuthFlowHandler,
   newsletterSlugs: newsletters,
@@ -270,13 +270,6 @@ const ConfirmSignupCode = ({
     'confirm-signup-code-page-title',
     'Enter confirmation code'
   );
-
-  // TODO: handle bounced emails/blocked accounts in FXA-8306
-  // poll for session verification (does not exist on Settings), and
-  // - if invalid token + account does not exist (no account for uid) - email bounced
-  //   --> Direct the user to sign up again
-  // - if the account is blocked (invalid token, but account exists)
-  //   --> redirect to signin_bounced
 
   return (
     <AppLayout title={localizedPageTitle}>

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -14,6 +14,7 @@ import {
 import { StoredAccountData } from '../../../lib/storage-utils';
 
 export type LocationState = {
+  origin: 'signup' | undefined;
   selectedNewsletterSlugs?: string[];
   keyFetchToken?: string;
   unwrapBKey?: string;
@@ -28,8 +29,8 @@ export type ConfirmSignupCodeContainerProps = {
 
 export type ConfirmSignupCodeProps = {
   email: string;
-  sessionToken: hexstring;
   uid: hexstring;
+  sessionToken: hexstring;
   integration: ConfirmSignupCodeIntegration;
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   newsletterSlugs?: string[];
@@ -63,3 +64,7 @@ export interface ConfirmSignupCodeOAuthIntegration {
 export type ConfirmSignupCodeIntegration =
   | ConfirmSignupCodeOAuthIntegration
   | ConfirmSignupCodeBaseIntegration;
+
+export interface GetEmailBounceStatusResponse {
+  emailBounceStatus: { hasHardBounce: boolean };
+}

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -223,19 +223,13 @@ const SignupContainer = ({
     navigate('/cannot_create_account');
   }
 
-  // TODO: In FXA-8305 - create option for LoadingSpinner to use these classes and use it throughout
-  // settings since we use this set of classes often
   if (showLoadingSpinner) {
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
 
   if (validationError) {
     hardNavigateToContentServer('/');
-    return (
-      <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
-    );
+    return <LoadingSpinner fullScreen />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -353,6 +353,7 @@ describe('Signup page', () => {
           {
             state: {
               keyFetchToken: MOCK_KEY_FETCH_TOKEN,
+              origin: 'signup',
               // we expect three newsletter options, but 4 slugs should be passed
               // because the first newsletter checkbox subscribes the user to 2 newsletters
               selectedNewsletterSlugs: [
@@ -411,6 +412,7 @@ describe('Signup page', () => {
           {
             state: {
               keyFetchToken: MOCK_KEY_FETCH_TOKEN,
+              origin: 'signup',
               selectedNewsletterSlugs: [],
               unwrapBKey: MOCK_UNWRAP_BKEY,
             },

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -243,6 +243,7 @@ export const Signup = ({
 
         navigate(`/confirm_signup_code${location.search}`, {
           state: {
+            origin: 'signup',
             selectedNewsletterSlugs,
             keyFetchToken: data.SignUp.keyFetchToken,
             unwrapBKey: data.unwrapBKey,


### PR DESCRIPTION
## Because

* We are converting the backbone signup flow to react and want to match behaviour for email bounces
* We want to redirect from confirm_signup_code if the email bounced

## This pull request

* Add GQL query to poll the db for hard bounces and redirect if a hard bounce was registered for the email
* Create an option for fullPage styling to the LoadingSpinner component

## Issue that this pull request solves

Closes: #FXA-8306, FXA-8305

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This draft PR does not include a playwright test for email bounce on React Signup. If deemed necessary, this work will be filled in a separate ticket. (The skeleton test is currently skipped)

To test locally: 
1. Navigate to [localhost with react params](http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react)
2. Start signing up for a new account
3. When the "Enter confirmation code" page is reached, use the CLI to add email bounces to the local database:
`nx email-bounce fxa-admin-server --email=username@example.com --count=10`
* This script creates random email bounces. Set the email argument to the email you used to create the account. The count is used to create multiple random bounces, at least one of which will be a hard bounce.
4. Observe the "Enter confirmation code" - it should redirect to `/` after a few seconds with an error tooltip indicating the email bounced.
