### PR TITLE
fix(auth): throw error on refused stripe credit note

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -328,14 +328,13 @@ export class StripeWebhookHandler extends StripeHandler {
           message: 'Paypal refund refused.',
         });
 
-        const sentryError = {
-          ...error,
+        const sentryError = Object.assign(error, {
           output: {
             payload: {
               invoiceId: invoice.id,
             },
           },
-        };
+        });
 
         reportSentryError(sentryError, request);
       } else {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -1569,11 +1569,8 @@ describe('StripeWebhookHandler', () => {
           invoice,
           'This transaction already has a chargeback filed'
         );
-        assert.calledOnceWithExactly(
-          sentryModule.reportSentryError,
-          { ...error, output: { payload: { invoiceId: invoice.id } } },
-          {}
-        );
+        error.output = { payload: { invoiceId: invoice.id } };
+        assert.calledOnceWithExactly(sentryModule.reportSentryError, error, {});
         assert.calledOnceWithExactly(
           StripeWebhookHandlerInstance.log.error,
           'handleCreditNoteEvent',


### PR DESCRIPTION
## Because

- Sentry expects an error object

## This pull request

- Assigns payload to existing error object before passing to Sentry

## Issue that this pull request solves

Closes: #FXA-8650

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
