### PR TITLE
chore(customs): Add statsd metrics for httpAgent socket status

### DIFF
--- a/packages/fxa-auth-server/test/local/customs.js
+++ b/packages/fxa-auth-server/test/local/customs.js
@@ -28,6 +28,7 @@ describe('Customs', () => {
   const statsd = {
     increment: () => {},
     timing: () => {},
+    gauge: () => {},
   };
   const log = {
     trace: () => {},
@@ -44,6 +45,7 @@ describe('Customs', () => {
   beforeEach(() => {
     sandbox.stub(statsd, 'increment');
     sandbox.stub(statsd, 'timing');
+    sandbox.stub(statsd, 'gauge');
     request = newRequest();
     ip = request.app.clientAddress;
     email = newEmail();
@@ -743,6 +745,12 @@ describe('Customs', () => {
           })
         );
         assert.isTrue(statsd.timing.calledWithMatch('customs.check.success'));
+        assert.isTrue(
+          statsd.gauge.calledWithMatch('httpAgent.createSocketCount')
+        );
+        assert.isTrue(
+          statsd.gauge.calledWithMatch('httpsAgent.createSocketCount')
+        );
       }
     });
 


### PR DESCRIPTION
## Because

- It is useful to log stats of custom server

## This pull request

- Updates the customs lib to log httpAgent status

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9169

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I didn't add logging for the `freeSocket` value since it was an object and not sure exactly how many keys it could have.
