### PR TITLE
feat(auth): update active subs with cancellation reason before deleting

### DIFF
--- a/packages/fxa-auth-server/test/local/account-delete.js
+++ b/packages/fxa-auth-server/test/local/account-delete.js
@@ -235,8 +235,13 @@ describe('AccountDeleteManager', function () {
       sinon.assert.calledWithMatch(mockFxaDb.deleteAccount, {
         uid,
       });
-      sinon.assert.callCount(mockStripeHelper.removeCustomer, 1);
-      sinon.assert.calledWithMatch(mockStripeHelper.removeCustomer, uid);
+      sinon.assert.calledOnceWithExactly(mockStripeHelper.removeCustomer, uid, {
+        cancellation_reason: deleteReason,
+      });
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.removeFirestoreCustomer,
+        uid
+      );
 
       sinon.assert.calledOnceWithExactly(
         mockAuthModels.getAllPayPalBAByUid,


### PR DESCRIPTION
Because:

* We want to track why a subscription was cancelled in Stripe.

This commit:

* Updates metadata with the reason on the Stripe subscriptions before deleteing them.

Closes FXA-9067

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
