### PR TITLE
task(content): Add Mozilla Account(s) to banned password names

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/models/password_strength/password_strength_balloon.js
@@ -27,6 +27,8 @@ const BANNED_SERVICE_NAMES = [
   'lockbox',
   'fxlockbox',
   'mozilla',
+  'mozilla account',
+  'mozillaaccount',
   'sumo',
   'sync',
   // These need to be sorted by length so that the largest match

--- a/packages/fxa-content-server/app/tests/spec/models/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/tests/spec/models/password_strength/password_strength_balloon.js
@@ -86,6 +86,8 @@ describe('models/password_strength/password_strength_balloon', () => {
     [
       'password',
       '12firefox account34',
+      'mozilla accounts',
+      'MozillaAccounts',
       'firefox accounts',
       'FirefoxAccounts',
       'firefox sync',


### PR DESCRIPTION
## Because
- We did this for Firefox Accounts

## This pull request

- Adds new case for banned names mozillaaccount
- Adds new case for banned names mozilla account

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
