### PR TITLE
feat(terms): Updated Monitor Terms for Premium launch

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -36,17 +36,17 @@
       <div id="tos-pp" class="text-grey-500 my-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to:<br />
-            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            By proceeding, you agree to the:<br />
+            Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
           {{#isMonitorClient}}
             {{#unsafeTranslate}}
-              By proceeding, you agree to:<br />
-              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
-              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+              By proceeding, you agree to the:<br />
+              Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
+              Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
             {{/unsafeTranslate}}
           {{/isMonitorClient}}
           {{^isMonitorClient}}

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -55,16 +55,16 @@
       {{/isSync}}
       {{#isPocketClient}}
         {{#unsafeTranslate}}
-          By proceeding, you agree to:<br />
-          Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+          By proceeding, you agree to the:<br />
+          Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
           Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
         {{/unsafeTranslate}}
       {{/isPocketClient}}
       {{^isPocketClient}}
         {{#isMonitorClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to:<br />
-            Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+            By proceeding, you agree to the:<br />
+            Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
             Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isMonitorClient}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -73,17 +73,17 @@
       <div id="tos-pp" class="text-grey-500 my-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to:<br />
-            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            By proceeding, you agree to the:<br />
+            Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
           {{#isMonitorClient}}
             {{#unsafeTranslate}}
-              By proceeding, you agree to:<br />
-              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
-              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+              By proceeding, you agree to the:<br />
+              Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
+              Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
             {{/unsafeTranslate}}
           {{/isMonitorClient}}
           {{^isMonitorClient}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -80,17 +80,17 @@
       <div id="tos-pp" class="text-grey-500 mt-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to:<br />
-            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            By proceeding, you agree to the:<br />
+            Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
           {{#isMonitorClient}}
             {{#unsafeTranslate}}
-              By proceeding, you agree to:<br />
-              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
-              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+              By proceeding, you agree to the:<br />
+              Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
+              Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
             {{/unsafeTranslate}}
           {{/isMonitorClient}}
           {{^isMonitorClient}}

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -175,7 +175,8 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#pocket-pp'), 0);
         assert.lengthOf(view.$('#pocket-tos'), 0);
         // only renders if service is monitor
-        assert.lengthOf(view.$('#monitor-tos'), 0);
+        assert.lengthOf(view.$('#moz-subscription-tos'), 0);
+        assert.lengthOf(view.$('#moz-subscription-privacy'), 0);
       });
     });
 
@@ -248,7 +249,8 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#fxa-tos'), 1);
         assert.lengthOf(view.$('#pocket-pp'), 1);
         assert.lengthOf(view.$('#pocket-tos'), 1);
-        assert.lengthOf(view.$('#monitor-tos'), 0);
+        assert.lengthOf(view.$('#moz-subscription-tos'), 0);
+        assert.lengthOf(view.$('#moz-subscription-privacy'), 0);
       });
     });
 
@@ -268,7 +270,8 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#fxa-tos'), 1);
         assert.lengthOf(view.$('#pocket-pp'), 0);
         assert.lengthOf(view.$('#pocket-tos'), 0);
-        assert.lengthOf(view.$('#monitor-tos'), 1);
+        assert.lengthOf(view.$('#moz-subscription-tos'), 1);
+        assert.lengthOf(view.$('#moz-subscription-privacy'), 1);
       });
     });
   });

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
@@ -3,13 +3,10 @@
 
 # This message is followed by a bulleted list
 terms-privacy-agreement-intro-2 = By proceeding, you agree to the:
-# links to Pocket's Terms of Service and Privacy Notice
 # links to Pocket's Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-pocket-2 = { -product-pocket } <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
-# link to Firefox Monitor's Terms of Service and Privacy Notice
-terms-privacy-agreement-monitor = { -product-firefox-monitor }'s <monitorTos>Terms of Service and Privacy Notice</monitorTos>
-# link to Firefox Monitor's Terms of Service and Privacy Notice, part of a bulleted list
-terms-privacy-agreement-monitor-2 = { -product-firefox-monitor } <monitorTos>Terms of Service and Privacy Notice</monitorTos>
+# link to Monitor's Terms of Service and Privacy Notice, part of a bulleted list
+terms-privacy-agreement-monitor-3 = { -brand-mozilla } Subscription Services <mozSubscriptionTosLink>Terms of Service</mozSubscriptionTosLink> and <mozSubscriptionPrivacyLink>Privacy Notice</mozSubscriptionPrivacyLink>
 # links to Mozilla Accounts Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-mozilla = { -product-mozilla-accounts(capitalization:"uppercase") } <mozillaAccountsTos>Terms of Service</mozillaAccountsTos> and <mozillaAccountsPrivacy>Privacy Notice</mozillaAccountsPrivacy>
 # links to Mozilla Account's Terms of Service and Privacy Notice

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
@@ -53,11 +53,15 @@ it('renders component as expected for Monitor clients', () => {
 
   const linkElements: HTMLElement[] = screen.getAllByRole('link');
 
-  expect(linkElements).toHaveLength(3);
+  expect(linkElements).toHaveLength(4);
   expect(linkElements[0]).toHaveAttribute(
     'href',
-    'https://www.mozilla.org/privacy/firefox-monitor/'
+    'https://www.mozilla.org/about/legal/terms/subscription-services/'
   );
-  expect(linkElements[1]).toHaveAttribute('href', '/legal/terms');
-  expect(linkElements[2]).toHaveAttribute('href', '/legal/privacy');
+  expect(linkElements[1]).toHaveAttribute(
+    'href',
+    'https://www.mozilla.org/privacy/subscription-services/'
+  );
+  expect(linkElements[2]).toHaveAttribute('href', '/legal/terms');
+  expect(linkElements[3]).toHaveAttribute('href', '/legal/privacy');
 });

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
@@ -65,25 +65,40 @@ const TermsPrivacyAgreement = ({
           )}
           {isMonitorClient && (
             <FtlMsg
-              id="terms-privacy-agreement-monitor-2"
+              id="terms-privacy-agreement-monitor-3"
               elems={{
-                monitorTos: (
+                mozSubscriptionTosLink: (
                   <LinkExternal
                     className="link-grey"
-                    href="https://www.mozilla.org/privacy/firefox-monitor/"
+                    href="https://www.mozilla.org/about/legal/terms/subscription-services/"
                   >
-                    Terms of Service and Privacy Notice
+                    Terms of Service
+                  </LinkExternal>
+                ),
+                mozSubscriptionPrivacyLink: (
+                  <LinkExternal
+                    className="link-grey"
+                    href="https://www.mozilla.org/privacy/subscription-services/"
+                  >
+                    Privacy Notice
                   </LinkExternal>
                 ),
               }}
             >
               <li>
-                Firefox Monitor{' '}
+                Mozilla Subscription Services{' '}
                 <LinkExternal
                   className="link-grey"
-                  href="https://www.mozilla.org/privacy/firefox-monitor/"
+                  href="https://www.mozilla.org/about/legal/terms/subscription-services/"
                 >
-                  Terms of Service and Privacy Notice
+                  Terms of Service
+                </LinkExternal>{' '}
+                and{' '}
+                <LinkExternal
+                  className="link-grey"
+                  href="https://www.mozilla.org/privacy/subscription-services/"
+                >
+                  Privacy Notice
                 </LinkExternal>
               </li>
             </FtlMsg>


### PR DESCRIPTION
## Because

* We are change Monitor terms from Firefox Monitor links to Mozilla Subscription Services

## This pull request

* Updates ToS and Privacy notice links for Monitor on backbone and react pages

## Issue that this pull request solves

Closes: #FXA-7979

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before (React - Storybook)
![image](https://github.com/mozilla/fxa/assets/22231637/a3aa96b5-f0d8-437d-8867-3e4762af2abe)

After (Backbone)
![image](https://github.com/mozilla/fxa/assets/22231637/9f5b93e7-221b-49f3-9d8d-a5ef5d581cb9)

After (React - Storybook)
![image](https://github.com/mozilla/fxa/assets/22231637/4754c1ee-4378-44a5-8ed0-0fcb18a70643)

## Other information (Optional)

Any other information that is important to this pull request.
