### PR TITLE
fix(react): Fall back to clientInfo.redirectUri when redirectUri is not provided via query params

### DIFF
--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -1,5 +1,6 @@
 import { BaseLayout } from './layout';
 import { getReactFeatureFlagUrl } from '../lib/react-flag';
+import { EmailHeader, EmailType } from '../lib/email';
 
 export class SignupReactPage extends BaseLayout {
   readonly path = 'signup';
@@ -75,6 +76,28 @@ export class SignupReactPage extends BaseLayout {
   async fillOutCodeForm(code: string) {
     await this.setCode(code);
     await this.submit('Confirm');
+  }
+
+  async goToEmailFirstAndCreateAccount(
+    params: URLSearchParams,
+    email: string,
+    password: string
+  ) {
+    await this.goto('/', params);
+    // fill out email first form
+    await this.fillOutEmailFirst(email);
+    await this.page.waitForURL(/signup/);
+    await this.page.waitForSelector('#root');
+    await this.fillOutSignupForm(password);
+
+    // Get code from email
+    const code = await this.target.email.waitForEmail(
+      email,
+      EmailType.verifyShortCode,
+      EmailHeader.shortCode
+    );
+
+    await this.fillOutCodeForm(code);
   }
 
   async submit(label: string) {

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -135,7 +135,7 @@ export class OAuthIntegrationData extends BaseIntegrationData {
   redirectUrl: string | undefined;
 
   // TODO - Validation - Needs custom validation, see IsRedirectUriValid in content server.
-  // TODO - Validation - Seems to be required for OAuth
+  // We fall back to clientInfo.redirectUri if this is not provided so only validate if it's present
   @IsString()
   @IsOptional()
   @bind(T.snakeCase)


### PR DESCRIPTION
Because:
* AMO is erroring out in React signup due to missing a redirect URI, but also does not provide us a redirect URI in its query params

This commit:
* Falls back to integration.clientInfo.redirectUri if redirectUri is not given via query params
* Adjusts OAuthErrorInvalidRedirectUri - we weren't checking redirectUri for sync mobile because it didn't give us a redirect_uri in query params, but we should be checking that clientInfo.redirectUri exists
* Adds playwright test for missing redirect_uri

fixes FXA-8743

---

EDIT: below is relevant but semi-outdated, please [see my comment](https://github.com/mozilla/fxa/pull/16234#discussion_r1446500203) instead

--

It looks like `redirect_uri` is not a required parameter. For the Sync OAuth flow we were already not checking for it, but AMO's oauth params come through like this for staging: 

<details>
```client_id=285dd6fd9907a74c&scope=profile%2Bopenid&state=8bb96f55cc1d9c8f8012e6a818fd9a978a9a1c35e968358e62fa774e34aa78f0%3AL2VuLVVTL2ZpcmVmb3gv&access_type=offline```
</details>

and like this for production:

<details>
```client_id=a4907de5fa9d78fc&scope=profile%2Bopenid&state=c4ddecbb1bd4f5975c02a3e07f8dc16356abe02d06c6cc4968ff86a2f81ab90b%3AL2VuLVVTL2ZpcmVmb3gv&access_type=offline```
</details>

In Backbone, we use the `redirectUri` coming back from the `/authorization` request. This PR does that for React.

This is tricky to test because the above client IDs error out with `invalid client`. If you use the above params but replace it with a local client ID you'll just get `Bad request - unknown state`. Instead, you can click "Email first" on 123done, remove the `redirect_uri`, append the React params, and go through the flow to see you're still taken to 123done. This is what I essentially did for the functional test.