### PR TITLE
fix(auth): Revise getPaymentProvider

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1625,16 +1625,20 @@ export class StripeHelper extends StripeHelperBase {
     );
   }
 
-  getPaymentProvider(customer: Stripe.Customer) {
-    const subscription = customer.subscriptions?.data.find((sub) =>
-      ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status)
-    );
-    if (subscription) {
-      return subscription.collection_method === 'send_invoice'
-        ? 'paypal'
-        : 'stripe';
+  getPaymentProvider(
+    customer: Stripe.Customer
+  ): 'not_chosen' | 'paypal' | 'stripe' {
+    const defaultPaymentMethod =
+      customer.invoice_settings.default_payment_method;
+    const paypalBillingAgreementId = customer.metadata.paypalAgreementId;
+
+    if (paypalBillingAgreementId) {
+      return 'paypal';
+    } else if (defaultPaymentMethod) {
+      return 'stripe';
+    } else {
+      return 'not_chosen';
     }
-    return 'not_chosen';
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -536,48 +536,32 @@ describe('#integration - StripeHelper', () => {
       customerExpanded = deepCopy(customer1);
     });
 
-    describe('returns correct value based on collection_method', () => {
-      describe('when collection_method is "send_invoice"', () => {
-        it('payment_provider is "paypal"', async () => {
-          subscription2.collection_method = 'send_invoice';
-          customerExpanded.subscriptions.data[0] = subscription2;
-          assert.strictEqual(
-            stripeHelper.getPaymentProvider(customerExpanded),
-            'paypal'
-          );
-        });
-      });
+    it('returns payment_provider is "paypal"', async () => {
+      customerExpanded.invoice_settings.default_payment_method = null;
+      customerExpanded.metadata.paypalAgreementId = 'ppba12345';
 
-      describe('when the customer has a canceled subscription', () => {
-        it('payment_provider is "not_chosen"', async () => {
-          customerExpanded.subscriptions.data[0] = cancelledSubscription;
-          assert.strictEqual(
-            stripeHelper.getPaymentProvider(customerExpanded),
-            'not_chosen'
-          );
-        });
-      });
+      assert.strictEqual(
+        stripeHelper.getPaymentProvider(customerExpanded),
+        'paypal'
+      );
+    });
 
-      describe('when the customer has no subscriptions', () => {
-        it('payment_provider is "not_chosen"', async () => {
-          customerExpanded.subscriptions.data = [];
-          assert.strictEqual(
-            stripeHelper.getPaymentProvider(customerExpanded),
-            'not_chosen'
-          );
-        });
-      });
+    it('returns payment_provider is "stripe"', async () => {
+      customerExpanded.invoice_settings.default_payment_method = 'pm_12345';
 
-      describe('when collection_method is "instant"', () => {
-        it('payment_provider is "stripe"', async () => {
-          subscription2.collection_method = 'instant';
-          customerExpanded.subscriptions.data[0] = subscription2;
-          assert.strictEqual(
-            stripeHelper.getPaymentProvider(customerExpanded),
-            'stripe'
-          );
-        });
-      });
+      assert.strictEqual(
+        stripeHelper.getPaymentProvider(customerExpanded),
+        'stripe'
+      );
+    });
+
+    it('returns payment_provider is "not_chosen"', async () => {
+      customerExpanded.invoice_settings.default_payment_method = null;
+
+      assert.strictEqual(
+        stripeHelper.getPaymentProvider(customerExpanded),
+        'not_chosen'
+      );
     });
   });
 
@@ -5206,6 +5190,9 @@ describe('#integration - StripeHelper', () => {
         email,
         metadata: {
           userid: uid,
+        },
+        invoice_settings: {
+          default_payment_method: 'pm_12345',
         },
         subscriptions: {
           data: [


### PR DESCRIPTION
## Because

- customer was unable to enter in new payment method after Support removed default payment method - "Use saved payment option" still appeared during checkout despite not having no default payment method

## This pull request

- updates getPaymentProvider based on customer's default payment method instead of active subscriptions.

## Issue that this pull request solves

Closes: FXA-9156

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
After removing the payment method and going to a new product's checkout page: 
<img width="1019" alt="Screenshot 2024-02-21 at 9 59 13 AM" src="https://github.com/mozilla/fxa/assets/28129806/279a385e-5b93-4fc3-a305-ec9b0162a9b3">
