### PR TITLE
feat(react): Add React signin Sync web channel events for fx_desktop_v3 + oauth_webchannel_v1

### DIFF
--- a/_scripts/config-fxios.js
+++ b/_scripts/config-fxios.js
@@ -19,7 +19,12 @@ const replaceFrom = /\bserver: server\b/;
 const replaceTo = 'contentUrl: "http://localhost:3030"';
 
 function replace() {
-  const filePath = path.join(iosPath, 'RustFxA', 'RustFirefoxAccounts.swift');
+  const filePath = path.join(
+    iosPath,
+    'firefox-ios',
+    'RustFxA',
+    'RustFirefoxAccounts.swift'
+  );
   let fileContent = fs.readFileSync(filePath, 'utf8');
   const match = fileContent.match(regex);
 

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -108,7 +108,7 @@ export type FxAOAuthLogin = {
   code: string;
   redirect: string;
   state: string;
-  // For sync oauth
+  // For sync oauth signup
   declinedSyncEngines?: string[];
   offeredSyncEngines?: string[];
 };
@@ -337,7 +337,7 @@ export class Firefox extends EventTarget {
   }
 
   fxaCanLinkAccount(options: FxACanLinkAccount) {
-    this.send(FirefoxCommand.Login, options);
+    this.send(FirefoxCommand.CanLinkAccount, options);
   }
 
   async requestSignedInUser(context: string) {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -131,9 +131,7 @@ describe('SigninTokenCode container', () => {
         await waitFor(() => {
           expect(CacheModule.currentAccount).not.toBeCalled();
         });
-        expect(currentSigninTokenCodeProps?.signinLocationState.email).toBe(
-          MOCK_EMAIL
-        );
+        expect(currentSigninTokenCodeProps?.signinState.email).toBe(MOCK_EMAIL);
         expect(currentSigninTokenCodeProps?.integration).toBe(integration);
         expect(SigninTokenCodeModule.default).toBeCalled();
       });
@@ -142,7 +140,7 @@ describe('SigninTokenCode container', () => {
         render();
         expect(CacheModule.currentAccount).not.toBeCalled();
         await waitFor(() => {
-          expect(currentSigninTokenCodeProps?.signinLocationState.email).toBe(
+          expect(currentSigninTokenCodeProps?.signinState.email).toBe(
             MOCK_EMAIL
           );
         });
@@ -154,7 +152,7 @@ describe('SigninTokenCode container', () => {
         render();
         expect(CacheModule.currentAccount).toBeCalled();
         await waitFor(() => {
-          expect(currentSigninTokenCodeProps?.signinLocationState.email).toBe(
+          expect(currentSigninTokenCodeProps?.signinState.email).toBe(
             MOCK_STORED_ACCOUNT.email
           );
         });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -29,7 +29,7 @@ const SigninTokenCodeContainer = ({
     state?: SigninLocationState;
   };
 
-  const signinLocationState =
+  const signinState =
     location.state && Object.keys(location.state).length > 0
       ? location.state
       : getStoredAccountInfo();
@@ -44,8 +44,8 @@ const SigninTokenCodeContainer = ({
   const { data: totpData, loading: totpLoading } =
     useQuery<TotpStatusResponse>(GET_TOTP_STATUS);
 
-  if (Object.keys(signinLocationState).length < 1) {
-    hardNavigateToContentServer(`/${location.search ? location.search : ''}`);
+  if (Object.keys(signinState).length < 1) {
+    hardNavigateToContentServer(`/${location.search || ''}`);
     return <LoadingSpinner fullScreen />;
   }
 
@@ -77,7 +77,7 @@ const SigninTokenCodeContainer = ({
       {...{
         finishOAuthFlowHandler,
         integration,
-        signinLocationState,
+        signinState,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
@@ -9,7 +9,7 @@ import { SigninIntegration, SigninLocationState } from '../interfaces';
 export interface SigninTokenCodeProps {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
-  signinLocationState: SigninLocationState;
+  signinState: SigninLocationState;
 }
 
 export interface TotpStatusResponse {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -3,13 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { LocationProvider } from '@reach/router';
-import { Integration, IntegrationType } from '../../../models';
+import { IntegrationType } from '../../../models';
 import { SigninTokenCodeProps } from './interfaces';
 import SigninTokenCode from '.';
 import {
   MOCK_EMAIL,
+  MOCK_KEY_FETCH_TOKEN,
   MOCK_SESSION_TOKEN,
   MOCK_UID,
+  MOCK_UNWRAP_BKEY,
   mockFinishOAuthFlowHandler,
 } from '../../mocks';
 import { MozServices } from '../../../lib/types';
@@ -21,10 +23,11 @@ export function createMockWebIntegration() {
     getService: () => MozServices.Default,
     isSync: () => false,
     wantsKeys: () => false,
-  } as Integration;
+  };
 }
 
 export const createMockSigninLocationState = (
+  wantsKeys = false,
   verificationReason?: VerificationReasons
 ) => {
   return {
@@ -32,7 +35,11 @@ export const createMockSigninLocationState = (
     uid: MOCK_UID,
     sessionToken: MOCK_SESSION_TOKEN,
     verified: false,
-    ...(verificationReason && { verificationReason }),
+    verificationReason,
+    ...(wantsKeys && {
+      keyFetchToken: MOCK_KEY_FETCH_TOKEN,
+      unwrapBKey: MOCK_UNWRAP_BKEY,
+    }),
   };
 };
 
@@ -50,7 +57,10 @@ export const Subject = ({
           finishOAuthFlowHandler,
           integration,
         }}
-        signinLocationState={createMockSigninLocationState(verificationReason)}
+        signinState={createMockSigninLocationState(
+          integration.wantsKeys(),
+          verificationReason
+        )}
       />
     </LocationProvider>
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -145,7 +145,7 @@ export const SigninTotpCode = ({
         queryParams: location.search,
       };
 
-      handleNavigation(navigationOptions, navigate);
+      await handleNavigation(navigationOptions, navigate, true);
     }
   };
 

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -385,25 +385,6 @@ describe('signin container', () => {
         );
       });
     });
-    describe('web channel messages', () => {
-      let fxaLoginSpy: jest.SpyInstance;
-      beforeEach(() => {
-        fxaLoginSpy = jest.spyOn(firefox, 'fxaCanLinkAccount');
-      });
-
-      // TODO in Sync ticket. Is this being sent under the right conditions?
-      // it('are sent for sync', async () => {
-      //   mockSyncDesktopV3Integration();
-      //   render();
-      //   await waitFor(() => {
-      //     expect(fxaLoginSpy).toBeCalledWith({ email: MOCK_QUERY_PARAM_EMAIL });
-      //   });
-      // });
-      it('are not sent for non-sync', () => {
-        render([mockGqlAvatarUseQuery()]);
-        expect(fxaLoginSpy).not.toBeCalled();
-      });
-    });
   });
 
   describe('hasLinkedAccount and hasPassword are provided', () => {

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -6,7 +6,11 @@ import React from 'react';
 import Signin from '.';
 import { MozServices } from '../../lib/types';
 import { Meta } from '@storybook/react';
-import { Subject, createMockSigninSyncIntegration } from './mocks';
+import {
+  Subject,
+  createMockSigninOAuthIntegration,
+  createMockSigninSyncIntegration,
+} from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { SigninProps } from './interfaces';
 import { MOCK_SERVICE, MOCK_SESSION_TOKEN } from '../mocks';
@@ -28,9 +32,10 @@ export const SignInToSettingsWithPassword = storyWithProps();
 export const SignInToRelyingPartyWithPassword = storyWithProps({
   serviceName: MOCK_SERVICE,
 });
-// TODO with OAuth ticket, needs OAuth integration
+
 export const SignInToPocketWithPassword = storyWithProps({
   serviceName: MozServices.Pocket,
+  integration: createMockSigninOAuthIntegration(),
 });
 
 export const SignInToSettingsWithCachedCredentials = storyWithProps({
@@ -40,10 +45,16 @@ export const SignInToRelyingPartyWithCachedCredentials = storyWithProps({
   sessionToken: MOCK_SESSION_TOKEN,
   serviceName: MOCK_SERVICE,
 });
-// TODO with OAuth ticket, needs OAuth integration
+
 export const SignInToPocketWithCachedCredentials = storyWithProps({
   sessionToken: MOCK_SESSION_TOKEN,
   serviceName: MozServices.Pocket,
+  integration: createMockSigninOAuthIntegration(),
+});
+
+export const SignInToSyncWithCachedCredentials = storyWithProps({
+  sessionToken: MOCK_SESSION_TOKEN,
+  integration: createMockSigninOAuthIntegration({ wantsKeys: true }),
 });
 
 export const HasLinkedAccountAndNoPassword = storyWithProps({

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -79,7 +79,8 @@ const Signin = ({
   // We must use a ref because we may update this value in a callback
   let isPasswordNeededRef = useRef(
     (!sessionToken && hasPassword) ||
-      (isOAuth && (integration.wantsKeys() || integration.wantsLogin()))
+      integration.wantsKeys() ||
+      (isOAuth && integration.wantsLogin())
   );
 
   const localizedPasswordFormLabel = ftlMsgResolver.getMsg(
@@ -190,12 +191,13 @@ const Signin = ({
           email,
           signinData: data.signIn,
           unwrapBKey: data.unwrapBKey,
+          verified: data.signIn.verified,
           integration,
           finishOAuthFlowHandler,
           queryParams: location.search,
         };
 
-        await handleNavigation(navigationOptions, navigate);
+        await handleNavigation(navigationOptions, navigate, true);
       }
       if (error) {
         GleanMetrics.login.error({ reason: error.message });
@@ -289,8 +291,7 @@ const Signin = ({
     ]
   );
 
-  const hideThirdPartyAuth =
-    integration.isSync() && hasLinkedAccount && hasPassword;
+  const hideThirdPartyAuth = integration.isSync() && hasPassword;
 
   return (
     <AppLayout>

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -17,7 +17,7 @@ export interface AvatarResponse {
 }
 
 export type SigninIntegration =
-  | Pick<Integration, 'type' | 'isSync' | 'getService'>
+  | Pick<Integration, 'type' | 'isSync' | 'getService' | 'wantsKeys'>
   | SigninOAuthIntegration;
 
 export type SigninOAuthIntegration = Pick<
@@ -160,10 +160,11 @@ export interface NavigationOptions {
     verified: boolean;
     verificationMethod?: VerificationMethods;
     verificationReason?: VerificationReasons;
-    // keyFetchToken and unwrapBKey are included if options.keys=true
-    // These will never exist for the cached signin (prompt=none)
+    // keyFetchToken is included if options.keys=true
+    // This (and unwrapBKey) will never exist for the cached signin (prompt=none)
     keyFetchToken?: hexstring;
   };
+  // unwrapBKey is included if integration.wantsKeys()
   unwrapBKey?: hexstring;
   integration: SigninIntegration;
   finishOAuthFlowHandler: FinishOAuthFlowHandler;

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -93,6 +93,7 @@ export function createMockSigninWebIntegration(): SigninIntegration {
     type: IntegrationType.Web,
     isSync: () => false,
     getService: () => MozServices.Default,
+    wantsKeys: () => false,
   };
 }
 
@@ -105,14 +106,19 @@ export function createMockSigninSyncIntegration(): SigninIntegration {
   };
 }
 
-export function createMockSigninOAuthIntegration(
-  clientId?: string,
-  wantsKeys: boolean = true
-): SigninOAuthIntegration {
+export function createMockSigninOAuthIntegration({
+  clientId,
+  wantsKeys = true,
+  isSync = false,
+}: {
+  clientId?: string;
+  wantsKeys?: boolean;
+  isSync?: boolean;
+} = {}): SigninOAuthIntegration {
   return {
     type: IntegrationType.OAuth,
     getService: () => clientId || MOCK_CLIENT_ID,
-    isSync: () => false,
+    isSync: () => isSync,
     wantsKeys: () => wantsKeys,
     wantsLogin: () => false,
     wantsTwoStepAuthentication: () => false,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -43,6 +43,7 @@ import firefox from '../../../lib/channels/firefox';
 import GleanMetrics from '../../../lib/glean';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { storeAccountData } from '../../../lib/storage-utils';
+import { getSyncNavigate } from '../../Signin/utils';
 
 export const viewName = 'confirm-signup-code';
 
@@ -119,14 +120,6 @@ const ConfirmSignupCode = ({
     }
   }
 
-  function navigateToCAD() {
-    // Connect another device tells Sync the user is signed in
-    // TODO: regular navigate when this page is converted
-    const searchParams = new URLSearchParams(location.search);
-    searchParams.set('showSuccessMessage', 'true');
-    hardNavigateToContentServer(`/connect_another_device?${searchParams}`);
-  }
-
   async function verifySession(code: string) {
     logViewEvent(`flow.${viewName}`, 'submit', REACT_ENTRYPOINT);
     GleanMetrics.signupConfirmation.submit();
@@ -162,7 +155,8 @@ const ConfirmSignupCode = ({
       }
 
       if (isSyncDesktopV3Integration(integration)) {
-        navigateToCAD();
+        const { to } = getSyncNavigate(location.search);
+        hardNavigateToContentServer(to);
       } else if (isOAuthIntegration(integration)) {
         // Check to see if the relier wants TOTP.
         // Newly created accounts wouldn't have this so lets redirect them to signin.
@@ -197,7 +191,8 @@ const ConfirmSignupCode = ({
               state,
             });
             // Mobile sync will close the web view, OAuth Desktop mimics DesktopV3 behavior
-            navigateToCAD();
+            const { to } = getSyncNavigate(location.search);
+            hardNavigateToContentServer(to);
             return;
           } else {
             // Navigate to relying party

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -8,7 +8,6 @@ import { useForm } from 'react-hook-form';
 import {
   isOAuthIntegration,
   isSyncDesktopV3Integration,
-  isSyncOAuthIntegration,
   useFtlMsgResolver,
 } from '../../models';
 import {
@@ -246,10 +245,7 @@ export const Signup = ({
         const getOfferedSyncEngines = () =>
           getSyncEngineIds(offeredSyncEngineConfigs || []);
 
-        if (
-          isSyncDesktopV3Integration(integration) ||
-          isSyncOAuthIntegration(integration)
-        ) {
+        if (integration.isSync()) {
           await firefox.fxaLogin({
             email,
             // keyFetchToken and unwrapBKey should always exist if Sync integration


### PR DESCRIPTION
Because:
* We are moving from Backbone to React and want to meet parity with Sync functionality

This commit:
* Tweaks config-fxios script since iOS changed directory nesting
* Adds firefox.fxaLogin and firefox.fxaOAuthLogin web channel events where needed; it should talk to the browser with a happy path login, signin_token_code flow, and signin_totp_code flow
* Return unwrapBKey as part of signin callback data for sync
* Always displays password input for Sync (no cached login)
* Adds temp 'hack' (tempHandleSyncLogin) to allow a hard navigate to CAD to work in these flows
* Fixes bug where we were sending fxaLogin instead of fxaCanLinkAccount. Removed these from signin and signup container pages because we send one on the index page and it's causing multiple Sync dialogs
* Renames signinLocationState in signintotpcode to signinState since it can be set to local storage values
* Tweaks when to display third party auth for Sync (only show in the Sync flow when user does not have a PW set)

closes FXA-9059

---

~Draft for early manual testing, tests TBD. I've given Vijay and Tarik the heads up.~

To test desktop v3, run the fxa-dev-launcher and then [go to this link ](localhost:3030/?context=fx_desktop_v3&entrypoint=preferences&action=email&service=sync&forceExperiment=generalizedReactApp&forceExperimentGroup=react)(same thing as clicking "sign in" through the browser and manually add the React params). The 3 main flows to check are:
* Happy path where you're verified, e.g. you're taken from the login screen to CAD
* With 2FA auth set up
* From the signin_token_code flow screen when extra verification is needed (I _think_ you can do this by creating an account in another browser then trying to login through dev launcher FF, otherwise there's a global config option for this... I was hitting this scenario more often than the happy path)
* Bonus, when you need to enter a signup code (though, this enters the signup flow and that's already been tested)
* Also try to sign into another account via Sync and compare experiences (note in PR comment)

Standby for desktop oauth webchannel v1 instructions. You'll need to at least flip `identity.fxaccounts.oauth.enabled` to true and set `identity.fxaccounts.contextParam` to `oauth_webchannel_v1` but I was having some scope validation problems even when adding the expected redirect URI to local config (`http://localhost:3030/oauth/success/5882386c6d801776` instead of `urn:ietf:wg:oauth:2.0:oob`), and must be missing a step. It does appear to work for me though when I comment out Backbone's complaints.

I tested this in iOS and it seems to work as expected. Make sure you've pulled latest from `firefox-ios`, then run the dev launcher, then import into XCode (follow their instructions) and build. Then double click the version in Settings 5 times to pull up "Advanced Sync options" and choose React content-server.