### PR TITLE
feat(cloud): scaffold cloud tasks configs and route

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1990,6 +1990,31 @@ const convictConf = convict({
       format: String,
     },
   },
+
+  cloudTasks: {
+    oidc: {
+      aud: {
+        default: '',
+        doc: 'The audience value of the id token payload.',
+        env: 'AUTH_CLOUDTASKS_OIDC_AUD',
+        format: String,
+      },
+      serviceAccountEmail: {
+        default: '',
+        doc: 'The GCP service account email address.',
+        env: 'AUTH_CLOUDTASKS_OIDC_EMAIL',
+        format: String,
+      },
+    },
+    deleteAccounts: {
+      queueName: {
+        default: '',
+        doc: 'The name of the queue.  It should match the x-cloudtasks-queuename header value sent to the target.',
+        env: 'AUTH_CLOUDTASKS_DEL_ACCT_QUEUENAME',
+        format: String,
+      },
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/google-oidc.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/google-oidc.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { OAuth2Client } from 'google-auth-library';
+import { Request, ResponseToolkit } from '@hapi/hapi';
+import AppError from '../../error';
+
+export const strategy = ({
+  aud,
+  serviceAccountEmail,
+}: {
+  aud: string;
+  serviceAccountEmail: string;
+}) => {
+  const googleAuthClient = new OAuth2Client();
+
+  return () => ({
+    authenticate: async function (req: Request, h: ResponseToolkit) {
+      const auth = req.headers.authorization;
+
+      if (!auth || auth.indexOf('Bearer') !== 0) {
+        throw AppError.unauthorized('Bearer token not provided');
+      }
+
+      const tok = auth.split(' ')[1];
+
+      try {
+        const info = await googleAuthClient.verifyIdToken({
+          idToken: tok,
+          audience: aud,
+        });
+        if (info.getPayload()?.email !== serviceAccountEmail) {
+          throw new Error('Email address does not match.');
+        }
+        return h.authenticated({
+          credentials: info.getPayload() as Record<string, any>,
+        });
+      } catch (err) {
+        throw AppError.unauthorized(`Bearer token invalid: ${err.message}`);
+      }
+    },
+  });
+};

--- a/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import isA from 'joi';
+import { AuthRequest } from '../types';
+import { ConfigType } from '../../config';
+import DESCRIPTION from '../../docs/swagger/shared/descriptions';
+import validators from './validators';
+
+export type DeleteAccountTaskPayload = {
+  uid: string;
+  customerId?: string;
+};
+
+export class CloudTaskHandler {
+  private config: ConfigType;
+
+  constructor(config: ConfigType) {
+    this.config = config;
+  }
+
+  deleteAccount(taskPayload: DeleteAccountTaskPayload) {
+    return {};
+  }
+}
+
+export const cloudTaskRoutes = (config: ConfigType) => {
+  const cloudTaskHandler = new CloudTaskHandler(config);
+  const routes = [
+    {
+      method: 'POST',
+      path: '/cloud-tasks/accounts/delete',
+      options: {
+        auth: {
+          mode: 'required',
+          payload: false,
+          strategy: 'cloudTasksOIDC',
+        },
+        validate: {
+          headers: isA.object({
+            'x-cloudtasks-queuename': isA
+              .string()
+              .equal(config.cloudTasks.deleteAccounts.queueName),
+          }),
+          payload: isA.object({
+            uid: validators.uid.required().description(DESCRIPTION.uid),
+            customerId: isA
+              .string()
+              .optional()
+              .description(DESCRIPTION.customerId),
+          }),
+        },
+      },
+      handler: (request: AuthRequest) =>
+        cloudTaskHandler.deleteAccount(
+          request.payload as DeleteAccountTaskPayload
+        ),
+    },
+  ];
+
+  return routes;
+};

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -194,6 +194,9 @@ module.exports = function (
     statsd
   );
 
+  const { cloudTaskRoutes } = require('./cloud-tasks');
+  const cloudTasks = cloudTaskRoutes(config);
+
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {
     basePath = '';
@@ -216,7 +219,8 @@ module.exports = function (
     recoveryKey,
     subscriptions,
     newsletters,
-    linkedAccounts
+    linkedAccounts,
+    cloudTasks
   );
 
   function optionallyIgnoreTrace(fn) {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -114,6 +114,7 @@ module.exports.service = isA
   .max(16)
   .regex(/^[a-zA-Z0-9\-]*$/);
 module.exports.hexString = isA.string().regex(HEX_STRING);
+module.exports.uid = module.exports.hexString.length(32);
 module.exports.clientId = module.exports.hexString.length(16);
 module.exports.clientSecret = module.exports.hexString;
 module.exports.idToken = module.exports.jwt;

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -15,6 +15,7 @@ const schemeRefreshToken = require('./routes/auth-schemes/refresh-token');
 const authOauth = require('./routes/auth-schemes/auth-oauth');
 const sharedSecretAuth = require('./routes/auth-schemes/shared-secret');
 const pubsubAuth = require('./routes/auth-schemes/pubsub');
+const googleOIDC = require('./routes/auth-schemes/google-oidc');
 const { HEX_STRING } = require('./routes/validators');
 const { configureSentry } = require('./sentry');
 const { swaggerOptions } = require('../docs/swagger/swagger-options');
@@ -453,6 +454,12 @@ async function create(log, error, config, routes, db, statsd, glean) {
   server.auth.strategy('supportSecret', 'supportSecret');
 
   server.auth.strategy('pubsub', 'jwt', pubsubAuth.strategy(config));
+
+  server.auth.scheme(
+    'cloudTasksOIDC',
+    googleOIDC.strategy(config.cloudTasks.oidc)
+  );
+  server.auth.strategy('cloudTasksOIDC', 'cloudTasksOIDC');
 
   // register all plugins and Swagger configuration
   await server.register([

--- a/packages/fxa-auth-server/test/lib/server.js
+++ b/packages/fxa-auth-server/test/lib/server.js
@@ -8,6 +8,8 @@ process.env.CONFIG_FILES = require.resolve('./oauth-test.json');
 const { config } = require('../../config');
 const version = config.get('oauthServer.api.version');
 config.set('log.level', 'critical');
+config.set('cloudTasks.oidc.aud', 'cloud-tasks');
+config.set('cloudTasks.oidc.serviceAccountEmail', 'testo@iam.gcp.g.co');
 const testConfig = config.getProperties();
 const createServer = require('../../bin/key_server');
 const { CapabilityService } = require('../../lib/payments/capability');

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/google-oidc.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/google-oidc.js
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const AppError = require('../../../../lib/error');
+
+let verifyIdTokenStub;
+const GoogleOIDCScheme = proxyquire(
+  '../../../../lib/routes/auth-schemes/google-oidc',
+  {
+    'google-auth-library': {
+      OAuth2Client: class OAuth2Client {
+        constructor() {}
+        verifyIdToken(...args) {
+          return verifyIdTokenStub.apply(null, args);
+        }
+      },
+    },
+  }
+);
+
+const googleOIDCStrategy = GoogleOIDCScheme.strategy({
+  aud: 'cloud-tasks',
+  serviceAccountEmail: 'testo@iam.gcp.g.co',
+})();
+
+describe('lib/routes/auth-schemes/shared-secret', () => {
+  beforeEach(() => {
+    verifyIdTokenStub = sinon.stub().resolves({});
+  });
+
+  it('throws when the bearer token is missing', async () => {
+    const request = { headers: {} };
+
+    try {
+      await googleOIDCStrategy.authenticate(request, {});
+      assert.fail('Missing bearer token');
+    } catch (err) {
+      assert.deepEqual(err, AppError.unauthorized('Bearer token not provided'));
+    }
+  });
+
+  it('throws when the id token is invalid', async () => {
+    const request = { headers: { authorization: 'Bearer eeff.00.00' } };
+    verifyIdTokenStub = sinon.stub().rejects(new Error('invalid id token'));
+
+    try {
+      await googleOIDCStrategy.authenticate(request, {});
+      assert.fail('Invalid id token');
+    } catch (err) {
+      assert.deepEqual(
+        err,
+        AppError.unauthorized(`Bearer token invalid: invalid id token`)
+      );
+    }
+  });
+
+  it('throws when the service account email does not match', async () => {
+    const request = { headers: { authorization: 'Bearer eeff.00.00' } };
+    verifyIdTokenStub = sinon
+      .stub()
+      .resolves({ getPayload: () => ({ email: 'failing' }) });
+
+    try {
+      await googleOIDCStrategy.authenticate(request, {});
+      assert.fail('Invalid id token');
+    } catch (err) {
+      assert.deepEqual(
+        err,
+        AppError.unauthorized(
+          `Bearer token invalid: Email address does not match.`
+        )
+      );
+    }
+  });
+
+  it('authenticates successfully', async () => {
+    const request = { headers: { authorization: 'Bearer eeff.00.00' } };
+    const h = { authenticated: sinon.stub() };
+    verifyIdTokenStub = sinon
+      .stub()
+      .resolves({ getPayload: () => ({ email: 'testo@iam.gcp.g.co' }) });
+
+    try {
+      await googleOIDCStrategy.authenticate(request, h);
+      sinon.assert.calledOnceWithExactly(h.authenticated, {
+        credentials: { email: 'testo@iam.gcp.g.co' },
+      });
+      sinon.assert.calledOnceWithExactly(verifyIdTokenStub, {
+        idToken: 'eeff.00.00',
+        audience: 'cloud-tasks',
+      });
+    } catch (err) {
+      assert.fail('Test should have passed');
+    }
+  });
+});

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -842,5 +842,11 @@ function getConfig() {
       dsn: '',
       env: 'local',
     },
+    cloudTasks: {
+      oidc: {
+        aud: 'cloud-tasks',
+        serviceAccountEmail: 'testo@iam.gcp.g.co',
+      },
+    },
   };
 }


### PR DESCRIPTION
Because:
 - we want to use GCP Cloud Tasks to delete accounts

This commit:
 - adds few configuration options
 - adds a new route as task handler (currently no-op)
 - authenticates new route via ID token
