### PR TITLE
fix(auth): fallback to null locations rather than empty object

### DIFF
--- a/packages/fxa-auth-server/lib/geodb.js
+++ b/packages/fxa-auth-server/lib/geodb.js
@@ -71,7 +71,17 @@ module.exports = (log) => {
       };
     } catch (err) {
       log.trace('geodb.1', { err: err.message });
-      return {};
+      return {
+        location: {
+          city: null,
+          country: null,
+          countryCode: null,
+          state: null,
+          stateCode: null,
+          postalCode: null,
+        },
+        timeZone: null,
+      };
     }
   };
 };


### PR DESCRIPTION
## Because

- We are seeing errors when geodb throws an error, causing metrics to fail.

## This pull request

- Falls back to object with null properties (which is compatible with what fxa-geodb returns if it's unable to geolocate an IP address).

## Issue that this pull request solves

Closes: FXA-8571
