### PR TITLE
test(functional-tests): add minimum coverage PayPal test

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -64,6 +64,20 @@ export class SubscribePage extends BaseLayout {
     await pay.click();
   }
 
+  async clickPayPal() {
+    const paypalButtonSelector = '[data-testid="paypal-button-container"]';
+
+    // Start waiting for popup before clicking
+    const paypalPopupPromise = this.page.waitForEvent('popup');
+    await this.page.locator(paypalButtonSelector).click();
+    const paypalPopup = await paypalPopupPromise;
+
+    // Wait for the popup to load
+    await paypalPopup.waitForLoadState();
+
+    return paypalPopup;
+  }
+
   async addCouponCode(code) {
     const input = this.page.locator('[data-testid="coupon-input"]');
     await input.waitFor({ state: 'visible' });

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -73,6 +73,23 @@ test.describe('severity-2 #smoke', () => {
       });
       expect(actualEventTypes).toMatchObject(expectedEventTypes);
     });
+
+    test('subscribe with paypal opens popup', async ({
+      pages: { relier, subscribe },
+    }, { project }) => {
+      test.skip(
+        project.name === 'production',
+        'no real payment method available in prod'
+      );
+      await relier.goto();
+      await relier.clickSubscribe();
+      await subscribe.setConfirmPaymentCheckbox();
+      const paypalPopup = await subscribe.clickPayPal();
+      expect(
+        await paypalPopup.title(),
+        'The PayPal popup title was not as expected'
+      ).toContain('PayPal');
+    });
   });
 
   test.describe('Flow, acquisition and new user checkout funnel metrics', () => {


### PR DESCRIPTION
## Because

- We want to maximize test coverage while respecting third party interface boundaries

## This pull request

- adds a test that assures when users click on the PayPal payment option they are directed to a PayPal popup

N/A (Relates To #FXA-9180)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

Example error message:
<img width="409" alt="Screenshot 2024-03-07 at 10 39 10 AM" src="https://github.com/mozilla/fxa/assets/3422688/1b0341a7-a07d-4484-a17b-736b894e9044">

## Other information (Optional)

Any other information that is important to this pull request.

- Related PR: https://github.com/mozilla/fxa/pull/16477
