### PR TITLE
fix(contentful): validate that items in planIdsToClientCapabilities are populated

### DIFF
--- a/libs/payments/capability/src/lib/capability.manager.spec.ts
+++ b/libs/payments/capability/src/lib/capability.manager.spec.ts
@@ -117,6 +117,39 @@ describe('CapabilityManager', () => {
       expect(Object.keys(result).length).toBe(0);
     });
 
+    it('should return empty results when there are no capability collection items', async () => {
+      const offeringResult = CapabilityOfferingResultFactory({
+        capabilitiesCollection: {
+          items: [],
+        },
+      });
+      mockResult.capabilityOfferingForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult);
+      const result = await manager.planIdsToClientCapabilities(['planId1']);
+      expect(Object.keys(result).length).toBe(0);
+    });
+
+    it('should return empty results when there are no service collection items', async () => {
+      const offeringResult = CapabilityOfferingResultFactory({
+        capabilitiesCollection: {
+          items: [
+            CapabilityCapabilitiesResultFactory({
+              slug: 'slug1',
+              servicesCollection: {
+                items: [],
+              },
+            }),
+          ],
+        },
+      });
+      mockResult.capabilityOfferingForPlanId = jest
+        .fn()
+        .mockReturnValueOnce(offeringResult);
+      const result = await manager.planIdsToClientCapabilities(['planId1']);
+      expect(Object.keys(result).length).toBe(0);
+    });
+
     it('should return planIds to client capabilities', async () => {
       const offeringResult = CapabilityOfferingResultFactory({
         capabilitiesCollection: {

--- a/libs/payments/capability/src/lib/capability.manager.ts
+++ b/libs/payments/capability/src/lib/capability.manager.ts
@@ -51,10 +51,18 @@ export class CapabilityManager {
       const capabilityOffering =
         purchaseDetails.capabilityOfferingForPlanId(subscribedPrice);
 
-      if (!capabilityOffering) continue;
+      // continue if neither offering nor capabilities exist
+      if (
+        !capabilityOffering ||
+        !capabilityOffering?.capabilitiesCollection?.items
+      )
+        continue;
 
       for (const capabilityCollection of capabilityOffering
         .capabilitiesCollection.items) {
+        // continue if individual capability does not contain any services
+        if (!capabilityCollection.servicesCollection?.items) continue;
+
         for (const capability of capabilityCollection.servicesCollection
           .items) {
           result[capability.oauthClientId] ||= [];


### PR DESCRIPTION
## Because

- Sentry is throwing an "items undefined" error when `items` are missing.

## This pull request

- Validates that `capabilitiesCollection` items and `servicesCollection` items are populated before proceeding.
- Adds additional tests to check that both collections are populated.
- In both cases, similar to when no `capabilityOffering` is found, an empty array is returned.

## Issue that this pull request solves

Closes FXA-9052

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Items in both collections are required and expected. Since Contentful does not verify these fields are populated before publishing, these checks serve as an additional failsafe.
