### PR TITLE
fix(l10n): Fix l10n string in signin unblock

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/en.ftl
@@ -9,6 +9,6 @@ signin-unblock-submit-button = Continue
 # Shown when the user attempts to submit the form without including a code
 signin-unblock-code-required-error = Authorization code required
 signin-unblock-code-incorrect-length = Authorization code must contain 8 characters
-signin-unblock-code-incorrect-format = Authorization can only contain letters and/or numbers
+signin-unblock-code-incorrect-format-2 = Authorization code can only contain letters and/or numbers
 signin-unblock-resend-code-button = Not in inbox or spam folder? Resend
 signin-unblock-support-link = Why is this happening?

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -151,7 +151,7 @@ describe('SigninUnblock', () => {
       submitButton.click();
       await waitFor(() => {
         expect(screen.getByTestId('tooltip')).toHaveTextContent(
-          'Authorization can only contain letters and/or numbers'
+          'Authorization code can only contain letters and/or numbers'
         );
       });
       expect(GleanMetrics.login.submit).not.toHaveBeenCalled();

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -89,8 +89,8 @@ const SigninUnblock = ({
     }
     if (!isValidCodeFormat(unblockCode)) {
       return ftlMsgResolver.getMsg(
-        'signin-unblock-code-incorrect-format',
-        'Authorization can only contain letters and/or numbers'
+        'signin-unblock-code-incorrect-format-2',
+        'Authorization code can only contain letters and/or numbers'
       );
     }
     return;


### PR DESCRIPTION
## Because

* There is a word missing in an error message string

## This pull request

* Add missing word and replace l10n string

## Issue that this pull request solves

Issue #FXA-9030

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
