### PR TITLE
task(react): Setup report_signin in React

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -326,7 +326,11 @@ Router = Router.extend({
         }
       );
     },
-    'report_signin(/)': createViewHandler(ReportSignInView),
+    'report_signin(/)': function () {
+      this.createReactOrBackboneViewHandler('report_signin', ReportSignInView, {
+        ...Url.searchParams(this.window.location.search),
+      });
+    },
 
     'reset_password(/)': function () {
       this.createReactOrBackboneViewHandler(

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -67,6 +67,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signin_confirmed',
         'signin_verified',
         'signin_bounced',
+        'report_signin',
       ]),
       fullProdRollout: false,
     },

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -4,10 +4,15 @@
 
 import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps, Router, useLocation } from '@reach/router';
-import { ScrollToTop } from '../Settings/ScrollToTop';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+
+import { QueryParams } from '../..';
 
 import { currentAccount, sessionToken } from '../../lib/cache';
+import { firefox } from '../../lib/channels/firefox';
+import GleanMetrics from '../../lib/glean';
+import * as Metrics from '../../lib/metrics';
+import { LinkType, MozServices } from '../../lib/types';
+
 import {
   Integration,
   isWebIntegration,
@@ -16,48 +21,46 @@ import {
   useIntegration,
   useLocalSignedInQueryState,
 } from '../../models';
-import * as Metrics from '../../lib/metrics';
-
-import sentryMetrics from 'fxa-shared/sentry/browser';
-import CannotCreateAccount from '../../pages/CannotCreateAccount';
-import Clear from '../../pages/Clear';
-import CookiesDisabled from '../../pages/CookiesDisabled';
-import ResetPassword from '../../pages/ResetPassword';
-import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
-
-import ResetPasswordWithRecoveryKeyVerified from '../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified';
-import Legal from '../../pages/Legal';
-import LegalTerms from '../../pages/Legal/Terms';
-import LegalPrivacy from '../../pages/Legal/Privacy';
-
-import PrimaryEmailVerified from '../../pages/Signup/PrimaryEmailVerified';
-
-import ResetPasswordConfirmed from '../../pages/ResetPassword/ResetPasswordConfirmed';
-import AccountRecoveryConfirmKey from '../../pages/ResetPassword/AccountRecoveryConfirmKey';
-
-import ConfirmSignupCodeContainer from '../../pages/Signup/ConfirmSignupCode/container';
-import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
-
-import SigninConfirmed from '../../pages/Signin/SigninConfirmed';
-import SigninReported from '../../pages/Signin/SigninReported';
-import SigninBounced from '../../pages/Signin/SigninBounced';
-import LinkValidator from '../LinkValidator';
-import { LinkType, MozServices } from 'fxa-settings/src/lib/types';
-import Confirm from 'fxa-settings/src/pages/Signup/Confirm';
-import WebChannelExample from '../../pages/WebChannelExample';
-import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
-import ThirdPartyAuthCallback from '../../pages/PostVerify/ThirdPartyAuthCallback';
 import {
   SettingsContext,
   initializeSettingsContext,
 } from '../../models/contexts/SettingsContext';
-import CompleteResetPasswordContainer from '../../pages/ResetPassword/CompleteResetPassword/container';
-import AccountRecoveryResetPasswordContainer from '../../pages/ResetPassword/AccountRecoveryResetPassword/container';
-import { QueryParams } from '../..';
-import SignupContainer from '../../pages/Signup/container';
-import GleanMetrics from '../../lib/glean';
+import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
+
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
-import { firefox } from '../../lib/channels/firefox';
+
+import sentryMetrics from 'fxa-shared/sentry/browser';
+
+// Components
+import { ScrollToTop } from '../Settings/ScrollToTop';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+
+// Pages
+import AccountRecoveryConfirmKey from '../../pages/ResetPassword/AccountRecoveryConfirmKey';
+import AccountRecoveryResetPasswordContainer from '../../pages/ResetPassword/AccountRecoveryResetPassword/container';
+import CannotCreateAccount from '../../pages/CannotCreateAccount';
+import Clear from '../../pages/Clear';
+import CookiesDisabled from '../../pages/CookiesDisabled';
+import CompleteResetPasswordContainer from '../../pages/ResetPassword/CompleteResetPassword/container';
+import Confirm from 'fxa-settings/src/pages/Signup/Confirm';
+import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
+import ConfirmSignupCodeContainer from '../../pages/Signup/ConfirmSignupCode/container';
+import Legal from '../../pages/Legal';
+import LegalTerms from '../../pages/Legal/Terms';
+import LegalPrivacy from '../../pages/Legal/Privacy';
+import LinkValidator from '../LinkValidator';
+import PrimaryEmailVerified from '../../pages/Signup/PrimaryEmailVerified';
+import ReportSigninContainer from '../../pages/Signin/ReportSignin/container';
+import ResetPassword from '../../pages/ResetPassword';
+import ResetPasswordConfirmed from '../../pages/ResetPassword/ResetPasswordConfirmed';
+import ResetPasswordWithRecoveryKeyVerified from '../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified';
+import SigninBounced from '../../pages/Signin/SigninBounced';
+import SigninConfirmed from '../../pages/Signin/SigninConfirmed';
+import SigninReported from '../../pages/Signin/SigninReported';
+import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
+import SignupContainer from '../../pages/Signup/container';
+import ThirdPartyAuthCallback from '../../pages/PostVerify/ThirdPartyAuthCallback';
+import WebChannelExample from '../../pages/WebChannelExample';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -287,6 +290,7 @@ const AuthAndAccountSetupRoutes = ({
       />
 
       {/* Signin */}
+      <ReportSigninContainer path="/report_signin/*" />
       <SigninBounced email={localAccount?.email} path="/signin_bounced/*" />
       <SigninConfirmed
         path="/signin_confirmed/*"

--- a/packages/fxa-settings/src/components/LinkDamaged/en.ftl
+++ b/packages/fxa-settings/src/components/LinkDamaged/en.ftl
@@ -8,5 +8,9 @@ reset-pwd-link-damaged-header = Reset password link damaged
 # but the link was damaged (for example mistyped or broken by the email client).
 signin-link-damaged-header = Confirmation link damaged
 
-# The user followed a password reset or confirmation link received by email, but the link was damaged.
+# The user followed a link to report an invalid signin attempt that was received by email
+# but the link was damaged (for example mistyped or broken by the email client).
+report-signin-link-damaged-header = Link damaged
+
+# The user followed a link received by email, but the link was damaged.
 reset-pwd-link-damaged-message = The link you clicked was missing characters, and may have been broken by your email client. Copy the address carefully, and try again.

--- a/packages/fxa-settings/src/components/LinkDamaged/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.stories.tsx
@@ -4,7 +4,11 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { ResetPasswordLinkDamaged, SigninLinkDamaged } from '.';
+import {
+  ReportSigninLinkDamaged,
+  ResetPasswordLinkDamaged,
+  SigninLinkDamaged,
+} from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 
 export default {
@@ -16,3 +20,5 @@ export default {
 export const DamagedResetPasswordLink = () => <ResetPasswordLinkDamaged />;
 
 export const DamagedSigninLink = () => <SigninLinkDamaged />;
+
+export const DamagedReportSigninLink = () => <ReportSigninLinkDamaged />;

--- a/packages/fxa-settings/src/components/LinkDamaged/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.test.tsx
@@ -5,7 +5,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import { ResetPasswordLinkDamaged, SigninLinkDamaged } from '.';
+import {
+  ReportSigninLinkDamaged,
+  ResetPasswordLinkDamaged,
+  SigninLinkDamaged,
+} from '.';
 
 describe('LinkDamaged', () => {
   it('renders the component as expected for a damaged Reset Password link', () => {
@@ -24,6 +28,17 @@ describe('LinkDamaged', () => {
 
     screen.getByRole('heading', {
       name: 'Confirmation link damaged',
+    });
+    screen.getByText(
+      'The link you clicked was missing characters, and may have been broken by your email client. Copy the address carefully, and try again.'
+    );
+  });
+
+  it('renders the component as expected for a damaged report signin link', () => {
+    renderWithLocalizationProvider(<ReportSigninLinkDamaged />);
+
+    screen.getByRole('heading', {
+      name: 'Link damaged',
     });
     screen.getByText(
       'The link you clicked was missing characters, and may have been broken by your email client. Copy the address carefully, and try again.'

--- a/packages/fxa-settings/src/components/LinkDamaged/index.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.tsx
@@ -45,3 +45,12 @@ export const SigninLinkDamaged = () => {
     />
   );
 };
+
+export const ReportSigninLinkDamaged = () => {
+  return (
+    <LinkDamaged
+      headingText="Link damaged"
+      headingTextFtlId="report-signin-link-damaged-header"
+    />
+  );
+};

--- a/packages/fxa-settings/src/models/pages/signin/index.ts
+++ b/packages/fxa-settings/src/models/pages/signin/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './report-signin-query-params';

--- a/packages/fxa-settings/src/models/pages/signin/report-signin-query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signin/report-signin-query-params.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsHexadecimal, IsString, Length } from 'class-validator';
+import { bind, ModelDataProvider } from '../../../lib/model-data';
+
+export class ReportSigninQueryParams extends ModelDataProvider {
+  @IsHexadecimal()
+  @Length(32)
+  @bind()
+  uid: string = '';
+
+  @IsString()
+  @Length(8)
+  @bind()
+  unblockCode: string = '';
+}

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * TIP - See signup/container.test.tsx for helpful tips about writing container tests
+ */
+
+import React from 'react';
+import * as ReportSigninModule from './index';
+import * as LinkDamagedModule from '../../../components/LinkDamaged';
+import * as UseValidateModule from '../../../lib/hooks/useValidate';
+import * as ModelsModule from '../../../models';
+
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { screen, waitFor } from '@testing-library/react';
+import ReportSigninContainer from './container';
+import { ModelDataProvider } from '../../../lib/model-data';
+import AuthClient from 'fxa-auth-client/browser';
+import { MOCK_UID, MOCK_UNBLOCK_CODE } from '../../mocks';
+import { ReportSigninProps } from './interfaces';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+
+let currentReportSigninProps: ReportSigninProps | undefined;
+function mockReportSigninModule() {
+  currentReportSigninProps = undefined;
+  jest
+    .spyOn(ReportSigninModule, 'ReportSignin')
+    .mockImplementation((props: ReportSigninProps) => {
+      currentReportSigninProps = props;
+      return <div>report signin mock</div>;
+    });
+}
+
+function mockDamagedLinkModule() {
+  jest
+    .spyOn(LinkDamagedModule, 'ReportSigninLinkDamaged')
+    .mockImplementation(() => {
+      return <div>link damaged mock</div>;
+    });
+}
+
+function mockUseValidateModule() {
+  jest.spyOn(UseValidateModule, 'useValidatedQueryParams').mockReturnValue({
+    queryParamModel: {
+      uid: MOCK_UID,
+      unblockCode: MOCK_UNBLOCK_CODE,
+    } as unknown as ModelDataProvider,
+    validationError: undefined,
+  });
+}
+
+const mockNavigate = jest.fn();
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../models', () => {
+  return {
+    ...jest.requireActual('../../../models'),
+    useAuthClient: jest.fn(),
+  };
+});
+
+let mockAuthClient: AuthClient;
+function mockModelsModule() {
+  mockAuthClient = new AuthClient('localhost:9000');
+  mockAuthClient.rejectUnblockCode = jest.fn().mockResolvedValue({});
+  (ModelsModule.useAuthClient as jest.Mock).mockImplementation(
+    () => mockAuthClient
+  );
+}
+
+function applyMocks() {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+
+  // Run default mocks
+  mockReportSigninModule();
+  mockDamagedLinkModule();
+  mockModelsModule();
+  mockUseValidateModule();
+}
+
+async function render(text?: string) {
+  renderWithLocalizationProvider(<ReportSigninContainer />);
+
+  await screen.findByText(text || 'report signin mock');
+}
+
+describe('report-signin-container', () => {
+  beforeEach(() => {
+    applyMocks();
+  });
+
+  describe('default-state', () => {
+    it('renders', async () => {
+      await render();
+      expect(ReportSigninModule.ReportSignin).toBeCalled();
+    });
+  });
+
+  describe('error-states', () => {
+    it('handles invalid uid', async () => {
+      jest
+        .spyOn(UseValidateModule, 'useValidatedQueryParams')
+        .mockImplementation((_params) => {
+          return {
+            queryParamModel: {
+              uid: 'invalid',
+              unblockCode: MOCK_UNBLOCK_CODE,
+            } as unknown as ModelDataProvider,
+            validationError: {
+              property: 'uid',
+            },
+          };
+        });
+      await render('link damaged mock');
+    });
+
+    it('handles empty uid', async () => {
+      jest
+        .spyOn(UseValidateModule, 'useValidatedQueryParams')
+        .mockImplementation((_params) => {
+          return {
+            queryParamModel: {
+              email: '',
+              unblockCode: MOCK_UNBLOCK_CODE,
+            } as unknown as ModelDataProvider,
+            validationError: {
+              property: 'uid',
+            },
+          };
+        });
+      await render('link damaged mock');
+    });
+
+    it('handles invalid unblock code', async () => {
+      jest
+        .spyOn(UseValidateModule, 'useValidatedQueryParams')
+        .mockImplementation((_params) => {
+          return {
+            queryParamModel: {
+              uid: MOCK_UID,
+              unblockCode: 'invalid',
+            } as unknown as ModelDataProvider,
+            validationError: {
+              property: 'unblockCode',
+            },
+          };
+        });
+      await render('link damaged mock');
+    });
+
+    it('handles empty unblock code', async () => {
+      jest
+        .spyOn(UseValidateModule, 'useValidatedQueryParams')
+        .mockImplementation((_params) => {
+          return {
+            queryParamModel: {
+              uid: MOCK_UID,
+              unblockCode: '',
+            } as unknown as ModelDataProvider,
+            validationError: {
+              property: 'unblockCode',
+            },
+          };
+        });
+      await render('link damaged mock');
+    });
+  });
+
+  describe('submitReport', () => {
+    it('functions as expected when provided with valid params', async () => {
+      await render();
+      expect(currentReportSigninProps).toBeDefined();
+      await currentReportSigninProps?.submitReport();
+      expect(mockAuthClient.rejectUnblockCode).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/signin_reported?showReactApp=true'
+      );
+      expect(currentReportSigninProps?.errorMessage).toBe('');
+    });
+
+    it('returns an error message when unblock code is invalid', async () => {
+      // override locally with rejected value
+      const mockAuthClient = new AuthClient('localhost:9000');
+      mockAuthClient.rejectUnblockCode = jest
+        .fn()
+        .mockRejectedValue(AuthUiErrors.INVALID_UNBLOCK_CODE);
+      (ModelsModule.useAuthClient as jest.Mock).mockImplementation(
+        () => mockAuthClient
+      );
+
+      await render();
+      expect(currentReportSigninProps).toBeDefined();
+      await waitFor(() => currentReportSigninProps?.submitReport());
+      expect(mockAuthClient.rejectUnblockCode).toHaveBeenCalled();
+      await waitFor(() =>
+        expect(currentReportSigninProps?.errorMessage).toBe(
+          'Sorry, there was a problem submitting the report.'
+        )
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.tsx
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useState } from 'react';
+import { RouteComponentProps, useNavigate } from '@reach/router';
+import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
+import { useAuthClient, useFtlMsgResolver } from '../../../models';
+import { ReportSigninQueryParams } from '../../../models/pages/signin';
+import { ReportSigninLinkDamaged } from '../../../components/LinkDamaged';
+import { ReportSignin } from './index';
+
+const ReportSigninContainer = (_: RouteComponentProps) => {
+  const authClient = useAuthClient();
+  const ftlMsg = useFtlMsgResolver();
+  const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const { queryParamModel, validationError } = useValidatedQueryParams(
+    ReportSigninQueryParams
+  );
+
+  const submitReport = async () => {
+    try {
+      await authClient.rejectUnblockCode(
+        queryParamModel.uid,
+        queryParamModel.unblockCode
+      );
+      navigate('/signin_reported?showReactApp=true');
+    } catch (e) {
+      // TODO verify error message to display
+      setErrorMessage(
+        ftlMsg.getMsg(
+          'report-signin-error',
+          'Sorry, there was a problem submitting the report.'
+        )
+      );
+    }
+  };
+
+  if (validationError) {
+    return <ReportSigninLinkDamaged />;
+  }
+
+  return <ReportSignin {...{ errorMessage, submitReport }} />;
+};
+
+export default ReportSigninContainer;

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/en.ftl
@@ -1,0 +1,13 @@
+## ReportSignin Page
+## When users receive an "Is this you signing in?" email with an unblock code,
+## they can click "report it to us" if they did not attempt to sign in.
+## This will be the page shown to users to block the sign in and report it.
+
+report-signin-link-damaged-header = Link damaged
+report-signin-link-damaged-body = The link you clicked was missing characters, and may have been broken by your email client. Copy the address carefully, and try again.
+
+report-signin-header = Report unauthorized sign-in?
+report-signin-body = You received an email about attempted access to your account. Would you like to report this activity as suspicious?
+report-signin-submit-button = Report activity
+report-signin-support-link = Why is this happening?
+report-signin-error = Sorry, there was a problem submitting the report.

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/index.stories.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import ReportSignin from '.';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+
+export default {
+  title: 'Pages/Signin/ReportSignin',
+  component: ReportSignin,
+  decorators: [withLocalization],
+} as Meta;
+
+const submitReport = () => {};
+
+export const Default = () => (
+  <LocationProvider>
+    <ReportSignin {...{ submitReport }} />
+  </LocationProvider>
+);
+
+export const WithErrorBanner = () => {
+  const errorMessage = 'Error message appears here';
+  return (
+    <LocationProvider>
+      <ReportSignin {...{ errorMessage, submitReport }} />
+    </LocationProvider>
+  );
+};

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/index.test.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import ReportSignin, { viewName } from '.';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../../constants';
+
+jest.mock('../../../lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
+}));
+
+const submitReport = jest.fn();
+
+describe('ReportSignin', () => {
+  it('renders Ready component as expected', () => {
+    renderWithLocalizationProvider(<ReportSignin {...{ submitReport }} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Report unauthorized sign-in?' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Report activity' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: /Why is this happening/ })
+    ).toBeInTheDocument();
+  });
+
+  it('emits the expected metrics on render', () => {
+    renderWithLocalizationProvider(<ReportSignin {...{ submitReport }} />);
+    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/index.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { usePageViewEvent } from '../../../lib/metrics';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { RouteComponentProps } from '@reach/router';
+import { REACT_ENTRYPOINT } from '../../../constants';
+import CardHeader from '../../../components/CardHeader';
+import AppLayout from '../../../components/AppLayout';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import Banner, { BannerType } from '../../../components/Banner';
+import { ReportSigninProps } from './interfaces';
+
+export const viewName = 'report-signin';
+
+export const ReportSignin = ({
+  errorMessage,
+  submitReport,
+}: ReportSigninProps & RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingText="Report unauthorized sign-in?"
+        headingTextFtlId="report-signin-header"
+      />
+      {errorMessage && <Banner type={BannerType.error}>{errorMessage}</Banner>}
+      <FtlMsg id="report-signin-body">
+        <p>
+          You received an email about attempted access to your account. Would
+          you like to report this activity as suspicious?
+        </p>
+      </FtlMsg>
+      <form
+        noValidate
+        className="my-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitReport();
+        }}
+      >
+        <FtlMsg id="report-signin-submit-button">
+          {/* TODO submit handling */}
+          <button
+            id="submit-btn"
+            type="submit"
+            className="cta-primary w-full cta-xl"
+          >
+            Report activity
+          </button>
+        </FtlMsg>
+      </form>
+      <FtlMsg id="report-signin-support-link">
+        <LinkExternal
+          className="link-blue text-sm"
+          href="https://support.mozilla.org/kb/accounts-blocked"
+        >
+          Why is this happening?
+        </LinkExternal>
+      </FtlMsg>
+    </AppLayout>
+  );
+};
+
+export default ReportSignin;

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/interfaces.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export interface ReportSigninProps {
+  errorMessage?: string;
+  submitReport: () => void;
+}

--- a/packages/fxa-settings/src/pages/mocks.ts
+++ b/packages/fxa-settings/src/pages/mocks.ts
@@ -16,3 +16,4 @@ export const MOCK_KEY_FETCH_TOKEN = 'keyFetchToken';
 export const MOCK_RESET_TOKEN = 'mockResetToken';
 export const MOCK_AUTH_AT = 12345;
 export const MOCK_PASSWORD = 'notYourAveragePassW0Rd';
+export const MOCK_UNBLOCK_CODE = 'A1B2C3D4';


### PR DESCRIPTION
## Because

* We are converting signin route pages to React

## This pull request

* Build out `report_signin` page in React, including Storybook and unit tests
* Hook up the page functionality to report an unauthorized sign in attempt
* Reorganize fxa-settings `App` imports list

## Issue that this pull request solves

Closes: #FXA-7047

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

![image](https://github.com/mozilla/fxa/assets/22231637/f78f12c9-8e7d-4416-b086-21d1f3237805)

![image](https://github.com/mozilla/fxa/assets/22231637/04efd8d8-b8f9-409c-922f-0e274420bf97)

## Other information (Optional)

- `signinRoutes` must be set to `true` in content-server `local.json`
- `showReactApp`,`uid`, `unblockCode` are required search params

For example: `localhost:3030/report_signin?showReactApp=true&uid=863a51659b8f615a25fad03248412979&unblockCode=12345678` (uses randomly generated hex string as uid)

NOTE: Currently, omitting the `uid` and `unblockCode` params entirely will render the link damaged component - **however**, introducing errors into the param values (e.g., localhost:3030/report_signin?showReactApp=true&uid=boop&unblockCode=blah) leads to uncaught errors and general application errors. Appears to be related to: https://mozilla-hub.atlassian.net/browse/FXA-8696