### PR TITLE
test(functional-tests): audit reset-password

### DIFF
--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -8,8 +8,10 @@ test.describe('severity-1 #smoke', () => {
   test.describe('force auth', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
-      // TODO: Remove forceAuth tests. React pages don't have this flow.
-      test.skip(config.showReactApp.resetPasswordRoutes === true);
+      test.skip(
+        config.showReactApp.resetPasswordRoutes === true,
+        'Scheduled for removal as part of React conversion (see FXA-8267).'
+      );
     });
     test('with a registered email, registered uid', async ({
       credentials,

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -8,8 +8,10 @@ test.describe('severity-1 #smoke', () => {
   test.describe('OAuth force auth', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
-      // TODO: Remove forceAuth tests. React pages don't have this flow.
-      test.skip(config.showReactApp.resetPasswordRoutes === true);
+      test.skip(
+        config.showReactApp.resetPasswordRoutes === true,
+        'Scheduled for removal as part of React conversion (see FXA-8267).'
+      );
     });
     test('with a registered email', async ({
       credentials,

--- a/packages/functional-tests/tests/oauth/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/oauth/resetPassword.spec.ts
@@ -11,7 +11,10 @@ test.describe('severity-1 #smoke', () => {
       test.slow();
 
       const config = await configPage.getConfig();
-      test.skip(config.showReactApp.resetPasswordRoutes === true);
+      test.skip(
+        config.showReactApp.resetPasswordRoutes === true,
+        'Scheduled for removal as part of React conversion (see FXA-8267).'
+      );
       test.skip(config.showReactApp.oauthRoutes === true);
     });
 

--- a/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/reset-password/resetPassword.spec.ts
@@ -13,7 +13,10 @@ test.describe('severity-2 #smoke', () => {
       test.slow();
 
       const config = await configPage.getConfig();
-      test.skip(config.showReactApp.resetPasswordRoutes === true);
+      test.skip(
+        config.showReactApp.resetPasswordRoutes === true,
+        'Scheduled for removal as part of React conversion (see FXA-8267).'
+      );
     });
 
     test('can reset password', async ({

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -12,7 +12,10 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
     test.slow();
 
     const config = await configPage.getConfig();
-    test.skip(config.showReactApp.resetPasswordRoutes === true);
+    test.skip(
+      config.showReactApp.resetPasswordRoutes === true,
+      'Scheduled for removal as part of React conversion (see FXA-8267).'
+    );
   });
 
   test('reset pw, test pw validation, verify same browser', async ({


### PR DESCRIPTION
## Because

the functional tests have a nightly 90-day success rate < 95% and a skip rate ~ 11-12% indicating waning stability and sustainability respectively.

## This pull request

adds a clarifying statement and JIRA ticket link for tests covering the backbone version of reset password flows. These tests are currently inflating the skip rate.

## Issue that this pull request solves

Closes: #FXA-8957

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
