### PR TITLE
feat(sync): Allow React Sync desktop to use OAuth flow via context=oauth_webchannel_v1

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -55,6 +55,8 @@ import { QueryParams } from '../..';
 import SignupContainer from '../../pages/Signup/container';
 import GleanMetrics from '../../lib/glean';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { isSyncDesktopOAuthIntegration } from '../../models/integrations/sync-desktop-oauth-integration';
+import firefox, { FirefoxCommand } from '../../lib/channels/firefox';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -105,6 +107,22 @@ export const App = ({
     flowQueryParams,
     integration,
   ]);
+
+  if (integration && integration.isSync()) {
+    // send up fxaStatus request here
+    // merge sync account if config.sendFxAStatusOnSettings
+
+    if (isSyncDesktopOAuthIntegration(integration)) {
+      // receive web channel message with OAuth params and set integration values
+      // If not received, assume desktop v3
+      integration.data.setModelData('scope', 'test1');
+      integration.data.setModelData('keysJwk', 'test2');
+      integration.data.setModelData('state', 'test3');
+      integration.data.setModelData('client_id', 'test4');
+      integration.data.setModelData('service', 'sync');
+      // etc., not sure if we need `access_type` etc.
+    }
+  }
 
   useEffect(() => {
     Metrics.init(data?.account?.metricsEnabled || !isSignedIn, flowQueryParams);

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -71,7 +71,7 @@ const Ready = ({
 }: ReadyProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  // TODO: Do we want to check isSyncDesktopIntegration instead?
+  // TODO: use `integration.isSync()`
   // This component in general could use some clean up...
   const isSync = serviceName === MozServices.FirefoxSync;
 

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -32,7 +32,10 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
   }
 
   isDevicePairingAsSupplicant() {
-    return DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname);
+    return (
+      this.isOAuthWebChannelContext() &&
+      DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname)
+    );
   }
 
   isOAuth() {
@@ -42,7 +45,6 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
     const isOAuthVerificationDifferentBrowser =
       this._isOAuthVerificationDifferentBrowser();
     const isOAuthPath = /oauth/.test(this.pathname);
-
     return (
       !!clientId ||
       isOAuthVerificationSameBrowser ||
@@ -53,6 +55,16 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
 
   isV3DesktopContext() {
     return this.searchParam('context') === Constants.FX_DESKTOP_V3_CONTEXT;
+  }
+
+  /* Sync mobile, Sync FF Desktop 123+, and supplicant pairing use this context.
+   * However, Sync mobile provides a `client_id` and other OAuth data through query
+   * parameters and use the OAuth integration. Sync Desktop using this context can
+   * be accessed through a link on the index page or through the browser and
+   * receives required OAuth data through a web channel message.
+   */
+  isOAuthWebChannelContext() {
+    return this.searchParam('context') === Constants.OAUTH_WEBCHANNEL_CONTEXT;
   }
 
   isOAuthSuccessFlow() {

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
@@ -12,7 +12,7 @@ import {
   PairingSupplicantIntegration,
   RelierClientInfo,
   RelierSubscriptionInfo,
-  SyncDesktopIntegration,
+  SyncDesktopV3Integration,
 } from '../../models/integrations';
 import { StorageData, UrlHashData, UrlQueryData } from '../model-data';
 import { IntegrationFactory, DefaultIntegrationFlags } from '../integrations';
@@ -28,7 +28,7 @@ type IntegrationFlagOverrides = {
 
 type FactoryCallCounts = {
   initIntegration?: number;
-  initSyncDesktopIntegration?: number;
+  initSyncDesktopV3Integration?: number;
   initOAuthIntegration?: number;
   initClientInfo?: number;
 };
@@ -168,13 +168,13 @@ describe('lib/integrations/integration-factory', () => {
     const CONTEXT = 'fx_desktop_v3';
     const COUNTRY = 'RO';
     const SYNC_SERVICE = 'sync';
-    let integration: SyncDesktopIntegration;
+    let integration: SyncDesktopV3Integration;
 
     beforeAll(async () => {
-      integration = await setup<SyncDesktopIntegration>(
+      integration = await setup<SyncDesktopV3Integration>(
         { isServiceSync: true, isV3DesktopContext: true },
-        { initIntegration: 1, initSyncDesktopIntegration: 1 },
-        (i: Integration) => i instanceof SyncDesktopIntegration
+        { initIntegration: 1, initSyncDesktopV3Integration: 1 },
+        (i: Integration) => i instanceof SyncDesktopV3Integration
       );
     });
 
@@ -183,7 +183,7 @@ describe('lib/integrations/integration-factory', () => {
     });
 
     it('has correct state', () => {
-      expect(integration.type).toEqual(IntegrationType.SyncDesktop);
+      expect(integration.type).toEqual(IntegrationType.SyncDesktopV3);
       expect(integration.isOAuth()).toBeFalsy();
       expect(integration.isSync()).toBeTruthy();
       expect(integration.wantsKeys()).toBeTruthy();

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.ts
@@ -8,12 +8,13 @@ import {
   PairingSupplicantIntegration,
   Integration,
   SyncBasicIntegration,
-  SyncDesktopIntegration,
+  SyncDesktopV3Integration,
   WebIntegration,
   RelierClientInfo,
   RelierSubscriptionInfo,
 } from '../../models/integrations';
 import {
+  GenericData,
   ModelDataStore,
   StorageData,
   UrlHashData,
@@ -24,6 +25,7 @@ import { ReachRouterWindow } from '../window';
 import { IntegrationFlags } from './interfaces';
 import { DefaultIntegrationFlags } from '.';
 import config from '../config';
+import { SyncDesktopOAuthIntegration } from '../../models/integrations/sync-desktop-oauth-integration';
 
 function getClientRedirect(
   clientRedirectUris: string[] | undefined,
@@ -101,8 +103,10 @@ export class IntegrationFactory {
       return this.createPairingSupplicationIntegration(data, storageData);
     } else if (flags.isOAuth()) {
       return this.createOAuthIntegration(data, storageData);
+    } else if (flags.isOAuthWebChannelContext()) {
+      return this.createSyncDesktopOAuthIntegration(storageData);
     } else if (flags.isV3DesktopContext()) {
-      return this.createSyncDesktopIntegration(data);
+      return this.createSyncDesktopV3Integration(data);
     } else if (flags.isServiceSync()) {
       return this.createSyncBasicIntegration(data);
     } else {
@@ -162,8 +166,19 @@ export class IntegrationFactory {
     return integration;
   }
 
-  private createSyncDesktopIntegration(data: ModelDataStore) {
-    const integration = new SyncDesktopIntegration(data);
+  private createSyncDesktopV3Integration(data: ModelDataStore) {
+    const integration = new SyncDesktopV3Integration(data);
+    this.initIntegration(integration);
+    return integration;
+  }
+
+  private createSyncDesktopOAuthIntegration(storageData: ModelDataStore) {
+    const integration = new SyncDesktopOAuthIntegration(
+      // Use generic data because data is set from a web channel message
+      new GenericData({}),
+      storageData,
+      config.oauth
+    );
     this.initIntegration(integration);
     return integration;
   }

--- a/packages/fxa-settings/src/lib/integrations/interfaces/integration-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/interfaces/integration-flags.ts
@@ -10,6 +10,7 @@ export interface IntegrationFlags {
   isDevicePairingAsSupplicant(): boolean;
   isOAuth(): boolean;
   isV3DesktopContext(): boolean;
+  isOAuthWebChannelContext(): boolean;
   isOAuthSuccessFlow(): { status: boolean; clientId: string };
   isOAuthVerificationFlow(): boolean;
 

--- a/packages/fxa-settings/src/lib/integrations/mocks.tsx
+++ b/packages/fxa-settings/src/lib/integrations/mocks.tsx
@@ -11,8 +11,8 @@ export function createMockWebIntegration(): IntegrationSubsetType {
   };
 }
 
-export function createMockSyncDesktopIntegration(): IntegrationSubsetType {
+export function createMockSyncDesktopV3Integration(): IntegrationSubsetType {
   return {
-    type: IntegrationType.SyncDesktop,
+    type: IntegrationType.SyncDesktopV3,
   };
 }

--- a/packages/fxa-settings/src/models/integrations/base-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/base-integration.ts
@@ -3,15 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { MozServices } from '../../lib/types';
+import { OAuthIntegration } from './oauth-integration';
+import { SyncDesktopOAuthIntegration } from './sync-desktop-oauth-integration';
+import { SyncDesktopV3Integration } from './sync-desktop-v3-integration';
 
 export enum IntegrationType {
   OAuth = 'OAuth',
   PairingAuthority = 'PairingAuthority', // TODO
   PairingSupplicant = 'PairingSupplicant', // TODO
   SyncBasic = 'SyncBasic',
-  SyncDesktop = 'SyncDesktop',
+  SyncDesktopV3 = 'SyncDesktopV3',
+  SyncDesktopOAuth = 'SyncDesktopOAuth',
   Web = 'Web', // default
 }
+
+export type OAuthIntegrations = OAuthIntegration | SyncDesktopOAuthIntegration;
 
 /* TODO, do we care about this feature (capability in content-server)?
  * -isOpenWebmailButtonVisible: we have a webmail link showing only in desktop v3
@@ -95,12 +101,14 @@ export abstract class Integration<
     this.features = { ...this.features, ...features } as T;
   }
 
-  // TODO: do we need this/isSync?
-  isOAuth(): boolean {
+  isOAuth(): this is OAuthIntegrations {
     return false;
   }
 
-  isSync(): boolean {
+  isSync(): this is
+    | OAuthIntegration
+    | SyncDesktopOAuthIntegration
+    | SyncDesktopV3Integration {
     return false;
   }
 

--- a/packages/fxa-settings/src/models/integrations/index.ts
+++ b/packages/fxa-settings/src/models/integrations/index.ts
@@ -11,5 +11,6 @@ export * from './pairing-supplicant-integration';
 export * from './signin-signup-info';
 export * from './supplicant-info';
 export * from './sync-basic-integration';
-export * from './sync-desktop-integration';
+export * from './sync-desktop-oauth-integration';
+export * from './sync-desktop-v3-integration';
 export * from './web-integration';

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -39,6 +39,7 @@ export enum OAuthPrompt {
 
 type OAuthIntegrationTypes =
   | IntegrationType.OAuth
+  | IntegrationType.SyncDesktopOAuth
   | IntegrationType.PairingSupplicant
   | IntegrationType.PairingAuthority;
 
@@ -182,8 +183,6 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
     this.setFeatures({
       handleSignedInNotification: false,
       reuseExistingSession: true,
-      webChannelSupport:
-        this.data.context === Constants.OAUTH_WEBCHANNEL_CONTEXT,
     });
   }
 
@@ -255,15 +254,8 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
     return true;
   }
 
-  // TODO: Sync mobile currently uses the OAuth integration for key derivation.
-  // Whenever desktop FF moves to this as well (e.g. from context=fx_desktop_v3
-  // to context=oauth_webchannel_v1) in SYNC-3768, we can refactor this and the
-  // SyncDesktop integration accordingly - maybe we'll only need one Sync
-  // integration once we no longer need to support desktop_v3. For now,
-  // `isOAuthIntegration(integration) && serviceName === MozServices.FirefoxSync`
-  // is the equivalent of this method's check.
   isSync() {
-    return this.getServiceName() === Constants.RELIER_SYNC_SERVICE_NAME;
+    return this.data.context === Constants.OAUTH_WEBCHANNEL_CONTEXT;
   }
 
   isTrusted() {
@@ -278,7 +270,7 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
     return this.data.prompt === OAuthPrompt.LOGIN || this.data.maxAge === 0;
   }
 
-  wantsTwoStepAuthentication() {
+  wantsTwoStepAuthentication(): boolean {
     const acrValues = this.data.acrValues;
     if (!acrValues) {
       return false;

--- a/packages/fxa-settings/src/models/integrations/sync-basic-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/sync-basic-integration.ts
@@ -63,13 +63,13 @@ export interface SyncIntegrationFeatures extends IntegrationFeatures {
 
 type SyncIntegrationTypes =
   | IntegrationType.SyncBasic
-  | IntegrationType.SyncDesktop;
+  | IntegrationType.SyncDesktopV3;
 
 /**
  * This integration offers basic Sync page support _without_ browser communication
  * via webchannels. Currently it is only used 1) when a user is on a verification page
  * through Sync in a different browser, which will no longer be the case once we use
- * codes for reset PW, and 2) as a base class for sync desktop.
+ * codes for reset PW, and 2) as a base class for sync desktop v3.
  */
 export class SyncBasicIntegration<
   T extends SyncIntegrationFeatures

--- a/packages/fxa-settings/src/models/integrations/sync-desktop-oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/sync-desktop-oauth-integration.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// new data store from web channel message instead of query params
+
+import { Constants } from '../../lib/constants';
+import { ModelDataStore } from '../../lib/model-data';
+import { IntegrationType } from './base-integration';
+import { OAuthIntegration, OAuthIntegrationOptions } from './oauth-integration';
+
+export function isSyncDesktopOAuthIntegration(integration: {
+  type: IntegrationType;
+}): integration is SyncDesktopOAuthIntegration {
+  return (
+    (integration as SyncDesktopOAuthIntegration).type === IntegrationType.OAuth
+  );
+}
+
+/*
+ * Firefox desktop 123+ uses the oauth_webchannel_v1 context and sends oauth data
+ * usually passed via query params to us through a web channel message `fxa_status`
+ * instead. This happens due to the index page "Looking for Firefox Sync?" link
+ * needing this data, and the in-browser link follows suite for consistency.
+ */
+export class SyncDesktopOAuthIntegration extends OAuthIntegration {
+  constructor(
+    data: ModelDataStore,
+    protected readonly storageData: ModelDataStore,
+    public readonly opts: OAuthIntegrationOptions
+  ) {
+    super(data, storageData, opts, IntegrationType.SyncDesktopOAuth);
+  }
+
+  getServiceName() {
+    return Constants.RELIER_SYNC_SERVICE_NAME;
+  }
+}

--- a/packages/fxa-settings/src/models/integrations/sync-desktop-v3-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/sync-desktop-v3-integration.ts
@@ -9,17 +9,21 @@ import {
   SyncIntegrationFeatures,
 } from './sync-basic-integration';
 
-export function isSyncDesktopIntegration(integration: {
+export function isSyncDesktopV3Integration(integration: {
   type: IntegrationType;
-}): integration is SyncDesktopIntegration {
+}): integration is SyncDesktopV3Integration {
   return (
-    (integration as SyncDesktopIntegration).type === IntegrationType.SyncDesktop
+    (integration as SyncDesktopV3Integration).type ===
+    IntegrationType.SyncDesktopV3
   );
 }
 
-export class SyncDesktopIntegration extends SyncBasicIntegration<SyncIntegrationFeatures> {
+/* This is a legacy integration for desktop Firefox < 123 that must be supported
+ * for the foreseeable future.
+ */
+export class SyncDesktopV3Integration extends SyncBasicIntegration<SyncIntegrationFeatures> {
   constructor(data: ModelDataStore) {
-    super(data, IntegrationType.SyncDesktop);
+    super(data, IntegrationType.SyncDesktopV3);
     this.setFeatures({ allowUidChange: true });
   }
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.stories.tsx
@@ -14,7 +14,7 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { AppContext, AppContextValue } from '../../../models';
 import {
-  createMockAccountRecoveryResetPasswordSyncDesktopIntegration,
+  createMockAccountRecoveryResetPasswordSyncDesktopV3Integration,
   mockAccount,
 } from './mocks';
 import { mockAppContext } from '../../../models/mocks';
@@ -33,7 +33,7 @@ const storyWithProps = (ctx: AppContextValue, history?: History) => {
     <AppContext.Provider value={ctx}>
       <LocationProvider {...{ history }}>
         <AccountRecoveryResetPassword
-          integration={createMockAccountRecoveryResetPasswordSyncDesktopIntegration()}
+          integration={createMockAccountRecoveryResetPasswordSyncDesktopV3Integration()}
         />
       </LocationProvider>
     </AppContext.Provider>

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -25,7 +25,7 @@ import {
   MOCK_SEARCH_PARAMS,
   MOCK_VERIFICATION_INFO,
   createMockAccountRecoveryResetPasswordOAuthIntegration,
-  createMockAccountRecoveryResetPasswordSyncDesktopIntegration,
+  createMockAccountRecoveryResetPasswordSyncDesktopV3Integration,
   mockAccount,
 } from './mocks';
 import { AccountRecoveryResetPasswordBaseIntegration } from './interfaces';
@@ -104,7 +104,7 @@ const render = (ui = <Subject />, account = mockAccount()) => {
 };
 
 const Subject = ({
-  integration = createMockAccountRecoveryResetPasswordSyncDesktopIntegration(),
+  integration = createMockAccountRecoveryResetPasswordSyncDesktopV3Integration(),
 }) => <AccountRecoveryResetPassword {...{ integration }} />;
 
 describe('AccountRecoveryResetPassword page', () => {
@@ -283,7 +283,7 @@ describe('AccountRecoveryResetPassword page', () => {
     let fxaLoginSignedInUserSpy: jest.SpyInstance;
     beforeEach(async () => {
       integration =
-        createMockAccountRecoveryResetPasswordSyncDesktopIntegration();
+        createMockAccountRecoveryResetPasswordSyncDesktopV3Integration();
       account.resetPasswordWithRecoveryKey = jest
         .fn()
         .mockResolvedValue(MOCK_RESET_DATA);
@@ -300,7 +300,7 @@ describe('AccountRecoveryResetPassword page', () => {
       expect(integration.data.resetPasswordConfirm).toBeTruthy();
     });
     it('calls fxaLoginSignedInUserSpy', () => {
-      expect(integration.type).toEqual(IntegrationType.SyncDesktop);
+      expect(integration.type).toEqual(IntegrationType.SyncDesktopV3);
       expect(fxaLoginSignedInUserSpy).toHaveBeenCalled();
     });
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -217,7 +217,7 @@ const AccountRecoveryResetPassword = ({
       switch (integration.type) {
         // NOTE: SyncBasic check is temporary until we implement codes
         // See https://docs.google.com/document/d/1K4AD69QgfOCZwFLp7rUcMOkOTslbLCh7jjSdR9zpAkk/edit#heading=h.kkt4eylho93t
-        case IntegrationType.SyncDesktop:
+        case IntegrationType.SyncDesktopV3:
         case IntegrationType.SyncBasic:
           firefox.fxaLoginSignedInUser({
             authAt: accountResetData.authAt,

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
@@ -69,9 +69,9 @@ export function createMockAccountRecoveryResetPasswordOAuthIntegration(
   };
 }
 
-export function createMockAccountRecoveryResetPasswordSyncDesktopIntegration(): AccountRecoveryResetPasswordBaseIntegration {
+export function createMockAccountRecoveryResetPasswordSyncDesktopV3Integration(): AccountRecoveryResetPasswordBaseIntegration {
   return {
-    type: IntegrationType.SyncDesktop,
+    type: IntegrationType.SyncDesktopV3,
     data: {
       uid: MOCK_UID,
       resetPasswordConfirm: false,

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -435,7 +435,7 @@ describe('CompleteResetPassword page', () => {
         );
         render(
           <Subject
-            integrationType={IntegrationType.SyncDesktop}
+            integrationType={IntegrationType.SyncDesktopV3}
             params={paramsWithSyncDesktop}
           />,
           account

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -232,7 +232,7 @@ const CompleteResetPassword = ({
         switch (integration.type) {
           // NOTE: SyncBasic check is temporary until we implement codes
           // See https://docs.google.com/document/d/1K4AD69QgfOCZwFLp7rUcMOkOTslbLCh7jjSdR9zpAkk/edit#heading=h.kkt4eylho93t
-          case IntegrationType.SyncDesktop:
+          case IntegrationType.SyncDesktopV3:
           case IntegrationType.SyncBasic:
             firefox.fxaLoginSignedInUser({
               authAt: accountResetData.authAt,

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -15,7 +15,7 @@ import {
 import { MOCK_UID } from '../../mocks';
 import LinkValidator from '../../../components/LinkValidator';
 import {
-  createMockSyncDesktopIntegration,
+  createMockSyncDesktopV3Integration,
   createMockWebIntegration,
 } from '../../../lib/integrations/mocks';
 
@@ -103,8 +103,8 @@ export const Subject = ({
       completeResetPasswordIntegration =
         createMockResetPasswordOAuthIntegration();
       break;
-    case IntegrationType.SyncDesktop:
-      completeResetPasswordIntegration = createMockSyncDesktopIntegration();
+    case IntegrationType.SyncDesktopV3:
+      completeResetPasswordIntegration = createMockSyncDesktopV3Integration();
       break;
     case IntegrationType.Web:
     default:

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -14,7 +14,7 @@ import {
   renderWithRouter,
 } from '../../../models/mocks';
 import {
-  createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopIntegration,
+  createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopV3Integration,
   createMockResetPasswordWithRecoveryKeyVerifiedWebIntegration,
 } from './mocks';
 import GleanMetrics from '../../../lib/glean';
@@ -58,11 +58,11 @@ const ResetPasswordWithRecoveryKeyVerifiedWithWebIntegration = ({
   />
 );
 
-const ResetPasswordWithRecoveryKeyVerifiedWithSyncDesktopIntegration = ({
+const ResetPasswordWithRecoveryKeyVerifiedWithSyncDesktopV3Integration = ({
   isSignedIn = true,
 }) => (
   <ResetPasswordWithRecoveryKeyVerified
-    integration={createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopIntegration()}
+    integration={createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopV3Integration()}
     {...{ isSignedIn }}
   />
 );
@@ -101,7 +101,9 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
   });
 
   it('renders default content for sync service', async () => {
-    render(<ResetPasswordWithRecoveryKeyVerifiedWithSyncDesktopIntegration />);
+    render(
+      <ResetPasswordWithRecoveryKeyVerifiedWithSyncDesktopV3Integration />
+    );
     await screen.findByText(syncText);
     screen.getByText(startBrowsingText);
     screen.getByText(createRecoveryKeyText);

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/mocks.tsx
@@ -14,9 +14,9 @@ export function createMockResetPasswordWithRecoveryKeyVerifiedWebIntegration(): 
   };
 }
 
-export function createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopIntegration(): ResetPasswordWithRecoveryKeyVerifiedIntegration {
+export function createMockResetPasswordWithRecoveryKeyVerifiedSyncDesktopV3Integration(): ResetPasswordWithRecoveryKeyVerifiedIntegration {
   return {
-    type: IntegrationType.SyncDesktop,
+    type: IntegrationType.SyncDesktopV3,
     getServiceName: () => MozServices.FirefoxSync,
     isSync: () => true,
   };

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -5,11 +5,13 @@
 import { RouteComponentProps } from '@reach/router';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
+  BaseIntegration,
   BaseIntegrationData,
   Integration,
   IntegrationType,
   OAuthIntegration,
   OAuthIntegrationData,
+  OAuthIntegrations,
 } from '../../../models';
 import { StoredAccountData } from '../../../lib/storage-utils';
 
@@ -49,6 +51,7 @@ export interface ConfirmSignupCodeBaseIntegration {
     uid: BaseIntegrationData['uid'];
     redirectTo: BaseIntegrationData['redirectTo'];
   };
+  isOAuth: () => this is OAuthIntegrations;
 }
 
 export interface ConfirmSignupCodeOAuthIntegration {
@@ -57,6 +60,7 @@ export interface ConfirmSignupCodeOAuthIntegration {
     uid: OAuthIntegrationData['uid'];
     redirectTo: OAuthIntegrationData['redirectTo'];
   };
+  isOAuth: () => this is OAuthIntegrations;
   getService: () => ReturnType<OAuthIntegration['getService']>;
   getRedirectUri: () => ReturnType<OAuthIntegration['getService']>;
 }

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -59,7 +59,7 @@ import AuthClient from 'fxa-auth-client/browser';
 let integration: SignupContainerIntegration;
 function mockIntegration() {
   integration = {
-    type: IntegrationType.SyncDesktop,
+    type: IntegrationType.SyncDesktopV3,
     getService: () => MozServices.Default,
     features: {
       allowUidChange: false,
@@ -324,7 +324,7 @@ describe('sign-up-container', () => {
         // here we override some key behaviors to alter the containers behavior
         serviceName = MozServices.FirefoxSync;
         integration.getService = () => MozServices.FirefoxSync;
-        integration.type = IntegrationType.SyncDesktop;
+        integration.type = IntegrationType.SyncDesktopV3;
       });
 
       it('added event listeners', async () => {
@@ -388,7 +388,7 @@ describe('sign-up-container', () => {
     beforeEach(() => {
       serviceName = MozServices.FirefoxSync;
       integration.getService = () => MozServices.FirefoxSync;
-      integration.type = IntegrationType.SyncDesktop;
+      integration.type = IntegrationType.SyncDesktopV3;
     });
 
     it('runs handler and invokes sign up mutation', async () => {

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -5,8 +5,7 @@
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import {
   Integration,
-  isOAuthIntegration,
-  isSyncDesktopIntegration,
+  isSyncDesktopV3V3Integration,
   useAuthClient,
 } from '../../models';
 import { Signup } from '.';
@@ -61,15 +60,13 @@ import { Constants } from '../../lib/constants';
 
 export type SignupContainerIntegration = Pick<
   Integration,
-  'type' | 'getService' | 'features'
-> & { features?: { webChannelSupport?: boolean } };
+  'type' | 'getService' | 'features' | 'isOAuth' | 'isSync'
+>;
 
 const SignupContainer = ({
   integration,
-  serviceName,
 }: {
   integration: SignupContainerIntegration;
-  serviceName: MozServices;
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const navigate = useNavigate();
@@ -84,14 +81,10 @@ const SignupContainer = ({
     string[] | undefined
   >();
 
-  const isOAuth = isOAuthIntegration(integration);
-  const hasWebChannelSupport = integration.features.webChannelSupport === true;
-  // TODO: Sync mobile cleanup, see note in oauth-integration isSync, FXA-8671
-  const isSyncMobile = isOAuth && serviceName === MozServices.FirefoxSync;
-  const isSyncMobileWebChannel = isSyncMobile && hasWebChannelSupport;
-  const isSyncDesktop = isSyncDesktopIntegration(integration);
-  const isSyncWebChannel = isSyncMobileWebChannel || isSyncDesktop;
-  const isSync = isSyncMobile || isSyncDesktop;
+  const isOAuth = integration.isOAuth();
+  const isSyncOAuth = isOAuth && integration.isSync();
+  const isSyncDesktopV3 = isSyncDesktopV3V3Integration(integration);
+  const isSyncWebChannel = isSyncOAuth || isSyncDesktopV3;
 
   useEffect(() => {
     (async () => {
@@ -138,7 +131,7 @@ const SignupContainer = ({
       requestAnimationFrame(() => {
         firefox.send(FirefoxCommand.FxAStatus, {
           // TODO: Improve getting 'context', probably set this on the integration
-          context: isSyncDesktop
+          context: isSyncDesktopV3
             ? Constants.FX_DESKTOP_V3_CONTEXT
             : Constants.OAUTH_CONTEXT,
           isPairing: false,
@@ -154,8 +147,8 @@ const SignupContainer = ({
       // choose_what_to_sync may be disabled for mobile sync, see:
       // https://github.com/mozilla/application-services/issues/1761
       if (
-        isSyncDesktop ||
-        (isSyncMobile && status.capabilities.choose_what_to_sync)
+        isSyncDesktopV3 ||
+        (isSyncOAuth && status.capabilities.choose_what_to_sync)
       ) {
         setWebChannelEngines(status.capabilities.engines);
         firefox.removeEventListener(
@@ -174,7 +167,7 @@ const SignupContainer = ({
       const options: BeginSignUpOptions = {
         verificationMethod: 'email-otp',
         // keys must be true to receive keyFetchToken for oAuth and syncDesktop
-        keys: isOAuthIntegration(integration) || isSyncDesktop,
+        keys: isOAuth || isSyncDesktopV3,
         service: service !== MozServices.Default ? service : undefined,
       };
       try {
@@ -215,7 +208,7 @@ const SignupContainer = ({
         }
       }
     },
-    [beginSignup, integration, isSyncDesktop]
+    [beginSignup, integration, isSyncDesktopV3, isOAuth]
   );
 
   // TODO: probably a better way to read this?
@@ -239,8 +232,8 @@ const SignupContainer = ({
         queryParamModel,
         beginSignupHandler,
         webChannelEngines,
-        isSyncMobileWebChannel,
-        isSync,
+        isSyncWebChannel,
+        isSyncOAuth,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -9,7 +9,7 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import {
   createMockSignupOAuthIntegration,
-  createMockSignupSyncDesktopIntegration,
+  createMockSignupSyncDesktopV3Integration,
   createMockSignupWebIntegration,
   mockBeginSignupHandler,
   signupQueryParams,
@@ -66,6 +66,6 @@ export const ClientIsMonitor = storyWithProps({
 });
 
 export const ChooseWhatToSyncIsEnabled = storyWithProps({
-  integration: createMockSignupSyncDesktopIntegration(),
+  integration: createMockSignupSyncDesktopV3Integration(),
   isSync: true,
 });

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -21,7 +21,7 @@ import {
   MOCK_SEARCH_PARAMS,
   Subject,
   createMockSignupOAuthIntegration,
-  createMockSignupSyncDesktopIntegration,
+  createMockSignupSyncDesktopV3Integration,
 } from './mocks';
 import {
   MOCK_CLIENT_ID,
@@ -208,7 +208,7 @@ describe('Signup page', () => {
 
   it('shows options to choose what to sync when CWTS is enabled', async () => {
     renderWithLocalizationProvider(
-      <Subject integration={createMockSignupSyncDesktopIntegration()} />
+      <Subject integration={createMockSignupSyncDesktopV3Integration()} />
     );
 
     await screen.findByText('Choose what to sync');
@@ -440,7 +440,7 @@ describe('Signup page', () => {
             .mockResolvedValue(BEGIN_SIGNUP_HANDLER_RESPONSE);
           renderWithLocalizationProvider(
             <Subject
-              integration={createMockSignupSyncDesktopIntegration()}
+              integration={createMockSignupSyncDesktopV3Integration()}
               beginSignupHandler={mockBeginSignupHandler}
             />
           );

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -44,14 +44,15 @@ export interface SignupProps {
   queryParamModel: SignupQueryParams;
   beginSignupHandler: BeginSignupHandler;
   webChannelEngines: string[] | undefined;
-  isSyncMobileWebChannel: boolean;
-  isSync: boolean;
+  isSyncWebChannel: boolean;
+  isSyncOAuth: boolean;
 }
 
 export type SignupIntegration = SignupOAuthIntegration | SignupBaseIntegration;
 
 export interface SignupOAuthIntegration {
   type: IntegrationType.OAuth;
+  isSync: () => ReturnType<OAuthIntegration['isSync']>;
   getRedirectUri: () => ReturnType<OAuthIntegration['getRedirectUri']>;
   saveOAuthState: () => ReturnType<OAuthIntegration['saveOAuthState']>;
   getService: () => ReturnType<OAuthIntegration['getService']>;
@@ -59,6 +60,7 @@ export interface SignupOAuthIntegration {
 
 export interface SignupBaseIntegration {
   type: IntegrationType;
+  isSync: () => ReturnType<BaseIntegration['isSync']>;
   getService: () => ReturnType<BaseIntegration['getService']>;
 }
 

--- a/packages/fxa-settings/src/pages/Signup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/mocks.tsx
@@ -5,7 +5,7 @@
 import { LocationProvider } from '@reach/router';
 import Signup from '.';
 import { MozServices } from '../../lib/types';
-import { IntegrationType, isSyncDesktopIntegration } from '../../models';
+import { IntegrationType, isSyncDesktopV3Integration } from '../../models';
 import { mockUrlQueryData } from '../../models/mocks';
 import { SignupQueryParams } from '../../models/pages/signup';
 import {
@@ -36,9 +36,9 @@ export function createMockSignupWebIntegration(): SignupBaseIntegration {
   };
 }
 
-export function createMockSignupSyncDesktopIntegration(): SignupBaseIntegration {
+export function createMockSignupSyncDesktopV3Integration(): SignupBaseIntegration {
   return {
-    type: IntegrationType.SyncDesktop,
+    type: IntegrationType.SyncDesktopV3,
     getService: () => Promise.resolve(MozServices.FirefoxSync),
   };
 }
@@ -105,7 +105,7 @@ export const Subject = ({
           integration,
           queryParamModel,
           beginSignupHandler,
-          isSync: isSyncDesktopIntegration(integration),
+          isSync: isSyncDesktopV3Integration(integration),
           isSyncMobileWebChannel: false,
           webChannelEngines: getSyncEngineIds(),
         }}


### PR DESCRIPTION
Because:
* Sync Desktop wants to use the keys already available in web content, which sync mobile already does with oauth_webchannel_v1 context

This commit:
* Renames SyncDesktop integration to SyncDesktopV3Integration
* Creates a new integration SyncDesktopOAuthIntegration which extends from the OAuth integration, because we must receive the oauth parameter data differently
* Alters isSync and isOAuth integration methods for type guard usage, changes OAuth integration isSync() to check against context instead of service name since technically, other RPs can request the sync scope and we always set the service name to 'Sync' when that scope is requested
* Cleans up sync mobile web channel references

closes FXA-8671

---

### Still need to...

* Fix/edit/add tests and check Storybook
* Check overlap with/see what can/should be moved to #15723. Content-server needs some edits to listen for the web channel message and add the "Looking for Firefox Sync?" link `context`