### PR TITLE
fix(functional-tests): Mark failing smoke tests as fixme

### DIFF
--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -155,6 +155,7 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('unverified', async ({ target, page, pages: { login } }) => {
+      test.fixme(true, 'FXA-9226');
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });


### PR DESCRIPTION
## Because

* Two Playwright tests are regularly failing in smoke tests but passing locally
* Tickets were created to fix these two tests
* Cleanup function on react-conversion/signup was causing even skipped tests to fail

## This pull request

* Mark the tests as fixme so they will be skipped until fixed
* Update the cleanup function for react-conversion/signup so it will only attempt account destroy if an account has in fact been created

## This pull request relates to...

Issues 9096, 9226

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Failures on recent smoke tests:
https://app.circleci.com/pipelines/github/mozilla/fxa/48195/workflows/bff7e946-9985-402a-8bd3-05f539a7d35e
https://app.circleci.com/pipelines/github/mozilla/fxa/48139/workflows/4deda324-c579-4b64-9e18-206aae6b7625/jobs/486946
