### PR TITLE
chore(settings): load react-pdf lazily

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -74,7 +74,10 @@ describe('FlowRecoveryKeyDownload', () => {
     const listItems = within(list).getAllByRole('listitem');
     expect(listItems.length).toBe(4);
 
-    screen.getByRole('button', { name: 'Download and continue' });
+    await waitFor(() => {
+      const b = screen.getByRole('button', { name: 'Download and continue' });
+      expect(b).toBeInTheDocument();
+    });
 
     screen.getByRole('link', {
       name: 'Continue without downloading',

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import FlowContainer from '../FlowContainer';
 import ProgressBar from '../ProgressBar';
 import DataBlock from '../../DataBlock';
@@ -16,7 +16,16 @@ import {
   LockIconListItem,
   PrinterIconListItem,
 } from '../../IconListItem';
-import ButtonDownloadRecoveryKeyPDF from '../../ButtonDownloadRecoveryKeyPDF';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+
+const ButtonDownloadRecoveryKeyPDF = lazy(
+  () => import('../../ButtonDownloadRecoveryKeyPDF')
+);
+
+// TODO FXA-8305
+const spinner = (
+  <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
+);
 
 export type FlowRecoveryKeyDownloadProps = {
   localizedBackButtonTitle: string;
@@ -97,9 +106,11 @@ export const FlowRecoveryKeyDownload = ({
           </ul>
         </div>
 
-        <ButtonDownloadRecoveryKeyPDF
-          {...{ navigateForward, recoveryKeyValue, viewName }}
-        />
+        <Suspense fallback={spinner}>
+          <ButtonDownloadRecoveryKeyPDF
+            {...{ navigateForward, recoveryKeyValue, viewName }}
+          />
+        </Suspense>
 
         <FtlMsg id="flow-recovery-key-download-next-link-v2">
           <Link


### PR DESCRIPTION
Because:
 - we don't want to load the rather large react-pdf dependency whenever a user lands in Settings

This commit:
 - loads react-pdf lazily with React

