### PR TITLE
chore(reset): delete more tokens when resetting account

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -210,11 +210,11 @@ class OauthDB extends ConnectedServicesDb {
     return ok;
   }
 
-  async removeUser(uid) {
+  async removeTokensAndCodes(uid) {
     await this.ready();
     await this.redis.removeAccessTokensForUser(uid);
     await this.redis.removeRefreshTokensForUser(uid);
-    await this.mysql._removeUser(uid);
+    await this.mysql._removeTokensAndCodes(uid);
   }
 
   getPocketIds() {

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -582,7 +582,7 @@ class MysqlStore extends MysqlOAuthShared {
     });
   }
 
-  _removeUser(userId) {
+  _removeTokensAndCodes(userId) {
     // TODO this should be a transaction or stored procedure
     var id = buf(userId);
     return this._write(QUERY_ACCESS_TOKEN_DELETE_USER, [id])

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -609,7 +609,6 @@ export class AccountHandler {
         keysHaveChanged: true,
       }
     );
-    await this.db.resetAccountTokens(uid);
   }
 
   async finishSetup(request: AuthRequest) {
@@ -1348,7 +1347,6 @@ export class AccountHandler {
         verifierVersion: password.version,
         keysHaveChanged,
       });
-      await this.db.resetAccountTokens(accountResetToken.uid);
       // Notify various interested parties about this password reset.
       // These can all safely happen in parallel.
       account = await this.db.account(accountResetToken.uid);
@@ -1370,7 +1368,7 @@ export class AccountHandler {
           uid: account.uid,
           generation: account.verifierSetAt,
         }),
-        this.oauth.removePublicAndCanGrantTokens(account.uid),
+        this.oauth.removeTokensAndCodes(account.uid),
         this.customs.reset(account.email),
       ]);
     };
@@ -1616,7 +1614,7 @@ export class AccountHandler {
     await this.db.deleteAccount(accountRecord);
     this.log.info('accountDeleted.byRequest', { ...accountRecord });
 
-    await this.oauth.removeUser(uid);
+    await this.oauth.removeTokensAndCodes(uid);
 
     // No need to await and block the other notifications.  The pushbox records
     // will be deleted once they expire even if they were not successfully

--- a/packages/fxa-auth-server/scripts/must-reset/index.js
+++ b/packages/fxa-auth-server/scripts/must-reset/index.js
@@ -40,7 +40,7 @@ module.exports = async function main(items, dbFunction) {
         );
 
         // Removes oauth related tokens
-        await oauth.removeUser(result.uid);
+        await oauth.removeTokensAndCodes(result.uid);
         console.info('account reset');
         console.info('  email: ', result.email);
         console.info('    uid: ', result.uid);

--- a/packages/fxa-auth-server/test/oauth/db/index.js
+++ b/packages/fxa-auth-server/test/oauth/db/index.js
@@ -99,7 +99,7 @@ describe('#integration - db', function () {
     });
   });
 
-  describe('removeUser', function () {
+  describe('removeTokensAndCodes', function () {
     var clientId = buf(randomString(8));
     var userId = buf(randomString(16));
     var email = 'a@b.c';
@@ -112,7 +112,7 @@ describe('#integration - db', function () {
       return db
         .registerClient({
           id: clientId,
-          name: 'removeUserTest',
+          name: 'removeTokensAndCodesTest',
           hashedSecret: randomString(32),
           imageUri: 'https://example.domain/logo',
           redirectUri: 'https://example.domain/return?foo=bar',
@@ -165,7 +165,7 @@ describe('#integration - db', function () {
 
     it('should delete tokens and codes for the given userId', function () {
       return db
-        .removeUser(userId)
+        .removeTokensAndCodes(userId)
         .then(function () {
           return db.getCode(code);
         })
@@ -738,9 +738,9 @@ describe('#integration - db', function () {
         assert.isUndefined(tt);
       });
 
-      it('deletes them with removeUser', async () => {
+      it('deletes them with removeTokensAndCodes', async () => {
         const t = await db.generateAccessToken(tokenData);
-        await db.removeUser(t.userId);
+        await db.removeTokensAndCodes(t.userId);
         const tt = await db.getAccessToken(t.tokenId);
         assert.isUndefined(tt);
       });


### PR DESCRIPTION
Because:
 - we should delete more tokens when resetting an account

This commit:
 - deletes all oauth tokens when resetting an account
 - removes a couple unnecessary `resetAccountTokens` calls
