### PR TITLE
chore(css): Add grunttask to fix content-server Tailwind selectors

### DIFF
--- a/packages/fxa-content-server/grunttasks/build.js
+++ b/packages/fxa-content-server/grunttasks/build.js
@@ -48,6 +48,15 @@ module.exports = function (grunt) {
     // Update leaf node font and image URLs in the CSS bundle.
     'usemin:css',
 
+    // Tailwind 3.4.1 changed ltr: and rtl: classes to use a `:where... &` selector
+    // that can output an asterisk selector, e.g. `:where([dir="rtl"] *)`. Our `cssmin`
+    // grunttask minifies this to `:where([dir="rtl"]*)`, removing the space, which
+    // causes the style not to load. clean-css does not offer any formatting options
+    // to fix this for us, and since we plan to sunset content-server anyway and this
+    // is not a problem in our minification process for Settings, this is a temp hack
+    // that replaces `]*` with `] *` in our content-server Tailwind CSS file.
+    'replace:cssSelectorFix',
+
     // URLs inside the resources with children have been updated
     // and SRI hashes added to the main JS bundle. These files
     // are in their final state and can now be revved.

--- a/packages/fxa-content-server/grunttasks/replace.js
+++ b/packages/fxa-content-server/grunttasks/replace.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  grunt.config('replace', {
+    cssSelectorFix: {
+      src: ['<%= yeoman.dist %>/styles/tailwind.out.css'],
+      overwrite: true,
+      replacements: [
+        {
+          from: /](?=\*)/g,
+          to: '] ',
+        },
+      ],
+    },
+  });
+};


### PR DESCRIPTION
Because:
* Our content-server CSS minification build task is stripping a space between brackets and asterisks, invalidating the selector and causing some styles to not apply. See comment included in commit for more details

This commit:
* Adds a grunttask to add the whitespace back

fixes FXA-9167, fixes FXA-9170

---

In #16445, I wondered if removing `--minify` would not fix the problem (see the "EDIT" and comments). We included the fix in a dot release and I've since confirmed a few things:
* Stage is still having the problems described in the linked tickets
* `--minify` does not do anything for us for content-server at least, I compared what was uploaded to stage before and after this option and there is no diff because...
* We're using a grunt task to minify our content-server CSS not handled by webpack
* This bug was introduced because of the recent Tailwind upgrade, [see this](https://github.com/tailwindlabs/tailwindcss/pull/12584). Before this upgrade, our `ltr` and `rtl` classes did not produce `:where([dir="ltr"], [dir="ltr"] *)` selectors. It's possible this selector output (specifically the asterisk) is a bug in Tailwind but I'd need to do more investigating.

I tried [every available formatting option](https://github.com/clean-css/clean-css?tab=readme-ov-file#formatting-options) for the `cssmin` task and also tried tweaking the level to prevent needing a new task, and nothing addressed this problem. I also tried excluding the Tailwind file from the `cssmin` task but couldn't get this to work.

I started adjusting the classes themselves to not use these selectors, but we've got a few that we'd have to change to something like `[dir='rtl'] & {`, and then we'd have to know and abide by not use these Tailwind classes in content-server due to the minify problem. 

This seemed like a reasonable solution for now since we hope to sunset content-server soon anyway. Other options were described above, or downgrading Tailwind and pinning us to a version until we've sunsetted content-server or until/unless they tweak the selector.

This fix can be verified by running `yarn build` before and after this change in content-server and checking the `dist/styles/[hash].tailwind.out.css` file. See that before, there are several `]*` references and after, they've become `] *`.