### PR TITLE
feat(payments-paypal): Create PayPal processInvoice, processZeroInvoice, and processNonZeroInvoice

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -3,13 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
+import { Stripe } from 'stripe';
+
+import { StripeManager } from '@fxa/payments/stripe';
 import { AccountDatabase } from '@fxa/shared/db/mysql/account';
 import { PayPalClient } from './paypal.client';
 import { BillingAgreement, BillingAgreementStatus } from './paypal.types';
 
 @Injectable()
 export class PayPalManager {
-  constructor(private db: AccountDatabase, private client: PayPalClient) {}
+  constructor(
+    private db: AccountDatabase,
+    private client: PayPalClient,
+    private stripeManager: StripeManager
+  ) {}
 
   /**
    * Get Billing Agreement details by calling the update Billing Agreement API.
@@ -42,5 +49,54 @@ export class PayPalManager {
   async getCheckoutToken(currencyCode: string) {
     const response = await this.client.setExpressCheckout({ currencyCode });
     return response.TOKEN;
+  }
+
+  /**
+   * Process an invoice when amount is greater than minimum amount
+   *
+   * @param customer
+   * @param invoice
+   * @param ipaddress
+   */
+  async processNonZeroInvoice(
+    customer: Stripe.Customer,
+    invoice: Stripe.Invoice,
+    ipaddress?: string
+  ) {
+    // TODO in M3b: Implement legacy processInvoice as processNonZeroInvoice here
+    // TODO: Add spec
+    console.log(customer, invoice, ipaddress);
+  }
+
+  /**
+   * Finalize and process a draft invoice that has no amounted owed.
+   *
+   * @param invoice
+   */
+  async processZeroInvoice(invoiceId: string) {
+    // It appears for subscriptions that do not require payment, the invoice
+    // transitions to paid automatially.
+    // https://stripe.com/docs/billing/invoices/subscription#sub-invoice-lifecycle
+    return this.stripeManager.finalizeInvoiceWithoutAutoAdvance(invoiceId);
+  }
+
+  /**
+   * Process an invoice
+   * If amount is less than minimum amount, call processZeroInvoice
+   * If amount is greater than minimum amount, call processNonZeroInvoice (legacy PaypalHelper processInvoice)
+   *
+   * @param invoice
+   */
+  async processInvoice(invoice: Stripe.Invoice) {
+    const amountInCents = invoice.amount_due;
+
+    if (amountInCents < this.stripeManager.getMinimumAmount(invoice.currency)) {
+      return await this.processZeroInvoice(invoice.id);
+    } else {
+      const customer = await this.stripeManager.fetchActiveCustomer(
+        invoice.customer as string
+      );
+      return await this.processNonZeroInvoice(customer, invoice);
+    }
   }
 }

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -8,4 +8,6 @@ export { ProductFactory } from './lib/factories/product.factory';
 export { SubscriptionItemFactory } from './lib/factories/subscription-item.factory';
 export { SubscriptionFactory } from './lib/factories/subscription.factory';
 export * from './lib/stripe.client';
+export * from './lib/stripe.constants';
+export * from './lib/stripe.error';
 export * from './lib/stripe.manager';

--- a/libs/payments/stripe/src/lib/stripe.client.config.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.config.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class StripeClientConfig {
+  @IsString()
+  public readonly apiKey!: string;
+}

--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { CustomerFactory } from './factories/customer.factory';
+import { InvoiceFactory } from './factories/invoice.factory';
+import { StripeClient } from './stripe.client';
+
+describe('StripeClient', () => {
+  let mockClient: StripeClient;
+
+  beforeEach(() => {
+    mockClient = new StripeClient({
+      apiKey: faker.string.uuid(),
+    });
+  });
+
+  it('should be defined', () => {
+    expect(mockClient).toBeDefined();
+  });
+
+  describe('fetchCustomer', () => {
+    it('returns an existing customer from Stripe', async () => {
+      const mockCustomer = CustomerFactory();
+
+      mockClient.stripe.customers.retrieve = jest
+        .fn()
+        .mockResolvedValueOnce(mockCustomer);
+
+      const result = await mockClient.fetchCustomer(mockCustomer.id);
+      expect(result).toEqual(mockCustomer);
+    });
+  });
+
+  describe('finalizeInvoice', () => {
+    it('works successfully', async () => {
+      const mockInvoice = InvoiceFactory({
+        auto_advance: false,
+      });
+
+      mockClient.stripe.invoices.finalizeInvoice = jest
+        .fn()
+        .mockResolvedValueOnce({});
+
+      const result = await mockClient.finalizeInvoice(mockInvoice.id, {
+        auto_advance: false,
+      });
+
+      expect(result).toEqual({});
+      expect(mockClient.stripe.invoices.finalizeInvoice).toBeCalledWith(
+        mockInvoice.id,
+        { auto_advance: false }
+      );
+    });
+  });
+});

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -3,8 +3,35 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
+import { Stripe } from 'stripe';
+
+import { StripeClientConfig } from './stripe.client.config';
 
 @Injectable()
 export class StripeClient {
-  constructor() {}
+  public readonly stripe: Stripe;
+
+  constructor(private stripeClientConfig: StripeClientConfig) {
+    this.stripe = new Stripe(this.stripeClientConfig.apiKey, {
+      apiVersion: '2022-11-15',
+      maxNetworkRetries: 3,
+    });
+  }
+
+  /**
+   * Retrieves a customer record directly from Stripe
+   *
+   * @param customerId The Stripe customer ID of the customer to fetch
+   * @returns The customer record for the customerId provided
+   */
+  async fetchCustomer(customerId: string) {
+    return this.stripe.customers.retrieve(customerId);
+  }
+
+  async finalizeInvoice(
+    invoiceId: string,
+    params?: Stripe.InvoiceFinalizeInvoiceParams | undefined
+  ) {
+    return this.stripe.invoices.finalizeInvoice(invoiceId, params);
+  }
 }

--- a/libs/payments/stripe/src/lib/stripe.constants.ts
+++ b/libs/payments/stripe/src/lib/stripe.constants.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Stripe minimum charge amounts as set here
+// https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+export const STRIPE_MINIMUM_CHARGE_AMOUNTS = {
+  usd: 50,
+  aed: 200,
+  aud: 50,
+  bgn: 100,
+  brl: 50,
+  cad: 50,
+  chf: 50,
+  czk: 1500,
+  dkk: 250,
+  eur: 50,
+  gbp: 30,
+  hkd: 400,
+  huf: 17500,
+  inr: 50,
+  jpy: 50,
+  mxn: 1000,
+  myr: 200,
+  nok: 300,
+  nzd: 50,
+  pln: 200,
+  ron: 200,
+  sek: 300,
+  sgd: 50,
+} as { [key: string]: number };

--- a/libs/payments/stripe/src/lib/stripe.error.ts
+++ b/libs/payments/stripe/src/lib/stripe.error.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseError } from '@fxa/shared/error';
+
+export class StripeError extends BaseError {
+  constructor(message: string, cause?: Error) {
+    super(
+      {
+        ...(cause && { cause }),
+      },
+      message
+    );
+  }
+}
+
+export class CustomerDeletedError extends StripeError {
+  constructor() {
+    super('Customer deleted');
+  }
+}
+
+export class SubscriptionStripeError extends StripeError {
+  constructor() {
+    super('Currency does not have a minimum charge amount available.');
+  }
+}

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -1,37 +1,78 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { CustomerFactory } from './factories/customer.factory';
+import { InvoiceFactory } from './factories/invoice.factory';
 import { StripeClient } from './stripe.client';
 import { StripeManager } from './stripe.manager';
 
 describe('StripeManager', () => {
+  let manager: StripeManager;
+  let mockClient: StripeClient;
+
+  beforeEach(async () => {
+    mockClient = new StripeClient({} as any);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: StripeClient, useValue: mockClient },
+        StripeManager,
+      ],
+    }).compile();
+
+    manager = module.get<StripeManager>(StripeManager);
+  });
+
+  it('should be defined', async () => {
+    expect(manager).toBeDefined();
+    expect(manager).toBeInstanceOf(StripeManager);
+  });
+
+  describe('fetchActiveCustomer', () => {
+    it('returns an existing customer from Stripe', async () => {
+      const mockCustomer = CustomerFactory();
+
+      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+
+      const result = await manager.fetchActiveCustomer(mockCustomer.id);
+      expect(result).toEqual(mockCustomer);
+    });
+  });
+
+  describe('finalizeInvoiceWithoutAutoAdvance', () => {
+    it('works successfully', async () => {
+      const mockInvoice = InvoiceFactory({
+        auto_advance: false,
+      });
+
+      mockClient.finalizeInvoice = jest.fn().mockResolvedValueOnce({});
+
+      const result = await manager.finalizeInvoiceWithoutAutoAdvance(
+        mockInvoice.id
+      );
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('getMinimumAmount', () => {
+    it('returns minimum amout for valid currency', () => {
+      const expected = 50;
+      const result = manager.getMinimumAmount('usd');
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should throw an error if currency is invalid', () => {
+      expect(() => manager.getMinimumAmount('fake')).toThrow(
+        'Currency does not have a minimum charge amount available.'
+      );
+    });
+  });
+
   describe('isCustomerStripeTaxEligible', () => {
-    let manager: StripeManager;
-    let mockStripeClient: StripeClient;
-    let mockResult: any;
-
-    beforeEach(async () => {
-      mockResult = {};
-      mockStripeClient = {};
-
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          { provide: StripeClient, useValue: mockStripeClient },
-          StripeManager,
-        ],
-      }).compile();
-
-      manager = module.get<StripeManager>(StripeManager);
-    });
-
-    it('should be defined', async () => {
-      expect(manager).toBeDefined();
-      expect(manager).toBeInstanceOf(StripeManager);
-    });
-
     it('should throw an error if no tax in customer', async () => {
       const mockCustomer = CustomerFactory();
 
@@ -49,10 +90,6 @@ describe('StripeManager', () => {
         },
       });
 
-      mockResult.isCustomerStripeTaxEligible = jest
-        .fn()
-        .mockReturnValueOnce(true);
-
       const result = await manager.isCustomerStripeTaxEligible(mockCustomer);
       expect(result).toEqual(true);
     });
@@ -65,10 +102,6 @@ describe('StripeManager', () => {
           location: null,
         },
       });
-
-      mockResult.isCustomerStripeTaxEligible = jest
-        .fn()
-        .mockReturnValueOnce(true);
 
       const result = await manager.isCustomerStripeTaxEligible(mockCustomer);
       expect(result).toEqual(true);

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -4,12 +4,56 @@
 
 import { Injectable } from '@nestjs/common';
 import { Stripe } from 'stripe';
+
 import { StripeClient } from './stripe.client';
+import { STRIPE_MINIMUM_CHARGE_AMOUNTS } from './stripe.constants';
+import { CustomerDeletedError, SubscriptionStripeError } from './stripe.error';
 
 @Injectable()
 export class StripeManager {
   constructor(private client: StripeClient) {}
 
+  /**
+   * Retrieves a customer record
+   *
+   * @param customerId
+   * @returns
+   */
+  async fetchActiveCustomer(customerId: string) {
+    const customer = await this.client.fetchCustomer(customerId);
+    if (customer.deleted) throw new CustomerDeletedError();
+    return customer;
+  }
+
+  /**
+   * Finalizes an invoice and marks auto_advance as false.
+   */
+  async finalizeInvoiceWithoutAutoAdvance(invoiceId: string) {
+    return this.client.finalizeInvoice(invoiceId, {
+      auto_advance: false,
+    });
+  }
+
+  /**
+   * Returns minimum amount for valid currency
+   * Throws error for invalid currency
+   *
+   * @param currency
+   * @returns
+   */
+  getMinimumAmount(currency: string): number {
+    if (STRIPE_MINIMUM_CHARGE_AMOUNTS[currency]) {
+      return STRIPE_MINIMUM_CHARGE_AMOUNTS[currency];
+    }
+
+    throw new SubscriptionStripeError();
+  }
+
+  /**
+   * Check if customer's automatic tax status indicates that they're eligible for automatic tax.
+   * Creating a subscription with automatic_tax enabled requires a customer with an address
+   * that is in a recognized location with an active tax registration.
+   */
   async isCustomerStripeTaxEligible(customer: Stripe.Customer) {
     if (!customer.tax) {
       // TODO: FXA-8891

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -1,4 +1,4 @@
-/* This Source Code Form is subject to the terms of the Mozilla Publiclib/payments/paypal/helper.ts
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { hasPaypalSubscription } from 'fxa-shared/subscriptions/stripe';


### PR DESCRIPTION
## This pull request

- [x] Migrates processZeroInvoice & processNonZeroInvoice implementation to PaypalManager processZeroInvoice & processNonZeroInvoice (ref: existing implementation in processZeroInvoice, processInvoice)
  - [x] For processInvoice
     -  If amount is less than minimum amount (see current processZeroInvoice implementation for constant), call processZeroInvoice
     - If amount is greater than minimum amount, call PaypalManager processNonZeroInvoice
  - [x] For processZeroInvoice - Call StripeManager finalizeInvoiceWithoutAutoAdvance
  - [x] For processNonZeroInvoice
    - Per the ticket, we are to call the existing PaypalHelper processInvoice. However, we are unable to do so, and instead a comment has been added to remind us to update this in M3b.
    - Leave a todo comment regarding migrating processInvoice rather than calling it directly

## Issue that this pull request solves

Closes: FXA-8942

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.