### PR TITLE
feat(settings): Signin Recovery Code page in React

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -476,7 +476,12 @@ Router = Router.extend({
     'signin_permissions(/)': createViewHandler(PermissionsView, {
       type: VerificationReasons.SIGN_IN,
     }),
-    'signin_recovery_code(/)': createViewHandler(SignInRecoveryCodeView),
+    'signin_recovery_code(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'signin_recovery_code',
+        SignInRecoveryCodeView
+      );
+    },
     'signin_reported(/)': function () {
       this.createReactOrBackboneViewHandler(
         'signin_reported',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -75,6 +75,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'complete_signin',
         'signin_unblock',
         'force_auth',
+        'signin_recovery_code',
       ]),
       fullProdRollout: false,
     },

--- a/packages/fxa-graphql-api/src/gql/dto/input/consume-recovery-code.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/consume-recovery-code.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class ConsumeRecoveryCodeInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({
+    description: 'The user-submitted 2FA backup authentication (recovery) code',
+  })
+  public code!: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/consume-recovery-code.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/consume-recovery-code.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class ConsumeRecoveryCodePayload {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({
+    description:
+      'The number of backup authentication (recovery) codes remaining for 2FA after consuming a code was successful',
+  })
+  public remaining!: number;
+}

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -134,4 +134,22 @@ describe('SessionResolver', () => {
       clientMutationId: 'testid',
     });
   });
+
+  it('consumes a backup authentication (recovery) code', async () => {
+    const token = 'totallylegit';
+    const mockRespPayload = { remaining: 3 };
+    authClient.consumeRecoveryCode = jest
+      .fn()
+      .mockResolvedValue(mockRespPayload);
+    const result = await resolver.consumeRecoveryCode(token, {
+      clientMutationId: 'testid',
+      code: '00000000',
+    });
+    expect(authClient.consumeRecoveryCode).toBeCalledTimes(1);
+    expect(authClient.consumeRecoveryCode).toBeCalledWith(token, '00000000');
+    expect(result).toStrictEqual({
+      clientMutationId: 'testid',
+      ...mockRespPayload,
+    });
+  });
 });

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -24,6 +24,9 @@ import { SessionReauthedAccountPayload } from './dto/payload/session-reauthed-ac
 import { CatchGatewayError } from './lib/error';
 import { Session as SessionType, SessionStatus } from './model/session';
 import { SessionVerifyCodeInput } from './dto/input/session-verify-code';
+import { ConsumeRecoveryCodePayload } from './dto/payload/consume-recovery-code';
+import { ConsumeRecoveryCodeInput } from './dto/input/consume-recovery-code';
+import { UnverifiedSessionGuard } from '../auth/unverified-session-guard';
 
 @Resolver((of: any) => SessionType)
 export class SessionResolver {
@@ -121,6 +124,24 @@ export class SessionResolver {
     );
     return {
       clientMutationId: input.clientMutationId,
+    };
+  }
+
+  @Mutation((returns) => ConsumeRecoveryCodePayload, {
+    description:
+      'Verify session with a 2FA backup authentication (recovery) code',
+  })
+  @UseGuards(UnverifiedSessionGuard, GqlCustomsGuard)
+  @CatchGatewayError
+  public async consumeRecoveryCode(
+    @GqlSessionToken() token: string,
+    @Args('input', { type: () => ConsumeRecoveryCodeInput })
+    input: ConsumeRecoveryCodeInput
+  ): Promise<ConsumeRecoveryCodePayload> {
+    const result = await this.authAPI.consumeRecoveryCode(token, input.code);
+    return {
+      clientMutationId: input.clientMutationId,
+      ...result,
     };
   }
 }

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -63,6 +63,7 @@ import SigninContainer from '../../pages/Signin/container';
 import ReportSigninContainer from '../../pages/Signin/ReportSignin/container';
 import SigninBounced from '../../pages/Signin/SigninBounced';
 import SigninConfirmed from '../../pages/Signin/SigninConfirmed';
+import SigninRecoveryCodeContainer from '../../pages/Signin/SigninRecoveryCode/container';
 import SigninReported from '../../pages/Signin/SigninReported';
 import SigninTokenCodeContainer from '../../pages/Signin/SigninTokenCode/container';
 import SigninTotpCodeContainer from '../../pages/Signin/SigninTotpCode/container';
@@ -313,6 +314,10 @@ const AuthAndAccountSetupRoutes = ({
       <SigninConfirmed
         path="/signin_confirmed/*"
         {...{ isSignedIn, serviceName }}
+      />
+      <SigninRecoveryCodeContainer
+        path="/signin_recovery_code/*"
+        {...{ integration, serviceName }}
       />
       <SigninReported path="/signin_reported/*" />
       <SigninTokenCodeContainer

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
@@ -4,7 +4,7 @@
 
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
-import InlineRecoverySetup, { viewName } from '.';
+import InlineRecoverySetup from '.';
 import { REACT_ENTRYPOINT } from '../../constants';
 import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
@@ -178,10 +178,5 @@ describe('InlineRecoverySetup', () => {
     await screen.findByText(
       'There was a problem confirming your backup authentication code'
     );
-  });
-
-  it('emits the expected metrics on render', () => {
-    renderWithRouter(<InlineRecoverySetup {...props} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -4,12 +4,10 @@
 
 import React, { useCallback, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
 import DataBlock from '../../components/DataBlock';
-import { REACT_ENTRYPOINT } from '../../constants';
 import { RecoveryCodesImage } from '../../components/images';
 import CardHeader from '../../components/CardHeader';
 import AppLayout from '../../components/AppLayout';
@@ -29,8 +27,6 @@ export type InlineRecoverySetupProps = {
   successfulSetupHandler: () => void;
 };
 
-export const viewName = 'inline-recovery-setup';
-
 const InlineRecoverySetup = ({
   recoveryCodes,
   serviceName,
@@ -38,8 +34,6 @@ const InlineRecoverySetup = ({
   verifyTotpHandler,
   successfulSetupHandler,
 }: InlineRecoverySetupProps & RouteComponentProps) => {
-  usePageViewEvent(viewName, REACT_ENTRYPOINT);
-
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedIncorrectBackupCodeError = ftlMsgResolver.getMsg(
     'tfa-incorrect-recovery-code-1',

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -5,17 +5,10 @@
 import { act, screen } from '@testing-library/react';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import InlineTotpSetup, { viewName } from '.';
-import { REACT_ENTRYPOINT } from '../../constants';
+import InlineTotpSetup from '.';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
-import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { MOCK_EMAIL, MOCK_TOTP_TOKEN } from './mocks';
-
-jest.mock('../../lib/metrics', () => ({
-  logViewEvent: jest.fn(),
-  usePageViewEvent: jest.fn(),
-}));
 
 const cancelSetupHandler = jest.fn();
 const verifyCodeHandler = jest.fn();
@@ -154,10 +147,5 @@ describe('InlineTotpSetup', () => {
     );
     await screen.findByText('Invalid two-step authentication code');
     expect(verifyCodeHandler).toBeCalledWith('000000');
-  });
-
-  it('emits the expected metrics on render', () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
   });
 });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -7,12 +7,10 @@ import classNames from 'classnames';
 import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { Account, useFtlMsgResolver } from '../../models';
-import { usePageViewEvent } from '../../lib/metrics';
 import { TwoFactorAuthImage } from '../../components/images';
 import CardHeader from '../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode from '../../components/FormVerifyCode';
-import { REACT_ENTRYPOINT } from '../../constants';
 import AppLayout from '../../components/AppLayout';
 import Banner, { BannerType } from '../../components/Banner';
 
@@ -26,8 +24,6 @@ type InlineTotpSetupProps = {
   verifyCodeHandler: (code: string) => void;
 };
 
-export const viewName = 'inline-totp-setup';
-
 export const InlineTotpSetup = ({
   totp,
   email,
@@ -35,8 +31,6 @@ export const InlineTotpSetup = ({
   cancelSetupHandler,
   verifyCodeHandler,
 }: InlineTotpSetupProps) => {
-  usePageViewEvent(viewName, REACT_ENTRYPOINT);
-
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedQRCodeAltText = ftlMsgResolver.getMsg(
     'tfa-qr-code-alt',

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
@@ -1,0 +1,195 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as ReachRouterModule from '@reach/router';
+import * as ReactUtils from 'fxa-react/lib/utils';
+import * as CacheModule from '../../../lib/cache';
+import * as SigninRecoveryCodeModule from './index';
+
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
+import { LocationProvider } from '@reach/router';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import SigninRecoveryCodeContainer from './container';
+import { createMockWebIntegration } from '../../../lib/integrations/mocks';
+import { MozServices } from '../../../lib/types';
+import { Integration } from '../../../models';
+import {
+  MOCK_STORED_ACCOUNT,
+  MOCK_RECOVERY_CODE,
+  mockLoadingSpinnerModule,
+} from '../../mocks';
+import { SigninRecoveryCodeProps } from './interfaces';
+import { mockGqlError, mockSigninLocationState } from '../mocks';
+import { mockConsumeRecoveryCodeUseMutation } from './mocks';
+import { waitFor } from '@testing-library/react';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+
+let integration: Integration;
+function mockWebIntegration() {
+  integration = createMockWebIntegration() as Integration;
+}
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    loginBackupCode: {
+      view: jest.fn(),
+      submit: jest.fn(),
+      success: jest.fn(),
+    },
+    isDone: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models', () => {
+  return {
+    ...jest.requireActual('../../../models'),
+    useAuthClient: jest.fn(),
+  };
+});
+
+let currentSigninRecoveryCodeProps: SigninRecoveryCodeProps | undefined;
+function mockSigninRecoveryCodeModule() {
+  currentSigninRecoveryCodeProps = undefined;
+  jest
+    .spyOn(SigninRecoveryCodeModule, 'default')
+    .mockImplementation((props) => {
+      currentSigninRecoveryCodeProps = props;
+      return <div>signin recovery code mock</div>;
+    });
+}
+
+function mockCache(opts: any = {}, isEmpty = false) {
+  jest.spyOn(CacheModule, 'currentAccount').mockReturnValue(
+    isEmpty
+      ? undefined
+      : {
+          sessionToken: '123',
+          ...(opts || {}),
+        }
+  );
+}
+
+function mockReactUtilsModule() {
+  jest
+    .spyOn(ReactUtils, 'hardNavigateToContentServer')
+    .mockImplementation(() => {});
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
+}
+
+const mockLocation = (pathname: string, mockLocationState: Object) => {
+  return {
+    ...global.window.location,
+    pathname,
+    state: mockLocationState,
+  };
+};
+
+function mockReachRouter(
+  mockNavigate = jest.fn(),
+  pathname = '',
+  mockLocationState = {}
+) {
+  mockNavigate.mockReset();
+  jest.spyOn(ReachRouterModule, 'useNavigate').mockReturnValue(mockNavigate);
+  jest
+    .spyOn(ReachRouterModule, 'useLocation')
+    .mockImplementation(() => mockLocation(pathname, mockLocationState));
+}
+
+function applyDefaultMocks() {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+  mockSigninRecoveryCodeModule();
+  mockLoadingSpinnerModule();
+  //   mockUseValidateModule();
+  mockReactUtilsModule();
+  mockCache();
+  mockReachRouter(undefined, 'signin_recovery_code', mockSigninLocationState);
+  mockWebIntegration();
+}
+
+function render(mocks: Array<MockedResponse>) {
+  loadDevMessages();
+  loadErrorMessages();
+
+  renderWithLocalizationProvider(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <LocationProvider>
+        <SigninRecoveryCodeContainer
+          {...{
+            integration,
+            serviceName: MozServices.Default,
+          }}
+        />
+      </LocationProvider>
+    </MockedProvider>
+  );
+}
+
+describe('SigninRecoveryCode container', () => {
+  beforeEach(() => {
+    applyDefaultMocks();
+  });
+  describe('initial state', () => {
+    it('redirects if page is reached without location state', async () => {
+      mockReachRouter(undefined, 'signin_recovery_code');
+      mockCache({}, true);
+      await render([]);
+      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+    });
+
+    it('redirects if there is no sessionToken', async () => {
+      mockReachRouter(undefined, 'signin_recovery_code');
+      mockCache({ sessionToken: '' });
+      await render([]);
+      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+    });
+
+    it('retrieves the session token from local storage if no location state', async () => {
+      mockReachRouter(undefined, 'signin_recovery_code', {});
+      mockCache(MOCK_STORED_ACCOUNT);
+      await render([]);
+      expect(ReactUtils.hardNavigateToContentServer).not.toBeCalledWith('/');
+    });
+  });
+
+  describe('submitRecoveryCode', () => {
+    it('successful', async () => {
+      await render([mockConsumeRecoveryCodeUseMutation()]);
+      expect(currentSigninRecoveryCodeProps).toBeDefined();
+      await waitFor(async () => {
+        const response =
+          await currentSigninRecoveryCodeProps?.submitRecoveryCode(
+            MOCK_RECOVERY_CODE
+          );
+        expect(response?.data?.consumeRecoveryCode).toEqual({
+          remaining: 3,
+        });
+      });
+    });
+
+    it('handles errors', async () => {
+      await render([
+        {
+          ...mockConsumeRecoveryCodeUseMutation(),
+          error: mockGqlError(AuthUiErrors.INVALID_RECOVERY_CODE),
+        },
+      ]);
+      expect(currentSigninRecoveryCodeProps).toBeDefined();
+      await waitFor(async () => {
+        const response =
+          await currentSigninRecoveryCodeProps?.submitRecoveryCode(
+            MOCK_RECOVERY_CODE
+          );
+
+        expect(response?.data?.consumeRecoveryCode).toBeUndefined();
+        expect(response?.error?.errno).toEqual(
+          AuthUiErrors.INVALID_RECOVERY_CODE.errno
+        );
+      });
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { MozServices } from '../../../lib/types';
+import SigninRecoveryCode from '.';
+import { Integration, useAuthClient } from '../../../models';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { useMutation } from '@apollo/client';
+import { CONSUME_RECOVERY_CODE_MUTATION } from './gql';
+import { useCallback } from 'react';
+import { getStoredAccountInfo, handleGQLError } from '../utils';
+import { SigninLocationState } from '../interfaces';
+import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
+import { SigninQueryParams } from '../../../models/pages/signin';
+import { ConsumeRecoveryCodeResponse, SubmitRecoveryCode } from './interfaces';
+import AppLayout from '../../../components/AppLayout';
+import CardHeader from '../../../components/CardHeader';
+
+export type SigninRecoveryCodeContainerProps = {
+  integration: Integration;
+  serviceName: MozServices;
+};
+
+export const SigninRecoveryCodeContainer = ({
+  integration,
+  serviceName,
+}: SigninRecoveryCodeContainerProps & RouteComponentProps) => {
+  const authClient = useAuthClient();
+  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
+    authClient,
+    integration
+  );
+  // TODO: FXA-9177, likely use Apollo cache here instead of location state
+  const location = useLocation() as ReturnType<typeof useLocation> & {
+    state: SigninLocationState;
+  };
+  const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
+  const { redirectTo } = queryParamModel;
+
+  const signinLocationState =
+    location.state && location.state.sessionToken
+      ? location.state
+      : getStoredAccountInfo();
+
+  const { sessionToken } = signinLocationState;
+
+  const [consumeRecoveryCode] = useMutation<ConsumeRecoveryCodeResponse>(
+    CONSUME_RECOVERY_CODE_MUTATION
+  );
+
+  const submitRecoveryCode: SubmitRecoveryCode = useCallback(
+    async (recoveryCode: string) => {
+      try {
+        // this mutation returns the number of remaining codes,
+        // but we're not currently using that value client-side
+        // may want to see if we need it for /settings (display number of remaining backup codes?)
+        const { data } = await consumeRecoveryCode({
+          variables: { input: { code: recoveryCode } },
+        });
+
+        return { data };
+      } catch (error) {
+        return handleGQLError(error);
+      }
+    },
+    [consumeRecoveryCode]
+  );
+
+  // TODO: UX for this, FXA-8106
+  if (oAuthDataError) {
+    return (
+      <AppLayout>
+        <CardHeader
+          headingText="Unexpected error"
+          headingTextFtlId="auth-error-999"
+        />
+      </AppLayout>
+    );
+  }
+
+  if (!sessionToken) {
+    hardNavigateToContentServer(`/${location.search}`);
+    return <LoadingSpinner fullScreen />;
+  }
+
+  return (
+    <SigninRecoveryCode
+      {...{
+        finishOAuthFlowHandler,
+        integration,
+        redirectTo,
+        serviceName,
+        signinLocationState,
+        submitRecoveryCode,
+      }}
+    />
+  );
+};
+
+export default SigninRecoveryCodeContainer;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/gql.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/gql.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const CONSUME_RECOVERY_CODE_MUTATION = gql`
+  mutation ConsumeRecoveryCode($input: ConsumeRecoveryCodeInput!) {
+    consumeRecoveryCode(input: $input) {
+      remaining
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
@@ -4,29 +4,74 @@
 
 import React from 'react';
 import SigninRecoveryCode from '.';
-import AppLayout from '../../../components/AppLayout';
 import { Meta } from '@storybook/react';
-import { MOCK_ACCOUNT } from '../../../models/mocks';
 import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { BeginSigninError } from '../interfaces';
+import { LocationProvider } from '@reach/router';
+import { mockSigninLocationState } from '../mocks';
+import { mockFinishOAuthFlowHandler } from '../../mocks';
+import { mockWebIntegration } from './mocks';
 
 export default {
   title: 'Pages/Signin/SigninRecoveryCode',
   component: SigninRecoveryCode,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    (Story) => (
+      <LocationProvider>
+        <Story />
+      </LocationProvider>
+    ),
+  ],
 } as Meta;
 
+const mockSubmitSuccess = () =>
+  Promise.resolve({ data: { consumeRecoveryCode: { remaining: 3 } } });
+const mockCodeError = () =>
+  Promise.resolve({
+    error: AuthUiErrors.INVALID_RECOVERY_CODE as BeginSigninError,
+  });
+
+const mockOtherError = () =>
+  Promise.resolve({
+    error: AuthUiErrors.UNEXPECTED_ERROR as BeginSigninError,
+  });
+
 export const Default = () => (
-  <AppLayout>
-    <SigninRecoveryCode email={MOCK_ACCOUNT.primaryEmail.email} />
-  </AppLayout>
+  <SigninRecoveryCode
+    finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+    integration={mockWebIntegration}
+    signinLocationState={mockSigninLocationState}
+    submitRecoveryCode={mockSubmitSuccess}
+  />
 );
 
 export const WithServiceName = () => (
-  <AppLayout>
-    <SigninRecoveryCode
-      email={MOCK_ACCOUNT.primaryEmail.email}
-      serviceName={MozServices.MozillaVPN}
-    />
-  </AppLayout>
+  <SigninRecoveryCode
+    serviceName={MozServices.MozillaVPN}
+    finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+    integration={mockWebIntegration}
+    signinLocationState={mockSigninLocationState}
+    submitRecoveryCode={mockSubmitSuccess}
+  />
+);
+
+export const WithCodeErrorOnSubmit = () => (
+  <SigninRecoveryCode
+    finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+    integration={mockWebIntegration}
+    signinLocationState={mockSigninLocationState}
+    submitRecoveryCode={mockCodeError}
+  />
+);
+
+export const WithBannerErrorOnSubmit = () => (
+  <SigninRecoveryCode
+    finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+    integration={mockWebIntegration}
+    signinLocationState={mockSigninLocationState}
+    submitRecoveryCode={mockOtherError}
+  />
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -2,44 +2,55 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useState } from 'react';
-import { Link, RouteComponentProps } from '@reach/router';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Link,
+  RouteComponentProps,
+  useLocation,
+  useNavigate,
+} from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
-import { usePageViewEvent } from '../../../lib/metrics';
-// import { useAlertBar } from '../../models';
 import { RecoveryCodesImage } from '../../../components/images';
 import CardHeader from '../../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
-import { MozServices } from '../../../lib/types';
-import { REACT_ENTRYPOINT } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
-
-export type SigninRecoveryCodeProps = {
-  email: string;
-  serviceName?: MozServices;
-};
+import AppLayout from '../../../components/AppLayout';
+import { SigninRecoveryCodeProps } from './interfaces';
+import {
+  AuthUiErrors,
+  getLocalizedErrorMessage,
+} from '../../../lib/auth-errors/auth-errors';
+import Banner, { BannerType } from '../../../components/Banner';
+import { storeAccountData } from '../../../lib/storage-utils';
+import { handleNavigation } from '../utils';
 
 export const viewName = 'signin-recovery-code';
 
 const SigninRecoveryCode = ({
-  email,
+  finishOAuthFlowHandler,
+  integration,
+  redirectTo,
   serviceName,
+  signinLocationState,
+  submitRecoveryCode,
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
-  usePageViewEvent(viewName, REACT_ENTRYPOINT);
   useEffect(() => {
     GleanMetrics.loginBackupCode.view();
   }, []);
 
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
+  const [bannerErrorMessage, setBannerErrorMessage] = useState<string>('');
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
     'signin-recovery-code-required-error',
     'Backup authentication code required'
   );
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-recovery-code-input-label',
@@ -50,29 +61,93 @@ const SigninRecoveryCode = ({
     submitButtonText: 'Confirm',
   };
 
-  const onSubmit = async () => {
-    try {
-      GleanMetrics.loginBackupCode.submit();
+  const {
+    email,
+    sessionToken,
+    uid,
+    verificationMethod,
+    verificationReason,
+    keyFetchToken,
+    unwrapBKey,
+  } = signinLocationState;
 
-      // Check recovery code
-      // Log success event
+  const onSuccessNavigate = useCallback(() => {
+    const navigationOptions = {
+      email,
+      signinData: {
+        uid,
+        sessionToken,
+        verificationReason,
+        verificationMethod,
+        verified: true,
+        keyFetchToken,
+      },
+      unwrapBKey,
+      integration,
+      finishOAuthFlowHandler,
+      redirectTo,
+      queryParams: location.search,
+    };
+
+    handleNavigation(navigationOptions, navigate);
+  }, [
+    email,
+    integration,
+    finishOAuthFlowHandler,
+    keyFetchToken,
+    location.search,
+    redirectTo,
+    navigate,
+    sessionToken,
+    verificationMethod,
+    verificationReason,
+    uid,
+    unwrapBKey,
+  ]);
+
+  const onSubmit = async (code: string) => {
+    setBannerErrorMessage('');
+    GleanMetrics.loginBackupCode.submit();
+    const response = await submitRecoveryCode(code.toLowerCase());
+
+    if (response.data?.consumeRecoveryCode.remaining !== undefined) {
       GleanMetrics.loginBackupCode.success();
-      // The await of isDone is not entirely necessary when we are not
-      // redirecting the user to an RP.  However at the time of implementation
-      // for the Glean ping the redirect logic has not been implemented.
-      await GleanMetrics.isDone();
+      storeAccountData({
+        sessionToken,
+        email,
+        uid,
+        // Update verification status of stored current account
+        verified: true,
+      });
+      onSuccessNavigate();
+    }
 
-      // Check if isForcePasswordChange
-    } catch (e) {
-      // TODO: error handling, error message confirmation
-      // This will likely use auth-errors, and errors should be displayed in a tooltip or banner
+    if (response.error) {
+      let localizedError: string;
+
+      switch (response.error.errno) {
+        // 107 is an "invalid parameter" error, not localizable or user facing
+        case AuthUiErrors.RECOVERY_CODE_NOT_FOUND.errno:
+        case AuthUiErrors.INVALID_RECOVERY_CODE.errno:
+        case 107:
+          const localizedInvalidCodeError = getLocalizedErrorMessage(
+            ftlMsgResolver,
+            AuthUiErrors.INVALID_RECOVERY_CODE
+          );
+          setCodeErrorMessage(localizedInvalidCodeError);
+          break;
+        default:
+          localizedError = getLocalizedErrorMessage(
+            ftlMsgResolver,
+            response.error
+          );
+          setBannerErrorMessage(localizedError);
+      }
     }
   };
 
   return (
-    // TODO: redirect to force_auth or signin if user has not initiated sign in
-
-    <>
+    <AppLayout>
       <CardHeader
         headingWithDefaultServiceFtlId="signin-recovery-code-heading-w-default-service"
         headingWithCustomServiceFtlId="signin-recovery-code-heading-w-custom-service"
@@ -80,41 +155,47 @@ const SigninRecoveryCode = ({
         {...{ serviceName }}
       />
 
-      <main>
-        <div className="flex justify-center mx-auto">
-          <RecoveryCodesImage className="w-3/5" />
-        </div>
+      {bannerErrorMessage && (
+        <Banner type={BannerType.error}>{bannerErrorMessage}</Banner>
+      )}
+      <div className="flex justify-center mx-auto">
+        <RecoveryCodesImage className="w-3/5" />
+      </div>
 
-        <FtlMsg id="signin-recovery-code-instruction">
-          <p className="m-5 text-sm">
-            Please enter a backup authentication code that was provided to you
-            during two step authentication setup.
-          </p>
+      <FtlMsg id="signin-recovery-code-instruction">
+        <p className="m-5 text-sm">
+          Please enter a backup authentication code that was provided to you
+          during two step authentication setup.
+        </p>
+      </FtlMsg>
+
+      <FormVerifyCode
+        {...{
+          formAttributes,
+          viewName,
+          verifyCode: onSubmit,
+          localizedCustomCodeRequiredMessage,
+          codeErrorMessage,
+          setCodeErrorMessage,
+        }}
+      />
+
+      <div className="mt-5 link-blue text-sm flex justify-between">
+        <FtlMsg id="signin-recovery-code-back-link">
+          <Link
+            to={`/signin_totp_code${location.search || ''}`}
+            state={signinLocationState}
+          >
+            Back
+          </Link>
         </FtlMsg>
-
-        <FormVerifyCode
-          {...{
-            formAttributes,
-            viewName,
-            verifyCode: onSubmit,
-            localizedCustomCodeRequiredMessage,
-            codeErrorMessage,
-            setCodeErrorMessage,
-          }}
-        />
-
-        <div className="mt-5 link-blue text-sm flex justify-between">
-          <FtlMsg id="signin-recovery-code-back-link">
-            <Link to="/signin_totp_code">Back</Link>
-          </FtlMsg>
-          <FtlMsg id="signin-recovery-code-support-link">
-            <LinkExternal href="https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication">
-              Are you locked out?
-            </LinkExternal>
-          </FtlMsg>
-        </div>
-      </main>
-    </>
+        <FtlMsg id="signin-recovery-code-support-link">
+          <LinkExternal href="https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication">
+            Are you locked out?
+          </LinkExternal>
+        </FtlMsg>
+      </div>
+    </AppLayout>
   );
 };
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { MozServices } from '../../../lib/types';
+import {
+  BeginSigninError,
+  SigninIntegration,
+  SigninLocationState,
+} from '../interfaces';
+
+export type SigninRecoveryCodeProps = {
+  finishOAuthFlowHandler: FinishOAuthFlowHandler;
+  integration: SigninIntegration;
+  redirectTo?: string;
+  serviceName?: MozServices;
+  signinLocationState: SigninLocationState;
+  submitRecoveryCode: SubmitRecoveryCode;
+};
+
+export type SubmitRecoveryCode = (
+  code: string
+) => Promise<SubmitRecoveryCodeResult>;
+
+export type SubmitRecoveryCodeResult = {
+  data?: ConsumeRecoveryCodeResponse | null;
+  error?: BeginSigninError;
+};
+
+export type ConsumeRecoveryCodeResponse = {
+  consumeRecoveryCode: { remaining: number };
+};

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/mocks.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MozServices } from '../../../lib/types';
+import { Integration, IntegrationType } from '../../../models';
+import { MOCK_RECOVERY_CODE } from '../../mocks';
+import { CONSUME_RECOVERY_CODE_MUTATION } from './gql';
+import { ConsumeRecoveryCodeResponse } from './interfaces';
+
+export function mockConsumeRecoveryCodeUseMutation() {
+  const result = createConsumeRecoveryCodeResponse();
+  return {
+    request: {
+      query: CONSUME_RECOVERY_CODE_MUTATION,
+      variables: { input: { code: MOCK_RECOVERY_CODE } },
+    },
+    result,
+  };
+}
+
+export function createConsumeRecoveryCodeResponse(): {
+  data: ConsumeRecoveryCodeResponse;
+} {
+  return {
+    data: {
+      consumeRecoveryCode: {
+        remaining: 3,
+      },
+    },
+  };
+}
+
+export const mockWebIntegration = {
+  type: IntegrationType.Web,
+  getService: () => MozServices.Default,
+  isSync: () => false,
+  wantsKeys: () => false,
+} as Integration;
+
+export * from '../../mocks';

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Integration, IntegrationType } from '../../../models';
 import { SigninTokenCodeProps } from './interfaces';

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -8,7 +8,6 @@ import * as UseValidateModule from '../../../lib/hooks/useValidate';
 import * as CacheModule from '../../../lib/cache';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import * as ReachRouterModule from '@reach/router';
-import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
 import * as ApolloModule from '@apollo/client';
 
 // Regular imports
@@ -27,6 +26,7 @@ import {
   MOCK_TOTP_LOCATION_STATE,
 } from './mocks';
 import { SigninLocationState } from '../interfaces';
+import { mockLoadingSpinnerModule } from '../../mocks';
 
 let integration: Integration;
 
@@ -43,12 +43,6 @@ function mockSigninTotpModule() {
       currentPageProps = props;
       return <div>signin totp code mock</div>;
     });
-}
-
-function mockLoadingSpinnerModule() {
-  jest.spyOn(LoadingSpinnerModule, 'LoadingSpinner').mockImplementation(() => {
-    return <div>loading spinner mock</div>;
-  });
 }
 
 function mockUseValidateModule(opts: any = {}) {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -19,8 +19,6 @@ import CardHeader from '../../../components/CardHeader';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
-export const viewName = 'signin-totp-code';
-
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
   serviceName: MozServices;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -186,12 +186,16 @@ export const SigninTotpCode = ({
         />
         <div className="mt-5 link-blue text-sm flex justify-between">
           <FtlMsg id="signin-totp-code-other-account-link">
-            <Link to="/signin" className="text-start">
+            <Link to={`/signin${location.search}`} className="text-start">
               Use a different account
             </Link>
           </FtlMsg>
           <FtlMsg id="signin-totp-code-recovery-code-link">
-            <Link to="/signin_recovery_code" className="text-end">
+            <Link
+              to={`/signin_recovery_code${location.search}`}
+              state={signinLocationState}
+              className="text-end"
+            >
               Trouble entering code?
             </Link>
           </FtlMsg>

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Integration, IntegrationType } from '../../../models';
 import { SigninTotpCode, SigninTotpCodeProps } from '.';

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -88,6 +88,13 @@ export const MOCK_NO_TOTP = {
   },
 };
 
+export const mockSigninLocationState = {
+  email: MOCK_EMAIL,
+  sessionToken: MOCK_SESSION_TOKEN,
+  uid: MOCK_UID,
+  verified: false,
+};
+
 export function createMockSigninWebIntegration(): SigninIntegration {
   return {
     type: IntegrationType.Web,

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -28,7 +28,6 @@ import React from 'react';
 // TIP - Import modules for mocking. Not that `* as` lend themselves to using jest.spyOn.
 import * as SignupModule from './index';
 import * as ModelsModule from '../../models';
-import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
 import * as ApolloModule from '@apollo/client';
 import * as UseValidateModule from '../../lib/hooks/useValidate';
 import * as FirefoxModule from '../../lib/channels/firefox';
@@ -51,6 +50,7 @@ import { ApolloClient } from '@apollo/client';
 import { ModelDataProvider } from '../../lib/model-data';
 import AuthClient from 'fxa-auth-client/browser';
 import { LocationProvider } from '@reach/router';
+import { mockLoadingSpinnerModule } from '../mocks';
 
 // TIP - Sometimes, we want to mock inputs. In this case they can be mocked directly and
 // often times a mocking util isn't even necessary. Note that using the Dependency Inversion
@@ -90,11 +90,6 @@ function mockSignupModule() {
       currentSignupProps = props;
       return <div>signup mock</div>;
     });
-}
-function mockLoadingSpinnerModule() {
-  jest.spyOn(LoadingSpinnerModule, 'LoadingSpinner').mockImplementation(() => {
-    return <div>loading spinner mock</div>;
-  });
 }
 
 // TIP - Most modules can be easily mocked via jest.spyOn. As you can see this very clean.

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
+
 import { MozServices } from '../lib/types';
 import { MOCK_ACCOUNT } from '../models/mocks';
 
@@ -20,6 +22,7 @@ export const MOCK_RESET_TOKEN = 'mockResetToken';
 export const MOCK_AUTH_AT = 12345;
 export const MOCK_PASSWORD = 'notYourAveragePassW0Rd';
 export const MOCK_UNBLOCK_CODE = 'A1B2C3D4';
+export const MOCK_RECOVERY_CODE = 'a1b2c3d4e5';
 export const MOCK_AVATAR_NON_DEFAULT = {
   id: 'abc123',
   url: 'http://placekitten.com/512/512',
@@ -51,3 +54,9 @@ export const MOCK_UNWRAP_BKEY_V2 = '20000000000000000123456789abcdef';
 export const MOCK_WRAP_KB_V2 = '20000000000000000123456789abcdef';
 export const MOCK_AUTH_PW_V2 = 'apw234';
 export const MOCK_PASSWORD_CHANGE_TOKEN = '123456789abcdef0';
+
+export function mockLoadingSpinnerModule() {
+  jest.spyOn(LoadingSpinnerModule, 'LoadingSpinner').mockImplementation(() => {
+    return <div>loading spinner mock</div>;
+  });
+}


### PR DESCRIPTION
## Because

* We are converting backbone routes to React, and this is the last route to be converted to enable React sign in

## This pull request

* Add signin_recovery_code to routes that can be served with React
* Create container component for SigninRecoveryCode page and add logic to hook up the page
* Add unit tests and update storybook
* Fix error with react import for SigninTotpCode and SigninTokenCode

## Issue that this pull request solves

Closes: #FXA-9082

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Enabled page: 
![image](https://github.com/mozilla/fxa/assets/22231637/0eab9f37-7427-4e87-a039-1cb6bad59733)

## Other information (Optional)

How to test:

- Create a new account and set up Two-factor authentication from /settings (make sure to save backup codes for later!)
- Sign out
- Set `forceGlobally`/`SIGNIN_CONFIRMATION_FORCE_GLOBALLY` to `true` to force the 2FA verification on signin (in auth-server config)
- Sign in with react experiment: http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react
- When prompted for 2FA, click on "Trouble entering code?" to reach the `signin_recovery_code` page
- Verify that previously saved backup code can be used to login
- Also test with OAuth (123Done) and experiment params added, it should navigate back to the RP with a lock icon to indicate the session is TOTP verified