### PR TITLE
feat(react): Enable ThirdPartyAuth in React Signup

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -634,7 +634,9 @@ export default class AuthClient {
   ): Promise<{
     uid: hexstring;
     sessionToken: hexstring;
-    verified: boolean;
+    providerUid: hexstring;
+    email: string;
+    verificationMethod?: string;
   }> {
     const payload = {
       code,

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -443,6 +443,7 @@ export class LinkedAccountHandler {
       uid: sessionToken.uid,
       sessionToken: sessionToken.data,
       providerUid: userid,
+      email,
       ...(verificationMethod ? { verificationMethod } : {}),
     };
   }
@@ -501,6 +502,7 @@ export const linkedAccountRoutes = (
               .string()
               .required()
               .description(DESCRIPTION.providerUid),
+            email: isA.string().required().description(DESCRIPTION.email),
             verificationMethod: isA
               .string()
               .optional()

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -31,7 +31,6 @@ import SignInTokenCodeView from '../views/sign_in_token_code';
 import SignInTotpCodeView from '../views/sign_in_totp_code';
 import SignInUnblockView from '../views/sign_in_unblock';
 import SignUpPasswordView from '../views/sign_up_password';
-import ThirdPartyAuthCallbackView from '../views/post_verify/third_party_auth/callback';
 import ThirdPartyAuthSetPasswordView from '../views/post_verify/third_party_auth/set_password';
 import Storage from './storage';
 import SubscriptionsProductRedirectView from '../views/subscriptions_product_redirect';
@@ -304,12 +303,9 @@ Router = Router.extend({
         type: VerificationReasons.SECONDARY_EMAIL_VERIFIED,
       }
     ),
-    'post_verify/third_party_auth/callback(/)': function () {
-      this.createReactOrBackboneViewHandler(
-        'post_verify/third_party_auth/callback',
-        ThirdPartyAuthCallbackView
-      );
-    },
+    'post_verify/third_party_auth/callback(/)': createViewHandler(
+      'post_verify/third_party_auth/callback'
+    ),
     'post_verify/third_party_auth/set_password(/)': function () {
       this.createReactOrBackboneViewHandler(
         'post_verify/third_party_auth/set_password',

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -258,6 +258,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'REACT_CONVERSION_POST_VERIFY_OTHER_ROUTES',
     },
+    postVerifyThirdPartyAuthRoutes: {
+      default: false,
+      doc: 'Enable users to visit the React version of third party auth "post verify" routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_POST_VERIFY_THIRD_PARTY_AUTH',
+    },
     postVerifyCADViaQRRoutes: {
       default: false,
       doc: 'Enable users to visit the React version of "post verify CAD via QR code" routes',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -105,7 +105,10 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
 
     postVerifyThirdPartyAuthRoutes: {
       featureFlagOn: showReactApp.postVerifyThirdPartyAuthRoutes,
-      routes: reactRoute.getRoutes(['post_verify/third_party_auth/callback']),
+      routes: reactRoute.getRoutes([
+        'post_verify/third_party_auth/callback',
+        'post_verify/third_party_auth/set_password',
+      ]),
       fullProdRollout: false,
     },
 

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -170,9 +170,10 @@ function deleteParams(searchParams: URLSearchParams, paramsToDelete: string[]) {
 
 function getState() {
   // We stash originating location in the state oauth param
-  // because we will need it to use it to log the user into FxA
-  const originParams = new URLSearchParams(window.location.search);
-  const modifiedParams = deleteParams(originParams, [
+  // because we will need it to use it to reconstruct the redirect URL for RP
+  const params = new URLSearchParams(window.location.search);
+  // we won't need these params that are used for internal backbone/react navigation
+  const modifiedParams = deleteParams(params, [
     'deeplink',
     'email',
     'emailFromContent',

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -2,15 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useRef, FormEventHandler } from 'react';
+import React, { useRef, FormEventHandler } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
 import { ReactComponent as GoogleLogo } from './google-logo.svg';
 import { ReactComponent as AppleLogo } from './apple-logo.svg';
 
-import { useAccount, useConfig } from '../../models';
-import Storage from '../../lib/storage';
-import { AUTH_PROVIDER } from 'fxa-auth-client/browser';
+import { useConfig } from '../../models';
 import { ReactElement } from 'react-markdown/lib/react-markdown';
 
 export type ThirdPartyAuthProps = {
@@ -29,41 +27,7 @@ const ThirdPartyAuth = ({
   onContinueWithApple,
   showSeparator = true,
 }: ThirdPartyAuthProps) => {
-  const account = useAccount();
   const config = useConfig();
-
-  useEffect(() => {
-    // TODO: Figure out why `storageData` is not available
-    const authParams = Storage.factory('localStorage', window).get(
-      'fxa_third_party_params'
-    );
-    if (authParams) {
-      completeSignIn();
-    }
-  });
-
-  async function completeSignIn() {
-    try {
-      const authParams = Storage.factory('localStorage', window).get(
-        'fxa_third_party_params'
-      );
-      const code = authParams.code;
-      const provider = authParams.provider || AUTH_PROVIDER.GOOGLE;
-
-      // Verify and link the third party account to FxA. Note, this
-      // will create a new FxA account if one does not exist.
-      await account.verifyAccountThirdParty(code, provider);
-
-      // TODO: The response from above contains a session token
-      // which can be used to sign the user in to FxA or used
-      // to complete an Oauth flow.
-    } catch (error) {
-      // Fail silently on errors, this could be some leftover
-      // state from a previous attempt.
-    }
-
-    clearStoredParams();
-  }
 
   return (
     <>
@@ -162,7 +126,6 @@ const ThirdPartySignInForm = ({
   const stateRef = useRef<HTMLInputElement>(null);
 
   function onClick() {
-    clearStoredParams();
     stateRef.current!.value = getState();
   }
 
@@ -200,23 +163,29 @@ const ThirdPartySignInForm = ({
   );
 };
 
+function deleteParams(searchParams: URLSearchParams, paramsToDelete: string[]) {
+  paramsToDelete.forEach((param) => searchParams.delete(param));
+  return searchParams;
+}
+
 function getState() {
   // We stash originating location in the state oauth param
   // because we will need it to use it to log the user into FxA
-  const currentParams = new URLSearchParams(window.location.search);
-  currentParams.delete('deeplink');
-  currentParams.set('showReactApp', 'true');
+  const originParams = new URLSearchParams(window.location.search);
+  const modifiedParams = deleteParams(originParams, [
+    'deeplink',
+    'email',
+    'emailFromContent',
+    'forceExperiment',
+    'forceExperimentGroup',
+    'showReactApp',
+  ]);
   const state = encodeURIComponent(
     `${window.location.origin}${
       window.location.pathname
-    }?${currentParams.toString()}`
+    }?${modifiedParams.toString()}`
   );
   return state;
-}
-
-function clearStoredParams() {
-  // TODO: Use the correct storage mechanism
-  Storage.factory('localStorage', window).remove('fxa_third_party_params');
 }
 
 export default ThirdPartyAuth;

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -10,6 +10,7 @@ import AuthClient, {
   generateRecoveryKey,
   getRecoveryKeyIdByUid,
   getCredentials,
+  MetricsContext,
 } from 'fxa-auth-client/browser';
 import {
   currentAccount,
@@ -917,15 +918,40 @@ export class Account implements AccountData {
 
   async verifyAccountThirdParty(
     code: string,
-    provider: AUTH_PROVIDER
+    provider: AUTH_PROVIDER = AUTH_PROVIDER.GOOGLE,
+    service?: string,
+    metricsContext: MetricsContext = {}
   ): Promise<{
     uid: hexstring;
     sessionToken: hexstring;
-    verified: boolean;
+    providerUid: hexstring;
+    email: string;
+    verificationMethod?: string;
   }> {
-    return this.withLoadingStatus(
-      this.authClient.verifyAccountThirdParty(code, provider)
+    const linkedAccount = await this.withLoadingStatus(
+      this.authClient.verifyAccountThirdParty(
+        code,
+        provider,
+        service,
+        metricsContext
+      )
     );
+    await this.apolloClient.cache.modify({
+      fields: {
+        session: () => {
+          return { verified: true };
+        },
+      },
+    });
+    // TODO: Move this to ConfirmSignupCode container component
+    // If we can use GQL here when we do that, also be sure to add
+    // the operation name to the auth list in `lib/gql.ts`.
+    // Look @ in FXA-7626 or FXA-7184
+    await this.apolloClient.cache.writeQuery({
+      query: GET_LOCAL_SIGNED_IN_STATUS,
+      data: { isSignedIn: true },
+    });
+    return linkedAccount;
   }
 
   // TODO: Move this method to the Session model - this method was temporarily added to the Account model

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -936,21 +936,6 @@ export class Account implements AccountData {
         metricsContext
       )
     );
-    await this.apolloClient.cache.modify({
-      fields: {
-        session: () => {
-          return { verified: true };
-        },
-      },
-    });
-    // TODO: Move this to ConfirmSignupCode container component
-    // If we can use GQL here when we do that, also be sure to add
-    // the operation name to the auth list in `lib/gql.ts`.
-    // Look @ in FXA-7626 or FXA-7184
-    await this.apolloClient.cache.writeQuery({
-      query: GET_LOCAL_SIGNED_IN_STATUS,
-      data: { isSignedIn: true },
-    });
     return linkedAccount;
   }
 

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -3,40 +3,150 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect } from 'react';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import {
+  FtlMsg,
+  hardNavigate,
+  hardNavigateToContentServer,
+} from 'fxa-react/lib/utils';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import AppLayout from '../../../components/AppLayout';
-import Storage from '../../../lib/storage';
+import { AUTH_PROVIDER } from 'fxa-auth-client/browser';
+import { useAccount } from '../../../models';
+import {
+  StoredAccountData,
+  persistAccount,
+  setCurrentAccount,
+} from '../../../lib/storage-utils';
+import { sessionToken } from '../../../lib/cache';
+
+// TODO this page to be completed/activated in FXA-8834
+// User reaches this page when redirected back from third party auth provider
+// requires /post_verify/third_party_auth/callback route to be turned on for react
+// otherwise users authenticating with the react version of signin/signup are directed
+// to the backbone version of the callback to complete their authentication
 
 const ThirdPartyAuthCallback = (_: RouteComponentProps) => {
   const navigate = useNavigate();
+  const account = useAccount();
+  const params = new URLSearchParams(window.location.search);
 
-  function handleOauthResponse() {
-    try {
-      // To finish the oauth flow, we will need to stash away the response from
-      // 3rd party auth provider (contains state and code) and redirect back to the original FxA login page.
-      const searchParams = new URLSearchParams(window.location.search);
-      const redirectUrl = decodeURIComponent(searchParams.get('state') || '');
-      const url = new URL(redirectUrl);
-
-      if (url.origin === window.location.origin) {
-        Storage.factory('localStorage', window).set(
-          'fxa_third_party_params',
-          searchParams
-        );
-
-        navigate(redirectUrl, { replace: true });
+  const getRedirectUrl = () => {
+    // get the stashed state with origin information
+    // use it to reconstruct redirect for oauth
+    // the state is the entire URL of the origin and includes the redirect_uri in a param
+    // if authenticating from a RP
+    const state = params.get('state');
+    if (state) {
+      // we may need to deconstruct the state to access/modify the redirect URL
+      const stateParams = new URL(decodeURIComponent(state)).searchParams;
+      const redirect = stateParams.get('redirect_uri');
+      // if the state contains a redirect_uri, we need to redirect to RP
+      // otherwise we redirect internally
+      if (redirect) {
+        const url = new URL(redirect);
+        // TODO append other params from state to the redirect URL
+        return url;
       }
-    } catch (e) {
-      // noop. navigate to home below.
+    }
+    return undefined;
+  };
+
+  // auth params are received from the third party auth provider
+  // and are required to verify the account
+  const getAuthParams = () => {
+    const code = params.get('code');
+    const providerFromParams = params.get('provider');
+    let provider: AUTH_PROVIDER | undefined;
+    if (providerFromParams === 'apple') {
+      provider = AUTH_PROVIDER.APPLE;
+    } else {
+      provider = AUTH_PROVIDER.GOOGLE;
     }
 
-    navigate('/', { replace: true });
+    return { code, provider };
+  };
+
+  const handlePostSignInNavigation = () => {
+    // TODO ensure correct redirects for all integrations (OAuth, Desktop, Mobile)
+    // redirect is constructed from state param in the URL params
+    const redirectURL = getRedirectUrl();
+    if (redirectURL) {
+      // get the stashed state with origin information
+      // use it to reconstruct redirect for oauth
+      // the state is the entire URL of the origin and includes the redirect_uri in a param
+      // if authenticating from a RP
+      const state = params.get('state');
+      if (state) {
+        // we may need to deconstruct the state to access/modify the redirect URL
+        const stateParams = new URL(decodeURIComponent(state)).searchParams;
+        const redirect = stateParams.get('redirect_uri');
+        // if the state contains a redirect_uri, we need to redirect to RP
+        // otherwise we redirect internally
+        if (redirect) {
+          hardNavigate(redirect);
+        } else {
+          // general redirect to settings for non-RP
+          // currently, redirect to /settings fails with an "unauthenticated" error from GQL
+          // and redirects to /signin where signin in *again* with ThirdPArty Auth successfully
+          // navigates to /settings
+          // however, after signup we can see the account is successfully created in the db
+          // and added to local storage
+          // need to determine what is missing to directly be considered signed in
+          // when signup with thrid party auth is handled with react from end to end
+          navigate(`/settings${window.location.search}`);
+        }
+      }
+    }
+  };
+
+  // Persist account data to local storage to match parity with content-server
+  // this allows the recent account to be used for /signin
+  const storeAccountData = (accountData: StoredAccountData) => {
+    persistAccount(accountData);
+    setCurrentAccount(accountData.uid);
+    sessionToken(accountData.sessionToken);
+  };
+
+  async function verifyAndContinue() {
+    const { code, provider } = getAuthParams();
+
+    if (code && provider) {
+      try {
+        // Verify and link the third party account to FxA. Note, this
+        // will create a new FxA account if one does not exist.
+        // The response contains a session token that can be used
+        // to sign the user in to FxA or to complete an Oauth flow.
+        const linkedAccount = await account.verifyAccountThirdParty(
+          code,
+          provider
+        );
+
+        const accountData: StoredAccountData = {
+          // We are using the email that was returned from the Third Party Auth
+          // Not the email entered in the email-first form as they might be different
+          email: linkedAccount.email,
+          uid: linkedAccount.uid,
+          lastLogin: Date.now(),
+          sessionToken: linkedAccount.sessionToken,
+          verified: true,
+          metricsEnabled: true,
+        };
+
+        await storeAccountData(accountData);
+        handlePostSignInNavigation();
+      } catch (error) {
+        // TODO add error handling
+      }
+    } else {
+      // TODO validate what should happen if we hit this page
+      // without the required auth params to verify the account
+      hardNavigateToContentServer('/');
+    }
   }
 
   useEffect(() => {
-    handleOauthResponse();
+    verifyAndContinue();
   });
 
   return (

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -102,6 +102,13 @@ describe('Signup page', () => {
     expect(
       screen.getByRole('button', { name: 'Create account' })
     ).toBeDisabled();
+    // Third party auth options
+    expect(
+      screen.getByRole('button', { name: /Continue with Google/ })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: /Continue with Apple/ })
+    ).toBeVisible();
     const firefoxTermsLink: HTMLElement = screen.getByRole('link', {
       name: 'Terms of Service',
     });
@@ -206,15 +213,23 @@ describe('Signup page', () => {
     );
   });
 
-  it('shows options to choose what to sync when CWTS is enabled', async () => {
+  it('renders as expected when integration is sync', async () => {
     renderWithLocalizationProvider(
       <Subject integration={createMockSignupSyncDesktopIntegration()} />
     );
 
+    // Choose what to sync options should be displayed if integration is sync
     await screen.findByText('Choose what to sync');
-
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(8);
+
+    // Third party auth options are not offered if integration is Sync
+    expect(
+      screen.queryByRole('button', { name: /Continue with Google/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Continue with Apple/ })
+    ).not.toBeInTheDocument();
   });
 
   it('renders and handles newsletters', async () => {


### PR DESCRIPTION
## Because

* We want to match parity with backbone Signup and allow users to sign up with third party authentication when enrolled in the React Signup experiment

## This pull request

* Adds the ThirdPartyAuth component to the React Signup form
* Builds on the initial scaffolding for the React ThirdPartyAuthCallback, but does not enable this React route to complete sign in after third party auth. The final steps are still handled by backbone until FXA-8834

## Issue that this pull request solves

Closes: #FXA-8761

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

React signup form with ThirdPartyAuth options:
![image](https://github.com/mozilla/fxa/assets/22231637/dabcf9c9-bc9a-4b11-909f-10cbba0cf5bc)

## Other information (Optional)

With this PR, it is expected that users will be able to:
- Sign up and sign in with Third Party Auth options whether or not they are enrolled in the React Signup experiment
- Third Party Auth options remain unavailable for both backbone and react if the signup is for Sync