### PR TITLE
fix(events): Fix bugs for third party auth events

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
@@ -47,7 +47,7 @@ export type AppleJWTSETPayload = {
   aud: string;
   iat: number;
   jti: string;
-  events: AppleSETEvent;
+  events: string;
 };
 
 async function getUidFromSub(sub: string, db: any, provider: Provider) {

--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -837,6 +837,7 @@ describe('/linked_account', function () {
         },
       };
       baseEvent.events.type = type;
+      baseEvent.events = JSON.stringify(baseEvent.events);
       return baseEvent;
     }
 


### PR DESCRIPTION
## Because

- Apple events don't specify JWT in header, they pass it as a POST param

## This pull request

- Removes the jwt authentication check, manually parses payload to get jwt for Apple
- Adds additional logging to both Apple and Google events

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9068

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This PR should fix Apple events, however I could not simulate a Google event happening so opted to get more logs to debug them.
