### PR TITLE
feat(contentful): Add statsd metrics to contentful

### DIFF
--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -26,9 +26,10 @@ describe('StripeMapperService', () => {
         .mockResolvedValue(
           mockContentfulConfigUtil as unknown as PurchaseWithDetailsOfferingContentUtil
         );
-      const contentfulClient = {} as ContentfulClient;
+      const contentfulClient = new ContentfulClient({} as any);
+      const mockStatsd = {} as any;
       stripeMapper = new StripeMapperService(
-        new ContentfulManager(contentfulClient)
+        new ContentfulManager(contentfulClient, mockStatsd)
       );
     });
 

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -129,7 +129,7 @@ async function run(config) {
         graphqlSpaceId: config.contentful.spaceId,
         graphqlEnvironment: config.contentful.environment,
       });
-      const contentfulManager = new ContentfulManager(contentfulClient);
+      const contentfulManager = new ContentfulManager(contentfulClient, statsd);
       Container.set(ContentfulManager, contentfulManager);
       const capabilityManager = new CapabilityManager(contentfulManager);
       const eligibilityManager = new EligibilityManager(contentfulManager);


### PR DESCRIPTION
## Because

- Want to track number of requests and timings of those requests made to contentful.

## This pull request

- Adds event emitter to Contentful Client, similar to PayPal Client.
- Add statsd to Contentful Manager to to track requests timings on contentful client event.

## Issue that this pull request solves

Closes: #FXA-9031

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
