### PR TITLE
fix(next): error on page refresh

### DIFF
--- a/libs/shared/l10n/src/lib/l10n.ts
+++ b/libs/shared/l10n/src/lib/l10n.ts
@@ -88,7 +88,7 @@ export async function getBundle(languages: string[] | undefined) {
 }
 
 // Temporary
-export async function getFormattedMsg(
+export function getFormattedMsg(
   l10n: FluentBundle,
   msgId: string,
   fallback: string,


### PR DESCRIPTION
## Because

- Async function in render logic caused hydration error on page refresh

## This pull request

- Remove async from `getFormatedMsg` wrapper function

## Issue that this pull request solves

Closes: #FXA-8852

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).