### PR TITLE
test(signup): audit and remove the TODO statements

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -238,7 +238,9 @@ export class LoginPage extends BaseLayout {
   }
 
   async cannotCreateAccountHeader() {
-    return this.page.locator(selectors.COPPA_HEADER).isVisible();
+    const header = this.page.locator(selectors.COPPA_HEADER);
+    await header.waitFor({ state: 'visible' });
+    return header.isVisible();
   }
 
   async waitForSignUpCodeHeader() {

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -101,8 +101,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Verify navigated to the cannot create account page
       await page.waitForURL(/cannot_create_account/);
-      // TODO: this is flaky
-      // expect(await login.cannotCreateAccountHeader()).toBe(true);
+      expect(await login.cannotCreateAccountHeader()).toBe(true);
     });
 
     test('sign up with non matching passwords', async ({


### PR DESCRIPTION
## Because

Audited Signup modules and these are the conclusions:
- Removed the TODO comment - as the assert was already performed on the [URL](https://github.com/mozilla/fxa/blob/main/packages/functional-tests/tests/signUp/signUp.spec.ts#L104)
- Found the reason for High Failure rate for [relier test](https://github.com/mozilla/fxa/blob/main/packages/functional-tests/tests/signUp/signUp.spec.ts#L151) was due to GCP load balancer issue for the Timeouts [refer this](https://docs.google.com/document/d/14d-Z8LEsuf05zDhfrcasORNTYyVjJ8TA-WcMWBirtkI/edit) Doc for June 7, 2023 notes)
More info on [FXA-7347](https://mozilla-hub.atlassian.net/browse/FXA-7347)

## This pull request

- Removes unnecessary comments found during the audit process

## Issue that this pull request solves

Closes: FXA-8955

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-7347]: https://mozilla-hub.atlassian.net/browse/FXA-7347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ