### PR TITLE
fix(auth): use direct subscription query

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -339,10 +339,7 @@ export class AccountDeleteManager {
         'paid',
         createdDate
       );
-
-    if (!invoices.length) {
-      return;
-    }
+    if (!invoices.length) return;
     this.log.debug('AccountDeleteManager.refundSubscriptions', {
       customerId,
       invoicesToRefund: invoices.length,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1779,33 +1779,27 @@ export class StripeHelper extends StripeHelperBase {
     status: Stripe.InvoiceListParams.Status,
     earliestCreatedDate?: Date
   ) {
-    const customer = await this.fetchCustomer(customerId, ['subscriptions']);
-    const subscriptions = customer?.subscriptions?.data;
-    if (subscriptions) {
-      const activeSubscriptionIds = subscriptions.map((sub) => sub.id);
-      const created = earliestCreatedDate
-        ? { gte: Math.floor(earliestCreatedDate.getTime() / 1000) }
-        : undefined;
-      const invoices = await this.stripe.invoices.list({
+    const activeSubscriptionIds = (
+      await this.stripe.subscriptions.list({
         customer: customerId,
-        status,
-        created,
-      });
+        status: 'active',
+      })
+    ).data.map((sub) => sub.id);
+    if (!activeSubscriptionIds.length) return [];
 
-      return invoices.data.filter((invoice) => {
-        if (!invoice?.subscription) {
-          return false;
-        }
+    const invoices = await this.stripe.invoices.list({
+      customer: customerId,
+      status,
+      created: earliestCreatedDate
+        ? { gte: Math.floor(earliestCreatedDate.getTime() / 1000) }
+        : undefined,
+    });
 
-        const subscriptionId =
-          typeof invoice.subscription === 'string'
-            ? invoice.subscription
-            : invoice.subscription.id;
-        return activeSubscriptionIds.includes(subscriptionId);
-      });
-    }
-
-    return [];
+    return invoices.data.filter((invoice) => {
+      // The invoice list we fetched did not expand the subscription so these must be strings
+      if (typeof invoice.subscription !== 'string') return false;
+      return activeSubscriptionIds.includes(invoice.subscription);
+    });
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4086,17 +4086,10 @@ describe('#integration - StripeHelper', () => {
   });
 
   describe('fetchInvoicesForActiveSubscriptions', () => {
-    it('returns empty array if no stripe customer', async () => {
-      const noCustomer = '192499bcb0cf4da2bf1b37f1a37f3b88';
-      const result = await stripeHelper.fetchInvoicesForActiveSubscriptions(
-        noCustomer,
-        'paid'
-      );
-      assert.deepEqual(result, []);
-    });
-
     it('returns empty array if customer has no active subscriptions', async () => {
-      sandbox.stub(stripeHelper, 'fetchCustomer').resolves({});
+      sandbox
+        .stub(stripeHelper.stripe.subscriptions, 'list')
+        .resolves({ data: [] });
       const result = await stripeHelper.fetchInvoicesForActiveSubscriptions(
         existingUid,
         'paid'
@@ -4105,8 +4098,12 @@ describe('#integration - StripeHelper', () => {
     });
 
     it('fetches invoices no older than earliestCreatedDate', async () => {
-      sandbox.stub(stripeHelper, 'fetchCustomer').resolves({
-        subscriptions: { data: [] },
+      sandbox.stub(stripeHelper.stripe.subscriptions, 'list').resolves({
+        data: [
+          {
+            id: 'idNull',
+          },
+        ],
       });
       sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({ data: [] });
       const expectedDateTime = 1706667661086;
@@ -4127,39 +4124,28 @@ describe('#integration - StripeHelper', () => {
     });
 
     it('returns only invoices of active subscriptions', async () => {
-      const expectedExpanded = {
-        id: 'idExpanded',
-        subscription: {
-          id: 'subIdExpanded',
-        },
-      };
       const expectedString = {
         id: 'idString',
         subscription: 'idSub',
       };
-      sandbox.stub(stripeHelper, 'fetchCustomer').resolves({
-        subscriptions: {
-          data: [
-            {
-              id: 'idNull',
-            },
-            {
-              id: 'subIdExpanded',
-            },
-            {
-              id: 'idSub',
-            },
-          ],
-        },
+      sandbox.stub(stripeHelper.stripe.subscriptions, 'list').resolves({
+        data: [
+          {
+            id: 'idNull',
+          },
+          {
+            id: 'subIdExpanded',
+          },
+          {
+            id: 'idSub',
+          },
+        ],
       });
       sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({
         data: [
           {
             id: 'idNull',
             subscription: null,
-          },
-          {
-            ...expectedExpanded,
           },
           {
             ...expectedString,
@@ -4170,7 +4156,7 @@ describe('#integration - StripeHelper', () => {
         existingUid,
         'paid'
       );
-      assert.deepEqual(result, [expectedExpanded, expectedString]);
+      assert.deepEqual(result, [expectedString]);
     });
   });
 


### PR DESCRIPTION
Because:

* We want to use a direct stripe query to locate the subscriptions for a customer instead of relying on methods that may use firestore during delete.

This commit:

* Changes the fetch query to use the stripe customer id directly.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
