### PR TITLE
fxa(deps): Add keepalive library for axios

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1014,20 +1014,6 @@ const convictConf = convict({
       format: Array,
       default: ['megaz0rd'],
     },
-    poolee: {
-      timeout: {
-        default: '30 seconds',
-        format: 'duration',
-        env: 'OAUTH_POOLEE_TIMEOUT',
-        doc: 'Time in milliseconds to wait for oauth query completion',
-      },
-      maxPending: {
-        default: 1000,
-        format: 'int',
-        env: 'OAUTH_POOLEE_MAX_PENDING',
-        doc: 'Number of pending requests to fxa-oauth-server to allow',
-      },
-    },
   },
   oauthServer: {
     admin: {
@@ -1056,20 +1042,6 @@ const convictConf = convict({
       env: 'OAUTH_URL',
     },
     auth: {
-      poolee: {
-        timeout: {
-          default: '30 seconds',
-          doc: 'Time in milliseconds to wait for auth server query completion',
-          env: 'AUTH_POOLEE_TIMEOUT',
-          format: 'duration',
-        },
-        maxPending: {
-          default: 1000,
-          doc: 'Number of pending requests to fxa-auth-server to allow',
-          env: 'AUTH_POOLEE_MAX_PENDING',
-          format: 'int',
-        },
-      },
       jwtSecretKey: {
         default: 'megaz0rd',
         doc: 'Shared secret for signing oauth-to-auth server JWT assertions',

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -6,6 +6,7 @@
 
 const axios = require('axios');
 const { config } = require('../config');
+const { createHttpAgent, createHttpsAgent } = require('../lib/http-agent');
 
 const localizeTimestamp =
   require('../../../libs/shared/l10n/src').localizeTimestamp({
@@ -20,7 +21,11 @@ class CustomsClient {
     this.error = error;
     this.statsd = statsd;
     if (url !== 'none') {
-      this.axiosInstance = axios.create({ baseURL: url });
+      this.axiosInstance = axios.create({
+        baseURL: url,
+        httpAgent: createHttpAgent(),
+        httpsAgent: createHttpsAgent(),
+      });
     }
   }
 

--- a/packages/fxa-auth-server/lib/http-agent.ts
+++ b/packages/fxa-auth-server/lib/http-agent.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Agent from 'agentkeepalive';
+
+/**
+ * Creates an HTTP agent using the `agentkeepalive` library.
+ *
+ * @param {number} [maxSockets=100] - The maximum number of sockets to be opened per host.
+ * @param {number} [maxFreeSockets=10] - The maximum number of free sockets to keep open for a host.
+ * @param {number} [timeoutMs=60000] - The timeout in milliseconds for the sockets.
+ * @param {number} [freeSocketTimeoutMs=30000] - The time in milliseconds for which a socket should remain open while unused.
+ * @returns {Agent} An instance of Agent, configured with the specified settings.
+ */
+export function createHttpAgent(
+  maxSockets = 100,
+  maxFreeSockets = 10,
+  timeoutMs = 60000,
+  freeSocketTimeoutMs = 30000
+) {
+  return new Agent({
+    maxSockets,
+    maxFreeSockets,
+    timeout: timeoutMs,
+    freeSocketTimeout: freeSocketTimeoutMs,
+  });
+}
+
+/**
+ * Creates an HTTPS agent using the `agentkeepalive` library.
+ *
+ * @param {number} [maxSockets=100] - The maximum number of sockets to be opened per host for HTTPS requests.
+ * @param {number} [maxFreeSockets=10] - The maximum number of free sockets to keep open for a host for HTTPS requests.
+ * @param {number} [timeoutMs=60000] - The timeout in milliseconds for the sockets for HTTPS requests.
+ * @param {number} [freeSocketTimeoutMs=30000] - The time in milliseconds for which a socket should remain open while unused for HTTPS requests.
+ * @returns {Agent.HttpsAgent} An instance of Agent.HttpsAgent, configured with the specified settings.
+ */
+export function createHttpsAgent(
+  maxSockets = 100,
+  maxFreeSockets = 10,
+  timeoutMs = 60000,
+  freeSocketTimeoutMs = 30000
+) {
+  return new Agent.HttpsAgent({
+    maxSockets,
+    maxFreeSockets,
+    timeout: timeoutMs,
+    freeSocketTimeout: freeSocketTimeoutMs,
+  });
+}

--- a/packages/fxa-auth-server/lib/profile/client.js
+++ b/packages/fxa-auth-server/lib/profile/client.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const axios = require('axios');
+const { createHttpAgent, createHttpsAgent } = require('../http-agent');
 
 const PATH_PREFIX = '/v1';
 
@@ -17,7 +18,11 @@ class Profile {
     this.error = error;
     this.statsd = statsd;
     this.config = config;
-    this.axiosInstance = axios.create({ baseURL: config.profileServer.url });
+    this.axiosInstance = axios.create({
+      baseURL: config.profileServer.url,
+      httpAgent: createHttpAgent(),
+      httpsAgent: createHttpsAgent(),
+    });
 
     // Authorization header is required for all requests to the profile server
     this.axiosInstance.defaults.headers.common[

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -75,6 +75,7 @@
     "@types/convict": "5.2.2",
     "@types/ejs": "^3.0.6",
     "@types/mjml": "^4.7.0",
+    "agentkeepalive": "^4.5.0",
     "ajv": "^8.11.2",
     "app-store-server-api": "^0.7.0",
     "aws-sdk": "^2.1515.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22263,6 +22263,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agentkeepalive@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "agentkeepalive@npm:4.5.0"
+  dependencies:
+    humanize-ms: ^1.2.1
+  checksum: 13278cd5b125e51eddd5079f04d6fe0914ac1b8b91c1f3db2c1822f99ac1a7457869068997784342fe455d59daaff22e14fb7b8c3da4e741896e7e31faf92481
+  languageName: node
+  linkType: hard
+
 "aggregate-error@npm:^3.0.0":
   version: 3.0.1
   resolution: "aggregate-error@npm:3.0.1"
@@ -34748,6 +34757,7 @@ fsevents@~2.1.1:
     "@types/verror": ^1.10.4
     "@types/webpack": 5.28.0
     acorn: ^8.8.0
+    agentkeepalive: ^4.5.0
     ajv: ^8.11.2
     app-store-server-api: ^0.7.0
     async-retry: ^1.3.3


### PR DESCRIPTION
## Because

- We also need to set specify the keep alive value for axios

## This pull request

- Adds the `keepalive` library and uses the defaults from their example
- Removes unused auth-server poolee config

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8640

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

