### PR TITLE
chore(test): disable failing signInTotp test

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -12,7 +12,9 @@ test.describe('severity-1 #smoke', () => {
 
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1293446
     // https://testrail.stage.mozaws.net/index.php?/cases/view/1293452
-    test('add and remove totp', async ({
+    // FXA-9178
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip('add and remove totp', async ({
       credentials,
       target,
       pages: { settings, totp, page, signupReact },


### PR DESCRIPTION
## Because

- Test is currently failing, and ticket has been created to debug the test.

## This pull request

- Disables the test with a ticket number.