### PR TITLE
fix(contentful): Remove 'default' from newsletterLabelTextCode

### DIFF
--- a/libs/shared/contentful/src/__generated__/graphql.ts
+++ b/libs/shared/contentful/src/__generated__/graphql.ts
@@ -1774,6 +1774,7 @@ export enum PurchaseOrder {
 export type Query = {
   __typename?: 'Query';
   _entities: Array<Maybe<_Entity>>;
+  _node: Maybe<_Node>;
   _service: _Service;
   asset: Maybe<Asset>;
   assetCollection: Maybe<AssetCollection>;
@@ -1800,6 +1801,12 @@ export type Query = {
 
 export type Query_EntitiesArgs = {
   representations: Array<Scalars['_Any']['input']>;
+};
+
+export type Query_NodeArgs = {
+  id: Scalars['ID']['input'];
+  locale: InputMaybe<Scalars['String']['input']>;
+  preview: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type QueryAssetArgs = {
@@ -2317,6 +2324,10 @@ export type _Entity =
   | PurchaseDetails
   | Service
   | SubGroup;
+
+export type _Node = {
+  _id: Scalars['ID']['output'];
+};
 
 export type _Service = {
   __typename?: '_Service';

--- a/packages/db-migrations/contentful/1707142161051_fxa-8977.js
+++ b/packages/db-migrations/contentful/1707142161051_fxa-8977.js
@@ -1,0 +1,10 @@
+function migrationFunction(migration, context) {
+  const commonContent = migration.editContentType('commonContent');
+  const commonContentNewsletterLabelTextCode = commonContent.editField(
+    'newsletterLabelTextCode'
+  );
+  commonContentNewsletterLabelTextCode.validations([
+    { in: ['hubs', 'mdnplus', 'snp'] },
+  ]);
+}
+module.exports = migrationFunction;


### PR DESCRIPTION
## Because

- `default` is not a valid option for newsletterLabelTextCode

## This pull request

- removes `default` option from choices

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
