### PR TITLE
feat(payments-paypal): Create PayPalManager getCheckoutToken

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -1,27 +1,31 @@
-import { PayPalManager } from './paypal.manager';
-import { Kysely } from 'kysely';
-import { DB, testAccountDatabaseSetup } from '@fxa/shared/db/mysql/account';
-import { PayPalClient } from './paypal.client';
 import { faker } from '@faker-js/faker';
+import { Kysely } from 'kysely';
+
+import { DB, testAccountDatabaseSetup } from '@fxa/shared/db/mysql/account';
+
+import { NVPSetExpressCheckoutResponseFactory } from './factories';
+import { PayPalClient } from './paypal.client';
+import { PayPalManager } from './paypal.manager';
 
 describe('paypalManager', () => {
-  let paypalManager: PayPalManager;
   let kyselyDb: Kysely<DB>;
+  let paypalClient: PayPalClient;
+  let paypalManager: PayPalManager;
 
   beforeAll(async () => {
     kyselyDb = await testAccountDatabaseSetup([
       'paypalCustomers',
       'accountCustomers',
     ]);
-    paypalManager = new PayPalManager(
-      kyselyDb,
-      new PayPalClient({
-        sandbox: false,
-        user: faker.string.uuid(),
-        pwd: faker.string.uuid(),
-        signature: faker.string.uuid(),
-      })
-    );
+
+    paypalClient = new PayPalClient({
+      sandbox: false,
+      user: faker.string.uuid(),
+      pwd: faker.string.uuid(),
+      signature: faker.string.uuid(),
+    });
+
+    paypalManager = new PayPalManager(kyselyDb, paypalClient);
   });
 
   afterAll(async () => {
@@ -32,5 +36,26 @@ describe('paypalManager', () => {
 
   it('instantiates class (TODO: remove me)', () => {
     expect(paypalManager).toBeTruthy();
+  });
+
+  describe('getCheckoutToken', () => {
+    it('returns token and calls setExpressCheckout with passed options', async () => {
+      const currencyCode = faker.finance.currencyCode();
+      const token = faker.string.uuid();
+      const successfulSetExpressCheckoutResponse =
+        NVPSetExpressCheckoutResponseFactory({
+          TOKEN: token,
+        });
+
+      paypalClient.setExpressCheckout = jest
+        .fn()
+        .mockResolvedValueOnce(successfulSetExpressCheckoutResponse);
+
+      const result = await paypalManager.getCheckoutToken(currencyCode);
+
+      expect(result).toEqual(successfulSetExpressCheckoutResponse.TOKEN);
+      expect(paypalClient.setExpressCheckout).toBeCalledTimes(1);
+      expect(paypalClient.setExpressCheckout).toBeCalledWith({ currencyCode });
+    });
   });
 });

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -3,10 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
-import { PayPalClient } from './paypal.client';
 import { AccountDatabase } from '@fxa/shared/db/mysql/account';
+import { PayPalClient } from './paypal.client';
 
 @Injectable()
 export class PayPalManager {
   constructor(private db: AccountDatabase, private client: PayPalClient) {}
+
+  /**
+   * Get a token authorizing transaction to move to the next stage.
+   *
+   * If the call to PayPal fails, a PayPalClientError will be thrown.
+   *
+   */
+  async getCheckoutToken(currencyCode: string) {
+    const response = await this.client.setExpressCheckout({ currencyCode });
+    return response.TOKEN;
+  }
 }


### PR DESCRIPTION
## This pull request

-  [x] creates PayPalManager getCheckoutToken
   - [x] Should take argument currencyCode (string)
   - [x] Should call the PayPalClient setExpressCheckout
   - [x] Should return the resulting token from setExpressCheckout

Ref: PayPalHelper getCheckoutToken

## Issue that this pull request solves

Closes: FXA-8932

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.