### PR TITLE
fix: directly query for customer to avoid db changes

### DIFF
--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -4,6 +4,7 @@
 
 import {
   deleteAllPayPalBAs,
+  getAccountCustomerByUid,
   getAllPayPalBAByUid,
 } from 'fxa-shared/db/models/auth';
 import { StatsD } from 'hot-shots';
@@ -153,10 +154,11 @@ export class AccountDeleteManager {
   }
 
   private async enqueueByUid(options: EnqueueByUidParam) {
-    const customer = await this.stripeHelper?.fetchCustomer(options.uid);
+    const { stripeCustomerId } =
+      (await getAccountCustomerByUid(options.uid)) || {};
     const task: DeleteTask = {
       uid: options.uid,
-      customerId: customer?.id,
+      customerId: stripeCustomerId,
       reason: options.reason,
     };
     return this.enqueueTask(task);
@@ -164,10 +166,11 @@ export class AccountDeleteManager {
 
   private async enqueueByEmail(options: EnqueueByEmailParam) {
     const account = await this.fxaDb.accountRecord(options.email);
-    const customer = await this.stripeHelper?.fetchCustomer(account.uid);
+    const { stripeCustomerId } =
+      (await getAccountCustomerByUid(account.uid)) || {};
     const task: DeleteTask = {
       uid: account.uid,
-      customerId: customer?.id,
+      customerId: stripeCustomerId,
       reason: options.reason,
     };
     return this.enqueueTask(task);


### PR DESCRIPTION
Because:

* We want to avoid making changes to the database when queueing account delete tasks.

This commit:

* Directly queries the accountCustomers table to fetch the linked customer record instead of a fetchCustomer which may make db changes.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
