### PR TITLE
task(settings): Add glean metrics for totp

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
@@ -64,9 +64,13 @@ export const SigninTotpCode = ({
     submitButtonText: 'Confirm',
   };
 
+  useEffect(() => {
+    GleanMetrics.totpForm.view();
+  }, []);
+
   const onSubmit = async (code: string) => {
     const { status, error } = await submitTotpCode(code);
-    GleanMetrics.loginConfirmation.submit();
+    GleanMetrics.totpForm.submit();
     logViewEvent('flow', `${viewName}.submit`);
 
     setGeneralError('');
@@ -86,6 +90,7 @@ export const SigninTotpCode = ({
       );
       setCodeErrorMessage(localizedErrorMessage);
     } else {
+      GleanMetrics.totpForm.success();
       handleNavigation();
     }
   };


### PR DESCRIPTION
## Because

- We need to add glean metrics

## This pull request
- Adds glean metric call for totpForm.success (event: login_totp_code_success_view)
- Adds glean metric call for totpForm.submit (event: login_totp_code_submit)
- Adds glean metric call for totpForm.view (event: login_totp_form_view)

## Issue that this pull request solves

Closes: FXA-8026, FXA-8027, FXA-8028

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
