### PR TITLE
fix(functional-tests): Fix flaky React Signup tests

### DIFF
--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -40,7 +40,7 @@ export abstract class BaseLayout {
       await new Promise((resolve, reject) => {
         const timeoutHandle = setTimeout(
           () => reject(noNotificationError),
-          2000
+          5000
         );
 
         function findMessage() {


### PR DESCRIPTION
Because:
* These tests are not reliably passing in staging

This commit:
* Waits until page load before checking for user's avatar on SubPlat
* Increases the timeout for checking for a web channel message response since confirming an account and sending the message can take longer than 2s

fixes FXA-8877
fixes FXA-8879