### PR TITLE
feat(react): Full prod rollout of react signup

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -16,18 +16,20 @@ export const selectors = {
   ERROR: '.error',
   LINK_LOST_RECOVERY_KEY: '.lost-recovery-key',
   LINK_RESET_PASSWORD: 'a[href^="/reset_password"]',
-  LINK_USE_DIFFERENT: '#use-different',
+  LINK_CHANGE_EMAIL: 'a:has-text("Change email")',
+  LINK_USE_DIFFERENT: 'a:has-text("Use a different account")',
   LINK_USE_RECOVERY_CODE: '#use-recovery-code-link',
   NUMBER_INPUT: 'input[type=number]',
-  PASSWORD: '#password',
-  PASSWORD_HEADER: '#fxa-signin-password-header',
+  // TODO: update this selector to get from label once backbone signup/signin are entirely removed
+  PASSWORD: ':nth-match(input[type=password],1)',
+  PASSWORD_HEADER: 'h1:has-text("Enter your password")',
   PERMISSIONS_HEADER: '#fxa-permissions-header',
   PASSWORD_MASK_INPUT: '#password[type=password]',
   PASSWORD_TEXT_INPUT: '#password[type=text]',
   SHOW_PASSWORD: '#password ~ [for="show-password"]',
   RESET_PASSWORD_EXPIRED_HEADER: '#fxa-reset-link-expired-header',
   RESET_PASSWORD_HEADER: '#fxa-reset-password-header',
-  SIGN_UP_CODE_HEADER: '#fxa-confirm-signup-code-header',
+  SIGN_UP_CODE_HEADER: 'h1:has-text("Enter confirmation code")',
   SIGNIN_BOUNCED_HEADER: '#fxa-signin-bounced-header',
   BOUNCED_CREATE_ACCOUNT: '#create-account',
   SIGN_IN_CODE_HEADER: '#fxa-signin-code-header',
@@ -40,7 +42,8 @@ export const selectors = {
   SUBMIT_USER_SIGNED_IN: '#use-logged-in',
   RECOVERY_KEY_TEXT_INPUT: 'input[type=text]',
   TOOLTIP: '.tooltip',
-  VPASSWORD: '#vpassword',
+  // TODO: update this selector to get from label once backbone signup/signin are entirely removed
+  VPASSWORD: ':nth-match(input[type=password],2)',
   SYNC_CONNECTED_HEADER: '#fxa-connected-heading',
   NOTES_HEADER: '#notes-by-firefox',
   MIN_LENGTH_MET: '#password-too-short.password-strength-met',
@@ -338,6 +341,15 @@ export class LoginPage extends BaseLayout {
     return this.page.click(selectors.LINK_USE_DIFFERENT);
   }
 
+  async isChangeEmailLinkVisible() {
+    const link = await this.page.locator(selectors.LINK_CHANGE_EMAIL);
+    return link.isVisible();
+  }
+
+  async useChangeEmailLink() {
+    return this.page.click(selectors.LINK_CHANGE_EMAIL);
+  }
+
   async getTooltipError() {
     return this.page.locator(selectors.TOOLTIP).innerText();
   }
@@ -460,13 +472,15 @@ export class LoginPage extends BaseLayout {
   }
 
   async signInPasswordHeader() {
-    const header = this.page.locator('#fxa-signin-password-header');
+    const header = this.page.locator(selectors.PASSWORD_HEADER);
     await header.waitFor();
     return header.isVisible();
   }
 
   async signUpPasswordHeader() {
-    const header = this.page.locator('#fxa-signup-password-header');
+    const header = this.page.getByRole('heading', {
+      name: 'Set your password',
+    });
     await header.waitFor();
     return header.isVisible();
   }

--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -29,8 +29,8 @@ export class SignupReactPage extends BaseLayout {
 
   getPassword() {
     return this.page.getByRole('textbox', {
-      // simple text string was matching both password inputs
-      name: /^Password$/,
+      name: 'Password',
+      exact: true,
     });
   }
 
@@ -73,7 +73,12 @@ export class SignupReactPage extends BaseLayout {
     }
   }
 
-  async fillOutCodeForm(code: string) {
+  async fillOutCodeForm(email: string) {
+    const code = await this.target.email.waitForEmail(
+      email,
+      EmailType.verifyShortCode,
+      EmailHeader.shortCode
+    );
     await this.setCode(code);
     await this.submit('Confirm');
   }
@@ -89,15 +94,8 @@ export class SignupReactPage extends BaseLayout {
     await this.page.waitForURL(/signup/);
     await this.page.waitForSelector('#root');
     await this.fillOutSignupForm(password);
-
-    // Get code from email
-    const code = await this.target.email.waitForEmail(
-      email,
-      EmailType.verifyShortCode,
-      EmailHeader.shortCode
-    );
-
-    await this.fillOutCodeForm(code);
+    await this.page.waitForURL(/confirm_signup_code/);
+    await this.fillOutCodeForm(email);
   }
 
   async submit(label: string) {

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -19,18 +19,20 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('login_hint specified by relier, not registered', async ({
+      page,
       pages: { login, relier },
+      target,
     }) => {
       const email = login.createEmail();
       await relier.goto(`login_hint=${email}`);
       await relier.clickEmailFirst();
 
-      // Email is prefilled
-      await expect(await login.getPrefilledEmail()).toEqual(email);
+      await page.waitForURL(`${target.contentServerUrl}/oauth/signup**`);
       expect(await login.signUpPasswordHeader()).toEqual(true);
+      // email provided as login hint is displayed on the signup page
+      await expect(page.getByText(email).isVisible()).toBeTruthy();
 
-      await login.useDifferentAccountLink();
-
+      await login.useChangeEmailLink();
       // Email first page has email input prefilled
       await expect(await login.getEmailInput()).toEqual(email);
     });

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -9,7 +9,12 @@ const password = 'passwordzxcv';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth permissions for trusted reliers - sign up', () => {
-    test.beforeEach(async ({ pages: { login } }) => {
+    test.beforeEach(async ({ pages: { configPage, login } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'these tests are specific to backbone, skip if seeing React version'
+      );
       test.slow();
       email = login.createEmail();
       await login.clearCache();

--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -10,11 +10,20 @@ const password = 'passwordzxcv';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Oauth sign up', () => {
-    test.beforeEach(async ({ pages: { login } }) => {
-      test.slow();
-      email = login.createEmail();
-      bouncedEmail = login.createEmail('bounced{id}');
-      await login.clearCache();
+    test.beforeEach(async ({ pages: { configPage, login } }) => {
+      const config = await configPage.getConfig();
+      if (config.showReactApp.signUpRoutes === true) {
+        email = '';
+        test.skip(
+          true,
+          'this test is specific to backbone, skip if serving react'
+        );
+      } else {
+        test.slow();
+        email = login.createEmail();
+        bouncedEmail = login.createEmail('bounced{id}');
+        await login.clearCache();
+      }
     });
 
     test.afterEach(async ({ target }) => {

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -13,7 +13,13 @@ test.describe('severity-1 #smoke', () => {
       await login.clearCache();
     });
 
-    test('signup', async ({ pages: { login, relier } }) => {
+    test('signup', async ({ pages: { configPage, login, relier } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'this test is specific to backbone, skip if seeing React version'
+      );
+
       const customEventDetail = createCustomEventDetail(
         FirefoxCommand.FxAStatus,
         {

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -3,21 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
-import { getReactFeatureFlagUrl } from '../../lib/react-flag';
-
-test.beforeEach(async ({ pages: { configPage } }) => {
-  // This test requires simple react routes to be enabled
-  const config = await configPage.getConfig();
-  test.skip(config.showReactApp.simpleRoutes !== true);
-});
 
 test.describe('severity-2 #smoke', () => {
   test.describe('legal', () => {
     test('start at legal page', async ({ page, target }) => {
-      await page.goto(getReactFeatureFlagUrl(target, '/legal'));
-
-      // Verify react page has been loaded
-      await page.waitForSelector('#root');
+      await page.goto(`${target.contentServerUrl}/legal`);
 
       // Verify legal page is visible
       expect(
@@ -40,15 +30,14 @@ test.describe('severity-2 #smoke', () => {
         await page.locator('a:has-text("Privacy Notice")').isVisible()
       ).toBeTruthy();
       await page.locator('a:has-text("Privacy Notice")').click();
+      await page.waitForURL(`${target.contentServerUrl}/legal/privacy`);
       await page.locator('button:has-text("Back")').click();
+      await page.waitForURL(`${target.contentServerUrl}/legal`);
       await page.waitForSelector('.card-header:has-text("Legal")');
     });
 
     test('start at terms page', async ({ page, target }) => {
-      await page.goto(getReactFeatureFlagUrl(target, '/legal/terms'));
-
-      // Verify react page has been loaded
-      await page.waitForSelector('#root');
+      await page.goto(`${target.contentServerUrl}/legal/terms`);
 
       // Verify legal page is visible
       // this text is not in our codebase, it's pulled from the `legal-docs` repo
@@ -58,10 +47,7 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('start at privacy page', async ({ page, target }) => {
-      await page.goto(getReactFeatureFlagUrl(target, '/legal/privacy'));
-
-      // Verify react page has been loaded
-      await page.waitForSelector('#root');
+      await page.goto(`${target.contentServerUrl}/legal/privacy`);
 
       // Verify privacy page is visible
       await page.waitForTimeout(1000);

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -99,8 +99,10 @@ test.describe('severity-1 #smoke', () => {
     test('can change primary email, delete account', async ({
       credentials,
       page,
-      pages: { settings, deleteAccount, login, secondaryEmail },
+      pages: { configPage, deleteAccount, login, signupReact, settings },
     }) => {
+      const config = await configPage.getConfig();
+
       // Click delete account
       await settings.clickDeleteAccount();
       await deleteAccount.checkAllBoxes();
@@ -111,7 +113,14 @@ test.describe('severity-1 #smoke', () => {
       await deleteAccount.submit();
 
       // // Try creating a new account with the same secondary email as previous account and new password
-      await login.fillOutFirstSignUp(newEmail, credentials.password);
+      if (config.showReactApp.signUpRoutes !== true) {
+        await login.fillOutFirstSignUp(newEmail, credentials.password);
+      } else {
+        await signupReact.fillOutEmailFirst(newEmail);
+        await signupReact.fillOutSignupForm(credentials.password);
+        await signupReact.fillOutCodeForm(newEmail);
+      }
+
       expect(await settings.alertBarText()).toContain(
         'Account confirmed successfully'
       );

--- a/packages/functional-tests/tests/settings/password.spec.ts
+++ b/packages/functional-tests/tests/settings/password.spec.ts
@@ -122,8 +122,13 @@ test.describe('password strength tests', () => {
 
   test('test different password errors and success', async ({
     credentials,
-    pages: { login },
+    pages: { configPage, login },
   }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'password errors and success tests were converted to unit tests in PasswordStrengthBalloon component'
+    );
     //Submit without providing a password
     await login.submitButton.click();
 

--- a/packages/functional-tests/tests/settings/passwordVisibility.spec.ts
+++ b/packages/functional-tests/tests/settings/passwordVisibility.spec.ts
@@ -8,8 +8,13 @@ test.describe('password visibility tests', () => {
   test('show password ended with second mousedown', async ({
     page,
     target,
-    pages: { login },
+    pages: { configPage, login },
   }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'this test was replaced by a unit test'
+    );
     const email = login.createEmail();
     await page.goto(target.contentServerUrl, { waitUntil: 'load' });
     await login.setEmail(email);

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -8,7 +8,12 @@ const password = 'password12345678';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signup here', () => {
-    test.beforeEach(async () => {
+    test.beforeEach(async ({ pages: { configPage } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'these tests are specific to backbone, skip if serving React version'
+      );
       test.slow();
     });
 

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -9,7 +9,12 @@ let email;
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sign up with code', () => {
-    test.beforeEach(async ({ pages: { login } }) => {
+    test.beforeEach(async ({ pages: { configPage, login } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'these tests are specific to backbone, skip if serving React version'
+      );
       test.slow();
       email = login.createEmail();
       await login.clearCache();

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -10,15 +10,29 @@ test.describe('severity-2 #smoke', () => {
       credentials,
       target,
     }) => {
-      const { browser, page, login, connectAnotherDevice } =
-        await newPagesForSync(target);
+      const {
+        browser,
+        configPage,
+        connectAnotherDevice,
+        page,
+        login,
+        signupReact,
+      } = await newPagesForSync(target);
+      const config = await configPage.getConfig();
       await target.auth.accountDestroy(credentials.email, credentials.password);
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
         { waitUntil: 'load' }
       );
-      await login.fillOutFirstSignUp(credentials.email, credentials.password);
+
+      if (config.showReactApp.signUpRoutes === true) {
+        await signupReact.fillOutEmailFirst(credentials.email);
+        await signupReact.fillOutSignupForm(credentials.password);
+        await signupReact.fillOutCodeForm(credentials.email);
+      } else {
+        await login.fillOutFirstSignUp(credentials.email, credentials.password);
+      }
 
       // Move on to the connect another device page
       await connectAnotherDevice.goto('load');

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -2,49 +2,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { EmailHeader, EmailType } from '../../lib/email';
 import { test, expect } from '../../lib/fixtures/standard';
 
+let signUpReactEnabled = false;
 test.describe('severity-2 #smoke', () => {
   test.describe('redirect_to', () => {
-    test.beforeEach(async ({ credentials, pages: { settings, login } }) => {
-      await settings.goto();
-      await settings.signOut();
-      await login.login(credentials.email, credentials.password);
-    });
+    test.beforeEach(
+      async ({ credentials, pages: { settings, login, configPage } }) => {
+        const config = await configPage.getConfig();
+        signUpReactEnabled = config.showReactApp.signUpRoutes === true;
 
-    async function engageRedirect(page, target, redirectTo) {
+        await settings.goto();
+        await settings.signOut();
+        await login.login(credentials.email, credentials.password);
+      }
+    );
+
+    async function engageRedirect(page, target, redirectTo, email: string) {
       await page.goto(
         `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`
       );
+      // In React, we show the message after the user submits
+      if (signUpReactEnabled) {
+        const emailNewCodeText = 'text=/Email new code/';
+        await page.waitForSelector(emailNewCodeText);
+        page.click(emailNewCodeText);
+        const code = await target.email.waitForEmail(
+          email,
+          EmailType.verifyLoginCode,
+          EmailHeader.signinCode
+        );
+        page.getByLabel('Enter 6-digit code').fill(code);
+      }
       await page.click('button[type=submit]');
     }
 
     test('prevent invalid redirect_to parameter', async ({
+      credentials,
       target,
       pages: { page },
     }) => {
       const redirectTo = 'https://evil.com/';
-      await engageRedirect(page, target, redirectTo);
-
-      const error = await page.waitForSelector('.error');
-      expect(await error.isVisible()).toBeTruthy();
-      expect(await error.textContent()).toEqual('Invalid redirect!');
+      await engageRedirect(page, target, redirectTo, credentials.email);
+      await page.waitForSelector('text=/Invalid redirect/');
       expect(page.url).not.toEqual(redirectTo);
     });
 
     test('prevent xss in redirect_to parameter', async ({
+      credentials,
       target,
       pages: { page },
     }) => {
       const redirectTo = 'javascript:alert(1)';
-      await engageRedirect(page, target, redirectTo);
-
-      const error = await page.waitForSelector('.error');
-      expect(await error.isVisible()).toBeTruthy();
-      expect(await error.textContent()).toEqual('Invalid redirect!');
+      await engageRedirect(page, target, redirectTo, credentials.email);
+      await page.waitForSelector('text=/Invalid redirect/');
     });
 
     test('allows valid redirect_to parameter', async ({
+      credentials,
       target,
       pages: { page },
     }) => {
@@ -52,11 +68,20 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`
       );
+      // In React, we show the message after the user submits
+      if (signUpReactEnabled) {
+        const emailNewCodeText = 'text=/Email new code/';
+        await page.waitForSelector(emailNewCodeText);
+        page.click(emailNewCodeText);
+        const code = await target.email.waitForEmail(
+          credentials.email,
+          EmailType.verifyLoginCode,
+          EmailHeader.signinCode
+        );
+        page.getByLabel('Enter 6-digit code').fill(code);
+      }
       await page.click('button[type=submit]');
-
-      await page.waitForURL(/settings\?/);
-
-      expect(page.url().startsWith(redirectTo)).toBeTruthy();
+      await page.waitForURL(redirectTo);
     });
   });
 });

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -105,8 +105,13 @@ test.describe('severity-2 #smoke', () => {
     test('with bounced email', async ({
       target,
       page,
-      pages: { login, settings },
+      pages: { configPage, login },
     }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'bounced email functionality does not currently work for react'
+      );
       const email = login.createEmail('sync{id}');
       const password = 'password123';
       await target.createAccount(email, password);

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -101,8 +101,13 @@ test.describe('severity-1 #smoke', () => {
 
     test('sync v3 with an unregistered email, no uid', async ({
       credentials,
-      target,
+      pages: { configPage },
     }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'force_auth is no longer supported for signup with react'
+      );
       const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
 
       const email = `sync${Math.random()}@restmail.net`;
@@ -130,8 +135,13 @@ test.describe('severity-1 #smoke', () => {
 
     test('sync v3 with an unregistered email, registered uid', async ({
       credentials,
-      target,
+      pages: { configPage },
     }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'force_auth is no longer supported for signup with react'
+      );
       const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
 
       const email = `sync${Math.random()}@restmail.net`;
@@ -151,8 +161,13 @@ test.describe('severity-1 #smoke', () => {
 
     test('sync v3 with an unregistered email, unregistered uid', async ({
       credentials,
-      target,
+      pages: { configPage },
     }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'force_auth is no longer supported for signup with react'
+      );
       const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
 
       const email = `sync${Math.random()}@restmail.net`;

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -43,9 +43,16 @@ test.describe('severity-2 #smoke', () => {
       expect(await connectAnotherDevice.fxaConnected.isEnabled()).toBeTruthy();
     });
 
+    // TODO in FXA-8973 - use sign in not sign up flow
     test('verified, resend', async ({ target }) => {
-      const { page, login, connectAnotherDevice, signinTokenCode } =
+      const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
+
+      const config = await configPage.getConfig();
+      test.fixme(
+        config.showReactApp.signUpRoutes,
+        'this test goes through the signup flow instead of sign in, skipping for react'
+      );
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
@@ -74,9 +81,16 @@ test.describe('severity-2 #smoke', () => {
       expect(await connectAnotherDevice.fxaConnected.isVisible()).toBeTruthy();
     });
 
+    // TODO in FXA-8973 - use sign in not sign up flow
     test('verified - invalid code', async ({ target }) => {
-      const { page, login, connectAnotherDevice, signinTokenCode } =
+      const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
+
+      const config = await configPage.getConfig();
+      test.fixme(
+        config.showReactApp.signUpRoutes,
+        'this test goes through the signup flow instead of sign in, skipping for react'
+      );
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -11,6 +11,14 @@ let email, syncBrowserPages;
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-1 #smoke', () => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'these tests are specific to backbone, skip if seeing React version'
+    );
+  });
+
   test.describe('Firefox Desktop Sync v3 sign up', () => {
     test.beforeEach(async ({ target, pages: { login } }) => {
       test.slow();

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -13,6 +13,14 @@ let syncBrowserPages;
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-1 #smoke', () => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'these tests are specific to backbone, skip if seeing React version'
+    );
+  });
+
   test.describe('Sync v3 sign up and CWTS', () => {
     test.beforeEach(async ({ target }) => {
       //Sync tests run a little slower and flake

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -20,9 +20,16 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     await syncBrowserPages.browser?.close();
   });
 
+  // TODO: is this something we want to support once index/email-first is converted to React?
   test('open directly to /signup page, refresh on the /signup page', async ({
+    pages: { configPage },
     target,
   }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'Not currently supported in React Signup'
+    );
     const { page, login } = syncBrowserPages;
     await page.goto(
       `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -6,7 +6,7 @@ cd "$DIR/.."
 export NODE_ENV=dev
 export CORS_ORIGIN="http://foo,http://bar"
 
-DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 10000 --exit "
+DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 20000 --exit "
 if [ "$TEST_TYPE" == 'unit' ]; then GREP_TESTS="--grep #integration --invert "; fi;
 if [ "$TEST_TYPE" == 'integration' ]; then GREP_TESTS="--grep #integration "; fi;
 

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -82,7 +82,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signup_verified',
         'oauth/signup',
       ]),
-      fullProdRollout: false,
+      fullProdRollout: true,
     },
 
     pairRoutes: {

--- a/packages/fxa-content-server/server/templates/pages/src/404.html
+++ b/packages/fxa-content-server/server/templates/pages/src/404.html
@@ -41,7 +41,7 @@
         </p>
 
         <div class="button-row">
-          <a href="/signup" class="button primary-button" id="fxa-404-home"
+          <a href="/" class="button primary-button" id="fxa-404-home"
             >{{#t}}Home{{/t}}</a
           >
         </div>

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -85,7 +85,7 @@ export const FormPasswordWithBalloons = ({
     useState<boolean>(false);
   const [isConfirmPwdBalloonVisible, setIsConfirmPwdBalloonVisible] =
     useState<boolean>(false);
-  const [hasEditedConfirmPwd, setHasEditedConfirmPwd] =
+  const [hasBlurredConfirmPwd, setHasBlurredConfirmPwd] =
     useState<boolean>(false);
 
   const ftlMsgResolver = useFtlMsgResolver();
@@ -150,20 +150,24 @@ export const FormPasswordWithBalloons = ({
   };
 
   const onNewPwdBlur = () => {
-    !hasUserTakenAction && setHasUserTakenAction(true);
     // do not hide the password strength balloon if there are errors in the new password
     if (getValues('newPassword') !== '' && !errors.newPassword) {
       hideNewPwdBalloon();
     }
-    if (getValues('confirmPassword') !== getValues('newPassword')) {
+    if (
+      hasBlurredConfirmPwd &&
+      getValues('confirmPassword') !== getValues('newPassword')
+    ) {
       setPasswordMatchErrorText(localizedPasswordMatchError);
-    } else if (!formState.isValid) {
-      // Try to retrigger
+    }
+
+    if (!formState.isValid) {
       trigger('confirmPassword');
     }
   };
 
   const onBlurConfirmPassword = useCallback(() => {
+    setHasBlurredConfirmPwd(true);
     passwordFormType === 'signup' &&
       isConfirmPwdBalloonVisible &&
       hideConfirmPwdBalloon();
@@ -183,12 +187,14 @@ export const FormPasswordWithBalloons = ({
     formState,
     trigger,
   ]);
+
   const onChangePassword = (inputName: string) => {
-    if (inputName === 'confirmPassword') {
-      setHasEditedConfirmPwd(true);
+    if (inputName === 'newPassword') {
+      !hasUserTakenAction && setHasUserTakenAction(true);
+      trigger('newPassword');
     }
 
-    if (!hasEditedConfirmPwd) {
+    if (!hasBlurredConfirmPwd) {
       return;
     }
 

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -160,18 +160,6 @@ describe('Signup page', () => {
     expect(newPasswordInput).toHaveAttribute('type', 'password');
   });
 
-  it('does not allow the user to change their email with oauth integration', async () => {
-    renderWithLocalizationProvider(
-      <Subject integration={createMockSignupOAuthIntegration()} />
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('link', { name: 'Change email' })
-      ).not.toBeInTheDocument();
-    });
-  });
-
   it('shows an info banner and Pocket-specific TOS when client is Pocket', async () => {
     renderWithLocalizationProvider(
       <Subject

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -64,7 +64,6 @@ export const Signup = ({
   }, []);
 
   const isSync = integration.isSync();
-  const canChangeEmail = !isOAuthIntegration(integration);
   const email = queryParamModel.email;
 
   const onFocusMetricsEvent = () => {
@@ -345,31 +344,29 @@ export const Signup = ({
       <div className="mt-4 mb-6">
         <p className="break-all">{email}</p>
 
-        {canChangeEmail && (
-          <FtlMsg id="signup-change-email-link">
-            {/* TODO: Replace this with `Link` once index page is Reactified */}
-            <a
-              href="/"
-              className="link-blue text-sm"
-              onClick={(e) => {
-                e.preventDefault();
-                const params = new URLSearchParams(location.search);
-                // Tell content-server to stay on index and prefill the email
-                params.set('prefillEmail', email);
-                // Passing back the 'email' param causes various behaviors in
-                // content-server since it marks the email as "coming from a RP".
-                // Also remove `emailFromContent` since we pass that when coming
-                // from content-server to Backbone, see Signup container component
-                // for more info.
-                params.delete('emailFromContent');
-                params.delete('email');
-                hardNavigateToContentServer(`/?${params.toString()}`);
-              }}
-            >
-              Change email
-            </a>
-          </FtlMsg>
-        )}
+        <FtlMsg id="signup-change-email-link">
+          {/* TODO: Replace this with `Link` once index page is Reactified */}
+          <a
+            href="/"
+            className="link-blue text-sm"
+            onClick={(e) => {
+              e.preventDefault();
+              const params = new URLSearchParams(location.search);
+              // Tell content-server to stay on index and prefill the email
+              params.set('prefillEmail', email);
+              // Passing back the 'email' param causes various behaviors in
+              // content-server since it marks the email as "coming from a RP".
+              // Also remove `emailFromContent` since we pass that when coming
+              // from content-server to Backbone, see Signup container component
+              // for more info.
+              params.delete('emailFromContent');
+              params.delete('email');
+              hardNavigateToContentServer(`/?${params.toString()}`);
+            }}
+          >
+            Change email
+          </a>
+        </FtlMsg>
       </div>
 
       <FormPasswordWithBalloons


### PR DESCRIPTION
## Because

* We are flipping the switch to 100% react signup

## This pull request

* Set fullProdRollout for react signUpRoutes to true
* Update functional-tests - skip backbone specific signup tests if showReactApp set to true for signUpRoutes
* Update other tests that are failing with the rollout
* Fixes a "passwords do not match" error causing issues in tests

## Issue that this pull request solves

Closes: #FXA-8927, fixes #FXA-8882

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
