### PR TITLE
feat(delete): Delete user firestore record on delete event

### DIFF
--- a/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
@@ -185,4 +185,18 @@ describe('#integration - FirestoreService', () => {
     },
     TEST_TIMEOUT
   );
+
+  it(
+    'deletes a user record',
+    async () => {
+      await service.storeLogin(uid1, 'fx_send');
+      let result = await service.fetchClientIds(uid1);
+      expect(result).toStrictEqual(['fx_send']);
+
+      await service.deleteUser(uid1);
+      result = await service.fetchClientIds(uid1);
+      expect(result).toStrictEqual([]);
+    },
+    TEST_TIMEOUT
+  );
 });

--- a/packages/fxa-event-broker/src/firestore/firestore.service.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.ts
@@ -88,6 +88,19 @@ export class FirestoreService {
   }
 
   /**
+   * Deletes a user record in firebase.
+   *
+   * @param uid
+   */
+  public async deleteUser(uid: string): Promise<void> {
+    const document = this.db.doc(
+      `${this.prefix}users/${uid}`
+    ) as TypedDocumentReference<UserDocument>;
+
+    await document.delete();
+  }
+
+  /**
    * Fetches the OAuth Client Ids that a user has directly logged in to
    * via a Relying Party flow.
    *

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -105,6 +105,7 @@ describe('QueueworkerService', () => {
   beforeEach(async () => {
     firestore = {
       storeLogin: jest.fn().mockResolvedValue({}),
+      deleteUser: jest.fn().mockResolvedValue({}),
       fetchClientIds: jest
         .fn()
         .mockResolvedValue(['444c5d137fc34d82ae65441d7f26a504']),

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -192,6 +192,18 @@ export class QueueworkerService
   }
 
   /**
+   * Send delete event to RPs and delete user record from datastore.
+   *
+   * @param message
+   * @private
+   */
+  private async handleDeleteEvent(message: dto.deleteSchema) {
+    await this.handleMessageFanout(message, 'delete');
+
+    await this.firestore.deleteUser(message.uid);
+  }
+
+  /**
    * Save login to RP to datastore.
    *
    * Logins are not distributed to RPs as they already know if a user has
@@ -320,7 +332,7 @@ export class QueueworkerService
         break;
       }
       case dto.DELETE_EVENT: {
-        await this.handleMessageFanout(message, 'delete');
+        await this.handleDeleteEvent(message);
         break;
       }
       case dto.PRIMARY_EMAIL_EVENT:


### PR DESCRIPTION
## Because

- We also want to delete the user record in firebase when the delete account event is sent

## This pull request

- Refactors code to delete it

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8842

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The original issue mentions deleting only login records, but since the user is being deleted I ended up removing their entire record. @bbangert is this the correct assumption?