### PR TITLE
fix(functional-tests): Fix relying party smoke tests

### DIFF
--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -39,9 +39,13 @@ export class RelierPage extends BaseLayout {
   }
 
   async clickEmailFirst() {
-    const waitForNavigation = this.page.waitForEvent('framenavigated');
+    await this.page.waitForTimeout(1000); //necessary for production environment otherwise waitForURL times out
     await this.page.locator('button.email-first-button').click();
-    return waitForNavigation;
+    // We need to add a `waitUntil` option here because the page gets redirected from
+    // /authorization to /oauth before the page is fully loaded.
+    return this.page.waitForURL(`${this.target.contentServerUrl}/**`, {
+      waitUntil: 'load',
+    });
   }
 
   async clickSignIn() {

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -5,6 +5,9 @@
 import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
+  // Slowing down test, was timing out on credentials teardown
+  test.slow();
+
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293471
   test('signin to sync and disconnect #1293471', async ({
     target,
@@ -37,11 +40,9 @@ test.describe('severity-1 #smoke', () => {
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293475
   test('disconnect RP #1293475', async ({
-    browser,
     credentials,
     pages: { relier, login, settings },
-    target,
-  }, { project }) => {
+  }) => {
     await relier.goto();
     await relier.clickEmailFirst();
 
@@ -56,7 +57,9 @@ test.describe('severity-1 #smoke', () => {
 
     // Sign out of 123Done
     const rp = services.find((service) => service.name.includes('123'));
-    await rp.signout();
+    if (rp) {
+      await rp.signout();
+    }
 
     await settings.waitForAlertBar();
     services = await settings.connectedServices.services();
@@ -67,23 +70,33 @@ test.describe('severity-1 #smoke', () => {
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293469
   test('can login to addons #1293362 #1293469', async ({
     credentials,
-    page,
-    pages: { login, settings },
+    pages: { page, login, settings },
   }, { project }) => {
     test.skip(project.name !== 'production', 'uses prod addons site');
+
     await page.goto('https://addons.mozilla.org/en-US/firefox/');
-    await Promise.all([page.click('text=Log in'), page.waitForNavigation()]);
+    await page.getByRole('link', { name: 'Log in' }).click();
+    await page.waitForURL(/accounts\.firefox\.com/);
     await login.login(credentials.email, credentials.password);
-    expect(page.url()).toContain(
-      'https://addons.mozilla.org/en-US/firefox/users/edit'
-    );
-    await page.click('text=Delete My Profile');
-    await page.click('button.Button--alert[type=submit]');
-    await page.waitForURL('https://addons.mozilla.org/en-US/firefox');
+    await page.waitForURL(/addons\.mozilla\.org\/en-US\/firefox\/users\/edit/);
+
+    // Can create AMO profile
+    await page
+      .getByRole('textbox', { name: /Display Name/ })
+      .fill('Example Name');
+    await page.getByRole('button', { name: 'Create my profile' }).click();
+
+    // User menu shows selected display name and user can log out of AMO
+    await page.waitForURL('https://addons.mozilla.org/en-US/firefox/');
+    await page.getByRole('button', { name: 'Example Name' }).hover();
+    await page.getByRole('button', { name: 'Log out' }).click();
+    await expect(page.getByText('You have been logged out.')).toBeVisible();
+
+    // Expect Mozilla Accounts to be signed in and AMO to be in Connected Services
     await settings.goto();
-    const services = await settings.connectedServices.services();
-    const names = services.map((s) => s.name);
-    expect(names?.some((x) => /^Add-ons/.test(x))).toBeTruthy();
+    await expect(page.getByRole('link', { name: 'Add-ons' })).toBeVisible();
+    await settings.clickAvatarIcon();
+    await settings.clickSignOut();
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293352
@@ -106,26 +119,22 @@ test.describe('severity-1 #smoke', () => {
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293364
-  /*test('can login to monitor #1293364', async ({
+  test('can login to monitor #1293364', async ({
     credentials,
     page,
     pages: { login },
   }, { project }) => {
     test.skip(project.name !== 'production', 'uses prod monitor');
-    await page.goto('https://monitor.firefox.com');
-    await Promise.all([
-      page.click('text=Sign Up for Alerts'),
-      page.waitForNavigation(),
-    ]);
+    await page.goto('https://monitor.mozilla.org/');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.waitForURL(/accounts\.firefox\.com/);
     await login.login(credentials.email, credentials.password);
-    expect(page.url()).toContain('https://monitor.firefox.com/user/dashboard');
-    await page.click('#avatar-wrapper');
-    await Promise.all([
-      page.click('text=Sign Out'),
-      page.waitForNavigation({ waitUntil: 'load' }),
-    ]);
-    await expect(page.locator('#sign-in-btn')).toBeVisible();
-  });*/
+    await page.waitForURL(/monitor\.mozilla\.org\/user\/breaches/);
+    await page.getByRole('img', { name: 'User menu' }).click();
+    await page.getByRole('button', { name: 'Sign out' }).click();
+    await page.waitForURL('https://monitor.mozilla.org/');
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+  });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293360
   test('can login to SUMO #1293360', async ({
@@ -134,19 +143,28 @@ test.describe('severity-1 #smoke', () => {
     pages: { login },
   }, { project }) => {
     test.skip(project.name !== 'production', 'uses prod monitor');
-    test.slow();
 
-    await page.goto('https://support.mozilla.org/en-US/');
+    await page.goto('https://support.mozilla.org/');
 
-    await Promise.all([page.click('text=Sign In/Up'), page.waitForLoadState()]);
-    await Promise.all([
-      page.click('text=Sign In or Sign Up'),
-      page.waitForLoadState(),
-    ]);
+    // Sumo support contains two Sign In/Up links (in header nav and footer)
+    // let's use the first one
+    await page
+      .getByRole('link', { name: /Sign In\/Up/ })
+      .first()
+      .click();
+    await page.waitForURL(/users\/auth/);
+    await page.getByRole('link', { name: 'Continue' }).click();
+
+    // Mozilla accounts sign in
+    await page.waitForURL(/accounts\.firefox\.com/);
     await login.login(credentials.email, credentials.password);
 
-    await page.hover('a[href="/en-US/users/auth"]');
-    await page.click('text=Sign Out');
-    await expect(page.locator('text=Sign In/Up').first()).toBeVisible();
+    // return to SUMO
+    await page.waitForURL(/support\.mozilla\.org/);
+    await page.getByRole('img', { name: 'Avatar for Username' }).hover();
+    await page.getByRole('link', { name: 'Sign Out' }).click();
+    await expect(
+      page.getByRole('link', { name: /Sign In\/Up/ }).first()
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Because

* Monitor and Sumo sites had been updated, which caused our functional tests to fail
* Disconnect RP test was intermittently timing out for stage and production

## This pull request

* Update relying party tests to reflect updated RP user flows and UI
* Upgrade locators to use accessible roles
* Add timeout to relier email first navigation

## Issue that this pull request solves

Closes: #FXA-8446, FXA-8816

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Tests for relying parties are passing locally for prod environment (`yarn playwright test` in `packages/functional-tests`)
- Filed FXA-8858 for the prod login with pocket test that will require more extensive fixes - it was disabled in 2022 with no issue filed