### PR TITLE
Revert "feat(terms): Updated Monitor Terms for Premium launch"

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -36,17 +36,17 @@
       <div id="tos-pp" class="text-grey-500 my-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to the:<br />
-            Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            By proceeding, you agree to:<br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
           {{#isMonitorClient}}
             {{#unsafeTranslate}}
-              By proceeding, you agree to the:<br />
-              Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
-              Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+              By proceeding, you agree to:<br />
+              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
             {{/unsafeTranslate}}
           {{/isMonitorClient}}
           {{^isMonitorClient}}

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -55,16 +55,16 @@
       {{/isSync}}
       {{#isPocketClient}}
         {{#unsafeTranslate}}
-          By proceeding, you agree to the:<br />
-          Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+          By proceeding, you agree to:<br />
+          Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
           Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
         {{/unsafeTranslate}}
       {{/isPocketClient}}
       {{^isPocketClient}}
         {{#isMonitorClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to the:<br />
-            Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
+            By proceeding, you agree to:<br />
+            Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
             Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isMonitorClient}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -73,17 +73,17 @@
       <div id="tos-pp" class="text-grey-500 my-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to the:<br />
-            Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            By proceeding, you agree to:<br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
           {{#isMonitorClient}}
             {{#unsafeTranslate}}
-              By proceeding, you agree to the:<br />
-              Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
-              Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+              By proceeding, you agree to:<br />
+              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
             {{/unsafeTranslate}}
           {{/isMonitorClient}}
           {{^isMonitorClient}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -80,17 +80,17 @@
       <div id="tos-pp" class="text-grey-500 mt-5 text-xs">
         {{#isPocketClient}}
           {{#unsafeTranslate}}
-            By proceeding, you agree to the:<br />
-            Pocket <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
-            Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+            By proceeding, you agree to:<br />
+            Pocket’s <a class="link-grey" id="pocket-tos" href="https://getpocket.com/tos/">Terms of Service</a> and <a id="pocket-pp" class="link-grey" href="https://getpocket.com/privacy/">Privacy Notice</a><br />
+            Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
           {{/unsafeTranslate}}
         {{/isPocketClient}}
         {{^isPocketClient}}
           {{#isMonitorClient}}
             {{#unsafeTranslate}}
-              By proceeding, you agree to the:<br />
-              Mozilla Subscription Services <a class="link-grey" id="moz-subscription-tos" href="https://www.mozilla.org/about/legal/terms/subscription-services/">Terms of Service</a> and <a class="link-grey" id="moz-subscription-privacy" href="https://www.mozilla.org/privacy/subscription-services/">Privacy Notice</a><br />
-              Mozilla Accounts <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
+              By proceeding, you agree to:<br />
+              Firefox Monitor’s <a class="link-grey" id="monitor-tos" href="https://www.mozilla.org/privacy/firefox-monitor/">Terms of Service and Privacy Notice</a><br />
+              Firefox’s <a class="link-grey" id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a class="link-grey" id="fxa-pp" href="/legal/privacy">Privacy Notice</a>
             {{/unsafeTranslate}}
           {{/isMonitorClient}}
           {{^isMonitorClient}}

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -175,8 +175,7 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#pocket-pp'), 0);
         assert.lengthOf(view.$('#pocket-tos'), 0);
         // only renders if service is monitor
-        assert.lengthOf(view.$('#moz-subscription-tos'), 0);
-        assert.lengthOf(view.$('#moz-subscription-privacy'), 0);
+        assert.lengthOf(view.$('#monitor-tos'), 0);
       });
     });
 
@@ -249,8 +248,7 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#fxa-tos'), 1);
         assert.lengthOf(view.$('#pocket-pp'), 1);
         assert.lengthOf(view.$('#pocket-tos'), 1);
-        assert.lengthOf(view.$('#moz-subscription-tos'), 0);
-        assert.lengthOf(view.$('#moz-subscription-privacy'), 0);
+        assert.lengthOf(view.$('#monitor-tos'), 0);
       });
     });
 
@@ -270,8 +268,7 @@ describe('views/sign_in_password', () => {
         assert.lengthOf(view.$('#fxa-tos'), 1);
         assert.lengthOf(view.$('#pocket-pp'), 0);
         assert.lengthOf(view.$('#pocket-tos'), 0);
-        assert.lengthOf(view.$('#moz-subscription-tos'), 1);
-        assert.lengthOf(view.$('#moz-subscription-privacy'), 1);
+        assert.lengthOf(view.$('#monitor-tos'), 1);
       });
     });
   });

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/en.ftl
@@ -3,10 +3,13 @@
 
 # This message is followed by a bulleted list
 terms-privacy-agreement-intro-2 = By proceeding, you agree to the:
+# links to Pocket's Terms of Service and Privacy Notice
 # links to Pocket's Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-pocket-2 = { -product-pocket } <pocketTos>Terms of Service</pocketTos> and <pocketPrivacy>Privacy Notice</pocketPrivacy>
-# link to Monitor's Terms of Service and Privacy Notice, part of a bulleted list
-terms-privacy-agreement-monitor-3 = { -brand-mozilla } Subscription Services <mozSubscriptionTosLink>Terms of Service</mozSubscriptionTosLink> and <mozSubscriptionPrivacyLink>Privacy Notice</mozSubscriptionPrivacyLink>
+# link to Firefox Monitor's Terms of Service and Privacy Notice
+terms-privacy-agreement-monitor = { -product-firefox-monitor }'s <monitorTos>Terms of Service and Privacy Notice</monitorTos>
+# link to Firefox Monitor's Terms of Service and Privacy Notice, part of a bulleted list
+terms-privacy-agreement-monitor-2 = { -product-firefox-monitor } <monitorTos>Terms of Service and Privacy Notice</monitorTos>
 # links to Mozilla Accounts Terms of Service and Privacy Notice, part of a bulleted list
 terms-privacy-agreement-mozilla = { -product-mozilla-accounts(capitalization:"uppercase") } <mozillaAccountsTos>Terms of Service</mozillaAccountsTos> and <mozillaAccountsPrivacy>Privacy Notice</mozillaAccountsPrivacy>
 # links to Mozilla Account's Terms of Service and Privacy Notice

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
@@ -53,15 +53,11 @@ it('renders component as expected for Monitor clients', () => {
 
   const linkElements: HTMLElement[] = screen.getAllByRole('link');
 
-  expect(linkElements).toHaveLength(4);
+  expect(linkElements).toHaveLength(3);
   expect(linkElements[0]).toHaveAttribute(
     'href',
-    'https://www.mozilla.org/about/legal/terms/subscription-services/'
+    'https://www.mozilla.org/privacy/firefox-monitor/'
   );
-  expect(linkElements[1]).toHaveAttribute(
-    'href',
-    'https://www.mozilla.org/privacy/subscription-services/'
-  );
-  expect(linkElements[2]).toHaveAttribute('href', '/legal/terms');
-  expect(linkElements[3]).toHaveAttribute('href', '/legal/privacy');
+  expect(linkElements[1]).toHaveAttribute('href', '/legal/terms');
+  expect(linkElements[2]).toHaveAttribute('href', '/legal/privacy');
 });

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
@@ -65,40 +65,25 @@ const TermsPrivacyAgreement = ({
           )}
           {isMonitorClient && (
             <FtlMsg
-              id="terms-privacy-agreement-monitor-3"
+              id="terms-privacy-agreement-monitor-2"
               elems={{
-                mozSubscriptionTosLink: (
+                monitorTos: (
                   <LinkExternal
                     className="link-grey"
-                    href="https://www.mozilla.org/about/legal/terms/subscription-services/"
+                    href="https://www.mozilla.org/privacy/firefox-monitor/"
                   >
-                    Terms of Service
-                  </LinkExternal>
-                ),
-                mozSubscriptionPrivacyLink: (
-                  <LinkExternal
-                    className="link-grey"
-                    href="https://www.mozilla.org/privacy/subscription-services/"
-                  >
-                    Privacy Notice
+                    Terms of Service and Privacy Notice
                   </LinkExternal>
                 ),
               }}
             >
               <li>
-                Mozilla Subscription Services{' '}
+                Firefox Monitor{' '}
                 <LinkExternal
                   className="link-grey"
-                  href="https://www.mozilla.org/about/legal/terms/subscription-services/"
+                  href="https://www.mozilla.org/privacy/firefox-monitor/"
                 >
-                  Terms of Service
-                </LinkExternal>{' '}
-                and{' '}
-                <LinkExternal
-                  className="link-grey"
-                  href="https://www.mozilla.org/privacy/subscription-services/"
-                >
-                  Privacy Notice
+                  Terms of Service and Privacy Notice
                 </LinkExternal>
               </li>
             </FtlMsg>


### PR DESCRIPTION
## Because

- Monitor Premium launch is not going live yet

## This pull request

- Reverts the ToS and Privacy notice update

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
