### PR TITLE
feat(cloud tasks): handle account delete cloud task

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -172,7 +172,6 @@ async function run(config) {
   const accountDeleteManager = new AccountDeleteManager({
     fxaDb: database,
     oauthDb,
-    push,
     pushbox,
     statsd,
   });

--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -11,24 +11,17 @@ import { AppleIAP } from './payments/iap/apple-app-store/apple-iap';
 import { PlayBilling } from './payments/iap/google-play/play-billing';
 import { PayPalHelper } from './payments/paypal/helper';
 import { StripeHelper } from './payments/stripe';
-
 import pushboxApi from './pushbox';
 import { accountDeleteCloudTaskPath } from './routes/cloud-tasks';
 import { AccountDeleteReasons, AppConfig, AuthLogger } from './types';
-/*
-import {
-  uid as uidValidator,
-  customerId as customerIdValidator,
-} from './routes/validators';
-//*/
 
 import {
   deleteAllPayPalBAs,
   getAllPayPalBAByUid,
-  Account,
 } from 'fxa-shared/db/models/auth';
 import { ConfigType } from '../config';
 import * as Sentry from '@sentry/node';
+import { StripeFirestoreMultiError } from './payments/stripe-firestore';
 
 type FxaDbDeleteAccount = Pick<
   Awaited<ReturnType<ReturnType<typeof DB>['connect']>>,
@@ -40,7 +33,9 @@ type PushboxDeleteAccount = Pick<
   'deleteAccount'
 >;
 
-export type ReasonForDeletion = typeof AccountDeleteReasons[number];
+export type ReasonForDeletion = (typeof AccountDeleteReasons)[number];
+export type AccountDeleteOptions = { notify?: () => Promise<void> };
+
 type DeleteTask = {
   uid: string;
   customerId?: string;
@@ -54,17 +49,6 @@ type EnqueueByEmailParam = {
   email: string;
   reason: ReasonForDeletion;
 };
-
-/*
-const isValidDeleteTask = (deleteTask: DeleteTask) => {
-  const uidValidationResult = uidValidator.validate(deleteTask.uid);
-  const customerIdValidationResult = customerIdValidator.validate(
-    deleteTask.customerId
-  );
-
-  return !uidValidationResult.error && !customerIdValidationResult.error;
-};
-//*/
 
 const isEnqueueByUidParam = (
   x: EnqueueByUidParam | EnqueueByEmailParam
@@ -197,21 +181,23 @@ export class AccountDeleteManager {
    * Delete the account from the FxA database, OAuth database, pushbox database, and
    * cancel any active subscriptions.
    *
-   * @param uid
+   * @param uid string
+   * @param options AccountDeleteOptions optional object with an optional `notify` function that will be called after the account's removed from MySQL.
    */
-  public async deleteAccount(uid: string) {
-    const accountRecord = await this.fxaDb.account(uid);
+  public async deleteAccount(uid: string, options?: AccountDeleteOptions) {
+    await this.deleteAccountFromDb(uid, options);
+    await this.deleteOAuthTokens(uid);
+    // see comment in the function on why we are not awaiting
+    this.deletePushboxRecords(uid);
 
-    await this.deleteSubscriptions(accountRecord);
+    await this.deleteSubscriptions(uid);
+    await this.deleteFirestoreCustomer(uid);
+  }
 
-    await this.deleteAccountDb(accountRecord);
-    this.log.info('accountDeleted.byRequest', accountRecord);
-
-    await this.deleteOAuthDb(accountRecord);
-
-    await this.deletePushboxRecord(accountRecord);
-
-    // TODO: Update to send notification to all devices
+  public async cleanupAccount(uid: string) {
+    await this.deleteSubscriptions(uid);
+    await this.deleteFirestoreCustomer(uid);
+    await this.deleteOAuthTokens(uid);
   }
 
   /**
@@ -219,8 +205,14 @@ export class AccountDeleteManager {
    *
    * @param accountRecord
    */
-  public async deleteAccountDb(accountRecord: Account) {
-    await this.fxaDb.deleteAccount(accountRecord);
+  public async deleteAccountFromDb(
+    uid: string,
+    options?: AccountDeleteOptions
+  ) {
+    await this.fxaDb.deleteAccount({ uid });
+    if (options?.notify) {
+      await options.notify();
+    }
   }
 
   /**
@@ -229,8 +221,8 @@ export class AccountDeleteManager {
    *
    * @param accountRecord
    */
-  public async deleteOAuthDb(accountRecord: Account) {
-    await this.oauthDb.removeTokensAndCodes(accountRecord.uid);
+  public async deleteOAuthTokens(uid: string) {
+    await this.oauthDb.removeTokensAndCodes(uid);
   }
 
   /**
@@ -238,8 +230,7 @@ export class AccountDeleteManager {
    *
    * @param accountRecord
    */
-  public async deletePushboxRecord(accountRecord: Account) {
-    const { uid } = accountRecord;
+  public async deletePushboxRecords(uid: string) {
     // No need to await and block the other notifications. The pushbox records
     // will be deleted once they expire even if they were not successfully
     // deleted here.
@@ -257,12 +248,10 @@ export class AccountDeleteManager {
    *
    * @param accountRecord
    */
-  public async deleteSubscriptions(accountRecord: Account) {
-    const { uid, email } = accountRecord;
-
+  public async deleteSubscriptions(uid: string) {
     if (this.config.subscriptions?.enabled && this.stripeHelper) {
       try {
-        await this.stripeHelper.removeCustomer(uid, email);
+        await this.stripeHelper.removeCustomer(uid);
       } catch (err) {
         if (err.message === 'Customer not available') {
           // if Stripe didn't know about the customer, no problem.
@@ -297,6 +286,18 @@ export class AccountDeleteManager {
     try {
       return await this.stripeHelper?.removeFirestoreCustomer(uid);
     } catch (error) {
+      // check for an instance of an error where the firestore service version
+      // does not support `BatchWrite`
+      if (error instanceof StripeFirestoreMultiError) {
+        const originalError = error.getPrimaryError().cause();
+        if (
+          originalError?.stack?.includes(
+            'UNIMPLEMENTED: Method google.firestore.v1.Firestore/BatchWrite is unimplemented'
+          )
+        ) {
+          return;
+        }
+      }
       this.log.error('AccountDeleteManager.deleteFirestoreCustomer', {
         uid,
         error,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1722,7 +1722,7 @@ export class StripeHelper extends StripeHelperBase {
    * - delete the stripe customer to delete
    * - remove the cache entry
    */
-  async removeCustomer(uid: string, email: string) {
+  async removeCustomer(uid: string) {
     const accountCustomer = await getAccountCustomerByUid(uid);
     if (accountCustomer && accountCustomer.stripeCustomerId) {
       const customer = await this.fetchCustomer(accountCustomer.uid, [

--- a/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
@@ -3,33 +3,106 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import isA from 'joi';
+import { Container } from 'typedi';
 import { ConfigType } from '../../config';
 import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-import { ReasonForDeletion } from '../account-delete';
-import { AuthRequest } from '../types';
+import { AccountDeleteManager, ReasonForDeletion } from '../account-delete';
+import DB from '../db/index';
+import { AuthLogger, AuthRequest } from '../types';
 import validators from './validators';
+import { ERRNO } from '../error';
+import pushBuilder from '../push';
 
 export type DeleteAccountTaskPayload = {
   uid: string;
   customerId?: string;
   reason: ReasonForDeletion;
 };
+type FxaDbForCloudTask = Pick<
+  Awaited<ReturnType<ReturnType<typeof DB>['connect']>>,
+  'account' | 'devices'
+>;
+type PushForCloudTask = Pick<
+  ReturnType<typeof pushBuilder>,
+  'notifyAccountDestroyed'
+>;
+type Log = AuthLogger & { activityEvent: (data: Record<string, any>) => void };
 
 export class CloudTaskHandler {
-  private config: ConfigType;
+  private log: Log;
+  private db: FxaDbForCloudTask;
+  private push: PushForCloudTask;
+  private accountDeleteManager: AccountDeleteManager;
 
-  constructor(config: ConfigType) {
-    this.config = config;
+  constructor({
+    log,
+    db,
+    push,
+  }: {
+    log: Log;
+    db: FxaDbForCloudTask;
+    push: PushForCloudTask;
+  }) {
+    this.log = log;
+    this.db = db;
+    this.push = push;
+
+    this.accountDeleteManager = Container.get(AccountDeleteManager);
   }
 
-  deleteAccount(taskPayload: DeleteAccountTaskPayload) {
+  async deleteAccount(taskPayload: DeleteAccountTaskPayload) {
+    try {
+      // get account from MySQL
+      const account = await this.db.account(taskPayload.uid);
+
+      // We fetch the devices to notify before deleteAccount()
+      // because obviously we can't retrieve the devices list after!
+      const devices = await this.db.devices(taskPayload.uid);
+      const push = this.push;
+      const log = this.log;
+
+      const notify = async () => {
+        try {
+          log.info('accountDeleted.byCloudTask', account);
+          await push.notifyAccountDestroyed(taskPayload.uid, devices);
+          await log.notifyAttachedServices('delete', {} as AuthRequest, {
+            uid: taskPayload.uid,
+          });
+          // because a cloud task request is very different from a user request
+          // we cannot emit metrics in the same fashion
+          log.activityEvent({ uid: account.uid, event: 'account.deleted' });
+        } catch (error) {
+          log.error('CloudTask.accountDelete.notify', {
+            uid: taskPayload.uid,
+            error,
+          });
+        }
+      };
+      // the account still exists in MySQL, delete as usual
+      await this.accountDeleteManager.deleteAccount(taskPayload.uid, {
+        notify,
+      });
+    } catch (err) {
+      // if the account is already deleted from the db, then try to clean up
+      // some potentially remaining other records
+      if (err.errno === ERRNO.ACCOUNT_UNKNOWN) {
+        await this.accountDeleteManager.cleanupAccount(taskPayload.uid);
+      } else {
+        throw err;
+      }
+    }
     return {};
   }
 }
 export const accountDeleteCloudTaskPath = '/cloud-tasks/accounts/delete';
 
-export const cloudTaskRoutes = (config: ConfigType) => {
-  const cloudTaskHandler = new CloudTaskHandler(config);
+export const cloudTaskRoutes = (
+  log: Log,
+  db: FxaDbForCloudTask,
+  config: ConfigType,
+  push: PushForCloudTask
+) => {
+  const cloudTaskHandler = new CloudTaskHandler({ log, db, push });
   const routes = [
     {
       method: 'POST',
@@ -65,3 +138,5 @@ export const cloudTaskRoutes = (config: ConfigType) => {
 
   return routes;
 };
+
+export default cloudTaskRoutes;

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -194,7 +194,7 @@ module.exports = function (
   );
 
   const { cloudTaskRoutes } = require('./cloud-tasks');
-  const cloudTasks = cloudTaskRoutes(config);
+  const cloudTasks = cloudTaskRoutes(log, db, config, push);
 
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {

--- a/packages/fxa-auth-server/lib/routes/utils/account.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.ts
@@ -26,10 +26,7 @@ export const deleteAccountIfUnverified = async (
       // If an unverified (stub) account has a Stripe customer without any
       // subscriptions, delete the customer.
       try {
-        await stripeHelper.removeCustomer(
-          secondaryEmailRecord.uid,
-          secondaryEmailRecord.email
-        );
+        await stripeHelper.removeCustomer(secondaryEmailRecord.uid);
       } catch (err) {
         // It's not an error where we'd want to stop the deletion of the
         // account.

--- a/packages/fxa-auth-server/scripts/refund-unverified-accounts.ts
+++ b/packages/fxa-auth-server/scripts/refund-unverified-accounts.ts
@@ -215,7 +215,7 @@ export async function cancelSubscriptionsAndDeleteCustomer(
   await stripeHelper.cancelSubscription(subscriptionId);
 
   // Remove the customer from stripe
-  await stripeHelper.removeCustomer(uid, email);
+  await stripeHelper.removeCustomer(uid);
 }
 
 async function mergeAccountData(database: any, subscription: SubscriptionData) {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -652,8 +652,7 @@ describe('deleteAccountIfUnverified', () => {
     );
     sinon.assert.calledOnceWithExactly(
       mockStripeHelper.removeCustomer,
-      emailRecord.uid,
-      emailRecord.email
+      emailRecord.uid
     );
   });
   it('should report to Sentry when a Stripe customer deletion fails', async () => {
@@ -674,8 +673,7 @@ describe('deleteAccountIfUnverified', () => {
       );
       sinon.assert.calledOnceWithExactly(
         mockStripeHelper.removeCustomer,
-        emailRecord.uid,
-        emailRecord.email
+        emailRecord.uid
       );
       sinon.assert.calledOnceWithExactly(
         sentryModule.reportSentryError,
@@ -3800,10 +3798,14 @@ describe('/account/destroy', () => {
       },
     });
     mockPush = mocks.mockPush();
-    mockStripeHelper = mocks.mockStripeHelper(['removeCustomer']);
+    mockStripeHelper = mocks.mockStripeHelper([
+      'removeCustomer',
+      'removeFirestoreCustomer',
+    ]);
     mockStripeHelper.removeCustomer = sinon.spy(async (uid, email) => {
       return;
     });
+    mockStripeHelper.removeFirestoreCustomer = sinon.stub().resolves();
     mockPaypalHelper = mocks.mockPayPalHelper(['cancelBillingAgreement']);
     mockPaypalHelper.cancelBillingAgreement = sinon.spy(async (ba) => {
       return;
@@ -3853,7 +3855,6 @@ describe('/account/destroy', () => {
       sinon.assert.calledOnceWithExactly(mockDB.accountRecord, email);
       sinon.assert.calledWithMatch(mockDB.deleteAccount, {
         uid,
-        email,
       });
       sinon.assert.callCount(mockStripeHelper.removeCustomer, 1);
       sinon.assert.calledWithMatch(mockStripeHelper.removeCustomer, uid);
@@ -3903,7 +3904,6 @@ describe('/account/destroy', () => {
       sinon.assert.calledOnceWithExactly(mockDB.accountRecord, email);
       sinon.assert.calledWithMatch(mockDB.deleteAccount, {
         uid,
-        email,
       });
     });
   });
@@ -4004,6 +4004,7 @@ describe('/account', () => {
     mockStripeHelper = mocks.mockStripeHelper([
       'fetchCustomer',
       'subscriptionsToResponse',
+      'removeFirestoreCustomer',
     ]);
     mockStripeHelper.fetchCustomer = sinon.spy(
       async (uid, email) => mockCustomer
@@ -4011,6 +4012,7 @@ describe('/account', () => {
     mockStripeHelper.subscriptionsToResponse = sinon.spy(
       async (subscriptions) => mockWebSubscriptionsResponse
     );
+    mockStripeHelper.removeFirestoreCustomer = sinon.stub().resolves();
     Container.set(CapabilityService, sinon.fake);
   });
 

--- a/packages/fxa-auth-server/test/local/routes/cloud-tasks.js
+++ b/packages/fxa-auth-server/test/local/routes/cloud-tasks.js
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { Container } = require('typedi');
+const { assert } = require('chai');
+const sinon = require('sinon');
+const mocks = require('../../mocks');
+const getRoute = require('../../routes_helpers').getRoute;
+const { cloudTaskRoutes } = require('../../../lib/routes/cloud-tasks');
+const { AccountDeleteManager } = require('../../../lib/account-delete');
+const error = require('../../../lib/error');
+
+const mockConfig = {
+  cloudTasks: {
+    deleteAccounts: { queueName: 'del-accts' },
+  },
+};
+
+const sandbox = sinon.createSandbox();
+
+describe('/cloud-tasks/accounts/delete', () => {
+  const uid = '0f0f0f9001';
+  let mockLog;
+  let mockDb;
+  let mockPush;
+  let route, routes;
+  let deleteAccountStub;
+  let cleanupAccountStub;
+
+  beforeEach(() => {
+    mockLog = mocks.mockLog();
+    mockDb = mocks.mockDB();
+    mockPush = mocks.mockPush();
+    sandbox.reset();
+
+    deleteAccountStub = sandbox.stub().callsFake((uid, { notify }) => {
+      notify();
+    });
+    cleanupAccountStub = sandbox.stub().resolves();
+    Container.set(AccountDeleteManager, {
+      deleteAccount: deleteAccountStub,
+      cleanupAccount: cleanupAccountStub,
+    });
+
+    routes = cloudTaskRoutes(mockLog, mockDb, mockConfig, mockPush);
+    route = getRoute(routes, '/cloud-tasks/accounts/delete');
+  });
+
+  it('should delete the account', async () => {
+    try {
+      const devices = [{ x: 'yz' }];
+      const account = { uid };
+      mockDb.account = sandbox.stub().resolves(account);
+      mockDb.devices = sandbox.stub().resolves(devices);
+
+      const req = {
+        payload: { uid },
+      };
+
+      await route.handler(req);
+
+      sinon.assert.calledOnceWithExactly(mockDb.account, uid);
+      sinon.assert.calledOnceWithExactly(mockDb.devices, uid);
+      sinon.assert.calledOnce(deleteAccountStub);
+      sinon.assert.notCalled(cleanupAccountStub);
+      assert.equal(deleteAccountStub.args[0][0], uid);
+      sinon.assert.calledOnceWithExactly(
+        mockLog.info,
+        'accountDeleted.byCloudTask',
+        account
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockPush.notifyAccountDestroyed,
+        uid,
+        devices
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockLog.notifyAttachedServices,
+        'delete',
+        {},
+        { uid }
+      );
+      sinon.assert.calledOnceWithExactly(mockLog.activityEvent, {
+        uid,
+        event: 'account.deleted',
+      });
+    } catch (err) {
+      assert.fail('An error should not have been thrown.');
+    }
+  });
+
+  it('should clean up the account data', async () => {
+    try {
+      mockDb.account = sandbox.stub().rejects(error.unknownAccount());
+      const req = {
+        payload: { uid },
+      };
+
+      await route.handler(req);
+      sinon.assert.calledOnceWithExactly(mockDb.account, uid);
+      sinon.assert.calledOnce(cleanupAccountStub);
+      sinon.assert.notCalled(deleteAccountStub);
+    } catch (err) {
+      assert.fail('An error should not have been thrown.');
+    }
+  });
+});


### PR DESCRIPTION
Because:
 - we need to handle the account deletion cloud tasks

This commit:
 - implements a route handler that
   - performs a full account delete if the account is found in the fxa relational database
   - performs a data "cleanup" if the account is not found in the db
