### PR TITLE
feat(auth): add firestore record delete

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -68,4 +68,13 @@ export class AccountDeleteManager {
     }
     this.log = Container.get(AuthLogger);
   }
+
+  async deleteFirestoreCustomer(uid: string) {
+    this.log.debug('AccountDeleteManager.deleteFirestoreCustomer', { uid });
+    const result = await this.stripeHelper?.removeFirestoreCustomer(uid);
+    if (!result?.length) {
+      this.log.error('AccountDeleteManager.deleteFirestoreCustomer', { uid });
+    }
+    return result;
+  }
 }

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -3402,6 +3402,15 @@ export class StripeHelper extends StripeHelperBase {
           {}
       : {};
   }
+
+  async removeFirestoreCustomer(uid: string) {
+    try {
+      return await this.stripeFirestore.removeCustomerRecursive(uid);
+    } catch (error) {
+      Sentry.captureException(error);
+      return [];
+    }
+  }
 }
 
 /**

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -7463,4 +7463,30 @@ describe('#integration - StripeHelper', () => {
       assert.equal(actual, false);
     });
   });
+
+  describe('removeFirestoreCustomer', () => {
+    it('completes successfully and returns array of deleted paths', async () => {
+      const expected = ['/path', '/path/subpath'];
+      stripeFirestore.removeCustomerRecursive = sandbox
+        .stub()
+        .resolves(expected);
+      const actual = await stripeHelper.removeFirestoreCustomer('uid');
+      assert.equal(actual, expected);
+    });
+
+    it('reports error to sentry and returns empty array', async () => {
+      const expected = [];
+      sandbox.stub(Sentry, 'captureException');
+      const expectedError = new Error('bad things');
+      stripeFirestore.removeCustomerRecursive = sandbox
+        .stub()
+        .rejects(expectedError);
+      const actual = await stripeHelper.removeFirestoreCustomer('uid');
+      assert.deepEqual(actual, expected);
+      sinon.assert.calledOnceWithExactly(
+        Sentry.captureException,
+        expectedError
+      );
+    });
+  });
 });

--- a/packages/fxa-shared/payments/stripe-firestore.ts
+++ b/packages/fxa-shared/payments/stripe-firestore.ts
@@ -50,11 +50,13 @@ export class StripeFirestore {
     protected firestore: Firestore,
     protected customerCollectionDbRef: CollectionReference,
     protected stripe: Stripe,
-    prefix: string
+    prefix: string,
+    protected MAX_RETRY_ATTEMPTS: number = 5
   ) {
     this.subscriptionCollection = `${prefix}subscriptions`;
     this.invoiceCollection = `${prefix}invoices`;
     this.paymentMethodCollection = `${prefix}payment_methods`;
+    this.MAX_RETRY_ATTEMPTS = 5;
   }
 
   /**


### PR DESCRIPTION
## Because

- Need to delete firestore customer document and all related subcollections.

## This pull request

- Uses firestore.recursiveDelete to delete customer document and all subcollections

## Issue that this pull request solves

Closes: #FXA-8839

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
