### PR TITLE
feat(auth): allow prompt=none without hint

### DIFF
--- a/apps/payments/next/tsconfig.json
+++ b/apps/payments/next/tsconfig.json
@@ -9,8 +9,15 @@
         "name": "next"
       }
     ],
-    "types": ["jest", "node"],
-    "lib": ["dom", "dom.iterable", "esnext"]
+    "types": [
+      "jest",
+      "node"
+    ],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ]
   },
   "include": [
     "**/*.ts",
@@ -19,7 +26,8 @@
     "**/*.jsx",
     "../../../apps/payments/next/.next/types/**/*.ts",
     "../../../dist/apps/payments/next/.next/types/**/*.ts",
-    "next-env.d.ts"
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -165,36 +165,6 @@ test.describe('severity-1 #smoke', () => {
       }
     });
 
-    test('fails if no login_hint', async ({
-      page,
-      target,
-      pages: { relier, login },
-    }) => {
-      await target.auth.signUp(email, password, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
-      await login.fillOutEmailFirstSignIn(email, password);
-
-      //Verify logged in on Settings page
-      expect(await login.isUserLoggedIn()).toBe(true);
-
-      const query = new URLSearchParams({
-        return_on_error: 'false',
-      });
-      await page.goto(`${target.relierUrl}/?${query.toString()}`);
-
-      await relier.signInPromptNone();
-
-      //Verify error message
-      expect(await relier.promptNoneError()).toContain(
-        'Missing OAuth parameter: login_hint'
-      );
-    });
-
     test('fails if login_hint is different to logged in user', async ({
       page,
       target,
@@ -245,6 +215,34 @@ test.describe('severity-1 #smoke', () => {
 
       const query = new URLSearchParams({
         login_hint: email,
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+
+      await relier.signInPromptNone();
+
+      //Verify logged in to relier
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('succeeds if no login_hint is provided', async ({
+      page,
+      target,
+      pages: { relier, login },
+    }) => {
+      await target.auth.signUp(email, password, {
+        lang: 'en',
+        preVerified: 'true',
+      });
+      await page.goto(target.contentServerUrl, {
+        waitUntil: 'load',
+      });
+      await login.fillOutEmailFirstSignIn(email, password);
+
+      //Verify logged in on Settings page
+      expect(await login.isUserLoggedIn()).toBe(true);
+
+      const query = new URLSearchParams({
         return_on_error: 'false',
       });
       await page.goto(`${target.relierUrl}/?${query.toString()}`);

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -449,23 +449,13 @@ var OAuthRelier = Relier.extend({
                 );
               }
             });
-        } else {
-          if (!requestedEmail) {
-            // yeah yeah, it's a bit strange to look at `email`
-            // and then say `login_hint` is missing. `login_hint`
-            // is the OIDC spec compliant name, we supported `email` first
-            // and don't want to break backwards compatibility.
-            // `login_hint` is copied to the `email` field if no `email`
-            // is specified. If neither is available, throw an error
-            // about `login_hint` since it's spec compliant.
-            throw OAuthErrors.toMissingParameterError('login_hint');
-          }
-
-          if (requestedEmail !== account.get('email')) {
-            throw OAuthErrors.toError('PROMPT_NONE_DIFFERENT_USER_SIGNED_IN');
-          }
-          return Promise.resolve();
         }
+
+        if (requestedEmail && requestedEmail !== account.get('email')) {
+          throw OAuthErrors.toError('PROMPT_NONE_DIFFERENT_USER_SIGNED_IN');
+        }
+
+        return Promise.resolve();
       })
       .then(() => {
         // account has all the right bits associated with it,

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -871,9 +871,14 @@ describe('models/reliers/oauth', () => {
         });
     });
 
-    it('rejects if the client does not specify an email or id_token_hint', () => {
+    it('allow if the client does not specify an email or id_token_hint', () => {
       relier.unset('email');
       relier.unset('idTokenHint');
+      sinon.stub(account, 'sessionVerificationStatus').callsFake(() => {
+        return Promise.resolve({
+          verified: true,
+        });
+      });
       account.set({
         email: 'testuser@testuser.com',
         sessionToken: 'token',
@@ -881,10 +886,7 @@ describe('models/reliers/oauth', () => {
       });
       return relier
         .validatePromptNoneRequest(account)
-        .then(assert.fail, (err) => {
-          assert.isTrue(OAuthErrors.is(err, 'MISSING_PARAMETER'));
-          assert.equal(err.param, 'login_hint');
-        });
+        .then(assert.true, assert.fail);
     });
 
     it('rejects if no user is signed in', () => {


### PR DESCRIPTION
## Because

- Allow prompt=none signin even if login_hint or id_token_hint is not provided, as the current spec has these as optional parameters.

## This pull request

- For prompt=none signin, if login_hint or id_token_hint is not provided it allows successful signin.
- For prompt=none signin, if login_hint or id_token_hint are provided it keeps the current checks as is.

## Issue that this pull request solves

Closes: #FXA-9035

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Based on my reading of the following note in the OIDC spec, login_hint and id_token_hint are optional params, and if neither is provided, prompt=none should still attempt to return successfully. ([Link here](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest))

> When possible, an id_token_hint SHOULD be present when prompt=none is used and an invalid_request error MAY be returned if it is not; however, the server SHOULD respond successfully when possible, even if it is not present.
