### PR TITLE
task(graphql): Add logging for incoming x-forwarded-for headers

### DIFF
--- a/packages/fxa-graphql-api/src/decorators.spec.ts
+++ b/packages/fxa-graphql-api/src/decorators.spec.ts
@@ -13,6 +13,16 @@ describe('gql decorators', () => {
       expect(headers.get('x-forwarded-for')).toEqual('127.0.0.1');
     });
 
+    it('respects previous x-forwarded-for header', () => {
+      const headers = extractRequiredHeaders({
+        ip,
+        headers: {
+          'x-forwarded-for': '127.0.0.11',
+        },
+      });
+      expect(headers.get('x-forwarded-for')).toEqual('127.0.0.11');
+    });
+
     it('forwards relevant headers', () => {
       const headers = extractRequiredHeaders({
         ip,

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -87,6 +87,7 @@ import { uuidTransformer } from 'fxa-shared/db/transformers';
 import { FinishedSetupAccountPayload } from './dto/payload/finished-setup-account';
 import { FinishSetupInput } from './dto/input/finish-setup';
 import { EmailBounceStatusPayload } from './dto/payload/email-bounce';
+import { checkForwardedFor } from './lib/util';
 
 function snakeToCamel(str: string) {
   return str.replace(/(_\w)/g, (m: string) => m[1].toUpperCase());
@@ -485,6 +486,11 @@ export class AccountResolver {
     @Args('input', { type: () => PasswordForgotSendCodeInput })
     input: PasswordForgotSendCodeInput
   ) {
+    checkForwardedFor(
+      this.log,
+      'account.resolver->passwordForgotSendCode',
+      headers
+    );
     return this.authAPI.passwordForgotSendCode(input.email, input, headers);
   }
 
@@ -497,6 +503,11 @@ export class AccountResolver {
     @Args('input', { type: () => PasswordForgotVerifyCodeInput })
     input: PasswordForgotVerifyCodeInput
   ) {
+    checkForwardedFor(
+      this.log,
+      'account.resolver->passwordForgotVerifyCode',
+      headers
+    );
     return this.authAPI.passwordForgotVerifyCode(
       input.code,
       input.token,
@@ -525,6 +536,7 @@ export class AccountResolver {
     @Args('input', { type: () => AccountResetInput })
     input: AccountResetInput
   ): Promise<AccountResetPayload> {
+    checkForwardedFor(this.log, 'account.resolver->accountReset', headers);
     const result = await this.authAPI.accountResetAuthPW(
       input.newPasswordAuthPW,
       input.accountResetToken,
@@ -546,6 +558,7 @@ export class AccountResolver {
     @Args('input', { type: () => SignUpInput })
     input: SignUpInput
   ): Promise<SignedUpAccountPayload> {
+    checkForwardedFor(this.log, 'account.resolver->SignUp', headers);
     const result = await this.authAPI.signUpWithAuthPW(
       input.email,
       input.authPW,
@@ -567,6 +580,7 @@ export class AccountResolver {
     @Args('input', { type: () => FinishSetupInput })
     input: FinishSetupInput
   ): Promise<FinishedSetupAccountPayload> {
+    checkForwardedFor(this.log, 'account.resolver->finishSetup', headers);
     const result = await this.authAPI.finishSetupWithAuthPW(
       input.token,
       input.authPW,
@@ -587,6 +601,7 @@ export class AccountResolver {
     @Args('input', { type: () => SignInInput })
     input: SignInInput
   ): Promise<SignedInAccountPayload> {
+    checkForwardedFor(this.log, 'account.resolver->signIn', headers);
     const result = await this.authAPI.signInWithAuthPW(
       input.email,
       input.authPW,
@@ -657,6 +672,7 @@ export class AccountResolver {
     @Args('input', { type: () => VerifyEmailCodeInput })
     input: VerifyEmailCodeInput
   ): Promise<BasicPayload> {
+    checkForwardedFor(this.log, 'account.resolver->emailVerifyCode', headers);
     await this.authAPI.verifyCode(
       input.uid,
       input.code,

--- a/packages/fxa-graphql-api/src/gql/lib/factories.ts
+++ b/packages/fxa-graphql-api/src/gql/lib/factories.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { faker } from '@faker-js/faker';
 import { CartState } from '@fxa/shared/db/mysql/account';
 import { CartIdInput } from '../dto/input/cart-id.input';

--- a/packages/fxa-graphql-api/src/gql/lib/util.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/lib/util.spec.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { checkForwardedFor } from './util';
+import { ILogger } from 'fxa-shared/log';
+
+describe('util', () => {
+  let log: ILogger;
+  beforeEach(() => {
+    log = {
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+      info: () => {},
+    } as ILogger;
+  });
+
+  it('logs no headers', async () => {
+    const warnSpy = jest.spyOn(log, 'warn');
+    checkForwardedFor(log, 'foo', null as unknown as Headers);
+    expect(warnSpy).toBeCalledWith('checkForwardedFor', {
+      msg: 'foo > headers missing!',
+    });
+  });
+
+  it('logs header missing', async () => {
+    const warnSpy = jest.spyOn(log, 'warn');
+    const headers = new Headers();
+    headers.append('foo-bar', '123');
+    checkForwardedFor(log, 'foo', new Headers({}));
+    expect(warnSpy).toBeCalledWith('checkForwardedFor', {
+      msg: 'foo > missing x-forwarded-for header!',
+    });
+  });
+
+  it('logs header value', async () => {
+    const debugSpy = jest.spyOn(log, 'info');
+    checkForwardedFor(
+      log,
+      'foo',
+      new Headers({ 'x-forwarded-for': '127.0.0.77' })
+    );
+    expect(debugSpy).toBeCalledWith('checkForwardedFor', {
+      msg: 'foo > received headers: x-forwarded-for: 127.0.0.77',
+    });
+  });
+});

--- a/packages/fxa-graphql-api/src/gql/lib/util.ts
+++ b/packages/fxa-graphql-api/src/gql/lib/util.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ILogger } from 'fxa-shared/log';
+
+// Temporary sanity check! Will be removed asap.
+export function checkForwardedFor(
+  log: ILogger,
+  method: string,
+  headers: Headers
+) {
+  if (!headers) {
+    log.warn('checkForwardedFor', {
+      msg: `${method} > headers missing!`,
+    });
+    return;
+  }
+
+  const xForwardedFor = headers.get('x-forwarded-for');
+  if (!xForwardedFor) {
+    log.warn('checkForwardedFor', {
+      msg: `${method} > missing x-forwarded-for header!`,
+    });
+  } else {
+    log.info('checkForwardedFor', {
+      msg: `${method} > received headers: x-forwarded-for: ${headers.get(
+        'x-forwarded-for'
+      )}`,
+    });
+  }
+}

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -15,7 +15,12 @@ describe('AccountResolver', () => {
   let authClient: any;
 
   beforeEach(async () => {
-    logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
+    logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
     const MockMozLogger: Provider = {
       provide: MozLoggerService,
       useValue: logger,

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -24,6 +24,7 @@ import { SessionReauthedAccountPayload } from './dto/payload/session-reauthed-ac
 import { CatchGatewayError } from './lib/error';
 import { Session as SessionType, SessionStatus } from './model/session';
 import { SessionVerifyCodeInput } from './dto/input/session-verify-code';
+import { checkForwardedFor } from './lib/util';
 
 @Resolver((of: any) => SessionType)
 export class SessionResolver {
@@ -73,6 +74,7 @@ export class SessionResolver {
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => SessionReauthInput }) input: SessionReauthInput
   ): Promise<SessionReauthedAccountPayload> {
+    checkForwardedFor(this.log, 'session.resolver->reauthSession', headers);
     const result = await this.authAPI.sessionReauthWithAuthPW(
       input.sessionToken,
       input.email,
@@ -96,6 +98,7 @@ export class SessionResolver {
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => BasicMutationInput }) input: BasicMutationInput
   ): Promise<BasicPayload> {
+    checkForwardedFor(this.log, 'session.resolver->resendVerifyCode', headers);
     await this.authAPI.sessionResendVerifyCode(token, headers);
     return {
       clientMutationId: input.clientMutationId,
@@ -113,6 +116,7 @@ export class SessionResolver {
     @Args('input', { type: () => SessionVerifyCodeInput })
     input: SessionVerifyCodeInput
   ): Promise<BasicPayload> {
+    checkForwardedFor(this.log, 'session.resolver->verifyCode', headers);
     await this.authAPI.sessionVerifyCode(
       token,
       input.code,


### PR DESCRIPTION
## Because

- After landing the previous patch, there was some concern that something might also be off with the headers being sent to the gql-api.

 
## This pull request

- Adds logs to ensure that the x-forwarded-for headers are being sent to graphql-api
- Adds extra edge case such that current x-forwarded-for headers are respected. Note that in stage / production, these values are provided by the ingress. It's possible that the previous implementation, which just looked at req.ip was dropping these.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

