### PR TITLE
feat(react): Move all session related functions into the Session hook

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -32,7 +32,7 @@ export const test = base.extend<TestOptions, WorkerOptions>({
 
   credentials: async ({ target }, use, testInfo) => {
     const email = EmailClient.emailFromTestTitle(testInfo.title);
-    const password = 'asdzxcasd';
+    const password = 'passwordzxcv';
     await target.email.clear(email);
     let credentials: Credentials;
     try {

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -35,6 +35,7 @@ export const selectors = {
   SIGN_IN_CODE_HEADER: '#fxa-signin-code-header',
   CONFIRM_EMAIL: '.email',
   SIGNIN_HEADER: '#fxa-signin-header',
+  SIGNIN_PASSWORD_HEADER: '#fxa-signin-password-header',
   SIGNIN_UNBLOCK_HEADER: '#fxa-signin-unblock-header',
   SIGNIN_UNBLOCK_VERIFICATION: '.verification-email-message',
   COPPA_HEADER: '#fxa-cannot-create-account-header',
@@ -121,7 +122,10 @@ export class LoginPage extends BaseLayout {
       // User is already signed in and attempting to sign in to another service,
       // we show a `Continue` button, and they don't have to re-enter password
       return this.submit();
-    } else if (await this.isSigninHeader()) {
+    } else if (
+      (await this.isSigninHeader()) ||
+      (await this.isSigninPasswordHeader())
+    ) {
       // The user has specified an email address in url or this service
       // requires them to set a password to login (ie Sync)
       await this.setPassword(password);
@@ -382,6 +386,12 @@ export class LoginPage extends BaseLayout {
 
   async isSigninHeader() {
     return this.page.isVisible(selectors.SIGNIN_HEADER, {
+      timeout: 100,
+    });
+  }
+
+  async isSigninPasswordHeader() {
+    return this.page.isVisible(selectors.SIGNIN_PASSWORD_HEADER, {
       timeout: 100,
     });
   }

--- a/packages/fxa-settings/src/components/App/gql.ts
+++ b/packages/fxa-settings/src/components/App/gql.ts
@@ -46,7 +46,7 @@ export const INITIAL_METRICS_QUERY = gql`
  * using auth-client for those calls.
  *
  * If you need to confirm that the session is _verified_, use
- * `GET_SESSION_VERIFIED`. We can improve or revisit this in FXA-7626 or FXA-7184.
+ * `GET_SESSION_VERIFIED`.
  * */
 export const GET_LOCAL_SIGNED_IN_STATUS = gql`
   query GetLocalSignedInStatus {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -162,10 +162,6 @@ export const App = ({
     return <LoadingSpinner fullScreen />;
   }
 
-  // TODO: Do we like passing `isSignedIn` here, or query in page components instead?
-  // If we want to query in the Settings for example, we can after FXA-8286 (first
-  // container component test coverage) and we follow the pattern set for tests.
-  // Can be looked at in FXA-7626 or FXA-7184
   return (
     <Router basepath="/">
       <AuthAndAccountSetupRoutes {...{ isSignedIn, integration }} path="/*" />
@@ -202,7 +198,7 @@ const SettingsRoutes = ({
     })();
   });
 
-  if (isSignedIn === false && !shouldCheckFxaStatus) {
+  if (!isSignedIn && !shouldCheckFxaStatus) {
     hardNavigateToContentServer(
       `/signin?redirect_to=${encodeURIComponent(location.pathname)}`
     );

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -10,6 +10,7 @@ import {
   renderWithRouter,
   mockAppContext,
   mockSettingsContext,
+  mockSession,
 } from 'fxa-settings/src/models/mocks';
 import { logViewEvent } from '../../../lib/metrics';
 import { isMobileDevice } from '../../../lib/utilities';
@@ -26,6 +27,8 @@ const account = {
   attachedClients: MOCK_SERVICES,
   disconnectClient: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
+
+const session = mockSession(true, false);
 
 const alertBarInfo = {
   success: jest.fn(),
@@ -275,7 +278,7 @@ describe('Connected Services', () => {
 
   it('renders proper modal when "sign out" is clicked', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <ConnectedServices />
       </AppContext.Provider>
     );
@@ -285,7 +288,7 @@ describe('Connected Services', () => {
 
   it('renders "lost" modal when user has selected "lost" option and emits metrics events', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <ConnectedServices />
       </AppContext.Provider>
     );
@@ -302,7 +305,7 @@ describe('Connected Services', () => {
 
   it('renders "suspicious" modal when user has selected "suspicious" option in survey modal and emits metrics events', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <ConnectedServices />
       </AppContext.Provider>
     );
@@ -324,7 +327,7 @@ describe('Connected Services', () => {
     } as unknown as Account;
 
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <SettingsContext.Provider value={mockSettingsContext({ alertBarInfo })}>
           <ConnectedServices />
         </SettingsContext.Provider>

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
@@ -33,14 +33,6 @@ const account = {
   displayName: 'John Dope',
 } as unknown as Account;
 
-const makeSession = (isError: boolean = false) => {
-  const s = mockSession();
-  s.destroy = isError
-    ? jest.fn().mockRejectedValue(new Error())
-    : jest.fn().mockResolvedValue(true);
-  return s;
-};
-
 describe('DropDownAvatarMenu', () => {
   const dropDownId = 'drop-down-avatar-menu';
 
@@ -131,7 +123,7 @@ describe('DropDownAvatarMenu', () => {
 
       renderWithLocalizationProvider(
         <AppContext.Provider
-          value={mockAppContext({ account, session: makeSession() })}
+          value={mockAppContext({ account, session: mockSession() })}
         >
           <DropDownAvatarMenu />
         </AppContext.Provider>
@@ -151,7 +143,10 @@ describe('DropDownAvatarMenu', () => {
     });
 
     it('displays an error in the AlertBar', async () => {
-      const context = mockAppContext({ account, session: makeSession(true) });
+      const context = mockAppContext({
+        account,
+        session: mockSession(true, true),
+      });
       const settingsContext = mockSettingsContext();
       renderWithLocalizationProvider(
         <AppContext.Provider value={context}>

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
@@ -20,14 +20,6 @@ export default {
 
 const session = mockSession(false);
 const account = MOCK_ACCOUNT as any;
-account.sendVerificationCode = () => Promise.resolve(true);
-account.verifySession = (code: string) => {
-  if (code === '123456') {
-    session.verified = true;
-    return Promise.resolve(true);
-  }
-  return Promise.reject(AuthUiErrors.INVALID_EXPIRED_SIGNUP_CODE);
-};
 
 type ModalToggleChildrenProps = {
   modalRevealed: boolean;

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.test.tsx
@@ -6,7 +6,7 @@ import 'mutationobserver-shim';
 import React from 'react';
 import { screen, fireEvent, act } from '@testing-library/react';
 import { mockSession, renderWithRouter } from '../../../models/mocks';
-import { Account, AppContext } from '../../../models';
+import { Account, AppContext, Session } from '../../../models';
 import { ModalVerifySession } from '.';
 import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 
@@ -14,9 +14,8 @@ const account = {
   primaryEmail: {
     email: 'jgruen@mozilla.com',
   },
-  sendVerificationCode: jest.fn().mockResolvedValue(true),
-  verifySession: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
+
 const session = mockSession(false);
 
 window.console.error = jest.fn();
@@ -51,13 +50,11 @@ describe('ModalVerifySession', () => {
   it('renders error messages', async () => {
     const error: any = new Error('invalid code');
     error.errno = AuthUiErrors.INVALID_EXPIRED_SIGNUP_CODE.errno;
-    const account = {
-      primaryEmail: {
-        email: 'jgruen@mozilla.com',
-      },
+    const session = {
       sendVerificationCode: jest.fn().mockResolvedValue(true),
       verifySession: jest.fn().mockRejectedValue(error),
-    } as unknown as Account;
+      isSessionVerified: jest.fn().mockResolvedValue(false),
+    } as unknown as Session;
     const onDismiss = jest.fn();
     const onError = jest.fn();
     renderWithRouter(
@@ -83,13 +80,11 @@ describe('ModalVerifySession', () => {
 
   it('bubbles other errors', async () => {
     const error = new Error('network error');
-    const account = {
-      primaryEmail: {
-        email: 'jgruen@mozilla.com',
-      },
+    const session = {
       sendVerificationCode: jest.fn().mockResolvedValue(true),
       verifySession: jest.fn().mockRejectedValue(error),
-    } as unknown as Account;
+      isSessionVerified: jest.fn().mockResolvedValue(false),
+    } as unknown as Session;
     const onDismiss = jest.fn();
     const onError = jest.fn();
     renderWithRouter(

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.test.tsx
@@ -11,6 +11,7 @@ import { typeByTestIdFn } from '../../../lib/test-utils';
 import {
   MOCK_ACCOUNT,
   mockAppContext,
+  mockSession,
   mockSettingsContext,
   renderWithRouter,
 } from '../../../models/mocks';
@@ -25,6 +26,8 @@ const account = {
   generateRecoveryCodes: jest.fn().mockReturnValue(recoveryCodes),
   updateRecoveryCodes: jest.fn().mockResolvedValue({ success: true }),
 } as unknown as Account;
+
+const session = mockSession(true, false);
 
 const config = {
   l10n: { strict: false },
@@ -45,7 +48,7 @@ window.URL.createObjectURL = jest.fn();
 async function renderPage2faReplaceRecoveryCodes() {
   await act(async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account, config })}>
+      <AppContext.Provider value={mockAppContext({ account, session, config })}>
         <SettingsContext.Provider value={mockSettingsContext()}>
           <Page2faReplaceRecoveryCodes />
         </SettingsContext.Provider>
@@ -78,7 +81,7 @@ it('displays an error when fails to fetch new backup authentication codes', asyn
     ...MOCK_ACCOUNT,
     generateRecoveryCodes: jest.fn().mockRejectedValue(new Error('wat')),
   } as unknown as Account;
-  const context = mockAppContext({ account, config });
+  const context = mockAppContext({ account, session, config });
   const settingsContext = mockSettingsContext();
   await act(async () => {
     renderWithRouter(

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
@@ -5,7 +5,11 @@
 import React from 'react';
 import 'mutationobserver-shim';
 import { screen, fireEvent, act, within } from '@testing-library/react';
-import { mockAppContext, renderWithRouter } from '../../../models/mocks';
+import {
+  mockAppContext,
+  mockSession,
+  renderWithRouter,
+} from '../../../models/mocks';
 import { PageDeleteAccount } from '.';
 import { typeByTestIdFn } from '../../../lib/test-utils';
 import { Account, AppContext } from '../../../models';
@@ -24,6 +28,8 @@ const account = {
   metricsEnabled: true,
   hasPassword: true,
 } as unknown as Account;
+
+const session = mockSession(true, false);
 
 window.URL.createObjectURL = jest.fn();
 console.error = jest.fn();
@@ -44,7 +50,7 @@ describe('PageDeleteAccount', () => {
 
   it('renders as expected', () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <PageDeleteAccount />
       </AppContext.Provider>
     );
@@ -77,7 +83,7 @@ describe('PageDeleteAccount', () => {
 
   it('Enables "continue" button once all 4 inputs are valid', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <PageDeleteAccount />
       </AppContext.Provider>
     );
@@ -94,7 +100,7 @@ describe('PageDeleteAccount', () => {
 
   it('Does not Enable "continue" button if all for checks are not confirmed', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <PageDeleteAccount />
       </AppContext.Provider>
     );
@@ -111,7 +117,7 @@ describe('PageDeleteAccount', () => {
 
   it('Enables "Delete" button once the password length is of 8 characters or more', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <PageDeleteAccount />
       </AppContext.Provider>
     );
@@ -125,7 +131,7 @@ describe('PageDeleteAccount', () => {
 
   it('Gets valid response on submit and emits metrics events', async () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
+      <AppContext.Provider value={mockAppContext({ account, session })}>
         <PageDeleteAccount />
       </AppContext.Provider>
     );
@@ -158,7 +164,9 @@ describe('PageDeleteAccount', () => {
     } as unknown as Account;
 
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account: pwdlessAccount })}>
+      <AppContext.Provider
+        value={mockAppContext({ account: pwdlessAccount, session })}
+      >
         <PageDeleteAccount />
       </AppContext.Provider>
     );

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -10,6 +10,7 @@ import {
   mockAppContext,
   MOCK_ACCOUNT,
   renderWithRouter,
+  mockSession,
 } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 
@@ -55,7 +56,9 @@ const accountWithKey = {
 
 const renderPageWithContext = (account: Account) => {
   renderWithRouter(
-    <AppContext.Provider value={mockAppContext({ account })}>
+    <AppContext.Provider
+      value={mockAppContext({ account, session: mockSession(true, false) })}
+    >
       <PageRecoveryKeyCreate />
     </AppContext.Provider>
   );

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
@@ -44,7 +44,6 @@ const account = {
   },
   createTotp: jest.fn().mockResolvedValue(totp),
   verifyTotp: jest.fn().mockResolvedValue(true),
-  sendVerificationCode: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 
 window.URL.createObjectURL = jest.fn();

--- a/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
@@ -14,12 +14,21 @@ import { Account, AppContext } from '../../../models';
 import { VerifiedSessionGuard } from '.';
 
 it('renders the content when verified', async () => {
+  const account = {
+    primaryEmail: {
+      email: 'smcarthur@mozilla.com',
+    },
+  } as unknown as Account;
   const onDismiss = jest.fn();
   const onError = jest.fn();
   renderWithRouter(
-    <VerifiedSessionGuard {...{ onDismiss, onError }}>
-      <div data-testid="children">Content</div>
-    </VerifiedSessionGuard>
+    <AppContext.Provider
+      value={mockAppContext({ account, session: mockSession(true, false) })}
+    >
+      <VerifiedSessionGuard {...{ onDismiss, onError }}>
+        <div data-testid="children">Content</div>
+      </VerifiedSessionGuard>
+    </AppContext.Provider>
   );
 
   expect(screen.getByTestId('children')).toBeInTheDocument();
@@ -32,7 +41,6 @@ it('renders the guard when unverified', async () => {
     primaryEmail: {
       email: 'smcarthur@mozilla.com',
     },
-    sendVerificationCode: jest.fn().mockResolvedValue(true),
   } as unknown as Account;
   renderWithRouter(
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.tsx
@@ -16,7 +16,9 @@ export const VerifiedSessionGuard = ({
   onError: (error: ApolloError) => void;
   children?: React.ReactNode;
 }) => {
-  return useSession().verified ? (
+  const session = useSession();
+
+  return session.verified ? (
     <>{children}</>
   ) : (
     <ModalVerifySession {...{ onDismiss, onError }} />

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -11,6 +11,7 @@ import {
   mockAppContext,
   MOCK_ACCOUNT,
   renderWithRouter,
+  mockSession,
 } from '../../models/mocks';
 import { Config } from '../../lib/config';
 import * as NavTiming from 'fxa-shared/metrics/navigation-timing';
@@ -89,6 +90,7 @@ describe('App component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    (useInitialSettingsState as jest.Mock).mockReturnValue({ loading: false });
   });
 
   it('renders `LoadingSpinner` component when loading initial state is true', () => {
@@ -112,8 +114,6 @@ describe('App component', () => {
       'General application error'
     );
   });
-
-  (useInitialSettingsState as jest.Mock).mockReturnValue({ loading: false });
 
   it('routes to PageSettings', async () => {
     const {
@@ -149,10 +149,16 @@ describe('App component', () => {
   });
 
   it('routes to PageChangePassword', async () => {
+    const session = mockSession(true);
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ session })}>
+        <App {...{ flowQueryParams }} />
+      </AppContext.Provider>,
+      { route: HomePath }
+    );
 
     await navigate(HomePath + '/change_password');
 
@@ -160,10 +166,16 @@ describe('App component', () => {
   });
 
   it('routes to PageSecondaryEmailAdd', async () => {
+    const session = mockSession(true);
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ session })}>
+        <App {...{ flowQueryParams }} />
+      </AppContext.Provider>,
+      { route: HomePath }
+    );
 
     await navigate(HomePath + '/emails');
 
@@ -171,10 +183,16 @@ describe('App component', () => {
   });
 
   it('routes to PageSecondaryEmailVerify', async () => {
+    const session = mockSession(true);
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ session })}>
+        <App {...{ flowQueryParams }} />
+      </AppContext.Provider>,
+      { route: HomePath }
+    );
 
     await navigate(HomePath + '/emails/verify');
 
@@ -182,10 +200,16 @@ describe('App component', () => {
   });
 
   it('routes to PageTwoStepAuthentication', async () => {
+    const session = mockSession(true);
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ session })}>
+        <App {...{ flowQueryParams }} />
+      </AppContext.Provider>,
+      { route: HomePath }
+    );
 
     await navigate(HomePath + '/two_step_authentication');
 
@@ -193,10 +217,16 @@ describe('App component', () => {
   });
 
   it('routes to Page2faReplaceRecoveryCodes', async () => {
+    const session = mockSession(true);
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ session })}>
+        <App {...{ flowQueryParams }} />
+      </AppContext.Provider>,
+      { route: HomePath }
+    );
 
     await navigate(HomePath + '/two_step_authentication/replace_codes');
 
@@ -204,10 +234,16 @@ describe('App component', () => {
   });
 
   it('routes to PageDeleteAccount', async () => {
+    const session = mockSession(true);
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ session })}>
+        <App {...{ flowQueryParams }} />
+      </AppContext.Provider>,
+      { route: HomePath }
+    );
 
     await navigate(HomePath + '/delete_account');
 

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -21,7 +21,6 @@ import firefox from '../lib/channels/firefox';
 import Storage from '../lib/storage';
 import random from '../lib/random';
 import { AuthUiErrorNos, AuthUiErrors } from '../lib/auth-errors/auth-errors';
-import { GET_SESSION_VERIFIED } from './Session';
 import { LinkedAccountProviderIds, MozServices } from '../lib/types';
 import { GET_LOCAL_SIGNED_IN_STATUS } from '../components/App/gql';
 
@@ -881,41 +880,6 @@ export class Account implements AccountData {
     );
   }
 
-  async sendVerificationCode() {
-    await this.withLoadingStatus(
-      this.authClient.sessionResendVerifyCode(sessionToken()!)
-    );
-  }
-
-  async verifySession(
-    code: string,
-    options: {
-      service?: string;
-      scopes?: string[];
-      marketingOptIn?: boolean;
-      newsletters?: string[];
-    } = {}
-  ) {
-    await this.withLoadingStatus(
-      this.authClient.sessionVerifyCode(sessionToken()!, code, options)
-    );
-    this.apolloClient.cache.modify({
-      fields: {
-        session: () => {
-          return { verified: true };
-        },
-      },
-    });
-    // TODO: Move this to ConfirmSignupCode container component
-    // If we can use GQL here when we do that, also be sure to add
-    // the operation name to the auth list in `lib/gql.ts`.
-    // Look @ in FXA-7626 or FXA-7184
-    this.apolloClient.cache.writeQuery({
-      query: GET_LOCAL_SIGNED_IN_STATUS,
-      data: { isSignedIn: true },
-    });
-  }
-
   async verifyAccountThirdParty(
     code: string,
     provider: AUTH_PROVIDER = AUTH_PROVIDER.GOOGLE,
@@ -939,45 +903,15 @@ export class Account implements AccountData {
     return linkedAccount;
   }
 
-  // TODO: Move this method to the Session model - this method was temporarily added to the Account model
-  // because the useSession hook can currently only be used behind a VerifiedSessionGuard and will error
-  // if used in a unverified page.
-  async isSessionVerified() {
-    const query = GET_SESSION_VERIFIED;
-    const { data } = await this.apolloClient.query({
-      fetchPolicy: 'network-only',
-      query,
-    });
-    const { session } = data;
-    const sessionStatus: boolean = session.verified;
-    return sessionStatus;
-  }
-
   async replaceRecoveryCodes() {
     return this.withLoadingStatus(
       this.authClient.replaceRecoveryCodes(sessionToken()!)
     );
   }
 
-  /* TODO in FXA-7626: Remove this and use GQL instead. We can't check for verified sessions
-   * unless you've already got one (oof) in at least the PW reset flow due to
-   * sessionToken.mustVerify which was added here: https://github.com/mozilla/fxa/pull/7512
-   * The unverified session token returned by a password reset contains `mustVerify`
-   * which causes the 'Must verify' error to be thrown and a redirect to occur */
-  async isSessionVerifiedAuthClient() {
-    try {
-      const { state } = await this.withLoadingStatus(
-        this.authClient.sessionStatus(sessionToken()!)
-      );
-      return state === 'verified';
-    } catch (e) {
-      // Proceed as if the user does not have a verified session,
-      // since they likely will not at this stage (password reset)
-      return false;
-    }
-  }
-
-  // TODO: Same as isSessionVerifiedAuthClient
+  /**
+   * Check if the user has TOTP set up. This should be converted to a GQL query.
+   */
   async hasTotpAuthClient() {
     try {
       const { verified } = await this.withLoadingStatus(
@@ -1124,6 +1058,9 @@ export class Account implements AccountData {
             return e;
           });
         },
+        primaryEmail() {
+          return { email, isPrimary: true, verified: true };
+        },
         avatar: (existing, { readField }) => {
           const id = readField<string>('id', existing);
           const oldUrl = readField<string>('url', existing);
@@ -1131,6 +1068,11 @@ export class Account implements AccountData {
         },
       },
     });
+
+    const legacyLocalStorageAccount = currentAccount()!;
+    legacyLocalStorageAccount.email = email;
+    currentAccount(legacyLocalStorageAccount);
+
     firefox.profileChanged({ uid: this.uid });
   }
 

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -1,8 +1,20 @@
-import { gql } from '@apollo/client';
+import { ApolloClient, gql, NormalizedCacheObject } from '@apollo/client';
+import AuthClient from 'fxa-auth-client/browser';
+import { sessionToken, clearSignedInAccountUid } from '../lib/cache';
+import { GET_LOCAL_SIGNED_IN_STATUS } from '../components/App/gql';
 
-export interface Session {
-  verified: boolean;
-  token: hexstring;
+export interface SessionData {
+  verified: boolean | null;
+  token: string | null;
+  verifySession?: (
+    code: string,
+    options: {
+      service?: string;
+      scopes?: string[];
+      marketingOptIn?: boolean;
+      newsletters?: string[];
+    }
+  ) => Promise<void>;
   destroy?: () => void;
 }
 
@@ -13,3 +25,114 @@ export const GET_SESSION_VERIFIED = gql`
     }
   }
 `;
+
+export const DESTROY_SESSION = gql`
+  mutation DestroySession {
+    destroySession(input: {}) {
+      clientMutationId
+    }
+  }
+`;
+
+export class Session implements SessionData {
+  private readonly authClient: AuthClient;
+  private readonly apolloClient: ApolloClient<object>;
+  private _loading: boolean;
+
+  constructor(
+    authClient: AuthClient,
+    apolloClient: ApolloClient<NormalizedCacheObject>
+  ) {
+    this.authClient = authClient;
+    this.apolloClient = apolloClient;
+    this._loading = false;
+  }
+
+  private async withLoadingStatus<T>(promise: Promise<T>) {
+    this._loading = true;
+    try {
+      return await promise;
+    } catch (e) {
+      throw e;
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  private get data() {
+    const { session } = this.apolloClient.cache.readQuery<{
+      session: Session;
+    }>({
+      query: GET_SESSION_VERIFIED,
+    })!;
+    return session;
+  }
+
+  get token(): string {
+    return this.data.token;
+  }
+
+  get verified(): boolean {
+    return this.data.verified;
+  }
+
+  async verifySession(
+    code: string,
+    options: {
+      service?: string;
+      scopes?: string[];
+      marketingOptIn?: boolean;
+      newsletters?: string[];
+    } = {}
+  ) {
+    await this.withLoadingStatus(
+      this.authClient.sessionVerifyCode(sessionToken()!, code, options)
+    );
+    this.apolloClient.cache.modify({
+      fields: {
+        session: () => {
+          return true;
+        },
+      },
+    });
+    this.apolloClient.cache.writeQuery({
+      query: GET_LOCAL_SIGNED_IN_STATUS,
+      data: { isSignedIn: true },
+    });
+  }
+
+  async sendVerificationCode() {
+    await this.withLoadingStatus(
+      this.authClient.sessionResendVerifyCode(sessionToken()!)
+    );
+  }
+
+  async destroy() {
+    await this.apolloClient.mutate({
+      mutation: DESTROY_SESSION,
+      variables: { input: {} },
+    });
+
+    clearSignedInAccountUid();
+  }
+
+  async isSessionVerified() {
+    const query = GET_SESSION_VERIFIED;
+    const { data } = await this.apolloClient.query({
+      fetchPolicy: 'network-only',
+      query,
+    });
+
+    const { session } = data;
+    const sessionStatus: boolean = session.verified;
+
+    this.apolloClient.cache.modify({
+      fields: {
+        session: () => {
+          return sessionStatus;
+        },
+      },
+    });
+    return sessionStatus;
+  }
+}

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -34,12 +34,14 @@ export function initializeAppContext() {
   const authClient = new AuthClient(config.servers.auth.url);
   const apolloClient = createApolloClient(config.servers.gql.url);
   const account = new Account(authClient, apolloClient);
+  const session = new Session(authClient, apolloClient);
 
   const context: AppContextValue = {
     authClient,
     apolloClient,
     config,
     account,
+    session,
   };
 
   return context;

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -26,6 +26,9 @@ const DEFAULT_APP_CONTEXT = defaultAppContext();
 export const MOCK_ACCOUNT: AccountData =
   DEFAULT_APP_CONTEXT.account as unknown as AccountData;
 
+export const MOCK_SESSION: Session =
+  DEFAULT_APP_CONTEXT.session as unknown as Session;
+
 export function createHistoryWithQuery(path: string, queryParams?: string) {
   const history = createHistory(createMemorySource(path));
   if (queryParams != null) {
@@ -83,11 +86,25 @@ export function renderWithRouter(
   };
 }
 
-export function mockSession(verified: boolean = true) {
-  return {
+export function mockSession(
+  verified: boolean = true,
+  isError: boolean = false
+) {
+  const session = {
     verified,
     token: 'deadc0de',
   } as Session;
+  session.destroy = isError
+    ? jest.fn().mockRejectedValue(new Error())
+    : jest.fn().mockResolvedValue(true);
+  session.sendVerificationCode = isError
+    ? jest.fn().mockRejectedValue(new Error())
+    : jest.fn().mockResolvedValue(true);
+  session.verifySession = isError
+    ? jest.fn().mockRejectedValue(new Error())
+    : jest.fn().mockResolvedValue(true);
+  session.isSessionVerified = jest.fn().mockResolvedValue(session.verified);
+  return session;
 }
 
 export function mockStorage() {
@@ -133,7 +150,7 @@ export function mockAppContext(context?: AppContextValue) {
   return Object.assign(
     {
       account: MOCK_ACCOUNT,
-      session: mockSession(),
+      session: mockSession(true, false),
       config: getDefault(),
     },
     context

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { MozServices } from '../../../lib/types';
-import { Account, Integration, IntegrationType } from '../../../models';
+import { Account, IntegrationType } from '../../../models';
 import {
   mockAppContext,
   MOCK_ACCOUNT,

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -243,7 +243,6 @@ describe('AccountRecoveryResetPassword page', () => {
       account.resetPasswordWithRecoveryKey = jest
         .fn()
         .mockResolvedValue(MOCK_RESET_DATA);
-      account.isSessionVerifiedAuthClient = jest.fn();
       account.hasTotpAuthClient = jest.fn().mockResolvedValue(false);
 
       render(<Subject />, account);
@@ -286,7 +285,6 @@ describe('AccountRecoveryResetPassword page', () => {
       account.resetPasswordWithRecoveryKey = jest
         .fn()
         .mockResolvedValue(MOCK_RESET_DATA);
-      account.isSessionVerifiedAuthClient = jest.fn();
       account.hasTotpAuthClient = jest.fn().mockResolvedValue(false);
       fxaLoginSignedInUserSpy = jest.spyOn(firefox, 'fxaLoginSignedInUser');
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -221,18 +221,6 @@ const CompleteResetPassword = ({
           location.state?.accountResetToken
         );
 
-        /* NOTE: Session check/totp check must come after completeResetPassword since those
-         * require session tokens that we retrieve in PW reset. We will want to refactor this
-         * later but there's a `mustVerify` check getting in the way (see Account.ts comment).
-         *
-         * We may also want to consider putting a different error message in place for when
-         * PW reset succeeds, but one of these fails. At the moment, the try/catch in Account
-         * just returns false for these if the request fails. */
-        const [sessionIsVerified] = await Promise.all([
-          account.isSessionVerifiedAuthClient(),
-          account.hasTotpAuthClient(),
-        ]);
-
         let isHardNavigate = false;
         switch (integration.type) {
           // NOTE: SyncBasic check is temporary until we implement codes
@@ -252,7 +240,7 @@ const CompleteResetPassword = ({
           case IntegrationType.OAuth:
             // allows a navigation to a "complete" screen or TOTP screen if it is setup
             // TODO: check if relier has state
-            if (sessionIsVerified && isOAuthIntegration(integration)) {
+            if (isOAuthIntegration(integration)) {
               // TODO: Consider redirecting back to RP, after success message is displayed.
               // NOTE: To fully sign in, totp must performed if 2FA is enabled.
             }

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.test.tsx
@@ -16,6 +16,7 @@ import {
   mockEmail,
   MOCK_ACCOUNT,
   MOCK_PROFILE_INFO,
+  mockSession,
 } from '../../../models/mocks';
 import Confirm, { viewName } from '.';
 import { MOCK_SESSION_TOKEN, MOCK_UNVERIFIED_SESSION } from './mocks';
@@ -104,13 +105,14 @@ describe('Confirm page', () => {
 
   it('resends the email when the user clicks the resend button', async () => {
     const account: Account = MOCK_ACCOUNT_WITH_SUCCESS;
-    renderWithContext(account, MOCK_UNVERIFIED_SESSION, MOCK_SESSION_TOKEN);
+    const session = mockSession(false, false);
+    renderWithContext(account, session, MOCK_SESSION_TOKEN);
     await waitFor(() => {
       const resendEmailButton = screen.getByRole('button', {
         name: 'Not in inbox or spam folder? Resend',
       });
       fireEvent.click(resendEmailButton);
-      expect(account.sendVerificationCode).toBeCalled();
+      expect(session.sendVerificationCode).toBeCalled();
       const successBannerText = `Email resent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a smooth delivery.`;
       expect(screen.getByText(successBannerText)).toBeInTheDocument();
     });
@@ -118,13 +120,14 @@ describe('Confirm page', () => {
 
   it('renders an error banner when resending an email fails', async () => {
     const account: Account = MOCK_ACCOUNT_WITH_ERROR;
-    renderWithContext(account, MOCK_UNVERIFIED_SESSION, MOCK_SESSION_TOKEN);
+    const session = mockSession(false, true);
+    renderWithContext(account, session, MOCK_SESSION_TOKEN);
     await waitFor(() => {
       const resendEmailButton = screen.getByRole('button', {
         name: 'Not in inbox or spam folder? Resend',
       });
       fireEvent.click(resendEmailButton);
-      expect(account.sendVerificationCode).toBeCalled();
+      expect(session.sendVerificationCode).toBeCalled();
       const bannerText = `Unexpected error`;
       expect(screen.getByText(bannerText)).toBeInTheDocument();
     });

--- a/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/Confirm/index.tsx
@@ -23,6 +23,7 @@ import {
   useAccount,
   useFtlMsgResolver,
   useInterval,
+  useSession,
 } from 'fxa-settings/src/models';
 import {
   AuthUiErrors,
@@ -59,6 +60,7 @@ export const Confirm = ({
   const [email, setEmail] = useState('');
 
   const account = useAccount();
+  const session = useSession();
   const navigate = useNavigate();
   const [isPolling, setIsPolling] = useState<number | null>(
     POLLING_INTERVAL_MS
@@ -145,8 +147,8 @@ export const Confirm = ({
   // navigate to the next screen.
   useInterval(async () => {
     try {
-      const sessionStatus = await account.isSessionVerified();
-      if (sessionStatus === true) {
+      const sessionVerified = await session.isSessionVerified();
+      if (sessionVerified) {
         navigateToNextScreen();
         setIsPolling(null);
       }
@@ -161,7 +163,7 @@ export const Confirm = ({
       // from confirmation link, this resend function sends a verification code
       // instead of a verification link and navigates to /signup_confirm_code.
       // This avoids adding a (to be discontinued) method to the React Account model.
-      await account.sendVerificationCode();
+      await session.sendVerificationCode();
       setResendStatus(ResendStatus.sent);
     } catch (err) {
       const localizedErrorMessage = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -17,9 +17,9 @@ import {
   hardNavigateToContentServer,
 } from 'fxa-react/lib/utils';
 import {
-  useAccount,
   useAlertBar,
   useFtlMsgResolver,
+  useSession,
 } from '../../../models/hooks';
 import AppLayout from '../../../components/AppLayout';
 import Banner, {
@@ -65,7 +65,7 @@ const ConfirmSignupCode = ({
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
   const alertBar = useAlertBar();
-  const account = useAccount();
+  const session = useSession();
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
     ResendStatus['not sent']
@@ -99,8 +99,8 @@ const ConfirmSignupCode = ({
 
   async function handleResendCode() {
     try {
-      await account.sendVerificationCode();
-      // if resending a code is succesful, clear any banner already present on screen
+      await session.sendVerificationCode();
+      // if resending a code is successful, clear any banner already present on screen
       if (resendStatus !== ResendStatus['sent']) {
         setBanner({
           type: undefined,
@@ -143,7 +143,7 @@ const ConfirmSignupCode = ({
         }),
       };
 
-      await account.verifySession(code, options);
+      await session.verifySession(code, options);
 
       logViewEvent(
         `flow.${viewName}`,


### PR DESCRIPTION
## Because

- We want to separate out session functions from account related ones
- We also want to be able to use the Session hook when a user is not signed in locally

## This pull request

- Moves all session related react functions into the Session hook
- Updates all components to use the new hook
- Updates all tests 

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-7184
Closes: https://mozilla-hub.atlassian.net/browse/FXA-7626

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Notes

To test this, you will need to signin with an unverified session, easiest way to set the `skipForNewAccounts` auth-server value to 0.