### PR TITLE
task(customs): Configure rate limiting for getCredentialsStatus

### DIFF
--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -373,6 +373,33 @@ module.exports = function (fs, path, url, convict) {
     },
     tracing: tracingConfig,
     userDefinedRateLimitRules: {
+      getCredentialsStatusRules: {
+        actions: {
+          doc: 'Array of actions that this rule should be applied to',
+          default: ['getCredentialsStatus'],
+          format: Array,
+        },
+        limits: {
+          max: {
+            doc: 'max actions during `period` that can occur before rate limit is applied',
+            format: 'nat',
+            default: 120,
+            env: 'GET_CREDENTIALS_STATUS_RULE_MAX',
+          },
+          periodMs: {
+            doc: 'period needed before rate limit is reset',
+            format: 'duration',
+            default: '60 seconds',
+            env: 'GET_CREDENTIALS_STATUS_RULE_PERIOD_MS',
+          },
+          rateLimitIntervalMs: {
+            doc: 'how long rate limit is applied',
+            format: 'duration',
+            default: '15 minutes',
+            env: 'GET_CREDENTIALS_STATUS_RULE_LIMIT_INTERVAL_MS',
+          },
+        },
+      },
       totpCodeRules: {
         actions: {
           doc: 'Array of actions that this rule should be applied to',

--- a/packages/fxa-customs-server/test/remote/user_defined_rules.js
+++ b/packages/fxa-customs-server/test/remote/user_defined_rules.js
@@ -19,13 +19,16 @@ function randomIp() {
 }
 
 const config = require('../../lib/config').getProperties();
+config.userDefinedRateLimitRules.getCredentialsStatusRules.limits.max = 2;
+config.userDefinedRateLimitRules.getCredentialsStatusRules.limits.periodMs = 1000;
+config.userDefinedRateLimitRules.getCredentialsStatusRules.limits.rateLimitIntervalMs = 1000;
 config.userDefinedRateLimitRules.totpCodeRules.limits.periodMs = 1000;
 config.userDefinedRateLimitRules.totpCodeRules.limits.rateLimitIntervalMs = 1000;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.max = 2;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.periodMs = 1000;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.rateLimitIntervalMs = 1000;
 
-const ACTIONS = ['verifyTotpCode', 'verifyTokenCode'];
+const ACTIONS = ['verifyTotpCode', 'verifyTokenCode', 'getCredentialsStatus'];
 
 const testServer = new TestServer(config);
 


### PR DESCRIPTION
## Because
- We need a custom configuration for rate limiting calls to `/account/credentials/status`


## This pull request
- Introduces a custom rate limiting rule for `getCredentialsStatus`
- Sets the config to allow up to 120 requests per minute and a rate limit interval of 15 minutes
- This call is automatically called in several scenarios, this should provide a generous upper limit of calls, allowing for page refreshes or multiple login attempts, while still preventing blatant abuse of the endpoint.

## Issue that this pull request solves

Closes: FXA-9112

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The actual customs check was already in place and can be found [here](https://github.com/mozilla/fxa/blob/30c28bc4a2faa4fb65f5046dadfb47f2877eb3c6/packages/fxa-auth-server/lib/routes/account.ts#L1760).

To manually test this, remove `"customsUrl": "none",` in `packages/fxa-auth-server/config/dev.json`. This will enable the content server. Then start hammering the login with bad passwords, and watch the network tab. Eventually, you will see a rate limit error (ie Too Many Requests) pop up for calls to the `/account/credentials/status` endpoint. Tinkering with the newly added config in customs server can be a further validation that this config is taking effect.
