### PR TITLE
fix(auth): Update eligibilityFromEligibilityManager

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -451,9 +451,20 @@ export class CapabilityService {
         eligibleSourcePlan: overlapAbbrev,
       };
 
+    if (
+      overlap.comparison === OfferingComparison.UPGRADE ||
+      intervalComparison(
+        { unit: overlapAbbrev.interval, count: overlapAbbrev.interval_count },
+        { unit: targetPlan.interval, count: targetPlan.interval_count }
+      ) === IntervalComparison.LONGER
+    )
+      return {
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+        eligibleSourcePlan: overlapAbbrev,
+      };
+
     return {
-      subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
-      eligibleSourcePlan: overlapAbbrev,
+      subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
     };
   }
 


### PR DESCRIPTION
## Because

- [Sentry](https://mozilla.sentry.io/issues/4993075790/?environment=stage&project=6231056&query=is%3Aunresolved+mismatch&referrer=issue-stream&statsPeriod=30d&stream_index=1) logged an event for when a customer with a VPN EUR Annual Plan tried to subscribe to a VPN USD Annual plan
  - eligibilityManagerResult: upgrade
  - stripeEligibilityResult: invalid

## This pull request

- Updates eligibilityFromEligibilityManager

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.