### PR TITLE
refactor(functional-tests): legal tests

### DIFF
--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -25,6 +25,8 @@ import { PostVerifyPage } from './postVerify';
 import { ResetPasswordReactPage } from './resetPasswordReact';
 import { SignupReactPage } from './signupReact';
 import { ConfigPage } from './config';
+import { PrivacyPage } from './privacy';
+import { TermsOfService } from './termsOfService';
 export function create(page: Page, target: BaseTarget) {
   return {
     avatar: new AvatarPage(page, target),
@@ -53,5 +55,7 @@ export function create(page: Page, target: BaseTarget) {
     postVerify: new PostVerifyPage(page, target),
     signupReact: new SignupReactPage(page, target),
     configPage: new ConfigPage(page, target),
+    privacy: new PrivacyPage(page, target),
+    termsOfService: new TermsOfService(page, target),
   };
 }

--- a/packages/functional-tests/pages/legal.ts
+++ b/packages/functional-tests/pages/legal.ts
@@ -1,7 +1,27 @@
 import { BaseLayout } from './layout';
 
-export const selectors = {};
-
 export class LegalPage extends BaseLayout {
-  readonly path = '';
+  readonly path = 'legal';
+
+  get pageHeader() {
+    return this.page.getByRole('heading', { name: 'Legal' });
+  }
+
+  get privacyNoticeLink() {
+    return this.page.getByRole('link', { name: 'Privacy Notice' });
+  }
+
+  get termsOfServiceLink() {
+    return this.page.getByRole('link', { name: 'Terms of Service' });
+  }
+
+  async clickPrivacyNoticeLink() {
+    this.privacyNoticeLink.click();
+    await this.page.waitForURL(/\/legal\/privacy/);
+  }
+
+  async clickTermsOfServiceLink() {
+    this.termsOfServiceLink.click();
+    await this.page.waitForURL(/\/legal\/terms/);
+  }
 }

--- a/packages/functional-tests/pages/privacy.ts
+++ b/packages/functional-tests/pages/privacy.ts
@@ -1,0 +1,20 @@
+import { BaseLayout } from './layout';
+
+export class PrivacyPage extends BaseLayout {
+  readonly path = 'legal/privacy';
+
+  get backButton() {
+    return this.page.getByRole('button', { name: 'Back' });
+  }
+
+  get pageHeader() {
+    return this.page.getByRole('heading', {
+      name: 'Mozilla Accounts Privacy Notice',
+    });
+  }
+
+  async clickBackButton() {
+    await this.backButton.click();
+    await this.page.waitForURL(/\/legal$/);
+  }
+}

--- a/packages/functional-tests/pages/termsOfService.ts
+++ b/packages/functional-tests/pages/termsOfService.ts
@@ -1,0 +1,20 @@
+import { BaseLayout } from './layout';
+
+export class TermsOfService extends BaseLayout {
+  readonly path = 'legal/terms';
+
+  get backButton() {
+    return this.page.getByRole('button', { name: 'Back' });
+  }
+
+  get pageHeader() {
+    return this.page.getByRole('heading', {
+      name: 'Mozilla Accounts Terms of Service',
+    });
+  }
+
+  async clickBackButton() {
+    await this.backButton.click();
+    await this.page.waitForURL(/\/legal$/);
+  }
+}

--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -6,53 +6,102 @@ import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('legal', () => {
-    test('start at legal page', async ({ page, target }) => {
-      await page.goto(`${target.contentServerUrl}/legal`);
+    test('users can navigate between legal and privacy notice', async ({
+      pages: { legal, privacy },
+    }) => {
+      await legal.goto();
 
-      // Verify legal page is visible
-      await expect(
-        page.locator('.card-header:has-text("Legal")')
-      ).toBeEnabled();
+      await expect(legal.pageHeader).toBeVisible();
+      await expect(legal.privacyNoticeLink).toBeVisible();
 
-      // Verify Terms Of Service link is visible
-      await expect(
-        page.locator('a:has-text("Terms of Service")')
-      ).toBeVisible();
+      await legal.clickPrivacyNoticeLink();
 
-      // Currently Back button on this page is not working,
-      // check https://mozilla-hub.atlassian.net/browse/FXA-6874
-      // await page.locator('a:has-text("Terms of Service")').click();
-      //await page.locator('button:has-text("Back")').click();
-      //expect(await page.locator('.card-header:has-text("Legal")').isVisible()).toBeTruthy();
+      await expect(privacy.pageHeader).toBeVisible();
 
-      // Verify Privacy Notice link is visible
-      await expect(
-        page.locator('a:has-text("Privacy Notice")')
-      ).toBeVisible();
-      await page.locator('a:has-text("Privacy Notice")').click();
-      await page.waitForURL(`${target.contentServerUrl}/legal/privacy`);
-      await page.locator('button:has-text("Back")').click();
-      await page.waitForURL(`${target.contentServerUrl}/legal`);
-      await page.waitForSelector('.card-header:has-text("Legal")');
+      await privacy.clickBackButton();
+
+      await expect(legal.pageHeader).toBeVisible();
     });
 
-    test('start at terms page', async ({ page, target }) => {
-      await page.goto(`${target.contentServerUrl}/legal/terms`);
+    test('users can navigate from privacy notice to legal', async ({
+      pages: { legal, privacy },
+    }) => {
+      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
 
-      // Verify legal page is visible
-      // this text is not in our codebase, it's pulled from the `legal-docs` repo
-      await page
-        .locator('text="Firefox Cloud Services: Terms of Service"')
-        .isVisible();
+      await privacy.goto();
+
+      await expect(privacy.pageHeader).toBeVisible();
+      await expect(privacy.backButton).toBeVisible();
+
+      await privacy.clickBackButton();
+
+      await expect(legal.pageHeader).toBeVisible();
     });
 
-    test('start at privacy page', async ({ page, target }) => {
-      await page.goto(`${target.contentServerUrl}/legal/privacy`);
+    test('users can navigate from privacy notice to legal from third-party', async ({
+      page,
+      pages: { legal, privacy },
+    }) => {
+      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
 
-      // Verify privacy page is visible
-      await page.waitForTimeout(1000);
-      // this text is not in our codebase, it's pulled from the `legal-docs` repo
-      await page.locator('text="Firefox Privacy Notice"').isVisible();
+      await page.goto(`https://www.mozilla.org/en-US/`);
+      await privacy.goto();
+
+      await expect(privacy.pageHeader).toBeVisible();
+      await expect(privacy.backButton).toBeVisible();
+
+      await privacy.clickBackButton();
+
+      await expect(legal.pageHeader).toBeVisible();
+    });
+
+    test('users can navigate between legal and terms of service', async ({
+      pages: { legal, termsOfService },
+    }) => {
+      await legal.goto();
+
+      await expect(legal.pageHeader).toBeVisible();
+      await expect(legal.termsOfServiceLink).toBeVisible();
+
+      await legal.clickTermsOfServiceLink();
+
+      await expect(termsOfService.pageHeader).toBeVisible();
+
+      await termsOfService.clickBackButton();
+
+      await expect(legal.pageHeader).toBeVisible();
+    });
+
+    test('users can navigate from terms of service to legal', async ({
+      pages: { legal, termsOfService },
+    }) => {
+      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
+
+      await termsOfService.goto();
+
+      await expect(termsOfService.pageHeader).toBeVisible();
+      await expect(termsOfService.backButton).toBeVisible();
+
+      await termsOfService.clickBackButton();
+
+      await expect(legal.pageHeader).toBeVisible();
+    });
+
+    test('users can navigate from terms of service to legal from third-party', async ({
+      page,
+      pages: { legal, termsOfService },
+    }) => {
+      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
+
+      await page.goto(`https://www.mozilla.org/en-US/`);
+      await termsOfService.goto();
+
+      await expect(termsOfService.pageHeader).toBeVisible();
+      await expect(termsOfService.backButton).toBeVisible();
+
+      await termsOfService.clickBackButton();
+
+      await expect(legal.pageHeader).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## Because

* we want to stabilize the functional test suite to improve it's success rate

## This pull request

* renames tests
* refactors the legal tests to use Page objects
* uses fixme test annotations to skip tests requiring maintenance
* removes uses of waitForTimeout and waitForSelector functions
* removes commented-out code

## Issue that this pull request solves

Relates to FXA-8960 & FXA-9280

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
