### PR TITLE
perf(content): Optimize tailwind output

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "yarn l10n-prime && yarn copy-local-config && yarn check-local-config ",
     "build": "yarn build-l10n && yarn build-css && yarn build-js",
-    "build-css": "tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css",
+    "build-css": "NODE_ENV=production tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css",
     "build-js": "NODE_ENV=production grunt build",
     "build-l10n": "yarn l10n-create-json",
     "check-local-config": "node scripts/check-local-config",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "yarn l10n-prime && yarn copy-local-config && yarn check-local-config ",
     "build": "yarn build-l10n && yarn build-css && yarn build-js",
-    "build-css": "NODE_ENV=production tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css",
+    "build-css": "NODE_ENV=production tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css --minify",
     "build-js": "NODE_ENV=production grunt build",
     "build-l10n": "yarn l10n-create-json",
     "check-local-config": "node scripts/check-local-config",


### PR DESCRIPTION
## Because

* Transferred tailwind.out.css was very large (>3mb) and unused styles were not purged

## This pull request

* Optimize build-css for production

## Issue that this pull request solves

Closes: #FXA-9129

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

## Other information (Optional)

After the initial change, the tailwind file is down from >5 mb to just over 0.1mb.
A second commit adds a minification step, this reduces a tad further to 0.06mb.