### PR TITLE
fix(content): Center default avatar

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -25,7 +25,6 @@
 }
 
 .avatar-wrapper {
-  align-self: center;
   border-radius: 50%;
   border-width: 0;
   height: $avatar-size;
@@ -47,9 +46,11 @@
 
   // remove when Payments isn't using `avatar-settings-view`
   &.avatar-settings-view {
+    align-items: center;
     border: 2px solid transparent;
-    display: block;
+    display: flex;
     flex-shrink: 0;
+    justify-content: center;
     margin: 0;
 
     &.spinner-completed {


### PR DESCRIPTION
## Because

- the default avatar was off-center

## This pull request

- centers the default avatar

## Issue that this pull request solves

Closes: FXA-8206

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
BEFORE
<img width="685" alt="Screenshot 2024-01-04 at 12 32 45 PM" src="https://github.com/mozilla/fxa/assets/28129806/2eb0ac3d-0b24-4cef-aa25-f29f5bf18910">

AFTER
Mobile
<img width="422" alt="Screenshot 2024-01-04 at 12 27 11 PM" src="https://github.com/mozilla/fxa/assets/28129806/6b48218a-9a8b-4356-90e7-e90e775d1dd0">

Tablet
<img width="767" alt="Screenshot 2024-01-04 at 12 30 45 PM" src="https://github.com/mozilla/fxa/assets/28129806/c9b0f0bb-0364-4d88-bed4-765ffe522235">

Desktop
<img width="1024" alt="Screenshot 2024-01-04 at 12 31 14 PM" src="https://github.com/mozilla/fxa/assets/28129806/68e4404e-0cde-448f-9607-cd8f29e108a3">
