### PR TITLE
feat(auth): Refund Stripe and PayPal invoices on delete

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1858,7 +1858,7 @@ export class AccountHandler {
       }
     };
 
-    await this.accountDeleteManager.deleteAccount(uid, { notify });
+    await this.accountDeleteManager.deleteAccount(uid, '', { notify });
 
     return {};
   }

--- a/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
@@ -79,15 +79,22 @@ export class CloudTaskHandler {
         }
       };
       // the account still exists in MySQL, delete as usual
-      await this.accountDeleteManager.deleteAccount(taskPayload.uid, {
-        notify,
-      });
+      await this.accountDeleteManager.deleteAccount(
+        taskPayload.uid,
+        taskPayload.customerId,
+        {
+          notify,
+        }
+      );
     } catch (err) {
       // if the account is already deleted from the db, then try to clean up
       // some potentially remaining other records
       if (err.errno === ERRNO.ACCOUNT_UNKNOWN) {
         this.log.info('accountCleanup.byCloudTask', { uid: taskPayload.uid });
-        await this.accountDeleteManager.cleanupAccount(taskPayload.uid);
+        await this.accountDeleteManager.cleanupAccount(
+          taskPayload.uid,
+          taskPayload.customerId
+        );
       } else {
         throw err;
       }

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2534,6 +2534,54 @@ describe('#integration - StripeHelper', () => {
     });
   });
 
+  describe('refundInvoices', () => {
+    it('refunds invoice with charge unexpanded', async () => {
+      sandbox.stub(stripeHelper.stripe.refunds, 'create').resolves({});
+      sandbox
+        .stub(stripeHelper.stripe.charges, 'retrieve')
+        .resolves({ refunded: false });
+      await stripeHelper.refundInvoices([
+        {
+          ...paidInvoice,
+          collection_method: 'charge_automatically',
+        },
+      ]);
+      sinon.assert.calledOnceWithExactly(stripeHelper.stripe.refunds.create, {
+        charge: paidInvoice.charge,
+      });
+    });
+
+    it('refunds invoice with charge expanded', async () => {
+      sandbox.stub(stripeHelper.stripe.refunds, 'create').resolves({});
+      sandbox
+        .stub(stripeHelper.stripe.charges, 'retrieve')
+        .resolves({ refunded: false });
+      await stripeHelper.refundInvoices([
+        {
+          ...paidInvoice,
+          collection_method: 'charge_automatically',
+          charge: {
+            id: paidInvoice.charge,
+          },
+        },
+      ]);
+      sinon.assert.calledOnceWithExactly(stripeHelper.stripe.refunds.create, {
+        charge: paidInvoice.charge,
+      });
+    });
+
+    it('does not refund invoice from PayPal', async () => {
+      sandbox.stub(stripeHelper.stripe.refunds, 'create').resolves({});
+      await stripeHelper.refundInvoices([
+        {
+          ...paidInvoice,
+          collection_method: 'send_invoice',
+        },
+      ]);
+      sinon.assert.notCalled(stripeHelper.stripe.refunds.create);
+    });
+  });
+
   describe('updateInvoiceWithPaypalTransactionId', () => {
     it('works successfully', async () => {
       sandbox.stub(stripeHelper.stripe.invoices, 'update').resolves({});
@@ -4034,6 +4082,95 @@ describe('#integration - StripeHelper', () => {
         tax: customerSecond.tax,
       };
       assert.deepEqual(result, customerResult);
+    });
+  });
+
+  describe('fetchInvoicesForActiveSubscriptions', () => {
+    it('returns empty array if no stripe customer', async () => {
+      const noCustomer = '192499bcb0cf4da2bf1b37f1a37f3b88';
+      const result = await stripeHelper.fetchInvoicesForActiveSubscriptions(
+        noCustomer,
+        'paid'
+      );
+      assert.deepEqual(result, []);
+    });
+
+    it('returns empty array if customer has no active subscriptions', async () => {
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves({});
+      const result = await stripeHelper.fetchInvoicesForActiveSubscriptions(
+        existingUid,
+        'paid'
+      );
+      assert.deepEqual(result, []);
+    });
+
+    it('fetches invoices no older than earliestCreatedDate', async () => {
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves({
+        subscriptions: { data: [] },
+      });
+      sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({ data: [] });
+      const expectedDateTime = 1706667661086;
+      const expectedDate = new Date(expectedDateTime);
+
+      const result = await stripeHelper.fetchInvoicesForActiveSubscriptions(
+        'customerId',
+        'paid',
+        expectedDate
+      );
+
+      assert.deepEqual(result, []);
+      sinon.assert.calledOnceWithExactly(stripeHelper.stripe.invoices.list, {
+        customer: 'customerId',
+        status: 'paid',
+        created: { gte: Math.floor(expectedDateTime / 1000) },
+      });
+    });
+
+    it('returns only invoices of active subscriptions', async () => {
+      const expectedExpanded = {
+        id: 'idExpanded',
+        subscription: {
+          id: 'subIdExpanded',
+        },
+      };
+      const expectedString = {
+        id: 'idString',
+        subscription: 'idSub',
+      };
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves({
+        subscriptions: {
+          data: [
+            {
+              id: 'idNull',
+            },
+            {
+              id: 'subIdExpanded',
+            },
+            {
+              id: 'idSub',
+            },
+          ],
+        },
+      });
+      sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({
+        data: [
+          {
+            id: 'idNull',
+            subscription: null,
+          },
+          {
+            ...expectedExpanded,
+          },
+          {
+            ...expectedString,
+          },
+        ],
+      });
+      const result = await stripeHelper.fetchInvoicesForActiveSubscriptions(
+        existingUid,
+        'paid'
+      );
+      assert.deepEqual(result, [expectedExpanded, expectedString]);
     });
   });
 

--- a/packages/fxa-auth-server/test/local/routes/cloud-tasks.js
+++ b/packages/fxa-auth-server/test/local/routes/cloud-tasks.js
@@ -34,9 +34,11 @@ describe('/cloud-tasks/accounts/delete', () => {
     mockPush = mocks.mockPush();
     sandbox.reset();
 
-    deleteAccountStub = sandbox.stub().callsFake((uid, { notify }) => {
-      notify();
-    });
+    deleteAccountStub = sandbox
+      .stub()
+      .callsFake((uid, customerId, { notify }) => {
+        notify();
+      });
     cleanupAccountStub = sandbox.stub().resolves();
     Container.set(AccountDeleteManager, {
       deleteAccount: deleteAccountStub,
@@ -86,6 +88,7 @@ describe('/cloud-tasks/accounts/delete', () => {
         event: 'account.deleted',
       });
     } catch (err) {
+      console.log(err);
       assert.fail('An error should not have been thrown.');
     }
   });


### PR DESCRIPTION
## Because

- For unverified accounts, refund invoices paid through PayPal, up to 180 days ago.
- For unverified accounts, refund all invoices paid through Stripe.

## This pull request

- Adds invoice fetch to StripeHelper
- Adds invoices refund method to StripeHelper
- Adds invoices refund method to PayPalHelper
- Adds refundSubscriptions method to AccountDeleteManager

## Issue that this pull request solves

Closes: #FXA-8841 and FXA-8840

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).