### PR TITLE
fix(payments): remove duplicate text in resubscribe modal

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -61,7 +61,7 @@ const ConfirmationDialogContent = ({
       >
         <h4 id={headerId}>Want to keep using {productName}?</h4>
       </Localized>
-      {(Provider.isPaypal(payment_provider) || !last4) && (
+      {Provider.isPaypal(payment_provider) || !last4 ? (
         <Localized
           id="reactivate-confirm-without-payment-method-copy"
           vars={{
@@ -70,15 +70,14 @@ const ConfirmationDialogContent = ({
             endDate: getLocalizedDate(periodEndDate),
           }}
         >
-          <p>
+          <p id={descId} data-testid="reactivate-modal-copy-paypal">
             Your access to {productName} will continue, and your billing cycle
             and payment will stay the same. Your next charge will be{' '}
             {getLocalizedCurrencyString(amount, currency)} on{' '}
             {getLocalizedDateString(periodEndDate)}.
           </p>
         </Localized>
-      )}
-      {last4 && (
+      ) : (
         <Localized
           id="reactivate-confirm-copy"
           vars={{


### PR DESCRIPTION
## Because

- Resubscription modal contained copy for both CC and non-CC confirmations.

## This pull request

- Updates the logic to an if/else rather than two ifs, since customers can have both PayPal and CC (last4).
- Updates all applicable tests.

## Issue that this pull request solves

Closes FXA-9018

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
