### PR TITLE
feat(auth): update remove customer error handling

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -40,7 +40,7 @@ type PushboxDeleteAccount = Pick<
   'deleteAccount'
 >;
 
-export type ReasonForDeletion = (typeof AccountDeleteReasons)[number];
+export type ReasonForDeletion = typeof AccountDeleteReasons[number];
 type DeleteTask = {
   uid: string;
   customerId?: string;
@@ -289,6 +289,19 @@ export class AccountDeleteManager {
         );
         await deleteAllPayPalBAs(uid);
       }
+    }
+  }
+
+  async deleteFirestoreCustomer(uid: string) {
+    this.log.debug('AccountDeleteManager.deleteFirestoreCustomer', { uid });
+    try {
+      return await this.stripeHelper?.removeFirestoreCustomer(uid);
+    } catch (error) {
+      this.log.error('AccountDeleteManager.deleteFirestoreCustomer', {
+        uid,
+        error,
+      });
+      throw error;
     }
   }
 }

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -74,7 +74,11 @@ import { PaymentConfigManager } from './configuration/manager';
 import { CurrencyHelper } from './currencies';
 import { AppStoreSubscriptionPurchase } from './iap/apple-app-store/subscription-purchase';
 import { PlayStoreSubscriptionPurchase } from './iap/google-play/subscription-purchase';
-import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
+import {
+  StripeFirestoreMultiError,
+  FirestoreStripeError,
+  StripeFirestore,
+} from './stripe-firestore';
 import { stripeInvoiceToLatestInvoiceItemsDTO } from './stripe-formatter';
 import { generateIdempotencyKey, roundTime } from './utils';
 import { ContentfulManager } from '@fxa/shared/contentful';
@@ -3407,8 +3411,10 @@ export class StripeHelper extends StripeHelperBase {
     try {
       return await this.stripeFirestore.removeCustomerRecursive(uid);
     } catch (error) {
-      Sentry.captureException(error);
-      return [];
+      if (error instanceof StripeFirestoreMultiError) {
+        Sentry.captureException(error);
+      }
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Because

- removeFirestoreCustomer should reject with error so that it can be
  handled by consumers.

## This pull request

- Adds StripeFirestoreError and StripeFirestoreMultiError to
stripe-firestore
- removeFirestoreCustomer rejects with error

## Issue that this pull request solves

Closes: #FXA-8839

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
