### PR TITLE
feat(cloud-tasks): add method to enqueue a delete account cloud task

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -174,6 +174,7 @@ async function run(config) {
     oauthDb,
     push,
     pushbox,
+    statsd,
   });
   Container.set(AccountDeleteManager, accountDeleteManager);
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -24,6 +24,12 @@ const convictConf = convict({
     format: ['dev', 'test', 'stage', 'prod'],
     env: 'NODE_ENV',
   },
+  apiVersion: {
+    doc: 'Number part of versioned endpoints - ex: /v1/account/status',
+    format: Number,
+    default: 1,
+    env: 'AUTH_API_VERSION',
+  },
   // TODO: Remove this after we have synchronized login records to Firestore
   firestore: {
     credentials: {
@@ -1022,12 +1028,6 @@ const convictConf = convict({
         default: ['@mozilla\\.com$'],
       },
     },
-    api: {
-      version: {
-        doc: 'Number part of versioned endpoints - ex: /v1/token',
-        default: 1,
-      },
-    },
     allowHttpRedirects: {
       arg: 'allowHttpRedirects',
       doc: 'If true, then it allows http OAuth redirect uris',
@@ -1992,6 +1992,26 @@ const convictConf = convict({
   },
 
   cloudTasks: {
+    projectId: {
+      default: '',
+      doc: 'The GCP project id.  Optional when in an environment with Application Default Credentials.',
+      env: 'AUTH_CLOUDTASKS_PROJECT_ID',
+      format: String,
+    },
+    locationId: {
+      default: '',
+      doc: 'Google cloud location id, e.g. us-west1',
+      env: 'AUTH_CLOUDTASKS_LOCATION_ID',
+      format: String,
+    },
+    credentials: {
+      keyFilename: {
+        default: '',
+        doc: 'Path to service account key.  Optional when in an environment where authentication with services is automatic.',
+        env: 'AUTH_CLOUDTASKS_KEY_FILE',
+        format: String,
+      },
+    },
     oidc: {
       aud: {
         default: '',

--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { CloudTasksClient } from '@google-cloud/tasks';
+import { StatsD } from 'hot-shots';
 import { Container } from 'typedi';
+import { ConfigType } from '../config';
 import DB from './db/index';
 import OAuthDb from './oauth/db';
 import { AppleIAP } from './payments/iap/apple-app-store/apple-iap';
@@ -11,11 +14,23 @@ import { PayPalHelper } from './payments/paypal/helper';
 import { StripeHelper } from './payments/stripe';
 import push from './push';
 import pushboxApi from './pushbox';
-import { AuthLogger } from './types';
+import { accountDeleteCloudTaskPath } from './routes/cloud-tasks';
+import { AppConfig, AuthLogger } from './types';
+/*
+import {
+  uid as uidValidator,
+  customerId as customerIdValidator,
+} from './routes/validators';
+//*/
+
+export const AccountDeleteReasons = [
+  'fxa_unverified_account_delete',
+  'fxa_user_requested_account_delete',
+] as const;
 
 type FxaDbDeleteAccount = Pick<
   Awaited<ReturnType<ReturnType<typeof DB>['connect']>>,
-  'deleteAccount'
+  'deleteAccount' | 'accountRecord'
 >;
 type OAuthDbDeleteAccount = Pick<typeof OAuthDb, 'removeTokensAndCodes'>;
 type PushDeleteAccount = Pick<
@@ -27,32 +42,73 @@ type PushboxDeleteAccount = Pick<
   'deleteAccount'
 >;
 
+export type ReasonForDeletion = (typeof AccountDeleteReasons)[number];
+type DeleteTask = {
+  uid: string;
+  customerId?: string;
+  reason: ReasonForDeletion;
+};
+type EnqueueByUidParam = {
+  uid: string;
+  reason: ReasonForDeletion;
+};
+type EnqueueByEmailParam = {
+  email: string;
+  reason: ReasonForDeletion;
+};
+
+/*
+const isValidDeleteTask = (deleteTask: DeleteTask) => {
+  const uidValidationResult = uidValidator.validate(deleteTask.uid);
+  const customerIdValidationResult = customerIdValidator.validate(
+    deleteTask.customerId
+  );
+
+  return !uidValidationResult.error && !customerIdValidationResult.error;
+};
+//*/
+
+const isEnqueueByUidParam = (
+  x: EnqueueByUidParam | EnqueueByEmailParam
+): x is EnqueueByUidParam => (x as EnqueueByUidParam).uid !== undefined;
+const isEnqueueByEmailParam = (
+  x: EnqueueByUidParam | EnqueueByEmailParam
+): x is EnqueueByEmailParam => (x as EnqueueByEmailParam).email !== undefined;
+
 export class AccountDeleteManager {
   private fxaDb: FxaDbDeleteAccount;
   private oauthDb: OAuthDbDeleteAccount;
   private push: PushDeleteAccount;
   private pushbox: PushboxDeleteAccount;
+  private statsd: StatsD;
   private stripeHelper?: StripeHelper;
   private paypalHelper?: PayPalHelper;
   private appleIap?: AppleIAP;
   private playBilling?: PlayBilling;
   private log: AuthLogger;
+  private config: ConfigType;
+  private cloudTasksClient: CloudTasksClient;
+  private queueName;
+  private taskUrl;
 
   constructor({
     fxaDb,
     oauthDb,
     push,
     pushbox,
+    statsd,
   }: {
     fxaDb: FxaDbDeleteAccount;
     oauthDb: OAuthDbDeleteAccount;
     push: PushDeleteAccount;
     pushbox: PushboxDeleteAccount;
+    statsd: StatsD;
   }) {
     this.fxaDb = fxaDb;
     this.oauthDb = oauthDb;
     this.push = push;
     this.pushbox = pushbox;
+    this.statsd = statsd;
 
     if (Container.has(StripeHelper)) {
       this.stripeHelper = Container.get(StripeHelper);
@@ -67,5 +123,75 @@ export class AccountDeleteManager {
       this.playBilling = Container.get(PlayBilling);
     }
     this.log = Container.get(AuthLogger);
+    this.config = Container.get(AppConfig);
+    const tasksConfig = this.config.cloudTasks;
+
+    this.cloudTasksClient = new CloudTasksClient({
+      projectId: tasksConfig.projectId,
+      keyFilename: tasksConfig.credentials.keyFilename ?? undefined,
+    });
+    this.queueName = `projects/${tasksConfig.projectId}/locations/${tasksConfig.locationId}/queues/${tasksConfig.deleteAccounts.queueName}`;
+    this.taskUrl = `${this.config.publicUrl}/v${this.config.apiVersion}${accountDeleteCloudTaskPath}`;
+  }
+
+  public async enqueue(options: EnqueueByUidParam | EnqueueByEmailParam) {
+    if (isEnqueueByUidParam(options)) {
+      return this.enqueueByUid(options);
+    }
+
+    if (isEnqueueByEmailParam(options)) {
+      return this.enqueueByEmail(options);
+    }
+
+    throw new Error(
+      `Failed to enqueue account delete cloud task with ${options}.`
+    );
+  }
+
+  private async enqueueByUid(options: EnqueueByUidParam) {
+    const customer = await this.stripeHelper?.fetchCustomer(options.uid);
+    const task: DeleteTask = {
+      uid: options.uid,
+      customerId: customer?.id ?? undefined,
+      reason: options.reason,
+    };
+    return this.enqueueTask(task);
+  }
+
+  private async enqueueByEmail(options: EnqueueByEmailParam) {
+    const account = await this.fxaDb.accountRecord(options.email);
+    const customer = await this.stripeHelper?.fetchCustomer(account.uid);
+    const task: DeleteTask = {
+      uid: account.uid,
+      customerId: customer?.id ?? undefined,
+      reason: options.reason,
+    };
+    return this.enqueueTask(task);
+  }
+
+  private async enqueueTask(task: DeleteTask) {
+    try {
+      const taskResult = await this.cloudTasksClient.createTask({
+        parent: this.queueName,
+        task: {
+          httpRequest: {
+            url: this.taskUrl,
+            httpMethod: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: Buffer.from(JSON.stringify(task)).toString('base64'),
+            oidcToken: {
+              audience: this.config.cloudTasks.oidc.aud,
+              serviceAccountEmail:
+                this.config.cloudTasks.oidc.serviceAccountEmail,
+            },
+          },
+        },
+      });
+      this.statsd.increment('cloud-tasks.account-delete.enqueue.success');
+      return taskResult[0].name;
+    } catch (err) {
+      this.statsd.increment('cloud-tasks.account-delete.enqueue.failure');
+      throw err;
+    }
   }
 }

--- a/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
@@ -3,14 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import isA from 'joi';
-import { AuthRequest } from '../types';
 import { ConfigType } from '../../config';
 import DESCRIPTION from '../../docs/swagger/shared/descriptions';
+import { ReasonForDeletion } from '../account-delete';
+import { AuthRequest } from '../types';
 import validators from './validators';
 
 export type DeleteAccountTaskPayload = {
   uid: string;
   customerId?: string;
+  reason: ReasonForDeletion;
 };
 
 export class CloudTaskHandler {
@@ -24,13 +26,14 @@ export class CloudTaskHandler {
     return {};
   }
 }
+export const accountDeleteCloudTaskPath = '/cloud-tasks/accounts/delete';
 
 export const cloudTaskRoutes = (config: ConfigType) => {
   const cloudTaskHandler = new CloudTaskHandler(config);
   const routes = [
     {
       method: 'POST',
-      path: '/cloud-tasks/accounts/delete',
+      path: accountDeleteCloudTaskPath,
       options: {
         auth: {
           mode: 'required',
@@ -49,6 +52,7 @@ export const cloudTaskRoutes = (config: ConfigType) => {
               .string()
               .optional()
               .description(DESCRIPTION.customerId),
+            reason: validators.accountDeleteReason,
           }),
         },
       },

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -248,7 +248,7 @@ module.exports = function (
   }
 
   v1Routes.forEach((r) => {
-    r.path = `${basePath}/v1${r.path}`;
+    r.path = `${basePath}/v${config.apiVersion}${r.path}`;
 
     if (tracing.isInitialized()) {
       if (r.handler) {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -8,6 +8,7 @@
 const { URL } = require('url');
 const punycode = require('punycode.js');
 const isA = require('joi');
+const { AccountDeleteReasons } = require('../account-delete');
 const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
 const {
   minimalConfigSchema,
@@ -633,8 +634,12 @@ module.exports.subscriptionsPlanWithProductConfigValidator = isA.object({
     .required(),
 });
 
+module.exports.customerId = isA
+  .string()
+  .optional()
+  .description(DESCRIPTIONS.customerId);
 module.exports.subscriptionsCustomerValidator = isA.object({
-  customerId: isA.string().optional().description(DESCRIPTIONS.customerId),
+  customerId: module.exports.customerId,
   billing_name: isA
     .alternatives(isA.string(), isA.any().allow(null))
     .optional()
@@ -789,7 +794,7 @@ module.exports.subscriptionsStripeCustomerValidator = isA
 
 module.exports.subscriptionsMozillaSubscriptionsValidator = isA
   .object({
-    customerId: isA.string().optional().description(DESCRIPTIONS.customerId),
+    customerId: module.exports.customerId,
     billing_name: isA
       .alternatives(isA.string(), isA.any().allow(null))
       .optional()
@@ -855,3 +860,7 @@ module.exports.thirdPartyProvider = isA
 
 module.exports.thirdPartyIdToken = module.exports.jwt.optional();
 module.exports.thirdPartyOAuthCode = isA.string().optional();
+
+module.exports.accountDeleteReason = isA
+  .string()
+  .valid(...AccountDeleteReasons);

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -65,6 +65,7 @@
     "@fluent/bundle": "^0.18.0",
     "@fluent/dom": "^0.9.0",
     "@fluent/langneg": "^0.6.2",
+    "@google-cloud/tasks": "^4.0.1",
     "@googlemaps/google-maps-services-js": "^3.3.16",
     "@hapi/hapi": "^20.2.1",
     "@hapi/hawk": "^8.0.0",

--- a/packages/fxa-auth-server/test/lib/server.js
+++ b/packages/fxa-auth-server/test/lib/server.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 
 process.env.CONFIG_FILES = require.resolve('./oauth-test.json');
 const { config } = require('../../config');
-const version = config.get('oauthServer.api.version');
+const version = config.get('apiVersion');
 config.set('log.level', 'critical');
 config.set('cloudTasks.oidc.aud', 'cloud-tasks');
 config.set('cloudTasks.oidc.serviceAccountEmail', 'testo@iam.gcp.g.co');

--- a/packages/fxa-auth-server/test/local/account-delete.js
+++ b/packages/fxa-auth-server/test/local/account-delete.js
@@ -1,0 +1,170 @@
+/*  */ /* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const sinon = require('sinon');
+const { assert } = require('chai');
+const proxyquire = require('proxyquire');
+const { default: Container } = require('typedi');
+const { AppConfig, AuthLogger } = require('../../lib/types');
+const { StripeHelper } = require('../../lib/payments/stripe');
+const mocks = require('../mocks');
+
+let createTaskStub;
+const { AccountDeleteManager } = proxyquire('../../lib/account-delete', {
+  '@google-cloud/tasks': {
+    CloudTasksClient: class CloudTasksClient {
+      constructor() {}
+      createTask(...args) {
+        return createTaskStub.apply(null, args);
+      }
+    },
+  },
+});
+
+const uid = 'uid';
+const email = 'testo@example.gg';
+const sandbox = sinon.createSandbox();
+
+describe('AccountDeleteManager', () => {
+  let mockFxaDb;
+  let mockOAuthDb;
+  let mockPush;
+  let mockPushbox;
+  let mockStatsd;
+  let mockStripeHelper;
+  let mockLog;
+  let mockConfig;
+  let accountDeleteManager;
+
+  beforeEach(() => {
+    sandbox.reset();
+    createTaskStub = sandbox.stub();
+    mockFxaDb = mocks.mockDB({ email, uid });
+    mockOAuthDb = {};
+    mockPush = mocks.mockPush();
+    mockPushbox = mocks.mockPushbox();
+    mockStatsd = { increment: sandbox.stub() };
+    mockStripeHelper = {};
+    mockLog = mocks.mockLog();
+
+    Container.set(StripeHelper, mockStripeHelper);
+    Container.set(AuthLogger, mockLog);
+
+    mockConfig = {
+      apiVersion: 1,
+      cloudTasks: mocks.mockCloudTasksConfig,
+      publicUrl: 'https://tasks.example.io',
+    };
+
+    Container.set(AppConfig, mockConfig);
+
+    accountDeleteManager = new AccountDeleteManager({
+      fxaDb: mockFxaDb,
+      oauthDb: mockOAuthDb,
+      push: mockPush,
+      pushbox: mockPushbox,
+      statsd: mockStatsd,
+    });
+  });
+
+  afterEach(() => {
+    Container.reset();
+  });
+
+  describe('create tasks', function () {
+    it('creates a delete account task by uid', async () => {
+      const fetchCustomerStub = sandbox.stub().resolves({ id: 'cus_997' });
+      mockStripeHelper['fetchCustomer'] = fetchCustomerStub;
+      const taskId = 'proj/testo/loc/us-n/q/del0/tasks/123';
+      createTaskStub = sandbox.stub().resolves([{ name: taskId }]);
+      const result = await accountDeleteManager.enqueue({
+        uid,
+        reason: 'fxa_unverified_account_delete',
+      });
+      sinon.assert.calledOnceWithExactly(fetchCustomerStub, uid);
+      sinon.assert.calledOnceWithExactly(
+        mockStatsd.increment,
+        'cloud-tasks.account-delete.enqueue.success'
+      );
+      sinon.assert.calledOnceWithExactly(createTaskStub, {
+        parent: `projects/${mockConfig.cloudTasks.projectId}/locations/${mockConfig.cloudTasks.locationId}/queues/${mockConfig.cloudTasks.deleteAccounts.queueName}`,
+        task: {
+          httpRequest: {
+            url: `${mockConfig.publicUrl}/v${mockConfig.apiVersion}/cloud-tasks/accounts/delete`,
+            httpMethod: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: Buffer.from(
+              JSON.stringify({
+                uid,
+                customerId: 'cus_997',
+                reason: 'fxa_unverified_account_delete',
+              })
+            ).toString('base64'),
+            oidcToken: {
+              audience: mockConfig.cloudTasks.oidc.aud,
+              serviceAccountEmail:
+                mockConfig.cloudTasks.oidc.serviceAccountEmail,
+            },
+          },
+        },
+      });
+      assert.equal(result, taskId);
+    });
+
+    it('creates a delete account task by email', async () => {
+      const fetchCustomerStub = sandbox.stub().resolves({ id: 'cus_993' });
+      mockStripeHelper['fetchCustomer'] = fetchCustomerStub;
+      const taskId = 'proj/testo/loc/us-n/q/del0/tasks/134';
+      createTaskStub = sandbox.stub().resolves([{ name: taskId }]);
+      const result = await accountDeleteManager.enqueue({
+        email,
+        reason: 'fxa_unverified_account_delete',
+      });
+      sinon.assert.calledOnceWithExactly(fetchCustomerStub, uid);
+      sinon.assert.calledOnceWithExactly(createTaskStub, {
+        parent: `projects/${mockConfig.cloudTasks.projectId}/locations/${mockConfig.cloudTasks.locationId}/queues/${mockConfig.cloudTasks.deleteAccounts.queueName}`,
+        task: {
+          httpRequest: {
+            url: `${mockConfig.publicUrl}/v${mockConfig.apiVersion}/cloud-tasks/accounts/delete`,
+            httpMethod: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: Buffer.from(
+              JSON.stringify({
+                uid,
+                customerId: 'cus_993',
+
+                reason: 'fxa_unverified_account_delete',
+              })
+            ).toString('base64'),
+            oidcToken: {
+              audience: mockConfig.cloudTasks.oidc.aud,
+              serviceAccountEmail:
+                mockConfig.cloudTasks.oidc.serviceAccountEmail,
+            },
+          },
+        },
+      });
+      assert.equal(result, taskId);
+    });
+
+    it('throws when task creation fails', async () => {
+      const fetchCustomerStub = sandbox.stub().resolves({ id: 'cus_997' });
+      mockStripeHelper['fetchCustomer'] = fetchCustomerStub;
+      createTaskStub = sandbox.stub().throws();
+      try {
+        await accountDeleteManager.enqueue({
+          uid,
+          reason: 'fxa_unverified_account_delete',
+        });
+        assert.fail('An error should have been thrown.');
+      } catch (err) {
+        sinon.assert.calledOnceWithExactly(
+          mockStatsd.increment,
+          'cloud-tasks.account-delete.enqueue.failure'
+        );
+        assert.instanceOf(err, Error);
+      }
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -12,6 +12,7 @@ const uuid = require('uuid');
 const { Container } = require('typedi');
 const { ProfileClient } = require('../../lib/types');
 const { AccountEventsManager } = require('../../lib/account-events');
+const { AccountDeleteManager } = require('../../lib/account-delete');
 const { gleanMetrics } = require('../../lib/metrics/glean');
 const defaultConfig = require('../../config').default.getProperties();
 
@@ -35,6 +36,7 @@ function makeRoutes(options = {}) {
   Container.set(AccountEventsManager, {
     recordSecurityEvent: () => {},
   });
+  Container.set(AccountDeleteManager, { enqueue: () => {} });
   const log = mocks.mockLog();
   const cadReminders = mocks.mockCadReminders();
   const customs = {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -61,6 +61,7 @@ const makeRoutes = function (options = {}, requireMocks) {
   config.authFirestore = config.authFirestore || {};
   config.securityHistory = config.securityHistory || {};
   config.gleanMetrics = config.gleanMetrics || defaultConfig.gleanMetrics;
+  config.cloudTasks = mocks.mockCloudTasksConfig;
 
   const log = options.log || mocks.mockLog();
   Container.set(AuthLogger, log);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -282,6 +282,21 @@ const MOCK_PLANS = [
   },
 ];
 
+const mockCloudTasksConfig = {
+  projectId: 'fxa-testo',
+  locationId: 'us-north1',
+  credentials: {
+    keyFilename: '/c/secrets/task-key.json',
+  },
+  oidc: {
+    aud: 'https://tasks.example.io/v1/cloud-tasks',
+    serviceAccountEmail: 'testo-tasks@iam.cloud.g.co',
+  },
+  deleteAccounts: {
+    queueName: 'del-accts',
+  },
+};
+
 module.exports = {
   MOCK_PUSH_KEY:
     'BDLugiRzQCANNj5KI1fAqui8ELrE7qboxzfa5K_R0wnUoJ89xY1D_SOXI_QJKNmellykaW_7U2BZ7hnrPW3A3LM',
@@ -291,6 +306,7 @@ module.exports = {
   mockContentfulClients: MOCK_CONTENTFUL_CLIENTS,
   mockContentfulPlanIdsToClientCapabilities:
     MOCK_CONTENTFUL_CLIENT_CAPABILITIES,
+  mockCloudTasksConfig,
   mockCustoms,
   mockDB,
   mockDevices,

--- a/packages/fxa-auth-server/test/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/test/scripts/verification-reminders.js
@@ -25,7 +25,7 @@ const execOptions = {
 
 describe('#integration - scripts/verification-reminders:', () => {
   it('does not fail', function () {
-    this.timeout(20000);
+    this.timeout(30000);
     return execAsync(
       'node -r esbuild-register scripts/verification-reminders',
       execOptions

--- a/yarn.lock
+++ b/yarn.lock
@@ -7898,6 +7898,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google-cloud/tasks@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "@google-cloud/tasks@npm:4.1.0"
+  dependencies:
+    google-gax: ^4.0.4
+  checksum: a04ec8ec8f538b74e81e6d2d5834d964ff86d78f67b3a1287779575180c998da6637dd41e8ec0913de208873d679deecde78d89fa8bd483094abb8ec5161992c
+  languageName: node
+  linkType: hard
+
 "@google-cloud/translate@npm:^8.0.2":
   version: 8.0.2
   resolution: "@google-cloud/translate@npm:8.0.2"
@@ -34766,6 +34775,7 @@ fsevents@~2.1.1:
     "@fluent/bundle": ^0.18.0
     "@fluent/dom": ^0.9.0
     "@fluent/langneg": ^0.6.2
+    "@google-cloud/tasks": ^4.0.1
     "@googlemaps/google-maps-services-js": ^3.3.16
     "@hapi/hapi": ^20.2.1
     "@hapi/hawk": ^8.0.0


### PR DESCRIPTION
Because:
 - we want to add a delete account task into the Clound Task queue

This commit:
 - uses @google-cloud/tasks to create a delete account task on a Cloud Task queue
