### PR TITLE
fix(capability): improve comparison logging

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -939,18 +939,17 @@ export class CapabilityService {
         return contentfulCapabilities;
       }
 
-      if (this.logToSentry('planIdsToClientCapabilities.NoMatch')) {
-        Sentry.withScope((scope) => {
-          scope.setContext('planIdsToClientCapabilities', {
-            contentful: contentfulCapabilities,
-            stripe: stripeCapabilities,
-          });
-          Sentry.captureMessage(
-            `CapabilityService.planIdsToClientCapabilities - Returned Stripe as plan ids to client capabilities did not match.`,
-            'error' as SeverityLevel
-          );
+      Sentry.withScope((scope) => {
+        scope.setContext('planIdsToClientCapabilities', {
+          subscribedPrices,
+          contentful: contentfulCapabilities,
+          stripe: stripeCapabilities,
         });
-      }
+        Sentry.captureMessage(
+          `CapabilityService.planIdsToClientCapabilities - Returned Stripe as plan ids to client capabilities did not match.`,
+          'error' as SeverityLevel
+        );
+      });
     } catch (error) {
       this.log.error('subscriptions.planIdsToClientCapabilities', {
         error: error,

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -1145,10 +1145,12 @@ describe('CapabilityService', () => {
         await assertExpectedCapabilities(clientId, expected[clientId]);
       }
 
-      sinon.assert.calledOnceWithExactly(
+      sinon.assert.callCount(sentryScope.setContext, 5);
+      sinon.assert.calledWithExactly(
         sentryScope.setContext,
         'planIdsToClientCapabilities',
         {
+          subscribedPrices: ['plan_123456', 'plan_876543', 'plan_PLAY'],
           contentful: {
             c1: ['capAlpha'],
             c4: ['capBeta', 'capDelta', 'capEpsilon'],
@@ -1164,7 +1166,8 @@ describe('CapabilityService', () => {
         }
       );
 
-      sinon.assert.calledOnceWithExactly(
+      sinon.assert.callCount(Sentry.captureMessage, 5);
+      sinon.assert.calledWithExactly(
         Sentry.captureMessage,
         `CapabilityService.planIdsToClientCapabilities - Returned Stripe as plan ids to client capabilities did not match.`,
         'error'


### PR DESCRIPTION
## Because

- To help identify mismatches in capability calculatation between Contentful and Stripe metadata, always log when there is a mismatches and include the subscribedPrices.

## This pull request

- Always logs when there is a mismatch in `planIdsToClientCapabilities`.
- Include subscribedPrices in the log.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).