### PR TITLE
task(fxa-settings): Add test coverage for key stretching v2 to signin container tests

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/mocks.tsx
@@ -20,11 +20,13 @@ import AccountRecoveryConfirmKey from '.';
 import { MOCK_SERVICE } from '../../mocks';
 import { AccountRecoveryConfirmKeyBaseIntegration } from './interfaces';
 
+// Extend base mocks
+export * from '../../mocks';
+
 export const MOCK_SERVICE_NAME = MozServices.FirefoxSync;
 export const MOCK_RECOVERY_KEY = 'ARJDF300TFEPRJ7SFYB8QVNVYT60WWS2';
 export const MOCK_RESET_TOKEN = 'mockResetToken';
 export const MOCK_RECOVERY_KEY_ID = 'mockRecoveryKeyId';
-export const MOCK_KB = 'mockkB';
 
 // TODO: combine a lot of mocks with AccountRecoveryResetPassword
 const fxDesktopV3ContextParam = { context: 'fx_desktop_v3' };

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -3,13 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as UseValidateModule from '../../lib/hooks/useValidate';
-import * as ApolloModule from '@apollo/client';
 import * as SigninModule from './index';
 import * as ModelsModule from '../../models';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import * as CacheModule from '../../lib/cache';
 import * as CryptoModule from 'fxa-auth-client/lib/crypto';
+import * as SentryModule from '@sentry/browser';
 
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
 import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SigninContainer from './container';
@@ -17,9 +19,9 @@ import { SigninProps } from './interfaces';
 import { MozServices } from '../../lib/types';
 import { screen, waitFor } from '@testing-library/react';
 import { ModelDataProvider } from '../../lib/model-data';
+import { IntegrationType } from '../../models';
 import {
   MOCK_STORED_ACCOUNT,
-  MOCK_AVATAR_DEFAULT,
   MOCK_EMAIL,
   MOCK_PASSWORD,
   MOCK_AUTH_PW,
@@ -27,16 +29,27 @@ import {
   MOCK_SESSION_TOKEN,
   MOCK_AUTH_AT,
   MOCK_UNWRAP_BKEY,
-} from '../mocks';
-import { IntegrationType } from '../../models';
-import { ApolloClient } from '@apollo/client';
-import { MOCK_VERIFICATION, createBeginSigninResponse } from './mocks';
+  MOCK_CLIENT_SALT,
+  MOCK_AUTH_PW_V2,
+  MOCK_WRAP_KB,
+  MOCK_WRAP_KB_V2,
+  MOCK_UNWRAP_BKEY_V2,
+  MOCK_VERIFICATION,
+  MOCK_KB,
+  mockBeginSigninMutationWithV2Password,
+  mockGqlAvatarUseQuery,
+  mockGqlBeginSigninMutation,
+  mockGqlCredentialStatusMutation,
+  mockGqlError,
+  mockGqlGetAccountKeysMutation,
+  mockGqlPasswordChangeFinishMutation,
+  mockGqlPasswordChangeStartMutation,
+} from './mocks';
 import firefox from '../../lib/channels/firefox';
 import AuthClient from 'fxa-auth-client/browser';
 import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
-import { GraphQLError } from 'graphql';
 import { Integration } from '../../models';
 
 let integration: Integration;
@@ -49,6 +62,7 @@ let integration: Integration;
 //     isSync: () => true,
 //   };
 // }
+
 function mockWebIntegration() {
   integration = {
     type: IntegrationType.Web,
@@ -64,7 +78,6 @@ function applyDefaultMocks() {
 
   mockReactUtilsModule();
   mockWebIntegration();
-  mockApolloClientModule();
   mockLocationState = {};
 
   mockSigninModule();
@@ -72,6 +85,7 @@ function applyDefaultMocks() {
   mockUseValidateModule({ queryParams: MOCK_QUERY_PARAM_MODEL_NO_VALUES });
   mockCurrentAccount();
   mockCryptoModule();
+  mockSentryModule();
 }
 
 jest.mock('../../models', () => {
@@ -166,37 +180,6 @@ jest.mock('@reach/router', () => {
   };
 });
 
-let mockBeginSigninMutation = jest.fn();
-let mockAvatarQuery = jest.fn();
-function mockApolloClientModule() {
-  mockBeginSigninMutation.mockImplementation(async () =>
-    createBeginSigninResponse()
-  );
-
-  jest.spyOn(ApolloModule, 'useMutation').mockReturnValue([
-    async (...args: any[]) => {
-      return mockBeginSigninMutation(...args);
-    },
-    {
-      loading: false,
-      called: true,
-      client: {} as ApolloClient<any>,
-      reset: () => {},
-    },
-  ]);
-  mockAvatarUseQuery();
-}
-
-function mockAvatarUseQuery() {
-  mockAvatarQuery.mockImplementation(() => {
-    return {
-      data: MOCK_AVATAR_DEFAULT,
-    };
-  });
-
-  jest.spyOn(ApolloModule, 'useQuery').mockReturnValue(mockAvatarQuery());
-}
-
 let currentSigninProps: SigninProps | undefined;
 function mockSigninModule() {
   currentSigninProps = undefined;
@@ -214,23 +197,54 @@ function mockReactUtilsModule() {
     .mockImplementation(() => {});
 }
 
+let mockGetCredentials: jest.SpyInstance;
+let mockGetCredentialsV2: jest.SpyInstance;
+let mockGetKeysV2: jest.SpyInstance;
+let mockUnwrapKB: jest.SpyInstance;
 function mockCryptoModule() {
-  jest.spyOn(CryptoModule, 'getCredentials').mockResolvedValue({
-    authPW: MOCK_AUTH_PW,
-    unwrapBKey: MOCK_UNWRAP_BKEY, // needed for type
+  mockGetCredentials = jest
+    .spyOn(CryptoModule, 'getCredentials')
+    .mockResolvedValue({
+      authPW: MOCK_AUTH_PW,
+      unwrapBKey: MOCK_UNWRAP_BKEY, // needed for type
+    });
+  mockGetCredentialsV2 = jest
+    .spyOn(CryptoModule, 'getCredentialsV2')
+    .mockResolvedValue({
+      clientSalt: MOCK_CLIENT_SALT,
+      authPW: MOCK_AUTH_PW_V2,
+      unwrapBKey: MOCK_UNWRAP_BKEY_V2,
+    });
+  mockGetKeysV2 = jest.spyOn(CryptoModule, 'getKeysV2').mockResolvedValue({
+    kB: MOCK_KB,
+    wrapKb: MOCK_WRAP_KB,
+    wrapKbVersion2: MOCK_WRAP_KB_V2,
   });
+  mockUnwrapKB = jest
+    .spyOn(CryptoModule, 'unwrapKB')
+    .mockImplementation(() => MOCK_KB);
 }
 
-function render() {
+let mockSentryCaptureMessage: jest.SpyInstance;
+function mockSentryModule() {
+  mockSentryCaptureMessage = jest.spyOn(SentryModule, 'captureMessage');
+}
+
+function render(mocks: Array<MockedResponse>) {
+  loadDevMessages();
+  loadErrorMessages();
+
   renderWithLocalizationProvider(
-    <LocationProvider>
-      <SigninContainer
-        {...{
-          integration,
-          serviceName: MozServices.Default,
-        }}
-      />
-    </LocationProvider>
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <LocationProvider>
+        <SigninContainer
+          {...{
+            integration,
+            serviceName: MozServices.Default,
+          }}
+        />
+      </LocationProvider>
+    </MockedProvider>
   );
 }
 
@@ -243,7 +257,7 @@ describe('signin container', () => {
     describe('email', () => {
       it('can be set from query param', async () => {
         mockUseValidateModule();
-        render();
+        render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).not.toBeCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
@@ -253,7 +267,7 @@ describe('signin container', () => {
       it('query param state takes precedence over router state', async () => {
         mockUseValidateModule();
         mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
-        render();
+        render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).not.toBeCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
@@ -262,7 +276,7 @@ describe('signin container', () => {
       });
       it('can be set from router state', async () => {
         mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
-        render();
+        render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
           expect(CacheModule.currentAccount).not.toBeCalled();
         });
@@ -271,7 +285,7 @@ describe('signin container', () => {
       });
       it('is read from localStorage if email is not provided via query param or router state', async () => {
         mockCurrentAccount(MOCK_STORED_ACCOUNT);
-        render();
+        render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).toBeCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_STORED_ACCOUNT.email);
@@ -279,7 +293,7 @@ describe('signin container', () => {
         expect(SigninModule.default).toBeCalled();
       });
       it('is handled if not provided in query params, location state, or local storage', async () => {
-        render();
+        render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).toBeCalled();
         expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
         expect(SigninModule.default).not.toBeCalled();
@@ -295,7 +309,7 @@ describe('signin container', () => {
             isV2: () => false,
           },
         });
-        render();
+        render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
           screen.getByLabelText('Loading…');
           expect(SigninModule.default).not.toBeCalled();
@@ -307,7 +321,7 @@ describe('signin container', () => {
           email: MOCK_ROUTER_STATE_EMAIL,
           hasLinkedAccount: false,
         };
-        render();
+        render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
           screen.getByLabelText('Loading…');
           expect(SigninModule.default).not.toBeCalled();
@@ -325,7 +339,7 @@ describe('signin container', () => {
           isV2: () => false,
         },
       });
-      render();
+      render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockAuthClient.accountStatusByEmail).toBeCalledWith(
           MOCK_QUERY_PARAM_EMAIL,
@@ -335,7 +349,7 @@ describe('signin container', () => {
     });
     it('accountStatusByEmail is called, email provided by local storage', async () => {
       mockCurrentAccount(MOCK_STORED_ACCOUNT);
-      render();
+      render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockAuthClient.accountStatusByEmail).toBeCalledWith(
           MOCK_STORED_ACCOUNT.email,
@@ -348,7 +362,7 @@ describe('signin container', () => {
         email: MOCK_ROUTER_STATE_EMAIL,
         hasPassword: true,
       };
-      render();
+      render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockAuthClient.accountStatusByEmail).toBeCalledWith(
           MOCK_ROUTER_STATE_EMAIL,
@@ -364,7 +378,7 @@ describe('signin container', () => {
         .fn()
         .mockResolvedValue({ exists: false });
 
-      render();
+      render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith(
           `/signup?email=${MOCK_QUERY_PARAM_EMAIL}&emailStatusChecked=true`
@@ -386,7 +400,7 @@ describe('signin container', () => {
       //   });
       // });
       it('are not sent for non-sync', () => {
-        render();
+        render([mockGqlAvatarUseQuery()]);
         expect(fxaLoginSpy).not.toBeCalled();
       });
     });
@@ -395,14 +409,14 @@ describe('signin container', () => {
   describe('hasLinkedAccount and hasPassword are provided', () => {
     it('accountStatusByEmail is not called, email provided by query params', async () => {
       mockUseValidateModule();
-      render();
+      render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockAuthClient.accountStatusByEmail).not.toHaveBeenCalled();
       });
     });
     it('accountStatusByEmail is not called, email provided by location state', async () => {
       mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
-      render();
+      render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockAuthClient.accountStatusByEmail).not.toHaveBeenCalled();
       });
@@ -415,25 +429,17 @@ describe('signin container', () => {
     });
 
     it('runs handler and invokes sign in mutation', async () => {
-      render();
+      render([
+        mockGqlAvatarUseQuery(),
+        mockGqlBeginSigninMutation({ keys: false }),
+      ]);
 
       expect(currentSigninProps).toBeDefined();
       const handlerResult = await currentSigninProps?.beginSigninHandler(
         MOCK_EMAIL,
         MOCK_PASSWORD
       );
-      expect(mockBeginSigninMutation).toBeCalledWith({
-        variables: {
-          input: {
-            email: MOCK_EMAIL,
-            authPW: MOCK_AUTH_PW,
-            options: {
-              verificationMethod: VerificationMethods.EMAIL_OTP,
-              keys: false,
-            },
-          },
-        },
-      });
+
       // these come from createBeginSigninResponse
       expect(handlerResult?.data?.signIn?.uid).toEqual(MOCK_UID);
       expect(handlerResult?.data?.signIn?.sessionToken).toEqual(
@@ -449,47 +455,230 @@ describe('signin container', () => {
         MOCK_VERIFICATION.verificationReason
       );
     });
-    it('handles gql mutation error', async () => {
-      mockBeginSigninMutation.mockImplementation(async () => {
-        const gqlError = new GraphQLError(
-          AuthUiErrors.INCORRECT_PASSWORD.message
-        );
-        const error: GraphQLError = Object.assign(gqlError, {
-          extensions: {
-            ...(gqlError.extensions || {}),
-            ...MOCK_VERIFICATION,
-            errno: AuthUiErrors.INCORRECT_PASSWORD.errno,
-          },
-        });
-        throw new ApolloModule.ApolloError({
-          graphQLErrors: [error],
-        });
-      });
 
-      await render();
+    it('handles gql mutation error', async () => {
+      await render([
+        mockGqlAvatarUseQuery(),
+        {
+          ...mockGqlBeginSigninMutation({ keys: false }),
+          error: mockGqlError(AuthUiErrors.INCORRECT_PASSWORD),
+        },
+      ]);
+
       await waitFor(async () => {
-        const result = await currentSigninProps?.beginSigninHandler(
+        const handlerResult = await currentSigninProps?.beginSigninHandler(
           MOCK_EMAIL,
           MOCK_PASSWORD
         );
 
-        expect(mockBeginSigninMutation).toBeCalledWith({
-          variables: {
-            input: {
-              email: MOCK_EMAIL,
-              authPW: MOCK_AUTH_PW,
-              options: {
-                verificationMethod: VerificationMethods.EMAIL_OTP,
-                keys: false,
-              },
-            },
-          },
-        });
-
-        expect(result?.data).toBeUndefined();
-        expect(result?.error?.message).toEqual(
+        expect(handlerResult?.data).toBeUndefined();
+        expect(handlerResult?.error?.message).toEqual(
           AuthUiErrors.INCORRECT_PASSWORD.message
         );
+      });
+    });
+
+    describe('v2 key stretching', () => {
+      beforeEach(() => {
+        mockUseValidateModule({
+          queryParams: {
+            ...MOCK_QUERY_PARAM_MODEL,
+            isV2: () => true,
+          },
+        });
+      });
+
+      it('runs handler and uses existing V2 credentials', async () => {
+        render([
+          mockGqlAvatarUseQuery(),
+          (() => {
+            const mock = mockGqlCredentialStatusMutation();
+            mock.result.data.credentialStatus.upgradeNeeded = false;
+            return mock;
+          })(),
+          mockBeginSigninMutationWithV2Password(),
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+
+          expect(handlerResult?.data?.signIn?.sessionToken).toEqual(
+            MOCK_SESSION_TOKEN
+          );
+        });
+      });
+
+      it('runs handler and upgrades to new V2 credentials', async () => {
+        render([
+          mockGqlAvatarUseQuery(),
+          mockGqlCredentialStatusMutation(),
+          mockGqlPasswordChangeStartMutation(),
+          mockGqlGetAccountKeysMutation(),
+          mockGqlPasswordChangeFinishMutation(),
+          mockBeginSigninMutationWithV2Password(),
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+
+          expect(handlerResult?.data?.signIn?.sessionToken).toEqual(
+            MOCK_SESSION_TOKEN
+          );
+          expect(mockGetCredentials).toBeCalledWith(MOCK_EMAIL, MOCK_PASSWORD);
+          expect(mockGetCredentialsV2).toBeCalledWith({
+            password: MOCK_PASSWORD,
+            clientSalt: MOCK_CLIENT_SALT,
+          });
+          expect(mockGetKeysV2).toBeCalledWith({
+            kB: await CryptoModule.unwrapKB(MOCK_WRAP_KB, MOCK_UNWRAP_BKEY),
+            v1: {
+              authPW: MOCK_AUTH_PW,
+              unwrapBKey: MOCK_UNWRAP_BKEY,
+            },
+            v2: {
+              authPW: MOCK_AUTH_PW_V2,
+              unwrapBKey: MOCK_UNWRAP_BKEY_V2,
+              clientSalt: MOCK_CLIENT_SALT,
+            },
+          });
+          expect(mockUnwrapKB).toBeCalledWith(MOCK_WRAP_KB, MOCK_UNWRAP_BKEY);
+        });
+      });
+
+      it('handles error fetching credentials status', async () => {
+        render([
+          mockGqlAvatarUseQuery(),
+          {
+            ...mockGqlCredentialStatusMutation(),
+            error: mockGqlError(),
+          },
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+
+          expect(handlerResult?.error).toBeDefined();
+          expect(handlerResult?.data?.signIn).toBeUndefined();
+          expect(mockSentryCaptureMessage).toBeCalledWith(
+            'Failure to finish v2 upgrade. Could not fetch credential status.'
+          );
+        });
+      });
+
+      it('handles error when starting upgrade', async () => {
+        render([
+          mockGqlAvatarUseQuery(),
+          mockGqlCredentialStatusMutation(),
+          {
+            ...mockGqlPasswordChangeStartMutation(),
+            error: mockGqlError(),
+          },
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+
+          expect(handlerResult?.error).toBeDefined();
+          expect(handlerResult?.data?.signIn).toBeUndefined();
+          expect(mockSentryCaptureMessage).toBeCalledWith(
+            'Failure to finish v2 upgrade. Could not start password change.'
+          );
+        });
+      });
+
+      it('handles error when fetching keys', async () => {
+        render([
+          mockGqlAvatarUseQuery(),
+          mockGqlCredentialStatusMutation(),
+          mockGqlPasswordChangeStartMutation(),
+          {
+            ...mockGqlGetAccountKeysMutation(),
+            error: mockGqlError(),
+          },
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+
+          expect(handlerResult?.error?.message).toEqual(mockGqlError().message);
+          expect(handlerResult?.data?.signIn).toBeUndefined();
+          expect(mockSentryCaptureMessage).toBeCalledTimes(1);
+          expect(mockSentryCaptureMessage).toBeCalledWith(
+            'Failure to finish v2 upgrade. Could not get wrapped keys.'
+          );
+        });
+      });
+
+      it('handles error when finishing password upgrade', async () => {
+        render([
+          mockGqlAvatarUseQuery(),
+          mockGqlCredentialStatusMutation(),
+          mockGqlPasswordChangeStartMutation(),
+          mockGqlGetAccountKeysMutation(),
+          {
+            ...mockGqlPasswordChangeFinishMutation(),
+            error: mockGqlError(),
+          },
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+
+          expect(handlerResult?.error?.message).toEqual(mockGqlError().message);
+          expect(handlerResult?.data?.signIn).toBeUndefined();
+          expect(mockSentryCaptureMessage).toBeCalledTimes(1);
+          expect(mockSentryCaptureMessage).toBeCalledWith(
+            'Failure to finish v2 upgrade. Could not finish password change.'
+          );
+        });
+      });
+
+      it('handles unverified accounts', async () => {
+        // Note, we cannot automatically upgrade unverified accounts, because the
+        // reset password mechanism won't work in this case, so we want to fallback
+        // to using V1 credentials in this scenario.
+        render([
+          mockGqlAvatarUseQuery(),
+          mockGqlCredentialStatusMutation(),
+          mockGqlPasswordChangeStartMutation(),
+          {
+            ...mockGqlGetAccountKeysMutation(),
+            error: mockGqlError(AuthUiErrors.UNVERIFIED_ACCOUNT),
+          },
+          mockGqlPasswordChangeFinishMutation(),
+          // Fallback to the V1 signin!
+          mockGqlBeginSigninMutation({ keys: false }),
+        ]);
+
+        await waitFor(async () => {
+          const handlerResult = await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+          expect(handlerResult?.error).toBeUndefined();
+          expect(mockSentryCaptureMessage).toBeCalledTimes(0);
+          expect(handlerResult?.data?.signIn?.sessionToken).toEqual(
+            MOCK_SESSION_TOKEN
+          );
+        });
       });
     });
   });
@@ -498,29 +687,37 @@ describe('signin container', () => {
     beforeEach(() => {
       mockCurrentAccount(MOCK_STORED_ACCOUNT);
     });
+
     it('runs handler, calls accountProfile and recoveryEmailStatus', async () => {
-      render();
+      render([mockGqlAvatarUseQuery()]);
 
       await waitFor(async () => {
         expect(currentSigninProps).toBeDefined();
       });
-      const handlerResult = await currentSigninProps?.cachedSigninHandler(
-        MOCK_SESSION_TOKEN
-      );
-      expect(mockAuthClient.accountProfile).toBeCalledWith(MOCK_SESSION_TOKEN);
-      expect(mockAuthClient.recoveryEmailStatus).toBeCalledWith(
-        MOCK_SESSION_TOKEN
-      );
-      expect(handlerResult?.data?.verificationMethod).toEqual(
-        VerificationMethods.EMAIL_OTP
-      );
-      expect(handlerResult?.data?.verificationReason).toEqual(
-        VerificationReasons.SIGN_IN
-      );
-      expect(handlerResult?.data?.verified).toEqual(true);
-      expect(handlerResult?.data?.sessionVerified).toEqual(true);
-      expect(handlerResult?.data?.emailVerified).toEqual(true);
+
+      await waitFor(async () => {
+        const handlerResult = await currentSigninProps?.cachedSigninHandler(
+          MOCK_SESSION_TOKEN
+        );
+
+        expect(mockAuthClient.accountProfile).toBeCalledWith(
+          MOCK_SESSION_TOKEN
+        );
+        expect(mockAuthClient.recoveryEmailStatus).toBeCalledWith(
+          MOCK_SESSION_TOKEN
+        );
+        expect(handlerResult?.data?.verificationMethod).toEqual(
+          VerificationMethods.EMAIL_OTP
+        );
+        expect(handlerResult?.data?.verificationReason).toEqual(
+          VerificationReasons.SIGN_IN
+        );
+        expect(handlerResult?.data?.verified).toEqual(true);
+        expect(handlerResult?.data?.sessionVerified).toEqual(true);
+        expect(handlerResult?.data?.emailVerified).toEqual(true);
+      });
     });
+
     it('returns TOTP_2FA verification method and SIGN_UP verification reason when expected', async () => {
       mockAuthClient.accountProfile = jest.fn().mockResolvedValue({
         authenticationMethods: ['pwd', 'email', 'otp'],
@@ -531,11 +728,13 @@ describe('signin container', () => {
         emailVerified: false,
       });
 
-      render();
+      render([mockGqlAvatarUseQuery()]);
+
       await waitFor(async () => {
         const handlerResult = await currentSigninProps?.cachedSigninHandler(
           MOCK_SESSION_TOKEN
         );
+
         expect(handlerResult?.data?.verificationMethod).toEqual(
           VerificationMethods.TOTP_2FA
         );
@@ -550,7 +749,7 @@ describe('signin container', () => {
       mockAuthClient.accountProfile = jest
         .fn()
         .mockRejectedValue(AuthUiErrors.INVALID_TOKEN);
-      render();
+      render([mockGqlAvatarUseQuery()]);
 
       await waitFor(async () => {
         const handlerResult = await currentSigninProps?.cachedSigninHandler(
@@ -566,16 +765,18 @@ describe('signin container', () => {
         );
       });
     });
+
     it('handles other errors', async () => {
       mockAuthClient.recoveryEmailStatus = jest
         .fn()
         .mockRejectedValue(AuthUiErrors.UNEXPECTED_ERROR);
-      render();
+      render([mockGqlAvatarUseQuery()]);
 
       await waitFor(async () => {
         const handlerResult = await currentSigninProps?.cachedSigninHandler(
           MOCK_SESSION_TOKEN
         );
+
         expect(CacheModule.discardSessionToken).not.toHaveBeenCalled();
         expect(handlerResult?.data).toBeUndefined();
         expect(handlerResult?.error).toEqual(AuthUiErrors.UNEXPECTED_ERROR);

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -314,6 +314,7 @@ describe('Signin', () => {
                     verified: false,
                     verificationReason: VerificationReasons.SIGN_UP,
                     keyFetchToken: MOCK_KEY_FETCH_TOKEN,
+                    unwrapBKey: MOCK_UNWRAP_BKEY,
                   })
                 );
                 const finishOAuthFlowHandler = jest

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -72,7 +72,6 @@ export interface BeginSigninResponse {
     verified: boolean;
     verificationMethod: VerificationMethods;
     verificationReason: VerificationReasons;
-    // keyFetchToken and unwrapBKey are included if options.keys=true
     keyFetchToken?: hexstring;
   };
   unwrapBKey?: hexstring;

--- a/packages/fxa-settings/src/pages/mocks.ts
+++ b/packages/fxa-settings/src/pages/mocks.ts
@@ -11,8 +11,11 @@ export const MOCK_REDIRECT_URI = 'http://localhost:8080/123Done';
 export const MOCK_CLIENT_ID = '123';
 export const MOCK_SERVICE = MozServices.TestService;
 export const MOCK_SESSION_TOKEN = 'sessionToken';
-export const MOCK_UNWRAP_BKEY = 'unwrapBKey';
+export const MOCK_UNWRAP_BKEY = '10000000000000000123456789abcdef';
+export const MOCK_KA = '10000000000000000123456789abcdef';
+export const MOCK_KB = '10000000000000000123456789abcdef';
 export const MOCK_KEY_FETCH_TOKEN = 'keyFetchToken';
+export const MOCK_KEY_FETCH_TOKEN_2 = 'keyFetchToken2';
 export const MOCK_RESET_TOKEN = 'mockResetToken';
 export const MOCK_AUTH_AT = 12345;
 export const MOCK_PASSWORD = 'notYourAveragePassW0Rd';
@@ -31,7 +34,6 @@ export const MOCK_STORED_ACCOUNT = {
   verified: false,
 };
 export const MOCK_AUTH_PW = 'apw123';
-export const MOCK_HEXSTRING_32 = '152e8ef9975a0f3356e062dfe09d3f23';
 export const MOCK_OAUTH_FLOW_HANDLER_RESPONSE = {
   redirect: 'someUri',
   code: 'someCode',
@@ -39,3 +41,13 @@ export const MOCK_OAUTH_FLOW_HANDLER_RESPONSE = {
 };
 export const mockFinishOAuthFlowHandler = () =>
   Promise.resolve(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+export const MOCK_WRAP_KB = '0123456789abcdef0123456789abcdef';
+export const MOCK_HEXSTRING_32 = '0123456789abcdef0123456789abcdef';
+
+export const MOCK_CLIENT_SALT =
+  'identity.mozilla.com/picl/v1/quickStretchV2:0123456789abcdef0123456789abcdef';
+
+export const MOCK_UNWRAP_BKEY_V2 = '20000000000000000123456789abcdef';
+export const MOCK_WRAP_KB_V2 = '20000000000000000123456789abcdef';
+export const MOCK_AUTH_PW_V2 = 'apw234';
+export const MOCK_PASSWORD_CHANGE_TOKEN = '123456789abcdef0';


### PR DESCRIPTION
## Because

- We want test coverage for automatically upgrading to a V2 password
- We want test coverage for signing in with a V2 password

## This pull request

- Adds tests for auto upgrading to a V2 password
- Adds tests for signing with a V2 password
- Adds tests for possible error states when upgrading a password
- Adds option to report apollo errors directly in test output
- Cleans up apollo test client warnings & errors
- Switches to using apollo client's mock provider.
  - This was necessary due to the number of gql calls made in these tests
  
## Issue that this pull request solves

Closes: FXA-9158

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
