### PR TITLE
feat(redis): Add support to customs server to use redis or memcache

### DIFF
--- a/packages/fxa-customs-server/lib/cache.js
+++ b/packages/fxa-customs-server/lib/cache.js
@@ -1,0 +1,43 @@
+const Memcached = require('memcached');
+const { RedisShared } = require('fxa-shared/db/redis');
+const P = require('bluebird');
+P.promisifyAll(Memcached.prototype);
+
+class Cache {
+  constructor(config) {
+    const customsRedisConfig = config.redis.customs;
+    this.useRedis = customsRedisConfig.enabled;
+
+    if (this.useRedis) {
+      this.client = new RedisShared(config.redis.customs);
+    } else {
+      this.client = new Memcached(config.memcache.address, {
+        timeout: 500,
+        retries: 1,
+        retry: 1000,
+        reconnect: 1000,
+        idle: 30000,
+        namespace: 'fxa~',
+      });
+    }
+  }
+
+  async setAsync(key, value, lifetime) {
+    if (this.useRedis) {
+      // Set the value in redis. We use 'EX' to set the expiration time in seconds.
+      return this.client.redis.set(key, JSON.stringify(value), 'EX', lifetime);
+    }
+    return this.client.setAsync(key, value, lifetime);
+  }
+
+  async getAsync(key) {
+    if (this.useRedis) {
+      const value = await this.client.redis.get(key);
+      return JSON.parse(value);
+    } else {
+      return this.client.getAsync(key);
+    }
+  }
+}
+
+module.exports = Cache;

--- a/packages/fxa-customs-server/lib/cache.js
+++ b/packages/fxa-customs-server/lib/cache.js
@@ -24,6 +24,9 @@ class Cache {
 
   async setAsync(key, value, lifetime) {
     if (this.useRedis) {
+      if (lifetime === 0) {
+        return this.client.redis.set(key, JSON.stringify(value));
+      }
       // Set the value in redis. We use 'EX' to set the expiration time in seconds.
       return this.client.redis.set(key, JSON.stringify(value), 'EX', lifetime);
     }
@@ -33,7 +36,11 @@ class Cache {
   async getAsync(key) {
     if (this.useRedis) {
       const value = await this.client.redis.get(key);
-      return JSON.parse(value);
+      try {
+        return JSON.parse(value);
+      } catch (err) {
+        return {};
+      }
     } else {
       return this.client.getAsync(key);
     }

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { tracingConfig } = require('fxa-shared/tracing/config');
+const { makeRedisConfig } = require('fxa-shared/db/config');
 
 module.exports = function (fs, path, url, convict) {
   var conf = convict({
@@ -186,6 +187,7 @@ module.exports = function (fs, path, url, convict) {
         env: 'RECORD_LIFETIME_SECONDS',
       },
     },
+    redis: makeRedisConfig(),
     allowedIPs: {
       doc: 'An array of IPs that will not be blocked or rate-limited.',
       format: Array,

--- a/packages/fxa-customs-server/lib/config/dev.json
+++ b/packages/fxa-customs-server/lib/config/dev.json
@@ -1,0 +1,7 @@
+{
+  "redis": {
+    "customs": {
+      "enabled": false
+    }
+  }
+}

--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -8,16 +8,16 @@
 
 const Hapi = require('@hapi/hapi');
 const HapiSwagger = require('hapi-swagger');
-const Memcached = require('memcached');
 const swaggerOptions = require('../docs/swagger/swagger-options');
 const API_DOCS = require('../docs/swagger/customs-server-api');
 const packageJson = require('../package.json');
 const blockReasons = require('./block_reasons');
 const P = require('bluebird');
-P.promisifyAll(Memcached.prototype);
+
 const { configureSentry } = require('./sentry');
 const dataflow = require('./dataflow');
 const { StatsD } = require('hot-shots');
+const Cache = require('./cache');
 
 module.exports = async function createServer(config, log) {
   var startupDefers = [];
@@ -47,14 +47,7 @@ module.exports = async function createServer(config, log) {
         timing: () => {},
       };
 
-  var mc = new Memcached(config.memcache.address, {
-    timeout: 500,
-    retries: 1,
-    retry: 1000,
-    reconnect: 1000,
-    idle: 30000,
-    namespace: 'fxa~',
-  });
+  const mc = new Cache(config);
 
   var reputationService = require('./reputationService')(config, log);
   const Settings = require('./settings/settings')(config, mc, log);

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -23,6 +23,7 @@
     "test": "scripts/test-local.sh",
     "test-unit": "yarn make-artifacts-dir && tap test/local --jobs=1 | tap-xunit > ../../artifacts/tests/$npm_package_name/tap-unit.xml",
     "test-integration": "yarn make-artifacts-dir && tap test/remote test/scripts --jobs=1 | tap-xunit > ../../artifacts/tests/$npm_package_name/tap-integration.xml",
+    "test-integration-redis": "CUSTOMS_REDIS_ENABLED=true yarn make-artifacts-dir && tap test/remote test/scripts --jobs=1 | tap-xunit > ../../artifacts/tests/$npm_package_name/tap-integration-redis.xml",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "make-artifacts-dir": "mkdir -p ../../artifacts/tests/$npm_package_name"
   },

--- a/packages/fxa-customs-server/scripts/test-local.sh
+++ b/packages/fxa-customs-server/scripts/test-local.sh
@@ -4,4 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+echo 'Testing with Memcache database'
 tap test/local test/remote test/scripts --no-coverage --jobs=1
+
+echo 'Testing with Redis database'
+CUSTOMS_REDIS_ENABLED=true tap test/local test/remote test/scripts --no-coverage --jobs=1

--- a/packages/fxa-customs-server/test/remote/block_email_tests.js
+++ b/packages/fxa-customs-server/test/remote/block_email_tests.js
@@ -5,13 +5,14 @@ var test = require('tap').test;
 var restifyClients = require('restify-clients');
 var TestServer = require('../test_server');
 var Promise = require('bluebird');
-var mcHelper = require('../memcache-helper');
+const { randomIp, randomEmail } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
+var TEST_EMAIL = randomEmail();
 var ALLOWED_EMAIL = 'test@restmail.net';
-var TEST_IP = '192.0.2.1';
+var TEST_IP = randomIp();
 
 const config = require('../../lib/config').getProperties();
+
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
@@ -24,13 +25,6 @@ test('startup', async function (t) {
   await testServer.start();
   t.type(testServer.server, 'object', 'test server was started');
   t.end();
-});
-
-test('clear everything', function (t) {
-  mcHelper.clearEverything(function (err) {
-    t.notOk(err, 'no errors were returned');
-    t.end();
-  });
 });
 
 test('missing email', function (t) {

--- a/packages/fxa-customs-server/test/remote/check_ip_only_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_ip_only_tests.js
@@ -3,20 +3,15 @@
 
 'use strict';
 
-const memcached = require('../memcache-helper');
 const restifyClients = require('restify-clients');
-const test = require('tap').test;
+const { randomIp } = require('../utils');
 const TestServer = require('../test_server');
+const test = require('tap').test;
 
-const IP = '192.168.1.1';
+const IP = randomIp();
 const ACTION = 'wibble';
 
-const config = {
-  listen: {
-    port: 7000,
-  },
-};
-
+const config = require('../../lib/config').getProperties();
 const testServer = new TestServer(config);
 
 const client = restifyClients.createJsonClient({
@@ -27,13 +22,6 @@ test('startup', async function (t) {
   await testServer.start();
   t.type(testServer.server, 'object', 'test server was started');
   t.end();
-});
-
-test('clear everything', (t) => {
-  memcached.clearEverything((err) => {
-    t.notOk(err, 'memcached.clearEverything should not return an error');
-    t.end();
-  });
 });
 
 test('with ip and action', (t) => {

--- a/packages/fxa-customs-server/test/remote/check_reputation_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_reputation_tests.js
@@ -29,7 +29,7 @@ config.reputationService = {
   suspectBelow: 60,
   hawkId: 'root',
   hawkKey: 'toor',
-  baseUrl: 'http://localhost:9009',
+  baseUrl: 'http://127.0.0.1:9009',
   timeout: 25,
 };
 

--- a/packages/fxa-customs-server/test/remote/config_update_tests.js
+++ b/packages/fxa-customs-server/test/remote/config_update_tests.js
@@ -6,6 +6,12 @@ var TestServer = require('../test_server');
 var Promise = require('bluebird');
 var restifyClients = Promise.promisifyAll(require('restify-clients'));
 var mcHelper = require('../memcache-helper');
+const {
+  randomIp,
+  randomEmail,
+  randomPhoneNumber,
+  randomEmailDomain,
+} = require('../utils');
 
 const config = require('../../lib/config').getProperties();
 config.updatePollIntervalSeconds = 1;
@@ -16,8 +22,8 @@ var client = restifyClients.createJsonClient({
   url: 'http://localhost:' + config.listen.port,
 });
 
-var IP = '10.0.0.5';
-var EMAIL = 'test@example.com';
+var IP = randomIp();
+var EMAIL = randomEmail();
 
 Promise.promisifyAll(client, { multiArgs: true });
 
@@ -94,7 +100,7 @@ test('change nested limits', function (t) {
 });
 
 test('change allowedIPs', function (t) {
-  var x = ['127.0.0.1'];
+  var x = [randomIp()];
   return client
     .getAsync('/allowedIPs')
     .spread(function (req, res, obj) {
@@ -121,7 +127,7 @@ test('change allowedIPs', function (t) {
 });
 
 test('change allowedEmailDomains', function (t) {
-  var x = ['restmail.net'];
+  var x = [randomEmailDomain()];
   return client
     .getAsync('/allowedEmailDomains')
     .spread(function (req, res, obj) {
@@ -148,7 +154,7 @@ test('change allowedEmailDomains', function (t) {
 });
 
 test('change allowedPhoneNumbers', function (t) {
-  var allowedPhoneNumbers = ['13133249901'];
+  var allowedPhoneNumbers = [randomPhoneNumber()];
   return client
     .getAsync('/allowedPhoneNumbers')
     .spread(function (req, res, obj) {

--- a/packages/fxa-customs-server/test/remote/failed_login_attempt_tests.js
+++ b/packages/fxa-customs-server/test/remote/failed_login_attempt_tests.js
@@ -5,15 +5,12 @@ var test = require('tap').test;
 var restifyClients = require('restify-clients');
 var TestServer = require('../test_server');
 var mcHelper = require('../memcache-helper');
+const { randomEmail, randomIp } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
-var TEST_IP = '192.0.2.1';
+var TEST_EMAIL = randomEmail();
+var TEST_IP = randomIp();
 
-var config = {
-  listen: {
-    port: 7000,
-  },
-};
+const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 test('startup', async function (t) {
@@ -47,17 +44,16 @@ test('well-formed request', function (t) {
 });
 
 test('missing ip', function (t) {
-  client.post('/failedLoginAttempt', { email: TEST_EMAIL }, function (
-    err,
-    req,
-    res,
-    obj
-  ) {
-    t.equal(res.statusCode, 400, 'bad request returns a 400');
-    t.type(obj.code, 'string', 'bad request returns an error code');
-    t.type(obj.message, 'string', 'bad request returns an error message');
-    t.end();
-  });
+  client.post(
+    '/failedLoginAttempt',
+    { email: TEST_EMAIL },
+    function (err, req, res, obj) {
+      t.equal(res.statusCode, 400, 'bad request returns a 400');
+      t.type(obj.code, 'string', 'bad request returns an error code');
+      t.type(obj.message, 'string', 'bad request returns an error message');
+      t.end();
+    }
+  );
 });
 
 test('missing email and ip', function (t) {

--- a/packages/fxa-customs-server/test/remote/ip_blocklist_disable.js
+++ b/packages/fxa-customs-server/test/remote/ip_blocklist_disable.js
@@ -6,19 +6,16 @@ var Promise = require('bluebird');
 var restifyClients = Promise.promisifyAll(require('restify-clients'));
 var TestServer = require('../test_server');
 var mcHelper = require('../memcache-helper');
+const { randomEmail } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
+var TEST_EMAIL = randomEmail();
 var ACTION = 'dummyAction';
 var BLOCK_IP = '1.93.0.224';
 const ENDPOINTS = ['/check', '/checkIpOnly'];
 
 process.env.IP_BLOCKLIST_ENABLE = false;
 
-var config = {
-  listen: {
-    port: 7000,
-  },
-};
+const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 test('startup', async function (t) {

--- a/packages/fxa-customs-server/test/remote/ip_blocklist_tests.js
+++ b/packages/fxa-customs-server/test/remote/ip_blocklist_tests.js
@@ -6,8 +6,9 @@ var Promise = require('bluebird');
 var restifyClients = Promise.promisifyAll(require('restify-clients'));
 var TestServer = require('../test_server');
 var mcHelper = require('../memcache-helper');
+const { randomEmail } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
+var TEST_EMAIL = randomEmail();
 var ACTION = 'dummyAction';
 var BLOCK_IP = '1.93.0.224';
 var LOG_ONLY_BOTH_LIST_IP = '1.93.0.225';

--- a/packages/fxa-customs-server/test/remote/memcache_error_tests.js
+++ b/packages/fxa-customs-server/test/remote/memcache_error_tests.js
@@ -11,6 +11,7 @@ var TEST_IP = '192.0.2.1';
 
 const config = require('../../lib/config').getProperties();
 config.memcache.address = '128.0.0.1:12131';
+config.redis.customs.port = '6380';
 
 var testServer = new TestServer(config);
 
@@ -31,18 +32,22 @@ var client = restifyClients.createJsonClient({
   url: 'http://localhost:' + config.listen.port,
 });
 
-test('request with disconnected memcache', function (t) {
-  client.post(
-    '/check',
-    { email: TEST_EMAIL, ip: TEST_IP, action: 'someRandomAction' },
-    function (err, req, res, obj) {
-      t.equal(res.statusCode, 200, 'check worked');
-      t.equal(obj.block, true, 'request was blocked');
-      t.equal(obj.retryAfter, 900, 'retry after');
-      t.end();
-    }
-  );
-});
+test(
+  'request with disconnected memcache',
+  { skip: config.redis.customs.enabled },
+  function (t) {
+    client.post(
+      '/check',
+      { email: TEST_EMAIL, ip: TEST_IP, action: 'someRandomAction' },
+      function (err, req, res, obj) {
+        t.equal(res.statusCode, 200, 'check worked');
+        t.equal(obj.block, true, 'request was blocked');
+        t.equal(obj.retryAfter, 900, 'retry after');
+        t.end();
+      }
+    );
+  }
+);
 
 test('teardown', async function (t) {
   await testServer.stop();

--- a/packages/fxa-customs-server/test/remote/never_blocked.js
+++ b/packages/fxa-customs-server/test/remote/never_blocked.js
@@ -65,7 +65,7 @@ test('maximum number of emails', function (t) {
       t.equal(obj.block, false, 'resending the code');
 
       return new Promise(function (resolve, reject) {
-        mcHelper.blockedEmailCheck(function (isBlocked) {
+        mcHelper.blockedEmailCheck(TEST_EMAIL, function (isBlocked) {
           t.equal(isBlocked, false, 'account is still not blocked');
           resolve();
         });

--- a/packages/fxa-customs-server/test/remote/password_reset_clears_bad_logins.js
+++ b/packages/fxa-customs-server/test/remote/password_reset_clears_bad_logins.js
@@ -6,16 +6,12 @@ var restifyClients = require('restify-clients');
 var TestServer = require('../test_server');
 var Promise = require('bluebird');
 var mcHelper = require('../memcache-helper');
+const { randomEmail, randomIp } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
-var TEST_IP = '192.0.2.1';
+var TEST_EMAIL = randomEmail();
+var TEST_IP = randomIp();
 
-var config = {
-  listen: {
-    port: 7000,
-  },
-};
-
+const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({

--- a/packages/fxa-customs-server/test/remote/password_reset_tests.js
+++ b/packages/fxa-customs-server/test/remote/password_reset_tests.js
@@ -5,14 +5,11 @@ var test = require('tap').test;
 var restifyClients = require('restify-clients');
 var TestServer = require('../test_server');
 var mcHelper = require('../memcache-helper');
+const { randomEmail } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
+var TEST_EMAIL = randomEmail();
 
-var config = {
-  listen: {
-    port: 7000,
-  },
-};
+const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 test('startup', async function (t) {
@@ -33,17 +30,16 @@ var client = restifyClients.createJsonClient({
 });
 
 test('well-formed request', function (t) {
-  client.post('/passwordReset', { email: TEST_EMAIL }, function (
-    err,
-    req,
-    res,
-    obj
-  ) {
-    t.notOk(err, 'good request is successful');
-    t.equal(res.statusCode, 200, 'good request returns a 200');
-    t.ok(obj, 'got an obj, make jshint happy');
-    t.end();
-  });
+  client.post(
+    '/passwordReset',
+    { email: TEST_EMAIL },
+    function (err, req, res, obj) {
+      t.notOk(err, 'good request is successful');
+      t.equal(res.statusCode, 200, 'good request returns a 200');
+      t.ok(obj, 'got an obj, make jshint happy');
+      t.end();
+    }
+  );
 });
 
 test('missing email', function (t) {

--- a/packages/fxa-customs-server/test/remote/root_tests.js
+++ b/packages/fxa-customs-server/test/remote/root_tests.js
@@ -6,11 +6,7 @@ var restifyClients = require('restify-clients');
 var TestServer = require('../test_server');
 var packageJson = require('../../package.json');
 
-var config = {
-  listen: {
-    port: 7000,
-  },
-};
+const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 test('startup', async function (t) {

--- a/packages/fxa-customs-server/test/remote/send_violations_tests.js
+++ b/packages/fxa-customs-server/test/remote/send_violations_tests.js
@@ -30,7 +30,7 @@ config.reputationService = {
   suspectBelow: 60,
   hawkId: 'root',
   hawkKey: 'toor',
-  baseUrl: 'http://localhost:9009',
+  baseUrl: 'http://127.0.0.1:9009',
   timeout: 25,
 };
 

--- a/packages/fxa-customs-server/test/remote/too_many_emails.js
+++ b/packages/fxa-customs-server/test/remote/too_many_emails.js
@@ -6,9 +6,10 @@ var restifyClients = require('restify-clients');
 var TestServer = require('../test_server');
 var Promise = require('bluebird');
 var mcHelper = require('../memcache-helper');
+const { randomEmail, randomIp } = require('../utils');
 
-var TEST_EMAIL = 'test@example.com';
-var TEST_IP = '192.0.2.1';
+var TEST_EMAIL = randomEmail();
+var TEST_IP = randomIp();
 
 const config = require('../../lib/config').getProperties();
 config.limits.rateLimitIntervalSeconds = 1;
@@ -76,7 +77,7 @@ test('too many sent emails', function (t) {
       t.equal(obj.block, true, 'operation blocked');
 
       return new Promise(function (resolve, reject) {
-        mcHelper.blockedEmailCheck(function (isBlocked) {
+        mcHelper.blockedEmailCheck(TEST_EMAIL, function (isBlocked) {
           t.equal(isBlocked, true, 'account is blocked');
           resolve();
         });
@@ -90,7 +91,7 @@ test('too many sent emails', function (t) {
 
 test('failed logins expire', function (t) {
   setTimeout(function () {
-    mcHelper.blockedEmailCheck(function (isBlocked) {
+    mcHelper.blockedEmailCheck(TEST_EMAIL, function (isBlocked) {
       t.equal(isBlocked, false, 'account no longer blocked');
       t.end();
     });

--- a/packages/fxa-customs-server/test/utils.js
+++ b/packages/fxa-customs-server/test/utils.js
@@ -6,8 +6,16 @@
 const crypto = require('crypto');
 
 module.exports = {
+  randomPhoneNumber: function () {
+    return `1${Math.floor(Math.random() * 10000000000)}`;
+  },
+
   randomEmail: function () {
     return Math.floor(Math.random() * 10000) + '@email.com';
+  },
+
+  randomEmailDomain: function () {
+    return `@${Math.floor(Math.random() * 10000) + 'email.com'}`;
   },
 
   randomIp: function () {

--- a/packages/fxa-shared/db/config.ts
+++ b/packages/fxa-shared/db/config.ts
@@ -261,5 +261,37 @@ export function makeRedisConfig() {
         doc: 'Minimum connection count for the subhub responses Redis pool',
       },
     },
+
+    customs: {
+      enabled: {
+        default: false,
+        doc: 'Enable Redis for customs server rate limiting',
+        format: Boolean,
+        env: 'CUSTOMS_REDIS_ENABLED',
+      },
+      host: {
+        default: 'localhost',
+        env: 'CUSTOMS_REDIS_HOST',
+        format: String,
+      },
+      port: {
+        default: 6379,
+        env: 'CUSTOMS_REDIS_PORT',
+        format: 'port',
+      },
+      password: {
+        default: '',
+        env: 'REDIS_PASSWORD',
+        format: String,
+        sensitive: true,
+        doc: `Password for connecting to redis`,
+      },
+      prefix: {
+        default: 'customs:',
+        env: 'CUSTOMS_REDIS_KEY_PREFIX',
+        format: String,
+        doc: 'Key prefix for custom server records in Redis',
+      },
+    },
   };
 }


### PR DESCRIPTION
## Because

- We want to eventually migrate over to redis for all our caching needs
- Customs server is the only service that uses memcache
- We should expect a performance increase (TBD on running loadtesting)

## This pull request

- Adds a new `Cache` library to custom server that switches between memcache and redis
- To reduce code churn, I opted to keep existing memcache function names `getAsync` `setAsync`
- Updated tests where needed, added new test command to run redis version of test
- Redis entries match the lifetime of memcache entries

## Issue that this pull request solves

Closes: 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Test:

1. Enabled custom server in auth-server, in fxa-auth-server/config/dev.json, set `customUrl: http://127.0.0.1:7000`
2. Enable redis in customs server, fxa-customs-server/config/dev.json, set `enabled: true`
3. Start services
4. Create an account, attempt to login with an invalid password, you should see rate limiting screen

To verify redis entries, I used [Redis Commander](https://github.com/joeferner/redis-commander). In memcache version keys were prefixed with `fxa~`, but in redis I opted to use `customs:` since that was pattern for other entries.
