### PR TITLE
fix(a11y): Enable screen reading for banner messages

### DIFF
--- a/packages/functional-tests/pages/resetPasswordReact.ts
+++ b/packages/functional-tests/pages/resetPasswordReact.ts
@@ -92,7 +92,7 @@ export class ResetPasswordReactPage extends BaseLayout {
   }
 
   async resendSuccessMessageVisible(page: BaseLayout['page'] = this.page) {
-    await page.getByText(/Email resent/).waitFor();
+    await page.getByText(/Email re-sent/).waitFor();
   }
 
   async unknownAccountError(page: BaseLayout['page'] = this.page) {

--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -203,7 +203,7 @@ test.describe('severity-1 #smoke', () => {
       });
       await resendButton.waitFor();
       await resendButton.click();
-      await page.getByText(/Email resent/).waitFor();
+      await page.getByText(/Email re-sent/).waitFor();
     });
 
     test('open /reset_password page, enter unknown email, wait for error', async ({

--- a/packages/fxa-settings/src/components/Banner/en.ftl
+++ b/packages/fxa-settings/src/components/Banner/en.ftl
@@ -8,6 +8,6 @@ banner-dismiss-button =
 
 # This message is displayed in a success banner
 # $accountsEmail is the senderʼs email address (origin of the email containing a new link). (e.g. accounts@firefox.com)
-link-expired-resent-link-success-message = Email resent. Add { $accountsEmail } to your contacts to ensure a smooth delivery.
+link-expired-resent-link-success-message = Email re-sent. Add { $accountsEmail } to your contacts to ensure a smooth delivery.
 # Error message displayed in an error banner. This is a general message when the cause of the error is unclear.
 link-expired-resent-code-error-message = Something went wrong. A new code could not be sent.

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -60,6 +60,7 @@ const Banner = ({
         additionalClassNames
       )}
       onAnimationEnd={animation?.handleAnimationEnd}
+      role="status"
     >
       {dismissible ? (
         <>
@@ -93,7 +94,7 @@ export const ResendEmailSuccessBanner = ({
         id="link-expired-resent-link-success-message"
         vars={{ accountsEmail: FIREFOX_NOREPLY_EMAIL }}
       >
-        {`Email resent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a
+        {`Email re-sent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a
     smooth delivery.`}
       </FtlMsg>
     </Banner>

--- a/packages/fxa-settings/src/components/ConfirmWithLink/index.test.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/index.test.tsx
@@ -39,12 +39,12 @@ describe('ConfirmWithLink component', () => {
     });
     expect(
       screen.queryByText(
-        'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+        'Email re-sent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
       )
     ).not.toBeInTheDocument();
     fireEvent.click(resendEmailButton);
     screen.getByText(
-      'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+      'Email re-sent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
     );
   });
 

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.test.tsx
@@ -69,7 +69,7 @@ describe('LinkExpiredResetPassword', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          `Email resent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a smooth delivery.`
+          `Email re-sent. Add ${FIREFOX_NOREPLY_EMAIL} to your contacts to ensure a smooth delivery.`
         )
       ).toBeInTheDocument();
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -116,7 +116,7 @@ describe('SigninTokenCode page', () => {
     it('on success, renders banner', async () => {
       session = mockSession();
       await renderAndResend();
-      screen.getByText('Email resent.', { exact: false });
+      screen.getByText('Email re-sent.', { exact: false });
     });
     it('on throttled error, renders banner with throttled message', async () => {
       session = {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -236,7 +236,7 @@ describe('SigninUnblock', () => {
       resendButton.click();
       expect(resendUnblockCodeHandler).toHaveBeenCalled();
       await waitFor(() => {
-        expect(screen.getByText(/Email resent/)).toBeInTheDocument();
+        expect(screen.getByText(/Email re-sent/)).toBeInTheDocument();
       });
     });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -292,7 +292,7 @@ describe('Resending a new code from ConfirmSignupCode page', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          'Email resent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+          'Email re-sent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
         )
       ).toBeInTheDocument();
     });


### PR DESCRIPTION
## Because

* Messages in banner were not read by screen reader

## This pull request

* Add role "status" to banners
* Update English only text string to correct voice-over pronunciation (should not impact other locales)

## Issue that this pull request solves

Closes: #FXA-9007

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Testing:
- Create a new account
- Turn on VoiceOver (or other screen reader) on `Confirm signup code` page
- Click "Email new code" and expect the banner message to be read by the screen reader

Additional testing - all banner message on React pages (including error banners) should now be read
