### PR TITLE
fix(bug): Ignore audience when verifying security token

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -203,6 +203,12 @@ const convictConf = convict({
       format: String,
       doc: 'Apple auth token endpoint',
     },
+    securityEventsClientIds: {
+      default: ['com.mozilla.firefox.accounts.auth'],
+      env: 'APPLE_AUTH_SECURITY_EVENTS_CLIENT_IDS',
+      format: Array,
+      doc: 'Apple auth security events client ids',
+    },
   },
   googleAuthConfig: {
     clientId: {
@@ -229,6 +235,14 @@ const convictConf = convict({
       env: 'GOOGLE_AUTH_TOKEN_ENDPOINT',
       format: String,
       doc: 'Google auth token endpoint',
+    },
+    securityEventsClientIds: {
+      default: [
+        '218517873053-th4taguk9dvf03rrgk8sigon84oigf5l.apps.googleusercontent.com',
+      ],
+      env: 'GOOGLE_AUTH_SECURITY_EVENTS_CLIENT_IDS',
+      format: Array,
+      doc: 'Google auth security events client ids',
     },
   },
   googleMapsApiKey: {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -94,6 +94,7 @@ export class LinkedAccountHandler {
     try {
       const jwtPayload = (await validateSecurityToken(
         token,
+        this.config.appleAuthConfig.securityEventsClientIds,
         this.applePublicKey.pem,
         APPLE_AUD
       )) as AppleJWTSETPayload;
@@ -152,6 +153,7 @@ export class LinkedAccountHandler {
 
       const jwtPayload = (await validateSecurityToken(
         token,
+        this.config.googleAuthConfig.securityEventsClientIds,
         this.goooglePublicKey.pem,
         this.goooglePublicKey.issuer
       )) as GoogleJWTSETPayload;

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -92,10 +92,8 @@ export class LinkedAccountHandler {
     }
 
     try {
-      const { clientId } = this.config.appleAuthConfig;
       const jwtPayload = (await validateSecurityToken(
         token,
-        clientId,
         this.applePublicKey.pem,
         APPLE_AUD
       )) as AppleJWTSETPayload;
@@ -154,7 +152,6 @@ export class LinkedAccountHandler {
 
       const jwtPayload = (await validateSecurityToken(
         token,
-        this.config.googleAuthConfig.clientId,
         this.goooglePublicKey.pem,
         this.goooglePublicKey.issuer
       )) as GoogleJWTSETPayload;

--- a/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
@@ -266,21 +266,18 @@ export async function getGooglePublicKey(
  * Validate a JWT security token against public key.
  *
  * @param token
- * @param clientId
  * @param publicKeyPem
  * @param issuer
  * @returns {Promise}
  */
 export async function validateSecurityToken(
   token: string,
-  clientId: string,
   publicKeyPem: any,
   issuer: string
 ) {
   // Decode the token, validating its signature, audience, and issuer
   return jwt.verify(token, publicKeyPem, {
     algorithms: ['RS256'],
-    audience: [clientId],
     issuer: issuer,
   });
 }

--- a/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
@@ -266,18 +266,21 @@ export async function getGooglePublicKey(
  * Validate a JWT security token against public key.
  *
  * @param token
+ * @param clientIds
  * @param publicKeyPem
  * @param issuer
  * @returns {Promise}
  */
 export async function validateSecurityToken(
   token: string,
+  clientIds: [string],
   publicKeyPem: any,
   issuer: string
 ) {
   // Decode the token, validating its signature, audience, and issuer
   return jwt.verify(token, publicKeyPem, {
     algorithms: ['RS256'],
+    audience: clientIds,
     issuer: issuer,
   });
 }


### PR DESCRIPTION
## Because

- This fixes the validation issue with Apple/Google security events
- FxA shouldn't check for the audience, just ensure that token is valid from auth provider

## This pull request

- Ignores audience 

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9315

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
