### PR TITLE
fix(auth): Sort clients from both Contentful and Stripe

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -863,6 +863,11 @@ export class CapabilityService {
     try {
       const clientsFromContentful = await this.capabilityManager.getClients();
 
+      clientsFromContentful.sort((a, b) =>
+        a.clientId.localeCompare(b.clientId)
+      );
+      clientsFromStripe.sort((a, b) => a.clientId.localeCompare(b.clientId));
+
       if (isEqual(clientsFromContentful, clientsFromStripe))
         return clientsFromContentful;
 


### PR DESCRIPTION
## Because

- Lodash's isEqual did not work when comparing array of objects

## This pull request

- sorts clients/services returned from Contentful and Stripe prior to comparison

## Issue that this pull request solves

Closes: FXA-8977

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.