### PR TITLE
task(react): Turn React sign up back to 15%

### DIFF
--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -10,8 +10,14 @@ let email;
 let email2;
 
 test.describe('severity-1 #smoke', () => {
-  test.beforeEach(async ({ target }) => {
+  test.beforeEach(async ({ pages: { configPage }, target }) => {
     test.slow();
+    // NOTE: These tests pass for React when `fullProdRollout` for React Signup is set
+    // to `true`, but when we're only at 15% and the flag is "on", flows would need to
+    // be accessed with the force experiment params. Since we'll be porting these over
+    // for React, for now, skip these tests if the flag is on.
+    const config = await configPage.getConfig();
+    test.skip(config.showReactApp.signUpRoutes === true);
   });
 
   test.describe('signin with OAuth after Sync', () => {

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -121,6 +121,11 @@ test.describe('severity-1 #smoke', () => {
       pages: { configPage, deleteAccount, login, signupReact, settings },
     }) => {
       const config = await configPage.getConfig();
+      // NOTE: This passes for React when `fullProdRollout` for React Signup is set
+      // to `true`, but when we're only at 15% and the flag is "on", flows would need to
+      // be accessed with the force experiment params. Since we'll be porting these over
+      // for React, for now, skip these tests if the flag is on.
+      test.skip(config.showReactApp.signUpRoutes === true);
 
       // Click delete account
       await settings.clickDeleteAccount();

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -29,7 +29,12 @@ test.describe('severity-2 #smoke', () => {
       );
 
       await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
+        `${
+          target.contentServerUrl
+        }?context=fx_desktop_v3&service=sync&action=email${
+          config.showReactApp.signUpRoutes &&
+          '&forceExperiment=generalizedReactApp&forceExperimentGroup=react'
+        }`,
         { waitUntil: 'load' }
       );
 

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -11,8 +11,13 @@ test.describe('severity-2 #smoke', () => {
     test.beforeEach(
       async ({ credentials, pages: { settings, login, configPage } }) => {
         const config = await configPage.getConfig();
-        signUpReactEnabled = config.showReactApp.signUpRoutes === true;
+        // NOTE: These tests pass for React when `fullProdRollout` for React Signup is set
+        // to `true`, but when we're only at 15% and the flag is "on", URLs need to have
+        // the force experiment params. Since we'll be porting these over for React, for now,
+        // skip these tests if the flag is on.
+        test.skip(config.showReactApp.signUpRoutes === true);
 
+        signUpReactEnabled = config.showReactApp.signUpRoutes === true;
         await settings.goto();
         await settings.signOut();
         await login.login(credentials.email, credentials.password);

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -89,7 +89,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signup_verified',
         'oauth/signup',
       ]),
-      fullProdRollout: true,
+      fullProdRollout: false,
     },
 
     pairRoutes: {


### PR DESCRIPTION
Because:
* We previously attempted to roll this out to 100% of users and had to turn it off via feature flag due to a GQL issues. This turns it back down to 15%

This commit:
* Updates fullProdRollout for signup from true to false

Closes FXA-9310