### PR TITLE
feat(payments-paypal): Create PayPalManager cancelBillingAgreement method

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -62,6 +62,29 @@ describe('PaypalManager', () => {
     }
   });
 
+  describe('cancelBillingAgreement', () => {
+    it('cancels a billing agreement', async () => {
+      const billingAgreementId = faker.string.sample();
+
+      paypalClient.baUpdate = jest
+        .fn()
+        .mockResolvedValueOnce(NVPBAUpdateTransactionResponseFactory());
+
+      const result = await paypalManager.cancelBillingAgreement(
+        billingAgreementId
+      );
+      expect(result).toBeUndefined();
+      expect(paypalClient.baUpdate).toBeCalledWith({
+        billingAgreementId,
+        cancel: true,
+      });
+    });
+
+    it('throws an error', async () => {
+      expect(paypalManager.cancelBillingAgreement).rejects.toThrowError();
+    });
+  });
+
   describe('getBillingAgreement', () => {
     it('returns agreement details (active status)', async () => {
       const billingAgreementId = faker.string.sample();

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -24,6 +24,13 @@ export class PayPalManager {
   ) {}
 
   /**
+   * Cancels a billing agreement.
+   */
+  async cancelBillingAgreement(billingAgreementId: string): Promise<void> {
+    await this.client.baUpdate({ billingAgreementId, cancel: true });
+  }
+
+  /**
    * Get Billing Agreement details by calling the update Billing Agreement API.
    * Parses the API call response for country code and billing agreement status
    */


### PR DESCRIPTION
## This pull request

- [x] creates PayPalManager cancelBillingAgreement method
- [x] it should be updated to return void rather than null

Reference: existing implementation in PayPalHelper.cancelBillingAgreement

## Issue that this pull request solves

Closes: FXA-8937

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.