### PR TITLE
feat(payments-paypal): Create PaypalManager getCustomerBillingAgreementId

### DIFF
--- a/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.error.ts
+++ b/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.error.ts
@@ -23,7 +23,7 @@ export class PaypalCustomerNotCreatedError extends PaypalCustomerManagerError {
 }
 
 export class PaypalCustomerNotFoundError extends PaypalCustomerManagerError {
-  constructor(uid: string, cause: Error) {
+  constructor(uid: string, cause?: Error) {
     super('PaypalCustomer not found', {
       info: {
         uid,
@@ -55,6 +55,17 @@ export class PaypalCustomerNotDeletedError extends PaypalCustomerManagerError {
       info: {
         uid,
         billingAgreementId,
+      },
+      cause,
+    });
+  }
+}
+
+export class PaypalCustomerMultipleRecordsError extends PaypalCustomerManagerError {
+  constructor(uid: string, cause?: Error) {
+    super('Multiple PaypalCustomer records', {
+      info: {
+        uid,
       },
       cause,
     });

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -20,9 +20,6 @@ export class StripeClient {
 
   /**
    * Retrieves a customer record directly from Stripe
-   *
-   * @param customerId The Stripe customer ID of the customer to fetch
-   * @returns The customer record for the customerId provided
    */
   async fetchCustomer(customerId: string) {
     return this.stripe.customers.retrieve(customerId);
@@ -30,9 +27,6 @@ export class StripeClient {
 
   /**
    * Retrieves subscriptions directly from Stripe
-   *
-   * @param customerId
-   * @returns
    */
   async fetchSubscriptions(customerId: string) {
     return this.stripe.subscriptions.list({

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -15,9 +15,6 @@ export class StripeManager {
 
   /**
    * Retrieves a customer record
-   *
-   * @param customerId
-   * @returns
    */
   async fetchActiveCustomer(customerId: string) {
     const customer = await this.client.fetchCustomer(customerId);
@@ -37,9 +34,6 @@ export class StripeManager {
   /**
    * Returns minimum amount for valid currency
    * Throws error for invalid currency
-   *
-   * @param currency
-   * @returns
    */
   getMinimumAmount(currency: string): number {
     if (STRIPE_MINIMUM_CHARGE_AMOUNTS[currency]) {
@@ -51,8 +45,6 @@ export class StripeManager {
 
   /**
    * Retrieves subscriptions
-   *
-   * @param customerId
    */
   async getSubscriptions(customerId: string) {
     return this.client.fetchSubscriptions(customerId);


### PR DESCRIPTION
## This pull request

- [x] takes a Stripe customer as a non-optional argument
- [x] gets the customer’s current paypal billing agreement ID from the auth database via the Paypal repository

## Issue that this pull request solves

Closes: FXA-8939

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
