### PR TITLE
task(settings): Support v2 key stretches for signin

### DIFF
--- a/packages/functional-tests/tests/misc/keyStretchingV2.spec.ts
+++ b/packages/functional-tests/tests/misc/keyStretchingV2.spec.ts
@@ -17,6 +17,10 @@ import { ResetPasswordReactPage } from '../../pages/resetPasswordReact';
 import { RecoveryKeyPage } from '../../pages/settings/recoveryKey';
 import { ChangePasswordPage } from '../../pages/settings/changePassword';
 
+// Disable this check for these tests. We are holding assertion in shared functions due
+// to how test permutations work, and these setup falsely trips this rule.
+/* eslint-disable playwright/expect-expect */
+
 /**
  * These tests represent various permutations between interacting with V1 and V2
  * key stretched passwords. We need to ensure that operations are interchangeable!
@@ -257,19 +261,13 @@ test.describe('key-stretching-v2', () => {
       target,
       pages: { signupReact, settings, login },
     }) => {
-      await testSignUpAndLogin(
-        1,
-        2,
-        // TODO: We still need to support V2 signin for react.
-        mode === 'react' ? 1 : 2,
-        {
-          page,
-          target,
-          signupReact,
-          login,
-          settings,
-        }
-      );
+      await testSignUpAndLogin(1, 2, 2, {
+        page,
+        target,
+        signupReact,
+        login,
+        settings,
+      });
     });
     test(`signs up as v2 and logins as v1 for ${mode}`, async ({
       page,

--- a/packages/fxa-auth-server/test/scripts/fixtures/accounts.sql
+++ b/packages/fxa-auth-server/test/scripts/fixtures/accounts.sql
@@ -18,6 +18,9 @@ CREATE TABLE `accounts` (
   `ecosystemAnonId` text CHARACTER SET ascii COLLATE ascii_bin,
   `disabledAt` bigint(20) unsigned DEFAULT NULL,
   `metricsOptOutAt` bigint(20) unsigned DEFAULT NULL,
+  `clientSalt` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifyHashVersion2` binary(32) DEFAULT NULL,
+  `wrapWrapKbVersion2` binary(32) DEFAULT NULL,
   `atLeast18AtReg` tinyint(1) unsigned DEFAULT NULL,
   PRIMARY KEY (`uid`),
   UNIQUE KEY `normalizedEmail` (`normalizedEmail`)

--- a/packages/fxa-graphql-api/src/gql/dto/input/credential-status.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/credential-status.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class CredentialStatusInput {
+  @Field({ description: 'The email to look up' })
+  public email!: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -25,3 +25,6 @@ export { VerifyTotpInput } from './verify-totp';
 export { AccountStatusInput } from './account-status';
 export { RecoveryKeyBundleInput } from './recovery-key';
 export { LegalInput } from './legal';
+export * from './credential-status';
+export * from './password-change-finish';
+export * from './password-change-start';

--- a/packages/fxa-graphql-api/src/gql/dto/input/password-change-finish.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/password-change-finish.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class PasswordChangeFinishInput {
+  @Field()
+  passwordChangeToken!: string;
+
+  @Field()
+  authPW!: string;
+
+  @Field()
+  wrapKb!: string;
+
+  @Field({ nullable: true })
+  authPWVersion2!: string;
+
+  @Field({ nullable: true })
+  wrapKbVersion2?: string;
+
+  @Field({ nullable: true })
+  clientSalt?: string;
+
+  @Field({ nullable: true })
+  sessionToken?: string;
+
+  @Field({ nullable: true })
+  keys?: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/input/password-change-start.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/password-change-start.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class PasswordChangeStartInput {
+  @Field()
+  email!: string;
+
+  @Field()
+  oldAuthPW!: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/credential-status.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/credential-status.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class CredentialStatusPayload {
+  @Field({
+    description:
+      'Indicates the credentials need to be upgraded to a later version. Note, this could also signal that the current version is fine, but the upgrade needs to be run again for some reason.',
+  })
+  public upgradeNeeded!: boolean;
+
+  @Field({
+    description: 'The current version of the credentials.',
+    nullable: true,
+  })
+  public version?: string;
+
+  @Field({
+    description:
+      'The current salt value used by the client. This was added in v2.',
+    nullable: true,
+  })
+  public clientSalt?: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -20,3 +20,7 @@ export { RecoveryKeyBundlePayload } from './recovery-key';
 export { LegalDoc } from './legal';
 export { ClientInfo } from './client-info';
 export { SubscriptionProductInfo } from './subscription-product-info';
+export * from './credential-status';
+export * from './password-change-start';
+export * from './password-change-finish';
+export * from './wrapped-keys';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/password-change-finish.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/password-change-finish.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class PasswordChangeFinishPayload {
+  @Field({ nullable: true })
+  uid?: string;
+
+  @Field({ nullable: true })
+  sessionToken?: string;
+
+  @Field({ nullable: true })
+  verified?: boolean;
+
+  @Field({ nullable: true })
+  authAt?: number;
+
+  @Field({ nullable: true })
+  keyFetchToken?: String;
+
+  @Field({ nullable: true })
+  keyFetchToken2?: String;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/password-change-start.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/password-change-start.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class PasswordChangeStartPayload {
+  @Field()
+  keyFetchToken!: String;
+
+  @Field()
+  passwordChangeToken!: String;
+
+  @Field()
+  verified!: Boolean;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/wrapped-keys.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/wrapped-keys.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class WrappedKeysPayload {
+  @Field()
+  kA!: String;
+
+  @Field()
+  wrapKB!: String;
+}

--- a/packages/fxa-graphql-api/test/accounts.sql
+++ b/packages/fxa-graphql-api/test/accounts.sql
@@ -18,6 +18,9 @@ CREATE TABLE `accounts` (
   `ecosystemAnonId` text CHARACTER SET ascii COLLATE ascii_bin,
   `disabledAt` bigint(20) unsigned DEFAULT NULL,
   `metricsOptOutAt` bigint(20) unsigned DEFAULT NULL,
+  `clientSalt` varchar(128) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifyHashVersion2` binary(32) DEFAULT NULL,
+  `wrapWrapKbVersion2` binary(32) DEFAULT NULL,
   `atLeast18AtReg` tinyint(1) unsigned DEFAULT NULL,
   PRIMARY KEY (`uid`),
   UNIQUE KEY `normalizedEmail` (`normalizedEmail`)

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -110,11 +110,13 @@ let MOCK_QUERY_PARAM_MODEL = {
   email: MOCK_QUERY_PARAM_EMAIL,
   hasPassword: 'true',
   hasLinkedAccount: 'false',
+  isV2: () => false,
 };
 const MOCK_QUERY_PARAM_MODEL_NO_VALUES = {
   email: '',
   hasPassword: undefined,
   hasLinkedAccount: undefined,
+  isV2: () => false,
 };
 
 // Call this when testing query params
@@ -126,6 +128,7 @@ function mockUseValidateModule(
       email?: string;
       hasPassword?: string; // TODO: should be 'true' or 'false'
       hasLinkedAccount?: string; // TODO: should be 'true' or 'false'
+      isV2: () => boolean;
     };
   } = { queryParams: MOCK_QUERY_PARAM_MODEL }
 ) {
@@ -284,7 +287,11 @@ describe('signin container', () => {
       it('renders if hasLinkedAccount is undefined', async () => {
         // test against query params
         mockUseValidateModule({
-          queryParams: { email: MOCK_QUERY_PARAM_EMAIL, hasPassword: 'true' },
+          queryParams: {
+            email: MOCK_QUERY_PARAM_EMAIL,
+            hasPassword: 'true',
+            isV2: () => false,
+          },
         });
         render();
         await waitFor(() => {
@@ -313,6 +320,7 @@ describe('signin container', () => {
         queryParams: {
           email: MOCK_QUERY_PARAM_EMAIL,
           hasLinkedAccount: 'true',
+          isV2: () => false,
         },
       });
       render();
@@ -348,7 +356,7 @@ describe('signin container', () => {
     });
     it('redirects to /signup if account does not exist', async () => {
       mockUseValidateModule({
-        queryParams: { email: MOCK_QUERY_PARAM_EMAIL },
+        queryParams: { email: MOCK_QUERY_PARAM_EMAIL, isV2: () => false },
       });
       mockAuthClient.accountStatusByEmail = jest
         .fn()
@@ -381,6 +389,7 @@ describe('signin container', () => {
       });
     });
   });
+
   describe('hasLinkedAccount and hasPassword are provided', () => {
     it('accountStatusByEmail is not called, email provided by query params', async () => {
       mockUseValidateModule();
@@ -402,6 +411,7 @@ describe('signin container', () => {
     beforeEach(() => {
       mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
     });
+
     it('runs handler and invokes sign in mutation', async () => {
       render();
 

--- a/packages/fxa-settings/src/pages/Signin/gql.ts
+++ b/packages/fxa-settings/src/pages/Signin/gql.ts
@@ -27,3 +27,44 @@ export const BEGIN_SIGNIN_MUTATION = gql`
     }
   }
 `;
+
+export const PASSWORD_CHANGE_START_MUTATION = gql`
+  mutation passwordChangeStart($input: PasswordChangeStartInput!) {
+    passwordChangeStart(input: $input) {
+      keyFetchToken
+      passwordChangeToken
+    }
+  }
+`;
+
+export const PASSWORD_CHANGE_FINISH_MUTATION = gql`
+  mutation PasswordChangeFinish($input: PasswordChangeFinishInput!) {
+    passwordChangeFinish(input: $input) {
+      uid
+      sessionToken
+      verified
+      authAt
+      keyFetchToken
+      keyFetchToken2
+    }
+  }
+`;
+
+export const GET_ACCOUNT_KEYS_MUTATION = gql`
+  mutation WrappedAccountKeys($input: String!) {
+    wrappedAccountKeys(input: $input) {
+      kA
+      wrapKB
+    }
+  }
+`;
+
+export const CREDENTIAL_STATUS_MUTATION = gql`
+  mutation CredentialStatus($input: String!) {
+    credentialStatus(input: $input) {
+      upgradeNeeded
+      version
+      clientSalt
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -103,3 +103,36 @@ export interface SigninFormData {
   email: string;
   password: string;
 }
+
+export interface CredentialStatusResponse {
+  credentialStatus: {
+    upgradeNeeded: boolean;
+    version?: string;
+    clientSalt?: string;
+  };
+}
+
+export interface PasswordChangeStartResponse {
+  passwordChangeStart: {
+    keyFetchToken: string;
+    passwordChangeToken: string;
+  };
+}
+
+export interface PasswordChangeFinishResponse {
+  passwordChangeFinish: {
+    uid: string;
+    sessionToken: string;
+    verified: boolean;
+    authAt: number;
+    keyFetchToken: string;
+    keyFetchToken2?: string;
+  };
+}
+
+export interface GetAccountKeysResponse {
+  wrappedAccountKeys: {
+    kA: string;
+    wrapKB: string;
+  };
+}


### PR DESCRIPTION
## Because

- Want  to support using V2 key stretching for react sign in

## This pull request

- Adds support for using v2 key stretching on sign in
- Updates functional tests to make sure V2 signin is active for react

## Issue that this pull request solves

Closes: FXA-9074

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There was not an existing container.test.ts for sign in. Is there a ticket somewhere for this? We do have quite a bit of test coverage due to the keyStertchV2 tests, which cover a bunch of key stretching use cases and interchangeability between v1 and v2 key stretching.
