### PR TITLE
bug(shared): Handle exception in email pii filter

### DIFF
--- a/packages/fxa-shared/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/sentry/pii-filter-actions.ts
@@ -244,11 +244,16 @@ export class EmailFilter extends PiiRegexFilter {
       if (url.pathname) {
         url.pathname = url.pathname.replace(this.regex, this.replaceWith);
       }
-      val = decodeURI(url.toString());
+      try {
+        val = decodeURI(url.toString());
+      } catch {
+        // Fallback incase the replaces made the url invalid
+        val = url.toString();
+      }
     }
 
     // Encode/decode to work around weird cases like email='foo@bar.com' which is
-    // technically a valid email, but ill advised an unlikely. Even if a user had
+    // technically a valid email, but ill advised and unlikely. Even if a user had
     // this odd example email, the majority of the email would stripped, for example,
     // email='[Filtered]' thereby eliminating PII.
     this.encode.forEach((x, i) => {


### PR DESCRIPTION
## Because

- We could see from breadcrumbs on other sentry events that uriDecode would sometimes produce an exception

## This pull request

- Handles any uriDecode error and falls back to just using the raw string if this happens

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
