### PR TITLE
fix(auth): Update Sentry error message to show capabilities

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -869,14 +869,8 @@ export class CapabilityService {
       if (this.logToSentry('getClients.NoMatch')) {
         Sentry.withScope((scope) => {
           scope.setContext('getClients', {
-            contentful: clientsFromContentful.map((service) => ({
-              ...service,
-              capabilities: service.capabilities.length,
-            })),
-            stripe: clientsFromStripe.map((service) => ({
-              ...service,
-              capabilities: service.capabilities.length,
-            })),
+            contentful: clientsFromContentful,
+            stripe: clientsFromStripe,
           });
           Sentry.captureMessage(
             `CapabilityService.getClients - Returned Stripe as clients did not match.`,

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -1216,14 +1216,8 @@ describe('CapabilityService', () => {
       assert.deepEqual(clients, mockClientsFromStripe);
 
       sinon.assert.calledOnceWithExactly(sentryScope.setContext, 'getClients', {
-        contentful: mockClientsFromContentful.map((service) => ({
-          ...service,
-          capabilities: service.capabilities.length,
-        })),
-        stripe: mockClientsFromStripe.map((service) => ({
-          ...service,
-          capabilities: service.capabilities.length,
-        })),
+        contentful: mockClientsFromContentful,
+        stripe: mockClientsFromStripe,
       });
       sinon.assert.calledOnceWithExactly(
         Sentry.captureMessage,
@@ -1235,14 +1229,8 @@ describe('CapabilityService', () => {
       await capabilityService.getClients();
 
       sinon.assert.calledOnceWithExactly(sentryScope.setContext, 'getClients', {
-        contentful: mockClientsFromContentful.map((service) => ({
-          ...service,
-          capabilities: service.capabilities.length,
-        })),
-        stripe: mockClientsFromStripe.map((service) => ({
-          ...service,
-          capabilities: service.capabilities.length,
-        })),
+        contentful: mockClientsFromContentful,
+        stripe: mockClientsFromStripe,
       });
     });
   });


### PR DESCRIPTION
## Because

- capabilities are not listed in Sentry error message

## This pull request

- updates Sentry error message to help debug process by showing capabilities within both Contentful and Stripe

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.