### PR TITLE
feat(react): Implement OAuth functionality for Signin flows

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -283,13 +283,6 @@ $(document).ready(function () {
     });
 
     $('button.prompt-none').click(function (ev) {
-      if (
-        !window.location.search.includes('login_hint=') &&
-        !navigator.userAgent.includes('FxATester')
-      ) {
-        alert('prompt=none requires a `login_hint` query parameter');
-        return;
-      }
       authenticate('prompt_none');
     });
 

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -260,7 +260,15 @@ Router = Router.extend({
     },
     'oauth(/)': createViewHandler(IndexView),
     'oauth/force_auth(/)': createViewHandler(ForceAuthView),
-    'oauth/signin(/)': createViewHandler(SignInPasswordView),
+    'oauth/signin(/)': function () {
+      this.createReactOrBackboneViewHandler('signin', SignInPasswordView, {
+        // see comment in fxa-settings/src/pages/Signin/container.tsx for param explanation
+        ...Url.searchParams(this.window.location.search),
+        email: this.user.get('emailFromIndex'),
+        hasLinkedAccount: this.user.get('hasLinkedAccount'),
+        hasPassword: this.user.get('hasPassword'),
+      });
+    },
     'oauth/signup(/)': function () {
       this.createReactOrBackboneViewHandler(
         'oauth/signup',
@@ -465,10 +473,22 @@ Router = Router.extend({
         SignInReportedView
       );
     },
-    'signin_token_code(/)': createViewHandler(SignInTokenCodeView, {
-      type: VerificationReasons.SIGN_IN,
-    }),
-    'signin_totp_code(/)': createViewHandler(SignInTotpCodeView),
+    'signin_token_code(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'signin_token_code',
+        SignInTokenCodeView,
+        null,
+        {
+          type: VerificationReasons.SIGN_IN,
+        }
+      );
+    },
+    'signin_totp_code(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'signin_totp_code',
+        SignInTotpCodeView
+      );
+    },
     'signin_unblock(/)': function () {
       this.createReactOrBackboneViewHandler(
         'signin_unblock',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -64,7 +64,9 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       featureFlagOn: showReactApp.signInRoutes,
       routes: reactRoute.getRoutes([
         'signin',
+        'oauth/signin',
         'signin_token_code',
+        'signin_totp_code',
         'signin_reported',
         'signin_confirmed',
         'signin_verified',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -620,7 +620,7 @@ describe('#integration - AccountResolver', () => {
         authClient.signUpWithAuthPW = jest
           .fn()
           .mockResolvedValue(mockRespPayload);
-        const result = await resolver.SignUp(headers, {
+        const result = await resolver.signUp(headers, {
           authPW: '00000000',
           email: 'testo@example.xyz',
           options: { service: 'testo-co', atLeast18AtReg: false },
@@ -649,7 +649,7 @@ describe('#integration - AccountResolver', () => {
         authClient.signUpWithAuthPW = jest
           .fn()
           .mockResolvedValue(mockRespPayload);
-        const result = await resolver.SignUp(headers, {
+        const result = await resolver.signUp(headers, {
           authPW: '00000000',
           email: 'testo@example.xyz',
           passwordV2: {

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -532,7 +532,7 @@ export class AccountResolver {
     description: 'Call auth-server to sign up an account',
   })
   @CatchGatewayError
-  public async SignUp(
+  public async signUp(
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => SignUpInput })
     input: SignUpInput

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -300,6 +300,10 @@ const AuthAndAccountSetupRoutes = ({
       {/* Signin */}
       <ReportSigninContainer path="/report_signin/*" />
       <SigninContainer path="/force_auth/*" {...{ integration, serviceName }} />
+      <SigninContainer
+        path="/oauth/signin/*"
+        {...{ integration, serviceName }}
+      />
       <SigninContainer path="/signin/*" {...{ integration, serviceName }} />
       <SigninBounced email={localAccount?.email} path="/signin_bounced/*" />
       <CompleteSigninContainer path="/complete_signin/*" />
@@ -314,7 +318,7 @@ const AuthAndAccountSetupRoutes = ({
       />
       <SigninTotpCodeContainer
         path="/signin_totp_code/*"
-        {...{ serviceName }}
+        {...{ integration, serviceName }}
       />
       <SigninConfirmed
         path="/signin_verified/*"

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.tsx
@@ -7,7 +7,6 @@ import HeaderLockup from '../HeaderLockup';
 import ContentSkip from '../ContentSkip';
 import Footer from 'fxa-react/components/Footer';
 import { AlertBar } from '../AlertBar';
-import { BrandMessagingPortal } from '../../BrandMessaging';
 
 type AppLayoutProps = {
   children: React.ReactNode;
@@ -21,7 +20,6 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
     >
       <ContentSkip />
       <div id="body-top" className="hidden mobileLandscape:block" />
-      <BrandMessagingPortal viewName="settings" />
       <HeaderLockup />
       <div className="max-w-screen-desktopXl flex-1 w-full mx-auto tablet:px-20 desktop:px-12">
         <main id="main" data-testid="main" className="w-full">

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
@@ -242,7 +242,7 @@ describe('lib/integrations/integration-factory', () => {
       it('has correct state', async () => {
         expect(integration.type).toEqual(IntegrationType.OAuth);
         expect(integration.isSync()).toBeTruthy();
-        expect(integration.wantsKeys()).toBeFalsy();
+        expect(integration.wantsKeys()).toBeTruthy();
         expect(integration.isTrusted()).toBeTruthy();
       });
     });

--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -136,8 +136,8 @@ function constructOAuthRedirectUrl(oauthCode: OAuthCode, redirectUri: string) {
 export type FinishOAuthFlowHandler = (
   accountUid: string,
   sessionToken: string,
-  keyFetchToken: string,
-  unwrapKB: string
+  keyFetchToken?: string,
+  unwrapKB?: string
 ) => Promise<{ redirect: string; code: string; state: string }>;
 
 type FinishOAuthFlowHandlerResult = {
@@ -150,7 +150,7 @@ type FinishOAuthFlowHandlerResult = {
  * @param accountUid - Current account uid
  * @param sessionToken - Current session token
  * @param keyFetchToken - Current key fetch token
- * @param unwrapKB - Used to unwrap the account keys
+ * @param unwrapBKey - Used to unwrap the account keys
  * @returns An object containing the redirect URL, that can relay the new OAuthCode.
  */
 export function useFinishOAuthFlowHandler(
@@ -160,12 +160,12 @@ export function useFinishOAuthFlowHandler(
   const isSyncOAuth = isSyncOAuthIntegration(integration);
 
   const finishOAuthFlowHandler: FinishOAuthFlowHandler = useCallback(
-    async (accountUid, sessionToken, keyFetchToken, unwrapKB) => {
+    async (accountUid, sessionToken, keyFetchToken, unwrapBKey) => {
       const oAuthIntegration = integration as OAuthIntegration;
 
       let keys;
-      if (integration.wantsKeys()) {
-        const { kB } = await authClient.accountKeys(keyFetchToken, unwrapKB);
+      if (integration.wantsKeys() && keyFetchToken && unwrapBKey) {
+        const { kB } = await authClient.accountKeys(keyFetchToken, unwrapBKey);
         keys = await constructKeysJwe(
           authClient,
           oAuthIntegration,

--- a/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
+++ b/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const t = (msg: string) => msg;
-
 export type AuthError = {
   errno: number;
   message: string;
@@ -11,40 +9,40 @@ export type AuthError = {
   interpolate?: boolean;
 };
 
-export const UNEXPECTED_ERROR = t('Unexpected error');
+export const UNEXPECTED_ERROR = 'Unexpected error';
 
 export const ERRORS: Record<string, AuthError> = {
   UNKNOWN_CLIENT: {
     errno: 101,
-    message: t('Unknown client'),
+    message: 'Unknown client',
   },
   INCORRECT_REDIRECT: {
     errno: 103,
-    message: t('Incorrect redirect_uri'),
+    message: 'Incorrect redirect_uri',
   },
   INVALID_ASSERTION: {
     errno: 104,
-    message: t('Invalid assertion'),
+    message: 'Invalid assertion',
   },
   UNKNOWN_CODE: {
     errno: 105,
-    message: t('Unknown code'),
+    message: 'Unknown code',
   },
   INCORRECT_CODE: {
     errno: 106,
-    message: t('Incorrect code'),
+    message: 'Incorrect code',
   },
   EXPIRED_CODE: {
     errno: 107,
-    message: t('Expired code'),
+    message: 'Expired code',
   },
   INVALID_TOKEN: {
     errno: 108,
-    message: t('Invalid token'),
+    message: 'Invalid token',
   },
   INVALID_PARAMETER: {
     errno: 109,
-    message: t('Invalid OAuth parameter: %(param)s'),
+    message: 'Invalid OAuth parameter: %(param)s',
   },
   INVALID_RESPONSE_TYPE: {
     errno: 110,
@@ -52,11 +50,11 @@ export const ERRORS: Record<string, AuthError> = {
   },
   UNAUTHORIZED: {
     errno: 111,
-    message: t('Unauthorized'),
+    message: 'Unauthorized',
   },
   FORBIDDEN: {
     errno: 112,
-    message: t('Forbidden'),
+    message: 'Forbidden',
   },
   INVALID_CONTENT_TYPE: {
     errno: 113,
@@ -69,7 +67,7 @@ export const ERRORS: Record<string, AuthError> = {
   },
   EXPIRED_TOKEN: {
     errno: 115,
-    message: t('Expired token'),
+    message: 'Expired token',
   },
   NOT_PUBLIC_CLIENT: {
     errno: 116,
@@ -97,15 +95,15 @@ export const ERRORS: Record<string, AuthError> = {
   },
   SERVER_UNAVAILABLE: {
     errno: 201,
-    message: t('System unavailable, try again soon'),
+    message: 'System unavailable, try again soon',
   },
   DISABLED_CLIENT_ID: {
     errno: 202,
-    message: t('System unavailable, try again soon'),
+    message: 'System unavailable, try again soon',
   },
   SERVICE_UNAVAILABLE: {
     errno: 998,
-    message: t('System unavailable, try again soon'),
+    message: 'System unavailable, try again soon',
   },
   UNEXPECTED_ERROR: {
     errno: 999,
@@ -113,7 +111,7 @@ export const ERRORS: Record<string, AuthError> = {
   },
   TRY_AGAIN: {
     errno: 1000,
-    message: t('Something went wrong. Please close this tab and try again.'),
+    message: 'Something went wrong. Please close this tab and try again.',
   },
   INVALID_RESULT: {
     errno: 1001,
@@ -132,11 +130,11 @@ export const ERRORS: Record<string, AuthError> = {
   */
   USER_CANCELED_OAUTH_LOGIN: {
     errno: 1004,
-    message: t('no message'),
+    message: 'no message',
   },
   MISSING_PARAMETER: {
     errno: 1005,
-    message: t('Missing OAuth parameter: %(param)s'),
+    message: 'Missing OAuth parameter: %(params)',
     response_error_code: 'invalid_request',
   },
   INVALID_PAIRING_CLIENT: {
@@ -160,22 +158,22 @@ export const ERRORS: Record<string, AuthError> = {
   },
   PROMPT_NONE_NOT_SIGNED_IN: {
     errno: 1010,
-    message: t('User is not signed in'),
+    message: 'User is not signed in',
     response_error_code: 'login_required',
   },
   PROMPT_NONE_DIFFERENT_USER_SIGNED_IN: {
     errno: 1011,
-    message: t('A different user is signed in'),
+    message: 'A different user is signed in',
     response_error_code: 'account_selection_required',
   },
   PROMPT_NONE_UNVERIFIED: {
     errno: 1012,
-    message: t('Unverified user or session'),
+    message: 'Unverified user or session',
     response_error_code: 'interaction_required',
   },
   PROMPT_NONE_INVALID_ID_TOKEN_HINT: {
     errno: 1013,
-    message: t('Invalid id_token_hint'),
+    message: 'Invalid id_token_hint',
     response_error_code: 'invalid_request',
   },
 };

--- a/packages/fxa-settings/src/models/integrations/base-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/base-integration.ts
@@ -142,6 +142,11 @@ export abstract class Integration<
   wantsKeys(): boolean {
     return false;
   }
+
+  wantsLogin(): boolean {
+    return false;
+  }
+
   wantsTwoStepAuthentication(): boolean {
     return false;
   }

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -283,6 +283,9 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
   }
 
   wantsKeys(): boolean {
+    if (this.isSync()) {
+      return true;
+    }
     if (!this.opts.scopedKeysEnabled) {
       return false;
     }

--- a/packages/fxa-settings/src/models/integrations/sync-desktop-v3-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/sync-desktop-v3-integration.ts
@@ -29,8 +29,4 @@ export class SyncDesktopV3Integration extends SyncBasicIntegration<SyncIntegrati
     super(data, IntegrationType.SyncDesktopV3);
     this.setFeatures({ allowUidChange: true });
   }
-
-  isSync() {
-    return true;
-  }
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -26,7 +26,6 @@ import { isEmailValid } from 'fxa-shared/email/helpers';
 import { setOriginalTabMarker } from '../../lib/storage-utils';
 import { ResetPasswordFormData, ResetPasswordProps } from './interfaces';
 import { ConfirmResetPasswordLocationState } from './ConfirmResetPassword/interfaces';
-import { BrandMessagingPortal } from '../../components/BrandMessaging';
 import GleanMetrics from '../../lib/glean';
 
 export const viewName = 'reset-password';
@@ -160,7 +159,6 @@ const ResetPassword = ({
 
   return (
     <AppLayout>
-      <BrandMessagingPortal {...{ viewName }} />
       <CardHeader
         headingWithDefaultServiceFtlId="reset-password-heading-w-default-service"
         headingWithCustomServiceFtlId="reset-password-heading-w-custom-service"

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
@@ -5,9 +5,8 @@
 import React from 'react';
 import SigninTokenCode from '.';
 import { Meta } from '@storybook/react';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { createMockWebIntegration } from './mocks';
+import { Subject } from './mocks';
 
 export default {
   title: 'Pages/Signin/SigninTokenCode',
@@ -15,9 +14,4 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
-  <SigninTokenCode
-    email={MOCK_ACCOUNT.primaryEmail.email}
-    integration={createMockWebIntegration()}
-  />
-);
+export const Default = () => <Subject />;

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
@@ -2,25 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import VerificationReasons from '../../../constants/verification-reasons';
 import { AccountTotp } from '../../../lib/interfaces';
-import { Integration } from '../../../models';
-
-export type SigninTokenCodeIntegration = Pick<Integration, 'type' | 'isSync'>;
+import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { SigninIntegration, SigninLocationState } from '../interfaces';
 
 export interface SigninTokenCodeProps {
-  email: string;
-  integration: SigninTokenCodeIntegration;
-  verificationReason?: VerificationReasons;
+  finishOAuthFlowHandler: FinishOAuthFlowHandler;
+  integration: SigninIntegration;
+  signinLocationState: SigninLocationState;
 }
 
-export interface TotpResponse {
+export interface TotpStatusResponse {
   account: {
     totp: AccountTotp;
   };
-}
-
-export interface SigninLocationState {
-  email?: string;
-  verificationReason?: VerificationReasons;
 }

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -3,34 +3,54 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { LocationProvider } from '@reach/router';
-import { IntegrationType } from '../../../models';
-import { SigninTokenCodeIntegration } from './interfaces';
+import { Integration, IntegrationType } from '../../../models';
+import { SigninTokenCodeProps } from './interfaces';
 import SigninTokenCode from '.';
-import { MOCK_EMAIL } from '../../mocks';
+import {
+  MOCK_EMAIL,
+  MOCK_SESSION_TOKEN,
+  MOCK_UID,
+  mockFinishOAuthFlowHandler,
+} from '../../mocks';
+import { MozServices } from '../../../lib/types';
 import VerificationReasons from '../../../constants/verification-reasons';
 
-export function createMockWebIntegration(): SigninTokenCodeIntegration {
+export function createMockWebIntegration() {
   return {
     type: IntegrationType.Web,
+    getService: () => MozServices.Default,
     isSync: () => false,
-  };
+    wantsKeys: () => false,
+  } as Integration;
 }
 
+export const createMockSigninLocationState = (
+  verificationReason?: VerificationReasons
+) => {
+  return {
+    email: MOCK_EMAIL,
+    uid: MOCK_UID,
+    sessionToken: MOCK_SESSION_TOKEN,
+    verified: false,
+    ...(verificationReason && { verificationReason }),
+  };
+};
+
 export const Subject = ({
+  finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   integration = createMockWebIntegration(),
-  verificationReason,
-}: {
-  integration?: SigninTokenCodeIntegration;
+  verificationReason = undefined,
+}: Partial<SigninTokenCodeProps> & {
   verificationReason?: VerificationReasons;
 }) => {
   return (
     <LocationProvider>
       <SigninTokenCode
         {...{
-          email: MOCK_EMAIL,
+          finishOAuthFlowHandler,
           integration,
-          verificationReason,
         }}
+        signinLocationState={createMockSigninLocationState(verificationReason)}
       />
     </LocationProvider>
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -10,6 +10,7 @@ import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { BeginSigninError } from '../interfaces';
+import { Subject } from './mocks';
 
 export default {
   title: 'Pages/Signin/SigninTotpCode',
@@ -18,20 +19,18 @@ export default {
 } as Meta;
 
 const storyWithProps = (props: {
-  handleNavigation: () => void;
   submitTotpCode: () => Promise<{ status: boolean; error?: BeginSigninError }>;
   serviceName: MozServices;
 }) => {
   const story = () => (
     <LocationProvider>
-      <SigninTotpCode {...props} />
+      <Subject {...props} />
     </LocationProvider>
   );
   return story;
 };
 
 export const Default = storyWithProps({
-  handleNavigation: () => {},
   submitTotpCode: async () => ({
     status: true,
   }),
@@ -39,7 +38,6 @@ export const Default = storyWithProps({
 });
 
 export const WithRelyingParty = storyWithProps({
-  handleNavigation: () => {},
   submitTotpCode: async () => ({
     status: true,
   }),
@@ -47,7 +45,6 @@ export const WithRelyingParty = storyWithProps({
 });
 
 export const WithIncorrectCode = storyWithProps({
-  handleNavigation: () => {},
   submitTotpCode: async () => ({
     status: false,
   }),
@@ -55,7 +52,6 @@ export const WithIncorrectCode = storyWithProps({
 });
 
 export const WithErrorState = storyWithProps({
-  handleNavigation: () => {},
   submitTotpCode: async () => ({
     status: false,
     error: AuthUiErrors.UNEXPECTED_ERROR as BeginSigninError,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LocationProvider } from '@reach/router';
+import { Integration, IntegrationType } from '../../../models';
+import { SigninTotpCode, SigninTotpCodeProps } from '.';
+import {
+  MOCK_EMAIL,
+  MOCK_SESSION_TOKEN,
+  MOCK_UID,
+  mockFinishOAuthFlowHandler,
+} from '../../mocks';
+import { MozServices } from '../../../lib/types';
+import VerificationMethods from '../../../constants/verification-methods';
+
+const mockWebIntegration = {
+  type: IntegrationType.Web,
+  getService: () => MozServices.Default,
+  isSync: () => false,
+  wantsKeys: () => false,
+} as Integration;
+
+export const MOCK_TOTP_LOCATION_STATE = {
+  email: MOCK_EMAIL,
+  uid: MOCK_UID,
+  sessionToken: MOCK_SESSION_TOKEN,
+  verified: false,
+  verificationMethod: VerificationMethods.TOTP_2FA,
+};
+
+export const MOCK_NON_TOTP_LOCATION_STATE = {
+  email: MOCK_EMAIL,
+  uid: MOCK_UID,
+  sessionToken: MOCK_SESSION_TOKEN,
+  verified: false,
+  verificationMethod: VerificationMethods.EMAIL_OTP,
+};
+
+export const mockOauthSigninLocationState = {};
+
+const mockSubmitTotpCode = async () => ({
+  status: true,
+});
+
+export const Subject = ({
+  finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
+  integration = mockWebIntegration,
+  serviceName = MozServices.Default,
+  signinLocationState = MOCK_TOTP_LOCATION_STATE,
+  submitTotpCode = mockSubmitTotpCode,
+}: Partial<SigninTotpCodeProps>) => {
+  return (
+    <LocationProvider>
+      <SigninTotpCode
+        {...{
+          finishOAuthFlowHandler,
+          integration,
+          serviceName,
+          signinLocationState,
+          submitTotpCode,
+        }}
+      />
+    </LocationProvider>
+  );
+};

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
@@ -12,9 +12,11 @@ import {
   MOCK_EMAIL,
   MOCK_SESSION_TOKEN,
   MOCK_UID,
+  mockFinishOAuthFlowHandler,
 } from '../../mocks';
 import VerificationMethods from '../../../constants/verification-methods';
 import VerificationReasons from '../../../constants/verification-reasons';
+import { createMockSigninWebIntegration } from '../mocks';
 
 export default {
   title: 'Pages/Signin/SigninUnblock',
@@ -49,6 +51,8 @@ export const Default = () => (
       email={MOCK_EMAIL}
       hasLinkedAccount={false}
       hasPassword={true}
+      finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+      integration={createMockSigninWebIntegration()}
       signinWithUnblockCode={mockSuccessResponse}
       resendUnblockCodeHandler={mockResendSuccessResponse}
     />
@@ -61,6 +65,8 @@ export const WithResendError = () => (
       email={MOCK_EMAIL}
       hasLinkedAccount={false}
       hasPassword={true}
+      finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+      integration={createMockSigninWebIntegration()}
       signinWithUnblockCode={mockSuccessResponse}
       resendUnblockCodeHandler={mockResendErrorResponse}
     />

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -9,10 +9,11 @@ import SigninUnblock, { viewName } from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { LocationProvider } from '@reach/router';
-import { MOCK_EMAIL } from '../../mocks';
+import { MOCK_EMAIL, mockFinishOAuthFlowHandler } from '../../mocks';
 import {
   createBeginSigninResponse,
   createBeginSigninResponseError,
+  createMockSigninWebIntegration,
 } from '../mocks';
 import GleanMetrics from '../../../lib/glean';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
@@ -49,6 +50,10 @@ const renderWithSuccess = () => {
     .fn()
     .mockReturnValue(createBeginSigninResponse());
   resendUnblockCodeHandler = jest.fn().mockReturnValue({ success: true });
+  const finishOAuthFlowHandler = jest
+    .fn()
+    .mockReturnValueOnce(mockFinishOAuthFlowHandler);
+  const integration = createMockSigninWebIntegration();
 
   renderWithLocalizationProvider(
     <LocationProvider>
@@ -57,6 +62,8 @@ const renderWithSuccess = () => {
           email,
           hasLinkedAccount,
           hasPassword,
+          integration,
+          finishOAuthFlowHandler,
           signinWithUnblockCode,
           resendUnblockCodeHandler,
         }}
@@ -73,6 +80,7 @@ const renderWithError = (errno = AuthUiErrors.UNEXPECTED_ERROR.errno) => {
     success: false,
     localizedErrorMessage: 'Something went wrong',
   });
+  const integration = createMockSigninWebIntegration();
 
   renderWithLocalizationProvider(
     <LocationProvider>
@@ -82,6 +90,8 @@ const renderWithError = (errno = AuthUiErrors.UNEXPECTED_ERROR.errno) => {
           hasLinkedAccount,
           hasPassword,
           signinWithUnblockCode,
+          integration,
+          finishOAuthFlowHandler: mockFinishOAuthFlowHandler,
           resendUnblockCodeHandler,
         }}
       />

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -30,8 +30,7 @@ import {
   StoredAccountData,
   storeAccountData,
 } from '../../../lib/storage-utils';
-import { NavigationOptions } from '../interfaces';
-import { getNavigationTarget } from '../utils';
+import { handleNavigation } from '../utils';
 import { ResendStatus } from '../../../lib/types';
 
 export const viewName = 'signin-unblock';
@@ -42,7 +41,8 @@ const SigninUnblock = ({
   hasPassword,
   signinWithUnblockCode,
   resendUnblockCodeHandler,
-  wantsTwoStepAuthentication = false,
+  integration,
+  finishOAuthFlowHandler,
 }: SigninUnblockProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -124,15 +124,16 @@ const SigninUnblock = ({
 
       storeAccountData(accountData);
 
-      const navigationOptions: NavigationOptions = {
-        verified: data.signIn.verified,
-        verificationMethod: data.signIn.verificationMethod,
-        verificationReason: data.signIn.verificationReason,
-        wantsTwoStepAuthentication,
+      const navigationOptions = {
+        email,
+        signinData: data.signIn,
+        unwrapBKey: data.unwrapBKey,
+        integration,
+        finishOAuthFlowHandler,
+        queryParams: location.search,
       };
 
-      const { to, state } = getNavigationTarget(navigationOptions);
-      state ? navigate(to, { state }) : navigate(to);
+      await handleNavigation(navigationOptions, navigate);
     }
     if (error) {
       const localizedErrorMessage = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { BeginSigninResult } from '../interfaces';
+import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { BeginSigninResult, SigninIntegration } from '../interfaces';
 
 export interface SigninUnblockLocationState {
   email: string;
@@ -17,7 +18,8 @@ export interface SigninUnblockProps {
   hasPassword: boolean;
   resendUnblockCodeHandler: ResendUnblockCodeHandler;
   signinWithUnblockCode: (code: string) => Promise<BeginSigninResult>;
-  wantsTwoStepAuthentication?: boolean;
+  finishOAuthFlowHandler: FinishOAuthFlowHandler;
+  integration: SigninIntegration;
 }
 
 export type BeginSigninWithUnblockCodeHandler = (

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -13,7 +13,7 @@ import * as CryptoModule from 'fxa-auth-client/lib/crypto';
 import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SigninContainer from './container';
-import { SigninContainerIntegration, SigninProps } from './interfaces';
+import { SigninProps } from './interfaces';
 import { MozServices } from '../../lib/types';
 import { screen, waitFor } from '@testing-library/react';
 import { ModelDataProvider } from '../../lib/model-data';
@@ -37,10 +37,11 @@ import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { GraphQLError } from 'graphql';
+import { Integration } from '../../models';
 
-let integration: SigninContainerIntegration;
+let integration: Integration;
 
-// TODO with Sync ticket
+// TODO: in FXA-9059 sync v3 desktop integration
 // function mockSyncDesktopV3Integration() {
 //   integration = {
 //     type: IntegrationType.SyncDesktopV3,
@@ -53,7 +54,8 @@ function mockWebIntegration() {
     type: IntegrationType.Web,
     getService: () => MozServices.Default,
     isSync: () => false,
-  };
+    wantsKeys: () => false,
+  } as Integration;
 }
 
 function applyDefaultMocks() {
@@ -427,6 +429,7 @@ describe('signin container', () => {
             authPW: MOCK_AUTH_PW,
             options: {
               verificationMethod: VerificationMethods.EMAIL_OTP,
+              keys: false,
             },
           },
         },
@@ -477,6 +480,7 @@ describe('signin container', () => {
               authPW: MOCK_AUTH_PW,
               options: {
                 verificationMethod: VerificationMethods.EMAIL_OTP,
+                keys: false,
               },
             },
           },

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -6,6 +6,7 @@ import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import { AuthUiError } from '../../lib/auth-errors/auth-errors';
 import { AccountAvatar } from '../../lib/interfaces';
+import { FinishOAuthFlowHandler } from '../../lib/oauth/hooks';
 import { MozServices } from '../../lib/types';
 import { Integration } from '../../models';
 
@@ -15,11 +16,18 @@ export interface AvatarResponse {
   };
 }
 
-export type SigninIntegration = Pick<Integration, 'type' | 'isSync'>;
+export type SigninIntegration =
+  | Pick<Integration, 'type' | 'isSync' | 'getService'>
+  | SigninOAuthIntegration;
 
-export type SigninContainerIntegration = Pick<
+export type SigninOAuthIntegration = Pick<
   Integration,
-  'type' | 'isSync' | 'getService'
+  | 'type'
+  | 'isSync'
+  | 'getService'
+  | 'wantsTwoStepAuthentication'
+  | 'wantsKeys'
+  | 'wantsLogin'
 >;
 
 export interface LocationState {
@@ -42,6 +50,7 @@ export interface SigninProps {
   avatarData: AvatarResponse | undefined;
   avatarLoading: boolean;
   localizedErrorFromLocationState?: string;
+  finishOAuthFlowHandler: FinishOAuthFlowHandler;
 }
 
 export type BeginSigninHandler = (
@@ -63,7 +72,10 @@ export interface BeginSigninResponse {
     verified: boolean;
     verificationMethod: VerificationMethods;
     verificationReason: VerificationReasons;
+    // keyFetchToken and unwrapBKey are included if options.keys=true
+    keyFetchToken?: hexstring;
   };
+  unwrapBKey?: hexstring;
 }
 
 export interface BeginSigninError {
@@ -89,6 +101,7 @@ export interface CachedSigninHandlerResponse {
   data?: {
     verificationMethod: VerificationMethods;
     verificationReason: VerificationReasons;
+    uid: hexstring;
   } & RecoveryEmailStatusResponse;
   error?: AuthUiError;
 }
@@ -141,10 +154,36 @@ export interface SendUnblockEmailHandlerResponse {
 }
 
 export interface NavigationOptions {
-  email?: string;
-  sessionVerified?: boolean;
-  verificationReason: VerificationReasons;
-  verificationMethod: VerificationMethods;
+  email: string;
+  signinData: {
+    uid: hexstring;
+    sessionToken: hexstring;
+    verified: boolean;
+    verificationMethod?: VerificationMethods;
+    verificationReason?: VerificationReasons;
+    // keyFetchToken and unwrapBKey are included if options.keys=true
+    // These will never exist for the cached signin (prompt=none)
+    keyFetchToken?: hexstring;
+  };
+  unwrapBKey?: hexstring;
+  integration: SigninIntegration;
+  finishOAuthFlowHandler: FinishOAuthFlowHandler;
+  redirectTo?: string;
+  queryParams: string;
+}
+
+export interface OAuthSigninResult {
+  to: string;
+  shouldHardNavigate: string;
+}
+
+export interface SigninLocationState {
+  email: string;
+  uid: hexstring;
+  sessionToken: hexstring;
   verified: boolean;
-  wantsTwoStepAuthentication?: boolean;
+  verificationMethod?: VerificationMethods;
+  verificationReason?: VerificationReasons;
+  keyFetchToken?: hexstring;
+  unwrapBKey?: hexstring;
 }

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -14,6 +14,9 @@ import {
   MOCK_SESSION_TOKEN,
   MOCK_UID,
   MOCK_AVATAR_NON_DEFAULT,
+  MOCK_UNWRAP_BKEY,
+  mockFinishOAuthFlowHandler,
+  MOCK_CLIENT_ID,
 } from '../mocks';
 import {
   BeginSigninError,
@@ -23,6 +26,7 @@ import {
   SendUnblockEmailHandler,
   SendUnblockEmailHandlerResponse,
   SigninIntegration,
+  SigninOAuthIntegration,
   SigninProps,
 } from './interfaces';
 import { LocationProvider } from '@reach/router';
@@ -42,6 +46,7 @@ export const MOCK_TOTP_STATUS_VERIFIED = {
     },
   },
 };
+
 export const MOCK_TOTP_STATUS = {
   account: {
     totp: {
@@ -51,17 +56,43 @@ export const MOCK_TOTP_STATUS = {
   },
 };
 
+export const MOCK_NO_TOTP = {
+  account: {
+    totp: {
+      exists: false,
+      verified: false,
+    },
+  },
+};
+
 export function createMockSigninWebIntegration(): SigninIntegration {
   return {
     type: IntegrationType.Web,
     isSync: () => false,
+    getService: () => MozServices.Default,
   };
 }
 
 export function createMockSigninSyncIntegration(): SigninIntegration {
   return {
-    type: IntegrationType.SyncDesktopV3,
+    type: IntegrationType.OAuth,
     isSync: () => true,
+    wantsKeys: () => true,
+    getService: () => MozServices.FirefoxSync,
+  };
+}
+
+export function createMockSigninOAuthIntegration(
+  clientId?: string,
+  wantsKeys: boolean = true
+): SigninOAuthIntegration {
+  return {
+    type: IntegrationType.OAuth,
+    getService: () => clientId || MOCK_CLIENT_ID,
+    isSync: () => false,
+    wantsKeys: () => wantsKeys,
+    wantsLogin: () => false,
+    wantsTwoStepAuthentication: () => false,
   };
 }
 
@@ -78,6 +109,7 @@ export function createBeginSigninResponse({
   verified = true,
   verificationMethod = MOCK_VERIFICATION.verificationMethod,
   verificationReason = MOCK_VERIFICATION.verificationReason,
+  keyFetchToken = undefined,
 }: Partial<BeginSigninResponse['signIn']> = {}): { data: BeginSigninResponse } {
   return {
     data: {
@@ -89,7 +121,9 @@ export function createBeginSigninResponse({
         verified,
         verificationMethod,
         verificationReason,
+        keyFetchToken,
       },
+      ...(keyFetchToken && { unwrapBKey: MOCK_UNWRAP_BKEY }),
     },
   };
 }
@@ -132,6 +166,7 @@ export const CACHED_SIGNIN_HANDLER_RESPONSE = {
     verified: true,
     sessionVerified: true,
     emailVerified: true,
+    uid: MOCK_UID,
     ...MOCK_VERIFICATION,
   },
 };
@@ -160,24 +195,28 @@ export const Subject = ({
   beginSigninHandler = mockBeginSigninHandler,
   cachedSigninHandler = mockCachedSigninHandler,
   sendUnblockEmailHandler = mockSendUnblockEmailHandler,
+  finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   ...props // overrides
-}: Partial<SigninProps> = {}) => (
-  <LocationProvider>
-    <Signin
-      {...{
-        integration,
-        email,
-        sessionToken,
-        serviceName,
-        hasLinkedAccount,
-        beginSigninHandler,
-        cachedSigninHandler,
-        sendUnblockEmailHandler,
-        hasPassword,
-        avatarData,
-        avatarLoading,
-        ...props,
-      }}
-    />
-  </LocationProvider>
-);
+}: Partial<SigninProps> = {}) => {
+  return (
+    <LocationProvider>
+      <Signin
+        {...{
+          integration,
+          email,
+          sessionToken,
+          serviceName,
+          hasLinkedAccount,
+          finishOAuthFlowHandler,
+          beginSigninHandler,
+          cachedSigninHandler,
+          sendUnblockEmailHandler,
+          hasPassword,
+          avatarData,
+          avatarLoading,
+          ...props,
+        }}
+      />
+    </LocationProvider>
+  );
+};

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -20,6 +20,9 @@ export type LocationState = {
   unwrapBKey?: string;
   offeredSyncEngines?: string[];
   declinedSyncEngines?: string[];
+  sessionToken?: hexstring;
+  email?: hexstring;
+  uid?: hexstring;
 };
 
 export type ConfirmSignupCodeContainerProps = {
@@ -28,9 +31,9 @@ export type ConfirmSignupCodeContainerProps = {
 } & RouteComponentProps;
 
 export type ConfirmSignupCodeProps = {
-  storedLocalAccount: StoredAccountData;
   email: string;
   sessionToken: hexstring;
+  uid: hexstring;
   integration: ConfirmSignupCodeIntegration;
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   newsletterSlugs?: string[];

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -12,6 +12,7 @@ import {
   MOCK_SESSION_TOKEN,
   MOCK_UID,
   MOCK_UNWRAP_BKEY,
+  mockFinishOAuthFlowHandler,
 } from '../../mocks';
 import {
   ConfirmSignupCodeBaseIntegration,
@@ -41,26 +42,19 @@ export const Subject = ({
   integration?: ConfirmSignupCodeIntegration;
   newsletterSlugs?: string[];
 }) => {
-  const storedLocalAccount = { uid: MOCK_UID };
   return (
     <LocationProvider>
       <ConfirmSignupCode
         {...{
-          storedLocalAccount,
-          email: MOCK_EMAIL,
-          sessionToken: MOCK_SESSION_TOKEN,
-          keyFetchToken: MOCK_KEY_FETCH_TOKEN,
-          unwrapBKey: MOCK_UNWRAP_BKEY,
-          newsletterSlugs,
           integration,
+          newsletterSlugs,
         }}
-        finishOAuthFlowHandler={() =>
-          Promise.resolve({
-            redirect: 'someUri',
-            code: 'someCode',
-            state: 'someState',
-          })
-        }
+        email={MOCK_EMAIL}
+        finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+        keyFetchToken={MOCK_KEY_FETCH_TOKEN}
+        sessionToken={MOCK_SESSION_TOKEN}
+        uid={MOCK_UID}
+        unwrapBKey={MOCK_UNWRAP_BKEY}
       />
     </LocationProvider>
   );

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -63,6 +63,7 @@ function mockIntegration() {
     type: IntegrationType.SyncDesktopV3,
     getService: () => MozServices.Default,
     isSync: () => true,
+    wantsKeys: () => true,
     features: {
       allowUidChange: false,
       fxaStatus: false,
@@ -146,7 +147,7 @@ function mockApolloClientModule() {
     return {
       data: {
         unwrapBKey: 'foo',
-        SignUp: {
+        signUp: {
           uid: 'uid123',
           keyFetchToken: 'kft123',
           sessionToken: 'st123',
@@ -413,9 +414,9 @@ describe('sign-up-container', () => {
         },
       });
       expect(handlerResult?.data?.unwrapBKey).toBeDefined();
-      expect(handlerResult?.data?.SignUp?.uid).toEqual('uid123');
-      expect(handlerResult?.data?.SignUp?.keyFetchToken).toEqual('kft123');
-      expect(handlerResult?.data?.SignUp?.sessionToken).toEqual('st123');
+      expect(handlerResult?.data?.signUp?.uid).toEqual('uid123');
+      expect(handlerResult?.data?.signUp?.keyFetchToken).toEqual('kft123');
+      expect(handlerResult?.data?.signUp?.sessionToken).toEqual('st123');
     });
 
     it('handles error fetching credentials', async () => {

--- a/packages/fxa-settings/src/pages/Signup/gql.ts
+++ b/packages/fxa-settings/src/pages/Signup/gql.ts
@@ -6,7 +6,7 @@ import { gql } from '@apollo/client';
 
 export const BEGIN_SIGNUP_MUTATION = gql`
   mutation SignUp($input: SignUpInput!) {
-    SignUp(input: $input) {
+    signUp(input: $input) {
       uid
       sessionToken
       authAt

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -504,9 +504,9 @@ describe('Signup page', () => {
         const commonFxaLoginOptions = {
           email: MOCK_EMAIL,
           keyFetchToken:
-            BEGIN_SIGNUP_HANDLER_RESPONSE.data.SignUp.keyFetchToken,
-          sessionToken: BEGIN_SIGNUP_HANDLER_RESPONSE.data.SignUp.sessionToken,
-          uid: BEGIN_SIGNUP_HANDLER_RESPONSE.data.SignUp.uid,
+            BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.keyFetchToken,
+          sessionToken: BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.sessionToken,
+          uid: BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.uid,
           unwrapBKey: BEGIN_SIGNUP_HANDLER_RESPONSE.data.unwrapBKey,
           verified: false,
         };

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -38,7 +38,6 @@ import AppLayout from '../../components/AppLayout';
 import { SignupFormData, SignupProps } from './interfaces';
 import { StoredAccountData, storeAccountData } from '../../lib/storage-utils';
 import GleanMetrics from '../../lib/glean';
-import { BrandMessagingPortal } from '../../components/BrandMessaging';
 import {
   isClientMonitor,
   isClientPocket,
@@ -233,9 +232,9 @@ export const Signup = ({
 
         const accountData: StoredAccountData = {
           email,
-          uid: data.SignUp.uid,
+          uid: data.signUp.uid,
           lastLogin: Date.now(),
-          sessionToken: data.SignUp.sessionToken,
+          sessionToken: data.signUp.sessionToken,
           verified: false,
           metricsEnabled: true,
         };
@@ -253,10 +252,11 @@ export const Signup = ({
         ) {
           await firefox.fxaLogin({
             email,
-            keyFetchToken: data.SignUp.keyFetchToken,
-            sessionToken: data.SignUp.sessionToken,
-            uid: data.SignUp.uid,
-            unwrapBKey: data.unwrapBKey,
+            // keyFetchToken and unwrapBKey should always exist if Sync integration
+            keyFetchToken: data.signUp.keyFetchToken!,
+            unwrapBKey: data.unwrapBKey!,
+            sessionToken: data.signUp.sessionToken,
+            uid: data.signUp.uid,
             verified: false,
             services: {
               sync: {
@@ -271,7 +271,7 @@ export const Signup = ({
           state: {
             origin: 'signup',
             selectedNewsletterSlugs,
-            keyFetchToken: data.SignUp.keyFetchToken,
+            keyFetchToken: data.signUp.keyFetchToken,
             unwrapBKey: data.unwrapBKey,
             // Sync desktop v3 sends a web channel message up on Signup
             // while OAuth Sync does on confirm signup
@@ -334,7 +334,6 @@ export const Signup = ({
     // TODO: FXA-8268, if force_auth && AuthErrors.is(error, 'DELETED_ACCOUNT'):
     //       - forceMessage('Account no longer exists. Recreate it?')
     <AppLayout>
-      <BrandMessagingPortal {...{ viewName }} />
       <CardHeader
         headingText="Set your password"
         headingTextFtlId="signup-heading"

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -11,12 +11,14 @@ import {
 import { SignupQueryParams } from '../../models/pages/signup';
 
 export interface BeginSignupResponse {
-  SignUp: {
+  signUp: {
     uid: string;
     sessionToken: hexstring;
     authAt: number;
-    keyFetchToken: hexstring;
+    // keyFetchToken and unwrapBKey are included if options.keys=true
+    keyFetchToken?: hexstring;
   };
+  unwrapBKey?: hexstring;
 }
 
 // full list @ fxa-auth-client/lib/client.ts, probably port over?
@@ -34,7 +36,7 @@ export type BeginSignupHandler = (
 ) => Promise<BeginSignupResult>;
 
 export interface BeginSignupResult {
-  data?: BeginSignupResponse & { unwrapBKey: hexstring };
+  data?: BeginSignupResponse;
   error?: HandledError;
 }
 

--- a/packages/fxa-settings/src/pages/Signup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/mocks.tsx
@@ -65,7 +65,7 @@ export function createMockSignupOAuthIntegration(
 
 export const BEGIN_SIGNUP_HANDLER_RESPONSE = {
   data: {
-    SignUp: {
+    signUp: {
       uid: MOCK_UID,
       sessionToken: MOCK_SESSION_TOKEN,
       authAt: MOCK_AUTH_AT,
@@ -77,7 +77,7 @@ export const BEGIN_SIGNUP_HANDLER_RESPONSE = {
 
 export const BEGIN_SIGNUP_HANDLER_RESPONSE_UNDER_18 = {
   data: {
-    SignUp: {
+    signUp: {
       uid: MOCK_UID,
       sessionToken: MOCK_SESSION_TOKEN,
       authAt: MOCK_AUTH_AT,

--- a/packages/fxa-settings/src/pages/mocks.ts
+++ b/packages/fxa-settings/src/pages/mocks.ts
@@ -32,3 +32,10 @@ export const MOCK_STORED_ACCOUNT = {
 };
 export const MOCK_AUTH_PW = 'apw123';
 export const MOCK_HEXSTRING_32 = '152e8ef9975a0f3356e062dfe09d3f23';
+export const MOCK_OAUTH_FLOW_HANDLER_RESPONSE = {
+  redirect: 'someUri',
+  code: 'someCode',
+  state: 'someState',
+};
+export const mockFinishOAuthFlowHandler = () =>
+  Promise.resolve(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);


### PR DESCRIPTION
## Because
* We're converting our legacy Backbone pages to React incrementally

## This pull request:
* Adds the 'oauth/signin' route
* Adds React views for 'signin_token_code' and 'signin_totp_code' to content-server router
* Includes some navigation utils shuffling and additions to accommodate the OAuth flow with our OAuth hook in signin flow components
* Tweaks OAuth integration.wantsKeys to return true if sync
* Makes 'keys' params in oauth hook optional, renames unwrapKB arg in oauth hook for consistency
* Removes 'login_hint' check from 123done prompt=none since it's no longer required
* Updates unit tests for Signup, Signin, ConfirmSignupCode, SigninTokenCode, SigninTotpCode
* Removes brand messaging portal from React pages
* Update TODOs with ticket numbers

## Issue that this pull request solves
closes FXA-6518

We will likely need a follow up issue for implementation on inline TOTP / recovery set up for after that lands (assigned to Barry).

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Manual testing suggestions:
- Test regular web flow (no auth) to verify still works as expected
- Test with OAuth (123done) and:
  - with/without cached login
  - with `forceGlobally` set to `true` to force verification with token/totp
  - with/without 2FA enabled for the account