### PR TITLE
chore: use dependabot groups to align dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,19 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      storybook:
+        patterns:
+          - "@storybook/*"
+      nx:
+        patterns:
+          - "@nx/*"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      open-telemetry:
+        patterns:
+          - "@opentelemetry/*"
     open-pull-requests-limit: 6
     labels:
       - 'maintenance'


### PR DESCRIPTION
Because:

* We want some dependencies to be updated together.

This commit:

* Configures groups for the larger dependencies that should be updated together.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
