### PR TITLE
fix(functional-tests): signInTotp tests in stage and prod

### DIFF
--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -23,6 +23,7 @@ import { LegalPage } from './legal';
 import { CookiesDisabledPage } from './cookiesDisabled';
 import { PostVerifyPage } from './postVerify';
 import { ResetPasswordReactPage } from './resetPasswordReact';
+import { SigninReactPage } from './signinReact';
 import { SignupReactPage } from './signupReact';
 import { ConfigPage } from './config';
 import { PrivacyPage } from './privacy';
@@ -53,6 +54,7 @@ export function create(page: Page, target: BaseTarget) {
     legal: new LegalPage(page, target),
     cookiesDisabled: new CookiesDisabledPage(page, target),
     postVerify: new PostVerifyPage(page, target),
+    signinReact: new SigninReactPage(page, target),
     signupReact: new SignupReactPage(page, target),
     configPage: new ConfigPage(page, target),
     privacy: new PrivacyPage(page, target),

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -67,6 +67,18 @@ export class SettingsPage extends SettingsLayout {
     return this.lazyRow('data-collection', DataCollectionRow);
   }
 
+  get settingsHeading() {
+    return this.page.getByRole('heading', { name: 'Settings' });
+  }
+
+  get twoStepAuthenticationStatus() {
+    return this.page.getByTestId('two-step-unit-row-header-value');
+  }
+
+  get addTwoStepAuthenticationButton() {
+    return this.page.getByTestId('two-step-unit-row-route');
+  }
+
   clickDeleteAccount() {
     return Promise.all([
       this.page.locator('[data-testid=settings-delete-account]').click(),

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -6,6 +6,10 @@ export abstract class SettingsLayout extends BaseLayout {
     return this.page.locator('[data-testid="drop-down-bento-menu"]');
   }
 
+  get alertBar() {
+    return this.page.getByTestId('alert-bar-content');
+  }
+
   get avatarDropDownMenu() {
     return this.page.getByTestId('drop-down-avatar-menu');
   }
@@ -24,11 +28,6 @@ export abstract class SettingsLayout extends BaseLayout {
 
   goto(query?: string) {
     return super.goto('load', query);
-  }
-
-  async alertBarText() {
-    const alert = this.page.locator('[data-testid=alert-bar-content]');
-    return alert.textContent();
   }
 
   async waitForAlertBar() {

--- a/packages/functional-tests/pages/signinReact.ts
+++ b/packages/functional-tests/pages/signinReact.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from '@playwright/test';
+import { BaseLayout } from './layout';
+import { getReactFeatureFlagUrl } from '../lib/react-flag';
+
+export class SigninReactPage extends BaseLayout {
+  readonly path = 'signin';
+
+  get authenticationFormHeading() {
+    return this.page.getByRole('heading', {
+      name: /^Enter (?:authentication|security) code/,
+    });
+  }
+
+  get authenticationCodeTextbox() {
+    return this.page
+      .getByRole('textbox', { name: 'code' })
+      .or(this.page.getByPlaceholder('Enter 6-digit code'));
+  }
+
+  get authenticationCodeTextboxTooltip() {
+    return this.page.getByText('Invalid two-step authentication code', {
+      exact: true,
+    });
+  }
+
+  get confirmButton() {
+    return this.page.getByRole('button', { name: 'Confirm' });
+  }
+
+  get passwordFormHeading() {
+    return this.page.getByRole('heading', { name: /^Enter your password/ });
+  }
+
+  get passwordTextbox() {
+    return this.page.getByRole('textbox', { name: 'password' });
+  }
+
+  get signInButton() {
+    return this.page.getByRole('button', { name: 'Sign in' });
+  }
+
+  goto(route = '/', params = new URLSearchParams()) {
+    params.set('forceExperiment', 'generalizedReactApp');
+    params.set('forceExperimentGroup', 'react');
+    return this.page.goto(
+      getReactFeatureFlagUrl(this.target, route, params.toString())
+    );
+  }
+
+  async fillOutAuthenticationForm(code: string): Promise<void> {
+    await expect(this.authenticationFormHeading).toBeVisible();
+
+    await this.authenticationCodeTextbox.fill(code);
+    await this.confirmButton.click();
+  }
+
+  async fillOutPasswordForm(password: string): Promise<void> {
+    await expect(this.passwordFormHeading).toBeVisible();
+
+    await this.passwordTextbox.fill(password);
+    await this.signInButton.click();
+  }
+}

--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -65,22 +65,14 @@ export class SignupReactPage extends BaseLayout {
   }
 
   async fillOutEmailForm(email: string) {
-    await expect(
-      this.emailFormHeading,
-      'The Email form heading is missing or not as expected. ' +
-        'Are you filling out the right form?'
-    ).toBeVisible();
+    await expect(this.emailFormHeading).toBeVisible();
 
     await this.emailTextbox.fill(email);
     await this.submitButton.click();
   }
 
   async fillOutSignupForm(password: string, age: string) {
-    await expect(
-      this.signupFormHeading,
-      'The Signup form heading is missing or not as expected. ' +
-        'Are you filling out the right form?'
-    ).toBeVisible();
+    await expect(this.signupFormHeading).toBeVisible();
 
     await this.passwordTextbox.fill(password);
     await this.verifyPasswordTextbox.fill(password);
@@ -95,11 +87,7 @@ export class SignupReactPage extends BaseLayout {
       EmailHeader.shortCode
     );
 
-    await expect(
-      this.codeFormHeading,
-      'The Confirmation Code form heading is missing or not as expected. ' +
-        'Are you filling out the right form?'
-    ).toBeVisible();
+    await expect(this.codeFormHeading).toBeVisible();
 
     await this.codeTextbox.fill(code);
     await this.confirmButton.click();

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -16,7 +16,8 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       await settings.goto();
       await settings.totp.clickAdd();
-      await totp.enable(credentials);
+      const { secret } = await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.signOut();
 
       await relier.goto();
@@ -33,7 +34,8 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       await settings.goto();
       await settings.totp.clickAdd();
-      await totp.enable(credentials);
+      const { secret } = await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
 
       await settings.totp.clickDisable();
       await settings.clickModalConfirm();

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -189,7 +189,8 @@ test.describe('severity-1 #smoke', () => {
   async function addTotpFlow({ credentials, pages: { totp, settings } }) {
     await settings.goto();
     await settings.totp.clickAdd();
-    await totp.enable(credentials);
+    const { secret } = await totp.fillTwoStepAuthenticationForm();
+    credentials.secret = secret;
   }
 
   /**

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -145,7 +145,7 @@ test.describe('severity-1 #smoke', () => {
         await signupReact.fillOutCodeForm(newEmail);
       }
 
-      expect(await settings.alertBarText()).toContain(
+      await expect(settings.alertBar).toHaveText(
         'Account confirmed successfully'
       );
       const primaryEmail = await settings.primaryEmail.statusText();

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -19,7 +19,7 @@ test.describe('severity-1 #smoke', () => {
     await settings.closeAlertBar();
     await settings.secondaryEmail.clickDelete();
     await settings.waitForAlertBar();
-    expect(await settings.alertBarText()).toContain('successfully deleted');
+    await expect(settings.alertBar).toHaveText(/successfully deleted/);
     await settings.secondaryEmail.clickAdd();
     await secondaryEmail.setEmail(newEmail);
     await secondaryEmail.submit();
@@ -28,7 +28,7 @@ test.describe('severity-1 #smoke', () => {
     expect(await settings.secondaryEmail.statusText()).toContain('UNCONFIRMED');
     await settings.secondaryEmail.clickDelete();
     await settings.waitForAlertBar();
-    expect(await settings.alertBarText()).toContain('successfully deleted');
+    await expect(settings.alertBar).toHaveText(/successfully deleted/);
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293504

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -22,7 +22,8 @@ test.describe('severity-1 #smoke', () => {
       let status = await settings.totp.statusText();
       expect(status).toEqual('Not Set');
       await settings.totp.clickAdd();
-      await totp.enable(credentials);
+      const { secret } = await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.waitForAlertBar();
       status = await settings.totp.statusText();
       expect(status).toEqual('Enabled');
@@ -49,7 +50,8 @@ test.describe('severity-1 #smoke', () => {
       let status = await settings.totp.statusText();
       expect(status).toEqual('Not Set');
       await settings.totp.clickAdd();
-      await totp.enable(credentials, 'qr');
+      const { secret } = await totp.fillTwoStepAuthenticationForm('qr');
+      credentials.secret = secret;
       await settings.waitForAlertBar();
       status = await settings.totp.statusText();
       expect(status).toEqual('Enabled');
@@ -62,7 +64,8 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       await settings.goto();
       await settings.totp.clickAdd();
-      await totp.enable(credentials);
+      const { secret } = await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
       await login.setTotp(credentials.secret);
@@ -78,7 +81,9 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       await settings.goto();
       await settings.totp.clickAdd();
-      const { recoveryCodes } = await totp.enable(credentials);
+      const { secret, recoveryCodes } =
+        await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.totp.clickChange();
       await settings.clickModalConfirm();
       const newCodes = await totp.getRecoveryCodes();
@@ -86,8 +91,8 @@ test.describe('severity-1 #smoke', () => {
         expect(newCodes).not.toContain(code);
       }
       await settings.clickRecoveryCodeAck();
-      await totp.setRecoveryCode(newCodes[0]);
-      await totp.submit();
+      await totp.step3RecoveryCodeTextbox.fill(newCodes[0]);
+      await totp.step3FinishButton.click();
       await settings.waitForAlertBar();
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
@@ -113,7 +118,9 @@ test.describe('severity-1 #smoke', () => {
     }, { project }) => {
       await settings.goto();
       await settings.totp.clickAdd();
-      const { recoveryCodes } = await totp.enable(credentials);
+      const { secret, recoveryCodes } =
+        await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.signOut();
       for (let i = 0; i < recoveryCodes.length - 3; i++) {
         await login.login(
@@ -148,10 +155,11 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       await settings.goto();
       await settings.totp.clickAdd();
-      const { secret } = await totp.enable(credentials);
+      const { secret } = await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
-      await login.setTotp(secret);
+      await login.setTotp(credentials.secret);
       await settings.clickDeleteAccount();
       await deleteAccount.checkAllBoxes();
       await deleteAccount.clickContinue();

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -110,7 +110,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Toggle switch, verify the alert bar appears and its status
       await settings.dataCollection.toggleShareData('off');
-      expect(await settings.alertBarText()).toContain('Opt out successful.');
+      await expect(settings.alertBar).toHaveText(/Opt out successful/);
       expect(await settings.dataCollection.getToggleStatus()).toBe('false');
 
       // Subscribe to plan and verify URL does not include flow parameter

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -156,7 +156,8 @@ test.describe('severity-2 #smoke', () => {
 
       await settings.goto();
       await settings.totp.clickAdd();
-      await totp.enable(credentials);
+      const { secret } = await totp.fillTwoStepAuthenticationForm();
+      credentials.secret = secret;
       await settings.signOut();
 
       // Sync sign in


### PR DESCRIPTION
## Because

- The totp tests are failing in stage and prod and we want to promote stability and sustainability in the functional-tests

## This pull request

- ~Adds a configuration check for the React signInRoutes~
- Adds clarity and splits test concerns by separating and renaming the `add and remove totp` test into two tests.
- Refactors to use page object with auto-retrying assertions and built-in locators (causes cascading changes into other tests):
  - oauth/totp.spec.ts
  - oauthResetPassword.spec.ts
  - changeEmail.spec.ts
  - misc.spec.ts
  - settings/totp.spec.ts
  - subscription.spec.ts
  - signIn.spec.ts

## Issue that this pull request solves

Closes #FXA-9178
Relates To #FXA-8960

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
