### PR TITLE
fix(auth): Revise eligibilityFromEligibilityManager - blocked_iap

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -383,13 +383,10 @@ export class CapabilityService {
         subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
       };
     const iapProductIds = iapSubscribedPlans.map((p) => p.product_id);
-    const planIds = [
-      ...stripeSubscribedPlans.map((p) => p.plan_id),
-      ...iapSubscribedPlans.map((p) => p.plan_id),
-    ];
+    const planIds = stripeSubscribedPlans.map((p) => p.plan_id);
     const overlaps = await this.eligibilityManager.getOfferingOverlap(
       planIds,
-      [],
+      iapProductIds,
       targetPlan.plan_id
     );
 

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -820,6 +820,48 @@ describe('CapabilityService', () => {
         });
       });
     });
+
+    describe('eligibilityManagerResult and stripeEligibilityResult should match', () => {
+      let mockEligibilityManager;
+
+      beforeEach(() => {
+        mockEligibilityManager = {};
+        Container.set(EligibilityManager, mockEligibilityManager);
+        capabilityService = new CapabilityService();
+      });
+
+      it('returns blocked_iap result from both', async () => {
+        mockEligibilityManager.getOfferingOverlap = sinon.fake.resolves([
+          {
+            comparison: 'same',
+            offeringProductId: mockPlanTier1ShortInterval.product_id,
+            type: 'offering',
+          },
+        ]);
+
+        capabilityService.fetchSubscribedPricesFromAppStore =
+          sinon.fake.resolves(['plan_123456']);
+
+        const eligiblityActual =
+          await capabilityService.eligibilityFromEligibilityManager(
+            [],
+            [mockPlanTier1ShortInterval],
+            mockPlanTier1LongInterval
+          );
+
+        const stripeActual =
+          await capabilityService.eligibilityFromStripeMetadata(
+            [],
+            [mockPlanTier1ShortInterval],
+            mockPlanTier1LongInterval
+          );
+
+        assert.deepEqual(
+          eligiblityActual.subscriptionEligibilityResult,
+          stripeActual.subscriptionEligibilityResult
+        );
+      });
+    });
   });
 
   describe('processPriceIdDiff', () => {


### PR DESCRIPTION
## Because

- `eligibilityFromEligibilityManager` and `eligibilityFromStripeMetadata` returned different results - should have both returned `blocked_iap`

## This pull request

- revises `eligibilityFromEligibilityManager`

## Issue that this pull request solves

Closes: FXA-9011

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
