### PR TITLE
fix(contentful): add support for zero results

### DIFF
--- a/libs/shared/contentful/src/lib/contentful.manager.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.ts
@@ -43,7 +43,7 @@ export class ContentfulManager {
     const queryResults: DeepNonNullable<CapabilityServiceByPlanIdsQuery>[] = [];
     const pageSize = 20;
 
-    while (!total || count < total) {
+    while (total === undefined || count < total) {
       const queryResult = (await this.client.query(
         capabilityServiceByPlanIdsQuery,
         {

--- a/libs/shared/contentful/src/lib/queries/capability-service-by-plan-ids/factories.ts
+++ b/libs/shared/contentful/src/lib/queries/capability-service-by-plan-ids/factories.ts
@@ -15,10 +15,11 @@ import {
 export const CapabilityServiceByPlanIdsQueryFactory = (
   override?: Partial<CapabilityServiceByPlanIdsQuery>
 ): CapabilityServiceByPlanIdsQuery => {
+  const items = [CapabilityPurchaseResultFactory()];
   return {
     purchaseCollection: {
-      total: [CapabilityPurchaseResultFactory()].length,
-      items: [CapabilityPurchaseResultFactory()],
+      total: items.length,
+      items,
     },
     ...override,
   };


### PR DESCRIPTION
## Because

- Update ContentfulManager method to account for zero results returned by Contentful query.

## This pull request

- Updates while loop condition

## Issue that this pull request solves

Closes: #FXA-8865

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).