### PR TITLE
fix(shared-contentful): Fix Contentful errors regarding query size

### DIFF
--- a/libs/shared/contentful/src/lib/queries/purchase-with-details-offering-content/util.spec.ts
+++ b/libs/shared/contentful/src/lib/queries/purchase-with-details-offering-content/util.spec.ts
@@ -11,12 +11,14 @@ import { PurchaseWithDetailsOfferingContentUtil } from './util';
 describe('PurchaseWithDetailsOfferingContentUtil', () => {
   it('should create a util from response', () => {
     const result = PurchaseWithDetailsOfferingContentByPlanIdsResultFactory();
+    const result2 = PurchaseWithDetailsOfferingContentByPlanIdsResultFactory();
     const purchase = result.purchaseCollection?.items[0];
     const planId = purchase.stripePlanChoices?.[0];
     const legacyPlanId = purchase.offering.stripeLegacyPlans?.[0];
-    const util = new PurchaseWithDetailsOfferingContentUtil(
-      result as PurchaseWithDetailsOfferingContentByPlanIdsResult
-    );
+    const util = new PurchaseWithDetailsOfferingContentUtil([
+      result as PurchaseWithDetailsOfferingContentByPlanIdsResult,
+      result2 as PurchaseWithDetailsOfferingContentByPlanIdsResult,
+    ]);
     expect(util).toBeDefined();
     expect(
       util.transformedPurchaseWithCommonContentForPlanId(planId ?? '')?.offering
@@ -26,16 +28,16 @@ describe('PurchaseWithDetailsOfferingContentUtil', () => {
       util.transformedPurchaseWithCommonContentForPlanId(legacyPlanId ?? '')
         ?.offering.stripeProductId
     ).toBeDefined();
-    expect(util.purchaseCollection.items.length).toBe(1);
+    expect(util.purchaseCollection.items.length).toBe(2);
   });
 
   describe('transformPurchaseDetails', () => {
     let util: PurchaseWithDetailsOfferingContentUtil;
     beforeAll(() => {
       const result = PurchaseWithDetailsOfferingContentByPlanIdsResultFactory();
-      util = new PurchaseWithDetailsOfferingContentUtil(
-        result as PurchaseWithDetailsOfferingContentByPlanIdsResult
-      );
+      util = new PurchaseWithDetailsOfferingContentUtil([
+        result as PurchaseWithDetailsOfferingContentByPlanIdsResult,
+      ]);
     });
 
     it('should transform details', () => {


### PR DESCRIPTION
## Because

- we saw errors in Sentry after stage deploy regarding query size
  - `purchaseWithDetailsOfferingContentQuery`
  - `The maximum allowed size for a query is 8192 bytes but it was 8656 bytes`
  - "code":"QUERY_TOO_BIG"

## This pull request

- splits out stripePlanIds to reduce query size and calls Contentful multiple times instead

## Issue that this pull request solves

Closes: FXA-8721

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.