### PR TITLE
fix(shared-contentful): Update help text for work in progress features

### DIFF
--- a/packages/db-migrations/contentful/1704994340462_fxa-8921.js
+++ b/packages/db-migrations/contentful/1704994340462_fxa-8921.js
@@ -1,0 +1,109 @@
+function migrationFunction(migration, context) {
+  const offering = migration.editContentType('offering');
+  const offeringCountries = offering.editField('countries');
+  offeringCountries.items({
+    type: 'Symbol',
+    validations: [
+      {
+        in: [
+          'AT - Austria',
+          'BE - Belgium',
+          'BG - Bulgaria',
+          'CA - Canada',
+          'HR - Croatia',
+          'CY - Cyprus',
+          'CZ - Czech Republic',
+          'DK - Denmark',
+          'EE - Estonia',
+          'FI - Finland',
+          'FR - France',
+          'DE - Germany',
+          'GR - Greece',
+          'HU - Hungary',
+          'IE - Ireland',
+          'IT - Italy',
+          'LV - Latvia',
+          'LT - Lithuania',
+          'LU - Luxembourg',
+          'MY - Malaysia',
+          'MT - Malta',
+          'NL - Netherlands',
+          'NZ - New Zealand',
+          'PL - Poland',
+          'PT - Portugal',
+          'RO - Romania',
+          'SG - Singapore',
+          'SK - Slovakia',
+          'SI - Slovenia',
+          'ES - Spain',
+          'SE - Sweden',
+          'CH - Switzerland',
+          'UK - United Kingdom',
+          'US - United States',
+        ],
+      },
+    ],
+  });
+  offering.changeFieldControl('countries', 'builtin', 'checkbox', {
+    helpText:
+      'FEATURE - WORK IN PROGRESS: Select the countries in which this product offering is available.',
+  });
+  offering.changeFieldControl('couponConfig', 'builtin', 'entryLinksEditor', {
+    helpText:
+      'FEATURE - WORK IN PROGRESS (keep coupon configuration in Stripe until further notice): Coupons offered for this product offering.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+
+  const couponConfig = migration.editContentType('couponConfig');
+  const couponConfigCountries = couponConfig.editField('countries');
+  couponConfigCountries.items({
+    type: 'Symbol',
+    validations: [
+      {
+        in: [
+          'AT - Austria',
+          'BE - Belgium',
+          'BG - Bulgaria',
+          'CA - Canada',
+          'HR - Croatia',
+          'CY - Cyprus',
+          'CZ - Czech Republic',
+          'DK - Denmark',
+          'EE - Estonia',
+          'FI - Finland',
+          'FR - France',
+          'DE - Germany',
+          'GR - Greece',
+          'HU - Hungary',
+          'IE - Ireland',
+          'IT - Italy',
+          'LV - Latvia',
+          'LT - Lithuania',
+          'LU - Luxembourg',
+          'MY - Malaysia',
+          'MT - Malta',
+          'NL - Netherlands',
+          'NZ - New Zealand',
+          'PL - Poland',
+          'PT - Portugal',
+          'RO - Romania',
+          'SG - Singapore',
+          'SK - Slovakia',
+          'SI - Slovenia',
+          'ES - Spain',
+          'SE - Sweden',
+          'CH - Switzerland',
+          'UK - United Kingdom',
+          'US - United States',
+        ],
+      },
+    ],
+  });
+  couponConfig.changeFieldControl('internalName', 'builtin', 'singleLine', {
+    helpText:
+      'FEATURE - WORK IN PROGRESS: Keep coupon configuration in Stripe until further notice.',
+  });
+}
+module.exports = migrationFunction;


### PR DESCRIPTION
## Because

- we want to prevent any confusion with feature work that is currently in progress

## This pull request

- updates the help text to provide more clarity
- updates the list of [countries](https://mozilla-hub.atlassian.net/wiki/spaces/FJT/pages/173539548/Supported+Markets+and+Currencies) in Offering and CouponConfig

## Issue that this pull request solves

Closes: FXA-8921

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Other information (Optional)
- Updated Contentful onboarding doc in Ecosystem Platform - https://github.com/mozilla/ecosystem-platform/pull/495

## Screenshots
#### Offering - Countries
<img width="370" alt="Screenshot 2024-01-11 at 12 39 17 PM" src="https://github.com/mozilla/fxa/assets/28129806/70074d19-b605-47af-8b62-4e57e9e59f48">

#### Offering - Coupon Config
<img width="753" alt="Screenshot 2024-01-11 at 12 40 09 PM" src="https://github.com/mozilla/fxa/assets/28129806/e03f8fb2-53ed-4128-ae5c-0231c2e21d11">

#### Coupon Config
<img width="843" alt="Screenshot 2024-01-11 at 12 41 23 PM" src="https://github.com/mozilla/fxa/assets/28129806/3d56ce7c-758d-44d0-8859-97a3ff400836">