### PR TITLE
fix(functional-tests): Fix flaky React Signup tests

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -162,11 +162,11 @@ test.describe('severity-1 #smoke', () => {
       await signupReact.goto('/authorization', syncMobileOAuthQueryParams);
 
       await signupReact.fillOutEmailFirst(email);
-      // We need to `waitUntil: 'load'` before we can `sendWebChannelMessage`
       await page.waitForURL(/signup/, {
         waitUntil: 'load',
       });
       await page.waitForSelector('#root');
+      expect(page.getByText('Set your password')).toBeVisible();
 
       await signupReact.sendWebChannelMessage(customEventDetail);
       await login.waitForCWTSEngineHeader();
@@ -362,9 +362,11 @@ test.describe('severity-2 #smoke', () => {
        * Backbone signup staging goes from: 1) [stage]/confirm_signup_code ->
        * 2) [stage]/subscriptions/products -> 3) [payments-stage]/products
        * */
-      await page.waitForURL(/products/, {
+      await page.waitForURL(`${target.paymentsServerUrl}/**`, {
         waitUntil: 'load',
       });
+      const loadingSpinner = page.locator('[data-testid="loading-spinner"]');
+      await loadingSpinner.waitFor({ state: 'hidden' });
       await expect(page.getByTestId('avatar')).toBeVisible();
     });
   });


### PR DESCRIPTION
Because:
* These tests are not reliably passing in staging

This commit:
* For signup oauth webchannel, waits for 'Set your password' to be visible so we don't call sendWebChannelMessage early
* For signup via product page and redirect, updates the waitForURL check to test against paymentsServerUrl in case the previous '/products/' selector was checking for redirect_uri, and waits for a loading spinner to be hidden before checking for the visible avatar

fixes FXA-8877, fixes FXA-8879

---

Round 2!

Prior to this fix, these tests were not failing for me when I ran `yarn playwright test` to see them test against stage 6x (except for once when I saw the oauth webchannel one fail due to bad account cleanup) so it's going to be hard to verify that these are going to fix these tests for sure. 

However, I can see in at least one failing oauth webchannel trace that we aren't receiving a web channel message and loading the CWTS header accordingly, so checking for the `Set your password` text first ensures the page has loaded. For the SubPlat redirect, it looked to me like the trace was skipping right over `waitForURL` and so I wonder if it was seeing `product` inside the `redirect_uri` and not waiting at all. Since there are a couple redirects that happen, I updated the `waitForURL` and check that the loading spinner is hidden before we check for the avatar.

Everything for stage passed for me on 5x run of `yarn playwright test`, but it's not guaranteed to fix it since I can't seem to reproduce these failures locally against stage.