### PR TITLE
fix(css): Remove --minify flag from content-server build-css step

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "yarn l10n-prime && yarn copy-local-config && yarn check-local-config ",
     "build": "yarn build-l10n && yarn build-css && yarn build-js",
-    "build-css": "NODE_ENV=production tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css --minify",
+    "build-css": "NODE_ENV=production tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css",
     "build-js": "NODE_ENV=production grunt build",
     "build-l10n": "yarn l10n-create-json",
     "check-local-config": "node scripts/check-local-config",


### PR DESCRIPTION
Because:
* This flag appears to cause multiple selectors with an asterisk to not work, as it strips out a needed space. We already perform some minification on Settings which does not use this flag

This commit:
* Removes the --minify option in content-server's build-css step

closes FXA-9167, closes FXA-9170

---

In triage I thought this was a JS file inclusion issue, but after some digging I saw the selectors were present in the `.out.css` file in staging very similarly to locally, but the `right: 1px` style on `input-password-toggle-label-hide` wasn't being rendered properly. I tracked it down to this (for FXA-9170):

This is from our stage CSS ([link as of now](https://accounts-cdn.stage.mozaws.net/styles/6edd0aac.tailwind.out.css)):
```
.input-password-toggle-label-show:where([dir='ltr'], [dir='ltr']*) {
  right: 1px;
}
```

And then our local CSS (`fxa-content-server/app/styles/tailwind.out.css`):
```
.input-password-toggle-label-show:where([dir='ltr'], [dir='ltr'] *) {
  right: 1px;
}
```

If you copy-and-paste the entire CSS file from staging over our local styles you can repro the issue. If you add a space here then you'll see it fixed.

There must be another minification step that we already run (maybe PostCSS does this for us?). I think this for two reasons: 1) we don't use this `--minify` flag for Settings CSS, but if you check out the CSS file linked in Settings prod you'll see whitespace stripped, and 2) this is not reproducible locally when running `NODE_ENV=production npx tailwindcss --postcss -i ./app/styles/tailwind.css -o ./app/styles/tailwind.out.css --minify`. I'd like to do a direct comparison of the `.out` file to compare file size of what's on stage now vs what it'll be after we remove the flag (I downloaded the current one on stage), but in the meantime I'm fairly certain this will fix our selector problems. I'll spend more time investigating if this isn't.

**EDIT**: I'm now not completely certain this fixes it - running `yarn build` before and after this change and poking in the `dist` directory doesn't show me a difference in the above selector, I'm still seeing the space before `*` stripped. This PR definitely won't hurt to try but we might just need to change the selectors that do this if PostCSS is stripping this for us, or, maybe we can add a comment above the selectors for PostCSS to avoid.