### PR TITLE
fix(functional-tests): Fix relying party smoke tests

### DIFF
--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -40,6 +40,8 @@ export class RelierPage extends BaseLayout {
 
   async clickEmailFirst() {
     const waitForNavigation = this.page.waitForEvent('framenavigated');
+    // wait for navigation was timing out for stage and production
+    await this.page.waitForTimeout(1000);
     await this.page.locator('button.email-first-button').click();
     return waitForNavigation;
   }


### PR DESCRIPTION
## Because

* Monitor and Sumo sites had been updated, which caused our functional tests to fail
* Disconnect RP test was intermittently timing out for stage and production

## This pull request

* Update relying party tests to reflect updated RP user flows and UI
* Upgrade locators to use accessible roles
* Add timeout to relier email first navigation

## Issue that this pull request solves

Closes: #FXA-8446, FXA-8816

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
