### PR TITLE
fix(signin): Redirect to totp page if user lands on signin confirm with totp enabled

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
@@ -36,6 +36,7 @@ describe('views/sign_in_token_code', () => {
   let user;
   let view;
   let windowMock;
+  let accountProfile;
 
   beforeEach(() => {
     windowMock = new WindowMock();
@@ -78,6 +79,12 @@ describe('views/sign_in_token_code', () => {
     });
 
     sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+    accountProfile = {
+      authenticationMethods: [],
+    };
+    sinon
+      .stub(account, 'accountProfile')
+      .callsFake(() => Promise.resolve(accountProfile));
 
     return view.render();
   });
@@ -106,6 +113,27 @@ describe('views/sign_in_token_code', () => {
 
       it('redirects to the signin page', () => {
         assert.isTrue(view.navigate.calledWith('signin'));
+      });
+    });
+
+    describe('with totp enabled', () => {
+      beforeEach(() => {
+        view.getSignedInAccount.restore();
+        sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+        accountProfile = {
+          authenticationMethods: ['otp'],
+        };
+        account.accountProfile.restore();
+        sinon
+          .stub(account, 'accountProfile')
+          .callsFake(() => Promise.resolve(accountProfile));
+
+        sinon.spy(view, 'replaceCurrentPage');
+        return view.render();
+      });
+
+      it('redirects to the totp page', () => {
+        assert.isTrue(view.replaceCurrentPage.calledWith('/signin_totp_code'));
       });
     });
   });


### PR DESCRIPTION
## Because

- Users that have TOTP enabled can not verify their session with an email, our API will not send the email
- Users should be prompted to verify with TOTP if they have it

## This pull request

- Redirects the user to the verify TOTP page if they somehow land on the signin confirmation page with TOTP enabled

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8793

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test
1. Add TOTP to account
2. Sign out
3. Login and enter password, should be prompted to enter TOTP
4. Navigate to `/signin_token_code` page, should be redirected to TOTP page
