### PR TITLE
task(auth-client,gql): Add extra header support in all cases

### DIFF
--- a/libs/shared/db/mysql/account/src/test/accounts.sql
+++ b/libs/shared/db/mysql/account/src/test/accounts.sql
@@ -19,6 +19,9 @@ CREATE TABLE `accounts` (
   `disabledAt` bigint(20) unsigned DEFAULT NULL,
   `metricsOptOutAt` bigint(20) unsigned DEFAULT NULL,
   `atLeast18AtReg` tinyint(1) unsigned DEFAULT NULL,
+  `clientSalt` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifyHashVersion2` binary(32) DEFAULT NULL,
+  `wrapWrapKbVersion2` binary(32) DEFAULT NULL,
   PRIMARY KEY (`uid`),
   UNIQUE KEY `normalizedEmail` (`normalizedEmail`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/packages/fxa-auth-server/test/scripts/fixtures/accounts.sql
+++ b/packages/fxa-auth-server/test/scripts/fixtures/accounts.sql
@@ -19,6 +19,9 @@ CREATE TABLE `accounts` (
   `disabledAt` bigint(20) unsigned DEFAULT NULL,
   `metricsOptOutAt` bigint(20) unsigned DEFAULT NULL,
   `atLeast18AtReg` tinyint(1) unsigned DEFAULT NULL,
+  `clientSalt` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifyHashVersion2` binary(32) DEFAULT NULL,
+  `wrapWrapKbVersion2` binary(32) DEFAULT NULL,
   PRIMARY KEY (`uid`),
   UNIQUE KEY `normalizedEmail` (`normalizedEmail`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
@@ -58,7 +58,11 @@ describe('ProfileClientService', () => {
         set: jest.fn().mockResolvedValue({ text: '{}' }),
       }),
     });
-    const result = await service.updateDisplayName('token', 'name');
+    const result = await service.updateDisplayName(
+      new Headers(),
+      'token',
+      'name'
+    );
     expect(result).toBe(true);
   });
 
@@ -73,7 +77,12 @@ describe('ProfileClientService', () => {
         }),
       }),
     });
-    const result = await service.avatarUpload('token', 'app/json', 'somefile');
+    const result = await service.avatarUpload(
+      new Headers(),
+      'token',
+      'app/json',
+      'somefile'
+    );
     expect(result.url).toBe('testurl');
   });
 
@@ -84,7 +93,7 @@ describe('ProfileClientService', () => {
     (jest.spyOn(superagent, 'get') as jest.Mock).mockReturnValueOnce({
       set: jest.fn().mockResolvedValue({ text: '{"avatar":"x"}' }),
     });
-    const result = await service.getProfile('token');
+    const result = await service.getProfile(new Headers(), 'token');
     expect(result).toStrictEqual({ avatar: 'x' });
   });
 });

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.ts
@@ -27,42 +27,54 @@ export class ProfileClientService {
     this.profileServerUrl = profileConfig.url;
   }
 
-  private async fetchToken(token: string) {
+  private async fetchToken(headers: Headers, token: string) {
     const result = await this.authAPI.createOAuthToken(
       token,
       this.oauthClientId,
       {
         scope: 'profile:write clients:write',
-      }
+      },
+      headers
     );
     return result.access_token;
   }
 
   private async profilePostRequest(
+    headers: Headers,
     token: string,
     path: string,
     data: object
   ): Promise<superagent.Response> {
-    const accessToken = await this.fetchToken(token);
+    const accessToken = await this.fetchToken(headers, token);
     return superagent
       .post(this.profileServerUrl + path)
       .send(data)
       .set('Authorization', 'Bearer ' + accessToken);
   }
 
-  public async updateDisplayName(token: string, name: string) {
-    const result = await this.profilePostRequest(token, '/display_name', {
-      displayName: name,
-    });
+  public async updateDisplayName(
+    headers: Headers,
+    token: string,
+    name: string
+  ) {
+    const result = await this.profilePostRequest(
+      headers,
+      token,
+      '/display_name',
+      {
+        displayName: name,
+      }
+    );
     return result.text === '{}';
   }
 
   public async avatarUpload(
+    headers: Headers,
     token: string,
     contentType: string,
     file: any
   ): Promise<Avatar> {
-    const accessToken = await this.fetchToken(token);
+    const accessToken = await this.fetchToken(headers, token);
     const result = await superagent
       .post(this.profileServerUrl + '/avatar/upload')
       .set('Content-Type', contentType)
@@ -71,8 +83,8 @@ export class ProfileClientService {
     return result.body;
   }
 
-  public async avatarDelete(token: string, id?: string) {
-    const accessToken = await this.fetchToken(token);
+  public async avatarDelete(headers: Headers, token: string, id?: string) {
+    const accessToken = await this.fetchToken(headers, token);
     const result = await superagent
       .delete(this.profileServerUrl + '/avatar/' + id)
       .set('Authorization', 'Bearer ' + accessToken);
@@ -80,8 +92,8 @@ export class ProfileClientService {
     return result.text === '{}';
   }
 
-  public async getProfile(token: string) {
-    const accessToken = await this.fetchToken(token);
+  public async getProfile(headers: Headers, token: string) {
+    const accessToken = await this.fetchToken(headers, token);
     const result = await superagent
       .get(this.profileServerUrl + '/profile')
       .set('Authorization', 'Bearer ' + accessToken);

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -39,7 +39,12 @@ describe('#integration - AccountResolver', () => {
   });
 
   beforeEach(async () => {
-    logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
+    logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
     const MockMozLogger: Provider = {
       provide: MozLoggerService,
       useValue: logger,
@@ -123,7 +128,7 @@ describe('#integration - AccountResolver', () => {
         authClient.account = jest
           .fn()
           .mockResolvedValue({ subscriptions: [{ key: 1, key_two: 2 }] });
-        const result = await resolver.subscriptions('token');
+        const result = await resolver.subscriptions(new Headers(), 'token');
         expect(result).toStrictEqual([{ key: 1, keyTwo: 2 }]);
       });
 
@@ -131,19 +136,19 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryKeyExists = jest
           .fn()
           .mockResolvedValue({ exists: true });
-        const result = await resolver.recoveryKey('token');
+        const result = await resolver.recoveryKey(new Headers(), 'token');
         expect(result).toBeTruthy();
       });
 
       it('resolves totp', async () => {
         authClient.checkTotpTokenExists = jest.fn().mockResolvedValue(true);
-        const result = await resolver.totp('token');
+        const result = await resolver.totp(new Headers(), 'token');
         expect(result).toBeTruthy();
       });
 
       it('resolves attachedClients', async () => {
         authClient.attachedClients = jest.fn().mockResolvedValue(true);
-        const result = await resolver.attachedClients('token');
+        const result = await resolver.attachedClients(new Headers(), 'token');
         expect(result).toBeTruthy();
       });
 
@@ -191,7 +196,7 @@ describe('#integration - AccountResolver', () => {
           recoveryCodes: ['test1', 'test2'],
           secret: 'secretData',
         });
-        const result = await resolver.createTotp('token', {
+        const result = await resolver.createTotp(new Headers(), 'token', {
           metricsContext: { deviceId: 'device1', flowBeginTime: 4238248 },
           clientMutationId: 'testid',
         });
@@ -209,7 +214,7 @@ describe('#integration - AccountResolver', () => {
         authClient.verifyTotpCode = jest
           .fn()
           .mockResolvedValue({ success: true });
-        const result = await resolver.verifyTotp('token', {
+        const result = await resolver.verifyTotp(new Headers(), 'token', {
           code: 'code1234',
           clientMutationId: 'testid',
         });
@@ -225,7 +230,7 @@ describe('#integration - AccountResolver', () => {
         authClient.deleteTotpToken = jest
           .fn()
           .mockResolvedValue({ success: true });
-        const result = await resolver.deleteTotp('token', {
+        const result = await resolver.deleteTotp(new Headers(), 'token', {
           clientMutationId: 'testid',
         });
         expect(authClient.deleteTotpToken).toBeCalledTimes(1);
@@ -238,9 +243,13 @@ describe('#integration - AccountResolver', () => {
     describe('deleteRecoveryKey', () => {
       it('succeeds', async () => {
         authClient.deleteRecoveryKey = jest.fn().mockResolvedValue(true);
-        const result = await resolver.deleteRecoveryKey('token', {
-          clientMutationId: 'testid',
-        });
+        const result = await resolver.deleteRecoveryKey(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+          }
+        );
         expect(authClient.deleteRecoveryKey).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -253,9 +262,13 @@ describe('#integration - AccountResolver', () => {
         authClient.replaceRecoveryCodes = jest
           .fn()
           .mockResolvedValue({ recoveryCodes: ['test1', 'test2'] });
-        const result = await resolver.changeRecoveryCodes('token', {
-          clientMutationId: 'testid',
-        });
+        const result = await resolver.changeRecoveryCodes(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+          }
+        );
         expect(authClient.replaceRecoveryCodes).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -267,10 +280,14 @@ describe('#integration - AccountResolver', () => {
     describe('updateDisplayName', () => {
       it('succeeds', async () => {
         profileClient.updateDisplayName = jest.fn().mockResolvedValue(true);
-        const result = await resolver.updateDisplayName('token', {
-          clientMutationId: 'testid',
-          displayName: 'fred',
-        });
+        const result = await resolver.updateDisplayName(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            displayName: 'fred',
+          }
+        );
         expect(profileClient.updateDisplayName).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -282,7 +299,7 @@ describe('#integration - AccountResolver', () => {
     describe('deleteAvatar', () => {
       it('succeeds', async () => {
         profileClient.avatarDelete = jest.fn().mockResolvedValue(true);
-        await resolver.deleteAvatar('token', {
+        await resolver.deleteAvatar(new Headers(), 'token', {
           clientMutationId: 'testid',
           id: 'blah',
         });
@@ -299,10 +316,14 @@ describe('#integration - AccountResolver', () => {
     describe('createSecondaryEmail', () => {
       it('succeeds', async () => {
         authClient.recoveryEmailCreate = jest.fn().mockResolvedValue(true);
-        const result = await resolver.createSecondaryEmail('token', {
-          clientMutationId: 'testid',
-          email: 'test@example.com',
-        });
+        const result = await resolver.createSecondaryEmail(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            email: 'test@example.com',
+          }
+        );
         expect(authClient.recoveryEmailCreate).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -315,10 +336,14 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSecondaryResendCode = jest
           .fn()
           .mockResolvedValue(true);
-        const result = await resolver.resendSecondaryEmailCode('token', {
-          clientMutationId: 'testid',
-          email: 'test@example.com',
-        });
+        const result = await resolver.resendSecondaryEmailCode(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            email: 'test@example.com',
+          }
+        );
         expect(authClient.recoveryEmailSecondaryResendCode).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -331,11 +356,15 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSecondaryVerifyCode = jest
           .fn()
           .mockResolvedValue(true);
-        const result = await resolver.verifySecondaryEmail('token', {
-          clientMutationId: 'testid',
-          email: 'test@example.com',
-          code: 'ABCD1234',
-        });
+        const result = await resolver.verifySecondaryEmail(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            email: 'test@example.com',
+            code: 'ABCD1234',
+          }
+        );
         expect(authClient.recoveryEmailSecondaryVerifyCode).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -346,10 +375,14 @@ describe('#integration - AccountResolver', () => {
     describe('deleteSecondaryEmail', () => {
       it('succeeds', async () => {
         authClient.recoveryEmailDestroy = jest.fn().mockResolvedValue(true);
-        const result = await resolver.deleteSecondaryEmail('token', {
-          clientMutationId: 'testid',
-          email: 'test@example.com',
-        });
+        const result = await resolver.deleteSecondaryEmail(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            email: 'test@example.com',
+          }
+        );
         expect(authClient.recoveryEmailDestroy).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -362,10 +395,14 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSetPrimaryEmail = jest
           .fn()
           .mockResolvedValue(true);
-        const result = await resolver.updatePrimaryEmail('token', {
-          clientMutationId: 'testid',
-          email: 'test@example.com',
-        });
+        const result = await resolver.updatePrimaryEmail(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            email: 'test@example.com',
+          }
+        );
         expect(authClient.recoveryEmailSetPrimaryEmail).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -376,13 +413,17 @@ describe('#integration - AccountResolver', () => {
     describe('attachedClientDisconnect', () => {
       it('succeeds', async () => {
         authClient.attachedClientDestroy = jest.fn().mockResolvedValue(true);
-        const result = await resolver.attachedClientDisconnect('token', {
-          clientMutationId: 'testid',
-          clientId: 'client1234',
-          sessionTokenId: 'sesssion1234',
-          refreshTokenId: 'refresh1234',
-          deviceId: 'device1234',
-        });
+        const result = await resolver.attachedClientDisconnect(
+          new Headers(),
+          'token',
+          {
+            clientMutationId: 'testid',
+            clientId: 'client1234',
+            sessionTokenId: 'sesssion1234',
+            refreshTokenId: 'refresh1234',
+            deviceId: 'device1234',
+          }
+        );
         expect(authClient.attachedClientDestroy).toBeCalledTimes(1);
         expect(result).toStrictEqual({
           clientMutationId: 'testid',
@@ -500,7 +541,7 @@ describe('#integration - AccountResolver', () => {
         expect(authClient.passwordForgotVerifyCode).toHaveBeenLastCalledWith(
           'code',
           'passwordforgottoken',
-          {},
+          undefined,
           headers
         );
         expect(result).toStrictEqual({
@@ -517,7 +558,7 @@ describe('#integration - AccountResolver', () => {
           tries: 1,
           ttl: 2,
         });
-        const result = await resolver.passwordForgotCodeStatus({
+        const result = await resolver.passwordForgotCodeStatus(new Headers(), {
           token: 'passwordforgottoken',
         });
         expect(authClient.passwordForgotStatus).toBeCalledTimes(1);
@@ -579,7 +620,8 @@ describe('#integration - AccountResolver', () => {
             wrapKb: '1212'.repeat(8),
             authPWVersion2: '2323'.repeat(8),
             wrapKbVersion2: '3434'.repeat(8),
-            clientSalt: 'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef'
+            clientSalt:
+              'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef',
           },
           options: {},
         });
@@ -618,6 +660,7 @@ describe('#integration - AccountResolver', () => {
         expect(authClient.signUpWithAuthPW).toBeCalledWith(
           'testo@example.xyz',
           '00000000',
+          {},
           { service: 'testo-co', atLeast18AtReg: false },
           headers
         );
@@ -687,6 +730,7 @@ describe('#integration - AccountResolver', () => {
         expect(authClient.finishSetupWithAuthPW).toBeCalledWith(
           'jwttothemax',
           '00000000',
+          {},
           headers
         );
         expect(result).toStrictEqual(mockRespPayload);
@@ -710,8 +754,9 @@ describe('#integration - AccountResolver', () => {
             wrapKb: '1234'.repeat(8),
             authPWVersion2: '1234'.repeat(8),
             wrapKbVersion2: '1234'.repeat(8),
-            clientSalt: 'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef'
-          }
+            clientSalt:
+              'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef',
+          },
         });
         expect(authClient.finishSetupWithAuthPW).toBeCalledTimes(1);
         expect(authClient.finishSetupWithAuthPW).toBeCalledWith(
@@ -721,7 +766,8 @@ describe('#integration - AccountResolver', () => {
             wrapKb: '1234'.repeat(8),
             authPWVersion2: '1234'.repeat(8),
             wrapKbVersion2: '1234'.repeat(8),
-            clientSalt: 'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef'
+            clientSalt:
+              'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef',
           },
           headers
         );
@@ -835,13 +881,15 @@ describe('#integration - AccountResolver', () => {
         authClient.getRecoveryKey = jest.fn().mockResolvedValue({
           recoveryData: 'recoveryData',
         });
-        const result = await resolver.getRecoveryKeyBundle({
+        const headers = new Headers();
+        const result = await resolver.getRecoveryKeyBundle(headers, {
           accountResetToken: 'cooltokenyo',
           recoveryKeyId: 'recoveryKeyId',
         });
         expect(authClient.getRecoveryKey).toBeCalledWith(
           'cooltokenyo',
-          'recoveryKeyId'
+          'recoveryKeyId',
+          headers
         );
         expect(result).toStrictEqual({
           recoveryData: 'recoveryData',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -153,13 +153,18 @@ export class AccountResolver {
   })
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async createTotp(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => CreateTotpInput })
     input: CreateTotpInput
   ): Promise<CreateTotpPayload> {
-    const result = await this.authAPI.createTotpToken(token, {
-      metricsContext: input.metricsContext,
-    });
+    const result = await this.authAPI.createTotpToken(
+      token,
+      {
+        metricsContext: input.metricsContext,
+      },
+      headers
+    );
     return {
       clientMutationId: input.clientMutationId,
       ...result,
@@ -173,6 +178,7 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifyTotp(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => VerifyTotpInput })
     input: VerifyTotpInput
@@ -180,7 +186,8 @@ export class AccountResolver {
     const result = await this.authAPI.verifyTotpCode(
       token,
       input.code,
-      input.service ? { service: input.service } : undefined
+      input.service ? { service: input.service } : undefined,
+      headers
     );
     return {
       clientMutationId: input.clientMutationId,
@@ -194,11 +201,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteTotp(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DeleteTotpInput })
     input: DeleteTotpInput
   ): Promise<BasicPayload> {
-    await this.authAPI.deleteTotpToken(token);
+    await this.authAPI.deleteTotpToken(token, headers);
     return {
       clientMutationId: input.clientMutationId,
     };
@@ -210,11 +218,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteRecoveryKey(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DeleteRecoveryKeyInput })
     input: DeleteRecoveryKeyInput
   ): Promise<BasicPayload> {
-    await this.authAPI.deleteRecoveryKey(token);
+    await this.authAPI.deleteRecoveryKey(token, headers);
     return {
       clientMutationId: input.clientMutationId,
     };
@@ -227,11 +236,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async changeRecoveryCodes(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => ChangeRecoveryCodesInput })
     input: ChangeRecoveryCodesInput
   ): Promise<ChangeRecoveryCodesPayload> {
-    const result = await this.authAPI.replaceRecoveryCodes(token);
+    const result = await this.authAPI.replaceRecoveryCodes(token, headers);
     return {
       clientMutationId: input.clientMutationId,
       recoveryCodes: result.recoveryCodes,
@@ -244,11 +254,13 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async updateDisplayName(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => UpdateDisplayNameInput })
     input: UpdateDisplayNameInput
   ): Promise<UpdateDisplayNamePayload> {
     const result = await this.profileAPI.updateDisplayName(
+      headers,
       token,
       input.displayName
     );
@@ -287,10 +299,11 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteAvatar(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DeleteAvatarInput }) input: DeleteAvatarInput
   ): Promise<BasicPayload> {
-    await this.profileAPI.avatarDelete(token, input.id);
+    await this.profileAPI.avatarDelete(headers, token, input.id);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -300,12 +313,18 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async createSecondaryEmail(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailCreate(token, input.email, {
-      verificationMethod: 'email-otp',
-    });
+    await this.authAPI.recoveryEmailCreate(
+      token,
+      input.email,
+      {
+        verificationMethod: 'email-otp',
+      },
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -315,10 +334,15 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async resendSecondaryEmailCode(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailSecondaryResendCode(token, input.email);
+    await this.authAPI.recoveryEmailSecondaryResendCode(
+      token,
+      input.email,
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -328,13 +352,15 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifySecondaryEmail(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => VerifyEmailInput }) input: VerifyEmailInput
   ) {
     await this.authAPI.recoveryEmailSecondaryVerifyCode(
       token,
       input.email,
-      input.code
+      input.code,
+      headers
     );
     return { clientMutationId: input.clientMutationId };
   }
@@ -345,10 +371,11 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteSecondaryEmail(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailDestroy(token, input.email);
+    await this.authAPI.recoveryEmailDestroy(token, input.email, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -359,10 +386,15 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async updatePrimaryEmail(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailSetPrimaryEmail(token, input.email);
+    await this.authAPI.recoveryEmailSetPrimaryEmail(
+      token,
+      input.email,
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -373,11 +405,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async attachedClientDisconnect(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => AttachedClientDisconnectInput })
     input: AttachedClientDisconnectInput
   ) {
-    await this.authAPI.attachedClientDestroy(token, input);
+    await this.authAPI.attachedClientDestroy(token, input, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -491,7 +524,7 @@ export class AccountResolver {
     return this.authAPI.passwordForgotVerifyCode(
       input.code,
       input.token,
-      {},
+      undefined,
       headers
     );
   }
@@ -501,10 +534,11 @@ export class AccountResolver {
   })
   @CatchGatewayError
   public async passwordForgotCodeStatus(
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => PasswordForgotCodeStatusInput })
     input: PasswordForgotCodeStatusInput
   ) {
-    return this.authAPI.passwordForgotStatus(input.token);
+    return this.authAPI.passwordForgotStatus(input.token, headers);
   }
 
   @Mutation((returns) => AccountResetPayload, {
@@ -676,12 +710,14 @@ export class AccountResolver {
   })
   @CatchGatewayError
   public async getRecoveryKeyBundle(
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => RecoveryKeyBundleInput })
     input: RecoveryKeyBundleInput
   ): Promise<RecoveryKeyBundlePayload> {
     const { recoveryData } = await this.authAPI.getRecoveryKey(
       input.accountResetToken,
-      input.recoveryKeyId
+      input.recoveryKeyId,
+      headers
     );
 
     return { recoveryData };
@@ -705,6 +741,7 @@ export class AccountResolver {
 
   @ResolveField()
   public async avatar(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Parent() account: Account
   ) {
@@ -714,7 +751,7 @@ export class AccountResolver {
         return avatar;
       }
 
-      const profile = await this.profileAPI.getProfile(token);
+      const profile = await this.profileAPI.getProfile(headers, token);
       const url = profile.avatar;
       return {
         id: `default-${url[url.length - 1]}`,
@@ -755,25 +792,41 @@ export class AccountResolver {
   }
 
   @ResolveField()
-  public async subscriptions(@GqlSessionToken() token: string) {
-    const account = await this.authAPI.account(token);
+  public async subscriptions(
+    @GqlXHeaders() headers: Headers,
+    @GqlSessionToken() token: string
+  ) {
+    const account = await this.authAPI.account(token, headers);
     return account.subscriptions.map(snakeToCamelObject);
   }
 
   @ResolveField()
-  public async recoveryKey(@GqlSessionToken() token: string) {
-    const result = await this.authAPI.recoveryKeyExists(token);
+  public async recoveryKey(
+    @GqlXHeaders() headers: Headers,
+    @GqlSessionToken() token: string
+  ) {
+    const result = await this.authAPI.recoveryKeyExists(
+      token,
+      undefined,
+      headers
+    );
     return result.exists;
   }
 
   @ResolveField()
-  public totp(@GqlSessionToken() token: string) {
-    return this.authAPI.checkTotpTokenExists(token);
+  public totp(
+    @GqlXHeaders() headers: Headers,
+    @GqlSessionToken() token: string
+  ) {
+    return this.authAPI.checkTotpTokenExists(token, headers);
   }
 
   @ResolveField()
-  public attachedClients(@GqlSessionToken() token: string) {
-    return this.authAPI.attachedClients(token);
+  public attachedClients(
+    @GqlXHeaders() headers: Headers,
+    @GqlSessionToken() token: string
+  ) {
+    return this.authAPI.attachedClients(token, headers);
   }
 
   @ResolveField()

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -49,7 +49,7 @@ describe('AccountResolver', () => {
 
   it('destroys the session', async () => {
     authClient.sessionDestroy = jest.fn().mockResolvedValue(true);
-    const result = await resolver.destroySession('token', {
+    const result = await resolver.destroySession(new Headers(), 'token', {
       clientMutationId: 'testid',
     });
     expect(authClient.sessionDestroy).toBeCalledTimes(1);

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -38,11 +38,12 @@ export class SessionResolver {
   })
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async destroySession(
+    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DestroySessionInput })
     input: DestroySessionInput
   ): Promise<BasicPayload> {
-    await this.authAPI.sessionDestroy(token);
+    await this.authAPI.sessionDestroy(token, undefined, headers);
     return {
       clientMutationId: input.clientMutationId,
     };

--- a/packages/fxa-graphql-api/test/accounts.sql
+++ b/packages/fxa-graphql-api/test/accounts.sql
@@ -19,6 +19,9 @@ CREATE TABLE `accounts` (
   `disabledAt` bigint(20) unsigned DEFAULT NULL,
   `metricsOptOutAt` bigint(20) unsigned DEFAULT NULL,
   `atLeast18AtReg` tinyint(1) unsigned DEFAULT NULL,
+  `clientSalt` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifyHashVersion2` binary(32) DEFAULT NULL,
+  `wrapWrapKbVersion2` binary(32) DEFAULT NULL,
   PRIMARY KEY (`uid`),
   UNIQUE KEY `normalizedEmail` (`normalizedEmail`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-shared/test/db/models/auth/accounts.sql
+++ b/packages/fxa-shared/test/db/models/auth/accounts.sql
@@ -18,10 +18,10 @@ CREATE TABLE `accounts` (
   `ecosystemAnonId` text CHARACTER SET ascii COLLATE ascii_bin,
   `disabledAt` bigint(20) unsigned DEFAULT NULL,
   `metricsOptOutAt` bigint(20) unsigned DEFAULT NULL,
-  `verifyHashVersion2` binary(32),
-  `wrapWrapKbVersion2` binary(32),
-  `clientSalt` varchar(128),
   `atLeast18AtReg` tinyint(1) unsigned DEFAULT NULL,
+  `clientSalt` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifyHashVersion2` binary(32) DEFAULT NULL,
+  `wrapWrapKbVersion2` binary(32) DEFAULT NULL,
   PRIMARY KEY (`uid`),
   UNIQUE KEY `normalizedEmail` (`normalizedEmail`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION

## Because
- It's error prone to pick and choose which api calls may or may not extra headers.

## This pull request
- Adds optional extra header support to all auth-client functions
- Ensures that extra headers are always added into authClient calls in the graphql-api
- Fixes test db schemas for accounts table bring them up to date with the latest db patch

## Issue that this pull request solves

Closes: FXA-9086

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
