### PR TITLE
fix(a11y): Improve accessibility of signup form

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/en.ftl
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/en.ftl
@@ -12,3 +12,9 @@ form-reset-password-with-balloon-confirm-password =
   .label = Re-enter password
 form-reset-password-with-balloon-submit-button = Reset password
 form-reset-password-with-balloon-match-error = Passwords do not match
+
+form-password-sr-too-short-message = Password must contain at least 8 characters.
+form-password-sr-not-email-message = Password must not contain your email address.
+form-password-sr-not-common-message = Password must not be a commonly used password.
+form-password-sr-requirements-met = The entered password respects all password requirements.
+form-password-sr-passwords-match = Entered passwords match.

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
@@ -3,35 +3,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { typeByTestIdFn } from '../../lib/test-utils';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import { Subject } from './mocks';
-import { SHOW_BALLOON_TIMEOUT, HIDE_BALLOON_TIMEOUT } from '../../constants';
-
-export const inputNewPassword = typeByTestIdFn('new-password-input-field');
-export const inputVerifyPassword = typeByTestIdFn(
-  'verify-password-input-field'
-);
+import { SHOW_BALLOON_TIMEOUT } from '../../constants';
+import { MOCK_PASSWORD } from '../../pages/mocks';
 
 describe('FormPasswordWithBalloons component', () => {
   let bundle: FluentBundle;
   beforeAll(async () => {
     bundle = await getFtlBundle('settings');
   });
-  it('renders as expected for the reset form type', () => {
+  it('renders as expected for the reset form type', async () => {
     renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
     testAllL10n(screen, bundle);
-    screen.getByLabelText('New password');
+
+    await waitFor(() => {
+      screen.getByLabelText('New password');
+    });
     screen.getByLabelText('Re-enter password');
     screen.getByRole('button', { name: 'Reset password' });
   });
 
-  it('renders as expected for the signup form type', () => {
+  it('renders as expected for the signup form type', async () => {
     renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
-    screen.getByLabelText('Password');
+
+    await waitFor(() => {
+      screen.getByLabelText('Password');
+    });
     screen.getByLabelText('Repeat password');
     screen.getByRole('button', { name: 'Create account' });
   });
@@ -40,22 +41,18 @@ describe('FormPasswordWithBalloons component', () => {
     renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
     const newPasswordField = screen.getByLabelText('New password');
 
-    act(() => {
-      fireEvent.focus(newPasswordField);
-    });
+    fireEvent.focus(newPasswordField);
 
-    await waitFor(() =>
-      expect(screen.getByText('Password requirements')).toBeVisible()
-    );
+    await waitFor(() => screen.getByText('Password requirements'));
   });
 
   it('does not display the PasswordInfoBalloon for the reset form type', async () => {
     renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
+    const passwordField = screen.getByLabelText('New password');
     const confirmPasswordField = screen.getByLabelText('Re-enter password');
 
-    act(() => {
-      fireEvent.focus(confirmPasswordField);
-    });
+    fireEvent.change(passwordField, { target: { value: MOCK_PASSWORD } });
+    fireEvent.focus(confirmPasswordField);
 
     await waitFor(() => {
       expect(
@@ -68,11 +65,11 @@ describe('FormPasswordWithBalloons component', () => {
 
   it('displays the PasswordInfoBalloon for the signup form type when the confirm password field is in focus', async () => {
     renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
+    const passwordField = screen.getByLabelText('Password');
     const confirmPasswordField = screen.getByLabelText('Repeat password');
 
-    act(() => {
-      fireEvent.focus(confirmPasswordField);
-    });
+    fireEvent.change(passwordField, { target: { value: MOCK_PASSWORD } });
+    fireEvent.focus(confirmPasswordField);
 
     await waitFor(
       () =>
@@ -82,20 +79,6 @@ describe('FormPasswordWithBalloons component', () => {
           )
         ).toBeVisible(),
       { timeout: SHOW_BALLOON_TIMEOUT + 200 }
-    );
-
-    act(() => {
-      fireEvent.blur(confirmPasswordField);
-    });
-
-    await waitFor(
-      () =>
-        expect(
-          screen.queryByText(
-            'You need this password to access any encrypted data you store with us.'
-          )
-        ).not.toBeInTheDocument(),
-      { timeout: HIDE_BALLOON_TIMEOUT + 200 }
     );
   });
 });

--- a/packages/fxa-settings/src/components/IconListItem/index.tsx
+++ b/packages/fxa-settings/src/components/IconListItem/index.tsx
@@ -25,14 +25,14 @@ export const IconListItem = ({
   return (
     <li className={`flex gap-2 items-start my-2 ${listItemClassnames}`}>
       <span
-        className="ltr:mr-1 rtl:ml-1 text-grey-400"
+        className="me-1 text-grey-400"
         aria-hidden="true"
         role="img"
         data-testid="list-item-icon"
       >
         {icon}
       </span>
-      <span className="flex flex-col gap-4 text-start text-sm">{children}</span>
+      <span className="flex flex-col gap-4">{children}</span>
     </li>
   );
 };

--- a/packages/fxa-settings/src/components/InputPassword/en.ftl
+++ b/packages/fxa-settings/src/components/InputPassword/en.ftl
@@ -1,7 +1,14 @@
 ## Input Password
 
+# Tooltip displayed on a password input visibility toggle. Expresses the toggle action, where clicking on the toggle will hide the password.
 input-password-hide = Hide password
+# Tooltip displayed on a password input visibility toggle. Expresses the toggle action, where clicking on the toggle will show the password.
 input-password-show = Show password
-input-password-hide-aria = Hide password from screen.
-input-password-show-aria = Show password as plain text. Your password will be visible on screen.
-
+# Message read by screen readers when focus is on a password input visibility toggle. Expresses current (visible) state of the textbox content.
+input-password-hide-aria-2 = Your password is currently visible on screen.
+# Message read by screen readers when focus is on a password input visibility toggle. Expresses current (hidden) state of the textbox content.
+input-password-show-aria-2 = Your password is currently hidden.
+# Message read by screen readers after clicking on a password input visibility toggle to show the password. Expresses the new (visible) state of the textbox content.
+input-password-sr-only-now-visible = Your password is now visible on screen.
+# Message read by screen readers after clicking on a password input visibility toggle to hide the password. Expresses the new (hidden) state of the textbox content.
+input-password-sr-only-now-hidden = Your password is now hidden.

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -106,7 +106,7 @@ export const InputText = ({
   return (
     <label
       className={classNames(
-        'flex items-center rounded transition-all duration-100 ease-in-out border relative outline-none',
+        'flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none',
         hasErrors || errorText ? 'border-red-700 shadow-input-red-focus' : '',
         !hasErrors && focused
           ? 'border-blue-400 shadow-input-blue-focus'
@@ -132,7 +132,7 @@ export const InputText = ({
         <input
           className={classNames(
             inputOnlyClassName,
-            'pb-1 pt-5 px-3 w-full font-body rounded',
+            'pb-1 pt-5 px-3 w-full font-body rounded text-start',
             focused ? 'outline-none border-none placeholder-grey-500' : '',
             disabled ? 'bg-grey-10 placeholder-transparent cursor-default' : ''
           )}
@@ -160,7 +160,7 @@ export const InputText = ({
       {errorText && (
         <Tooltip
           type="error"
-          anchorPosition="start"
+          anchorPosition={anchorPosition || 'start'}
           position={tooltipPosition}
           className="-mb-px"
           message={errorText}

--- a/packages/fxa-settings/src/components/PasswordInfoBalloon/index.tsx
+++ b/packages/fxa-settings/src/components/PasswordInfoBalloon/index.tsx
@@ -8,24 +8,30 @@ import { KeyIconListItem } from '../IconListItem';
 
 export const PasswordInfoBalloon = () => {
   return (
-    <ul className="input-balloon">
-      <KeyIconListItem>
-        <>
-          <FtlMsg id="password-info-balloon-why-password-info">
-            <p>
-              You need this password to access any encrypted data you store with
-              us.
-            </p>
-          </FtlMsg>
-          <FtlMsg id="password-info-balloon-reset-risk-info">
-            <p>
-              A reset means potentially losing data like passwords and
-              bookmarks.
-            </p>
-          </FtlMsg>
-        </>
-      </KeyIconListItem>
-    </ul>
+    <div
+      className="input-balloon"
+      id="password-info-balloon"
+      aria-live="polite"
+    >
+      <ul>
+        <KeyIconListItem>
+          <>
+            <FtlMsg id="password-info-balloon-why-password-info">
+              <p>
+                You need this password to access any encrypted data you store
+                with us.
+              </p>
+            </FtlMsg>
+            <FtlMsg id="password-info-balloon-reset-risk-info">
+              <p>
+                A reset means potentially losing data like passwords and
+                bookmarks.
+              </p>
+            </FtlMsg>
+          </>
+        </KeyIconListItem>
+      </ul>
+    </div>
   );
 };
 

--- a/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.test.tsx
+++ b/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.test.tsx
@@ -37,6 +37,7 @@ describe('PasswordStrengthBalloon component', () => {
       'https://support.mozilla.org/kb/password-strength'
     );
   });
+
   it('displays checkmark icon when password requirements are respected', () => {
     renderWithLocalizationProvider(
       <PasswordStrengthBalloon
@@ -47,26 +48,11 @@ describe('PasswordStrengthBalloon component', () => {
       />
     );
 
-    const passwordMinCharRequirement = screen.getByTestId(
-      'password-min-char-req'
-    );
-    const passwordNotEmailRequirement = screen.getByTestId(
-      'password-not-email-req'
-    );
-    const passwordNotCommonRequirement = screen.getByTestId(
-      'password-not-common-req'
-    );
+    const checkmarks = screen.queryAllByText('icon-check-blue-50.svg');
+    expect(checkmarks).toHaveLength(3);
 
-    expect(
-      within(passwordMinCharRequirement).getByTitle('Pass')
-    ).toBeInTheDocument();
-    expect(
-      within(passwordNotEmailRequirement).getByTitle('Pass')
-    ).toBeInTheDocument();
-    expect(
-      within(passwordNotCommonRequirement).getByTitle('Pass')
-    ).toBeInTheDocument();
-    expect(screen.queryByTitle('Fail')).not.toBeInTheDocument();
+    const warnings = screen.queryAllByText('icon-warning-red-50.svg');
+    expect(warnings).toHaveLength(0);
   });
 
   it('displays alert icon when password is too short', () => {
@@ -82,9 +68,8 @@ describe('PasswordStrengthBalloon component', () => {
     const passwordMinCharRequirement = screen.getByTestId(
       'password-min-char-req'
     );
-    expect(
-      within(passwordMinCharRequirement).getByTitle('Fail')
-    ).toBeInTheDocument();
+    const imageElement = within(passwordMinCharRequirement).getByRole('img');
+    expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
   });
 
   it('displays alert icon when password is the same as email', () => {
@@ -100,9 +85,8 @@ describe('PasswordStrengthBalloon component', () => {
     const passwordNotEmailRequirement = screen.getByTestId(
       'password-not-email-req'
     );
-    expect(
-      within(passwordNotEmailRequirement).getByTitle('Fail')
-    ).toBeInTheDocument();
+    const imageElement = within(passwordNotEmailRequirement).getByRole('img');
+    expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
   });
 
   it('displays alert icon when password is common', () => {
@@ -118,8 +102,7 @@ describe('PasswordStrengthBalloon component', () => {
     const passwordNotCommonRequirement = screen.getByTestId(
       'password-not-common-req'
     );
-    expect(
-      within(passwordNotCommonRequirement).getByTitle('Fail')
-    ).toBeInTheDocument();
+    const imageElement = within(passwordNotCommonRequirement).getByRole('img');
+    expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
   });
 });

--- a/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.tsx
+++ b/packages/fxa-settings/src/components/PasswordStrengthBalloon/index.tsx
@@ -17,11 +17,7 @@ export type PasswordStrengthBalloonProps = {
 };
 
 const ValidationIcon = ({ hasError }: { hasError: boolean }) => {
-  return hasError ? (
-    <AlertIcon role="img" title="Fail" />
-  ) : (
-    <BlueCheckIcon role="img" title="Pass" />
-  );
+  return hasError ? <AlertIcon role="img" /> : <BlueCheckIcon role="img" />;
 };
 
 export const PasswordStrengthBalloon = ({
@@ -31,7 +27,11 @@ export const PasswordStrengthBalloon = ({
   isCommon,
 }: PasswordStrengthBalloonProps) => {
   return (
-    <div className="input-balloon text-xs">
+    <div
+      className="input-balloon"
+      id="password-strength-balloon"
+      aria-live="polite"
+    >
       <FtlMsg id="password-strength-balloon-heading">
         <h2 className="mb-2">Password requirements</h2>
       </FtlMsg>

--- a/packages/fxa-settings/src/components/Tooltip/index.test.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.test.tsx
@@ -9,23 +9,16 @@ import Tooltip from '.';
 
 const tooltipText = 'This is a tooltip';
 
-it('renders as expected with children', () => {
-  renderWithLocalizationProvider(<Tooltip message={tooltipText} />);
-  expect(screen.getByTestId('tooltip')).toHaveTextContent(tooltipText);
-});
+describe('tooltip component', () => {
+  it('renders as expected with children', () => {
+    renderWithLocalizationProvider(<Tooltip message={tooltipText} />);
+    expect(screen.getByTestId('tooltip')).toHaveTextContent(tooltipText);
+  });
 
-it('can be passed classNames', () => {
-  renderWithLocalizationProvider(
-    <Tooltip className="my-custom-class" message={tooltipText} />
-  );
-  expect(screen.getByTestId('tooltip')).toHaveClass('my-custom-class');
-});
-
-it('has title present when passed message', () => {
-  renderWithLocalizationProvider(
-    <Tooltip className="my-custom-class" message={tooltipText} />
-  );
-  expect(screen.getByTestId('tooltip').getAttribute('title')).toEqual(
-    tooltipText
-  );
+  it('can be passed classNames', () => {
+    renderWithLocalizationProvider(
+      <Tooltip className="my-custom-class" message={tooltipText} />
+    );
+    expect(screen.getByTestId('tooltip')).toHaveClass('my-custom-class');
+  });
 });

--- a/packages/fxa-settings/src/components/Tooltip/index.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.tsx
@@ -47,7 +47,7 @@ export const Tooltip = ({
   return (
     <div
       data-testid={formatDataTestId('tooltip')}
-      title={message}
+      aria-live="polite"
       className={classNames(
         `z-50 absolute py-2 px-6 text-center text-white
          rounded text-xs font-header font-bold
@@ -59,12 +59,11 @@ export const Tooltip = ({
           'ltr:left-1/2 ltr:-translate-x-1/2 rtl:right-1/2 rtl:translate-x-1/2':
             anchorPosition === 'middle',
           'start-0': anchorPosition === 'start',
-          'end-0': anchorPosition === 'end',
+          'end-0 me-1': anchorPosition === 'end',
           'bottom-full': position === 'top',
-          'top-full': position === 'bottom',
+          'top-full mt-2': position === 'bottom',
         }
       )}
-      aria-live="polite"
     >
       <span
         className={classNames('absolute', caretClass(type, position), {

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -94,7 +94,9 @@ describe('Signup page', () => {
     renderWithLocalizationProvider(<Subject />);
 
     // testAllL10n(screen, bundle);
-    await screen.findByRole('heading', { name: 'Set your password' });
+    await waitFor(() =>
+      screen.getByRole('heading', { name: 'Set your password' })
+    );
     screen.getByRole('link', { name: 'Change email' });
     screen.getByLabelText('Password');
     screen.getByLabelText('Repeat password');
@@ -152,8 +154,11 @@ describe('Signup page', () => {
   it('allows users to show and hide password input', async () => {
     renderWithLocalizationProvider(<Subject />);
 
-    const newPasswordInput = await screen.findByLabelText('Password');
+    const newPasswordInput = screen.getByLabelText('Password');
 
+    await waitFor(() => {
+      expect(newPasswordInput).toHaveAttribute('type', 'password');
+    });
     expect(newPasswordInput).toHaveAttribute('type', 'password');
     fireEvent.click(screen.getByTestId('new-password-visibility-toggle'));
     expect(newPasswordInput).toHaveAttribute('type', 'text');
@@ -168,7 +173,7 @@ describe('Signup page', () => {
       />
     );
 
-    const infoBannerLink = await screen.findByRole('link', {
+    const infoBannerLink = screen.getByRole('link', {
       name: /Find out here/,
     });
     await waitFor(() => {
@@ -208,7 +213,7 @@ describe('Signup page', () => {
     );
 
     // Choose what to sync options should be displayed if integration is sync
-    await screen.findByText('Choose what to sync');
+    await waitFor(() => screen.getByText('Choose what to sync'));
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(8);
 
@@ -224,7 +229,7 @@ describe('Signup page', () => {
   it('renders and handles newsletters', async () => {
     renderWithLocalizationProvider(<Subject />);
 
-    await screen.findByText('Get more from Mozilla:');
+    await waitFor(() => screen.getByText('Get more from Mozilla:'));
 
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(3);
@@ -386,9 +391,12 @@ describe('Signup page', () => {
             );
             await fillOutForm();
             submit();
-            await screen.findByText(
-              'Email masks can’t be used to create an account.'
-            );
+
+            await waitFor(() => {
+              screen.getByText(
+                'Email masks can’t be used to create an account.'
+              );
+            });
           });
         }
       );
@@ -677,7 +685,9 @@ describe('Signup page', () => {
       await fillOutForm();
       submit();
 
-      await screen.findByText(AuthUiErrors.UNEXPECTED_ERROR.message);
+      await waitFor(() => {
+        screen.getByText(AuthUiErrors.UNEXPECTED_ERROR.message);
+      });
       expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.registration.success).not.toHaveBeenCalled();
     });
@@ -740,7 +750,7 @@ describe('Signup page', () => {
   });
 
   describe('handle input errors', () => {
-    it('checks coppa is empty', () => {
+    it('checks coppa is empty', async () => {
       renderWithLocalizationProvider(
         <Subject
           {...{
@@ -769,16 +779,16 @@ describe('Signup page', () => {
       fireEvent.blur(ageInput);
       createAccountButton.click();
 
-      expect(
-        screen.getByText('You must enter your age to sign up')
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        screen.getByText('You must enter your age to sign up');
+      });
       expect(createAccountButton).toBeDisabled();
 
       // TODO: Make sure only valid values are accepted:
       //  https://mozilla-hub.atlassian.net/browse/FXA-8654
     });
 
-    it('shows error for non matching passwords', () => {
+    it('shows error for non matching passwords', async () => {
       renderWithLocalizationProvider(
         <Subject
           {...{
@@ -797,7 +807,9 @@ describe('Signup page', () => {
         target: { value: 'bar12346' },
       });
       fireEvent.blur(screen.getByTestId('verify-password-input-field'));
-      expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+      await waitFor(() => {
+        screen.getByText('Passwords do not match');
+      });
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -173,6 +173,7 @@ export const Signup = ({
   };
 
   const onFocusAgeInput = () => {
+    setAgeCheckErrorText('');
     if (!hasAgeInputFocused) {
       GleanMetrics.registration.engage({ reason: 'age' });
       setHasAgeInputFocused(true);
@@ -447,14 +448,14 @@ export const Signup = ({
             onBlurCb={onBlurAgeInput}
             errorText={ageCheckErrorText}
             tooltipPosition="bottom"
-            anchorPosition="start"
+            anchorPosition="end"
             prefixDataTestId="age"
           />
         </FtlMsg>
         <FtlMsg id="signup-coppa-check-explanation-link">
           <LinkExternal
             href="https://www.ftc.gov/business-guidance/resources/childrens-online-privacy-protection-rule-not-just-kids-sites"
-            className="link-blue text-start text-sm mb-8"
+            className="link-blue text-start text-sm py-1 -mt-2 mb-4 self-start"
           >
             Why do we ask?
           </LinkExternal>


### PR DESCRIPTION
## Because

* The password requirements dialog was not announced by screen readers
* Show/hide password control was not available to keyboard-only users
* Tooltip errors were not read by screen readers

## This pull request

* Add screen reader only password input feedback (positive and negative) to supplement existing visual feedback
* Modifies password visibility toggle to make it accessible w/ keyboard
* Add aria-live and aria-describedby arguments to ensure tooltips are read by screen readers
* Update anchor position of error tooltips for `confirm password` and `age` inputs
* Update styling of age link to nor stretch to full width
* Update tests and fix state update warnings for Signup tests

## Issue that this pull request solves

Closes: #FXA-9004, FXA-9005, FXA-9006

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Error states:

![image](https://github.com/mozilla/fxa/assets/22231637/9bee44e5-542a-4682-aab6-4f5f3ea77df4)

## Other information (Optional)

Tested with VoiceOver on Mac with Safari and Firefox. Note: VoiceOver support is better for Safari than Firefox (some text is repeated multiple times in Firefox, but not in Safari)
Experienced some issues with password requirement balloon overlapping inputs (or being overlapped by password manager bubble...) on mobile, but there is already an issue filed to inline password requirements.

(Manual) Testing notes:
- Signup form should be navigable by keyboard only (incl. toggling visibility on/off)
- Screen reader: turn on screen reader (VoiceOver, JAWS, NVDA) and fill out signup form. Test with/without errors, toggling password visibility on/off. Information conveyed by the screen reader should be equivalent but not necessarily identical to that presented visually. E.g., with screen reader, error state is presented on blur vs on change.
