### PR TITLE
refactor(auth): update types and logic for account deletion

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -172,6 +172,7 @@ async function run(config) {
   const accountDeleteManager = new AccountDeleteManager({
     fxaDb: database,
     oauthDb,
+    push,
     pushbox,
     statsd,
   });

--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -2,39 +2,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { CloudTasksClient } from '@google-cloud/tasks';
+import {
+  deleteAllPayPalBAs,
+  getAllPayPalBAByUid,
+} from 'fxa-shared/db/models/auth';
 import { StatsD } from 'hot-shots';
 import { Container } from 'typedi';
+
+import { CloudTasksClient } from '@google-cloud/tasks';
+import * as Sentry from '@sentry/node';
+
+import { ConfigType } from '../config';
 import DB from './db/index';
+import { ERRNO } from './error';
 import OAuthDb from './oauth/db';
 import { AppleIAP } from './payments/iap/apple-app-store/apple-iap';
 import { PlayBilling } from './payments/iap/google-play/play-billing';
 import { PayPalHelper } from './payments/paypal/helper';
 import { StripeHelper } from './payments/stripe';
+import { StripeFirestoreMultiError } from './payments/stripe-firestore';
+import pushBuilder from './push';
 import pushboxApi from './pushbox';
 import { accountDeleteCloudTaskPath } from './routes/cloud-tasks';
-import { AccountDeleteReasons, AppConfig, AuthLogger } from './types';
-
-import {
-  deleteAllPayPalBAs,
-  getAllPayPalBAByUid,
-} from 'fxa-shared/db/models/auth';
-import { ConfigType } from '../config';
-import * as Sentry from '@sentry/node';
-import { StripeFirestoreMultiError } from './payments/stripe-firestore';
+import { AppConfig, AuthLogger, AuthRequest } from './types';
 
 type FxaDbDeleteAccount = Pick<
   Awaited<ReturnType<ReturnType<typeof DB>['connect']>>,
-  'deleteAccount' | 'accountRecord' | 'account'
+  'deleteAccount' | 'accountRecord' | 'account' | 'devices'
 >;
 type OAuthDbDeleteAccount = Pick<typeof OAuthDb, 'removeTokensAndCodes'>;
 type PushboxDeleteAccount = Pick<
   ReturnType<typeof pushboxApi>,
   'deleteAccount'
 >;
+type PushForDeleteAccount = Pick<
+  ReturnType<typeof pushBuilder>,
+  'notifyAccountDestroyed'
+>;
+type Log = AuthLogger & { activityEvent: (data: Record<string, any>) => void };
 
-export type ReasonForDeletion = (typeof AccountDeleteReasons)[number];
-export type AccountDeleteOptions = { notify?: () => Promise<void> };
+export const ReasonForDeletionOptions = {
+  UserRequested: 'fxa_user_requested_account_delete',
+  Unverified: 'fxa_unverified_account_delete',
+  Cleanup: 'fxa_cleanup_account_delete',
+} as const;
+export type ReasonForDeletion =
+  (typeof ReasonForDeletionOptions)[keyof typeof ReasonForDeletionOptions];
+export const ReasonForDeletionValues = Object.values(ReasonForDeletionOptions);
 
 type DeleteTask = {
   uid: string;
@@ -60,14 +74,17 @@ const isEnqueueByEmailParam = (
 export class AccountDeleteManager {
   private fxaDb: FxaDbDeleteAccount;
   private oauthDb: OAuthDbDeleteAccount;
+  private push: PushForDeleteAccount;
   private pushbox: PushboxDeleteAccount;
   private statsd: StatsD;
   private stripeHelper?: StripeHelper;
   private paypalHelper?: PayPalHelper;
   private appleIap?: AppleIAP;
   private playBilling?: PlayBilling;
-  private log: AuthLogger;
+  private log: Log;
   private config: ConfigType;
+  private tasksEnabled = false;
+  private tasksRequired = false;
 
   private cloudTasksClient: CloudTasksClient;
   private queueName;
@@ -77,18 +94,21 @@ export class AccountDeleteManager {
     fxaDb,
     oauthDb,
     config,
+    push,
     pushbox,
     statsd,
   }: {
     fxaDb: FxaDbDeleteAccount;
     oauthDb: OAuthDbDeleteAccount;
     config: ConfigType;
+    push: PushForDeleteAccount;
     pushbox: PushboxDeleteAccount;
     statsd: StatsD;
   }) {
     this.fxaDb = fxaDb;
     this.oauthDb = oauthDb;
     this.config = config;
+    this.push = push;
     this.pushbox = pushbox;
     this.statsd = statsd;
 
@@ -104,7 +124,7 @@ export class AccountDeleteManager {
     if (Container.has(PlayBilling)) {
       this.playBilling = Container.get(PlayBilling);
     }
-    this.log = Container.get(AuthLogger);
+    this.log = Container.get(AuthLogger) as Log;
     this.config = Container.get(AppConfig);
     const tasksConfig = this.config.cloudTasks;
 
@@ -114,6 +134,8 @@ export class AccountDeleteManager {
     });
     this.queueName = `projects/${tasksConfig.projectId}/locations/${tasksConfig.locationId}/queues/${tasksConfig.deleteAccounts.queueName}`;
     this.taskUrl = `${this.config.publicUrl}/v${this.config.apiVersion}${accountDeleteCloudTaskPath}`;
+    this.tasksEnabled = !!tasksConfig.credentials.keyFilename;
+    this.tasksRequired = ['stage', 'prod'].includes(this.config.env);
   }
 
   public async enqueue(options: EnqueueByUidParam | EnqueueByEmailParam) {
@@ -134,7 +156,7 @@ export class AccountDeleteManager {
     const customer = await this.stripeHelper?.fetchCustomer(options.uid);
     const task: DeleteTask = {
       uid: options.uid,
-      customerId: customer?.id ?? undefined,
+      customerId: customer?.id,
       reason: options.reason,
     };
     return this.enqueueTask(task);
@@ -145,7 +167,7 @@ export class AccountDeleteManager {
     const customer = await this.stripeHelper?.fetchCustomer(account.uid);
     const task: DeleteTask = {
       uid: account.uid,
-      customerId: customer?.id ?? undefined,
+      customerId: customer?.id,
       reason: options.reason,
     };
     return this.enqueueTask(task);
@@ -181,60 +203,102 @@ export class AccountDeleteManager {
    * Delete the account from the FxA database, OAuth database, pushbox database, and
    * cancel any active subscriptions.
    *
-   * @param uid string
-   * @param options AccountDeleteOptions optional object with an optional `notify` function that will be called after the account's removed from MySQL.
+   * @param uid User id
+   * @param reason Enum describing the reason for the deletion.
+   * @param customerId Stripe customer id if the user had/has a subscription.
    */
   public async deleteAccount(
     uid: string,
-    customerId?: string,
-    options?: AccountDeleteOptions
+    reason: ReasonForDeletion,
+    customerId?: string
   ) {
-    await this.deleteAccountFromDb(uid, options);
+    const existsInDatabase = await this.deleteAccountFromDb(uid);
     await this.deleteOAuthTokens(uid);
     // see comment in the function on why we are not awaiting
     this.deletePushboxRecords(uid);
 
-    await this.deleteSubscriptions(uid, customerId);
+    await this.deleteSubscriptions(uid, reason, customerId);
     await this.deleteFirestoreCustomer(uid);
-  }
 
-  public async cleanupAccount(uid: string, customerId?: string) {
-    await this.deleteSubscriptions(uid, customerId);
-    await this.deleteFirestoreCustomer(uid);
-    await this.deleteOAuthTokens(uid);
+    // This is to avoid logging the same event twice if the account was already
+    // deleted from the db.
+    if (existsInDatabase) {
+      this.log.activityEvent({ uid, event: 'account.deleted' });
+    }
   }
 
   /**
-   * Delete the account from the FxA database.
-   *
-   * @param accountRecord
+   * Delete the account from the FxA database, OAuth database, and pushbox database.
+   * This method is intended to be used when the user is waiting to be deleted from
+   * the system so it only clears up the immediate database records and logs out the
+   * user. The rest of the cleanup is handled later after queuing the account for
+   * deletion.
    */
-  public async deleteAccountFromDb(
-    uid: string,
-    options?: AccountDeleteOptions
-  ) {
-    await this.fxaDb.deleteAccount({ uid });
-    if (options?.notify) {
-      await options.notify();
+  public async quickDelete(uid: string, reason: ReasonForDeletion) {
+    if (reason !== ReasonForDeletionOptions.UserRequested) {
+      throw new Error('quickDelete only supports user requested deletions');
     }
+
+    try {
+      await this.deleteAccountFromDb(uid);
+      await this.deleteOAuthTokens(uid);
+    } catch (error) {
+      // If the account wasn't fully deleted, we should log the error and
+      // still queue the account for cleanup.
+      this.log.error('quickDelete', { uid, error });
+    }
+    // Only queue if enabled or is in stage/prod.
+    if (this.tasksEnabled || this.tasksRequired) {
+      await this.enqueueByUid({ uid, reason });
+    }
+  }
+
+  /**
+   * Delete the account from the FxA database and notify devices and attached
+   * services about the account deletion.
+   */
+  private async deleteAccountFromDb(uid: string) {
+    // We fetch the devices to notify before attempting delete
+    // because obviously we can't retrieve the devices list after!
+    try {
+      // Check to see if we have an account, this throws if it was deleted
+      await this.fxaDb.account(uid);
+      const devices = await this.fxaDb.devices(uid);
+
+      await this.fxaDb.deleteAccount({ uid });
+      try {
+        await this.push.notifyAccountDestroyed(uid, devices);
+        await this.log.notifyAttachedServices('delete', {} as AuthRequest, {
+          uid,
+        });
+      } catch (error) {
+        this.log.error('accountDeleteManager.notify', {
+          uid,
+          error,
+        });
+      }
+    } catch (error) {
+      if (error.errno === ERRNO.ACCOUNT_UNKNOWN) {
+        // Proceed if the account is already deleted from the db.
+        return false;
+      }
+      throw error;
+    }
+    return true;
   }
 
   /**
    * Delete the account from the OAuth database. This will remove all tokens and
    * codes associated with the account.
-   *
-   * @param accountRecord
    */
-  public async deleteOAuthTokens(uid: string) {
+  private async deleteOAuthTokens(uid: string) {
     await this.oauthDb.removeTokensAndCodes(uid);
   }
 
   /**
    * Delete the account from the pushbox database.
-   *
-   * @param accountRecord
    */
-  public async deletePushboxRecords(uid: string) {
+  private deletePushboxRecords(uid: string) {
     // No need to await and block the other notifications. The pushbox records
     // will be deleted once they expire even if they were not successfully
     // deleted here.
@@ -246,7 +310,7 @@ export class AccountDeleteManager {
     });
   }
 
-  public async refundSubscriptions(
+  private async refundSubscriptions(
     deleteReason: ReasonForDeletion,
     customerId?: string,
     refundPeriod?: number
@@ -256,7 +320,7 @@ export class AccountDeleteManager {
     });
 
     // Currently only support auto refund of invoices for unverified accounts
-    if (deleteReason !== 'fxa_unverified_account_delete' || !customerId) {
+    if (deleteReason !== ReasonForDeletionOptions.Unverified || !customerId) {
       return;
     }
 
@@ -294,14 +358,13 @@ export class AccountDeleteManager {
    * Delete the account's subscriptions from Stripe and PayPal.
    * This will cancel any active subscriptions and remove the customer.
    *
-   * @param uid - Account UID
    * @param deleteReason -- @@TODO temporary default deleteReason, remove if necessary
    * @param refundPeriod -- @@TODO temporary default to 30. Remove if not necessary
    */
-  public async deleteSubscriptions(
+  private async deleteSubscriptions(
     uid: string,
+    deleteReason: ReasonForDeletion,
     customerId?: string,
-    deleteReason: ReasonForDeletion = 'fxa_user_requested_account_delete',
     refundPeriod?: number
   ) {
     if (this.config.subscriptions?.enabled && this.stripeHelper) {
@@ -338,7 +401,7 @@ export class AccountDeleteManager {
     }
   }
 
-  async deleteFirestoreCustomer(uid: string) {
+  private async deleteFirestoreCustomer(uid: string) {
     this.log.debug('AccountDeleteManager.deleteFirestoreCustomer', { uid });
     try {
       return await this.stripeHelper?.removeFirestoreCustomer(uid);

--- a/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
@@ -4,113 +4,44 @@
 
 import isA from 'joi';
 import { Container } from 'typedi';
+
 import { ConfigType } from '../../config';
 import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-import { AccountDeleteManager, ReasonForDeletion } from '../account-delete';
-import DB from '../db/index';
+import {
+  AccountDeleteManager,
+  ReasonForDeletion,
+  ReasonForDeletionValues,
+} from '../account-delete';
 import { AuthLogger, AuthRequest } from '../types';
 import validators from './validators';
-import { ERRNO } from '../error';
-import pushBuilder from '../push';
 
 export type DeleteAccountTaskPayload = {
   uid: string;
   customerId?: string;
   reason: ReasonForDeletion;
 };
-type FxaDbForCloudTask = Pick<
-  Awaited<ReturnType<ReturnType<typeof DB>['connect']>>,
-  'account' | 'devices'
->;
-type PushForCloudTask = Pick<
-  ReturnType<typeof pushBuilder>,
-  'notifyAccountDestroyed'
->;
-type Log = AuthLogger & { activityEvent: (data: Record<string, any>) => void };
 
 export class CloudTaskHandler {
-  private log: Log;
-  private db: FxaDbForCloudTask;
-  private push: PushForCloudTask;
   private accountDeleteManager: AccountDeleteManager;
 
-  constructor({
-    log,
-    db,
-    push,
-  }: {
-    log: Log;
-    db: FxaDbForCloudTask;
-    push: PushForCloudTask;
-  }) {
-    this.log = log;
-    this.db = db;
-    this.push = push;
-
+  constructor(private log: AuthLogger) {
     this.accountDeleteManager = Container.get(AccountDeleteManager);
   }
 
   async deleteAccount(taskPayload: DeleteAccountTaskPayload) {
-    try {
-      // get account from MySQL
-      const account = await this.db.account(taskPayload.uid);
-
-      // We fetch the devices to notify before deleteAccount()
-      // because obviously we can't retrieve the devices list after!
-      const devices = await this.db.devices(taskPayload.uid);
-      const push = this.push;
-      const log = this.log;
-
-      const notify = async () => {
-        try {
-          log.info('accountDeleted.byCloudTask', account);
-          await push.notifyAccountDestroyed(taskPayload.uid, devices);
-          await log.notifyAttachedServices('delete', {} as AuthRequest, {
-            uid: taskPayload.uid,
-          });
-          // because a cloud task request is very different from a user request
-          // we cannot emit metrics in the same fashion
-          log.activityEvent({ uid: account.uid, event: 'account.deleted' });
-        } catch (error) {
-          log.error('CloudTask.accountDelete.notify', {
-            uid: taskPayload.uid,
-            error,
-          });
-        }
-      };
-      // the account still exists in MySQL, delete as usual
-      await this.accountDeleteManager.deleteAccount(
-        taskPayload.uid,
-        taskPayload.customerId,
-        {
-          notify,
-        }
-      );
-    } catch (err) {
-      // if the account is already deleted from the db, then try to clean up
-      // some potentially remaining other records
-      if (err.errno === ERRNO.ACCOUNT_UNKNOWN) {
-        this.log.info('accountCleanup.byCloudTask', { uid: taskPayload.uid });
-        await this.accountDeleteManager.cleanupAccount(
-          taskPayload.uid,
-          taskPayload.customerId
-        );
-      } else {
-        throw err;
-      }
-    }
+    this.log.debug('Received delete account task', taskPayload);
+    await this.accountDeleteManager.deleteAccount(
+      taskPayload.uid,
+      taskPayload.reason,
+      taskPayload.customerId
+    );
     return {};
   }
 }
 export const accountDeleteCloudTaskPath = '/cloud-tasks/accounts/delete';
 
-export const cloudTaskRoutes = (
-  log: Log,
-  db: FxaDbForCloudTask,
-  config: ConfigType,
-  push: PushForCloudTask
-) => {
-  const cloudTaskHandler = new CloudTaskHandler({ log, db, push });
+export const cloudTaskRoutes = (log: AuthLogger, config: ConfigType) => {
+  const cloudTaskHandler = new CloudTaskHandler(log);
   const routes = [
     {
       method: 'POST',
@@ -133,7 +64,7 @@ export const cloudTaskRoutes = (
               .string()
               .optional()
               .description(DESCRIPTION.customerId),
-            reason: validators.accountDeleteReason,
+            reason: isA.string().valid(...ReasonForDeletionValues),
           }),
         },
       },

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -194,7 +194,7 @@ module.exports = function (
   );
 
   const { cloudTaskRoutes } = require('./cloud-tasks');
-  const cloudTasks = cloudTaskRoutes(log, db, config, push);
+  const cloudTasks = cloudTaskRoutes(log, config);
 
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -8,7 +8,6 @@
 const { URL } = require('url');
 const punycode = require('punycode.js');
 const isA = require('joi');
-const { AccountDeleteReasons } = require('../types');
 const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
 const {
   minimalConfigSchema,
@@ -865,7 +864,3 @@ module.exports.thirdPartyProvider = isA
 
 module.exports.thirdPartyIdToken = module.exports.jwt.optional();
 module.exports.thirdPartyOAuthCode = isA.string().optional();
-
-module.exports.accountDeleteReason = isA
-  .string()
-  .valid(...AccountDeleteReasons);

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -84,15 +84,6 @@ export interface AuthLogger extends Logger {
   ): Promise<void>;
 }
 
-// Exporting this here to avoid a circular dependency.  Can be moved to
-// lib/account-delete if we are ever at full ESM.
-export const AccountDeleteReasonsMap = {
-  unverified: 'fxa_unverified_account_delete',
-  requested: 'fxa_user_requested_account_delete',
-  cleanup: 'fxa_partial_data_cleanup_account_delete',
-} as const;
-export const AccountDeleteReasons = Object.values(AccountDeleteReasonsMap);
-
 // Container token types
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AuthLogger = new Token<AuthLogger>('AUTH_LOGGER');

--- a/packages/fxa-auth-server/scripts/clean-up-partial-account-customer.ts
+++ b/packages/fxa-auth-server/scripts/clean-up-partial-account-customer.ts
@@ -6,24 +6,23 @@ import { Command } from 'commander';
 import { AccountCustomers } from 'fxa-shared/db/models/auth';
 import { StatsD } from 'hot-shots';
 import { Container } from 'typedi';
+
 import appConfig from '../config';
-import { AccountDeleteManager } from '../lib/account-delete';
+import {
+  AccountDeleteManager,
+  ReasonForDeletionOptions,
+} from '../lib/account-delete';
 import * as random from '../lib/crypto/random';
 import DB from '../lib/db';
 import { setupFirestore } from '../lib/firestore-db';
 import initLog from '../lib/log';
 import oauthDb from '../lib/oauth/db';
 import { CurrencyHelper } from '../lib/payments/currencies';
-import { StripeHelper, createStripeHelper } from '../lib/payments/stripe';
+import { createStripeHelper, StripeHelper } from '../lib/payments/stripe';
 import { pushboxApi } from '../lib/pushbox';
 import initRedis from '../lib/redis';
 import Token from '../lib/tokens';
-import {
-  AccountDeleteReasonsMap,
-  AppConfig,
-  AuthFirestore,
-  AuthLogger,
-} from '../lib/types';
+import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
 import { parseDryRun } from './lib/args';
 
 const dryRun = async (program: Command, limit: number) => {
@@ -67,7 +66,7 @@ const init = async () => {
   program.parse(process.argv);
   const isDryRun = parseDryRun(program.dryRun);
   const limit = program.limit ? parseInt(program.limit) : Infinity;
-  const reason = AccountDeleteReasonsMap.cleanup;
+  const reason = ReasonForDeletionOptions.Cleanup;
 
   if (limit <= 0) {
     throw new Error('The limit should be a positive integer.');
@@ -113,6 +112,7 @@ const init = async () => {
     fxaDb,
     oauthDb,
     config,
+    push: {} as any, // Push isn't needed for enqueuing
     pushbox,
     statsd,
   });

--- a/packages/fxa-auth-server/scripts/delete-unverified-accounts.ts
+++ b/packages/fxa-auth-server/scripts/delete-unverified-accounts.ts
@@ -3,23 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Command } from 'commander';
-import { parseDryRun } from './lib/args';
-import { AccountDeleteManager } from '../lib/account-delete';
-import { Container } from 'typedi';
-import { StripeHelper, createStripeHelper } from '../lib/payments/stripe';
 import { StatsD } from 'hot-shots';
-import { setupFirestore } from '../lib/firestore-db';
-import { AccountDeleteReasonsMap, AuthFirestore } from '../lib/types';
-import { CurrencyHelper } from '../lib/payments/currencies';
+import { Container } from 'typedi';
+
 import appConfig from '../config';
-import initLog from '../lib/log';
-import { AuthLogger, AppConfig } from '../lib/types';
-import DB from '../lib/db';
-import Token from '../lib/tokens';
+import {
+  AccountDeleteManager,
+  ReasonForDeletionOptions,
+} from '../lib/account-delete';
 import * as random from '../lib/crypto/random';
-import initRedis from '../lib/redis';
+import DB from '../lib/db';
+import { setupFirestore } from '../lib/firestore-db';
+import initLog from '../lib/log';
 import oauthDb from '../lib/oauth/db';
+import { CurrencyHelper } from '../lib/payments/currencies';
+import { createStripeHelper, StripeHelper } from '../lib/payments/stripe';
 import { pushboxApi } from '../lib/pushbox';
+import initRedis from '../lib/redis';
+import Token from '../lib/tokens';
+import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
+import { parseDryRun } from './lib/args';
 
 const collect = () => (val: string, xs: string[]) => {
   xs.push(val);
@@ -117,7 +120,7 @@ const init = async () => {
   const hasEmail = program.email.length > 0;
   const hasDateRange =
     program.startDate && program.endDate && program.endDate > program.startDate;
-  const reason = AccountDeleteReasonsMap.unverified;
+  const reason = ReasonForDeletionOptions.Unverified;
 
   if (!hasUid && !hasEmail && !hasDateRange) {
     throw new Error(
@@ -176,6 +179,7 @@ const init = async () => {
     fxaDb,
     oauthDb,
     config,
+    push: {} as any, // Not needed when enqueuing
     pushbox,
     statsd,
   });


### PR DESCRIPTION
Because:

* We want to simplify account deletion logic.
* We want to avoid having the user wait on account deletion.

This commit:

* Moved types to a single location and used an enum.
* Consolidated notify logic for account deletion.
* Updated delete path to work for cleanup and first-time deletion.
* Updated tests to reflect changes.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
