### PR TITLE
fix(l10n): Reintroduce string to preserve l10n translations

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/en.ftl
@@ -8,3 +8,8 @@ add-secondary-email-enter-address =
   .label = Enter email address
 add-secondary-email-cancel-button = Cancel
 add-secondary-email-save-button = Save
+
+# This message is shown when a user tries to add a secondary email that is a
+# Firefox Relay email mask (generated email address that can be used in place of
+# your real email address)
+add-secondary-email-mask = Email masks can’t be used as a secondary email


### PR DESCRIPTION
## Because:

- #16289 reverted a previous patch which included an ftl string. Since this string will be introduced again in the future, we should keep this string in the files so the translations are preserved.

## This pull request:

- Restores "add-secondary-email-mask" to ensure translations are not deleted from l10n repos.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
