### PR TITLE
task(settings): Make signin_totp_code page functional

### DIFF
--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -35,6 +35,10 @@ export class TotpPage extends SettingsLayout {
     return secret;
   }
 
+  async getNextCode(secret: string) {
+    return await getCode(secret);
+  }
+
   async useManualCode() {
     await this.page.click('[data-testid=cant-scan-code]');
     const secret = (

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { test, expect } from '../../lib/fixtures/standard';
+
+test.describe('severity-1 #smoke', () => {
+  test.describe('two step auth', () => {
+    test.beforeEach(async () => {
+      test.slow();
+    });
+
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/1293446
+    // https://testrail.stage.mozaws.net/index.php?/cases/view/1293452
+    test('add and remove totp', async ({
+      credentials,
+      target,
+      pages: { settings, totp, page, signupReact },
+    }) => {
+      await settings.goto();
+      let status = await settings.totp.statusText();
+      expect(status).toEqual('Not Set');
+      await settings.totp.clickAdd();
+      const { secret } = await totp.enable(credentials);
+      await settings.waitForAlertBar();
+      status = await settings.totp.statusText();
+      expect(status).toEqual('Enabled');
+
+      await settings.signOut();
+
+      await page.goto(
+        `${target.contentServerUrl}/?showReactApp=true&forceExperiment=generalizedReactApp&forceExperimentGroup=react`
+      );
+
+      await signupReact.fillOutEmailFirst(credentials.email);
+      await page.fill('[name="password"]', credentials.password);
+      await page.click('[type="submit"]');
+      await page.waitForURL(/signin_totp_code/);
+      await page.waitForSelector('#root');
+      await page.fill('[name="code"]', '111111');
+      await page.click('[type="submit"]');
+      page.getByText('Invalid two-step authentication code');
+
+      const code = await totp.getNextCode(secret);
+      await page.fill('[name="code"]', code);
+      await page.click('[type="submit"]');
+      await page.waitForURL(/settings/);
+    });
+  });
+});

--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
@@ -13,11 +13,13 @@ export interface SessionTokenResult {
   session: SessionToken;
 }
 
+export const SESSION_TOKEN_REGEX = /^(?:[a-fA-F0-9]{2})+$/;
+
 @Injectable()
 export class SessionTokenStrategy extends PassportStrategy(Strategy) {
   async validate(token: string): Promise<SessionTokenResult> {
     try {
-      if (!/^(?:[a-fA-F0-9]{2})+$/.test(token)) {
+      if (!SESSION_TOKEN_REGEX.test(token)) {
         throw new UnauthorizedException('Invalid token');
       }
       const { id } = await deriveHawkCredentials(token, 'sessionToken');

--- a/packages/fxa-graphql-api/src/auth/unverified-session-guard.spec.ts
+++ b/packages/fxa-graphql-api/src/auth/unverified-session-guard.spec.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+
+const mockSession = {
+  SessionToken: {
+    findByTokenId: jest.fn(),
+  },
+};
+jest.mock('fxa-shared/db/models/auth/session-token', () => mockSession);
+
+// eslint-disable-next-line import/first
+import { UnverifiedSessionGuard } from './unverified-session-guard';
+
+describe('SessionTokenStrategy', () => {
+  const fakeToken =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+  let guard: UnverifiedSessionGuard;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    guard = new UnverifiedSessionGuard();
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('extracts token', () => {
+    const req = {
+      headers: {
+        authorization: `Bearer ${fakeToken}`,
+      },
+    };
+    const result = guard.extractSessionToken(req);
+    expect(result).toEqual(fakeToken);
+  });
+
+  it('rejects if authorization header is missing', () => {
+    const headers = { headers: {} };
+    expect(() => guard.extractSessionToken(headers)).toThrowError(
+      UnauthorizedException
+    );
+  });
+
+  it('rejects if authorization header is missing bearer prefix', () => {
+    const req = {
+      headers: {
+        authorization: `${fakeToken}`,
+      },
+    };
+    expect(() => guard.extractSessionToken(req)).toThrowError(
+      UnauthorizedException
+    );
+  });
+
+  it('rejects if authorization header contains invalid token', () => {
+    const req = {
+      headers: {
+        authorization: 'Bearer FOOOO',
+      },
+    };
+    expect(() => guard.extractSessionToken(req)).toThrowError(
+      UnauthorizedException
+    );
+  });
+
+  it('returns existing session token', async () => {
+    mockSession.SessionToken.findByTokenId.mockResolvedValue({
+      tokenId: 'fake',
+    });
+    const result = await guard.resolveSessionToken(fakeToken);
+    expect(result).toEqual({
+      tokenId: 'fake',
+    });
+  });
+
+  it('rejects if session token cannot be found', async () => {
+    mockSession.SessionToken.findByTokenId.mockResolvedValue(null);
+    await expect(async () => {
+      await guard.resolveSessionToken(fakeToken);
+    }).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('can activate', async () => {
+    jest.spyOn(guard, 'getRequest').mockImplementation(() => {
+      return {
+        user: {},
+        headers: {
+          authorization: `Bearer ${fakeToken}`,
+        },
+      };
+    });
+
+    mockSession.SessionToken.findByTokenId.mockResolvedValue({
+      tokenId: 'fake',
+    });
+
+    expect(
+      await guard.canActivate({} as unknown as ExecutionContext)
+    ).toBeTruthy();
+  });
+});

--- a/packages/fxa-graphql-api/src/auth/unverified-session-guard.ts
+++ b/packages/fxa-graphql-api/src/auth/unverified-session-guard.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { deriveHawkCredentials } from 'fxa-auth-client';
+import { SessionToken } from 'fxa-shared/db/models/auth/session-token';
+import { IncomingHttpHeaders } from 'http';
+import { SESSION_TOKEN_REGEX } from './session-token.strategy';
+
+/**
+ * This is a guard that explicitly requires a valid session token, but
+ * does not require that the session token be verified. There is really
+ * a limited applicability to this... It was introduced to allow
+ * us to validate unverified sessions during TOTP checks. In this case
+ * calls are made to graphql containing unverified session tokens. The
+ * act of submitting the TOTP is what validates the session, and
+ * therefore we need a guard that specifically does not check the session
+ * tokens verified status.
+ *
+ * Note: Our default AuthGuard requires that session tokens be verified. Note,
+ * that the pattern used for this only has access to the token itself,
+ * and lacks access to the greater context. As a result, the code in
+ * session-token.strategy has no good way to conditionally skip the verified
+ * check.
+ */
+export class UnverifiedSessionGuard implements CanActivate {
+  extractSessionToken(req: { headers: IncomingHttpHeaders }) {
+    const bearerToken = req.headers.authorization;
+    if (bearerToken == null) {
+      throw new UnauthorizedException('Invalid token');
+    }
+    if (!bearerToken.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    const token = bearerToken?.replace('Bearer ', '');
+    if (!SESSION_TOKEN_REGEX.test(token)) {
+      throw new UnauthorizedException('Invalid token');
+    }
+    return token;
+  }
+
+  async resolveSessionToken(token: string) {
+    const { id } = await deriveHawkCredentials(token, 'sessionToken');
+    const session = await SessionToken.findByTokenId(id);
+    if (!session) {
+      throw new UnauthorizedException('Invalid token');
+    }
+    return session;
+  }
+
+  getRequest(context: ExecutionContext): {
+    headers: IncomingHttpHeaders;
+    user: any;
+  } {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req;
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = this.getRequest(context);
+    const token = this.extractSessionToken(req);
+    const session = await this.resolveSessionToken(token);
+    req.user = {
+      token,
+      session,
+    };
+    return true;
+  }
+}

--- a/packages/fxa-graphql-api/src/decorators.ts
+++ b/packages/fxa-graphql-api/src/decorators.ts
@@ -4,7 +4,6 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { SessionTokenResult } from './auth/session-token.strategy';
-import { header } from 'fxa-auth-client';
 
 /**
  * Extracts the token from an authenticated user for a GraphQL request.

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -33,6 +33,7 @@ import {
 } from 'graphql-parse-resolve-info';
 
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
+import { UnverifiedSessionGuard } from '../auth/unverified-session-guard';
 import { GqlCustomsGuard } from '../auth/gql-customs.guard';
 import { AuthClientService } from '../backend/auth-client.service';
 import { ProfileClientService } from '../backend/profile-client.service';
@@ -170,7 +171,7 @@ export class AccountResolver {
     description:
       'Verifies the current session if the passed TOTP code is valid.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(UnverifiedSessionGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifyTotp(
     @GqlSessionToken() token: string,

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -63,6 +63,7 @@ import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
 import SignupContainer from '../../pages/Signup/container';
 import ThirdPartyAuthCallback from '../../pages/PostVerify/ThirdPartyAuthCallback';
 import WebChannelExample from '../../pages/WebChannelExample';
+import SigninTotpCodeContainer from '../../pages/Signin/SigninTotpCode/container';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -300,6 +301,10 @@ const AuthAndAccountSetupRoutes = ({
       <SigninConfirmed
         path="/signin_verified/*"
         {...{ isSignedIn, serviceName }}
+      />
+      <SigninTotpCodeContainer
+        path="/signin_totp_code/*"
+        {...{ serviceName }}
       />
 
       {/* Signup */}

--- a/packages/fxa-settings/src/models/pages/signin/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signin/query-params.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsBoolean, IsEmail, IsOptional } from 'class-validator';
+import { IsBoolean, IsEmail, IsOptional, IsString } from 'class-validator';
 import { bind, ModelDataProvider } from '../../../lib/model-data';
 
 export class SigninQueryParams extends ModelDataProvider {
@@ -20,4 +20,14 @@ export class SigninQueryParams extends ModelDataProvider {
   @IsBoolean()
   @bind()
   hasPassword: boolean | undefined = undefined;
+
+  @IsOptional()
+  @IsString()
+  @bind()
+  service: string | undefined = undefined;
+
+  @IsOptional()
+  @IsString()
+  @bind()
+  redirectTo: string | undefined = undefined;
 }

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -1,0 +1,218 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Mocked Module Imports
+import * as SigninTotpCodeModule from './index';
+import * as UseValidateModule from '../../../lib/hooks/useValidate';
+import * as CacheModule from '../../../lib/cache';
+import * as UtilsModule from 'fxa-react/lib/utils';
+import * as ReachRouterModule from '@reach/router';
+import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
+import * as ApolloModule from '@apollo/client';
+
+// Regular imports
+import { screen } from '@testing-library/react';
+import { LocationProvider } from '@reach/router';
+import { SigninTotpCodeContainer } from './container';
+import { MozServices } from '../../../lib/types';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import VerificationMethods from '../../../constants/verification-methods';
+import VerificationReasons from '../../../constants/verification-reasons';
+import { SigninTotpCodeProps } from './index';
+import { ApolloClient } from '@apollo/client';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+
+let currentPageProps: SigninTotpCodeProps | undefined;
+function mockSigninTotpModule() {
+  currentPageProps = undefined;
+  jest
+    .spyOn(SigninTotpCodeModule, 'SigninTotpCode')
+    .mockImplementation((props) => {
+      currentPageProps = props;
+      return <div>signin totp code mock</div>;
+    });
+}
+
+function mockLoadingSpinnerModule() {
+  jest.spyOn(LoadingSpinnerModule, 'LoadingSpinner').mockImplementation(() => {
+    return <div>loading spinner mock</div>;
+  });
+}
+
+function mockUseValidateModule(opts: any = {}) {
+  jest.spyOn(UseValidateModule, 'useValidatedQueryParams').mockReturnValue({
+    queryParamModel: {
+      redirectTo: '',
+      verificationReason: 'login',
+      service: 'sync',
+      ...opts,
+    },
+    validationError: undefined,
+  });
+}
+
+function mockCache(opts: any = {}, isEmpty = false) {
+  jest.spyOn(CacheModule, 'currentAccount').mockReturnValue(
+    isEmpty
+      ? undefined
+      : {
+          sessionToken: '123',
+          ...(opts || {}),
+        }
+  );
+}
+
+let mockHardNavigate = jest.fn();
+function mockUtils() {
+  mockHardNavigate.mockReset();
+  jest.spyOn(UtilsModule, 'hardNavigate').mockImplementation(mockHardNavigate);
+}
+
+let mockNavigate = jest.fn();
+function mockReachRouter(opts?: { verificationMethod?: string }) {
+  mockNavigate.mockReset();
+  jest.spyOn(ReachRouterModule, 'useNavigate').mockReturnValue(mockNavigate);
+  jest.spyOn(ReachRouterModule, 'useLocation').mockImplementation(() => {
+    return {
+      ...global.window.location,
+      state: {
+        verificationMethod:
+          opts?.verificationMethod || VerificationMethods.TOTP_2FA,
+        verificationReason: VerificationReasons.SIGN_IN,
+      },
+    };
+  });
+}
+
+let mockVerifyTotpMutation: jest.Mock;
+function mockVerifyTotp(success: boolean = true, errorOut: boolean = false) {
+  mockVerifyTotpMutation = jest.fn();
+  mockVerifyTotpMutation.mockImplementation(async () => {
+    if (errorOut) {
+      throw new Error();
+    }
+    return {
+      data: {
+        verifyTotp: {
+          success,
+        },
+      },
+    };
+  });
+
+  jest.spyOn(ApolloModule, 'useMutation').mockReturnValue([
+    async (...args: any[]) => {
+      return mockVerifyTotpMutation(...args);
+    },
+    {
+      loading: false,
+      called: true,
+      client: {} as ApolloClient<any>,
+      reset: () => {},
+    },
+  ]);
+}
+
+function applyDefaultMocks() {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+  mockSigninTotpModule();
+  mockLoadingSpinnerModule();
+  mockUseValidateModule();
+  mockCache();
+  mockReachRouter();
+  mockUtils();
+  mockVerifyTotp();
+}
+
+describe('signin container', () => {
+  beforeEach(() => {
+    applyDefaultMocks();
+  });
+
+  /** Renders the container with a fake page component */
+  async function render(waitForPageToRender = true) {
+    renderWithLocalizationProvider(
+      <LocationProvider>
+        <SigninTotpCodeContainer
+          {...{
+            serviceName: MozServices.Default,
+          }}
+        />
+      </LocationProvider>
+    );
+
+    if (waitForPageToRender) {
+      await screen.findByText('signin totp code mock');
+    }
+  }
+
+  it('validates code and goes to settings', async () => {
+    await render();
+    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+    const result = await currentPageProps?.submitTotpCode('123456');
+    currentPageProps?.handleNavigation();
+
+    expect(result?.status).toBeTruthy();
+    expect(mockHardNavigate).toBeCalledTimes(0);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith('/settings');
+  });
+
+  it('validates code and goes to redirectTo location', async () => {
+    mockUseValidateModule({
+      redirectTo: 'http://foo.com',
+    });
+
+    await render();
+    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+    const result = await currentPageProps?.submitTotpCode('123456');
+    currentPageProps?.handleNavigation();
+
+    expect(result?.status).toBeTruthy();
+    expect(mockHardNavigate).toBeCalledTimes(1);
+    expect(mockHardNavigate).toBeCalledWith('http://foo.com');
+    expect(mockNavigate).toBeCalledTimes(0);
+  });
+
+  it('shows invalid code error', async () => {
+    mockVerifyTotp(false);
+
+    await render();
+    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+
+    const result = await currentPageProps?.submitTotpCode('123456');
+    expect(result?.status).toBeFalsy();
+  });
+
+  it('handles general error', async () => {
+    mockVerifyTotp(true, true);
+    await render();
+
+    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+
+    const result = await currentPageProps?.submitTotpCode('123456');
+    expect(result?.status).toBeFalsy();
+    expect(result?.error).toEqual(AuthUiErrors.UNEXPECTED_ERROR);
+  });
+
+  it('redirects if there is no storedLocalAccount', async () => {
+    mockCache({}, true);
+    await render(false);
+    expect(mockNavigate).toBeCalledWith('/signin');
+  });
+
+  it('redirects if there is sessionToken', async () => {
+    mockCache({ sessionToken: '' });
+    await render(false);
+    expect(mockNavigate).toBeCalledWith('/signin');
+  });
+
+  it('redirects if verification method is not totp', async () => {
+    mockReachRouter({ verificationMethod: 'foo' });
+    await render(false);
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith('/signin');
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps, useNavigate, useLocation } from '@reach/router';
+import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
+import { SigninQueryParams } from '../../../models/pages/signin';
+import { SigninTotpCode } from './index';
+import { useMutation } from '@apollo/client';
+import { hardNavigate, hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import {
+  AuthUiErrorNos,
+  AuthUiErrors,
+} from '../../../lib/auth-errors/auth-errors';
+import { currentAccount } from '../../../lib/cache';
+import { MozServices } from '../../../lib/types';
+import VerificationMethods from '../../../constants/verification-methods';
+import VerificationReasons from '../../../constants/verification-reasons';
+import { GraphQLError } from 'graphql';
+import { VERIFY_TOTP_CODE_MUTATION } from './gql';
+
+export const viewName = 'signin-totp-code';
+
+export type SigninTotpCodeContainerProps = {
+  serviceName: MozServices;
+};
+
+export const SigninTotpCodeContainer = ({
+  serviceName,
+}: SigninTotpCodeContainerProps & RouteComponentProps) => {
+  const navigate = useNavigate();
+  const location = useLocation() as ReturnType<typeof useLocation> & {
+    state: {
+      verificationReason: string;
+      verificationMethod: string;
+    };
+  };
+  const { verificationReason, verificationMethod } = location.state;
+  const storedLocalAccount = currentAccount();
+  const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
+
+  const [verifyTotpCode] = useMutation(VERIFY_TOTP_CODE_MUTATION);
+
+  const handleNavigation = () => {
+    if (queryParamModel.redirectTo) {
+      hardNavigate(queryParamModel.redirectTo);
+    } else if (verificationReason === VerificationReasons.CHANGE_PASSWORD) {
+      // TODO: Check if postVerify routes are enabled. When they are, we won't
+      // need to hard navigate to content server.
+      hardNavigateToContentServer(
+        `/post_verify/password/force_password_change${location.search}`
+      );
+    } else {
+      navigate('/settings');
+    }
+  };
+
+  const submitTotpCode = async (code: string) => {
+    try {
+      const result = await verifyTotpCode({
+        variables: {
+          input: {
+            code,
+            service: queryParamModel.service,
+          },
+        },
+      });
+
+      // Check authentication code
+      if (result.data?.verifyTotp.success === true) {
+        return { status: true };
+      }
+
+      return { status: false };
+    } catch (error) {
+      const gqlError = processGraphQLError(error);
+      return { error: gqlError.error, status: false };
+    }
+  };
+
+  if (
+    !storedLocalAccount ||
+    !storedLocalAccount.sessionToken ||
+    verificationMethod !== VerificationMethods.TOTP_2FA
+  ) {
+    navigate(`/signin${location.search}`);
+  }
+
+  return (
+    <SigninTotpCode {...{ handleNavigation, submitTotpCode, serviceName }} />
+  );
+};
+
+// TODO: Move to signInUtils.
+const processGraphQLError = (error: any) => {
+  const graphQLError: GraphQLError = error.graphQLErrors?.[0];
+  const errno = graphQLError?.extensions?.errno as number;
+
+  if (errno && AuthUiErrorNos[errno]) {
+    if (errno === AuthUiErrors.THROTTLED.errno) {
+      const throttledErrorWithRetryAfter = {
+        name: AuthUiErrorNos[errno].name,
+        message: AuthUiErrorNos[errno].message,
+        errno,
+        verificationMethod:
+          (graphQLError.extensions.verificationMethod as VerificationMethods) ||
+          undefined,
+        verificationReason:
+          (graphQLError.extensions.verificationReason as VerificationReasons) ||
+          undefined,
+        retryAfter:
+          (graphQLError?.extensions?.retryAfter as number) || undefined,
+        retryAfterLocalized:
+          (graphQLError?.extensions?.retryAfterLocalized as string) ||
+          undefined,
+      };
+      return { error: throttledErrorWithRetryAfter };
+    } else {
+      return {
+        error: {
+          name: AuthUiErrorNos[errno].name,
+          message: AuthUiErrorNos[errno].message,
+          errno,
+          verificationMethod:
+            (graphQLError.extensions
+              .verificationMethod as VerificationMethods) || undefined,
+          verificationReason:
+            (graphQLError.extensions
+              .verificationReason as VerificationReasons) || undefined,
+        },
+      };
+    }
+    // if not a graphQLError or if no localizable message available for error
+  } else {
+    return { error: AuthUiErrors.UNEXPECTED_ERROR };
+  }
+};
+
+export default SigninTotpCodeContainer;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/gql.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/gql.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const VERIFY_TOTP_CODE_MUTATION = gql`
+  mutation VerifyTotp($input: VerifyTotpInput!) {
+    verifyTotp(input: $input) {
+      success
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -4,12 +4,14 @@
 
 import React from 'react';
 import SigninTotpCode from '.';
-import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import {
+  AuthUiError,
+  AuthUiErrors,
+} from '../../../lib/auth-errors/auth-errors';
 
 export default {
   title: 'Pages/Signin/SigninTotpCode',
@@ -17,19 +19,48 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = ({ ...props }) => {
+const storyWithProps = (props: {
+  handleNavigation: () => void;
+  submitTotpCode: () => Promise<{ status: boolean; error?: AuthUiError }>;
+  serviceName: MozServices;
+}) => {
   const story = () => (
     <LocationProvider>
-      <AppLayout>
-        <SigninTotpCode email={MOCK_ACCOUNT.primaryEmail.email} {...props} />
-      </AppLayout>
+      <SigninTotpCode {...props} />
     </LocationProvider>
   );
   return story;
 };
 
-export const Default = storyWithProps({});
+export const Default = storyWithProps({
+  handleNavigation: () => {},
+  submitTotpCode: async () => ({
+    status: true,
+  }),
+  serviceName: MozServices.Default,
+});
 
 export const WithRelyingParty = storyWithProps({
+  handleNavigation: () => {},
+  submitTotpCode: async () => ({
+    status: true,
+  }),
+  serviceName: MozServices.MozillaVPN,
+});
+
+export const WithIncorrectCode = storyWithProps({
+  handleNavigation: () => {},
+  submitTotpCode: async () => ({
+    status: false,
+  }),
+  serviceName: MozServices.MozillaVPN,
+});
+
+export const WithErrorState = storyWithProps({
+  handleNavigation: () => {},
+  submitTotpCode: async () => ({
+    status: false,
+    error: AuthUiErrors.UNEXPECTED_ERROR,
+  }),
   serviceName: MozServices.MozillaVPN,
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
-import { usePageViewEvent } from '../../../lib/metrics';
+import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { TwoFactorAuthImage } from '../../../components/images';
 import CardHeader from '../../../components/CardHeader';
 import FormVerifyCode, {
@@ -14,26 +14,39 @@ import FormVerifyCode, {
 } from '../../../components/FormVerifyCode';
 import { MozServices } from '../../../lib/types';
 import { REACT_ENTRYPOINT } from '../../../constants';
-
-// --serviceName-- is the relying party
+import {
+  AuthUiError,
+  AuthUiErrors,
+  getLocalizedErrorMessage,
+} from '../../../lib/auth-errors/auth-errors';
+import Banner, { BannerType } from '../../../components/Banner';
+import AppLayout from '../../../components/AppLayout';
+import GleanMetrics from '../../../lib/glean';
 
 // TODO: show a banner success message if a user is coming from reset password
 // in FXA-6491. This differs from content-server where currently, users only
 // get an email confirmation with no success message.
 
 export type SigninTotpCodeProps = {
-  email: string;
+  // TODO: Switch to gql error shaped object
+  submitTotpCode: (
+    totpCode: string
+  ) => Promise<{ error?: AuthUiError; status: boolean }>;
+  handleNavigation: () => void;
   serviceName?: MozServices;
 };
 
 export const viewName = 'signin-totp-code';
 
-const SigninTotpCode = ({
-  email,
+export const SigninTotpCode = ({
+  submitTotpCode,
+  handleNavigation,
   serviceName,
 }: SigninTotpCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
+  const [success, setSuccess] = useState<boolean>(false);
+  const [generalError, setGeneralError] = useState<string>('');
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
   const ftlMsgResolver = useFtlMsgResolver();
 
@@ -51,20 +64,34 @@ const SigninTotpCode = ({
     submitButtonText: 'Confirm',
   };
 
-  const onSubmit = () => {
-    try {
-      // Check authentication code
-      // logViewEvent('flow', `${viewName}.submit`, ENTRYPOINT_REACT);
-      // Check if isForcePasswordChange
-    } catch (e) {
-      // TODO: error handling, error message confirmation
-      // this should probably use auth-errors and message should be displayed in tooltip or banner
+  const onSubmit = async (code: string) => {
+    const { status, error } = await submitTotpCode(code);
+    GleanMetrics.loginConfirmation.submit();
+    logViewEvent('flow', `${viewName}.submit`);
+
+    setGeneralError('');
+    setCodeErrorMessage('');
+    setSuccess(status);
+
+    if (error) {
+      const localizedErrorMessage = getLocalizedErrorMessage(
+        ftlMsgResolver,
+        error
+      );
+      setGeneralError(localizedErrorMessage);
+    } else if (status === false) {
+      const localizedErrorMessage = getLocalizedErrorMessage(
+        ftlMsgResolver,
+        AuthUiErrors.INVALID_TOTP_CODE
+      );
+      setCodeErrorMessage(localizedErrorMessage);
+    } else {
+      handleNavigation();
     }
   };
 
   return (
-    // TODO: redirect to force_auth or signin if user has not initiated sign in
-    <>
+    <AppLayout>
       <CardHeader
         headingWithDefaultServiceFtlId="signin-totp-code-heading-w-default-service-v2"
         headingWithCustomServiceFtlId="signin-totp-code-heading-w-custom-service-v2"
@@ -73,6 +100,10 @@ const SigninTotpCode = ({
       />
 
       <main>
+        {!success && generalError && (
+          <Banner type={BannerType.error}>{generalError}</Banner>
+        )}
+
         <div className="flex justify-center mx-auto">
           <TwoFactorAuthImage className="w-3/5" />
         </div>
@@ -107,7 +138,7 @@ const SigninTotpCode = ({
           </FtlMsg>
         </div>
       </main>
-    </>
+    </AppLayout>
   );
 };
 

--- a/packages/fxa-settings/src/pages/Signin/gql.ts
+++ b/packages/fxa-settings/src/pages/Signin/gql.ts
@@ -24,6 +24,8 @@ export const BEGIN_SIGNIN_MUTATION = gql`
       metricsEnabled
       verified
       keyFetchToken
+      verificationMethod
+      verificationReason
     }
   }
 `;

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -216,7 +216,12 @@ describe('Signin', () => {
 
             enterPasswordAndSubmit();
             await waitFor(() => {
-              expect(mockNavigate).toHaveBeenCalledWith('/signin_totp_code');
+              expect(mockNavigate).toHaveBeenCalledWith('/signin_totp_code', {
+                state: {
+                  verificationMethod: VerificationMethods.TOTP_2FA,
+                  verificationReason: VerificationReasons.SIGN_IN,
+                },
+              });
             });
           });
           it('navigates to /confirm_signup_code when conditions are met', async () => {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -127,7 +127,9 @@ const Signin = ({
           // TODO with signin_totp_code ticket, content server says this (double check it):
           // Login requests that ask for 2FA but don't have it setup on their account
           // will return an error.
-          navigate('/signin_totp_code');
+          navigate('/signin_totp_code', {
+            state: { verificationReason, verificationMethod },
+          });
         } else if (verificationReason === VerificationReasons.SIGN_UP) {
           // do we need this?
           // if (verificationMethod !== VerificationMethods.EMAIL_OTP) {

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -243,9 +243,9 @@ describe('sign-up-container', () => {
     applyMocks();
   });
 
-  // TIP - Using nested describe is often helpful. It makes the test read easier
-  // and creates a natural partitioning of testing cases that are typically
-  // easier to understand than a bunch of individual tests. They are also a
+  // TIP - Using nested describe is often helpful. It makes the test easier to
+  // read and creates a natural partitioning of testing cases that are typically
+  // more understandable than a bunch of individual tests. They are also
   // easier to focus and skip.
   describe('default-state', () => {
     it('renders', async () => {


### PR DESCRIPTION
## Because

- We are porting over pages from backbone to react

## This pull request

- Makes the signin totp code page functional

## Issue that this pull request solves

Closes: FXA-6491

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![image](https://github.com/mozilla/fxa/assets/94418270/b3b3928f-5226-4eab-886e-26b5cd83be5a)
![image](https://github.com/mozilla/fxa/assets/94418270/d576dfaa-2765-4c53-862c-09bea4ece79a)
![image](https://github.com/mozilla/fxa/assets/94418270/d7f6dfda-9c78-4078-946d-28678d60fb15)


