### PR TITLE
Fix customs server not reporting statsd url timings

### DIFF
--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -7,6 +7,7 @@
 const axios = require('axios');
 const { config } = require('../config');
 const { createHttpAgent, createHttpsAgent } = require('../lib/http-agent');
+const { performance } = require('perf_hooks');
 
 const localizeTimestamp =
   require('../../../libs/shared/l10n/src').localizeTimestamp({
@@ -34,10 +35,28 @@ class CustomsClient {
       return;
     }
 
+    const method = endpoint.replaceAll('/', '');
+    const startTime = performance.now();
+
     try {
       const response = await this.axiosInstance.post(endpoint, requestData);
+
+      if (this.statsd) {
+        this.statsd.timing(
+          `${serviceName}.${method}.success`,
+          performance.now() - startTime
+        );
+      }
+
       return response.data;
     } catch (err) {
+      if (this.statsd) {
+        this.statsd.timing(
+          `${serviceName}.${method}.failure`,
+          performance.now() - startTime
+        );
+      }
+
       if (err.errno > -1 || (err.statusCode && err.statusCode < 500)) {
         throw err;
       } else {


### PR DESCRIPTION
## Because

- This wasn't ported over in https://github.com/mozilla/fxa/pull/16092, we ported over the block counts but not request timings

## This pull request

- Reports the customs server request timings

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9120

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
