### PR TITLE
fix(auth): contentful comparison per product

### DIFF
--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -479,19 +479,24 @@ export abstract class StripeHelper {
           );
 
         validPlansFinal.push(...validPlansMapped.mappedPlans);
-        if (
-          validPlansMapped.nonMatchingPlans.length &&
-          this.logToSentry('StripeMapper.Errors')
-        ) {
-          Sentry.withScope((scope) => {
-            scope.setContext('allAbbrevPlans', {
-              nonMatchingPlans: validPlansMapped.nonMatchingPlans,
-            });
-            Sentry.captureMessage(
-              `StripeHelper.allAbbrevPlans - Contentful config does not match Stripe metadata`,
-              'warning' as Sentry.SeverityLevel
-            );
+        if (validPlansMapped.nonMatchingPlans.length) {
+          const nonMatchingPlans = validPlansMapped.nonMatchingPlans;
+          this.log.debug(`stripeHelper.allAbbrevPlans.nonMatchingPlans`, {
+            acceptLanguage,
+            nonMatchingPlans,
           });
+          if (this.logToSentry('StripeMapper.Errors')) {
+            Sentry.withScope((scope) => {
+              scope.setContext('allAbbrevPlans', {
+                acceptLanguage,
+                nonMatchingPlans,
+              });
+              Sentry.captureMessage(
+                `StripeHelper.allAbbrevPlans - Contentful config does not match Stripe metadata`,
+                'warning' as Sentry.SeverityLevel
+              );
+            });
+          }
         }
       } catch (error) {
         Sentry.captureException(error);


### PR DESCRIPTION
## Because

- The Contentful content is fetched for only one locale, however the comparison logic was comparing it against all plan's for all "locales" configured for a product.

## This pull request

- Updates the error reporting to only include 1 error message per ID. Typically this will be a Stripe product ID.
- Adds the request acceptLanguage to Sentry context, so that it is easier to identify which language the comparison was done for.

## Issue that this pull request solves

Closes: #FXA-8856

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).