### PR TITLE
fix(test): Update Apple/Google third party auth tests

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -562,6 +562,11 @@ export class LoginPage extends BaseLayout {
     await this.page.waitForURL(/accounts\.google\.com/);
   }
 
+  async clickContinueWithApple() {
+    await this.page.getByText('Continue with Apple').click();
+    await this.page.waitForURL(/appleid\.apple\.com/);
+  }
+
   async clearCache() {
     await this.page.goto(`${this.target.contentServerUrl}/clear`);
     await this.page.context().clearCookies();

--- a/packages/functional-tests/tests/thirdPartyAuth/thirdPartyAuth.spec.ts
+++ b/packages/functional-tests/tests/thirdPartyAuth/thirdPartyAuth.spec.ts
@@ -2,58 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test } from '../../lib/fixtures/standard';
-import { authenticator } from 'otplib';
-
-const GOOGLE_TEST_EMAIL =
-  process.env.GOOGLE_TEST_EMAIL || 'fxalive2022@gmail.com';
-const GOOGLE_TEST_PASSWORD = process.env.GOOGLE_TEST_PASSWORD;
-const GOOGLE_TEST_2FA_SECRET = process.env.GOOGLE_TEST_2FA_SECRET;
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('third party auth', () => {
-    test('Google signin to settings', async ({
+    test('Continue with `Google` opens Google login', async ({
       target,
       pages: { login, page },
     }) => {
-      const shouldSkip =
-        !GOOGLE_TEST_EMAIL || !GOOGLE_TEST_PASSWORD || !GOOGLE_TEST_2FA_SECRET;
-      test.skip(
-        shouldSkip,
-        'Please contact FxA admin to get credentials for Google account'
-      );
-      test.slow();
       await page.goto(target.contentServerUrl, { waitUntil: 'load' });
-
       await login.clickContinueWithGoogle();
+      const title = await page.title();
+      expect(title).toContain('Google');
+    });
 
-      await page.locator('input[type="email"]').fill(GOOGLE_TEST_EMAIL);
-      await page.getByText('Next').click();
-      await page.waitForURL(/v3\/signin\/challenge\/pwd/);
-
-      await page.locator('input[type="password"]').fill(GOOGLE_TEST_PASSWORD);
-      await page.getByText('Next').click();
-
-      let token = authenticator.generate(GOOGLE_TEST_2FA_SECRET);
-      await page.locator('#totpPin').fill(token);
-      await page
-        .locator('#totpNext')
-        .getByRole('button', { name: 'Next' })
-        .click();
-
-      const invalidCodeLocator = page.getByText('Wrong code. Try again.');
-      if (await invalidCodeLocator.isVisible()) {
-        // Per chance the 2FA code expired, wait few seconds and try a new code
-        await page.waitForTimeout(5000);
-        token = authenticator.generate(GOOGLE_TEST_2FA_SECRET);
-        await page.locator('#totpPin').fill(token);
-        await page
-          .locator('#totpNext')
-          .getByRole('button', { name: 'Next' })
-          .click();
-      }
-
-      await page.waitForURL(/settings/);
+    test('Continue with `Apple` opens Apple login', async ({
+      target,
+      pages: { login, page },
+    }) => {
+      await page.goto(target.contentServerUrl, { waitUntil: 'load' });
+      await login.clickContinueWithApple();
+      const title = await page.title();
+      expect(title).toContain('Apple');
     });
   });
 });


### PR DESCRIPTION
## Because

- We currently don't run these tests

## This pull request

- Simplfy the tests and run them

## Issue that this pull request solves

Closes: # [FXA-8964](https://mozilla-hub.atlassian.net/browse/FXA-8964)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Previously, these tests tried to go through the entire Google login flow, while this provides good coverage, its very flaky. They also required lots of setup and used a custom gmail account to do the login. The new tests just verify that the Apple and Google login page loads.

Paired with @Trinaa on these

[FXA-8964]: https://mozilla-hub.atlassian.net/browse/FXA-8964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ