### PR TITLE
task(functional-tests): Fix button click for pocket login

### DIFF
--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -101,25 +101,6 @@ test.describe('severity-1 #smoke', () => {
     }
   );
 
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293352
-  test('can login to pocket #1293352', async ({
-    credentials,
-    page,
-    pages: { login },
-  }, { project }) => {
-    test.fixme(true, 'pocket logout hangs after link clicked');
-    test.skip(project.name !== 'production', 'uses prod pocket');
-    await page.goto('https://getpocket.com/login');
-    await Promise.all([
-      page.click('a:has-text("Continue with Firefox")'),
-      page.waitForNavigation(),
-    ]);
-    await login.login(credentials.email, credentials.password);
-    expect(page.url()).toContain('https://getpocket.com/my-list');
-    await page.click('[aria-label="Open Account Menu"]');
-    await page.click('a:has-text("Log out")');
-  });
-
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293364
   test.fixme(
     'can login to monitor #1293364',


### PR DESCRIPTION

## Because

- The test hangs
- The text has changed on this button

## This pull request

- Removes the 'test.fixme'
- updates the selector text to be 'Continue with Mozilla'

## Issue that this pull request solves

Closes: FXA-8603

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

New pocket login text:
![image](https://github.com/mozilla/fxa/assets/94418270/51523a3e-8e93-44fa-9940-89f73da8132d)

