### PR TITLE
fix(auth): offering comparison upgrade fix

### DIFF
--- a/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
@@ -61,7 +61,7 @@ describe('EligibilityManager', () => {
 
     it('should return subgroup upgrade target offeringStripeProductIds as upgrade comparison', async () => {
       const offeringResult = EligibilityOfferingResultFactory({
-        stripeProductId: 'prod_test2',
+        stripeProductId: 'prod_test3',
         linkedFrom: {
           subGroupCollection: {
             items: [
@@ -74,6 +74,10 @@ describe('EligibilityManager', () => {
                     }),
                     EligibilitySubgroupOfferingResultFactory({
                       stripeProductId: 'prod_test2',
+                      countries: ['usa'],
+                    }),
+                    EligibilitySubgroupOfferingResultFactory({
+                      stripeProductId: 'prod_test3',
                       countries: ['usa'],
                     }),
                   ],

--- a/libs/payments/eligibility/src/lib/utils.ts
+++ b/libs/payments/eligibility/src/lib/utils.ts
@@ -36,13 +36,14 @@ export const offeringComparison = (
   const targetIndex = subgroupProductIds.indexOf(
     targetOffering.stripeProductId
   );
-  switch (targetIndex - existingIndex) {
-    case 0:
-      return OfferingComparison.SAME;
-    case 1:
-      return OfferingComparison.UPGRADE;
-    default:
-      return OfferingComparison.DOWNGRADE;
+
+  const resultIndex = targetIndex - existingIndex;
+  if (resultIndex === 0) {
+    return OfferingComparison.SAME;
+  } else if (resultIndex > 0) {
+    return OfferingComparison.UPGRADE;
+  } else {
+    return OfferingComparison.DOWNGRADE;
   }
 };
 


### PR DESCRIPTION
## Because

- Offering comparison in the eligibility manager incorrectly indicates a downgrade if the difference between the target and source index is greater than 1, which can happen for subgroups with multiple offerings.

## This pull request

- During offering comparison, if the difference between target and source index is positive, return UPGRADE, for values that are the same return SAME, and negative values return DOWNGRADE.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).