### PR TITLE
bug(content): Fix SENTRY_TRACES_SAMPLE_RATE not being applied

### DIFF
--- a/packages/browserid-verifier/lib/config.js
+++ b/packages/browserid-verifier/lib/config.js
@@ -110,7 +110,7 @@ function loadConf() {
       },
       tracesSampleRate: {
         doc: 'Rate at which sentry traces are captured',
-        default: 1.0,
+        default: 0,
         format: 'Number',
         env: 'SENTRY_TRACES_SAMPLE_RATE',
       },

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -91,7 +91,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -122,7 +122,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1655,7 +1655,7 @@ const convictConf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -38,6 +38,7 @@ const settingsConfig = {
     dsn: config.get('sentry.dsn'),
     env: config.get('sentry.env'),
     sampleRate: config.get('sentry.sampleRate'),
+    tracesSampleRate: config.get('sentry.tracesSampleRate'),
     clientName: config.get('sentry.clientName'),
     serverName: config.get('sentry.serverName'),
   },

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -778,7 +778,7 @@ const conf = (module.exports = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -34,6 +34,7 @@ module.exports = function (config) {
   const SENTRY_CLIENT_DSN = config.get('sentry.dsn');
   const SENTRY_CLIENT_ENV = config.get('sentry.env');
   const SENTRY_SAMPLE_RATE = config.get('sentry.sampleRate');
+  const SENTRY_TRACES_SAMPLE_RATE = config.get('sentry.tracesSampleRate');
   const SENTRY_CLIENT_NAME = config.get('sentry.clientName');
   const OAUTH_SERVER_URL = config.get('oauth_url');
   const PAIRING_CHANNEL_URI = config.get('pairing.server_base_uri');
@@ -100,6 +101,7 @@ module.exports = function (config) {
       env: SENTRY_CLIENT_ENV,
       sampleRate: SENTRY_SAMPLE_RATE,
       clientName: SENTRY_CLIENT_NAME,
+      tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
     },
     staticResourceUrl: STATIC_RESOURCE_URL,
     subscriptions: SUBSCRIPTIONS,

--- a/packages/fxa-content-server/server/lib/sentry.js
+++ b/packages/fxa-content-server/server/lib/sentry.js
@@ -59,6 +59,7 @@ if (config.get('sentry.dsn')) {
         dsn: config.get('sentry.dsn'),
         env: config.get('sentry.env'),
         sampleRate: config.get('sentry.sampleRate'),
+        tracesSampleRate: config.get('sentry.tracesSampleRate'),
         serverName: config.get('sentry.serverName'),
       },
     },

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -330,7 +330,7 @@ module.exports = function (fs, path, url, convict) {
       },
       tracesSampleRate: {
         doc: 'Rate at which sentry traces are captured',
-        default: 1.0,
+        default: 0,
         format: 'Number',
         env: 'SENTRY_TRACES_SAMPLE_RATE',
       },

--- a/packages/fxa-event-broker/src/config.ts
+++ b/packages/fxa-event-broker/src/config.ts
@@ -218,7 +218,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -260,7 +260,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -297,7 +297,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -142,6 +142,7 @@ const expectedMergedConfig = {
     dsn: 'https://foo.sentry.io/bar',
     env: 'test',
     sampleRate: 1.0,
+    tracesSampleRate: 0,
     serverName: 'fxa-payments-server',
   },
   servers: {

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -15,13 +15,12 @@ export interface Config {
     termsOfService: string;
   };
   newsletterId: string;
-  productRedirectURLs: {
-    [productId: string]: string;
-  };
+  productRedirectURLs: { [productId: string]: string };
   sentry: {
     dsn: string;
     env: string;
     sampleRate: number;
+    tracesSampleRate?: number;
     clientName?: string;
     serverName?: string;
   };
@@ -74,6 +73,7 @@ export function defaultConfig(): Config {
       dsn: '',
       env: 'local',
       sampleRate: 1.0,
+      tracesSampleRate: 0,
       serverName: 'fxa-payments-server',
       clientName: 'fxa-payments-client',
     },

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -341,7 +341,7 @@ const conf = convict({
     },
     tracesSampleRate: {
       doc: 'Rate at which sentry traces are captured',
-      default: 1.0,
+      default: 0,
       format: 'Number',
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },

--- a/packages/fxa-shared/sentry/config-builder.ts
+++ b/packages/fxa-shared/sentry/config-builder.ts
@@ -35,7 +35,7 @@ export function buildSentryConfig(config: SentryConfigOpts, log: ILogger) {
     clientName: config.sentry?.clientName,
     serverName: config.sentry?.serverName,
     fxaName: config.sentry?.clientName || config.sentry?.serverName,
-    tracesSampleRate: config.sentry?.tracesSampleRate || 1.0,
+    tracesSampleRate: config.sentry?.tracesSampleRate,
   };
 
   return opts;


### PR DESCRIPTION
## Because

- SENTRY_TRACES_SAMPLE_RATE was having no effect on front-end

## This pull request

- Fixes oversight where sample rate wasn't being copied into the config sent to client side
- Stops defaulting tracesSampleRate to 1.0 in  buildSentryConfig(), since this could result in quota exhaustion

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
