### PR TITLE
feat(payments-stripe): Create StripeManager isCustomerStripeTaxEligible

### DIFF
--- a/libs/payments/stripe/project.json
+++ b/libs/payments/stripe/project.json
@@ -24,7 +24,7 @@
         ]
       }
     },
-    "test": {
+    "test-unit": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { CustomerFactory } from './factories/customer.factory';
+import { StripeClient } from './stripe.client';
+import { StripeManager } from './stripe.manager';
+
+describe('StripeManager', () => {
+  describe('isCustomerStripeTaxEligible', () => {
+    let manager: StripeManager;
+    let mockStripeClient: StripeClient;
+    let mockResult: any;
+
+    beforeEach(async () => {
+      mockResult = {};
+      mockStripeClient = {};
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          { provide: StripeClient, useValue: mockStripeClient },
+          StripeManager,
+        ],
+      }).compile();
+
+      manager = module.get<StripeManager>(StripeManager);
+    });
+
+    it('should be defined', async () => {
+      expect(manager).toBeDefined();
+      expect(manager).toBeInstanceOf(StripeManager);
+    });
+
+    it('should throw an error if no tax in customer', async () => {
+      const mockCustomer = CustomerFactory();
+
+      expect(manager.isCustomerStripeTaxEligible(mockCustomer)).rejects.toThrow(
+        'customer.tax is not present'
+      );
+    });
+
+    it('should return true for a taxable customer', async () => {
+      const mockCustomer = CustomerFactory({
+        tax: {
+          automatic_tax: 'supported',
+          ip_address: null,
+          location: { country: 'US', state: 'CA', source: 'billing_address' },
+        },
+      });
+
+      mockResult.isCustomerStripeTaxEligible = jest
+        .fn()
+        .mockReturnValueOnce(true);
+
+      const result = await manager.isCustomerStripeTaxEligible(mockCustomer);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true for a customer in a not-collecting location', async () => {
+      const mockCustomer = CustomerFactory({
+        tax: {
+          automatic_tax: 'not_collecting',
+          ip_address: null,
+          location: null,
+        },
+      });
+
+      mockResult.isCustomerStripeTaxEligible = jest
+        .fn()
+        .mockReturnValueOnce(true);
+
+      const result = await manager.isCustomerStripeTaxEligible(mockCustomer);
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -3,9 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
+import { Stripe } from 'stripe';
 import { StripeClient } from './stripe.client';
 
 @Injectable()
 export class StripeManager {
   constructor(private client: StripeClient) {}
+
+  async isCustomerStripeTaxEligible(customer: Stripe.Customer) {
+    if (!customer.tax) {
+      // TODO: FXA-8891
+      throw new Error('customer.tax is not present');
+    }
+
+    return (
+      customer.tax?.automatic_tax === 'supported' ||
+      customer.tax?.automatic_tax === 'not_collecting'
+    );
+  }
 }


### PR DESCRIPTION
## This pull request

- [x] Creates StripeManager isCustomerStripeTaxEligible
   - [x] Should take a Stripe customer as an argument
   - [x] Return true if customer’s tax status is “supported” or “not_collecting”

## Issue that this pull request solves

Closes: FXA-8947

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.