### PR TITLE
bug: Supports connect another device on oauth_webchannal_v1

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -166,6 +166,10 @@ export default BaseAuthenticationBroker.extend({
     });
   },
 
+  onFxaStatus(response) {
+    return proto.onFxaStatus.call(this, response);
+  },
+
   getOAuthResult(account) {
     if (!account || !account.get('sessionToken')) {
       return Promise.reject(AuthErrors.toError('INVALID_TOKEN'));

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -159,7 +159,8 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
 
     if (!cwtsStatus) {
       // applications may choose to skip the CWTS screen
-      return this.set('chooseWhatToSyncWebV1Engines', null);
+      this.set('chooseWhatToSyncWebV1Engines', null);
+      return proto.onFxaStatus.call(this, response);
     }
 
     const supportedEngines =
@@ -170,7 +171,8 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
         engines: supportedEngines,
         window: this.window,
       });
-      return this.set('chooseWhatToSyncWebV1Engines', syncEngines);
+      this.set('chooseWhatToSyncWebV1Engines', syncEngines);
+      return proto.onFxaStatus.call(this, response);
     }
     return proto.onFxaStatus.call(this, response);
   },

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -105,7 +105,8 @@ export default {
     const isNotActionEmail = this.relier.get('action') !== 'email';
     if (
       this.isDefault() &&
-      context === Constants.FX_DESKTOP_V3_CONTEXT &&
+      (context === Constants.FX_DESKTOP_V3_CONTEXT ||
+        context === Constants.OAUTH_WEBCHANNEL_CONTEXT) &&
       (entrypoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT ||
         (isNotActionEmail &&
           [


### PR DESCRIPTION
## Because

- Firefox desktop is moving to oauth_webchannel_v1 and wants to support connecting another device on that context

## This pull request

- Ensures that the `supportsPairing` capability is set on the oauth_webchannel_v1 broker, this is done by propagating the call to `onFxAStatus` up to the base broker, which will set the capability based on if the relying party returned "pairing: true"
- considers the `oauth_webchannel_v1` context a valid context where pairing can occur.

## How to test
Enable oauth on firefox by changing the following two prefs:
- `identity.fxaccounts.oauth.enabled` to true
-  `identity.fxaccounts.contextParam` to be `oauth_webchannel_v1`

Then, on the toolbar accounts button, click "Connect another device" - you'll be taken to a page where once you click the button, the browser will be instructed to show the pairing screen

## Issue that this pull request solves

Closes: FXA-9192

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

