### PR TITLE
fix(backstage): use api ref now that its allowed

### DIFF
--- a/backstage/firestore.resources.yaml
+++ b/backstage/firestore.resources.yaml
@@ -8,7 +8,7 @@ metadata:
     - firestore
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
 ---
 apiVersion: backstage.io/v1alpha1
@@ -20,5 +20,5 @@ metadata:
     - firestore
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/backstage/memcached.resources.yaml
+++ b/backstage/memcached.resources.yaml
@@ -6,5 +6,5 @@ metadata:
   description: Caches rate limits and IP reuptation scores.
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/backstage/mozilla-accounts.system.yaml
+++ b/backstage/mozilla-accounts.system.yaml
@@ -5,5 +5,5 @@ metadata:
   name: mozilla-accounts
   description: Mozilla Accounts
 spec:
-  owner: fxa-team
+  owner: fxa-devs
   domain: accounts

--- a/backstage/mysql.resources.yaml
+++ b/backstage/mysql.resources.yaml
@@ -8,7 +8,7 @@ metadata:
     - mysql
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
 ---
 apiVersion: backstage.io/v1alpha1
@@ -20,7 +20,7 @@ metadata:
     - mysql
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
 ---
 apiVersion: backstage.io/v1alpha1
@@ -32,7 +32,7 @@ metadata:
     - mysql
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
 ---
 apiVersion: backstage.io/v1alpha1
@@ -44,5 +44,5 @@ metadata:
     - mysql
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/backstage/redis.resources.yaml
+++ b/backstage/redis.resources.yaml
@@ -6,7 +6,7 @@ metadata:
   description: Stores aggregated profile data.
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
 ---
 apiVersion: backstage.io/v1alpha1
@@ -16,5 +16,5 @@ metadata:
   description: Stores OAuth access and session token info, and email reminders.
 spec:
   type: database
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/packages/123done/backstage.yaml
+++ b/packages/123done/backstage.yaml
@@ -17,5 +17,5 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/packages/browserid-verifier/backstage.yaml
+++ b/packages/browserid-verifier/backstage.yaml
@@ -15,5 +15,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/packages/fxa-admin-panel/backstage.yaml
+++ b/packages/fxa-admin-panel/backstage.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
   dependsOn:
     - component:fxa-admin-server

--- a/packages/fxa-admin-server/backstage.yaml
+++ b/packages/fxa-admin-server/backstage.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
   providesApis:
     - api:fxa-admin

--- a/packages/fxa-auth-server/backstage.yaml
+++ b/packages/fxa-auth-server/backstage.yaml
@@ -15,8 +15,10 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
+  providesApis:
+    - api:fxa-auth
   dependsOn:
     - component:fxa-browserid-verifier
     - component:fxa-customs-server
@@ -25,3 +27,16 @@ spec:
     - resource:fxa-pushbox-database
     - resource:fxa-stripe-database
     - resource:fxa-auth-cache
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: fxa-auth
+  description: Mozilla Accounts Auth API
+spec:
+  type: openapi
+  lifecycle: production
+  owner: fxa-devs
+  system: mozilla-accounts
+  definition:
+    $text: https://api.accounts.firefox.com/swagger.json

--- a/packages/fxa-content-server/backstage.yaml
+++ b/packages/fxa-content-server/backstage.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
-  dependsOn:
-    - component:fxa-auth-server
+  consumesApis:
+    - api:fxa-auth

--- a/packages/fxa-customs-server/backstage.yaml
+++ b/packages/fxa-customs-server/backstage.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
   dependsOn:
     - resource:fxa-customs-cache

--- a/packages/fxa-event-broker/backstage.yaml
+++ b/packages/fxa-event-broker/backstage.yaml
@@ -14,5 +14,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts

--- a/packages/fxa-graphql-api/backstage.yaml
+++ b/packages/fxa-graphql-api/backstage.yaml
@@ -15,5 +15,7 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
+  consumesApis:
+    - api:fxa-auth

--- a/packages/fxa-payments-server/backstage.yaml
+++ b/packages/fxa-payments-server/backstage.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
-  dependsOn:
-    - component:fxa-auth-server
+  consumesApis:
+    - api:fxa-auth

--- a/packages/fxa-profile-server/backstage.yaml
+++ b/packages/fxa-profile-server/backstage.yaml
@@ -14,9 +14,10 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
   dependsOn:
-    - component:fxa-auth-server
     - resource:fxa-profile-database
     - resource:fxa-profile-cache
+  consumesApis:
+    - api:fxa-auth

--- a/packages/fxa-settings/backstage.yaml
+++ b/packages/fxa-settings/backstage.yaml
@@ -21,9 +21,10 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: fxa-team
+  owner: fxa-devs
   system: mozilla-accounts
   dependsOn:
-    - component:fxa-auth-server
     - component:fxa-profile-server
     - component:fxa-graphl-api
+  consumesApis:
+    - api:fxa-auth


### PR DESCRIPTION
Because:

* We should now be able to use the API location ref.
* We want to use the right group name.

This commit:

* Updates the backstage files to use the new API location ref.
* Updates the backstage files to use the right group name.
