### PR TITLE
fix(sync): Request + set signedInUser from Sync in Settings

### DIFF
--- a/packages/functional-tests/lib/query-params.ts
+++ b/packages/functional-tests/lib/query-params.ts
@@ -4,7 +4,13 @@
 
 // This file contains query params that don't reflect states that can be reached from 123done.
 
+export const oauthWebchannelV1 = new URLSearchParams({
+  context: 'oauth_webchannel_v1',
+});
+
+// Minimum needed to complete OAuth flow
 export const syncMobileOAuthQueryParams = new URLSearchParams({
+  ...Object.fromEntries(oauthWebchannelV1.entries()),
   client_id: '1b1a3e44c54fbb58', // Firefox for iOS
   code_challenge_method: 'S256',
   code_challenge: '2oc_C4v1qHeefWAGu5LI5oDG1oX4FV_Itc148D8_oQI',
@@ -14,6 +20,5 @@ export const syncMobileOAuthQueryParams = new URLSearchParams({
   scope:
     'https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session',
   state: 'fakestate',
-  context: 'oauth_webchannel_v1',
   automatedBrowser: 'true',
 });

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { oauthWebchannelV1 } from '../../lib/query-params';
+
+const password = 'passwordzxcv';
+let syncBrowserPages;
+let browserEmail: string;
+let otherEmail: string;
+let skipTest = false;
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('fxa_status web channel message in Settings', () => {
+  test.beforeEach(async ({ target, pages: { configPage } }) => {
+    test.slow();
+    // Ensure that the feature flag is enabled
+    const config = await configPage.getConfig();
+    skipTest = config.featureFlags.sendFxAStatusOnSettings !== true;
+    test.skip(skipTest);
+
+    syncBrowserPages = await newPagesForSync(target);
+    const { login } = syncBrowserPages;
+    browserEmail = login.createEmail();
+    await target.auth.signUp(browserEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    otherEmail = login.createEmail();
+    await target.auth.signUp(otherEmail, password, {
+      lang: 'en',
+      preVerified: 'true',
+    });
+    // First we sign the browser into an account
+    await login.goto('load', 'context=fx_desktop_v3&service=sync');
+    await login.fillOutEmailFirstSignIn(browserEmail, password);
+    // Then, we sign into a **different** account
+    await login.goto();
+    await login.useDifferentAccountLink();
+    await login.fillOutEmailFirstSignIn(otherEmail, password);
+  });
+  test.afterEach(async ({ target }) => {
+    if (!skipTest) {
+      await syncBrowserPages.browser?.close();
+      // Cleanup any accounts created during the test
+      await target.auth.accountDestroy(browserEmail, password);
+      await target.auth.accountDestroy(otherEmail, password);
+    }
+  });
+
+  test('message is sent when loading with context = oauth_webchannel_v1', async () => {
+    const { settings } = syncBrowserPages;
+
+    // We verify that even though another email is signed in, when
+    // accessing the setting with a `context=oauth_webchannel_v1` the account
+    // signed into the browser takes precedence
+    await settings.goto(oauthWebchannelV1.toString());
+    expect(await settings.primaryEmail.statusText()).toBe(browserEmail);
+  });
+
+  test('message is not sent when loading without oauth web channel context', async () => {
+    const { settings } = syncBrowserPages;
+
+    // We verify that when accessing the setting without the `context=oauth_webchannel_v1`
+    // the newer account takes precedence
+    await settings.goto();
+    expect(await settings.primaryEmail.statusText()).toBe(otherEmail);
+  });
+});

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -54,5 +54,8 @@
     "resetPasswordRoutes": true,
     "signUpRoutes": true,
     "signInRoutes": true
+  },
+  "featureFlags": {
+    "sendFxAStatusOnSettings": true
   }
 }

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -76,6 +76,7 @@ const settingsConfig = {
   brandMessagingMode: config.get('brandMessagingMode'),
   glean: { ...config.get('glean'), appDisplayVersion: config.get('version') },
   redirectAllowlist: config.get('redirect_check.allow_list'),
+  sendFxAStatusOnSettings: config.get('featureFlags.sendFxAStatusOnSettings'),
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -214,6 +214,12 @@ const conf = (module.exports = convict({
         format: 'int',
       },
     },
+    sendFxAStatusOnSettings: {
+      default: false,
+      doc: 'Sends a webchannel message on the settings page to request auth data from the browser',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS',
+    },
   },
   showReactApp: {
     simpleRoutes: {

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -48,7 +48,9 @@ module.exports = function (config) {
   const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
   const SHOW_REACT_APP = config.get('showReactApp');
   const BRAND_MESSAGING_MODE = config.get('brandMessagingMode');
-
+  const FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS = config.get(
+    'featureFlags.sendFxAStatusOnSettings'
+  );
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
   const GLEAN_UPLOAD_ENABLED = config.get('glean.uploadEnabled');
@@ -100,7 +102,9 @@ module.exports = function (config) {
     webpackPublicPath: WEBPACK_PUBLIC_PATH,
     showReactApp: SHOW_REACT_APP,
     brandMessagingMode: BRAND_MESSAGING_MODE,
-
+    featureFlags: {
+      sendFxAStatusOnSettings: FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS,
+    },
     glean: {
       // feature toggle
       enabled: GLEAN_ENABLED,

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -236,6 +236,7 @@ describe('SettingsRoutes', () => {
       loading: false,
     });
     (useIntegration as jest.Mock).mockReturnValue({
+      isSync: jest.fn(),
       getServiceName: jest.fn(),
     });
   });

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { GET_LOCAL_SIGNED_IN_STATUS } from '../../components/App/gql';
+import { cache } from '../cache';
+import { StoredAccountData, storeAccountData } from '../storage-utils';
+
 export enum FirefoxCommand {
   AccountDeleted = 'fxaccounts:delete',
   ProfileChanged = 'profile:change',
@@ -15,19 +19,26 @@ export enum FirefoxCommand {
   CanLinkAccount = 'fxaccounts:can_link_account',
 }
 
-export interface FirefoxMessage {
+export interface FirefoxMessageDetail {
   id: string;
-  message?: {
-    command: FirefoxCommand;
-    data: Record<string, any> & {
-      error?: {
-        message: string;
-        stack: string;
-      };
+  message?: FirefoxMessage;
+}
+
+export interface FirefoxMessage {
+  command: FirefoxCommand;
+  data: Record<string, any> & {
+    error?: {
+      message: string;
+      stack: string;
     };
-    messageId: string;
-    error?: string;
   };
+  messageId: string;
+  error?: string;
+}
+
+export interface FirefoxMessageError {
+  error?: string;
+  stack?: string;
 }
 
 interface ProfileUid {
@@ -39,13 +50,13 @@ interface ProfileMetricsEnabled {
 }
 
 type Profile = ProfileUid | ProfileMetricsEnabled;
-type FirefoxEvent = CustomEvent<FirefoxMessage | string>;
+type FirefoxEvent = CustomEvent<FirefoxMessageDetail | string>;
 
 // This is defined in the Firefox source code:
 // https://searchfox.org/mozilla-central/source/services/fxaccounts/tests/xpcshell/test_web_channel.js#348
 type FxAStatusRequest = {
-  service: 'sync'; // ex. 'sync'
-  context: string; // ex. 'fx_desktop_v3'
+  service?: string; // ex. 'sync'
+  context?: string; // ex. 'fx_desktop_v3'
 };
 
 export type FxAStatusResponse = {
@@ -107,6 +118,8 @@ export type FxACanLinkAccount = {
   email: string;
 };
 
+const DEFAULT_SEND_TIMEOUT_LENGTH_MS = 5 * 1000; // 5 seconds in milliseconds
+
 let messageIdSuffix = 0;
 /**
  * Create a messageId for a given command/data combination.
@@ -151,7 +164,7 @@ export class Firefox extends EventTarget {
     try {
       const detail =
         typeof event.detail === 'string'
-          ? (JSON.parse(event.detail) as FirefoxMessage)
+          ? (JSON.parse(event.detail) as FirefoxMessageDetail)
           : event.detail;
       if (detail.id !== this.id) {
         return;
@@ -265,7 +278,7 @@ export class Firefox extends EventTarget {
         // if the event is what we expect.
         const detail =
           typeof firefoxEvent.detail === 'string'
-            ? (JSON.parse(firefoxEvent.detail) as FirefoxMessage)
+            ? (JSON.parse(firefoxEvent.detail) as FirefoxMessageDetail)
             : firefoxEvent.detail;
         if (detail.id !== this.id) {
           return;
@@ -297,6 +310,45 @@ export class Firefox extends EventTarget {
 
   fxaCanLinkAccount(options: FxACanLinkAccount) {
     this.send(FirefoxCommand.Login, options);
+  }
+
+  async requestSignedInUser(context: string) {
+    let timeout: NodeJS.Timeout;
+    return Promise.race([
+      new Promise<void>((resolve) => {
+        const handleFxAStatusEvent = (event: any) => {
+          const status = event.detail as FxAStatusResponse;
+          const signedInUser = status.signedInUser as StoredAccountData;
+          if (signedInUser) {
+            storeAccountData(signedInUser);
+            cache.writeQuery({
+              query: GET_LOCAL_SIGNED_IN_STATUS,
+              data: { isSignedIn: true },
+            });
+          }
+          this.removeEventListener(
+            FirefoxCommand.FxAStatus,
+            handleFxAStatusEvent
+          );
+          clearTimeout(timeout);
+          resolve();
+        };
+
+        this.addEventListener(FirefoxCommand.FxAStatus, handleFxAStatusEvent);
+        // requestAnimationFrame ensures the event listener is added first
+        // otherwise, there is a race condition
+        requestAnimationFrame(() => {
+          this.send(FirefoxCommand.FxAStatus, {
+            context,
+            isPairing: false,
+          });
+        });
+      }),
+      new Promise(
+        (resolve) =>
+          (timeout = setTimeout(resolve, DEFAULT_SEND_TIMEOUT_LENGTH_MS))
+      ),
+    ]);
   }
 }
 

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -77,6 +77,7 @@ export interface Config {
     debugViewTag: string;
   };
   redirectAllowlist: string[];
+  sendFxAStatusOnSettings: boolean;
 }
 
 export function getDefault() {
@@ -145,6 +146,7 @@ export function getDefault() {
       debugViewTag: '',
     },
     redirectAllowlist: ['localhost'],
+    sendFxAStatusOnSettings: false,
   } as Config;
 }
 

--- a/packages/fxa-settings/src/lib/storage-utils.ts
+++ b/packages/fxa-settings/src/lib/storage-utils.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { sessionToken } from './cache';
 import Storage from './storage';
 
 const ORIGINAL_TAB_KEY = 'originalTab';
@@ -71,4 +72,10 @@ export function persistAccount(accountData: StoredAccountData) {
 export function setCurrentAccount(uid: string) {
   const storage = localStorage();
   storage.set('currentAccountUid', uid);
+}
+
+export function storeAccountData(accountData: StoredAccountData) {
+  persistAccount(accountData);
+  setCurrentAccount(accountData.uid);
+  sessionToken(accountData.sessionToken);
 }

--- a/packages/fxa-settings/src/models/integrations/web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/web-integration.ts
@@ -17,6 +17,7 @@ import {
   IsString,
   Length,
 } from 'class-validator';
+import { Constants } from '../../lib/constants';
 
 // TODO: move this to other file, FXA-8099
 export class BaseIntegrationData extends ModelDataProvider {
@@ -119,6 +120,12 @@ export class WebIntegration extends BaseIntegration {
       reuseExistingSession: true,
       fxaStatus: this.isFxaStatusSupported(),
     });
+  }
+
+  // Special case of mobile accessing Settings through the browser's "Manage account"
+  // TODO: do we want a SyncMobileBasic integration for this?
+  isSync() {
+    return this.data.context === Constants.OAUTH_WEBCHANNEL_CONTEXT;
   }
 
   private isFxaStatusSupported(): boolean {

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -15,10 +15,8 @@ import { AUTH_PROVIDER } from 'fxa-auth-client/browser';
 import { useAccount } from '../../../models';
 import {
   StoredAccountData,
-  persistAccount,
-  setCurrentAccount,
+  storeAccountData,
 } from '../../../lib/storage-utils';
-import { sessionToken } from '../../../lib/cache';
 
 type LinkedAccountData = {
   uid: hexstring;
@@ -64,7 +62,7 @@ const ThirdPartyAuthCallback = (_: RouteComponentProps) => {
 
   // Persist account data to local storage to match parity with content-server
   // this allows the recent account to be used for /signin
-  const storeAccountData = async (linkedAccount: LinkedAccountData) => {
+  const storeLinkedAccountData = async (linkedAccount: LinkedAccountData) => {
     const accountData: StoredAccountData = {
       // We are using the email that was returned from the Third Party Auth
       // Not the email entered in the email-first form as they might be different
@@ -76,9 +74,7 @@ const ThirdPartyAuthCallback = (_: RouteComponentProps) => {
       metricsEnabled: true,
     };
 
-    persistAccount(accountData);
-    setCurrentAccount(accountData.uid);
-    sessionToken(accountData.sessionToken);
+    storeAccountData(accountData);
   };
 
   const completeSignIn = async (linkedAccount: LinkedAccountData) => {
@@ -87,7 +83,7 @@ const ThirdPartyAuthCallback = (_: RouteComponentProps) => {
     // this should also update graphQL cache (isSignedIn:true)
     // await account.signIn(linkedAccount)
 
-    await storeAccountData(linkedAccount);
+    await storeLinkedAccountData(linkedAccount);
 
     // TODO ensure correct redirects for all integrations (OAuth, Desktop, Mobile)
     // redirect is constructed from state param in the URL params

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -35,12 +35,7 @@ import CardHeader from '../../components/CardHeader';
 import { REACT_ENTRYPOINT } from '../../constants';
 import AppLayout from '../../components/AppLayout';
 import { SignupFormData, SignupProps } from './interfaces';
-import {
-  StoredAccountData,
-  persistAccount,
-  setCurrentAccount,
-} from '../../lib/storage-utils';
-import { sessionToken } from '../../lib/cache';
+import { StoredAccountData, storeAccountData } from '../../lib/storage-utils';
 import GleanMetrics from '../../lib/glean';
 import { BrandMessagingPortal } from '../../components/BrandMessaging';
 import {
@@ -179,14 +174,6 @@ export const Signup = ({
     getValues().age === '' && setAgeCheckErrorText(localizedAgeIsRequiredError);
   };
 
-  // Persist account data to local storage to match parity with content-server
-  // this allows the recent account to be used for /signin
-  const storeAccountData = (accountData: StoredAccountData) => {
-    persistAccount(accountData);
-    setCurrentAccount(accountData.uid);
-    sessionToken(accountData.sessionToken);
-  };
-
   // TODO: Add metrics events to match parity with content-server in FXA-8302
   // The legacy amplitude events will eventually be replaced by Glean,
   // but until that is ready we must ensure the expected metrics continue to be emitted
@@ -223,6 +210,8 @@ export const Signup = ({
           metricsEnabled: true,
         };
 
+        // Persist account data to local storage to match parity with content-server
+        // this allows the recent account to be used for /signin
         storeAccountData(accountData);
 
         const getOfferedSyncEngines = () =>


### PR DESCRIPTION
Because:
* Users are asked to sign in again if they sign in using the pairing flow and try to access Settings through the browser

This commit:
* In Settings, sends an fxa_status web channel message to request the user's data from the browser in Settings if web+sync integration
* Adds a functional test for Settings fxa_status
* Pulls out storeAccountData into its own function, related App cleanup and firefox.ts type improvements
* Adds a feature flag since this is difficult to test locally

closes FXA-7439

---

This is basically a combination and iteration on #15723 + #16237