### PR TITLE
refactor(functional-tests): creation and cleanup of Sync browser pages to a fixture

### DIFF
--- a/packages/functional-tests/README.md
+++ b/packages/functional-tests/README.md
@@ -198,30 +198,10 @@ async signOut() {
 }
 ```
 
-6. Use `beforeEach` and `afterEach`: Use `beforeEach` and `afterEach` hooks to set up and tear down the test environment, or using `test.slow()` to mark the test as slow and tripling the test timeout, or running a test in a particular environment etc.
+6. Use `fixtures` to set up and tear down the test environment or run a test in a particular environment etc.
 
-7. When writing any test that use Firefox Sync, use the `newPagesForSync` helper function. This function creates a new browser and a new browser context to avoid any Sync data being shared between tests. After your test is complete, ensure that the browser is closed to free up memory.
+7. Use `test.slow()` to mark the test as slow and triple the test timeout.
 
-Example:
-
-```ts
-let syncBrowserPages;
-test.beforeEach(async ({ target, pages: { login } }) => {
-  test.slow();
-  syncBrowserPages = await newPagesForSync(target);
-});
-
-test.afterEach(async () => {
-  await syncBrowserPages.browser?.close();
-});
-
-test('open directly to /signup page, refresh on the /signup page', async ({
-  target,
-}) => {
-  // Open new pages in browser specifcally for Sync
-  const { page, login } = syncBrowserPages;
-  // ... The rest of your test
-});
-```
+8. When writing tests that use Firefox Sync, use the `syncBrowserPages` fixture. This fixture creates a new browser and a new browser context to avoid any Sync data being shared between tests. After your test is complete, the fixture will ensure that the browser is closed to free up memory.
 
 By following these best practices, you can minimize the likelihood of race conditions in your Playwright tests and ensure more reliable and consistent test results.

--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -15,6 +15,7 @@ export type POMS = ReturnType<typeof createPages>;
 
 export type TestOptions = {
   pages: POMS;
+  syncBrowserPages: POMS;
   credentials: Credentials;
 };
 export type WorkerOptions = { targetName: TargetName; target: ServerTarget };
@@ -82,6 +83,14 @@ export const test = base.extend<TestOptions, WorkerOptions>({
   pages: async ({ target, page }, use) => {
     const pages = createPages(page, target);
     await use(pages);
+  },
+
+  syncBrowserPages: async ({ target }, use) => {
+    const syncBrowserPages = await newPagesForSync(target);
+
+    await use(syncBrowserPages);
+
+    await syncBrowserPages.browser?.close();
   },
 
   storageState: async ({ target, credentials }, use) => {

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 const password = 'passwordzxcv';
-let syncBrowserPages;
 let email;
 let email2;
 
 test.describe('severity-1 #smoke', () => {
-  test.describe('signin with OAuth after Sync', () => {
-    test.beforeEach(async ({ target }) => {
-      test.slow();
-      syncBrowserPages = await newPagesForSync(target);
-    });
+  test.beforeEach(async ({ target }) => {
+    test.slow();
+  });
 
+  test.describe('signin with OAuth after Sync', () => {
     test.afterEach(async ({ target }) => {
       if (email) {
         await target.auth.accountDestroy(email, password);
@@ -25,18 +23,19 @@ test.describe('severity-1 #smoke', () => {
         await target.auth.accountDestroy(email2, password);
         email2 = '';
       }
-      await syncBrowserPages.browser?.close();
     });
 
-    test('signin to OAuth with Sync creds', async ({ target }) => {
-      const {
+    test('signin to OAuth with Sync creds', async ({
+      target,
+      syncBrowserPages: {
         configPage,
         page,
         login,
         connectAnotherDevice,
         relier,
         signupReact,
-      } = syncBrowserPages;
+      },
+    }) => {
       const config = await configPage.getConfig();
 
       email = login.createEmail('sync{id}');
@@ -77,28 +76,24 @@ test.describe('severity-1 #smoke', () => {
   });
 
   test.describe('signin to Sync after OAuth', () => {
-    test.beforeEach(async ({ target }) => {
-      test.slow();
-      syncBrowserPages = await newPagesForSync(target);
-    });
-
     test.afterEach(async ({ target }) => {
       if (email) {
         await target.auth.accountDestroy(email, password);
         email = '';
       }
-      await syncBrowserPages.browser?.close();
     });
 
-    test('email-first Sync signin', async ({ target }) => {
-      const {
+    test('email-first Sync signin', async ({
+      target,
+      syncBrowserPages: {
         configPage,
         page,
         login,
         connectAnotherDevice,
         relier,
         signupReact,
-      } = syncBrowserPages;
+      },
+    }) => {
       const config = await configPage.getConfig();
 
       const email = login.createEmail('sync{id}');

--- a/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
@@ -2,17 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 let email;
 const password = 'password';
 const newPassword = 'new_password';
-let syncBrowserPages;
 
 test.describe('severity-2 #smoke', () => {
   test.describe('post verify - force password change sync', () => {
-    test.beforeEach(async ({ target }) => {
-      syncBrowserPages = await newPagesForSync(target);
-      const { login } = syncBrowserPages;
+    test.beforeEach(async ({ target, syncBrowserPages: { login } }) => {
       email = login.createEmail('forcepwdchange{id}');
       await target.auth.signUp(email, password, {
         lang: 'en',
@@ -21,14 +18,16 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test.afterEach(async ({ target }) => {
-      await syncBrowserPages.browser?.close();
       if (email) {
         // Cleanup any accounts created during the test
         await target.auth.accountDestroy(email, newPassword);
       }
     });
 
-    test('force change password on login - sync', async ({ target }) => {
+    test('force change password on login - sync', async ({
+      target,
+      syncBrowserPages,
+    }) => {
       const { page, login, postVerify, connectAnotherDevice } =
         syncBrowserPages;
       await page.goto(

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, newPagesForSync, test } from '../../lib/fixtures/standard';
-import { createCustomEventDetail, FirefoxCommand } from '../../lib/channels';
+import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import { expect, test } from '../../lib/fixtures/standard';
 import {
   syncDesktopV3QueryParams,
   syncMobileOAuthQueryParams,
@@ -108,12 +108,9 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup oauth webchannel - sync mobile or FF desktop 123+', async ({
-      target,
+      syncBrowserPages: { page, signupReact, login },
     }) => {
       test.fixme(true, 'FXA-9096');
-      const syncBrowserPages = await newPagesForSync(target);
-      const { page, signupReact, login } = syncBrowserPages;
-
       const customEventDetail = createCustomEventDetail(
         FirefoxCommand.FxAStatus,
         {
@@ -148,10 +145,10 @@ test.describe('severity-1 #smoke', () => {
       await signupReact.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
     });
 
-    test('signup sync desktop v3, verify account', async ({ target }) => {
+    test('signup sync desktop v3, verify account', async ({
+      syncBrowserPages: { page, signupReact, login },
+    }) => {
       test.slow();
-      const syncBrowserPages = await newPagesForSync(target);
-      const { page, signupReact, login } = syncBrowserPages;
 
       await signupReact.goto('/', syncDesktopV3QueryParams);
       await signupReact.fillOutEmailFirst(email);
@@ -180,8 +177,6 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/connect_another_device/);
       await expect(page.getByText('You’re signed into Firefox')).toBeVisible();
-
-      await syncBrowserPages.browser?.close();
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, newPagesForSync } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { test } from '../../lib/fixtures/standard';
 import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.describe.configure({ mode: 'parallel' });
-let syncBrowserPages;
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 reset password react', () => {
@@ -16,12 +15,13 @@ test.describe('severity-1 #smoke', () => {
       // Ensure that the feature flag is enabled
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-
-      syncBrowserPages = await newPagesForSync(target);
     });
 
-    test('reset pw for sync user', async ({ credentials, target }) => {
-      const { page, resetPasswordReact } = syncBrowserPages;
+    test('reset pw for sync user', async ({
+      credentials,
+      target,
+      syncBrowserPages: { page, resetPasswordReact },
+    }) => {
       await page.goto(
         getReactFeatureFlagUrl(
           target,

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 import { oauthWebchannelV1 } from '../../lib/query-params';
 
 const password = 'passwordzxcv';
-let syncBrowserPages;
 let browserEmail: string;
 let otherEmail: string;
 let skipTest = false;
@@ -14,45 +13,44 @@ let skipTest = false;
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('fxa_status web channel message in Settings', () => {
-  test.beforeEach(async ({ target, pages: { configPage } }) => {
-    test.slow();
-    // Ensure that the feature flag is enabled
-    const config = await configPage.getConfig();
-    skipTest = config.featureFlags.sendFxAStatusOnSettings !== true;
-    test.skip(skipTest);
+  test.beforeEach(
+    async ({ target, pages: { configPage }, syncBrowserPages: { login } }) => {
+      test.slow();
+      // Ensure that the feature flag is enabled
+      const config = await configPage.getConfig();
+      skipTest = config.featureFlags.sendFxAStatusOnSettings !== true;
+      test.skip(skipTest);
 
-    syncBrowserPages = await newPagesForSync(target);
-    const { login } = syncBrowserPages;
-    browserEmail = login.createEmail();
-    await target.auth.signUp(browserEmail, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
-    otherEmail = login.createEmail();
-    await target.auth.signUp(otherEmail, password, {
-      lang: 'en',
-      preVerified: 'true',
-    });
-    // First we sign the browser into an account
-    await login.goto('load', 'context=fx_desktop_v3&service=sync');
-    await login.fillOutEmailFirstSignIn(browserEmail, password);
-    // Then, we sign into a **different** account
-    await login.goto();
-    await login.useDifferentAccountLink();
-    await login.fillOutEmailFirstSignIn(otherEmail, password);
-  });
+      browserEmail = login.createEmail();
+      await target.auth.signUp(browserEmail, password, {
+        lang: 'en',
+        preVerified: 'true',
+      });
+      otherEmail = login.createEmail();
+      await target.auth.signUp(otherEmail, password, {
+        lang: 'en',
+        preVerified: 'true',
+      });
+      // First we sign the browser into an account
+      await login.goto('load', 'context=fx_desktop_v3&service=sync');
+      await login.fillOutEmailFirstSignIn(browserEmail, password);
+      // Then, we sign into a **different** account
+      await login.goto();
+      await login.useDifferentAccountLink();
+      await login.fillOutEmailFirstSignIn(otherEmail, password);
+    }
+  );
   test.afterEach(async ({ target }) => {
     if (!skipTest) {
-      await syncBrowserPages.browser?.close();
       // Cleanup any accounts created during the test
       await target.auth.accountDestroy(browserEmail, password);
       await target.auth.accountDestroy(otherEmail, password);
     }
   });
 
-  test('message is sent when loading with context = oauth_webchannel_v1', async () => {
-    const { settings } = syncBrowserPages;
-
+  test('message is sent when loading with context = oauth_webchannel_v1', async ({
+    syncBrowserPages: { settings },
+  }) => {
     // We verify that even though another email is signed in, when
     // accessing the setting with a `context=oauth_webchannel_v1` the account
     // signed into the browser takes precedence
@@ -60,9 +58,9 @@ test.describe('fxa_status web channel message in Settings', () => {
     expect(await settings.primaryEmail.statusText()).toBe(browserEmail);
   });
 
-  test('message is not sent when loading without oauth web channel context', async () => {
-    const { settings } = syncBrowserPages;
-
+  test('message is not sent when loading without oauth web channel context', async ({
+    syncBrowserPages: { settings },
+  }) => {
     // We verify that when accessing the setting without the `context=oauth_webchannel_v1`
     // the newer account takes precedence
     await settings.goto();

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -29,6 +29,10 @@ test.describe('severity-2 #smoke', () => {
         // Cleanup any accounts created during the test
         await target.auth.accountDestroy(email, password);
       }
+      if (email2) {
+        // Cleanup any accounts created during the test
+        await target.auth.accountDestroy(email2, password);
+      }
     });
 
     test('sign in twice, on second attempt email will be cached', async ({

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -2,18 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 const password = 'passwordzxcv';
 let email;
 let email2;
-let syncBrowserPages;
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signin cached', () => {
-    test.beforeEach(async ({ target }) => {
+    test.beforeEach(async ({ target, syncBrowserPages: { login } }) => {
       test.slow(); //This test has steps for email rendering that runs slow on stage
-      syncBrowserPages = await newPagesForSync(target);
-      const { login } = syncBrowserPages;
       email = login.createEmail('sync{id}');
       email2 = login.createEmail();
       await target.auth.signUp(email, password, {
@@ -28,7 +25,6 @@ test.describe('severity-2 #smoke', () => {
 
     test.afterEach(async ({ target }) => {
       test.slow(); //The cleanup was timing out and exceeding 3000ms
-      await syncBrowserPages.browser?.close();
       if (email) {
         // Cleanup any accounts created during the test
         await target.auth.accountDestroy(email, password);
@@ -37,8 +33,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('sign in twice, on second attempt email will be cached', async ({
       target,
+      syncBrowserPages: { page, login },
     }) => {
-      const { page, login } = syncBrowserPages;
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -60,8 +56,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('sign in with incorrect email case before normalization fix, on second attempt canonical form is used', async ({
       target,
+      syncBrowserPages: { page, login, settings },
     }) => {
-      const { page, login, settings } = syncBrowserPages;
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -88,8 +84,10 @@ test.describe('severity-2 #smoke', () => {
       expect(primary).toEqual(email);
     });
 
-    test('sign in once, use a different account', async ({ target }) => {
-      const { page, login } = syncBrowserPages;
+    test('sign in once, use a different account', async ({
+      target,
+      syncBrowserPages: { page, login },
+    }) => {
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -116,8 +114,10 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.getPrefilledEmail()).toContain(email2);
     });
 
-    test('expired cached credentials', async ({ target }) => {
-      const { page, login } = syncBrowserPages;
+    test('expired cached credentials', async ({
+      target,
+      syncBrowserPages: { page, login },
+    }) => {
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -140,8 +140,10 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
     });
 
-    test('cached credentials that expire while on page', async ({ target }) => {
-      const { page, login } = syncBrowserPages;
+    test('cached credentials that expire while on page', async ({
+      target,
+      syncBrowserPages: { page, login },
+    }) => {
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -173,9 +175,9 @@ test.describe('severity-2 #smoke', () => {
 
     test('unverified cached signin redirects to confirm email', async ({
       target,
+      syncBrowserPages: { page, login },
     }) => {
       test.fixme(true, 'test to be fixed, see FXA-9194');
-      const { page, login } = syncBrowserPages;
       const email_unverified = login.createEmail();
       await target.auth.signUp(email_unverified, password, {
         lang: 'en',

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -2,13 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-
+import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
-
 const password = 'passwordzxcv';
-let syncBrowserPages;
 let browserSignedInEmail;
 let otherEmail;
 
@@ -16,10 +13,8 @@ test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox desktop user info handshake', () => {
-    test.beforeEach(async ({ target, page }) => {
+    test.beforeEach(async ({ target, syncBrowserPages: { login } }) => {
       test.slow();
-      syncBrowserPages = await newPagesForSync(target);
-      const { login } = syncBrowserPages;
       browserSignedInEmail = login.createEmail();
       await target.auth.signUp(browserSignedInEmail, password, {
         lang: 'en',
@@ -33,7 +28,6 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test.afterEach(async ({ target }) => {
-      await syncBrowserPages.browser?.close();
       const emails = [browserSignedInEmail, otherEmail];
       for (const email of emails) {
         if (email) {
@@ -45,8 +39,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Non-Sync - user signed into browser, user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -85,8 +79,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Sync - no user signed into browser, no user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -101,8 +95,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Sync - no user signed into browser, user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -121,8 +115,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Non-Sync - no user signed into browser, no user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -142,8 +136,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Sync force_auth page - user signed into browser is different to requested user', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
         email: otherEmail,
@@ -166,8 +160,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Non-Sync force_auth page - user signed into browser is different to requested user', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
         email: otherEmail,
@@ -190,8 +184,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Sync - user signed into browser, no user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
         email: browserSignedInEmail,
@@ -214,8 +208,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Non-Sync - user signed into browser, no user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page },
     }) => {
-      const { login, page } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
         email: browserSignedInEmail,
@@ -239,8 +233,8 @@ test.describe('severity-2 #smoke', () => {
 
     test('Non-Sync settings page - no user signed into browser, user signed in locally', async ({
       target,
+      syncBrowserPages: { login, page, settings },
     }) => {
-      const { login, page, settings } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -2,14 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 const makeUid = () =>
   [...Array(32)]
     .map(() => Math.floor(Math.random() * 16).toString(16))
     .join('');
-
-let syncBrowserPages;
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -17,24 +15,17 @@ test.describe('severity-1 #smoke', () => {
   test.describe('Desktop Sync V3 force auth', () => {
     test.beforeEach(async ({ target }) => {
       test.slow();
-      syncBrowserPages = await newPagesForSync(target);
-    });
-
-    test.afterEach(async () => {
-      await syncBrowserPages.browser?.close();
     });
 
     test('sync v3 with a registered email, no uid', async ({
       credentials,
-      target,
-    }) => {
-      const {
+      syncBrowserPages: {
         fxDesktopV3ForceAuth,
         login,
         connectAnotherDevice,
         signinTokenCode,
-      } = syncBrowserPages;
-
+      },
+    }) => {
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         uid: undefined,
       });
@@ -51,15 +42,13 @@ test.describe('severity-1 #smoke', () => {
 
     test('sync v3 with a registered email, registered uid', async ({
       credentials,
-      target,
-    }) => {
-      const {
+      syncBrowserPages: {
         fxDesktopV3ForceAuth,
         login,
         connectAnotherDevice,
         signinTokenCode,
-      } = syncBrowserPages;
-
+      },
+    }) => {
       await fxDesktopV3ForceAuth.open(credentials);
       await login.setPassword(credentials.password);
       await login.submit();
@@ -74,15 +63,13 @@ test.describe('severity-1 #smoke', () => {
 
     test('sync v3 with a registered email, unregistered uid', async ({
       credentials,
-      target,
-    }) => {
-      const {
+      syncBrowserPages: {
         fxDesktopV3ForceAuth,
         login,
         connectAnotherDevice,
         signinTokenCode,
-      } = syncBrowserPages;
-
+      },
+    }) => {
       const uid = makeUid();
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         uid,
@@ -102,14 +89,13 @@ test.describe('severity-1 #smoke', () => {
     test('sync v3 with an unregistered email, no uid', async ({
       credentials,
       pages: { configPage },
+      syncBrowserPages: { fxDesktopV3ForceAuth, login },
     }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'force_auth is no longer supported for signup with react'
       );
-      const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
-
       const email = `sync${Math.random()}@restmail.net`;
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         email,
@@ -136,14 +122,13 @@ test.describe('severity-1 #smoke', () => {
     test('sync v3 with an unregistered email, registered uid', async ({
       credentials,
       pages: { configPage },
+      syncBrowserPages: { fxDesktopV3ForceAuth, login },
     }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'force_auth is no longer supported for signup with react'
       );
-      const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
-
       const email = `sync${Math.random()}@restmail.net`;
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         email,
@@ -162,14 +147,13 @@ test.describe('severity-1 #smoke', () => {
     test('sync v3 with an unregistered email, unregistered uid', async ({
       credentials,
       pages: { configPage },
+      syncBrowserPages: { fxDesktopV3ForceAuth, login },
     }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'force_auth is no longer supported for signup with react'
       );
-      const { fxDesktopV3ForceAuth, login } = syncBrowserPages;
-
       const email = `sync${Math.random()}@restmail.net`;
       const uid = makeUid();
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
@@ -189,7 +173,7 @@ test.describe('severity-1 #smoke', () => {
 
     test('blocked with an registered email, unregistered uid', async ({
       credentials,
-      target,
+      syncBrowserPages,
     }) => {
       const { fxDesktopV3ForceAuth, login, connectAnotherDevice } =
         syncBrowserPages;

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -2,30 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { expect, test } from '../../lib/fixtures/standard';
 
 const password = 'passwordzxcv';
 let email;
-let syncBrowserPages;
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 sign in', () => {
-    test.beforeEach(async ({ target }) => {
+    test.beforeEach(async ({ syncBrowserPages: { login } }) => {
       test.slow();
-      syncBrowserPages = await newPagesForSync(target);
-      const { login } = syncBrowserPages;
       email = login.createEmail('sync{id}');
     });
 
-    test.afterEach(async () => {
-      test.slow(); //The cleanup was timing out and exceeding 3000ms
-      await syncBrowserPages.browser?.close();
-    });
-
-    test('verified, does not need to confirm', async ({ target }) => {
+    test('verified, does not need to confirm', async ({
+      target,
+      syncBrowserPages,
+    }) => {
       const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
       const email = login.createEmail();
@@ -44,7 +39,7 @@ test.describe('severity-2 #smoke', () => {
     });
 
     // TODO in FXA-8973 - use sign in not sign up flow
-    test('verified, resend', async ({ target }) => {
+    test('verified, resend', async ({ target, syncBrowserPages }) => {
       const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
 
@@ -82,7 +77,7 @@ test.describe('severity-2 #smoke', () => {
     });
 
     // TODO in FXA-8973 - use sign in not sign up flow
-    test('verified - invalid code', async ({ target }) => {
+    test('verified - invalid code', async ({ target, syncBrowserPages }) => {
       const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
 
@@ -112,7 +107,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('verified, blocked', async ({ target }) => {
+    test('verified, blocked', async ({ target, syncBrowserPages }) => {
       const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
 
@@ -132,7 +127,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('unverified', async ({ target }) => {
+    test('unverified', async ({ target, syncBrowserPages }) => {
       const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
 
@@ -154,6 +149,7 @@ test.describe('severity-2 #smoke', () => {
     test('add TOTP and confirm sync signin', async ({
       credentials,
       target,
+      syncBrowserPages,
     }) => {
       const { page, login, connectAnotherDevice, settings, totp } =
         syncBrowserPages;
@@ -180,10 +176,8 @@ test.describe('severity-1 #smoke', () => {
     test('user signed into browser and OAuth login', async ({
       target,
       credentials,
+      syncBrowserPages: { page, login, relier, settings },
     }) => {
-      const { browser, page, login, relier, settings } = await newPagesForSync(
-        target
-      );
       await page.goto(
         target.contentServerUrl +
           '?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email'
@@ -225,8 +219,6 @@ test.describe('severity-1 #smoke', () => {
       await settings.disconnectSync(credentials);
 
       expect(page.url()).toContain(login.url);
-
-      await browser?.close();
     });
   });
 });

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -2,35 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 const password = 'passwordzxcv';
 const incorrectPassword = 'password123';
-let email, syncBrowserPages;
+let email;
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-1 #smoke', () => {
-  test.beforeEach(async ({ pages: { configPage } }) => {
-    const config = await configPage.getConfig();
-    test.skip(
-      config.showReactApp.signUpRoutes === true,
-      'these tests are specific to backbone, skip if seeing React version'
-    );
-  });
-
   test.describe('Firefox Desktop Sync v3 sign up', () => {
-    test.beforeEach(async ({ target, pages: { login } }) => {
+    test.beforeEach(async ({ pages: { configPage, login } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signUpRoutes === true,
+        'these tests are specific to backbone, skip if seeing React version'
+      );
       test.slow();
       email = login.createEmail('sync{id}');
-      syncBrowserPages = await newPagesForSync(target);
     });
 
-    test.afterEach(async () => {
-      await syncBrowserPages.browser?.close();
-    });
-
-    test('sync sign up', async ({ target }) => {
+    test('sync sign up', async ({ target, syncBrowserPages }) => {
       const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
 
@@ -60,8 +52,10 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('coppa disabled', async ({ target }) => {
-      const { page, login, connectAnotherDevice } = syncBrowserPages;
+    test('coppa disabled', async ({
+      target,
+      syncBrowserPages: { page, login, connectAnotherDevice },
+    }) => {
       const query = { coppa: 'false' };
       const queryParam = new URLSearchParams(query);
       await page.goto(
@@ -81,8 +75,10 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
 
-    test('email specified by relier, invalid', async ({ target }) => {
-      const { page, login } = syncBrowserPages;
+    test('email specified by relier, invalid', async ({
+      target,
+      syncBrowserPages: { page, login },
+    }) => {
       const invalidEmail = 'invalid@@';
       const query = { email: invalidEmail };
       const queryParam = new URLSearchParams(query);
@@ -94,8 +90,10 @@ test.describe('severity-1 #smoke', () => {
       expect(await login.getTooltipError()).toContain('Valid email required');
     });
 
-    test('email specified by relier, empty string', async ({ target }) => {
-      const { page, login } = syncBrowserPages;
+    test('email specified by relier, empty string', async ({
+      target,
+      syncBrowserPages: { page, login },
+    }) => {
       const emptyEmail = '';
       const query = { email: emptyEmail };
       const queryParam = new URLSearchParams(query);
@@ -107,8 +105,10 @@ test.describe('severity-1 #smoke', () => {
       expect(await login.getTooltipError()).toContain('Valid email required');
     });
 
-    test('email specified by relier, not registered', async ({ target }) => {
-      const { page, login } = syncBrowserPages;
+    test('email specified by relier, not registered', async ({
+      target,
+      syncBrowserPages: { page, login },
+    }) => {
       const query = { email };
       const queryParam = new URLSearchParams(query);
       await page.goto(
@@ -127,8 +127,8 @@ test.describe('severity-1 #smoke', () => {
     test('email specified by relier, registered', async ({
       credentials,
       target,
+      syncBrowserPages: { page, login },
     }) => {
-      const { page, login } = syncBrowserPages;
       const query = { email: credentials.email };
       const queryParam = new URLSearchParams(query);
       await page.goto(

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
-import uaStrings from '../../lib/ua-strings';
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import { expect, test } from '../../lib/fixtures/standard';
+import uaStrings from '../../lib/ua-strings';
 
 const password = 'passwordzxcv';
 let email;
-let syncBrowserPages;
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -22,19 +21,16 @@ test.describe('severity-1 #smoke', () => {
   });
 
   test.describe('Sync v3 sign up and CWTS', () => {
-    test.beforeEach(async ({ target }) => {
+    test.beforeEach(async ({ syncBrowserPages: { login } }) => {
       //Sync tests run a little slower and flake
       test.slow();
-      syncBrowserPages = await newPagesForSync(target);
-      const { login } = syncBrowserPages;
       email = login.createEmail('sync{id}');
     });
 
-    test.afterEach(async () => {
-      await syncBrowserPages.browser?.close();
-    });
-
-    test('verify with signup code and CWTS', async ({ target }) => {
+    test('verify with signup code and CWTS', async ({
+      target,
+      syncBrowserPages,
+    }) => {
       const { login, page, signinTokenCode, connectAnotherDevice } =
         syncBrowserPages;
       const query = new URLSearchParams({
@@ -89,7 +85,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('verify at CWTS', async ({ target }) => {
+    test('verify at CWTS', async ({ target, syncBrowserPages }) => {
       const { login, page, signinTokenCode, connectAnotherDevice } =
         syncBrowserPages;
       const query = new URLSearchParams({
@@ -134,8 +130,10 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('engines not supported', async ({ target }) => {
-      const { login, page, signinTokenCode } = syncBrowserPages;
+    test('engines not supported', async ({
+      target,
+      syncBrowserPages: { login, page, signinTokenCode },
+    }) => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -167,8 +165,8 @@ test.describe('severity-1 #smoke', () => {
 
     test('neither `creditcards` nor `addresses` supported', async ({
       target,
+      syncBrowserPages: { login, page, signinTokenCode },
     }) => {
-      const { login, page, signinTokenCode } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -201,8 +199,10 @@ test.describe('severity-1 #smoke', () => {
       expect(await login.isCWTSEngineCreditCards()).toBe(false);
     });
 
-    test('`creditcards` and `addresses` supported', async ({ target }) => {
-      const { login, page, signinTokenCode } = syncBrowserPages;
+    test('`creditcards` and `addresses` supported', async ({
+      target,
+      syncBrowserPages: { login, page, signinTokenCode },
+    }) => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
+
 const password = 'passwordzxcv';
 let email;
 let email2;
-let syncBrowserPages;
 
 test.describe('severity-2 #smoke', () => {
   test.describe('sync signin cached', () => {
-    test.beforeEach(async ({ target }) => {
+    test.beforeEach(async ({ target, syncBrowserPages: { login } }) => {
       test.slow(); //This test has steps for email rendering that runs slow on stage
-      syncBrowserPages = await newPagesForSync(target);
-      const { login } = syncBrowserPages;
       email = login.createEmail('sync{id}');
       email2 = login.createEmail();
       await target.auth.signUp(email, password, {
@@ -28,7 +26,6 @@ test.describe('severity-2 #smoke', () => {
 
     test.afterEach(async ({ target }) => {
       test.slow(); //The cleanup was timing out and exceeding 3000ms
-      await syncBrowserPages.browser?.close();
       const emails = [email, email2];
       for (const email of emails) {
         if (email) {
@@ -43,9 +40,9 @@ test.describe('severity-2 #smoke', () => {
 
     test('sign in on desktop then specify a different email on query parameter continues to cache desktop signin', async ({
       target,
+      syncBrowserPages: { page, login, connectAnotherDevice },
     }) => {
       test.fixme(true, 'test to be fixed, see FXA-9194');
-      const { page, login, connectAnotherDevice } = syncBrowserPages;
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`
       );
@@ -85,9 +82,9 @@ test.describe('severity-2 #smoke', () => {
 
     test('sign in with desktop context then no context, desktop credentials should persist', async ({
       target,
+      syncBrowserPages: { page, login },
     }) => {
       test.fixme(true, 'test to be fixed, see FXA-9194');
-      const { page, login } = syncBrowserPages;
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`
       );

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -2,35 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 const PASSWORD = 'passwordzxcv';
-let email, syncBrowserPages;
+let email;
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Firefox Desktop Sync v3 email first', () => {
-  test.beforeEach(async ({ target, pages: { login } }) => {
+  test.beforeEach(async ({ pages: { login } }) => {
     test.slow();
     email = login.createEmail('sync{id}');
-    syncBrowserPages = await newPagesForSync(target);
-  });
-
-  test.afterEach(async () => {
-    await syncBrowserPages.browser?.close();
   });
 
   // TODO: is this something we want to support once index/email-first is converted to React?
   test('open directly to /signup page, refresh on the /signup page', async ({
     pages: { configPage },
     target,
+    syncBrowserPages: { page, login },
   }) => {
     const config = await configPage.getConfig();
     test.skip(
       config.showReactApp.signUpRoutes === true,
       'Not currently supported in React Signup'
     );
-    const { page, login } = syncBrowserPages;
     await page.goto(
       `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'load' }
@@ -51,8 +46,8 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
 
   test('open directly to /signin page, refresh on the /signin page', async ({
     target,
+    syncBrowserPages: { page, login },
   }) => {
-    const { page, login } = syncBrowserPages;
     await target.auth.signUp(email, PASSWORD, {
       lang: 'en',
       preVerified: 'true',
@@ -75,8 +70,10 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     await login.waitForEmailHeader();
   });
 
-  test('enter a firefox.com address', async ({ target }) => {
-    const { page, login, signinTokenCode } = syncBrowserPages;
+  test('enter a firefox.com address', async ({
+    target,
+    syncBrowserPages: { login, page, signinTokenCode },
+  }) => {
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'load' }

--- a/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3ResetPassword.spec.ts
@@ -2,29 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, newPagesForSync } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Firefox Desktop Sync v3 reset password', () => {
-  test.beforeEach(async ({ pages: { configPage } }) => {
-    test.slow();
-
+  test('reset pw, test pw validation, verify same browser', async ({
+    pages: { configPage },
+    credentials,
+    target,
+    syncBrowserPages: { page, login, resetPassword },
+  }) => {
     const config = await configPage.getConfig();
     test.skip(
       config.showReactApp.resetPasswordRoutes === true,
       'Scheduled for removal as part of React conversion (see FXA-8267).'
     );
-  });
+    test.slow();
 
-  test('reset pw, test pw validation, verify same browser', async ({
-    credentials,
-    target,
-  }) => {
-    const { browser, page, login, resetPassword } = await newPagesForSync(
-      target
-    );
     await page.goto(
       `${target.contentServerUrl}/reset_password?context=fx_desktop_v3&service=sync&forceExperiment=generalizedReactApp&forceExperimentGroup=control`
     );
@@ -63,7 +59,5 @@ test.describe('Firefox Desktop Sync v3 reset password', () => {
 
     await resetPassword.resetNewPassword('Newpassword@');
     await resetPassword.completeResetPasswordHeader();
-
-    await browser?.close();
   });
 });


### PR DESCRIPTION
## Because

- we want to isolate and assure proper creation and cleanup of `syncBrowserPages`

## This pull request

- refactors common code in before, after and test methods to playwrite test [fixtures](https://playwright.dev/docs/test-fixtures)

## Issue that this pull request solves

Closes: # FXA-9137

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
