### PR TITLE
feat(auth): remove purchases on account delete

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -219,6 +219,8 @@ export class AccountDeleteManager {
 
     await this.deleteSubscriptions(uid, reason, customerId);
     await this.deleteFirestoreCustomer(uid);
+    await this.appleIap?.purchaseManager.deletePurchases(uid);
+    await this.playBilling?.purchaseManager.deletePurchases(uid);
 
     // This is to avoid logging the same event twice if the account was already
     // deleted from the db.

--- a/packages/fxa-auth-server/lib/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/apple-app-store/purchase-manager.ts
@@ -183,4 +183,17 @@ export class PurchaseManager extends PurchaseManagerBase {
       notification?.subtype
     );
   }
+
+  /**
+   * Delete all purchases for a user.
+   * This is intended to be used when a user deletes their account.
+   */
+  async deletePurchases(userId: string): Promise<void> {
+    const purchases = await this.purchasesDbRef
+      .where('userId', '==', userId)
+      .get();
+    const batch = this.purchasesDbRef.firestore.batch();
+    for (const purchase of purchases.docs) batch.delete(purchase.ref);
+    await batch.commit();
+  }
 }

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/purchase-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/purchase-manager.ts
@@ -76,6 +76,19 @@ export class PurchaseManager extends PurchaseManagerBase {
     return;
   }
 
+  /**
+   * Delete all purchases for a user.
+   * This is intended to be used when a user deletes their account.
+   */
+  public async deletePurchases(userId: string) {
+    const purchases = await this.purchasesDbRef
+      .where('userId', '==', userId)
+      .get();
+    const batch = this.purchasesDbRef.firestore.batch();
+    for (const purchase of purchases.docs) batch.delete(purchase.ref);
+    await batch.commit();
+  }
+
   /*
    * Register a purchase (both one-time product and recurring subscription) to a user.
    * It's intended to be exposed to Android app to verify purchases made in the app.

--- a/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/purchase-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/apple-app-store/purchase-manager.js
@@ -431,6 +431,43 @@ describe('PurchaseManager', () => {
     });
   });
 
+  describe('deletePurchases', () => {
+    let purchaseManager;
+    let mockPurchaseDoc;
+    let mockBatch;
+
+    beforeEach(() => {
+      mockPurchaseDoc = {
+        docs: [
+          {
+            ref: 'testRef',
+          },
+        ],
+      };
+      mockBatch = {
+        delete: sinon.fake.resolves({}),
+        commit: sinon.fake.resolves({}),
+      };
+      mockPurchaseDbRef.where = sinon.fake.returns({
+        get: sinon.fake.resolves(mockPurchaseDoc),
+      });
+      mockPurchaseDbRef.firestore = {
+        batch: sinon.fake.returns(mockBatch),
+      };
+      purchaseManager = new PurchaseManager(
+        mockPurchaseDbRef,
+        mockAppStoreHelper
+      );
+    });
+
+    it('deletes a purchase', async () => {
+      const result = await purchaseManager.deletePurchases('testToken');
+      assert.isUndefined(result);
+      sinon.assert.calledOnceWithExactly(mockBatch.delete, 'testRef');
+      sinon.assert.calledOnce(mockBatch.commit);
+    });
+  });
+
   describe('registerToUserAccount', () => {
     let purchaseManager;
     let mockPurchaseDoc;

--- a/packages/fxa-auth-server/test/local/payments/iap/google-play/purchase-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/iap/google-play/purchase-manager.js
@@ -338,6 +338,40 @@ describe('PurchaseManager', () => {
     });
   });
 
+  describe('deletePurchases', () => {
+    let purchaseManager;
+    let mockPurchaseDoc;
+    let mockBatch;
+
+    beforeEach(() => {
+      mockPurchaseDoc = {
+        docs: [
+          {
+            ref: 'testRef',
+          },
+        ],
+      };
+      mockBatch = {
+        delete: sinon.fake.resolves({}),
+        commit: sinon.fake.resolves({}),
+      };
+      mockPurchaseDbRef.where = sinon.fake.returns({
+        get: sinon.fake.resolves(mockPurchaseDoc),
+      });
+      mockPurchaseDbRef.firestore = {
+        batch: sinon.fake.returns(mockBatch),
+      };
+      purchaseManager = new PurchaseManager(mockPurchaseDbRef, mockApiClient);
+    });
+
+    it('deletes a purchase', async () => {
+      const result = await purchaseManager.deletePurchases('testToken');
+      assert.isUndefined(result);
+      sinon.assert.calledOnceWithExactly(mockBatch.delete, 'testRef');
+      sinon.assert.calledOnce(mockBatch.commit);
+    });
+  });
+
   describe('registerToUserAccount', () => {
     let purchaseManager;
     let mockPurchaseDoc;


### PR DESCRIPTION
Because:

* We want to remove all IAP data when an account is deleted.

This commit:

* Adds a `delete` method to the `PurchaseManager` interface.
* Adds delete methods to the Apple and Google IAP purchase managers.
* Adds delete calls to the account delete manager.

Closes FXA-9055

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
