### PR TITLE
fix(react): Remove confirm route from react signup routes

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -76,7 +76,6 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       featureFlagOn: showReactApp.signUpRoutes,
       routes: reactRoute.getRoutes([
         'signup',
-        'confirm',
         'confirm_signup_code',
         'primary_email_verified',
         'signup_confirmed',


### PR DESCRIPTION
## Because

* We don't want to show react version of confirm page when react signup is rolled out to production

## This pull request
* Remove 'confirm' from react app signup routes

## Issue that this pull request solves

Closes: #FXA-9071

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
