### PR TITLE
feat(payments-next): add `LocalizationProvider` wrapper client

### DIFF
--- a/apps/payments/next/app/layout.tsx
+++ b/apps/payments/next/app/layout.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 // TODO - Move shared SVGs to a shared library in fxa/libs/shared/*
 import mozillaLogo from '../images/moz-logo-bw-rgb.svg';
 import './styles/global.css';
+import { Providers } from './providers';
 
 // TODO - Replace these placeholders as part of FXA-8227
 export const metadata = {
@@ -36,7 +37,7 @@ export default function RootLayout({
           />
         </header>
         <main className="mt-16 mx-7 min-h-[calc(100vh_-_4rem)] tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mt-20 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-          {children}
+          <Providers>{children}</Providers>
         </main>
       </body>
     </html>

--- a/apps/payments/next/app/providers/index.tsx
+++ b/apps/payments/next/app/providers/index.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { ReactLocalization, LocalizationProvider } from '@fluent/react';
+import {
+  LocalizerClient,
+  LocalizerBindingsClient,
+} from '@fxa/shared/l10n/client';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [l10n, setL10n] = useState<ReactLocalization>();
+
+  useEffect(() => {
+    const setLocalization = async () => {
+      const locale = navigator.language;
+      const bindings = new LocalizerBindingsClient();
+      const localizerClient = new LocalizerClient(bindings);
+      const { l10n } = await localizerClient.setupReactLocalization(locale);
+
+      setL10n(l10n);
+    };
+
+    setLocalization();
+  }, []);
+
+  return (
+    <>
+      {l10n ? (
+        <LocalizationProvider l10n={l10n}>{children}</LocalizationProvider>
+      ) : (
+        <>{children}</>
+      )}
+    </>
+  );
+}

--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 'use client';
 
+import { Localized } from '@fluent/react';
 import { loadStripe, StripeElementsOptions } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 
@@ -25,8 +26,11 @@ export function StripeWrapper({ amount, currency }: StripeWrapperProps) {
   };
 
   return (
-    <Elements stripe={stripePromise} options={options}>
-      Hello there from Stripe
-    </Elements>
+    <>
+      <Localized id="pay-with-heading-card-only"></Localized>
+      <Elements stripe={stripePromise} options={options}>
+        Hello there from Stripe
+      </Elements>
+    </>
   );
 }

--- a/libs/payments/ui/src/lib/client/components/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/en.ftl
@@ -1,0 +1,1 @@
+pay-with-heading-card-only = Pay with card


### PR DESCRIPTION
## Because

- We want to localize all copy in `payments-next`.

## This pull request

- Wraps `children` in Fluent `<LocalizationProvider>`, which uses `Context` to pass down `l10n`.
- Uses `localizer.client` to get instance of `ReactLocalization`. 

## Issue that this pull request solves

Closes FXA-7827

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
