### PR TITLE
fix(bug): Set `isSignedIn` after reset password with recovery key

### DIFF
--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -50,7 +50,7 @@ test.describe('severity-1 #smoke', () => {
         expect(status).toEqual('Enabled');
 
         // Ensure password reset occurs with no session token available
-        login.clearCache();
+        await login.clearCache();
         // Stash original encryption keys to be verified later
         const res = await target.auth.sessionReauth(
           credentials.sessionToken,
@@ -103,6 +103,12 @@ test.describe('severity-1 #smoke', () => {
       await resetPasswordReact.submitNewPassword(NEW_PASSWORD);
       await page.waitForURL(/reset_password_with_recovery_key_verified/);
 
+      // After using a recovery key to reset password, expect to be prompted to create a new one
+      await page
+        .getByRole('button', { name: 'Generate a new account recovery key' })
+        .click();
+      await page.waitForURL(/settings\/account_recovery/);
+
       // Attempt to login with new password
       const { sessionToken } = await target.auth.signIn(
         credentials.email,
@@ -126,12 +132,6 @@ test.describe('severity-1 #smoke', () => {
 
       // Cleanup requires setting this value to correct password
       credentials.password = NEW_PASSWORD;
-
-      // After using a recovery key to reset password, expect to be prompted to create a new one
-      await page
-        .getByRole('button', { name: 'Generate a new account recovery key' })
-        .click();
-      await page.waitForURL(/settings\/account_recovery/);
     });
   });
 });

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1333,6 +1333,10 @@ export class Account implements AccountData {
         },
       },
     });
+    cache.writeQuery({
+      query: GET_LOCAL_SIGNED_IN_STATUS,
+      data: { isSignedIn: true },
+    });
     return data;
   }
 }


### PR DESCRIPTION
## Because

- The user was prompted to login again after resetting their password with a recovery key and clicking generate new key

## This pull request

- Sets the `isSignedIn` apollo client cache value to true, this value is what lets the settings app know the user is logged in

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8800

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

