### PR TITLE
test(functional-tests): remove tests for back button

### DIFF
--- a/packages/functional-tests/tests/react-conversion/legal.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/legal.spec.ts
@@ -23,38 +23,6 @@ test.describe('severity-2 #smoke', () => {
       await expect(legal.pageHeader).toBeVisible();
     });
 
-    test('users can navigate from privacy notice to legal', async ({
-      pages: { legal, privacy },
-    }) => {
-      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
-
-      await privacy.goto();
-
-      await expect(privacy.pageHeader).toBeVisible();
-      await expect(privacy.backButton).toBeVisible();
-
-      await privacy.clickBackButton();
-
-      await expect(legal.pageHeader).toBeVisible();
-    });
-
-    test('users can navigate from privacy notice to legal from third-party', async ({
-      page,
-      pages: { legal, privacy },
-    }) => {
-      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
-
-      await page.goto(`https://www.mozilla.org/en-US/`);
-      await privacy.goto();
-
-      await expect(privacy.pageHeader).toBeVisible();
-      await expect(privacy.backButton).toBeVisible();
-
-      await privacy.clickBackButton();
-
-      await expect(legal.pageHeader).toBeVisible();
-    });
-
     test('users can navigate between legal and terms of service', async ({
       pages: { legal, termsOfService },
     }) => {
@@ -66,38 +34,6 @@ test.describe('severity-2 #smoke', () => {
       await legal.clickTermsOfServiceLink();
 
       await expect(termsOfService.pageHeader).toBeVisible();
-
-      await termsOfService.clickBackButton();
-
-      await expect(legal.pageHeader).toBeVisible();
-    });
-
-    test('users can navigate from terms of service to legal', async ({
-      pages: { legal, termsOfService },
-    }) => {
-      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
-
-      await termsOfService.goto();
-
-      await expect(termsOfService.pageHeader).toBeVisible();
-      await expect(termsOfService.backButton).toBeVisible();
-
-      await termsOfService.clickBackButton();
-
-      await expect(legal.pageHeader).toBeVisible();
-    });
-
-    test('users can navigate from terms of service to legal from third-party', async ({
-      page,
-      pages: { legal, termsOfService },
-    }) => {
-      test.fixme(true, 'Fix required as of 2024/03/13 (see FXA-9280).');
-
-      await page.goto(`https://www.mozilla.org/en-US/`);
-      await termsOfService.goto();
-
-      await expect(termsOfService.pageHeader).toBeVisible();
-      await expect(termsOfService.backButton).toBeVisible();
 
       await termsOfService.clickBackButton();
 


### PR DESCRIPTION
## Because

- The “Back” button is intended to take users to the previous page and is a relic of backbone

## This pull request

- Removes the tests responsible for verifying logic that assures the button stays within the Mozilla domain

## Issue that this pull request solves

Closes: # FXA-9280

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
