### PR TITLE
feat(metrics): Add Glean login_submit_frontend_error event to React signin

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -195,6 +195,7 @@ const Signin = ({
         navigationHandler(data.signIn);
       }
       if (error) {
+        GleanMetrics.login.error({ reason: error.message });
         const { message, ftlId, errno } = error;
 
         if (


### PR DESCRIPTION
Because:
* We want to replace legacy amplitude events with Glean events

This commit:
* Emits this event when a user hits an error state when they attempt and fail to sign in with their password

closes FXA-8022

