### PR TITLE
fix(customs): Update customs axios maxSockets and timeoutMs

### DIFF
--- a/_dev/loadtesting/script.js
+++ b/_dev/loadtesting/script.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Load testing script for the FxA Auth Server.
+ *
+ * 1. Ensure `k6` is installed. [official k6 installation guide](https://k6.io/docs/getting-started/installation/)
+ * 3. Execute the script with the command: `k6 run script.js`.
+ *
+ */
+import http from 'k6/http';
+
+export const options = {
+  // A number specifying the number of VUs to run concurrently.
+  vus: 10,
+  // A string specifying the total duration of the test run.
+  duration: '30s',
+};
+
+export default function() {
+  const url = 'http://127.0.0.1:9000/v1/account/status';
+  // const url = 'https://api-accounts.stage.mozaws.net/v1/account/status';
+  const payload = JSON.stringify({
+    'email': 'a@aa.com',
+    'thirdPartyAuthStatus': true,
+  });
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  http.post(url, payload, params);
+}

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -340,6 +340,28 @@ const convictConf = convict({
     default: 'http://localhost:7000',
     env: 'CUSTOMS_SERVER_URL',
   },
+  customsHttpAgent: {
+    maxSockets: {
+      doc: 'The maximum number of sockets to be opened per host',
+      default: 10000,
+      env: 'CUSTOMS_MAX_SOCKETS',
+    },
+    maxFreeSockets: {
+      doc: 'The maximum number of free sockets to keep open for a host',
+      default: 10,
+      env: 'CUSTOMS_MAX_FREE_SOCKETS',
+    },
+    timeoutMs: {
+      doc: 'The timeout in milliseconds for the sockets',
+      default: 30000,
+      env: 'CUSTOMS_TIMEOUT_MS',
+    },
+    freeSocketTimeoutMs: {
+      doc: 'The time in milliseconds for which a socket should remain open while unused',
+      default: 15000,
+      env: 'CUSTOMS_FREE_SOCKET_TIMEOUT_MS',
+    },
+  },
   contentServer: {
     url: {
       doc: 'The url of the corresponding fxa-content-server instance',

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -21,11 +21,23 @@ class CustomsClient {
     this.log = log;
     this.error = error;
     this.statsd = statsd;
+    const customsHttpAgent = config.get('customsHttpAgent');
+
     if (url !== 'none') {
       this.axiosInstance = axios.create({
         baseURL: url,
-        httpAgent: createHttpAgent(),
-        httpsAgent: createHttpsAgent(),
+        httpAgent: createHttpAgent(
+          customsHttpAgent.maxSockets,
+          customsHttpAgent.maxFreeSockets,
+          customsHttpAgent.timeoutMs,
+          customsHttpAgent.freeSocketTimeoutMs
+        ),
+        httpsAgent: createHttpsAgent(
+          customsHttpAgent.maxSockets,
+          customsHttpAgent.maxFreeSockets,
+          customsHttpAgent.timeoutMs,
+          customsHttpAgent.freeSocketTimeoutMs
+        ),
       });
     }
   }

--- a/packages/fxa-auth-server/lib/http-agent.ts
+++ b/packages/fxa-auth-server/lib/http-agent.ts
@@ -14,10 +14,10 @@ import Agent from 'agentkeepalive';
  * @returns {Agent} An instance of Agent, configured with the specified settings.
  */
 export function createHttpAgent(
-  maxSockets = 100,
+  maxSockets = 1000,
   maxFreeSockets = 10,
-  timeoutMs = 60000,
-  freeSocketTimeoutMs = 30000
+  timeoutMs = 30000,
+  freeSocketTimeoutMs = 15000
 ) {
   return new Agent({
     maxSockets,
@@ -37,10 +37,10 @@ export function createHttpAgent(
  * @returns {Agent.HttpsAgent} An instance of Agent.HttpsAgent, configured with the specified settings.
  */
 export function createHttpsAgent(
-  maxSockets = 100,
+  maxSockets = 1000,
   maxFreeSockets = 10,
-  timeoutMs = 60000,
-  freeSocketTimeoutMs = 30000
+  timeoutMs = 30000,
+  freeSocketTimeoutMs = 15000
 ) {
   return new Agent.HttpsAgent({
     maxSockets,


### PR DESCRIPTION
## Because

- It appears that custom server is taking longer to respond on some requests, ref https://mozilla.sentry.io/performance/fxa-auth:c5096461f4ac4441b8d16c8480d0ef3d/?environment=stage&project=6231056&query=&statsPeriod=1h&transaction=POST#span-efeb80ef74e5b936
- When we migrated to use axios and keepalive, I [commented](https://github.com/mozilla/fxa/pull/16190/files#r1430547917) on using the defaults of keepalive (100) vs what was in our previous library (1000)

## This pull request

- Updates max sockets to 1000, reduces the timeoutMs

## Issue that this pull request solves

Connects to https://mozilla-hub.atlassian.net/browse/FXA-9117

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Once this lands, its pretty straightforward to verify in stage. We would need to run the load tester script and then check to see how the response times are.
