### PR TITLE
test(functional-tests): remove PayPal functional tests

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -64,30 +64,6 @@ export class SubscribePage extends BaseLayout {
     await pay.click();
   }
 
-  async setPayPalInfo() {
-    const paypalButton = this.page.locator(
-      '[data-testid="paypal-button-container"]'
-    );
-    await paypalButton.waitFor({ state: 'visible' });
-
-    const paypalWindowPromise = this.page.waitForEvent('popup');
-    await this.page.locator('[data-testid="paypal-button-container"]').click();
-    const paypalWindow = await paypalWindowPromise;
-
-    await paypalWindow.waitForLoadState('load');
-    await paypalWindow.waitForURL(/checkoutnow/);
-    await paypalWindow.fill(
-      'input[type=email]',
-      'qa-test-no-balance-16@personal.example.com'
-    );
-    await paypalWindow.click('button[id=btnNext]');
-    await paypalWindow.waitForLoadState('load');
-    await paypalWindow.fill('input[type=password]', 'Ah4SboP6UDZx95I');
-    await paypalWindow.click('button[id=btnLogin]');
-    await paypalWindow.waitForLoadState();
-    await paypalWindow.click('button[id=consentButton]');
-  }
-
   async addCouponCode(code) {
     const input = this.page.locator('[data-testid="coupon-input"]');
     await input.waitFor({ state: 'visible' });

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -38,19 +38,6 @@ export class SubscriptionManagementPage extends BaseLayout {
     await this.page.locator('[data-testid="submit"]').click();
   }
 
-  async clickPaypalChange() {
-    const changeButton = this.page.locator(
-      '[data-testid="change-payment-update-button"]'
-    );
-    await changeButton.waitFor({ state: 'visible' });
-    const [paypalWindow] = await Promise.all([
-      this.page.waitForEvent('popup'),
-      this.page.locator('[data-testid="change-payment-update-button"]').click(),
-    ]);
-    await paypalWindow.waitForLoadState('load');
-    return paypalWindow;
-  }
-
   async fillSupportForm() {
     await this.page.locator('[data-testid="contact-support-button"]').click();
     await this.page.locator('#product_chosen a.chosen-single').click();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -180,27 +180,6 @@ test.describe('severity-2 #smoke', () => {
       expect(await relier.isPro()).toBe(true);
     });
 
-    test('subscribe with paypal and use coupon', async ({
-      pages: { relier, login, subscribe },
-    }, { project }) => {
-      test.skip(
-        project.name === 'production',
-        'no real payment method available in prod'
-      );
-      await relier.goto();
-      await relier.clickSubscribe12Month();
-
-      // 'auto50ponetime' is a one time 50% discount coupon for a 12mo plan
-      await subscribe.addCouponCode('auto50ponetime');
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setPayPalInfo();
-      await subscribe.submit();
-      await relier.goto();
-      await relier.clickEmailFirst();
-      await login.submit();
-      expect(await relier.isPro()).toBe(true);
-    });
-
     test('remove a coupon and verify', async ({
       pages: { relier, subscribe, login },
     }, { project }) => {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -63,55 +63,6 @@ test.describe('severity-2 #smoke', () => {
       );
     });
 
-    test('resubscribe successfully with the same coupon after canceling for paypal', async ({
-      pages: { relier, subscribe, login, settings, subscriptionManagement },
-    }, { project }) => {
-      test.skip(
-        project.name === 'production',
-        'no real payment method available in prod'
-      );
-      await relier.goto();
-      await relier.clickSubscribe6Month();
-
-      // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
-
-      // Verify the coupon is applied successfully
-      expect(await subscribe.discountAppliedSuccess()).toBe(true);
-
-      const total = await subscribe.getTotalPrice();
-
-      //Subscribe successfully using Paypal
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setPayPalInfo();
-      await subscribe.submit();
-
-      //Login to FxA account
-      await login.goto();
-      await login.clickSignIn();
-      const subscriptionPage = await settings.clickPaidSubscriptions();
-      subscriptionManagement.page = subscriptionPage;
-
-      //Verify no coupon details are visible
-      expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
-        'Promo'
-      );
-
-      //Cancel subscription and then resubscribe
-      await subscriptionManagement.cancelSubscription();
-      await subscriptionManagement.resubscribe();
-
-      //Verify that the resubscription has the same coupon applied
-      expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
-        total
-      );
-
-      //Verify no coupon details are visible
-      expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
-        'Promo'
-      );
-    });
-
     test('update mode of payment for stripe', async ({
       pages: { relier, subscribe, login, settings, subscriptionManagement },
     }, { project }) => {
@@ -143,36 +94,6 @@ test.describe('severity-2 #smoke', () => {
 
       //Verify that the card info is updated
       expect(await subscriptionManagement.getCardInfo()).toContain('4444');
-    });
-
-    test('update mode of payment for paypal', async ({
-      pages: { relier, subscribe, login, settings, subscriptionManagement },
-    }, { project }) => {
-      test.skip(
-        project.name === 'production',
-        'no real payment method available in prod'
-      );
-      await relier.goto();
-      await relier.clickSubscribe();
-
-      // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
-
-      //Subscribe successfully
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setPayPalInfo();
-      await subscribe.submit();
-
-      //Login to FxA account
-      await login.goto();
-      await login.clickSignIn();
-      const subscriptionPage = await settings.clickPaidSubscriptions();
-      subscriptionManagement.page = subscriptionPage;
-
-      //Change Paypal information
-      const paypalPage = await subscriptionManagement.clickPaypalChange();
-      subscriptionManagement.page = paypalPage;
-      expect(subscriptionManagement.page.url()).toContain('paypal.com/signin');
     });
   });
 });

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -8,7 +8,7 @@ import { MetricsObserver } from '../../lib/metrics';
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-2 #smoke', () => {
-  test.describe('subscription test with cc and paypal', () => {
+  test.describe('subscription', () => {
     test.beforeEach(() => {
       test.slow();
     });
@@ -72,24 +72,6 @@ test.describe('severity-2 #smoke', () => {
         return event.type;
       });
       expect(actualEventTypes).toMatchObject(expectedEventTypes);
-    });
-
-    test('subscribe with paypal and login to product', async ({
-      pages: { relier, login, subscribe },
-    }, { project }) => {
-      test.skip(
-        project.name === 'production',
-        'no real payment method available in prod'
-      );
-      await relier.goto();
-      await relier.clickSubscribe();
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setPayPalInfo();
-      await subscribe.submit();
-      await relier.goto();
-      await relier.clickEmailFirst();
-      await login.submit();
-      expect(await relier.isPro()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Because

- the PayPal functional tests continue to be brittle, reporting false negatives and disrupting the CI pipeline

## This pull request

- removes PayPal functional tests

## Issue that this pull request solves

Closes: # FXA-9180

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Alternative methods, monitoring & manual testing, exists to detect breakages with the PayPal interface
- A follow-up spike has been created to research alternative automated test methods (see [FXA-9186](https://mozilla-hub.atlassian.net/browse/FXA-9186))


[FXA-9186]: https://mozilla-hub.atlassian.net/browse/FXA-9186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ