### PR TITLE
fix(settings): Localized components not wrapped in LocalizationProvider

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
@@ -103,24 +103,3 @@ it('displays a general error in the alert bar', async () => {
   await submitDisplayName('John Nope');
   expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
 });
-
-it('displays the GraphQL error', async () => {
-  const gqlError: any = new Error('test error');
-  gqlError.graphQLErrors = ['test'];
-  const account = {
-    displayName: 'jrgm',
-    setDisplayName: jest.fn().mockRejectedValue(gqlError),
-  } as unknown as Account;
-  renderWithRouter(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <PageDisplayName />
-    </AppContext.Provider>
-  );
-  // suppress the console output
-  let consoleErrorSpy = jest
-    .spyOn(console, 'error')
-    .mockImplementationOnce(() => {});
-  await submitDisplayName('Jane Nope');
-  expect(screen.getByTestId('tooltip')).toBeInTheDocument();
-  consoleErrorSpy.mockRestore();
-});

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { navigate, RouteComponentProps } from '@reach/router';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
@@ -30,7 +30,6 @@ export const PageDisplayName = (_: RouteComponentProps) => {
     );
     navigate(HomePath + '#display-name', { replace: true });
   }, [alertBar, l10n]);
-  const [errorText, setErrorText] = useState<string>();
   const initialValue = account.displayName || '';
   const { register, handleSubmit, formState, trigger } = useForm<{
     displayName: string;
@@ -48,20 +47,16 @@ export const PageDisplayName = (_: RouteComponentProps) => {
         await account.setDisplayName(displayName);
         alertSuccessAndGoHome();
       } catch (err) {
-        if (err.graphQLErrors?.length) {
-          setErrorText(err.message);
-        } else {
-          alertBar.error(
-            l10n.getString(
-              'display-name-update-error-2',
-              null,
-              'There was a problem updating your display name'
-            )
-          );
-        }
+        alertBar.error(
+          l10n.getString(
+            'display-name-update-error-2',
+            null,
+            'There was a problem updating your display name'
+          )
+        );
       }
     },
-    [account, alertSuccessAndGoHome, setErrorText, l10n, alertBar]
+    [account, alertSuccessAndGoHome, l10n, alertBar]
   );
 
   return (
@@ -80,7 +75,6 @@ export const PageDisplayName = (_: RouteComponentProps) => {
                 inputRef={register({
                   validate: isValidDisplayName,
                 })}
-                {...{ errorText }}
               />
             </Localized>
           </div>

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -53,18 +53,18 @@ try {
 
   render(
     <React.StrictMode>
-      <AppErrorBoundary>
-        <AppContext.Provider value={appContext}>
-          <AppLocalizationProvider
-            baseDir="/settings/locales"
-            userLocales={navigator.languages}
-          >
+      <AppLocalizationProvider
+        baseDir="/settings/locales"
+        userLocales={navigator.languages}
+      >
+        <AppErrorBoundary>
+          <AppContext.Provider value={appContext}>
             <ApolloProvider client={apolloClient}>
               <App {...{ flowQueryParams }} />
             </ApolloProvider>
-          </AppLocalizationProvider>
-        </AppContext.Provider>
-      </AppErrorBoundary>
+          </AppContext.Provider>
+        </AppErrorBoundary>
+      </AppLocalizationProvider>
     </React.StrictMode>,
     document.getElementById('root')
   );

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -278,8 +278,6 @@ const AccountRecoveryConfirmKey = ({
               setTooltipText('');
             }}
             prefixDataTestId="account-recovery-confirm-key"
-            // We don't have this marked as 'required: true` because we want to validate
-            // on submit, not on blur
             inputRef={register({ required: true })}
           />
         </FtlMsg>

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -128,14 +128,13 @@ const ResetPassword = ({
 
   const onSubmit = useCallback(async () => {
     const sanitizedEmail = getValues('email').trim();
-    if (sanitizedEmail === '') {
+    if (!sanitizedEmail) {
       setErrorText(
         ftlMsgResolver.getMsg(
           'reset-password-email-required-error',
           'Email required'
         )
       );
-      return;
     } else if (!isEmailValid(sanitizedEmail)) {
       setErrorText(
         ftlMsgResolver.getMsg('auth-error-1011', 'Valid email required')
@@ -218,7 +217,7 @@ const ResetPassword = ({
               autoComplete="off"
               spellCheck={false}
               prefixDataTestId="reset-password"
-              inputRef={register}
+              inputRef={register()}
             />
           </FtlMsg>
         )}


### PR DESCRIPTION
## Because

* We were seeing <Localized /> component was not properly wrapped in a <LocalizationProvider /> errors in Sentry
* Locally, replicated the error in ResetPassword and CompleteResetPassword pages when errors occurred with callback refs
* The AppErrorDialog compoment was outside the LocalizationProvider, so this error could occur when a general application error is encountered
* Error tooltip on the PageDisplayName was showing unlocalized messages that weren't intended to be user facing

## This pull request

* Resolves errors with callback refs in CompleteResetPassword and ResetPassword
* Moves the LocalizationProvider outside the AppErrorBoundary to provide access to localization for the AppErrorDialog component
* Removes the PageDisplayName tooltip and replace with a more user-appropriate error message

## Issue that this pull request solves

Closes: #FXA-8557

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
