### PR TITLE
bug(graphql-api): Fix relaying of client side IP

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -392,11 +392,22 @@ describe('#integration - AccountResolver', () => {
 
     describe('sendSessionVerificationCode', () => {
       it('succeeds', async () => {
-        authClient.sessionResendVerifyCode = jest.fn().mockResolvedValue(true);
-        const result = await resolver.sendSessionVerificationCode('token', {
-          clientMutationId: 'testid',
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
         });
+        authClient.sessionResendVerifyCode = jest.fn().mockResolvedValue(true);
+        const result = await resolver.sendSessionVerificationCode(
+          headers,
+          'token',
+          {
+            clientMutationId: 'testid',
+          }
+        );
         expect(authClient.sessionResendVerifyCode).toBeCalledTimes(1);
+        expect(authClient.sessionResendVerifyCode).toHaveBeenCalledWith(
+          'token',
+          headers
+        );
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
         });
@@ -405,12 +416,21 @@ describe('#integration - AccountResolver', () => {
 
     describe('verifySession', () => {
       it('succeeds', async () => {
+        const headers = new Headers({
+          'x-forwarded-for': '123.123.123.123',
+        });
         authClient.sessionVerifyCode = jest.fn().mockResolvedValue(true);
-        const result = await resolver.verifySession('token', {
+        const result = await resolver.verifySession(headers, 'token', {
           clientMutationId: 'testid',
           code: 'ABCD1234',
         });
         expect(authClient.sessionVerifyCode).toBeCalledTimes(1);
+        expect(authClient.sessionVerifyCode).toHaveBeenCalledWith(
+          'token',
+          'ABCD1234',
+          undefined,
+          headers
+        );
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
         });
@@ -492,6 +512,12 @@ describe('#integration - AccountResolver', () => {
           code: 'code',
         });
         expect(authClient.passwordForgotVerifyCode).toBeCalledTimes(1);
+        expect(authClient.passwordForgotVerifyCode).toHaveBeenLastCalledWith(
+          'code',
+          'passwordforgottoken',
+          {},
+          headers
+        );
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
           accountResetToken: 'cooltokenyo',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -406,11 +406,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async sendSessionVerificationCode(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => SendSessionVerificationInput })
     input: SendSessionVerificationInput
   ) {
-    await this.authAPI.sessionResendVerifyCode(token);
+    await this.authAPI.sessionResendVerifyCode(token, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -420,10 +421,11 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifySession(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => VerifySessionInput }) input: VerifySessionInput
   ) {
-    await this.authAPI.sessionVerifyCode(token, input.code);
+    await this.authAPI.sessionVerifyCode(token, input.code, undefined, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -495,7 +497,12 @@ export class AccountResolver {
     @Args('input', { type: () => PasswordForgotVerifyCodeInput })
     input: PasswordForgotVerifyCodeInput
   ) {
-    return this.authAPI.passwordForgotVerifyCode(input.code, input.token, {});
+    return this.authAPI.passwordForgotVerifyCode(
+      input.code,
+      input.token,
+      {},
+      headers
+    );
   }
 
   @Mutation((returns) => PasswordForgotCodeStatusPayload, {


### PR DESCRIPTION
## Because

- The clients IP wasn't making it to auth server, and there fore was being reported.

## This pull request

- Makes sure that headers are passed to auth client.

## Issue that this pull request solves

Closes: FXA-8629

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
