### PR TITLE
task(auth): Fix flaky unit tests in auth server

### DIFF
--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -6,7 +6,7 @@ cd "$DIR/.."
 export NODE_ENV=dev
 export CORS_ORIGIN="http://foo,http://bar"
 
-DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 20000 --exit "
+DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 20000 --exit --parallel=1 "
 if [ "$TEST_TYPE" == 'unit' ]; then GREP_TESTS="--grep #integration --invert "; fi;
 if [ "$TEST_TYPE" == 'integration' ]; then GREP_TESTS="--grep /#integration\s-/"; fi;
 if [ "$TEST_TYPE" == 'integration-v2' ]; then GREP_TESTS="--grep /#integrationV2\s-/"; fi;


### PR DESCRIPTION
## This pull request
- We were seeing some flaky unit tests in auth server

## Because
- Disables the parallel option for unit tests.
- Due to the way some tests are structured, we can't enable the parallel option here.


## Issue that this pull request solves

Closes: FXA-8875

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We might want to consider filing a follow up for supporting the parallel option for unit tests. Ideally this would work, but would require ensuring there's no shared state between tests. Since it's hard to trigger these failures, validating that any shared state was successfully removed is a bit tricky... Furthermore the savings may be inconsequential since we have other longer running CI jobs anyway.
