### PR TITLE
fix(storage): Don't persist `atLeast18AtReg` to local storage

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -23,7 +23,6 @@ import { emailsMatch } from 'fxa-shared/email/helpers';
 const PERSISTENT = {
   accountResetToken: undefined,
   alertText: undefined,
-  atLeast18AtReg: undefined,
   displayName: undefined,
   email: undefined,
   grantedPermissions: undefined,
@@ -74,6 +73,7 @@ const DEFAULTS = _.extend(
     verificationMethod: undefined,
     verificationReason: undefined,
     totpVerified: undefined,
+    atLeast18AtReg: undefined,
   },
   PERSISTENT
 );


### PR DESCRIPTION
## Because

- We don't use this value anywhere except during signup where it is sent and stored in database, so don't require it to be in localstorage

## This pull request

- Removes it from Backbone account model

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
