### PR TITLE
fix(backstage): update db references, add gql API ref

### DIFF
--- a/backstage/memcached.resources.yaml
+++ b/backstage/memcached.resources.yaml
@@ -4,7 +4,9 @@ kind: Resource
 metadata:
   name: fxa-customs-cache
   description: Caches rate limits and IP reuptation scores.
+  tags:
+    - memcached
 spec:
-  type: database
+  type: cache
   owner: fxa-devs
   system: mozilla-accounts

--- a/backstage/mozilla-accounts.system.yaml
+++ b/backstage/mozilla-accounts.system.yaml
@@ -6,4 +6,3 @@ metadata:
   description: Mozilla Accounts
 spec:
   owner: fxa-devs
-  domain: accounts

--- a/backstage/redis.resources.yaml
+++ b/backstage/redis.resources.yaml
@@ -4,8 +4,10 @@ kind: Resource
 metadata:
   name: fxa-profile-cache
   description: Stores aggregated profile data.
+  tags:
+    - redis
 spec:
-  type: database
+  type: cache
   owner: fxa-devs
   system: mozilla-accounts
 ---
@@ -14,7 +16,9 @@ kind: Resource
 metadata:
   name: fxa-auth-cache
   description: Stores OAuth access and session token info, and email reminders.
+  tags:
+    - redis
 spec:
-  type: database
+  type: cache
   owner: fxa-devs
   system: mozilla-accounts

--- a/packages/123done/backstage.yaml
+++ b/packages/123done/backstage.yaml
@@ -3,7 +3,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: fxa-123done
-  description: Demo app for Mozilla Accounts
+  description: Demo app for Mozilla Accounts and Subscription Platform.
   tags:
     - javascript
     - node

--- a/packages/fxa-content-server/backstage.yaml
+++ b/packages/fxa-content-server/backstage.yaml
@@ -9,7 +9,6 @@ metadata:
     - typescript
     - node
     - backbone
-    - react
   annotations:
     sentry.io/project-slug: mozilla/fxa-content-server
     circleci.com/project-slug: github/mozilla/fxa
@@ -27,3 +26,5 @@ spec:
   system: mozilla-accounts
   consumesApis:
     - api:fxa-auth
+  dependsOn:
+    - component:fxa-admin-server

--- a/packages/fxa-graphql-api/backstage.yaml
+++ b/packages/fxa-graphql-api/backstage.yaml
@@ -19,3 +19,16 @@ spec:
   system: mozilla-accounts
   consumesApis:
     - api:fxa-auth
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: fxa-graphql
+  description:  Mozilla Accounts GraphQL API
+spec:
+  type: graphql
+  lifecycle: production
+  owner: fxa-devs
+  system: mozilla-accounts
+  definition: |
+    $text: https://accounts-static.cdn.mozilla.net/fxa-graphql-api/schema.gql

--- a/packages/fxa-payments-server/backstage.yaml
+++ b/packages/fxa-payments-server/backstage.yaml
@@ -25,3 +25,5 @@ spec:
   system: mozilla-accounts
   consumesApis:
     - api:fxa-auth
+  dependsOn:
+    - component:fxa-auth-server

--- a/packages/fxa-profile-server/backstage.yaml
+++ b/packages/fxa-profile-server/backstage.yaml
@@ -17,6 +17,7 @@ spec:
   owner: fxa-devs
   system: mozilla-accounts
   dependsOn:
+    - component:fxa-auth-server
     - resource:fxa-profile-database
     - resource:fxa-profile-cache
   consumesApis:

--- a/packages/fxa-settings/backstage.yaml
+++ b/packages/fxa-settings/backstage.yaml
@@ -24,7 +24,9 @@ spec:
   owner: fxa-devs
   system: mozilla-accounts
   dependsOn:
+    - component:fxa-auth-server
     - component:fxa-profile-server
     - component:fxa-graphl-api
   consumesApis:
     - api:fxa-auth
+    - api:fxa-graphql


### PR DESCRIPTION
Because:

* We want to properly name cache vs. databases.
* We want to add the GraphQL API to the list of services.

This commit:

* Renames the database resources to cache resources.
* Adds the GraphQL API to the list of services.
