### PR TITLE
feat(sync): Update 'credit cards' to 'payment methods'

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -59,7 +59,7 @@ export const selectors = {
   CWTS_ENGINE_ADDONS: '#sync-engine-addons',
   CWTS_ENGINE_TABS: '#sync-engine-tabs',
   CWTS_ENGINE_PREFS: '#sync-engine-prefs',
-  CWTS_ENGINE_CREDITCARDS: 'label:has-text("Credit Cards")',
+  CWTS_ENGINE_CREDITCARDS: 'label:has-text("Payment Methods")',
   CWTS_ENGINE_ADDRESSES: '#sync-engine-addresses',
   DO_NOT_SYNC: '#do-not-sync-device',
   CWTS_PAGE_HEADER: '#fxa-choose-what-to-sync-header',

--- a/packages/fxa-content-server/app/scripts/models/sync-engines.js
+++ b/packages/fxa-content-server/app/scripts/models/sync-engines.js
@@ -66,7 +66,7 @@ const AVAILABLE_ENGINES = [
     id: 'creditcards',
     // credit cards will only be available via capabilities.
     test: () => false,
-    text: t('Credit Cards'),
+    text: t('Payment Methods'),
   },
 ];
 

--- a/packages/fxa-settings/src/components/ChooseWhatToSync/en.ftl
+++ b/packages/fxa-settings/src/components/ChooseWhatToSync/en.ftl
@@ -19,5 +19,5 @@ choose-what-to-sync-option-prefs =
   .label = Preferences
 choose-what-to-sync-option-addresses =
   .label = Addresses
-choose-what-to-sync-option-creditcards =
-  .label = Credit Cards
+choose-what-to-sync-option-paymentmethods =
+  .label = Payment Methods

--- a/packages/fxa-settings/src/components/ChooseWhatToSync/sync-engines.ts
+++ b/packages/fxa-settings/src/components/ChooseWhatToSync/sync-engines.ts
@@ -82,8 +82,8 @@ export const webChannelDesktopEngineConfigs: WebChannelEngineConfig[] = [
   {
     defaultChecked: true,
     id: 'creditcards',
-    text: 'Credit Cards',
-    ftlId: 'choose-what-to-sync-option-creditcards',
+    text: 'Payment Methods',
+    ftlId: 'choose-what-to-sync-option-paymentmethods',
     include: false,
   },
 ];


### PR DESCRIPTION
## Because

* The wording in CWTS was replaced elsewhere in Firefox

## This pull request

* Replace instances of 'credit cards' in CWTS options with 'Payment Methods'

## Issue that this pull request solves

Closes: #FXA-8837

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/mozilla/fxa/assets/22231637/d29a17ce-08b2-4d07-8e96-727e35468e3a)

## Other information (Optional)

Any other information that is important to this pull request.
