### PR TITLE
feat(react): add inline totp setup

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -233,8 +233,18 @@ Router = Router.extend({
         ...Url.searchParams(this.window.location.search),
       });
     },
-    'inline_totp_setup(/)': createViewHandler(InlineTotpSetupView),
-    'inline_recovery_setup(/)': createViewHandler(InlineRecoverySetupView),
+    'inline_totp_setup(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'inline_totp_setup',
+        InlineTotpSetupView
+      );
+    },
+    'inline_recovery_setup(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'inline_recovery_setup',
+        InlineRecoverySetupView
+      );
+    },
     'legal(/)': function () {
       this.createReactViewHandler('legal');
     },

--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -5,6 +5,7 @@
 // Shared implementation of `signIn` view method
 
 import AuthErrors from '../../lib/auth-errors';
+import GeneralizedReactAppExperimentMixin from '../../lib/generalized-react-app-experiment-mixin';
 import GleanMetrics from '../../lib/glean';
 import OAuthErrors from '../../lib/oauth-errors';
 import NavigateBehavior from '../behaviors/navigate';
@@ -14,7 +15,11 @@ import VerificationReasons from '../../lib/verification-reasons';
 import PushLoginExperiment from './push-login-experiment-mixin';
 
 export default {
-  dependsOn: [ResumeTokenMixin, PushLoginExperiment],
+  dependsOn: [
+    GeneralizedReactAppExperimentMixin,
+    ResumeTokenMixin,
+    PushLoginExperiment,
+  ],
 
   /**
    * Sign in a user
@@ -132,6 +137,14 @@ export default {
           AuthErrors.is(err, 'INSUFFICIENT_ACR_VALUES') ||
           OAuthErrors.is(err, 'MISMATCH_ACR_VALUES')
         ) {
+          if (
+            this.isInReactExperiment() &&
+            this.config?.showReactApp?.inlineTotpRoutes
+          ) {
+            return this.window.location.assign(
+              `/inline_totp_setup${this.window.location.search}`
+            );
+          }
           return this.navigate('inline_totp_setup', {
             account: account,
             onSubmitComplete: this.onSignInSuccess.bind(this),

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
@@ -89,6 +89,8 @@ describe('views/mixins/signin-mixin', function () {
         unsafeDisplayError: sinon.spy(),
         user: user,
         isInPushLoginExperiment: sinon.spy(),
+
+        isInReactExperiment: () => false,
       };
     });
 

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -81,6 +81,7 @@ const settingsConfig = {
   showReactApp: {
     signUpRoutes: config.get('showReactApp.signUpRoutes'),
     signInRoutes: config.get('showReactApp.signInRoutes'),
+    inlineTotpRoutes: config.get('showReactApp.inlineTotpRoutes'),
   },
   rolloutRates: {
     keyStretchV2: config.get('rolloutRates.keyStretchV2'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -288,6 +288,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'REACT_CONVERSION_WEB_CHANNEL_EXAMPLE_ROUTES',
     },
+    inlineTotpRoutes: {
+      default: false,
+      doc: 'Enable users to visit the "inline" 2fa setup routes',
+      format: Boolean,
+      env: 'REACT_CONVERSION_INLINE_TOTP_ROUTES',
+    },
   },
   brandMessagingMode: {
     default: 'none',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -124,6 +124,15 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       routes: reactRoute.getRoutes(['web_channel_example']),
       fullProdRollout: false,
     },
+
+    inlineTotpRoutes: {
+      featureFlagOn: showReactApp.inlineTotpRoutes,
+      routes: reactRoute.getRoutes([
+        'inline_totp_setup',
+        'inline_recovery_setup',
+      ]),
+      fullProdRollout: false,
+    },
   };
 };
 

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -57,6 +57,7 @@ type ShowReactApp = {
   postVerifyCADViaQRRoutes: boolean;
   postVerifyThirdPartyAuthRoutes: boolean;
   webChannelExampleRoutes: boolean;
+  inlineTotpRoutes: boolean;
 };
 
 export interface ReactRouteGroups {

--- a/packages/fxa-content-server/tests/server/routes/react-app.js
+++ b/packages/fxa-content-server/tests/server/routes/react-app.js
@@ -40,6 +40,7 @@ const showReactAppAll = {
   pairRoutes: true,
   postVerifyOtherRoutes: true,
   postVerifyCADViaQRRoutes: true,
+  inlineTotpRoutes: true,
 };
 
 function getEmptyClientReactRouteGroups(showReactApp = showReactAppAll) {

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -9,7 +9,7 @@ import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { AuthClientService } from '../backend/auth-client.service';
 import { SessionResolver } from './session.resolver';
 
-describe('AccountResolver', () => {
+describe('SessionResolver', () => {
   let resolver: SessionResolver;
   let logger: any;
   let authClient: any;

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import {
   RouteComponentProps,
   Router,
   useLocation,
   useNavigate,
 } from '@reach/router';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 
 import { QueryParams } from '../..';
 
@@ -21,14 +21,15 @@ import { LinkType, MozServices } from '../../lib/types';
 import {
   Integration,
   isWebIntegration,
+  OAuthIntegration,
   useConfig,
   useInitialMetricsQueryState,
   useIntegration,
   useLocalSignedInQueryState,
 } from '../../models';
 import {
-  SettingsContext,
   initializeSettingsContext,
+  SettingsContext,
 } from '../../models/contexts/SettingsContext';
 import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
 
@@ -37,39 +38,41 @@ import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import sentryMetrics from 'fxa-shared/sentry/browser';
 
 // Components
-import { ScrollToTop } from '../Settings/ScrollToTop';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { ScrollToTop } from '../Settings/ScrollToTop';
 
 // Pages
-import AccountRecoveryConfirmKey from '../../pages/ResetPassword/AccountRecoveryConfirmKey';
-import AccountRecoveryResetPasswordContainer from '../../pages/ResetPassword/AccountRecoveryResetPassword/container';
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
 import Clear from '../../pages/Clear';
 import CookiesDisabled from '../../pages/CookiesDisabled';
-import CompleteResetPasswordContainer from '../../pages/ResetPassword/CompleteResetPassword/container';
-import CompleteSigninContainer from '../../pages/Signin/CompleteSignin/container';
-import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
-import ConfirmSignupCodeContainer from '../../pages/Signup/ConfirmSignupCode/container';
+import InlineRecoverySetupContainer from '../../pages/InlineRecoverySetup/container';
+import InlineTotpSetupContainer from '../../pages/InlineTotpSetup/container';
 import Legal from '../../pages/Legal';
-import LegalTerms from '../../pages/Legal/Terms';
 import LegalPrivacy from '../../pages/Legal/Privacy';
-import LinkValidator from '../LinkValidator';
-import PrimaryEmailVerified from '../../pages/Signup/PrimaryEmailVerified';
-import ReportSigninContainer from '../../pages/Signin/ReportSignin/container';
+import LegalTerms from '../../pages/Legal/Terms';
+import ThirdPartyAuthCallback from '../../pages/PostVerify/ThirdPartyAuthCallback';
 import ResetPassword from '../../pages/ResetPassword';
+import AccountRecoveryConfirmKey from '../../pages/ResetPassword/AccountRecoveryConfirmKey';
+import AccountRecoveryResetPasswordContainer from '../../pages/ResetPassword/AccountRecoveryResetPassword/container';
+import CompleteResetPasswordContainer from '../../pages/ResetPassword/CompleteResetPassword/container';
+import ConfirmResetPassword from '../../pages/ResetPassword/ConfirmResetPassword';
 import ResetPasswordConfirmed from '../../pages/ResetPassword/ResetPasswordConfirmed';
 import ResetPasswordWithRecoveryKeyVerified from '../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified';
+import CompleteSigninContainer from '../../pages/Signin/CompleteSignin/container';
+import SigninContainer from '../../pages/Signin/container';
+import ReportSigninContainer from '../../pages/Signin/ReportSignin/container';
 import SigninBounced from '../../pages/Signin/SigninBounced';
 import SigninConfirmed from '../../pages/Signin/SigninConfirmed';
-import SigninContainer from '../../pages/Signin/container';
 import SigninReported from '../../pages/Signin/SigninReported';
 import SigninTokenCodeContainer from '../../pages/Signin/SigninTokenCode/container';
 import SigninTotpCodeContainer from '../../pages/Signin/SigninTotpCode/container';
 import SigninUnblockContainer from '../../pages/Signin/SigninUnblock/container';
-import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
+import ConfirmSignupCodeContainer from '../../pages/Signup/ConfirmSignupCode/container';
 import SignupContainer from '../../pages/Signup/container';
-import ThirdPartyAuthCallback from '../../pages/PostVerify/ThirdPartyAuthCallback';
+import PrimaryEmailVerified from '../../pages/Signup/PrimaryEmailVerified';
+import SignupConfirmed from '../../pages/Signup/SignupConfirmed';
 import WebChannelExample from '../../pages/WebChannelExample';
+import LinkValidator from '../LinkValidator';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -347,6 +350,17 @@ const AuthAndAccountSetupRoutes = ({
       />
       <SignupConfirmed
         path="/signup_verified/*"
+        {...{ isSignedIn, serviceName }}
+      />
+
+      <InlineTotpSetupContainer
+        path="/inline_totp_setup/*"
+        integration={integration as OAuthIntegration}
+        {...{ isSignedIn, serviceName }}
+      />
+      <InlineRecoverySetupContainer
+        path="/inline_recovery_setup/*"
+        integration={integration as OAuthIntegration}
         {...{ isSignedIn, serviceName }}
       />
     </Router>

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
@@ -1,0 +1,255 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as ApolloClientModule from '@apollo/client';
+import * as InlineRecoverySetupModule from './index';
+
+import { ApolloClient } from '@apollo/client';
+import { LocationProvider } from '@reach/router';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { MozServices } from '../../lib/types';
+import { OAuthIntegration } from '../../models';
+import { MOCK_TOTP_TOKEN } from '../InlineTotpSetup/mocks';
+import InlineRecoverySetupContainer from './container';
+import AuthClient from 'fxa-auth-client/browser';
+import { waitFor } from '@testing-library/react';
+
+const mockEmail = 'nomannisanislandexcepttheisleofmann@example.gg';
+const defaultQueryParams = {
+  client_id: 'dcdb5ae7add825d2',
+  pkce_client_id: '38a6b9b3a65a1871',
+  redirect_uri: 'http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth',
+  scope: 'profile%20openid',
+  acr_values: 'AAL2',
+};
+let locationState: any = { totp: MOCK_TOTP_TOKEN };
+const mockLocationHook = (
+  queryParams: Record<string, string> = defaultQueryParams,
+  state: unknown = locationState
+) => {
+  return {
+    pathname: '/inline_totp_setup',
+    search: '?' + new URLSearchParams(queryParams),
+    state,
+  };
+};
+const mockNavigateHook = jest.fn();
+jest.mock('@reach/router', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('@reach/router'),
+    useNavigate: () => mockNavigateHook,
+    useLocation: () => mockLocationHook(),
+  };
+});
+
+const mockAuthClient = new AuthClient('http://localhost:9000', {
+  keyStretchVersion: 1,
+});
+let mockAccountHook: () => any = () => null;
+let mockSessionHook: () => any = () => ({ token: 'ABBA' });
+jest.mock('../../models', () => {
+  return {
+    ...jest.requireActual('../../models'),
+    useAccount: jest.fn(() => mockAccountHook()),
+    useSession: jest.fn(() => mockSessionHook()),
+    useAuthClient: jest.fn(() => mockAuthClient),
+  };
+});
+
+let mockGetCode = jest.fn();
+jest.mock('../../lib/totp', () => {
+  return {
+    ...jest.requireActual('../../lib/totp'),
+    getCode: jest.fn((...args) => mockGetCode(...args)),
+  };
+});
+
+jest.mock('./index', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(),
+  };
+});
+
+let mockVerifyTotpMutation = jest
+  .fn()
+  .mockResolvedValue({ data: { verifyTotp: { success: true } } });
+
+function setMocks() {
+  locationState = { totp: MOCK_TOTP_TOKEN };
+  mockAccountHook = () => ({
+    uid: 'quux',
+    email: mockEmail,
+    refresh: () => {},
+    totpActive: false,
+  });
+  mockSessionHook = () => ({ token: 'ABBA' });
+
+  jest.spyOn(ApolloClientModule, 'useMutation').mockReturnValue([
+    async (...args: any[]) => {
+      return mockVerifyTotpMutation(...args);
+    },
+    {
+      loading: false,
+      called: true,
+      client: {} as ApolloClient<any>,
+      reset: () => {},
+    },
+  ]);
+
+  (InlineRecoverySetupModule.default as jest.Mock).mockReset();
+
+  mockNavigateHook.mockReset();
+}
+
+const defaultProps = {
+  isSignedIn: true,
+  integration: {
+    returnOnError: () => true,
+    getRedirectWithErrorUrl: (error: AuthUiError) =>
+      `https://localhost:8080/?error=${error.errno}`,
+  } as unknown as OAuthIntegration,
+  serviceName: MozServices.Default,
+};
+function render(props = {}) {
+  renderWithLocalizationProvider(
+    <LocationProvider>
+      <InlineRecoverySetupContainer {...{ ...defaultProps, ...props }} />
+    </LocationProvider>
+  );
+}
+
+describe('InlineRecoverySetupContainer', () => {
+  beforeEach(() => {
+    setMocks();
+  });
+
+  describe('redirects away', () => {
+    it('redirects when user is not signed in', () => {
+      render({ isSignedIn: false });
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`
+      );
+    });
+
+    it('redirects when there is no account', () => {
+      mockAccountHook = () => null;
+      render();
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`
+      );
+    });
+
+    it('redirects when there is no session', () => {
+      mockSessionHook = () => null;
+      render();
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`
+      );
+    });
+
+    it('redirects when there is no totp token', () => {
+      locationState = {};
+      render();
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`
+      );
+    });
+
+    it('redirects when totp is already active', () => {
+      mockAccountHook = () => ({ totpActive: true });
+      render();
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signin_totp_code${location.search}`
+      );
+    });
+  });
+
+  describe('renders', () => {
+    it('invokes InlineRecoverySetup with the correct props', async () => {
+      render();
+      await waitFor(() => {
+        expect(InlineRecoverySetupModule.default).toHaveBeenCalled();
+        const args = (InlineRecoverySetupModule.default as jest.Mock).mock
+          .calls[0][0];
+        expect(args.recoveryCodes).toBe(MOCK_TOTP_TOKEN.recoveryCodes);
+        expect(args.serviceName).toBe(MozServices.Default);
+      });
+    });
+
+    describe('callbacks', () => {
+      describe('cancelSetupHandler', () => {
+        it('redirects when returnOnError is true', async () => {
+          Object.defineProperty(window, 'location', {
+            writable: true,
+            value: { assign: jest.fn() },
+          });
+          render();
+          await waitFor(() => {
+            expect(InlineRecoverySetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineRecoverySetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const cancelSetupHandler = args.cancelSetupHandler;
+          cancelSetupHandler();
+          expect(window.location.assign).toHaveBeenCalledWith(
+            'https://localhost:8080/?error=160'
+          );
+        });
+
+        it('throws an error when returnOnError is false', async () => {
+          render({
+            integration: {
+              ...defaultProps.integration,
+              returnOnError: () => false,
+            },
+          });
+          await waitFor(() => {
+            expect(InlineRecoverySetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineRecoverySetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const cancelSetupHandler = args.cancelSetupHandler;
+
+          // jest didn't like some syntax in AuthUiErrors when I tried to use
+          // expect().toThrow()
+          try {
+            cancelSetupHandler();
+            expect(true).toBe(false); // an error should've been thrown
+          } catch (err) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(err).toBe(AuthUiErrors.TOTP_REQUIRED);
+          }
+        });
+      });
+
+      describe('verifyTotpHandler', () => {
+        it('returns the verifyTotp result', async () => {
+          render();
+          await waitFor(() => {
+            expect(InlineRecoverySetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineRecoverySetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const verifyTotpHandler = args.verifyTotpHandler;
+          const result = await verifyTotpHandler();
+          expect(mockGetCode).toHaveBeenCalledWith(MOCK_TOTP_TOKEN.secret);
+          expect(mockVerifyTotpMutation).toHaveBeenCalledTimes(1);
+          expect(result).toBe(true);
+        });
+      });
+
+      // The redirect implementation is to be completed in another issue:
+      // FXA-6518.  We'll add the test for that in a follow-up.
+      // describe('successfulSetupHandler', () => {});
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useMutation } from '@apollo/client';
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { useCallback, useEffect, useState } from 'react';
+import AppLayout from '../../components/AppLayout';
+import CardHeader from '../../components/CardHeader';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { useFinishOAuthFlowHandler } from '../../lib/oauth/hooks';
+import { getCode } from '../../lib/totp';
+import { MozServices } from '../../lib/types';
+import {
+  OAuthIntegration,
+  useAccount,
+  useAuthClient,
+  useSession,
+} from '../../models';
+import { TotpToken } from '../InlineTotpSetup';
+import { VERIFY_TOTP_MUTATION } from './gql';
+import InlineRecoverySetup from './index';
+
+export const InlineRecoverySetupContainer = ({
+  isSignedIn,
+  integration,
+  serviceName,
+}: {
+  isSignedIn: boolean;
+  integration: OAuthIntegration;
+  serviceName: MozServices;
+} & RouteComponentProps) => {
+  const account = useAccount();
+  const session = useSession();
+  const navigate = useNavigate();
+
+  const authClient = useAuthClient();
+  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
+    authClient,
+    integration
+  );
+
+  const location = useLocation() as ReturnType<typeof useLocation> & {
+    state: {
+      totp: TotpToken;
+    };
+  };
+  const totp = location.state?.totp;
+
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>();
+  const [verifyTotp] = useMutation<{ verifyTotp: { success: boolean } }>(
+    VERIFY_TOTP_MUTATION
+  );
+
+  const verifyTotpHandler = useCallback(async () => {
+    const code = await getCode(totp.secret);
+    const result = await verifyTotp({
+      variables: { input: { code, service: serviceName } },
+    });
+    return result.data!.verifyTotp.success;
+  }, [serviceName, totp, verifyTotp]);
+
+  const successfulSetupHandler = useCallback(async () => {
+    const { redirect } = await finishOAuthFlowHandler(
+      account.uid,
+      session.token
+    );
+    window.location.assign(redirect);
+  }, [account, finishOAuthFlowHandler, session]);
+
+  const cancelSetupHandler = useCallback(() => {
+    const error = AuthUiErrors.TOTP_REQUIRED;
+
+    if (integration.returnOnError()) {
+      const url = integration.getRedirectWithErrorUrl(error);
+      window.location.assign(url);
+      return;
+    }
+
+    throw error;
+  }, [integration]);
+
+  useEffect(() => {
+    // Some basic sanity checks
+    if (!isSignedIn || !account || !session || !totp) {
+      navigate(`/signup${location.search}`);
+      return;
+    }
+
+    if (account.totpActive) {
+      navigate(`/signin_totp_code${location.search}`);
+      return;
+    }
+
+    setRecoveryCodes(totp.recoveryCodes);
+  }, [isSignedIn, account, session, totp, navigate, location.search]);
+
+  if (!recoveryCodes) {
+    return <LoadingSpinner fullScreen />;
+  }
+
+  // TODO: UX for this, FXA-8106
+  if (oAuthDataError) {
+    return (
+      <AppLayout>
+        <CardHeader
+          headingText="Unexpected error"
+          headingTextFtlId="auth-error-999"
+        />
+      </AppLayout>
+    );
+  }
+
+  return (
+    <InlineRecoverySetup
+      recoveryCodes={recoveryCodes}
+      serviceName={serviceName}
+      cancelSetupHandler={cancelSetupHandler}
+      verifyTotpHandler={verifyTotpHandler}
+      successfulSetupHandler={successfulSetupHandler}
+    />
+  );
+};
+
+export default InlineRecoverySetupContainer;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/gql.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/gql.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const VERIFY_TOTP_MUTATION = gql`
+  mutation verifyTotp($input: VerifyTotpInput!) {
+    verifyTotp(input: $input) {
+      success
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import InlineRecoverySetup, { InlineRecoverySetupProps } from '.';
-import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_RECOVERY_CODES, MOCK_SERVICE_NAME } from './mocks';
@@ -16,49 +15,30 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+const cancelSetupHandler = () => {};
+const verifyTotpHandler = async () => true;
+const successfulSetupHandler = () => {};
+const props = {
+  recoveryCodes: MOCK_RECOVERY_CODES,
+  serviceName: MOCK_SERVICE_NAME,
+  cancelSetupHandler,
+  verifyTotpHandler,
+  successfulSetupHandler,
+};
+
 const ComponentWithRouter = (props: InlineRecoverySetupProps) => (
   <LocationProvider>
-    <AppLayout>
-      <InlineRecoverySetup {...props} />
-    </AppLayout>
+    <InlineRecoverySetup {...props} />
   </LocationProvider>
 );
 
 export const Default = () => (
   <ComponentWithRouter
     recoveryCodes={MOCK_RECOVERY_CODES}
-    showConfirmation={false}
+    cancelSetupHandler={cancelSetupHandler}
+    verifyTotpHandler={verifyTotpHandler}
+    successfulSetupHandler={successfulSetupHandler}
   />
 );
 
-export const ServiceNameDontShowConfirmation = () => (
-  <ComponentWithRouter
-    recoveryCodes={MOCK_RECOVERY_CODES}
-    showConfirmation={false}
-    serviceName={MOCK_SERVICE_NAME}
-  />
-);
-
-export const isIOS = () => (
-  <ComponentWithRouter
-    recoveryCodes={MOCK_RECOVERY_CODES}
-    showConfirmation={false}
-    serviceName={MOCK_SERVICE_NAME}
-    isIOS={true}
-  />
-);
-
-export const ShowConfirmation = () => (
-  <ComponentWithRouter
-    recoveryCodes={MOCK_RECOVERY_CODES}
-    showConfirmation={true}
-  />
-);
-
-export const ShowConfirmationWithServiceName = () => (
-  <ComponentWithRouter
-    recoveryCodes={MOCK_RECOVERY_CODES}
-    showConfirmation={true}
-    serviceName={MOCK_SERVICE_NAME}
-  />
-);
+export const WithServiceName = () => <ComponentWithRouter {...props} />;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -2,50 +2,130 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
-import InputText from '../../components/InputText';
 import DataBlock from '../../components/DataBlock';
 import { REACT_ENTRYPOINT } from '../../constants';
 import { RecoveryCodesImage } from '../../components/images';
 import CardHeader from '../../components/CardHeader';
+import AppLayout from '../../components/AppLayout';
+import Banner, { BannerType } from '../../components/Banner';
+import { copyRecoveryCodes } from '../../lib/totp';
+import FormVerifyCode from '../../components/FormVerifyCode';
+import {
+  AuthUiErrors,
+  composeAuthUiErrorTranslationId,
+} from '../../lib/auth-errors/auth-errors';
 
 export type InlineRecoverySetupProps = {
-  isIOS?: boolean;
   recoveryCodes: Array<string>;
   serviceName?: MozServices;
-  showConfirmation: boolean;
+  cancelSetupHandler: () => void;
+  verifyTotpHandler: () => Promise<boolean>;
+  successfulSetupHandler: () => void;
 };
 
 export const viewName = 'inline-recovery-setup';
 
 const InlineRecoverySetup = ({
-  isIOS,
   recoveryCodes,
   serviceName,
-  showConfirmation,
+  cancelSetupHandler,
+  verifyTotpHandler,
+  successfulSetupHandler,
 }: InlineRecoverySetupProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   const ftlMsgResolver = useFtlMsgResolver();
-  const localizedInputTextLabel = ftlMsgResolver.getMsg(
-    'inline-recovery-backup-authentication-code',
-    'Backup authentication code'
+  const localizedIncorrectBackupCodeError = ftlMsgResolver.getMsg(
+    'tfa-incorrect-recovery-code-1',
+    'Incorrect backup authentication code'
+  );
+  const localizedRecoveryCodeRequiredError = ftlMsgResolver.getMsg(
+    'signin-recovery-code-required-error',
+    'Backup authentication code required'
   );
 
-  /* TODO: - Add in copy/download/print/continue/cancel actions for all buttons
-   *       - Add in metrics for all events
-   *       - Add tests for all metrics
-   */
-  const cancelSetup = () => {};
-  const continueSetup = () => {};
+  const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
+  const [successfulTotpSetup, setSuccessfulTotpSetup] =
+    useState<boolean>(false);
+  const [recoveryCodeError, setRecoveryCodeError] = useState<string>('');
+
+  const showBannerSuccess = useCallback(
+    () =>
+      successfulTotpSetup ? (
+        <Banner type={BannerType.success}>
+          <p>
+            {ftlMsgResolver.getMsg(
+              'postAddTwoStepAuthentication-title-2',
+              'You turned on two-step authentication'
+            )}
+          </p>
+        </Banner>
+      ) : null,
+    [ftlMsgResolver, successfulTotpSetup]
+  );
+
+  const continueSetup = useCallback(() => {
+    setShowConfirmation(true);
+  }, []);
+  const goBackToCodes = useCallback(() => {
+    setRecoveryCodeError('');
+    setShowConfirmation(false);
+  }, []);
+
+  const completeSetup = useCallback(
+    async (code: string) => {
+      if (!recoveryCodes.includes(code.trim())) {
+        setRecoveryCodeError(localizedIncorrectBackupCodeError);
+        return;
+      }
+
+      try {
+        const success = await verifyTotpHandler();
+
+        if (success) {
+          setRecoveryCodeError('');
+          setSuccessfulTotpSetup(true);
+          setTimeout(successfulSetupHandler, 500);
+        } else {
+          // Some server side error occurred.  Generic error message in catch
+          // block.
+          throw new Error('cannot enable TOTP');
+        }
+      } catch (error) {
+        if (error.errno === AuthUiErrors.TOTP_TOKEN_NOT_FOUND.errno) {
+          setRecoveryCodeError(
+            ftlMsgResolver.getMsg(
+              composeAuthUiErrorTranslationId(error),
+              AuthUiErrors.TOTP_TOKEN_NOT_FOUND.message
+            )
+          );
+        } else {
+          setRecoveryCodeError(
+            ftlMsgResolver.getMsg(
+              'tfa-cannot-verify-code-4',
+              'There was a problem confirming your backup authentication code'
+            )
+          );
+        }
+      }
+    },
+    [
+      ftlMsgResolver,
+      localizedIncorrectBackupCodeError,
+      recoveryCodes,
+      successfulSetupHandler,
+      verifyTotpHandler,
+    ]
+  );
 
   return (
-    <>
+    <AppLayout>
       {showConfirmation ? (
         <>
           <CardHeader
@@ -54,44 +134,55 @@ const InlineRecoverySetup = ({
             headingWithCustomServiceFtlId="inline-recovery-confirmation-header"
             {...{ serviceName }}
           />
+          {showBannerSuccess()}
           <section>
-            <form noValidate>
-              <div>
-                <RecoveryCodesImage className="mx-auto" />
-                <FtlMsg id="inline-recovery-confirmation-description">
-                  <p className="text-sm mb-6">
-                    To ensure that you will be able to regain access to your
-                    account in the event of a lost device, please enter one of
-                    your saved backup authentication codes.
-                  </p>
-                </FtlMsg>
-                <InputText
-                  label={localizedInputTextLabel}
-                  className="tooltip-below recovery-code text-start my-4"
-                  anchorPosition="start"
-                  required
-                  autoFocus
-                  autoComplete="off"
-                />
-                <FtlMsg id="inline-recovery-confirm-button">
-                  <button type="submit" className="cta-primary cta-xl w-full">
-                    Confirm
+            <div>
+              <RecoveryCodesImage className="mx-auto" />
+              <FtlMsg id="inline-recovery-confirmation-description">
+                <p className="text-sm mb-6">
+                  To ensure that you will be able to regain access to your
+                  account in the event of a lost device, please enter one of
+                  your saved backup authentication codes.
+                </p>
+              </FtlMsg>
+              <FormVerifyCode
+                viewName="inline_recovery_setup"
+                verifyCode={completeSetup}
+                formAttributes={{
+                  inputLabelText: 'Backup authentication code',
+                  inputFtlId: 'inline-recovery-backup-authentication-code',
+                  submitButtonText: 'Confirm',
+                  submitButtonFtlId: 'inline-recovery-confirm-button',
+                  pattern: '\\w{10}',
+                  maxLength: 10,
+                }}
+                codeErrorMessage={recoveryCodeError}
+                setCodeErrorMessage={setRecoveryCodeError}
+                localizedCustomCodeRequiredMessage={
+                  localizedRecoveryCodeRequiredError
+                }
+              />
+              <div className="flex justify-between mt-4">
+                <FtlMsg id="inline-recovery-back-link">
+                  <button
+                    type="button"
+                    className="link-blue text-sm"
+                    onClick={goBackToCodes}
+                  >
+                    Back
                   </button>
                 </FtlMsg>
-                <div className="flex justify-between mt-4">
-                  <FtlMsg id="inline-recovery-back-link">
-                    <button type="button" className="link-blue text-sm">
-                      Back
-                    </button>
-                  </FtlMsg>
-                  <FtlMsg id="inline-recovery-cancel-setup">
-                    <button type="button" className="link-blue text-sm">
-                      Cancel setup
-                    </button>
-                  </FtlMsg>
-                </div>
+                <FtlMsg id="inline-recovery-cancel-setup">
+                  <button
+                    type="button"
+                    className="link-blue text-sm"
+                    onClick={cancelSetupHandler}
+                  >
+                    Cancel setup
+                  </button>
+                </FtlMsg>
               </div>
-            </form>
+            </div>
           </section>
         </>
       ) : (
@@ -109,13 +200,18 @@ const InlineRecoverySetup = ({
                 don’t have your mobile device.
               </p>
             </FtlMsg>
-            <DataBlock value={recoveryCodes} isIOS={isIOS} />
+            <DataBlock
+              value={recoveryCodes}
+              separator=" "
+              onCopy={copyRecoveryCodes}
+              contentType="Backup authentication codes"
+            ></DataBlock>
             <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">
               <FtlMsg id="inline-recovery-cancel-button">
                 <button
                   type="button"
                   className="cta-neutral mx-2 px-10 py-2 flex-1"
-                  onClick={cancelSetup}
+                  onClick={cancelSetupHandler}
                 >
                   Cancel
                 </button>
@@ -133,7 +229,7 @@ const InlineRecoverySetup = ({
           </section>
         </>
       )}
-    </>
+    </AppLayout>
   );
 };
 

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -1,0 +1,299 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as ApolloClientModule from '@apollo/client';
+import * as InlineTotpSetupModule from './index';
+
+import { ApolloClient } from '@apollo/client';
+import { LocationProvider } from '@reach/router';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { MozServices } from '../../lib/types';
+import { OAuthIntegration } from '../../models';
+import InlineTotpSetupContainer from './container';
+import { MOCK_TOTP_TOKEN } from './mocks';
+import { waitFor } from '@testing-library/react';
+import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+
+const defaultQueryParams = {
+  client_id: 'dcdb5ae7add825d2',
+  pkce_client_id: '38a6b9b3a65a1871',
+  redirect_uri: 'http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth',
+  scope: 'profile%20openid',
+  acr_values: 'AAL2',
+};
+const mockLocationHook = (
+  queryParams: Record<string, string> = defaultQueryParams,
+  state: unknown = undefined
+) => {
+  return {
+    pathname: '/inline_totp_setup',
+    search: '?' + new URLSearchParams(queryParams),
+    state,
+  };
+};
+const mockNavigateHook = jest.fn();
+jest.mock('@reach/router', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('@reach/router'),
+    useNavigate: () => mockNavigateHook,
+    useLocation: () => mockLocationHook(),
+  };
+});
+
+let mockAccountHook: () => any = () => null;
+let mockSessionHook: () => any = () => null;
+jest.mock('../../models', () => {
+  return {
+    ...jest.requireActual('../../models'),
+    useAccount: jest.fn(() => mockAccountHook()),
+    useSession: jest.fn(() => mockSessionHook()),
+  };
+});
+
+let mockCheckCode: () => boolean = () => true;
+jest.mock('../../lib/totp', () => {
+  return {
+    ...jest.requireActual('../../lib/totp'),
+    checkCode: jest.fn(() => mockCheckCode()),
+  };
+});
+
+function setMocks() {
+  mockCheckCode = () => true;
+  let mockCreateTotpMutation = jest
+    .fn()
+    .mockResolvedValue({ data: { createTotp: MOCK_TOTP_TOKEN } });
+  jest.spyOn(ApolloClientModule, 'useMutation').mockReturnValue([
+    async (...args: any[]) => {
+      return mockCreateTotpMutation(...args);
+    },
+    {
+      loading: false,
+      called: true,
+      client: {} as ApolloClient<any>,
+      reset: () => {},
+    },
+  ]);
+  jest.spyOn(InlineTotpSetupModule, 'default');
+  (InlineTotpSetupModule.default as jest.Mock).mockReset();
+  mockNavigateHook.mockReset();
+}
+
+const defaultProps = {
+  isSignedIn: true,
+  integration: {
+    returnOnError: () => true,
+    getRedirectWithErrorUrl: (error: AuthUiError) =>
+      `https://localhost:8080/?error=${error.errno}`,
+  } as unknown as OAuthIntegration,
+  serviceName: MozServices.Default,
+};
+function render(props = {}) {
+  renderWithLocalizationProvider(
+    <LocationProvider>
+      <InlineTotpSetupContainer {...{ ...defaultProps, ...props }} />
+    </LocationProvider>
+  );
+}
+
+describe('InlineTotpSetupContainer', () => {
+  beforeEach(() => {
+    setMocks();
+  });
+
+  describe('redirects away', () => {
+    it('redirects when user is not signed in', () => {
+      render({ isSignedIn: false });
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`,
+        { state: undefined }
+      );
+    });
+
+    it('redirects when there is no account', () => {
+      render();
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`,
+        { state: undefined }
+      );
+    });
+
+    it('redirects when there is no session', () => {
+      mockAccountHook = () => ({ uid: 'quux' });
+      render();
+      const location = mockLocationHook();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signup${location.search}`,
+        { state: undefined }
+      );
+    });
+
+    it('redirects when the session is not verified', async () => {
+      mockAccountHook = () => ({ uid: 'quux' });
+      mockSessionHook = () => ({ isSessionVerified: async () => false });
+      render();
+      const location = mockLocationHook();
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(
+          `/signin_token_code${location.search}`,
+          { state: undefined }
+        );
+      });
+    });
+
+    it('redirects when totp is active on the account', async () => {
+      mockAccountHook = () => ({
+        uid: 'quux',
+        refresh: () => {},
+        totpActive: true,
+      });
+      mockSessionHook = () => ({ isSessionVerified: async () => true });
+      render();
+      const location = mockLocationHook();
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(
+          `/signin_totp_code${location.search}`,
+          { state: undefined }
+        );
+      });
+    });
+  });
+
+  describe('renders', () => {
+    const mockEmail = 'nomannisanislandexcepttheisleofmann@example.gg';
+
+    beforeEach(() => {
+      mockAccountHook = () => ({
+        uid: 'quux',
+        email: mockEmail,
+        refresh: () => {},
+        totpActive: false,
+      });
+      mockSessionHook = () => ({ isSessionVerified: async () => true });
+    });
+
+    it('invokes InlineTotpSetup with the correct props', async () => {
+      render();
+      await waitFor(() => {
+        expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+        const args = (InlineTotpSetupModule.default as jest.Mock).mock
+          .calls[0][0];
+        expect(args.totp).toBe(MOCK_TOTP_TOKEN);
+        expect(args.email).toBe(mockEmail);
+        expect(args.serviceName).toBe(MozServices.Default);
+      });
+    });
+
+    describe('callbacks', () => {
+      describe('cancelSetupHandler', () => {
+        it('redirects when returnOnError is true', async () => {
+          Object.defineProperty(window, 'location', {
+            writable: true,
+            value: { assign: jest.fn() },
+          });
+          render();
+          await waitFor(() => {
+            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineTotpSetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const cancelSetupHandler = args.cancelSetupHandler;
+          cancelSetupHandler();
+          expect(window.location.assign).toHaveBeenCalledWith(
+            'https://localhost:8080/?error=160'
+          );
+        });
+
+        it('throws an error when returnOnError is false', async () => {
+          render({
+            integration: {
+              ...defaultProps.integration,
+              returnOnError: () => false,
+            },
+          });
+          await waitFor(() => {
+            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineTotpSetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const cancelSetupHandler = args.cancelSetupHandler;
+
+          // jest didn't like some syntax in AuthUiErrors when I tried to use
+          // expect().toThrow()
+          try {
+            cancelSetupHandler();
+            expect(true).toBe(false); // an error should've been thrown
+          } catch (err) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(err).toBe(AuthUiErrors.TOTP_REQUIRED);
+          }
+        });
+      });
+
+      describe('verifyCodeHandler', () => {
+        it('throws an error when the code is invalid', async () => {
+          mockCheckCode = () => false;
+          render();
+          await waitFor(() => {
+            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineTotpSetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const verifyCodeHandler = args.verifyCodeHandler;
+
+          // jest didn't like some syntax in AuthUiErrors when I tried to use
+          // expect().toThrow()
+          try {
+            await verifyCodeHandler('0101');
+            expect(true).toBe(false); // an error should've been thrown
+          } catch (err) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(err).toBe(AuthUiErrors.INVALID_TOTP_CODE);
+          }
+        });
+
+        it('throws an error when checking the code errors', async () => {
+          mockCheckCode = () => {
+            throw new Error();
+          };
+          render();
+          await waitFor(() => {
+            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineTotpSetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const verifyCodeHandler = args.verifyCodeHandler;
+
+          // jest didn't like some syntax in AuthUiErrors when I tried to use
+          // expect().toThrow()
+          try {
+            await verifyCodeHandler('1010');
+            expect(true).toBe(false); // an error should've been thrown
+          } catch (err) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(err).toBe(AuthUiErrors.INVALID_TOTP_CODE);
+          }
+        });
+
+        it('redirects to inline_recovery_setup when the code is valid', async () => {
+          render();
+          await waitFor(() => {
+            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineTotpSetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const verifyCodeHandler = args.verifyCodeHandler;
+          await verifyCodeHandler('1010');
+          expect(mockNavigateHook).toHaveBeenCalledWith(
+            `/inline_recovery_setup?${new URLSearchParams(defaultQueryParams)}`,
+            { state: { totp: MOCK_TOTP_TOKEN } }
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { useCallback, useEffect, useState } from 'react';
+import InlineTotpSetup, { TotpToken } from '.';
+import { MozServices } from '../../lib/types';
+import { OAuthIntegration, useAccount, useSession } from '../../models';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { checkCode } from '../../lib/totp';
+import { useMutation } from '@apollo/client';
+import { CREATE_TOTP_MUTATION } from './gql';
+
+export const InlineTotpSetupContainer = ({
+  isSignedIn,
+  integration,
+  serviceName,
+}: {
+  isSignedIn: boolean;
+  integration: OAuthIntegration;
+  serviceName: MozServices;
+} & RouteComponentProps) => {
+  const [totp, setTotp] = useState<TotpToken>();
+
+  const account = useAccount();
+  const session = useSession();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [createTotp] = useMutation<{ createTotp: TotpToken }>(
+    CREATE_TOTP_MUTATION
+  );
+
+  const navTo = useCallback(
+    (
+      uri:
+        | 'signup'
+        | 'signin_token_code'
+        | 'signin_totp_code'
+        | 'inline_recovery_setup',
+      state?: Record<string, any>
+    ) => {
+      navigate(`/${uri}${location.search}`, { state });
+    },
+    [location, navigate]
+  );
+
+  const cancelSetupHandler = useCallback(() => {
+    const error = AuthUiErrors.TOTP_REQUIRED;
+
+    if (integration.returnOnError()) {
+      const url = integration.getRedirectWithErrorUrl(error);
+      window.location.assign(url);
+      return;
+    }
+
+    throw error;
+  }, [integration]);
+
+  const verifyCodeHandler = useCallback(
+    async (code: string) => {
+      try {
+        const isValid = await checkCode(totp!.secret, code);
+
+        if (!isValid) {
+          throw AuthUiErrors.INVALID_TOTP_CODE;
+        }
+
+        navTo('inline_recovery_setup', { totp });
+      } catch (error) {
+        throw AuthUiErrors.INVALID_TOTP_CODE;
+      }
+    },
+    [navTo, totp]
+  );
+
+  useEffect(() => {
+    // The user is navigated to this page by the web application in response to
+    // a sign-in attempt.  But let's do some sanity checks.
+
+    if (!isSignedIn || !account || !session) {
+      navTo('signup');
+      return;
+    }
+
+    (async () => {
+      try {
+        const sessionVerified = await session.isSessionVerified();
+        if (!sessionVerified) {
+          navTo('signin_token_code');
+        }
+
+        await account.refresh('account');
+
+        if (account.totpActive) {
+          navTo('signin_totp_code');
+        }
+
+        const totpResp = await createTotp({ variables: { input: {} } });
+
+        setTotp(totpResp.data?.createTotp);
+      } catch (_) {
+        navTo('signup');
+      }
+    })();
+  }, [isSignedIn, account, session, navTo, createTotp]);
+
+  if (!totp) {
+    return <LoadingSpinner fullScreen />;
+  }
+
+  return (
+    <InlineTotpSetup
+      totp={totp!}
+      email={account.email}
+      serviceName={serviceName}
+      cancelSetupHandler={cancelSetupHandler}
+      verifyCodeHandler={verifyCodeHandler}
+    />
+  );
+};
+
+export default InlineTotpSetupContainer;

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/gql.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/gql.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const CREATE_TOTP_MUTATION = gql`
+  mutation createTotp($input: CreateTotpInput!) {
+    createTotp(input: $input) {
+      qrCodeUrl
+      secret
+      recoveryCodes
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
@@ -6,8 +6,7 @@ import React from 'react';
 import InlineTotpSetup from '.';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
-import AppLayout from '../../components/AppLayout';
-import { MOCK_CODE, MOCK_EMAIL } from './mocks';
+import { MOCK_EMAIL, MOCK_TOTP_TOKEN } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 
 export default {
@@ -16,18 +15,24 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+const cancelSetupHandler = () => {};
+const verifyCodeHandler = () => {};
+
 export const Default = () => (
-  <AppLayout>
-    <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
-  </AppLayout>
+  <InlineTotpSetup
+    totp={MOCK_TOTP_TOKEN}
+    email={MOCK_EMAIL}
+    cancelSetupHandler={cancelSetupHandler}
+    verifyCodeHandler={verifyCodeHandler}
+  />
 );
 
 export const WithCustomService = () => (
-  <AppLayout>
-    <InlineTotpSetup
-      code={MOCK_CODE}
-      email={MOCK_EMAIL}
-      serviceName={MozServices.Monitor}
-    />
-  </AppLayout>
+  <InlineTotpSetup
+    totp={MOCK_TOTP_TOKEN}
+    email={MOCK_EMAIL}
+    serviceName={MozServices.Monitor}
+    cancelSetupHandler={cancelSetupHandler}
+    verifyCodeHandler={verifyCodeHandler}
+  />
 );

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -2,35 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
-import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
-// import { FluentBundle } from '@fluent/bundle';
+import { act, screen } from '@testing-library/react';
+import { UserEvent, userEvent } from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import InlineTotpSetup, { viewName } from '.';
+import { REACT_ENTRYPOINT } from '../../constants';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
-import { MOCK_CODE, MOCK_EMAIL } from './mocks';
-import { REACT_ENTRYPOINT } from '../../constants';
+import { MOCK_EMAIL, MOCK_TOTP_TOKEN } from './mocks';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
   usePageViewEvent: jest.fn(),
 }));
 
+const cancelSetupHandler = jest.fn();
+const verifyCodeHandler = jest.fn();
+const mockProps = {
+  totp: MOCK_TOTP_TOKEN,
+  email: MOCK_EMAIL,
+  cancelSetupHandler,
+  verifyCodeHandler,
+};
+
 describe('InlineTotpSetup', () => {
-  // let bundle: FluentBundle;
+  let user: UserEvent;
+
   beforeAll(async () => {
     global.URL.createObjectURL = jest.fn();
-    //   bundle = await getFtlBundle('settings');
   });
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
   it('renders default as expected', () => {
-    renderWithLocalizationProvider(
-      <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
-    );
-    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    // testL10n(ftlMsgMock, bundle, {
-    //   email: exampleEmail,
-    // });
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
     screen.getByRole('heading', {
       name: `Enable two-step authentication to continue to ${MozServices.Default}`,
     });
@@ -49,15 +57,9 @@ describe('InlineTotpSetup', () => {
   it('renders intro view as expected with custom service name', () => {
     renderWithLocalizationProvider(
       <InlineTotpSetup
-        code={MOCK_CODE}
-        email={MOCK_EMAIL}
-        serviceName={MozServices.Monitor}
+        {...{ ...mockProps, serviceName: MozServices.Monitor }}
       />
     );
-    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    // testL10n(ftlMsgMock, bundle, {
-    //   email: exampleEmail,
-    // });
     screen.getByRole('heading', {
       name: `Enable two-step authentication to continue to ${MozServices.Monitor}`,
     });
@@ -74,71 +76,88 @@ describe('InlineTotpSetup', () => {
   });
 
   it('renders QR code by default when a user clicks "Continue"', async () => {
-    renderWithLocalizationProvider(
-      <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+    await act(
+      async () =>
+        await user.click(screen.getByRole('button', { name: 'Continue' }))
     );
-    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    // testL10n(ftlMsgMock, bundle, {
-    //   email: exampleEmail,
-    // });
-    const continueButton = screen.getByRole('button', { name: 'Continue' });
-    fireEvent.click(continueButton);
     await screen.findByAltText(
-      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
   });
 
   it('toggles from QR code to manual secret code view when user clicks "Can\'t scan code"', async () => {
-    renderWithLocalizationProvider(
-      <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+    await act(
+      async () =>
+        await user.click(screen.getByRole('button', { name: 'Continue' }))
     );
-    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    // testL10n(ftlMsgMock, bundle, {
-    //   email: exampleEmail,
-    // });
-    const continueButton = screen.getByRole('button', { name: 'Continue' });
-    fireEvent.click(continueButton);
     await screen.findByAltText(
-      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
 
     const changeToManualModeButton = screen.getByRole('button', {
       name: 'Can’t scan code?',
     });
-    fireEvent.click(changeToManualModeButton);
+    await act(async () => await user.click(changeToManualModeButton));
     await screen.findByRole('button', { name: 'Scan QR code instead?' });
   });
 
   it('toggles from secret code to QR code view when user clicks "Scan QR code instead?', async () => {
-    renderWithLocalizationProvider(
-      <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+    await act(
+      async () =>
+        await user.click(screen.getByRole('button', { name: 'Continue' }))
     );
-    // const ftlMsgMock = screen.getAllByTestId('ftlmsg-mock')[1];
-    // testL10n(ftlMsgMock, bundle, {
-    //   email: exampleEmail,
-    // });
-    const continueButton = screen.getByRole('button', { name: 'Continue' });
-    fireEvent.click(continueButton);
     await screen.findByAltText(
-      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
     const changeToManualModeButton = screen.getByRole('button', {
       name: 'Can’t scan code?',
     });
-    fireEvent.click(changeToManualModeButton);
+    await act(async () => await user.click(changeToManualModeButton));
     await screen.findByRole('button', { name: 'Scan QR code instead?' });
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Scan QR code instead?' })
+    await act(
+      async () =>
+        await user.click(
+          screen.getByRole('button', { name: 'Scan QR code instead?' })
+        )
     );
     await screen.findByAltText(
-      `Use the code ${MOCK_CODE} to set up two-step authentication in supported applications.`
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
   });
 
-  it('emits the expected metrics on render', () => {
+  it('shows error on incorrect totp submission', async () => {
+    const verifyCodeHandler = jest
+      .fn()
+      .mockRejectedValue(AuthUiErrors.INVALID_TOTP_CODE);
     renderWithLocalizationProvider(
-      <InlineTotpSetup code={MOCK_CODE} email={MOCK_EMAIL} />
+      <InlineTotpSetup
+        {...{
+          ...mockProps,
+          verifyCodeHandler,
+        }}
+      />
     );
+    await act(
+      async () =>
+        await user.click(screen.getByRole('button', { name: 'Continue' }))
+    );
+    await act(
+      async () =>
+        await user.type(screen.getByLabelText('Authentication code'), '000000')
+    );
+    await act(
+      async () =>
+        await user.click(screen.getByRole('button', { name: 'Ready' }))
+    );
+    await screen.findByText('Invalid two-step authentication code');
+    expect(verifyCodeHandler).toBeCalledWith('000000');
+  });
+
+  it('emits the expected metrics on render', () => {
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
@@ -1,2 +1,6 @@
-export const MOCK_CODE = '123456';
 export const MOCK_EMAIL = 'example@example.com';
+export const MOCK_TOTP_TOKEN = {
+  secret: '1234567890',
+  qrCodeUrl: 'data:image/png;base64,pewpewpew',
+  recoveryCodes: ['recoveryCode1', 'recoveryCode2'],
+};

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -2,38 +2,38 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { usePageViewEvent } from '../../lib/metrics';
-import { isOAuthIntegration, useFtlMsgResolver } from '../../models';
-import { FtlMsg, hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import {
-  RouteComponentProps,
   Link,
+  RouteComponentProps,
   useLocation,
   useNavigate,
 } from '@reach/router';
-import InputPassword from '../../components/InputPassword';
-import TermsPrivacyAgreement from '../../components/TermsPrivacyAgreement';
-import { REACT_ENTRYPOINT } from '../../constants';
-import CardHeader from '../../components/CardHeader';
-import ThirdPartyAuth from '../../components/ThirdPartyAuth';
-import GleanMetrics from '../../lib/glean';
-import AppLayout from '../../components/AppLayout';
-import { SigninFormData, SigninProps } from './interfaces';
-import Avatar from '../../components/Settings/Avatar';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import classNames from 'classnames';
-import {
-  isClientMonitor,
-  isClientPocket,
-} from '../../models/integrations/client-matching';
-import { StoredAccountData, storeAccountData } from '../../lib/storage-utils';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { FtlMsg, hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import AppLayout from '../../components/AppLayout';
 import Banner, { BannerType } from '../../components/Banner';
+import CardHeader from '../../components/CardHeader';
+import InputPassword from '../../components/InputPassword';
+import Avatar from '../../components/Settings/Avatar';
+import TermsPrivacyAgreement from '../../components/TermsPrivacyAgreement';
+import ThirdPartyAuth from '../../components/ThirdPartyAuth';
+import { REACT_ENTRYPOINT } from '../../constants';
 import {
   AuthUiErrors,
   getLocalizedErrorMessage,
 } from '../../lib/auth-errors/auth-errors';
+import GleanMetrics from '../../lib/glean';
+import { usePageViewEvent } from '../../lib/metrics';
+import { StoredAccountData, storeAccountData } from '../../lib/storage-utils';
+import { isOAuthIntegration, useFtlMsgResolver } from '../../models';
+import {
+  isClientMonitor,
+  isClientPocket,
+} from '../../models/integrations/client-matching';
+import { SigninFormData, SigninProps } from './interfaces';
 import { handleNavigation } from './utils';
 
 export const viewName = 'signin';
@@ -142,6 +142,13 @@ const Signin = ({
         if (error.errno === AuthUiErrors.SESSION_EXPIRED.errno) {
           isPasswordNeededRef.current = true;
         }
+        if (
+          error.errno === AuthUiErrors.TOTP_REQUIRED.errno ||
+          error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
+        ) {
+          navigate('/inline_totp_setup');
+          return;
+        }
         setLocalizedBannerMessage(localizedErrorMessage);
         setSigninLoading(false);
       }
@@ -237,8 +244,6 @@ const Signin = ({
               break;
             case AuthUiErrors.TOTP_REQUIRED.errno:
             case AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno:
-              // TODO in FXA-9235 OAuth error handling ticket
-              // case OAuthError.MISMATCH_ACR_VALUES.errno:
               navigate('/inline_totp_setup');
               break;
             default:


### PR DESCRIPTION
Because:
 - a RP can optionally require 2FA from the user who is signing in

This commit:
 - implements "inline" TOTP setup after the user successfully signed in but before redirecting back to the RP


Sorry about the draft quality but I have a hard stop and want to put something up to get feedback.

### Notes
This is not quite feature complete.  It's missing a couple things.
  - The redirect back to the RP is not done.  It's being implemented in FXA-6518.  We'll need to incorporate that in once it's ready.
  - Since the flow is not completely done we don't have a functional test.  Lauren said we can do that in a follow-up; I don't know the issue number.

I tailed the auth-server and content-server logs while I stepped through the flow in Backbone and I didn't notice any inline-totp specific events, so there aren't any corresponding glean events in the PR.  I will check with Product and Data Science to see if they want to add some in the future.