### PR TITLE
feat(payments-stripe): create StripeManager addTaxIdToCustomer

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -34,6 +34,23 @@ describe('StripeClient', () => {
     });
   });
 
+  describe('updateCustomer', () => {
+    it('updates an existing customer from Stripe', async () => {
+      const mockCustomer = CustomerFactory();
+      const mockUpdatedCustomer = CustomerFactory();
+
+      mockClient.stripe.customers.update = jest
+        .fn()
+        .mockResolvedValueOnce(mockUpdatedCustomer);
+
+      const result = await mockClient.updateCustomer(mockCustomer.id, {
+        balance: mockUpdatedCustomer.balance,
+      });
+
+      expect(result.balance).toEqual(mockUpdatedCustomer.balance);
+    });
+  });
+
   describe('fetchSubscriptions', () => {
     it('returns subscriptions from Stripe', async () => {
       const mockCustomer = CustomerFactory();

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -29,6 +29,20 @@ export class StripeClient {
   }
 
   /**
+   * Updates customer object with the values of the parameters passed
+   *
+   * @param customerId The Stripe customer ID of the customer to update
+   * @param params Values to be updated in customer object
+   * @returns The updated customer object or throws an error if paramaters are invalid
+   */
+  async updateCustomer(
+    customerId: string,
+    params: Stripe.CustomerUpdateParams
+  ) {
+    return this.stripe.customers.update(customerId, params);
+  }
+
+  /**
    * Retrieves subscriptions directly from Stripe
    *
    * @param customerId

--- a/libs/payments/stripe/src/lib/stripe.constants.ts
+++ b/libs/payments/stripe/src/lib/stripe.constants.ts
@@ -38,3 +38,5 @@ export const STRIPE_MINIMUM_CHARGE_AMOUNTS = {
   sek: 300,
   sgd: 50,
 } as { [key: string]: number };
+
+export const MOZILLA_TAX_ID = 'Tax ID';

--- a/libs/payments/stripe/src/lib/stripe.error.ts
+++ b/libs/payments/stripe/src/lib/stripe.error.ts
@@ -21,6 +21,12 @@ export class CustomerDeletedError extends StripeError {
   }
 }
 
+export class CustomerNotFoundError extends StripeError {
+  constructor() {
+    super('Customer not found');
+  }
+}
+
 export class SubscriptionStripeError extends StripeError {
   constructor() {
     super('Currency does not have a minimum charge amount available.');

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -141,4 +141,75 @@ describe('StripeManager', () => {
       expect(result).toEqual(true);
     });
   });
+
+  describe('update customer tax ID', () => {
+    it('returns customer tax id if found', async () => {
+      const mockCustomer = CustomerFactory({
+        invoice_settings: {
+          custom_fields: [{ name: 'Tax ID', value: 'LeeroyJenkins' }],
+          default_payment_method: null,
+          footer: null,
+          rendering_options: null,
+        },
+      });
+
+      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+
+      const result = await manager.getCustomerTaxId(mockCustomer.id);
+
+      expect(result).toEqual('LeeroyJenkins');
+    });
+
+    it('returns undefined when customer tax id not found', async () => {
+      const mockCustomer = CustomerFactory();
+
+      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+
+      const result = await manager.getCustomerTaxId(mockCustomer.id);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('updates customer object with incoming tax id when match is not found', async () => {
+      const mockCustomer = CustomerFactory();
+      const mockUpdatedCustomer = CustomerFactory({
+        invoice_settings: {
+          custom_fields: [{ name: 'Tax ID', value: 'EU1234' }],
+          default_payment_method: null,
+          footer: null,
+          rendering_options: null,
+        },
+      });
+
+      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+
+      mockClient.updateCustomer = jest
+        .fn()
+        .mockResolvedValueOnce(mockUpdatedCustomer);
+
+      const result = await manager.setCustomerTaxId(mockCustomer.id, 'EU1234');
+
+      expect(result).toEqual(mockUpdatedCustomer);
+    });
+
+    it('does not update customer object when incoming tax id matches existing tax id', async () => {
+      const mockCustomer = CustomerFactory({
+        invoice_settings: {
+          custom_fields: [{ name: 'Tax ID', value: 'T43CAK315A713' }],
+          default_payment_method: null,
+          footer: null,
+          rendering_options: null,
+        },
+      });
+
+      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+
+      const result = await manager.setCustomerTaxId(
+        mockCustomer.id,
+        'T43CAK315A713'
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Because

- Part of M3a.
- We want `addTaxIdToCustomer` added to StripeManager.
  - See **Other information** below

## This pull request

- Adds aforementioned method to `StripeManager` using existing implementation for reference.
- Updates customer metadata with `taxId` when customer `taxId` does not match incoming `taxId`.
  - See **Other information** below

## Issue that this pull request solves

Closes FXA-8944, FXA-8945

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

After discussing with @julianpoy via Slack, it was decided to update the function to `setCustomerTaxId` and `getCustomerTaxId` respectively. This option would allow more flexibility in future and a function to retrieve a customer's tax id directly.