### PR TITLE
bug(graphql): Fix mismatch in test state

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -182,7 +182,12 @@ describe('#integration - AccountResolver', () => {
         ];
         const securityEvents = resolver.securityEvents(user!);
         expect(securityEvents).toStrictEqual([
-          { name: 'account.created', verified: true, createdAt },
+          {
+            name: 'account.created',
+            verified: true,
+            createdAt,
+            ipAddr: undefined,
+          },
         ]);
       });
     });

--- a/packages/fxa-graphql-api/test/security-events.sql
+++ b/packages/fxa-graphql-api/test/security-events.sql
@@ -5,6 +5,7 @@ CREATE TABLE `securityEvents` (
   `ipAddrHmac` binary(32) NOT NULL,
   `createdAt` bigint NOT NULL,
   `tokenVerificationId` binary(16) DEFAULT NULL,
+  `ipAddr` VARCHAR(39) DEFAULT NULL,
   KEY `nameId` (`nameId`),
   KEY `securityEvents_uid_tokenVerificationId` (`uid`,`tokenVerificationId`),
   KEY `securityEvents_uid_ipAddrHmac_createdAt` (`uid`,`ipAddrHmac`,`createdAt`),


### PR DESCRIPTION
## Because

- We could get in state where tests would fail

## This pull request

- Makes sure the test database is inline with the latest state

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
