### PR TITLE
fix(sync): When loading settings from mobile, use the signed in user

### DIFF
--- a/libs/shared/db/mysql/core/src/lib/config.ts
+++ b/libs/shared/db/mysql/core/src/lib/config.ts
@@ -65,7 +65,7 @@ export function makeConvictMySQLConfig(envPrefix: string, database: string) {
       format: String,
     },
     host: {
-      default: 'localhost',
+      default: '::1',
       doc: 'MySQL host',
       env: envPrefix + '_MYSQL_HOST',
       format: String,


### PR DESCRIPTION
…if avaible

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
