### PR TITLE
chore(env): set default for firestore cache collection name

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2012,7 +2012,7 @@ const convictConf = convict({
       format: String,
     },
     firestoreCacheCollectionName: {
-      default: '',
+      default: 'fxa-auth-server-contentful-query-cache',
       doc: 'Firestore collection name to store Contentful query cache',
       env: 'CONTENTFUL_FIRESTORE_CACHE_COLLECTION_NAME',
       format: String,

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -76,7 +76,7 @@ const conf = convict({
       doc: 'Firestore collection name to store Contentful query cache',
       format: String,
       env: 'CONTENTFUL_FIRESTORE_CACHE_COLLECTION_NAME',
-      default: '',
+      default: 'fxa-graphql-api-contentful-query-cache',
     },
   },
   corsOrigin: {


### PR DESCRIPTION
## Because

- Setting a default would be good here, since the value is relatively unimportant.

## This pull request

- Adds a default

## Issue that this pull request solves

Closes: No relevant issue -- polish pr
