### PR TITLE
fix(payments): Adjust price and value for GA4 reports

### DIFF
--- a/packages/fxa-payments-server/src/lib/reactga-event.ts
+++ b/packages/fxa-payments-server/src/lib/reactga-event.ts
@@ -67,9 +67,14 @@ export const ReactGALog = {
         product_name: productName,
       } = plan;
 
+      // Currently, only currencies with decimals are supported in Subscription Platform.
+      // If currencies without subunits (e.g., cents) are included at a later time, this
+      // will need to be updated.
+      const planPrice: number = (amount || 0) / 100;
+
       let planOptions: PlanOptionsProps = {
         currency: currencyCode,
-        value: amount,
+        value: planPrice,
         payment_type: paymentType,
         items: [
           {
@@ -77,7 +82,7 @@ export const ReactGALog = {
             item_name: planName,
             item_brand: productName,
             item_variant: interval,
-            price: amount,
+            price: planPrice,
             discount,
           },
         ],


### PR DESCRIPTION
## Because

- product price and value were both reported in cents (e.g., $8388 for the bundle when the annual subscription is $83.88)

## This pull request

- adjusts price and value

## Issue that this pull request solves

Closes: FXA-8857

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Other information (Optional)
It has been observed that price is reported 1000x in DebugView - reports show the correct price.