### PR TITLE
bug(shared): Don't report gql errors that are due to http errors.

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/sentry.plugin.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.plugin.ts
@@ -28,9 +28,10 @@ import { Transaction } from '@sentry/types';
 import {
   ExtraContext,
   isApolloError,
+  isOriginallyHttpError,
   reportRequestException,
 } from './reporting';
-import { Inject } from '@nestjs/common';
+import { Inject, UnauthorizedException } from '@nestjs/common';
 import { MozLoggerService } from '../logger/logger.service';
 
 interface Context extends BaseContext {
@@ -102,15 +103,19 @@ export class SentryPlugin implements ApolloServerPlugin<Context> {
         for (const err of errors) {
           // Only report internal server errors,
           // all errors extending ApolloError should be user-facing
-          if (err.originalError instanceof GraphQLError) {
+          if (isApolloError(err)) {
             continue;
           }
-          // Skip errors with a status already set or already reported
-          if (
-            isApolloError(err) ||
-            (err.originalError && isApolloError(err.originalError))
-          )
+
+          // Skip errors that are originally http errors. There are two expected scenarios where this happens:
+          //  1. When we hit a case where auth server responds with an http error
+          //  2. When we hit an unauthorized state due to an invalid session token
+          //
+          // In either case, the error is considered expected, and should not be reported to sentry.
+          //
+          if (isOriginallyHttpError(err as any)) {
             continue;
+          }
 
           const excContexts: ExtraContext[] = [];
           if ((err as any).path?.join) {


### PR DESCRIPTION
## Because

- These aren't actually unexpected errors.
- Auth server will return http errors intentionally
- Invalid or missing session tokens on requests will result in intentional HTTP 401 errors.

## This pull request

- Won't report these kinds of errors to sentry.

## Issue that this pull request solves

Closes: FXA-8817

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)


Note that before the graphql upgrade we didn't report these. The logic surrounding originalError.status just got lost in the shuffle.
