### PR TITLE
chore(react): Port over some missing pieces of signup functional tests

### DIFF
--- a/packages/functional-tests/lib/query-params.ts
+++ b/packages/functional-tests/lib/query-params.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // This file contains query params that don't reflect states that can be reached from 123done.
+import uaStrings from './ua-strings';
 
 export const syncMobileOAuthQueryParams = new URLSearchParams({
   client_id: '1b1a3e44c54fbb58', // Firefox for iOS
@@ -16,4 +17,12 @@ export const syncMobileOAuthQueryParams = new URLSearchParams({
   state: 'fakestate',
   context: 'oauth_webchannel_v1',
   automatedBrowser: 'true',
+});
+
+export const syncDesktopV3QueryParams = new URLSearchParams({
+  context: 'fx_desktop_v3',
+  service: 'sync',
+  action: 'email',
+  automatedBrowser: 'true',
+  forceUA: uaStrings['desktop_firefox_79'],
 });

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -201,6 +201,33 @@ export class Firefox extends EventTarget {
     return JSON.stringify(detail);
   }
 
+  /**
+   * Save the name of the event into sessionStorage, used for testing.
+   *
+   * @param {String} command
+   * @private
+   */
+  private saveEventForTests(command: FirefoxCommand, data: any) {
+    const agent = navigator.userAgent;
+    const isWebDriver = navigator.webdriver;
+    if (!isWebDriver && agent.indexOf('FxATester') === -1) {
+      // not running in automated tests, no reason to store this info.
+      return;
+    }
+
+    let storedEvents;
+    try {
+      storedEvents =
+        JSON.parse(sessionStorage.getItem('webChannelEvents') || '') || [];
+    } catch (e) {
+      storedEvents = [];
+    }
+    storedEvents.push({ command, data });
+    try {
+      sessionStorage.setItem('webChannelEvents', JSON.stringify(storedEvents));
+    } catch (e) {}
+  }
+
   // send a message to the browser chrome
   send(command: FirefoxCommand, data: any, messageId?: string) {
     const detail = this.formatEventDetail(command, data, messageId);
@@ -209,6 +236,7 @@ export class Firefox extends EventTarget {
         detail,
       })
     );
+    this.saveEventForTests(command, data);
   }
 
   // broadcast a message to other tabs


### PR DESCRIPTION
Because:
* We want to transfer relevant tests to React signup

This commit:
* Adds a couple missing web channel message checks in our React signup tests, ports content-server's saveEventForTests
* Changes the desktop v3 UA to our likely min supported version, tests for web channel events sent by the browser instead of sending a custom list since we respond to the first event received, which the browser sends automatically
* Adjusts oauth web channel to waitForURL before checking for the web channel event

fixes FXA-8854

---

Note the ticket calls out [this test file](https://github.com/mozilla/fxa/blob/main/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts), but this is actually the CWTS page seen _after_ Signup, which we only display in FF 58 and below. We previously said we don't want to create this page in React, and in Slack, we're discussing only supporting FF 79+. I transferred over relevant pieces of tests seen in that file.