### PR TITLE
feat(accounts): create a AccountDeleteManager class

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Container } from 'typedi';
+import DB from './db/index';
+import OAuthDb from './oauth/db';
+import { AppleIAP } from './payments/iap/apple-app-store/apple-iap';
+import { PlayBilling } from './payments/iap/google-play/play-billing';
+import { PayPalHelper } from './payments/paypal/helper';
+import { StripeHelper } from './payments/stripe';
+import push from './push';
+import pushboxApi from './pushbox';
+import { AuthLogger } from './types';
+
+type FxaDbDeleteAccount = Pick<
+  Awaited<ReturnType<ReturnType<typeof DB>['connect']>>,
+  'deleteAccount'
+>;
+type OAuthDbDeleteAccount = Pick<typeof OAuthDb, 'removeTokensAndCodes'>;
+type PushDeleteAccount = Pick<
+  ReturnType<typeof push>,
+  'notifyAccountDestroyed'
+>;
+type PushboxDeleteAccount = Pick<
+  ReturnType<typeof pushboxApi>,
+  'deleteAccount'
+>;
+
+export class AccountDeleteManager {
+  private fxaDb: FxaDbDeleteAccount;
+  private oauthDb: OAuthDbDeleteAccount;
+  private push: PushDeleteAccount;
+  private pushbox: PushboxDeleteAccount;
+  private stripeHelper?: StripeHelper;
+  private paypalHelper?: PayPalHelper;
+  private appleIap?: AppleIAP;
+  private playBilling?: PlayBilling;
+  private log: AuthLogger;
+
+  constructor({
+    fxaDb,
+    oauthDb,
+    push,
+    pushbox,
+  }: {
+    fxaDb: FxaDbDeleteAccount;
+    oauthDb: OAuthDbDeleteAccount;
+    push: PushDeleteAccount;
+    pushbox: PushboxDeleteAccount;
+  }) {
+    this.fxaDb = fxaDb;
+    this.oauthDb = oauthDb;
+    this.push = push;
+    this.pushbox = pushbox;
+
+    if (Container.has(StripeHelper)) {
+      this.stripeHelper = Container.get(StripeHelper);
+    }
+    if (Container.has(PayPalHelper)) {
+      this.paypalHelper = Container.get(PayPalHelper);
+    }
+    if (Container.has(AppleIAP)) {
+      this.appleIap = Container.get(AppleIAP);
+    }
+    if (Container.has(PlayBilling)) {
+      this.playBilling = Container.get(PlayBilling);
+    }
+    this.log = Container.get(AuthLogger);
+  }
+}

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -46,6 +46,7 @@ import requestHelper from './utils/request_helper';
 import validators from './validators';
 import { AccountEventsManager } from '../account-events';
 import { gleanMetrics } from '../metrics/glean';
+import { AccountDeleteManager } from '../account-delete';
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -65,6 +66,7 @@ export class AccountHandler {
   private skipConfirmationForEmailAddresses: string[];
   private capabilityService: CapabilityService;
   private accountEventsManager: AccountEventsManager;
+  private accountDeleteManager: AccountDeleteManager;
 
   constructor(
     private log: AuthLogger,
@@ -101,6 +103,7 @@ export class AccountHandler {
     }
     this.capabilityService = Container.get(CapabilityService);
     this.accountEventsManager = Container.get(AccountEventsManager);
+    this.accountDeleteManager = Container.get(AccountDeleteManager);
   }
 
   private async generateRandomValues() {

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -21,12 +21,11 @@ module.exports = function (
   profile,
   stripeHelper,
   redis,
-  glean
+  glean,
+  push,
+  pushbox
 ) {
   // Various extra helpers.
-  const push = require('../push')(log, db, config, statsd);
-  const { pushboxApi } = require('../pushbox');
-  const pushbox = pushboxApi(log, config, statsd);
   const devicesImpl = require('../devices')(log, db, push, pushbox);
   const cadReminders = require('../cad-reminders')(config, log);
   const signinUtils = require('./utils/signin')(


### PR DESCRIPTION
Because:
 - we want to have something to handle account deletes outside of a route handler

This commit:
 - adds the AccountDeleteManager class (without no functionality yet)
 - moves some dependency initialization
