### PR TITLE
feat(auth): add boolean flag that skips Stripe comparison and returns Contentful

### DIFF
--- a/libs/payments/legacy/src/lib/plan-mapper.util.spec.ts
+++ b/libs/payments/legacy/src/lib/plan-mapper.util.spec.ts
@@ -24,7 +24,8 @@ describe('PlanMapperUtil', () => {
       defaultMapper = new PlanMapperUtil(
         defaultCommonContent,
         defaultPurchaseDetails,
-        stripeMetadata
+        stripeMetadata,
+        false
       );
     });
 
@@ -85,7 +86,8 @@ describe('PlanMapperUtil', () => {
     const defaultMapper = new PlanMapperUtil(
       commonContent,
       defaultPurchaseDetails,
-      stripeMetadata
+      stripeMetadata,
+      false
     );
     // Instead of having a test for each Stripe Metadata Key, only test
     // for keys with mapping logic, e.g. newsletterSlug
@@ -105,7 +107,8 @@ describe('PlanMapperUtil', () => {
       const mapper = new PlanMapperUtil(
         commonContent,
         defaultPurchaseDetails,
-        stripeMetadata
+        stripeMetadata,
+        false
       );
       const expected = null;
       const actual = mapper.getContentfulForMetadataKey(
@@ -131,7 +134,8 @@ describe('PlanMapperUtil', () => {
       const mapper = new PlanMapperUtil(
         defaultCommonContent,
         defaultPurchaseDetails,
-        metadata
+        metadata,
+        false
       );
       const expected = 'hubs,mdnplus,snp';
       const actual = mapper.getStripeForMetadataKey(
@@ -145,7 +149,8 @@ describe('PlanMapperUtil', () => {
       const mapper = new PlanMapperUtil(
         defaultCommonContent,
         defaultPurchaseDetails,
-        metadata
+        metadata,
+        false
       );
       const expected = undefined;
       const actual = mapper.getStripeForMetadataKey(
@@ -160,7 +165,8 @@ describe('PlanMapperUtil', () => {
       const defaultMapper = new PlanMapperUtil(
         defaultCommonContent,
         defaultPurchaseDetails,
-        stripeMetadata
+        stripeMetadata,
+        false
       );
       const result = defaultMapper.mergeStripeAndContentful();
       expect(result.errorFields.length).toBe(1);

--- a/libs/payments/legacy/src/lib/plan-mapper.util.ts
+++ b/libs/payments/legacy/src/lib/plan-mapper.util.ts
@@ -13,7 +13,8 @@ export class PlanMapperUtil {
   constructor(
     private commonContent: OfferingCommonContentResult,
     private purchaseDetails: PurchaseDetailsTransformed,
-    private stripeMetadata: Stripe.Metadata | null
+    private stripeMetadata: Stripe.Metadata | null,
+    private contentfulEnabled: boolean
   ) {}
 
   /**
@@ -25,6 +26,12 @@ export class PlanMapperUtil {
     stripeValue?: string,
     contentfulValue?: string | null
   ) {
+    // If contentful config enabled, skip comparison and
+    // return undefined if null, otherwise contentfulValue
+    if (this.contentfulEnabled) {
+      return contentfulValue === null ? undefined : contentfulValue;
+    }
+
     // Return undefined if stripe and contentful aren't provided
     if (stripeValue === undefined && contentfulValue === null) {
       return undefined;

--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -42,7 +42,11 @@ describe('StripeMapperService', () => {
         metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
-        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+        await stripeMapper.mapContentfulToStripePlans(
+          [stripePlan],
+          'en',
+          false
+        );
       expect(mappedPlans[0].metadata?.['webIconURL']).toBe(
         validMetadata.webIconURL
       );
@@ -63,7 +67,11 @@ describe('StripeMapperService', () => {
         }),
       });
       const { mappedPlans, nonMatchingPlans } =
-        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+        await stripeMapper.mapContentfulToStripePlans(
+          [stripePlan],
+          'en',
+          false
+        );
       const actualProduct = mappedPlans[0].product as Stripe.Product;
       expect(actualProduct.metadata?.['webIconURL']).toBe(
         validMetadata.webIconURL
@@ -87,7 +95,11 @@ describe('StripeMapperService', () => {
         }),
       });
       const { mappedPlans, nonMatchingPlans } =
-        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+        await stripeMapper.mapContentfulToStripePlans(
+          [stripePlan],
+          'en',
+          false
+        );
       const actualProduct = mappedPlans[0].product as Stripe.Product;
       expect(actualProduct.metadata?.['webIconURL']).toBe(
         validMetadata.webIconURL
@@ -115,7 +127,11 @@ describe('StripeMapperService', () => {
         metadata: planOverrideMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
-        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+        await stripeMapper.mapContentfulToStripePlans(
+          [stripePlan],
+          'en',
+          false
+        );
       const actualProduct = mappedPlans[0].product as Stripe.Product;
       expect(actualProduct.metadata?.['webIconURL']).toBe(
         planOverrideMetadata.webIconURL
@@ -137,7 +153,11 @@ describe('StripeMapperService', () => {
         }),
       });
       const { mappedPlans, nonMatchingPlans } =
-        await stripeMapper.mapContentfulToStripePlans([stripePlan], 'en');
+        await stripeMapper.mapContentfulToStripePlans(
+          [stripePlan],
+          'en',
+          false
+        );
       const actualProduct = mappedPlans[0].product as Stripe.Product;
       expect(mappedPlans[0].metadata?.['webIconURL']).toBe(
         expected.purchaseDetails.webIcon
@@ -186,7 +206,8 @@ describe('StripeMapperService', () => {
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
           [stripePlan1, stripePlan2],
-          'en'
+          'en',
+          false
         );
 
       expect(nonMatchingPlans.length).toBe(0);
@@ -238,7 +259,8 @@ describe('StripeMapperService', () => {
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
           [stripePlan1, stripePlan2],
-          'en'
+          'en',
+          false
         );
 
       expect(nonMatchingPlans[0].split(' - ')[1]).toBe(

--- a/libs/payments/legacy/src/lib/stripe-mapper.service.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.ts
@@ -58,7 +58,8 @@ export class StripeMapperService {
    */
   async mapContentfulToStripePlans(
     plans: Stripe.Plan[],
-    acceptLanguage: string
+    acceptLanguage: string,
+    contentfulEnabled: boolean
   ) {
     const mappedPlans: Stripe.Plan[] = [];
     const validPlanIds = plans.map((plan) => plan.id);
@@ -100,7 +101,8 @@ export class StripeMapperService {
       const planMapper = new PlanMapperUtil(
         commonContent,
         purchaseDetails,
-        mergedStripeMetadata
+        mergedStripeMetadata,
+        contentfulEnabled
       );
 
       const { metadata, errorFields } = planMapper.mergeStripeAndContentful();

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -576,6 +576,14 @@ const conf = convict({
       env: 'NEWSLETTER_HOST',
     },
   },
+  contentful: {
+    enabled: {
+      doc: 'Whether to use Contentful',
+      format: Boolean,
+      default: false,
+      env: 'CONTENTFUL_ENABLED',
+    },
+  },
 });
 
 const configDir = __dirname;

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -130,6 +130,7 @@ export class StripeService extends StripeHelper {
       authFirestore: configService.get('authFirestore'),
       subhub: configService.get('subhub'),
       redis: configService.get('redis'),
+      contentful: configService.get('contentful'),
     };
     super(config, metrics, logger);
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2017,6 +2017,12 @@ const convictConf = convict({
       env: 'CONTENTFUL_FIRESTORE_CACHE_COLLECTION_NAME',
       format: String,
     },
+    enabled: {
+      default: false,
+      doc: 'Whether to use Contentful',
+      env: 'CONTENTFUL_ENABLED',
+      format: Boolean,
+    },
   },
 
   cloudTasks: {

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -94,6 +94,9 @@ export type StripeHelperConfig = {
     plansCacheTtlSeconds: number;
   };
   redis: any; // TODO
+  contentful: {
+    enabled: boolean;
+  };
 };
 
 /**
@@ -475,7 +478,8 @@ export abstract class StripeHelper {
         const validPlansMapped =
           await contentfulToStripeMapper.mapContentfulToStripePlans(
             validPlans,
-            acceptLanguage
+            acceptLanguage,
+            this.config.contentful.enabled
           );
 
         validPlansFinal.push(...validPlansMapped.mappedPlans);
@@ -536,7 +540,7 @@ export abstract class StripeHelper {
    */
   async expandResource<T>(
     resource: string | T,
-    resourceType: (typeof VALID_RESOURCE_TYPES)[number],
+    resourceType: typeof VALID_RESOURCE_TYPES[number],
     statusFilter?: Stripe.Subscription.Status[]
   ): Promise<T> {
     if (typeof resource !== 'string') {


### PR DESCRIPTION
## Because

- We want a seamless cutover from using Stripe metadata to Contentful.

## This pull request

- Adds a boolean feature flag to use Contentful data directly.
- Adds flag to comparison sections.
- Updates tests where applicable.

## Issue that this pull request solves

Closes FXA-9062

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
