### PR TITLE
feat(contentful): ease capability validation

### DIFF
--- a/packages/db-migrations/contentful/1708637169029_fxa-8978.js
+++ b/packages/db-migrations/contentful/1708637169029_fxa-8978.js
@@ -1,0 +1,9 @@
+function migrationFunction(migration, context) {
+  const capability = migration.editContentType('capability');
+  const capabilitySlug = capability.editField('slug');
+  capabilitySlug.validations([]);
+  capability.changeFieldControl('slug', 'builtin', 'singleLine', {
+    helpText: 'The raw capability string provided to the service by Accounts.',
+  });
+}
+module.exports = migrationFunction;


### PR DESCRIPTION
## Because

- Need to ease validations on the capability slug string to accommodate the following scenarios
  - Capability string greater than 20 characters
  - Same capability string used by multiple services

## This pull request

- Removes the character limits and unique constraint from the capability slug string.

## Issue that this pull request solves

Closes: #FXA-8978

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).