### PR TITLE
feat(glean): add option to skip client ip address

### DIFF
--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -431,6 +431,18 @@ describe('Glean server side events', () => {
     });
   });
 
+  describe('oauth', () => {
+    describe('tokenChecked', () => {
+      it('sends an empty ip address', async () => {
+        const glean = gleanMetrics(config);
+        await glean.oauth.tokenChecked(request);
+        sinon.assert.calledOnce(recordStub);
+        const metrics = recordStub.args[0][0];
+        assert.equal(metrics['ip_address'], '');
+      });
+    });
+  });
+
   describe('logErrorWithGlean hapi preResponse error logger', () => {
     const error = AppError.requestBlocked();
     const glean = mocks.mockGlean();


### PR DESCRIPTION
Because:
 - for certain server-side events we don't want to send the client ip for Glean ingestion

This commit:
 - adds an option to skip the client ip in the event logging function
 - uses the option for `access_token_checked` events
