### PR TITLE
chore(test): Enable functional test for React Signup redirect to SubPlat

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -8,7 +8,6 @@ import { createCustomEventDetail, FirefoxCommand } from '../../lib/channels';
 
 const PASSWORD = 'passwordzxcv';
 
-
 let email;
 let skipCleanup = false;
 
@@ -21,7 +20,7 @@ test.beforeEach(async ({ pages: { configPage, login } }) => {
     email = undefined;
   } else {
     email = login.createEmail('signup_react{id}');
-        await login.clearCache();
+    await login.clearCache();
   }
 });
 
@@ -310,7 +309,6 @@ test.describe('severity-2 #smoke', () => {
       expect(await signupReact.getAge().inputValue()).toEqual('');
     });
 
-    // TODO: Not currently supported
     test('signup via product page and redirect after confirm', async ({
       page,
       target,
@@ -338,9 +336,8 @@ test.describe('severity-2 #smoke', () => {
       );
 
       await signupReact.fillOutCodeForm(code);
-      // TODO: The redirect back to products isn't working. https://mozilla-hub.atlassian.net/browse/FXA-8795
-      // await page.waitForURL(/products/);
-      // await expect(page.getByTestId('avatar')).toBeVisible();
+      await page.waitForURL(/products/);
+      await expect(page.getByTestId('avatar')).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
Because:
* We want a functional test for this path which was commented out

This commit:
* Enables the last bit of this test, as it is passing

closes FXA-8795

--

This is passing for me locally, and I can go through the flow locally as well as in staging.

To test this, go to 123done and click a subscription product, then click "Sign in". Append the force experiment React params, and go through the flow. [Here's](http://localhost:3030/?device_id=aec7913a470a4fc9870b5c451a7cd334&flow_begin_time=1704239315404&flow_id=fda9de5b4f3fd8c55272f19d22423d7a9cc8fb2a282b17077a8bd3a1f2f06238&plan=price_1KbomlBVqmGyQTMaa0Tq7UaW&signin=yes&redirect_to=http%3A%2F%2Flocalhost%3A3031%2Fproducts%2Fprod_GqM9ToKK62qjkK%3Fdevice_id%3Daec7913a470a4fc9870b5c451a7cd334%26flow_begin_time%3D1704239315404%26flow_id%3Dfda9de5b4f3fd8c55272f19d22423d7a9cc8fb2a282b17077a8bd3a1f2f06238%26plan%3Dprice_1KbomlBVqmGyQTMaa0Tq7UaW&forceExperiment=generalizedReactApp&forceExperimentGroup=react) a handy staging link.