### PR TITLE
chore(auth): log better error on deleteFirestoreCustomer

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -300,7 +300,10 @@ export class AccountDeleteManager {
       }
       this.log.error('AccountDeleteManager.deleteFirestoreCustomer', {
         uid,
-        error,
+        error:
+          error instanceof StripeFirestoreMultiError
+            ? error.getSummary()
+            : String(error),
       });
       throw error;
     }


### PR DESCRIPTION
## Because

- Error log for deleteFirestoreCustomer does not log original errors.

## This pull request

- Add getSummary method to StripeFirestoreMultiError to log errors of all errors.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
