### PR TITLE
task(admin-panel): Remove 'Firefox Accounts' references

### DIFF
--- a/packages/fxa-admin-panel/README.md
+++ b/packages/fxa-admin-panel/README.md
@@ -1,4 +1,4 @@
-# Firefox Accounts Admin Panel
+# Mozilla Accounts Admin Panel
 
 The FxA Admin Panel is an internal resource for FxA Admins to access a set of convenience tools.
 

--- a/packages/fxa-admin-panel/src/components/AppLayout/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AppLayout/index.tsx
@@ -17,7 +17,7 @@ type AppLayoutProps = {
 export const AppLayout = ({ children }: AppLayoutProps) => {
   const logoLockup = (
     <LogoLockup className="text-white font-semibold text-shadow-md">
-      Firefox Accounts Admin Panel
+      Mozilla Accounts Admin Panel
     </LogoLockup>
   );
 

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/index.tsx
@@ -118,7 +118,7 @@ export const AccountSearch = () => {
     <div data-testid="account-search">
       <h2 className="header-page">Account Search</h2>
       <p className="mb-1">
-        Search for a Firefox user account by email or UID and view its details,
+        Search for a Mozilla user account by email or UID and view its details,
         including: secondary emails, email bounces, time-based one-time
         passwords, recovery keys, and current session.
       </p>

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -244,9 +244,9 @@ export const PageRelyingParties = () => {
       </p>
 
       <p>
-        Firefox accounts integrates with Mozilla groups on request via OAuth,
+        Mozilla accounts integrates with Mozilla groups on request via OAuth,
         OpenID, and webhooks, allowing them to offer users authentication and/or
-        authorization with their Firefox account. These groups assume an RP
+        authorization with their Mozilla account. These groups assume an RP
         role. See{' '}
         <LinkExternal
           href="https://mozilla.github.io/ecosystem-platform/relying-parties/tutorials/integration-with-fxa"


### PR DESCRIPTION
## Because
- We want this to say Mozilla Accounts

## This pull request

- Updates the readme
- Updates the app layout
- Updates some verbiage on the account search page
- Updates some verbiage on the relying parties page

## Issue that this pull request solves

Closes: FXA-8601

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Note that we decided not to make further styling adjustments, since it's just the admin panel, and just dropped this to a 1 pointer.
