### PR TITLE
chore(tests): Fix production tests

### DIFF
--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -161,8 +161,15 @@ test.describe('severity-1 #smoke', () => {
 
     test.afterEach(async ({ target }) => {
       // Cleanup any accounts created during the test
-      const creds = await target.auth.signIn(email, password);
-      await target.auth.accountDestroy(email, password, {}, creds.sessionToken);
+      if (email) {
+        const creds = await target.auth.signIn(email, password);
+        await target.auth.accountDestroy(
+          email,
+          password,
+          {},
+          creds.sessionToken
+        );
+      }
     });
 
     test('fails if login_hint is different to logged in user', async ({


### PR DESCRIPTION
## Because

- These tests fail in production with new delete account route

## This pull request

- Fixes the test to pass a session token and not run afterEach

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9318

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Ran this in production and all passing/skipped as needed

![Screenshot 2024-03-20 at 4 51 43 PM](https://github.com/mozilla/fxa/assets/1295288/f8c1a08d-a4ff-47e4-ac8d-a8dfb78e9927)
