### PR TITLE
fix(auth): add `proration_date` to subscription update

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1951,6 +1951,7 @@ export class StripeHelper extends StripeHelperBase {
           },
         ],
         proration_behavior: 'always_invoice',
+        proration_date: Math.floor(Date.now() / 1000),
         metadata: updatedMetadata,
       }
     );

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -720,9 +720,13 @@ export class StripeHelper extends StripeHelperBase {
       let proratedInvoice;
       if (isUpgrade && requestObject.subscription_items?.length) {
         try {
+          // get start of today's local time and date to calculate subscription_proration_date
+          const d = new Date();
+          d.setHours(0, 0, 0, 0);
+
           requestObject.subscription_proration_behavior = 'always_invoice';
           requestObject.subscription_proration_date = Math.floor(
-            Date.now() / 1000
+            d.valueOf() / 1000
           );
           const subscriptionItem = customer?.subscriptions?.data
             .flatMap((sub) => sub.items.data)
@@ -1940,6 +1944,10 @@ export class StripeHelper extends StripeHelperBase {
       plan_change_date: moment().unix(),
     };
 
+    // get start of today's local time and date to calculate proration_date
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+
     const updatedSubscription = await this.updateSubscriptionAndBackfill(
       subscription,
       {
@@ -1951,7 +1959,7 @@ export class StripeHelper extends StripeHelperBase {
           },
         ],
         proration_behavior: 'always_invoice',
-        proration_date: Math.floor(Date.now() / 1000),
+        proration_date: Math.floor(d.valueOf() / 1000),
         metadata: updatedMetadata,
       }
     );

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3661,6 +3661,7 @@ describe('#integration - StripeHelper', () => {
             },
           ],
           proration_behavior: 'always_invoice',
+          proration_date: Math.floor(Date.now() / 1000),
           metadata: {
             key: 'value',
             previous_plan_id: subscription1.items.data[0].plan.id,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3638,6 +3638,10 @@ describe('#integration - StripeHelper', () => {
         plan_change_date: 12345678,
       };
 
+      // get start of today's local time and date to calculate proration_date
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+
       sandbox.stub(moment, 'unix').returns(unixTimestamp);
       sandbox
         .stub(stripeHelper, 'updateSubscriptionAndBackfill')
@@ -3661,7 +3665,7 @@ describe('#integration - StripeHelper', () => {
             },
           ],
           proration_behavior: 'always_invoice',
-          proration_date: Math.floor(Date.now() / 1000),
+          proration_date: Math.floor(d.valueOf() / 1000),
           metadata: {
             key: 'value',
             previous_plan_id: subscription1.items.data[0].plan.id,

--- a/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.ts
@@ -122,6 +122,7 @@ describe('CustomerPlanMover', () => {
     subscriptionUpdater = new SubscriptionUpdater(
       planIdMap,
       'none',
+      undefined,
       100,
       './update-subscriptions-to-new-plan.tmp.csv',
       stripeHelperStub,


### PR DESCRIPTION
## Because

- Proration amount inconsistent across upgrade page and emails.

## This pull request

- Adds `proration_date` to updated subscription, which matches `subscription_proration_date` for upcoming invoice.

## Issue that this pull request solves

Closes FXA-8070

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
