### PR TITLE
test(functional-tests): audit subscription-tests functional tests

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -242,9 +242,9 @@ export class LoginPage extends BaseLayout {
   }
 
   async waitForEmailHeader() {
-    await this.page.waitForSelector(selectors.EMAIL_HEADER, {
-      timeout: 2000,
-    });
+    const emailHeader = this.page.locator(selectors.EMAIL_HEADER);
+    await emailHeader.waitFor({ state: 'visible', timeout: 2000 });
+    return emailHeader.isVisible();
   }
 
   async cannotCreateAccountHeader() {

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -51,30 +51,6 @@ export class SubscriptionManagementPage extends BaseLayout {
     return paypalWindow;
   }
 
-  async loginPaypal() {
-    await this.page.locator('input[type=password]').fill('Ah4SboP6UDZx95I');
-    await this.page.locator('button[id=btnLogin]').click();
-  }
-
-  async updatePaypalAccount() {
-    await this.page.locator('#fundingLink').click();
-    await this.page.waitForLoadState();
-    const cardOption = this.page.locator(
-      'input[type="radio"][data-type="CREDIT_CARD"]'
-    );
-    await cardOption.click();
-    const saveChanges = this.page.locator('button[name="SaveFI"]');
-    await saveChanges.click();
-    const submit = this.page.locator('button[name="modalClose"]');
-    await submit.click();
-  }
-
-  async checkPaypalAccount() {
-    const account = this.page.locator('#fundingLink');
-    await account.waitFor({ state: 'visible' });
-    return account.textContent();
-  }
-
   async fillSupportForm() {
     await this.page.locator('[data-testid="contact-support-button"]').click();
     await this.page.locator('#product_chosen a.chosen-single').click();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -17,7 +17,7 @@ test.describe('severity-2 #smoke', () => {
     }) => {
       test.skip(
         project.name === 'production',
-        'test plan not yet available in prod'
+        'test plan not available in prod'
       );
       await relier.goto();
       await relier.clickSubscribe6Month();
@@ -36,7 +36,7 @@ test.describe('severity-2 #smoke', () => {
     }) => {
       test.skip(
         project.name === 'production',
-        'test plan not yet available in prod'
+        'test plan not available in prod'
       );
       await relier.goto();
       await relier.clickSubscribe6Month();
@@ -206,7 +206,7 @@ test.describe('severity-2 #smoke', () => {
     }, { project }) => {
       test.skip(
         project.name === 'production',
-        'test plan not yet available in prod'
+        'test plan not available in prod'
       );
 
       await relier.goto();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -13,7 +13,6 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('resubscribe successfully with the same coupon after canceling for stripe', async ({
-      page,
       pages: { relier, subscribe, login, settings, subscriptionManagement },
     }, { project }) => {
       test.skip(
@@ -65,7 +64,6 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('resubscribe successfully with the same coupon after canceling for paypal', async ({
-      page,
       pages: { relier, subscribe, login, settings, subscriptionManagement },
     }, { project }) => {
       test.skip(
@@ -115,7 +113,6 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('update mode of payment for stripe', async ({
-      page,
       pages: { relier, subscribe, login, settings, subscriptionManagement },
     }, { project }) => {
       test.skip(
@@ -148,13 +145,11 @@ test.describe('severity-2 #smoke', () => {
       expect(await subscriptionManagement.getCardInfo()).toContain('4444');
     });
 
-    //Disable as paypal sandbox is taking a long time to load
-    /*test('update mode of payment for paypal', async ({
-      page,
+    test('update mode of payment for paypal', async ({
       pages: { relier, subscribe, login, settings, subscriptionManagement },
     }, { project }) => {
       test.skip(
-        project.name !== 'local',
+        project.name === 'production',
         'no real payment method available in prod'
       );
       await relier.goto();
@@ -177,23 +172,7 @@ test.describe('severity-2 #smoke', () => {
       //Change Paypal information
       const paypalPage = await subscriptionManagement.clickPaypalChange();
       subscriptionManagement.page = paypalPage;
-
-      //Login to Paypal sandbox
-      await subscriptionManagement.loginPaypal();
-
-      //Verify the account as 'CREDIT UNION'
-      expect(await subscriptionManagement.checkPaypalAccount()).toContain(
-        'CREDIT UNION'
-      );
-
-      //Change account from 'Credit Union' to 'Visa'
-      await subscriptionManagement.updatePaypalAccount();
-
-      //Added this timeout wait for page to be loaded correctly
-      await page.waitForTimeout(2000);
-
-      //Verify that the payment info is updated
-      expect(await subscriptionManagement.checkPaypalAccount()).toContain('Visa');
-    });*/
+      expect(subscriptionManagement.page.url()).toContain('paypal.com/signin');
+    });
   });
 });

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -7,22 +7,18 @@ import { MetricsObserver } from '../../../lib/metrics';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('ui functionality', () => {
-    let metricsObserver: MetricsObserver;
-
-    test.beforeEach(({ pages: { subscribe } }) => {
-      test.slow();
-      metricsObserver = new MetricsObserver(subscribe);
-      metricsObserver.startTracking();
-    });
-
     test('verify plan change funnel metrics & coupon feature not available when changing plans', async ({
-      page,
       pages: { relier, subscribe },
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
+      test.slow();
+
+      const metricsObserver = new MetricsObserver(subscribe);
+      metricsObserver.startTracking();
+
       await relier.goto();
       await relier.clickSubscribe6Month();
 

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -9,12 +9,8 @@ test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-2 #smoke', () => {
   test.describe('subscription test with cc and paypal', () => {
-    let metricsObserver: MetricsObserver;
-
-    test.beforeEach(({ pages: { subscribe } }) => {
+    test.beforeEach(() => {
       test.slow();
-      metricsObserver = new MetricsObserver(subscribe);
-      metricsObserver.startTracking();
     });
 
     test('subscribe with credit card and login to product', async ({
@@ -44,6 +40,10 @@ test.describe('severity-2 #smoke', () => {
         project.name === 'production',
         'no real payment method available in prod'
       );
+
+      const metricsObserver = new MetricsObserver(subscribe);
+      metricsObserver.startTracking();
+
       await relier.goto();
       await relier.clickSubscribe();
       await subscribe.setConfirmPaymentCheckbox();
@@ -94,147 +94,141 @@ test.describe('severity-2 #smoke', () => {
   });
 
   test.describe('Flow, acquisition and new user checkout funnel metrics', () => {
-    let metricsObserver: MetricsObserver;
-
-    test.beforeEach(({ pages: { subscribe } }) => {
+    test.beforeEach(() => {
       test.slow();
-      metricsObserver = new MetricsObserver(subscribe);
+    });
+
+    test('Metrics disabled: existing user checkout URL to not have flow params', async ({
+      pages: { settings, relier, page },
+    }, { project }) => {
+      test.skip(
+        project.name === 'production',
+        'test plan not available in prod'
+      );
+      // Go to settings page and verify the Data Collection toggle switch is visible
+      await settings.goto();
+      expect(await settings.dataCollection.isToggleSwitch()).toBe(true);
+
+      // Toggle switch, verify the alert bar appears and its status
+      await settings.dataCollection.toggleShareData('off');
+      expect(await settings.alertBarText()).toContain('Opt out successful.');
+      expect(await settings.dataCollection.getToggleStatus()).toBe('false');
+
+      // Subscribe to plan and verify URL does not include flow parameter
+      await relier.goto();
+      await relier.clickSubscribe6Month();
+      expect(page.url()).not.toContain('&flow_begin_time=');
+    });
+
+    test('Existing user checkout URL to have flow params', async ({
+      pages: { settings, relier, page },
+    }, { project }) => {
+      test.skip(
+        project.name === 'production',
+        'test plan not available in prod'
+      );
+      // Go to settings page and verify the Data Collection toggle switch is visible
+      await settings.goto();
+      expect(await settings.dataCollection.isToggleSwitch()).toBe(true);
+
+      // Toggle switch and verify its status
+      await settings.dataCollection.toggleShareData('on');
+      expect(await settings.dataCollection.getToggleStatus()).toBe('true');
+
+      // Subscribe to plan and verify URL does include flow parameter
+      await relier.goto();
+      await relier.clickSubscribe6Month();
+      expect(page.url()).toContain('&flow_begin_time=');
+    });
+
+    test('New user checkout URL to have flow params', async ({
+      pages: { settings, relier, page },
+    }, { project }) => {
+      test.skip(
+        project.name === 'production',
+        'test plan not available in prod'
+      );
+      await settings.goto();
+      await settings.signOut();
+      await relier.goto();
+      await relier.clickSubscribe6Month();
+      expect(page.url()).toContain('&flow_begin_time=');
+    });
+
+    test('New user checkout URL to have flow params with cache cleared', async ({
+      pages: { settings, login, relier, page },
+    }, { project }) => {
+      test.skip(
+        project.name === 'production',
+        'test plan not available in prod'
+      );
+      await settings.goto();
+      await settings.signOut();
+      await login.clearCache();
+      await relier.goto();
+      await relier.clickSubscribe6Month();
+      expect(page.url()).toContain('&flow_begin_time=');
+    });
+
+    test('New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics', async ({
+      pages: { settings, relier, page, subscribe },
+    }, { project }) => {
+      test.fixme(true, 'Fix required as of 2023/10/09 (see FXA-8447).');
+      test.skip(
+        project.name === 'production',
+        'test plan not available in prod'
+      );
+
+      const metricsObserver = new MetricsObserver(subscribe);
       metricsObserver.startTracking();
-    });
 
-    test.describe('severity-2', () => {
-      test('Metrics disabled: existing user checkout URL to not have flow params', async ({
-        pages: { settings, relier, page },
-      }, { project }) => {
-        test.skip(
-          project.name === 'production',
-          'test plan not yet available in prod'
-        );
-        // Go to settings page and verify the Data Collection toggle switch is visible
-        await settings.goto();
-        expect(await settings.dataCollection.isToggleSwitch()).toBe(true);
+      await settings.goto();
+      await settings.signOut();
+      await relier.goto();
 
-        // Toggle swtich, verify the alert bar appears and its status
-        await settings.dataCollection.toggleShareData('off');
-        expect(await settings.alertBarText()).toContain('Opt out successful.');
-        expect(await settings.dataCollection.getToggleStatus()).toBe('false');
+      const subscribeUrl = await relier.getUrl();
+      expect(subscribeUrl, 'Subscribe button has no href.').toBeTruthy();
 
-        // Subscribe to plan and verify URL does not include flow parameter
-        await relier.goto();
-        await relier.clickSubscribe6Month();
-        expect(page.url()).not.toContain('&flow_begin_time=');
+      const rpSearchParamsBefore = relier.getRpSearchParams(subscribeUrl);
+      const rpFlowParamsBefore = relier.getRpFlowParams(rpSearchParamsBefore);
+      const acquisitionParamsBefore =
+        relier.getRpAcquisitionParams(rpSearchParamsBefore);
+
+      // check flow metrics
+      await relier.clickSubscribeRPFlowMetrics();
+      const rpSearchParamsAfter = relier.getRpSearchParams(page.url());
+      const rpFlowParamsAfter = relier.getRpFlowParams(rpSearchParamsAfter);
+      expect(rpFlowParamsAfter).toStrictEqual(rpFlowParamsBefore);
+
+      // subscribe, failing first then succeeding
+      await subscribe.setEmailAndConfirmNewUser();
+      await subscribe.setConfirmPaymentCheckbox();
+      await subscribe.setFullName();
+      await subscribe.setFailedCreditCardInfo();
+      await subscribe.clickPayNow();
+      await subscribe.clickTryAgain();
+      await subscribe.setCreditCardInfo();
+      await subscribe.clickPayNow();
+      await subscribe.submit();
+
+      // check acquisition metrics
+      const acquisitionParamsAfter =
+        metricsObserver.getAcquisitionParamsFromEvents();
+      expect(acquisitionParamsAfter).toStrictEqual(acquisitionParamsBefore);
+
+      // check conversion funnel metrics
+      const expectedEventTypes = [
+        'amplitude.subPaySetup.view',
+        'amplitude.subPaySetup.engage',
+        'amplitude.subPaySetup.submit',
+        'amplitude.subPaySetup.fail',
+        'amplitude.subPaySetup.submit',
+        'amplitude.subPaySetup.success',
+      ];
+      const actualEventTypes = metricsObserver.rawEvents.map((event) => {
+        return event.type;
       });
-    });
-
-    test.describe('severity-2', () => {
-      test('Existing user checkout URL to have flow params', async ({
-        pages: { settings, relier, page },
-      }, { project }) => {
-        test.skip(
-          project.name === 'production',
-          'test plan not yet available in prod'
-        );
-        // Go to settings page and verify the Data Collection toggle switch is visible
-        await settings.goto();
-        expect(await settings.dataCollection.isToggleSwitch()).toBe(true);
-
-        // Toggle swtich and verify its status
-        await settings.dataCollection.toggleShareData('on');
-        expect(await settings.dataCollection.getToggleStatus()).toBe('true');
-
-        // Subscribe to plan and verify URL does not include flow parameter
-        await relier.goto();
-        await relier.clickSubscribe6Month();
-        expect(page.url()).toContain('&flow_begin_time=');
-      });
-
-      test('New user checkout URL to have flow params', async ({
-        pages: { settings, relier, page },
-      }, { project }) => {
-        test.skip(
-          project.name === 'production',
-          'test plan not yet available in prod'
-        );
-        await settings.goto();
-        await settings.signOut();
-        await relier.goto();
-        await relier.clickSubscribe6Month();
-        expect(page.url()).toContain('&flow_begin_time=');
-      });
-
-      test('New user checkout URL to have flow params with cache cleared', async ({
-        pages: { settings, login, relier, page },
-      }, { project }) => {
-        test.skip(
-          project.name === 'production',
-          'test plan not yet available in prod'
-        );
-        await settings.goto();
-        await settings.signOut();
-        await login.clearCache();
-        await relier.goto();
-        await relier.clickSubscribe6Month();
-        expect(page.url()).toContain('&flow_begin_time=');
-      });
-
-      /* Disabling test - to fix in FXA-8447
-      test('New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics', async ({
-        pages: { settings, relier, page, subscribe },
-      }, { project }) => {
-        test.skip(
-          project.name === 'production',
-          'test plan not yet available in prod'
-        );
-        await settings.goto();
-        await settings.signOut();
-        await relier.goto();
-
-        const subscribeUrl = await relier.getUrl();
-        if (!subscribeUrl) {
-          fail('Subscribe button has no href.');
-        }
-        const rpSearchParamsBefore = relier.getRpSearchParams(subscribeUrl);
-        const rpFlowParamsBefore = relier.getRpFlowParams(rpSearchParamsBefore);
-        const acquisitionParamsBefore =
-          relier.getRpAcquisitionParams(rpSearchParamsBefore);
-
-        // check flow metrics
-        await relier.clickSubscribeRPFlowMetrics();
-        const rpSearchParamsAfter = relier.getRpSearchParams(page.url());
-        const rpFlowParamsAfter = relier.getRpFlowParams(rpSearchParamsAfter);
-        expect(rpFlowParamsAfter).toStrictEqual(rpFlowParamsBefore);
-
-        // subscribe, failing first then succeeding
-        await subscribe.setEmailAndConfirmNewUser();
-        await subscribe.setConfirmPaymentCheckbox();
-        await subscribe.setFullName();
-        await subscribe.setFailedCreditCardInfo();
-        await subscribe.clickPayNow();
-        await subscribe.clickTryAgain();
-        await subscribe.setCreditCardInfo();
-        await subscribe.clickPayNow();
-        await subscribe.submit();
-
-        // check acquisition metrics
-        const acquisitionParamsAfter =
-          metricsObserver.getAcquisitionParamsFromEvents();
-        expect(acquisitionParamsAfter).toStrictEqual(acquisitionParamsBefore);
-
-        // check conversion funnel metrics
-        const expectedEventTypes = [
-          'amplitude.subPaySetup.view',
-          'amplitude.subPaySetup.engage',
-          'amplitude.subPaySetup.submit',
-          'amplitude.subPaySetup.fail',
-          'amplitude.subPaySetup.submit',
-          'amplitude.subPaySetup.success',
-        ];
-        const actualEventTypes = metricsObserver.rawEvents.map((event) => {
-          return event.type;
-        });
-        expect(actualEventTypes).toMatchObject(expectedEventTypes);
-      });
-    */
+      expect(actualEventTypes).toMatchObject(expectedEventTypes);
     });
   });
 });

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -15,7 +15,7 @@ test.describe('severity-1 #smoke', () => {
       await page.goto(`${target.contentServerUrl}/support`, {
         waitUntil: 'load',
       });
-      await login.waitForEmailHeader();
+      expect(await login.waitForEmailHeader()).toBe(true);
     });
   });
 
@@ -37,45 +37,17 @@ test.describe('severity-1 #smoke', () => {
 
 test.describe('severity-2 #smoke', () => {
   test.describe('support form with active subscriptions', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
-    test('go to support form, submits the form', async ({
-      pages: { login, relier, subscribe, settings, subscriptionManagement },
-    }, { project }) => {
-      test.skip(
-        project.name === 'production',
-        'no real payment method available in prod'
-      );
-      await relier.goto();
-      await relier.clickSubscribe();
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
-
-      //Login to FxA account
-      await login.goto();
-      await login.clickSignIn();
-      const subscriptionPage = await settings.clickPaidSubscriptions();
-      subscriptionManagement.page = subscriptionPage;
-      await subscriptionManagement.fillSupportForm();
-
-      //Since we don't have proper Zendesk config in CircleCI, the form cannot be successfully submitted
-      //await subscriptionManagement.submitSupportForm();
-      //expect(await subscriptionManagement.subscriptionManagementHeader()).toBe(true);
-    });
+    // Since we don't have a proper Zendesk config in CircleCI, the test
+    // case where a form is successfully submitted cannot be covered.
 
     test('go to support form, cancel, redirects to subscription management', async ({
-      page,
       pages: { login, relier, subscribe, settings, subscriptionManagement },
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
+      test.slow();
       await relier.goto();
       await relier.clickSubscribe();
       await subscribe.setConfirmPaymentCheckbox();


### PR DESCRIPTION
## Because

the functional tests have a nightly 90-day success rate < 95% and a skip rate ~ 11-12% indicating waning stability and sustainability respectively.

## This pull request

audits the 'subscription-tests' functional test module making changes to improve these metrics:
1. remove test case 'support form with active subscriptions > go to support form, submits the form
    - The test case can present as a false positive since it can't be fulfilled due to Zendesk limitations in CI. Furthermore, the steps it does execute are repeated in 'support form with active subscriptions > go to support form, cancel, redirects to subscription management' so we can reduce CI cost and execution time by removing it.
2. uncomment and add fixme annotation to  'Flow, acquisition and new user checkout funnel metrics > New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics'
3. uncomment 'resubscription test > update mode of payment for paypal' and reduce scope to respect the boundary between SubPlat and PayPal UI to reduce intermittency risk in CI.
4. isolate the MetricsObserver to tests where it is relevant
5. remove duplicate `severity-2` describe groups
6. fix lint errors and warnings

## Issue that this pull request solves

Closes: [FXA-8954](https://mozilla-hub.atlassian.net/browse/FXA-8954)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

- I suggest to 'Hide Widespace' as one of the commits required shifting the code left
- Changes with explanations are split by commit, so I suggest going through them one by one. I will squash when merging. 


[FXA-8954]: https://mozilla-hub.atlassian.net/browse/FXA-8954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ