### PR TITLE
task(payments): Fix doc on accountsCdn config

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -352,7 +352,7 @@ const conf = convict({
     accountsCdn: {
       url: {
         default: 'https://accounts-static.cdn.mozilla.net',
-        doc: 'The URL of the Firefox Accounts static content CDN',
+        doc: 'The URL of the Mozilla Accounts static content CDN',
         env: 'FXA_STATIC_CDN_URL',
         format: 'url',
       },


### PR DESCRIPTION
## Because
- The doc string still referenced Firefox Accounts

## This pull request

- Updates the doc string to say Mozilla Accounts

## Issue that this pull request solves

Closes: FXA-8602

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that FXA-8602 also calls out another string the auth-server's config that has already been fixed. So that part of the ticket is not applicable.
