### PR TITLE
feat(react): Add support for the `/force_auth` route in React

### DIFF
--- a/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+import { getReactFeatureFlagUrl } from '../../lib/react-flag';
+
+test.describe('force auth react', () => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    test.slow();
+    // Ensure that the feature flag is enabled
+    const config = await configPage.getConfig();
+    test.skip(config.showReactApp.signInRoutes !== true);
+    test.skip(config.showReactApp.signUpRoutes !== true);
+  });
+
+  test('displays signin with registered email', async ({
+    page,
+    target,
+    credentials,
+    pages: { signupReact, resetPasswordReact },
+  }) => {
+    const url = getReactFeatureFlagUrl(
+      target,
+      '/force_auth',
+      `email=${encodeURIComponent(
+        credentials.email
+      )}&context=fx_desktop_v3&entrypoint=fxa_app_menu_reverify&action=email&service=sync`
+    );
+    await page.goto(url);
+    await page.waitForURL(/\/force_auth/);
+
+    // Verify react page has been loaded
+    await page.waitForSelector('#root');
+    await page.waitForSelector('input[name="password"]');
+
+    await expect(page.getByText('Enter your password')).toBeVisible();
+    await expect(page.getByText(credentials.email)).toBeVisible();
+    await expect(page.getByText('Sign in')).toBeVisible();
+  });
+
+  test('redirects to signup with unregistered email', async ({
+    page,
+    target,
+    credentials,
+    context,
+    pages: { login, resetPasswordReact },
+  }) => {
+    const randoEmail = `rando${Math.random()}@example.com`;
+    const url = getReactFeatureFlagUrl(
+      target,
+      '/force_auth',
+      `email=${encodeURIComponent(
+        randoEmail
+      )}&context=fx_desktop_v3&entrypoint=fxa_app_menu_reverify&action=email&service=sync`
+    );
+    await page.goto(url);
+    await page.waitForURL(/\/signup/);
+
+    // Verify react page has been loaded
+    await page.waitForSelector('#root');
+    await page.waitForSelector('input[name="newPassword"]');
+    await page.waitForSelector('input[name="confirmPassword"]');
+
+    await expect(page.getByText('Set your password')).toBeVisible();
+    await expect(page.getByText(randoEmail)).toBeVisible();
+    await expect(page.getByText('Create account')).toBeVisible();
+  });
+});

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -228,7 +228,11 @@ Router = Router.extend({
         }),
       });
     },
-    'force_auth(/)': createViewHandler(ForceAuthView),
+    'force_auth(/)': function () {
+      this.createReactOrBackboneViewHandler('force_auth', ForceAuthView, {
+        ...Url.searchParams(this.window.location.search),
+      });
+    },
     'inline_totp_setup(/)': createViewHandler(InlineTotpSetupView),
     'inline_recovery_setup(/)': createViewHandler(InlineRecoverySetupView),
     'legal(/)': function () {

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -70,6 +70,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signin_bounced',
         'report_signin',
         'complete_signin',
+        'force_auth',
       ]),
       fullProdRollout: false,
     },

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -289,6 +289,7 @@ const AuthAndAccountSetupRoutes = ({
 
       {/* Signin */}
       <ReportSigninContainer path="/report_signin/*" />
+      <SigninContainer path="/force_auth/*" {...{ integration, serviceName }} />
       <SigninContainer path="/signin/*" {...{ integration, serviceName }} />
       <SigninBounced email={localAccount?.email} path="/signin_bounced/*" />
       <CompleteSigninContainer path="/complete_signin/*" />


### PR DESCRIPTION
## Because

- We have some browser that link to this route and we should still support it

## This pull request

- Adds support for the React version of `/force_auth`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-8268

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

I opted to redirect to the Signin component because it already validates the email and will send the user to create account page if email doesn't exist. This seemed like the most straightward thing to do.

To test:

1. Open http://localhost:3030/force_auth?context=fx_desktop_v3&entrypoint=fxa_app_menu&action=email&service=sync&email=<existing user email>, this should redirect to signin the user
2. Open http://localhost:3030/force_auth?context=fx_desktop_v3&entrypoint=fxa_app_menu&action=email&service=sync&email=<non exisitn user email>, this should redirect user to create account
