### PR TITLE
feat(mysql): add AccountCustomers and PaypalCustomers

### DIFF
--- a/libs/payments/paypal/project.json
+++ b/libs/payments/paypal/project.json
@@ -22,7 +22,7 @@
         "lintFilePatterns": ["libs/payments/paypal/**/*.ts"]
       }
     },
-    "test-unit": {
+    "test-integration": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -1,0 +1,36 @@
+import { PayPalManager } from './paypal.manager';
+import { Kysely } from 'kysely';
+import { DB, testAccountDatabaseSetup } from '@fxa/shared/db/mysql/account';
+import { PayPalClient } from './paypal.client';
+import { faker } from '@faker-js/faker';
+
+describe('paypalManager', () => {
+  let paypalManager: PayPalManager;
+  let kyselyDb: Kysely<DB>;
+
+  beforeAll(async () => {
+    kyselyDb = await testAccountDatabaseSetup([
+      'paypalCustomers',
+      'accountCustomers',
+    ]);
+    paypalManager = new PayPalManager(
+      kyselyDb,
+      new PayPalClient({
+        sandbox: false,
+        user: faker.string.uuid(),
+        pwd: faker.string.uuid(),
+        signature: faker.string.uuid(),
+      })
+    );
+  });
+
+  afterAll(async () => {
+    if (kyselyDb) {
+      await kyselyDb.destroy();
+    }
+  });
+
+  it('instantiates class (TODO: remove me)', () => {
+    expect(paypalManager).toBeTruthy();
+  });
+});

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -4,8 +4,9 @@
 
 import { Injectable } from '@nestjs/common';
 import { PayPalClient } from './paypal.client';
+import { AccountDatabase } from '@fxa/shared/db/mysql/account';
 
 @Injectable()
 export class PayPalManager {
-  constructor(private client: PayPalClient) {}
+  constructor(private db: AccountDatabase, private client: PayPalClient) {}
 }

--- a/libs/shared/account/account/src/lib/account.manager.spec.ts
+++ b/libs/shared/account/account/src/lib/account.manager.spec.ts
@@ -11,16 +11,16 @@ import { AccountManager } from './account.manager';
 
 describe('accountManager', () => {
   let accountManager: AccountManager;
-  let kysleyDb: Kysely<DB>;
+  let kyselyDb: Kysely<DB>;
 
   beforeAll(async () => {
-    kysleyDb = await testAccountDatabaseSetup(['accounts', 'emails']);
-    accountManager = new AccountManager(kysleyDb);
+    kyselyDb = await testAccountDatabaseSetup(['accounts', 'emails']);
+    accountManager = new AccountManager(kyselyDb);
   });
 
   afterAll(async () => {
-    if (kysleyDb) {
-      await kysleyDb.destroy();
+    if (kyselyDb) {
+      await kyselyDb.destroy();
     }
   });
 
@@ -31,7 +31,7 @@ describe('accountManager', () => {
       expect(uid).toBeTruthy();
 
       // Fetch the account row
-      const account = await kysleyDb
+      const account = await kyselyDb
         .selectFrom('accounts')
         .selectAll()
         .where('uid', '=', Buffer.from(uid, 'hex'))
@@ -39,7 +39,7 @@ describe('accountManager', () => {
       expect(account?.email).toBe(email);
 
       // Fetch the emails row
-      const emailRow = await kysleyDb
+      const emailRow = await kyselyDb
         .selectFrom('emails')
         .selectAll()
         .where('uid', '=', Buffer.from(uid, 'hex'))

--- a/libs/shared/db/mysql/account/src/index.ts
+++ b/libs/shared/db/mysql/account/src/index.ts
@@ -4,7 +4,11 @@
 
 export * from './lib/associated-types';
 export * from './lib/keysley-types';
-export { CartFactory } from './lib/factories';
+export {
+  CartFactory,
+  AccountCustomerFactory,
+  PaypalCustomerFactory,
+} from './lib/factories';
 export { setupAccountDatabase, AccountDbProvider } from './lib/setup';
 export { testAccountDatabaseSetup } from './lib/tests';
 export type { ACCOUNT_TABLES } from './lib/tests';

--- a/libs/shared/db/mysql/account/src/lib/associated-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/associated-types.ts
@@ -2,15 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /**
- * Additional associated types for kysley db types.
+ * Additional associated types for kysely db types.
  */
 import { Insertable, Selectable, Updateable } from 'kysely';
 
-import { Accounts, Carts } from './keysley-types';
+import {
+  AccountCustomers,
+  Accounts,
+  Carts,
+  PaypalCustomers,
+} from './keysley-types';
 
 export type Account = Selectable<Accounts>;
 export type NewAccount = Insertable<Accounts>;
 export type AccountUpdate = Updateable<Accounts>;
+
+export type AccountCustomer = Selectable<AccountCustomers>;
+export type NewAccountCustomer = Insertable<AccountCustomers>;
+export type AccountCustomerUpdate = Updateable<AccountCustomers>;
+
+export type PaypalCustomer = Selectable<PaypalCustomers>;
+export type NewPaypalCustomer = Insertable<PaypalCustomers>;
+export type PaypalCustomerUpdate = Updateable<PaypalCustomers>;
 
 export type Cart = Selectable<Carts>;
 export type NewCart = Insertable<Carts>;

--- a/libs/shared/db/mysql/account/src/lib/factories.ts
+++ b/libs/shared/db/mysql/account/src/lib/factories.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { faker } from '@faker-js/faker';
 
-import { NewCart } from './associated-types';
+import { AccountCustomer, NewCart, PaypalCustomer } from './associated-types';
 import { CartState } from './keysley-types';
 
 export const CartFactory = (override?: Partial<NewCart>): NewCart => ({
@@ -28,5 +28,26 @@ export const CartFactory = (override?: Partial<NewCart>): NewCart => ({
   updatedAt: faker.date.recent().getTime(),
   amount: faker.number.int(10000),
   version: 0,
+  ...override,
+});
+
+export const AccountCustomerFactory = (
+  override?: Partial<AccountCustomer>
+): AccountCustomer => ({
+  uid: Buffer.from(faker.string.uuid()),
+  stripeCustomerId: faker.string.uuid(),
+  createdAt: faker.date.recent().getTime(),
+  updatedAt: faker.date.recent().getTime(),
+  ...override,
+});
+
+export const PaypalCustomerFactory = (
+  override?: Partial<PaypalCustomer>
+): PaypalCustomer => ({
+  uid: Buffer.from(faker.string.uuid()),
+  billingAgreementId: faker.string.uuid(),
+  status: 'active',
+  createdAt: faker.date.recent().getTime(),
+  endedAt: null,
   ...override,
 });

--- a/libs/shared/db/mysql/account/src/lib/tests.ts
+++ b/libs/shared/db/mysql/account/src/lib/tests.ts
@@ -10,7 +10,12 @@ import { DB, setupAccountDatabase } from '@fxa/shared/db/mysql/account';
 const TEST_DB = 'testAccount';
 const SQL_FILE_LOCATION = '../test';
 
-export type ACCOUNT_TABLES = 'accounts' | 'carts' | 'emails';
+export type ACCOUNT_TABLES =
+  | 'accounts'
+  | 'accountCustomers'
+  | 'paypalCustomers'
+  | 'carts'
+  | 'emails';
 
 export async function testAccountDatabaseSetup(
   tables: ACCOUNT_TABLES[]

--- a/libs/shared/db/mysql/account/src/test/accountCustomers.sql
+++ b/libs/shared/db/mysql/account/src/test/accountCustomers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `accountCustomers` (
+  `uid` binary(16) NOT NULL,
+  `stripeCustomerId` varchar(32),
+  `createdAt` bigint(20) unsigned NOT NULL,
+  `updatedAt` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`uid`),
+  INDEX `accountCustomers_stripeCustomerId` (`stripeCustomerId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/libs/shared/db/mysql/account/src/test/paypalCustomers.sql
+++ b/libs/shared/db/mysql/account/src/test/paypalCustomers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `paypalCustomers` (
+  `uid` BINARY(16),
+  `billingAgreementId` CHAR(19),
+  `status` VARCHAR(9) NOT NULL,
+  `createdAt` BIGINT UNSIGNED NOT NULL,
+  `endedAt` BIGINT UNSIGNED,
+  PRIMARY KEY (`uid`, `billingAgreementId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
## Because

- We need Kysely interface for both AccountCustomers and PaypalCustomers

## This pull request

- Adds both to the mysql accounts library

## Issue that this pull request solves

Closes: FXA-8887 and FXA-8886