### PR TITLE
Reject Relay email masks on signup

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -624,6 +624,10 @@ var ERRORS = {
     errno: 1065,
     message: t('The image file size is too large to be uploaded.'),
   },
+  EMAIL_MASK_NEW_ACCOUNT: {
+    errno: 1066,
+    message: t('Email masks can’t be used to create an account.'),
+  },
 };
 
 export default _.extend({}, Errors, {

--- a/packages/fxa-content-server/app/scripts/lib/vat.js
+++ b/packages/fxa-content-server/app/scripts/lib/vat.js
@@ -18,6 +18,7 @@ Vat.register('channelKey', Vat.string().test(Validate.isBase64Url));
 Vat.register('codeChallenge', Vat.string().min(43).max(128));
 Vat.register('codeChallengeMethod', Vat.string().valid('S256'));
 Vat.register('email', Vat.string().test(Validate.isEmailValid));
+Vat.register('emailMask', Vat.string().test(Validate.isEmailMask));
 Vat.register('hex', Vat.string().test(Validate.isHexValid));
 Vat.register('idToken', Vat.string());
 Vat.register('keyFetchToken', Vat.string());

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -174,6 +174,10 @@ class IndexView extends FormView {
       return false;
     }
 
+    if (this._isEmailRelayDomain(this._getEmail())) {
+      return false;
+    }
+
     return super.isValidEnd.call(this);
   }
 
@@ -188,6 +192,11 @@ class IndexView extends FormView {
         EMAIL_SELECTOR,
         AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN')
       );
+    } else if (this._isEmailRelayDomain(this._getEmail())) {
+      this.showValidationError(
+        EMAIL_SELECTOR,
+        AuthErrors.toError('EMAIL_MASK_NEW_ACCOUNT')
+      );
     }
   }
 
@@ -201,6 +210,15 @@ class IndexView extends FormView {
     // the added 'i' disallows uppercase letters
     const firefoxMail = new RegExp('@firefox(\\.com)?$', 'i');
     return firefoxMail.test(email);
+  }
+
+  _isEmailRelayDomain(email) {
+    // Checks to see if the email is a Firefox Relay email mask. Current masks are
+    // @mozmail.com
+    // @relay.firefox.com
+    // @<any sub>.mozmail.com
+    const relayMail = /@([a-zA-Z0-9.-]+\.)?(mozmail|relay\.firefox)\.(com)$/i;
+    return relayMail.test(email);
   }
 
   _hasEmailBounced() {

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -352,6 +352,30 @@ describe('views/index', () => {
       );
     });
 
+    it('shows error when signing up with Relay mask email (@mozmail.com)', () => {
+      view.$(Selectors.EMAIL).val('a@mozmail.com');
+      view.showValidationErrorsEnd();
+      assert.isTrue(view.showValidationError.called);
+      const err = view.showValidationError.args[0][1];
+      assert.isTrue(AuthErrors.is(err, 'EMAIL_MASK_NEW_ACCOUNT'));
+    });
+
+    it('shows error when signing up with Relay mask email (@sub.mozmail.com)', () => {
+      view.$(Selectors.EMAIL).val('a@sub.mozmail.com');
+      view.showValidationErrorsEnd();
+      assert.isTrue(view.showValidationError.called);
+      const err = view.showValidationError.args[0][1];
+      assert.isTrue(AuthErrors.is(err, 'EMAIL_MASK_NEW_ACCOUNT'));
+    });
+
+    it('shows error when signing up with Relay mask email (@relay.firefox.com)', () => {
+      view.$(Selectors.EMAIL).val('a@relay.firefox.com');
+      view.showValidationErrorsEnd();
+      assert.isTrue(view.showValidationError.called);
+      const err = view.showValidationError.args[0][1];
+      assert.isTrue(AuthErrors.is(err, 'EMAIL_MASK_NEW_ACCOUNT'));
+    });
+
     it('shows an error if the user provides a @firefox email', () => {
       view.$(Selectors.EMAIL).val('firefox@firefox');
       view.showValidationErrorsEnd();

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/en.ftl
@@ -8,3 +8,8 @@ add-secondary-email-enter-address =
   .label = Enter email address
 add-secondary-email-cancel-button = Cancel
 add-secondary-email-save-button = Save
+
+# This message is shown when a user tries to add a secondary email that is a
+# Firefox Relay email mask (generated email address that can be used in place of
+# your real email address)
+add-secondary-email-mask = Email masks can’t be used as a secondary email

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.test.tsx
@@ -70,6 +70,26 @@ describe('PageSecondaryEmailAdd', () => {
 
       expect(screen.getByTestId('save-button')).toHaveAttribute('disabled');
     });
+
+    it('should display tooltip error when using email mask', async () => {
+      renderWithRouter(
+        <AppContext.Provider value={mockAppContext({ account })}>
+          <PageSecondaryEmailAdd />
+        </AppContext.Provider>
+      );
+
+      const input = screen.getByTestId('input-field');
+      fireEvent.change(input, { target: { value: 'user@mozmail.com' } });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-button'));
+      });
+
+      expect(screen.queryByTestId('tooltip')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Email masks can’t be used as a secondary email')
+      ).toBeInTheDocument();
+    });
   });
 
   describe('createSecondaryEmailCode', () => {

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -6,7 +6,7 @@ import { HomePath } from '../../../constants';
 import InputText from '../../InputText';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
-import { isEmailValid } from 'fxa-shared/email/helpers';
+import { isEmailMask, isEmailValid } from 'fxa-shared/email/helpers';
 import { useAccount, useAlertBar } from 'fxa-settings/src/models';
 import {
   AuthUiErrorNos,
@@ -66,8 +66,18 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
       setSaveBtnDisabled(!isValid);
       setEmail(inputRef.current?.value);
       setErrorText('');
+
+      if (isEmailMask(email)) {
+        const errorText = l10n.getString(
+          'add-secondary-email-mask',
+          null,
+          'Email masks can’t be used as a secondary email'
+        );
+        setErrorText(errorText);
+        setSaveBtnDisabled(true);
+      }
     },
-    [setSaveBtnDisabled]
+    [setSaveBtnDisabled, setErrorText, l10n]
   );
 
   return (

--- a/packages/fxa-shared/email/helpers.ts
+++ b/packages/fxa-shared/email/helpers.ts
@@ -1,3 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Mozmail.com is the Firefox Relay email mask, we prohibit creating accounts with it
+const emailMaskRegex = /@([a-zA-Z0-9.-]+\.)?(mozmail|relay\.firefox)\.(com)$/i;
+
 export function normalizeEmail(originalEmail: string): string {
   return originalEmail.toLowerCase();
 }
@@ -32,7 +39,8 @@ export function emailsMatch(firstEmail: string, secondEmail: string): boolean {
 //   * http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
 // '/' in the character class is (redundantly) backslash-escaped to produce
 // the same minimized form in node 4.x and node 0.10.
-const emailRegex = /^[\w.!#$%&'*+\/=?^`{|}~-]{1,64}@[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?)+$/i;
+const emailRegex =
+  /^[\w.!#$%&'*+\/=?^`{|}~-]{1,64}@[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?)+$/i;
 
 /**
  * Check if an email address is valid
@@ -54,4 +62,15 @@ export function isEmailValid(email: string): boolean {
   // the auth server. :-/
 
   return emailRegex.test(email);
+}
+
+/**
+ * Check if an email address is an email mask. Currently, the only email mask
+ * we check is mozmail.com, relay.firefox.com and *.mozmail.com from Firefox Relay.
+ *
+ * @param {String} email
+ * @return {Boolean} true if email is mask, false otw.
+ */
+export function isEmailMask(email: string): boolean {
+  return emailMaskRegex.test(email);
 }


### PR DESCRIPTION
## Because

- We don't want to create new accounts with Relay mask

## This pull request

- Disables the ability to create new accounts

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5229

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

<img width="507" alt="Screenshot 2024-01-03 at 11 10 36 AM" src="https://github.com/mozilla/fxa/assets/1295288/927769f6-2b28-432e-80dd-0695585b18bc">

Ran into some issues trying to get my new laptop working with Settings, so couldn't fully test that it is disabled in secondary emails, added code in email helper so I can do a follow up more easily
