### PR TITLE
feat(sync): Send Sync oauth login data via firefox.fxaLogin

### DIFF
--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -8,6 +8,7 @@ import {
   Integration,
   OAuthIntegration,
   isOAuthIntegration,
+  isSyncOAuthIntegration,
 } from '../../models';
 import { createEncryptedBundle } from '../crypto/scoped-keys';
 import { Constants } from '../constants';
@@ -156,8 +157,7 @@ export function useFinishOAuthFlowHandler(
   authClient: AuthClient,
   integration: Integration
 ): FinishOAuthFlowHandlerResult {
-  // Sync mobile or sync desktop with context=oauth_webchannel_v1
-  const isSyncOAuth = isOAuthIntegration(integration) && integration.isSync();
+  const isSyncOAuth = isSyncOAuthIntegration(integration);
 
   const finishOAuthFlowHandler: FinishOAuthFlowHandler = useCallback(
     async (accountUid, sessionToken, keyFetchToken, unwrapKB) => {

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -4,6 +4,7 @@
 
 import {
   BaseIntegration,
+  Integration,
   IntegrationFeatures,
   IntegrationType,
   RelierAccount,
@@ -49,6 +50,13 @@ export function isOAuthIntegration(integration: {
 }): integration is OAuthIntegration {
   return (integration as OAuthIntegration).type === IntegrationType.OAuth;
 }
+
+/**
+ * Sync mobile or sync desktop with context=oauth_webchannel_v1 (FF 123+)
+ */
+export const isSyncOAuthIntegration = (
+  integration: Pick<Integration, 'type'>
+) => isOAuthIntegration(integration) && integration.isSync();
 
 // TODO: probably move this somewhere else
 export class OAuthIntegrationData extends BaseIntegrationData {

--- a/packages/fxa-settings/src/models/integrations/sync-desktop-v3-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/sync-desktop-v3-integration.ts
@@ -9,6 +9,9 @@ import {
   SyncIntegrationFeatures,
 } from './sync-basic-integration';
 
+/**
+ * Sync desktop with context=fx_desktop_v3 (FF < 123)
+ */
 export function isSyncDesktopV3Integration(integration: {
   type: IntegrationType;
 }): integration is SyncDesktopV3Integration {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -25,7 +25,11 @@ import {
 } from '../../../lib/metrics';
 import { useAccount } from '../../../models/hooks';
 import { LinkStatus } from '../../../lib/types';
-import { IntegrationType, isOAuthIntegration } from '../../../models';
+import {
+  isOAuthIntegration,
+  isSyncDesktopV3Integration,
+  isSyncOAuthIntegration,
+} from '../../../models';
 import {
   AccountRecoveryResetPasswordBannerState,
   AccountRecoveryResetPasswordFormData,
@@ -214,24 +218,19 @@ const AccountRecoveryResetPassword = ({
 
       logViewEvent(viewName, 'verification.success');
 
-      switch (integration.type) {
-        // NOTE: SyncBasic check is temporary until we implement codes
-        // See https://docs.google.com/document/d/1K4AD69QgfOCZwFLp7rUcMOkOTslbLCh7jjSdR9zpAkk/edit#heading=h.kkt4eylho93t
-        case IntegrationType.SyncDesktopV3:
-        case IntegrationType.SyncBasic:
-          firefox.fxaLoginSignedInUser({
-            authAt: accountResetData.authAt,
-            email,
-            keyFetchToken: accountResetData.keyFetchToken,
-            sessionToken: accountResetData.sessionToken,
-            uid: accountResetData.uid,
-            unwrapBKey: accountResetData.unwrapBKey,
-            verified: accountResetData.verified,
-          });
-          break;
-        case IntegrationType.OAuth:
-          // TODO: Consider providing a way to redirect user back to RP.
-          break;
+      if (
+        isSyncDesktopV3Integration(integration) ||
+        isSyncOAuthIntegration(integration)
+      ) {
+        firefox.fxaLoginSignedInUser({
+          authAt: accountResetData.authAt,
+          email,
+          keyFetchToken: accountResetData.keyFetchToken,
+          sessionToken: accountResetData.sessionToken,
+          uid: accountResetData.uid,
+          unwrapBKey: accountResetData.unwrapBKey,
+          verified: accountResetData.verified,
+        });
       }
 
       alertSuccess();

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/interfaces.ts
@@ -42,6 +42,7 @@ export interface AccountRecoveryResetPasswordOAuthIntegration {
   };
   getService: () => ReturnType<OAuthIntegration['getService']>;
   getRedirectUri: () => ReturnType<OAuthIntegration['getService']>;
+  isSync: () => ReturnType<OAuthIntegration['isSync']>;
 }
 
 export interface AccountRecoveryResetPasswordBaseIntegration {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/mocks.tsx
@@ -56,7 +56,8 @@ export const MOCK_RESET_DATA = {
 };
 
 export function createMockAccountRecoveryResetPasswordOAuthIntegration(
-  serviceName = MOCK_SERVICE
+  serviceName = MOCK_SERVICE,
+  isSync = false
 ): AccountRecoveryResetPasswordOAuthIntegration {
   return {
     type: IntegrationType.OAuth,
@@ -66,6 +67,7 @@ export function createMockAccountRecoveryResetPasswordOAuthIntegration(
     },
     getRedirectUri: () => MOCK_REDIRECT_URI,
     getService: () => serviceName,
+    isSync: () => isSync,
   };
 }
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -16,6 +16,7 @@ import {
   paramsWithMissingEmailToHashWith,
   paramsWithMissingToken,
   paramsWithSyncDesktop,
+  paramsWithSyncOAuth,
   Subject,
 } from './mocks';
 import firefox from '../../../lib/channels/firefox';
@@ -429,23 +430,32 @@ describe('CompleteResetPassword page', () => {
         );
       });
     });
-    describe('SyncDesktop integration', () => {
-      it('calls fxaLoginSignedInUser', async () => {
+    describe('Sync integrations', () => {
+      const testSyncIntegration = async (
+        integrationType: IntegrationType,
+        params: Record<string, string>
+      ) => {
         const fxaLoginSignedInUserSpy = jest.spyOn(
           firefox,
           'fxaLoginSignedInUser'
         );
-        render(
-          <Subject
-            integrationType={IntegrationType.SyncDesktopV3}
-            params={paramsWithSyncDesktop}
-          />,
-          account,
-          session
-        );
+        render(<Subject {...{ integrationType, params }} />, account, session);
         await enterPasswordAndSubmit();
-
         expect(fxaLoginSignedInUserSpy).toBeCalled();
+      };
+
+      describe('desktop v3', () => {
+        it('calls fxaLoginSignedInUser', async () => {
+          await testSyncIntegration(
+            IntegrationType.SyncDesktopV3,
+            paramsWithSyncDesktop
+          );
+        });
+      });
+      describe('OAuth sync', () => {
+        it('calls fxaLoginSignedInUser', async () => {
+          await testSyncIntegration(IntegrationType.OAuth, paramsWithSyncOAuth);
+        });
       });
     });
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -11,10 +11,10 @@ import {
   settingsViewName,
 } from '../../../lib/metrics';
 import {
-  IntegrationType,
   useAccount,
-  isOAuthIntegration,
   useFtlMsgResolver,
+  isSyncDesktopV3Integration,
+  isSyncOAuthIntegration,
 } from '../../../models';
 import WarningMessage from '../../../components/WarningMessage';
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
@@ -222,33 +222,20 @@ const CompleteResetPassword = ({
         );
 
         let isHardNavigate = false;
-        switch (integration.type) {
-          // NOTE: SyncBasic check is temporary until we implement codes
-          // See https://docs.google.com/document/d/1K4AD69QgfOCZwFLp7rUcMOkOTslbLCh7jjSdR9zpAkk/edit#heading=h.kkt4eylho93t
-          case IntegrationType.SyncDesktopV3:
-          case IntegrationType.SyncBasic:
-            firefox.fxaLoginSignedInUser({
-              authAt: accountResetData.authAt,
-              email,
-              keyFetchToken: accountResetData.keyFetchToken,
-              sessionToken: accountResetData.sessionToken,
-              uid: accountResetData.uid,
-              unwrapBKey: accountResetData.unwrapBKey,
-              verified: accountResetData.verified,
-            });
-            break;
-          case IntegrationType.OAuth:
-            // allows a navigation to a "complete" screen or TOTP screen if it is setup
-            // TODO: check if relier has state
-            if (isOAuthIntegration(integration)) {
-              // TODO: Consider redirecting back to RP, after success message is displayed.
-              // NOTE: To fully sign in, totp must performed if 2FA is enabled.
-            }
-            break;
-          case IntegrationType.Web:
-            // TODO: Consider redirecting back to settings after success message is displayed.
-            // NOTE: To fully sign in, totp must be performed if 2FA is enabled.
-            break;
+
+        if (
+          isSyncDesktopV3Integration(integration) ||
+          isSyncOAuthIntegration(integration)
+        ) {
+          firefox.fxaLoginSignedInUser({
+            authAt: accountResetData.authAt,
+            email,
+            keyFetchToken: accountResetData.keyFetchToken,
+            sessionToken: accountResetData.sessionToken,
+            uid: accountResetData.uid,
+            unwrapBKey: accountResetData.unwrapBKey,
+            verified: accountResetData.verified,
+          });
         }
 
         if (!isHardNavigate) {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
@@ -4,7 +4,11 @@
 
 import { IntegrationSubsetType } from '../../../lib/integrations';
 import { LinkStatus } from '../../../lib/types';
-import { IntegrationType, OAuthIntegrationData } from '../../../models';
+import {
+  IntegrationType,
+  OAuthIntegration,
+  OAuthIntegrationData,
+} from '../../../models';
 import { CompleteResetPasswordLink } from '../../../models/reset-password/verification';
 
 export enum CompleteResetPasswordErrorType {
@@ -37,6 +41,7 @@ export interface CompleteResetPasswordParams {
 export interface CompleteResetPasswordOAuthIntegration {
   type: IntegrationType.OAuth;
   data: { uid: OAuthIntegrationData['uid'] };
+  isSync: () => ReturnType<OAuthIntegration['isSync']>;
 }
 
 export type CompleteResetPasswordIntegration =

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -18,9 +18,11 @@ import {
   createMockSyncDesktopV3Integration,
   createMockWebIntegration,
 } from '../../../lib/integrations/mocks';
+import { Constants } from '../../../lib/constants';
 
 // TODO: combine a lot of mocks with AccountRecoveryResetPassword
 const fxDesktopV3ContextParam = { context: 'fx_desktop_v3' };
+const oauthSyncContextParam = { context: Constants.OAUTH_WEBCHANNEL_CONTEXT };
 
 export const mockAccountNoRecoveryKey = {
   resetPasswordStatus: () => Promise.resolve(true),
@@ -58,6 +60,10 @@ export const mockCompleteResetPasswordParams = {
 export const paramsWithSyncDesktop = {
   ...mockCompleteResetPasswordParams,
   ...fxDesktopV3ContextParam,
+};
+export const paramsWithSyncOAuth = {
+  ...mockCompleteResetPasswordParams,
+  ...oauthSyncContextParam,
 };
 
 export const paramsWithMissingEmail = {
@@ -101,7 +107,9 @@ export const Subject = ({
   switch (integrationType) {
     case IntegrationType.OAuth:
       completeResetPasswordIntegration =
-        createMockResetPasswordOAuthIntegration();
+        createMockResetPasswordOAuthIntegration(
+          params.context === Constants.OAUTH_WEBCHANNEL_CONTEXT
+        );
       break;
     case IntegrationType.SyncDesktopV3:
       completeResetPasswordIntegration = createMockSyncDesktopV3Integration();
@@ -131,9 +139,12 @@ export const Subject = ({
   );
 };
 
-function createMockResetPasswordOAuthIntegration(): CompleteResetPasswordOAuthIntegration {
+function createMockResetPasswordOAuthIntegration(
+  isSync = false
+): CompleteResetPasswordOAuthIntegration {
   return {
     type: IntegrationType.OAuth,
+    isSync: () => isSync,
     data: {
       uid: MOCK_UID,
     },

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -21,7 +21,10 @@ import {
   POCKET_CLIENTIDS,
 } from '../../models/integrations/client-matching';
 import { getSyncEngineIds } from '../../components/ChooseWhatToSync/sync-engines';
-import { isOAuthIntegration, isSyncDesktopV3Integration } from '../../models';
+import {
+  isSyncOAuthIntegration,
+  isSyncDesktopV3Integration,
+} from '../../models';
 import { MOCK_CLIENT_ID } from '../mocks';
 
 export default {
@@ -36,7 +39,7 @@ const queryParamModel = new SignupQueryParams(urlQueryData);
 const storyWithProps = (
   integration: SignupIntegration = createMockSignupOAuthIntegration()
 ) => {
-  const isSyncOAuth = isOAuthIntegration(integration) && integration.isSync();
+  const isSyncOAuth = isSyncOAuthIntegration(integration);
 
   const story = () => (
     <LocationProvider>

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -457,7 +457,7 @@ describe('Signup page', () => {
         );
       });
 
-      describe('on success with Sync integration', () => {
+      describe('Sync integrations', () => {
         const commonFxaLoginOptions = {
           email: MOCK_EMAIL,
           keyFetchToken:
@@ -474,92 +474,131 @@ describe('Signup page', () => {
           mockBeginSignupHandler = jest
             .fn()
             .mockResolvedValue(BEGIN_SIGNUP_HANDLER_RESPONSE);
-          renderWithLocalizationProvider(
-            <Subject
-              integration={createMockSignupSyncDesktopV3Integration()}
-              beginSignupHandler={mockBeginSignupHandler}
-            />
-          );
         });
-        it('all CWTS options selected (default)', async () => {
-          await fillOutForm();
-          submit();
 
-          await waitFor(() => {
-            expect(mockBeginSignupHandler).toHaveBeenCalledWith(
-              MOCK_EMAIL,
-              MOCK_PASSWORD,
-              true
+        describe('on success with Sync desktop v3 integration', () => {
+          beforeEach(() => {
+            renderWithLocalizationProvider(
+              <Subject
+                integration={createMockSignupSyncDesktopV3Integration()}
+                beginSignupHandler={mockBeginSignupHandler}
+              />
             );
           });
+          it('all CWTS options selected (default)', async () => {
+            await fillOutForm();
+            submit();
 
-          expect(fxaLoginSpy).toBeCalledWith({
-            ...commonFxaLoginOptions,
-            services: {
-              sync: {
-                declinedEngines: [],
-                offeredEngines,
+            await waitFor(() => {
+              expect(mockBeginSignupHandler).toHaveBeenCalledWith(
+                MOCK_EMAIL,
+                MOCK_PASSWORD,
+                true
+              );
+            });
+
+            expect(fxaLoginSpy).toBeCalledWith({
+              ...commonFxaLoginOptions,
+              services: {
+                sync: {
+                  declinedEngines: [],
+                  offeredEngines,
+                },
               },
-            },
+            });
+            expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
           });
-          expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
         });
-        it('some CWTS options selected', async () => {
-          await fillOutForm();
 
-          // deselect
-          fireEvent.click(screen.getByText('Open Tabs'));
-          fireEvent.click(screen.getByText('Preferences'));
-          fireEvent.click(screen.getByText('Bookmarks'));
-          // reselect
-          fireEvent.click(screen.getByText('Open Tabs'));
-
-          submit();
-
-          await waitFor(() => {
-            expect(mockBeginSignupHandler).toHaveBeenCalledWith(
-              MOCK_EMAIL,
-              MOCK_PASSWORD,
-              true
+        describe('on success with Sync OAuth integration', () => {
+          beforeEach(() => {
+            renderWithLocalizationProvider(
+              <Subject
+                integration={createMockSignupOAuthIntegration('', true)}
+                beginSignupHandler={mockBeginSignupHandler}
+              />
             );
           });
+          it('all CWTS options selected (default)', async () => {
+            await fillOutForm();
+            submit();
 
-          expect(fxaLoginSpy).toBeCalledWith({
-            ...commonFxaLoginOptions,
-            services: {
-              sync: {
-                declinedEngines: ['prefs', 'bookmarks'],
-                offeredEngines,
+            await waitFor(() => {
+              expect(mockBeginSignupHandler).toHaveBeenCalledWith(
+                MOCK_EMAIL,
+                MOCK_PASSWORD,
+                true
+              );
+            });
+
+            expect(fxaLoginSpy).toBeCalledWith({
+              ...commonFxaLoginOptions,
+              services: {
+                sync: {
+                  declinedEngines: [],
+                  offeredEngines,
+                },
               },
-            },
+            });
+            expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
           });
-        });
-        it('zero CWTS options selected', async () => {
-          await fillOutForm();
+          it('some CWTS options selected', async () => {
+            await fillOutForm();
 
-          act(() => {
-            syncEngineConfigs.forEach((engineConfig) => {
-              fireEvent.click(screen.getByText(engineConfig.text));
+            // deselect
+            fireEvent.click(screen.getByText('Open Tabs'));
+            fireEvent.click(screen.getByText('Preferences'));
+            fireEvent.click(screen.getByText('Bookmarks'));
+            // reselect
+            fireEvent.click(screen.getByText('Open Tabs'));
+
+            submit();
+
+            await waitFor(() => {
+              expect(mockBeginSignupHandler).toHaveBeenCalledWith(
+                MOCK_EMAIL,
+                MOCK_PASSWORD,
+                true
+              );
+            });
+
+            expect(fxaLoginSpy).toBeCalledWith({
+              ...commonFxaLoginOptions,
+              services: {
+                sync: {
+                  declinedEngines: ['prefs', 'bookmarks'],
+                  offeredEngines,
+                },
+              },
             });
           });
-          submit();
+          it('zero CWTS options selected', async () => {
+            await fillOutForm();
 
-          await waitFor(() => {
-            expect(mockBeginSignupHandler).toHaveBeenCalledWith(
-              MOCK_EMAIL,
-              MOCK_PASSWORD,
-              true
-            );
-          });
+            act(() => {
+              syncEngineConfigs.forEach((engineConfig) => {
+                fireEvent.click(screen.getByText(engineConfig.text));
+              });
+            });
+            submit();
 
-          expect(fxaLoginSpy).toBeCalledWith({
-            ...commonFxaLoginOptions,
-            services: {
-              sync: {
-                declinedEngines: offeredEngines,
-                offeredEngines,
+            await waitFor(() => {
+              expect(mockBeginSignupHandler).toHaveBeenCalledWith(
+                MOCK_EMAIL,
+                MOCK_PASSWORD,
+                true
+              );
+            });
+
+            expect(fxaLoginSpy).toBeCalledWith({
+              ...commonFxaLoginOptions,
+              services: {
+                sync: {
+                  declinedEngines: offeredEngines,
+                  offeredEngines,
+                },
               },
-            },
+            });
           });
         });
       });

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -8,6 +8,7 @@ import { useForm } from 'react-hook-form';
 import {
   isOAuthIntegration,
   isSyncDesktopV3Integration,
+  isSyncOAuthIntegration,
   useFtlMsgResolver,
 } from '../../models';
 import {
@@ -222,7 +223,10 @@ export const Signup = ({
         const getOfferedSyncEngines = () =>
           getSyncEngineIds(offeredSyncEngineConfigs || []);
 
-        if (isSyncDesktopV3Integration(integration)) {
+        if (
+          isSyncDesktopV3Integration(integration) ||
+          isSyncOAuthIntegration(integration)
+        ) {
           await firefox.fxaLogin({
             email,
             keyFetchToken: data.SignUp.keyFetchToken,

--- a/packages/fxa-settings/src/pages/Signup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/mocks.tsx
@@ -7,8 +7,8 @@ import Signup from '.';
 import { MozServices } from '../../lib/types';
 import {
   IntegrationType,
-  isOAuthIntegration,
   isSyncDesktopV3Integration,
+  isSyncOAuthIntegration,
 } from '../../models';
 import { mockUrlQueryData } from '../../models/mocks';
 import { SignupQueryParams } from '../../models/pages/signup';
@@ -119,7 +119,7 @@ export const Subject = ({
 }) => {
   const urlQueryData = mockUrlQueryData(queryParams);
   const queryParamModel = new SignupQueryParams(urlQueryData);
-  const isSyncOAuth = isOAuthIntegration(integration) && integration.isSync();
+  const isSyncOAuth = isSyncOAuthIntegration(integration);
   return (
     <LocationProvider>
       <Signup


### PR DESCRIPTION
Because:
* Sync desktop is moving to oauth_webchannel_v1 context and we need to accomodate to allow content and oauth sync to share the same session token

This commit:
* Sends oauth sync data up via firefox.fxaLogin and firefox.fxaLoginSignedInUser for signup and reset password
* Removes switch statements around integration type, as we're not following this pattern on new pages, and removes now obsolete comments
* Updates tests

closes FXA-8905