### PR TITLE
feat(next): reorg checkout pages

### DIFF
--- a/apps/payments/next/app/[offeringId]/checkout/layout.tsx
+++ b/apps/payments/next/app/[offeringId]/checkout/layout.tsx
@@ -1,0 +1,20 @@
+// TODO - Replace these placeholders as part of FXA-8227
+export const metadata = {
+  title: 'Mozilla accounts',
+  description: 'Mozilla accounts',
+};
+
+export interface CheckoutSearchParams {
+  interval?: string;
+  promotion_code?: string;
+  experiment?: string;
+  locale?: string;
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/payments/next/app/[offeringId]/checkout/new/page.tsx
+++ b/apps/payments/next/app/[offeringId]/checkout/new/page.tsx
@@ -1,0 +1,3 @@
+export default async function CheckoutNew() {
+  return <></>;
+}

--- a/apps/payments/next/app/_lib/stubs.ts
+++ b/apps/payments/next/app/_lib/stubs.ts
@@ -50,7 +50,7 @@ export async function fetchFromContentful() {
 
 export async function fetchCartData(cartId: string) {
   return {
-    id: '',
+    id: 'b6115e72-2a3f-4de8-a58a-e231bfeea85d',
     // state: CartState.START,
     state: CartState.FAIL,
     // errorReasonId: CartErrorReasonId.BASIC_ERROR,

--- a/apps/payments/next/app/page.tsx
+++ b/apps/payments/next/app/page.tsx
@@ -14,7 +14,7 @@ export default function Index() {
           <h2>123Done - Monthly</h2>
           <Link
             className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-            href="/123done/checkout?interval=monthly"
+            href="/123done/checkout/b6115e72-2a3f-4de8-a58a-e231bfeea85d?interval=monthly"
           >
             Redirect
           </Link>
@@ -23,7 +23,7 @@ export default function Index() {
           <h2>123Done - Yearly</h2>
           <Link
             className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-            href="/123done/checkout?interval=yearly"
+            href="/123done/checkout/b6115e72-2a3f-4de8-a58a-e231bfeea85d?interval=yearly"
           >
             Redirect
           </Link>

--- a/libs/payments/ui/src/lib/server/purchase-details.tsx
+++ b/libs/payments/ui/src/lib/server/purchase-details.tsx
@@ -6,7 +6,6 @@ import {
   getLocalizedCurrencyString,
 } from '@fxa/shared/l10n';
 import { FluentBundle } from '@fluent/bundle';
-import { headers } from 'next/headers';
 import Image from 'next/image';
 import { formatPlanPricing } from '../utils/helpers';
 import '../../styles/index.css';
@@ -57,6 +56,7 @@ export const ListLabelItem = ({
 
 type PurchaseDetailsProps = {
   interval: string;
+  locale: string;
   invoice: Invoice;
   purchaseDetails: {
     details: string[];
@@ -75,20 +75,12 @@ export async function PurchaseDetails(props: PurchaseDetailsProps) {
     (taxAmount) => !taxAmount.inclusive
   );
 
-  // TODO - Temporary
-  // Identify an approach to ensure we don't have to perform this logic
-  // in every component/page that requires localization.
-  const languages = headers()
-    .get('Accept-Language')
-    ?.split(',')
-    .map((language) => language.split(';')[0]);
-
   // TODO
   // Move to instantiation on start up. Ideally getBundle's, generateBundle, is only called once at startup,
   // and then that instance is used for all requests.
   // Approach 1 (Experimental): https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
   // Approach 2 (Node global): https://github.com/vercel/next.js/blob/canary/examples/with-knex/knex/index.js#L13
-  const l10n = await getBundle(languages);
+  const l10n = await getBundle([props.locale]);
 
   return (
     <div className="component-card text-sm px-4 rounded-t-none tablet:rounded-t-lg">

--- a/libs/payments/ui/src/lib/server/terms-and-privacy.tsx
+++ b/libs/payments/ui/src/lib/server/terms-and-privacy.tsx
@@ -1,6 +1,5 @@
 import { FluentBundle } from '@fluent/bundle';
 import { getBundle } from '@fxa/shared/l10n';
-import { headers } from 'next/headers';
 import {
   GenericTermItem,
   GenericTermsListItem,
@@ -59,6 +58,7 @@ function GenericTerms({
 }
 
 export interface TermsAndPrivacyProps {
+  locale: string;
   paymentProvider?: PaymentProvider;
   productName: string;
   termsOfServiceUrl: string;
@@ -68,6 +68,7 @@ export interface TermsAndPrivacyProps {
 }
 
 export async function TermsAndPrivacy({
+  locale,
   paymentProvider,
   productName,
   termsOfServiceUrl,
@@ -88,20 +89,12 @@ export async function TermsAndPrivacy({
     ),
   ];
 
-  // TODO - Temporary
-  // Identify an approach to ensure we don't have to perform this logic
-  // in every component/page that requires localization.
-  const languages = headers()
-    .get('Accept-Language')
-    ?.split(',')
-    .map((language) => language.split(';')[0]);
-
   // TODO
   // Move to instantiation on start up. Ideally getBundle's, generateBundle, is only called once at startup,
   // and then that instance is used for all requests.
   // Approach 1 (Experimental): https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
   // Approach 2 (Node global): https://github.com/vercel/next.js/blob/canary/examples/with-knex/knex/index.js#L13
-  const l10n = await getBundle(languages);
+  const l10n = await getBundle([locale]);
 
   return (
     <aside className="pt-14" aria-label="Terms and Privacy Notices">

--- a/libs/shared/l10n/src/lib/determine-locale.spec.ts
+++ b/libs/shared/l10n/src/lib/determine-locale.spec.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { determineLocale } from './determine-locale';
+import { determineLocale, getLocaleFromRequest } from './determine-locale';
 
 describe('l10n/determineLocale:', () => {
   it('finds a locale', () => {
@@ -57,5 +57,27 @@ describe('l10n/determineLocale:', () => {
     // by forcing them into that range.
     expect(determineLocale('en;q=0.5, fr;q=1.1')).toEqual('fr');
     expect(determineLocale('en;q=0.5, fr;q=-.1')).toEqual('en');
+  });
+
+  describe('getLocaleFromRequest', () => {
+    it('return searchParams', () => {
+      expect(getLocaleFromRequest({ locale: 'fr-FR' }, null)).toEqual('fr');
+    });
+
+    it('return searchParams in supportedLanguages', () => {
+      expect(
+        getLocaleFromRequest({ locale: 'ra-ND' }, null, ['ra-ND'])
+      ).toEqual('ra-ND');
+    });
+
+    it('return accept language', () => {
+      expect(getLocaleFromRequest({}, 'en-US;q=0.1, es-MX;q=0.8')).toEqual(
+        'es-MX'
+      );
+    });
+
+    it('return default locale', () => {
+      expect(getLocaleFromRequest({}, null)).toEqual('en-US');
+    });
   });
 });

--- a/libs/shared/l10n/src/lib/determine-locale.ts
+++ b/libs/shared/l10n/src/lib/determine-locale.ts
@@ -1,7 +1,30 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { DEFAULT_LOCALE } from './l10n';
 import { parseAcceptLanguage } from './parse-accept-language';
+
+/**
+ * Get the best fitting locale, prioritizing request search params, followed by request header AcceptLanguage and DEFAULT_LOCALE as default
+ * @param searchParams - Search parameters of the request
+ * @param acceptLanguage - Accept language from request header
+ * @returns The best fitting locale
+ */
+export function getLocaleFromRequest(
+  searchParams: { locale?: string },
+  acceptLanguage: string | null,
+  supportedLanguages?: string[]
+) {
+  if (searchParams.locale) {
+    return determineLocale(searchParams?.locale, supportedLanguages);
+  }
+
+  if (acceptLanguage) {
+    return determineLocale(acceptLanguage, supportedLanguages);
+  }
+
+  return DEFAULT_LOCALE;
+}
 
 /**
  * Given a set of supported languages and an accept-language http header value, this resolves language that fits best.

--- a/libs/shared/l10n/src/lib/l10n.ts
+++ b/libs/shared/l10n/src/lib/l10n.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 //   fr: new URL('./fr.ftl', import.meta.url),
 // };
 
-const DEFAULT_LOCALE = 'en-US';
+export const DEFAULT_LOCALE = 'en-US';
 // const AVAILABLE_LOCALES = {
 //   'en-US': 'English',
 //   fr: 'French',


### PR DESCRIPTION
## Because

- Reorganize checkout pages to include intent and cartId in path, and allow for landing page.

## This pull request

- Reorganizes checkout pages
- Add checkout landing page
- Add getLocaleFromRequest and update l10n locale logic

## Issue that this pull request solves

Closes: #FXA-7804

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).