### PR TITLE
fix(backstage): update definition errors

### DIFF
--- a/packages/fxa-graphql-api/backstage.yaml
+++ b/packages/fxa-graphql-api/backstage.yaml
@@ -19,6 +19,8 @@ spec:
   system: mozilla-accounts
   consumesApis:
     - api:fxa-auth
+  providesApis:
+    - api:fxa-graphql
 ---
 apiVersion: backstage.io/v1alpha1
 kind: API
@@ -30,5 +32,5 @@ spec:
   lifecycle: production
   owner: fxa-devs
   system: mozilla-accounts
-  definition: |
+  definition:
     $text: https://accounts-static.cdn.mozilla.net/fxa-graphql-api/schema.gql


### PR DESCRIPTION
[skip ci]

Because:

* We want to show the right provider.

This commit:

* Updates the definition errors to show the right provider.
