### PR TITLE
chore(customs): Add statsd to custom server and url request timings

### DIFF
--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -333,6 +333,44 @@ module.exports = function (fs, path, url, convict) {
         env: 'SENTRY_TRACES_SAMPLE_RATE',
       },
     },
+    statsd: {
+      enabled: {
+        doc: 'Enable StatsD',
+        format: Boolean,
+        default: false,
+        env: 'STATSD_ENABLE',
+      },
+      sampleRate: {
+        doc: 'Sampling rate for StatsD',
+        format: Number,
+        default: 1,
+        env: 'STATSD_SAMPLE_RATE',
+      },
+      maxBufferSize: {
+        doc: 'StatsD message buffer size in number of characters',
+        format: Number,
+        default: 500,
+        env: 'STATSD_BUFFER_SIZE',
+      },
+      host: {
+        doc: 'StatsD host to report to',
+        format: String,
+        default: 'localhost',
+        env: 'DD_AGENT_HOST',
+      },
+      port: {
+        doc: 'Port number of StatsD server',
+        format: Number,
+        default: 8125,
+        env: 'DD_DOGSTATSD_PORT',
+      },
+      prefix: {
+        doc: 'StatsD metrics name prefix',
+        format: String,
+        default: 'fxa-customs-server.',
+        env: 'STATSD_PREFIX',
+      },
+    },
     tracing: tracingConfig,
     userDefinedRateLimitRules: {
       totpCodeRules: {

--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -17,6 +17,7 @@ const P = require('bluebird');
 P.promisifyAll(Memcached.prototype);
 const { configureSentry } = require('./sentry');
 const dataflow = require('./dataflow');
+const { StatsD } = require('hot-shots');
 
 module.exports = async function createServer(config, log) {
   var startupDefers = [];
@@ -33,6 +34,18 @@ module.exports = async function createServer(config, log) {
     );
     blockListManager.pollForUpdates();
   }
+
+  const statsd = config.statsd.enabled
+    ? new StatsD({
+        ...config.statsd,
+        errorHandler: (err) => {
+          // eslint-disable-next-line no-use-before-define
+          log.error('statsd.error', err);
+        },
+      })
+    : {
+        timing: () => {},
+      };
 
   var mc = new Memcached(config.memcache.address, {
     timeout: 500,
@@ -68,7 +81,8 @@ module.exports = async function createServer(config, log) {
       mc,
       reputationService,
       limits,
-      config.memcache.recordLifetimeSeconds
+      config.memcache.recordLifetimeSeconds,
+      statsd
     );
 
   const checkUserDefinedRateLimitRules = require('./user_defined_rules')(
@@ -119,6 +133,33 @@ module.exports = async function createServer(config, log) {
     log.error({ op: 'memcachedError', err: err });
     throw err;
   }
+
+  function reportMetrics(request) {
+    const path = request._route.path.replace(/^\//, '').replace(/\//g, '_');
+    const statusCode = request.response.isBoom
+      ? request.response.output.statusCode
+      : request.response.statusCode;
+
+    const errno =
+      request.response.errno ||
+      (request.response.source && request.response.source.errno) ||
+      0;
+    statsd.timing(
+      'url_request',
+      request.info.completed - request.info.received,
+      1,
+      {
+        path,
+        method: request.method.toUpperCase(),
+        statusCode,
+        errno,
+      }
+    );
+  }
+
+  api.events.on('response', (request) => {
+    reportMetrics(request);
+  });
 
   function isAllowed(ip, email, phoneNumber) {
     return (

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -39,6 +39,7 @@
     "dedent": "^1.5.1",
     "deep-equal": "2.2.0",
     "hapi-swagger": "^17.1.0",
+    "hot-shots": "^10.0.0",
     "ip": "^1.1.8",
     "ip-reputation-js-client": "^6.0.4",
     "lodash.isequal": "4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37290,6 +37290,7 @@ fsevents@~2.1.1:
     grunt-copyright: 0.3.0
     grunt-eslint: ^23.0.0
     hapi-swagger: ^17.1.0
+    hot-shots: ^10.0.0
     ip: ^1.1.8
     ip-reputation-js-client: ^6.0.4
     load-grunt-tasks: ^5.1.0


### PR DESCRIPTION
## Because

- We want to find out how long requests are taking in the custom server

## This pull request

- Adds statsd to custom server

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9174

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
