### PR TITLE
feat(payments-stripe): Create StripeManager getTaxIdForCurrency

### DIFF
--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -1,4 +1,5 @@
 import { Stripe } from 'stripe';
+
 import {
   ContentfulClient,
   PurchaseWithDetailsOfferingContentUtil,
@@ -6,8 +7,9 @@ import {
   PurchaseWithDetailsOfferingContentTransformedFactory,
   PurchaseDetailsTransformedFactory,
 } from '@fxa/shared/contentful';
+import { StripePlanFactory, StripeProductFactory } from '@fxa/payments/stripe';
+
 import { StripeMapperService } from './stripe-mapper.service';
-import { ProductFactory, PlanFactory } from '@fxa/payments/stripe';
 import { StripeMetadataWithContentfulFactory } from './factories';
 
 describe('StripeMapperService', () => {
@@ -37,7 +39,7 @@ describe('StripeMapperService', () => {
       const validMetadata = StripeMetadataWithContentfulFactory({
         webIconURL: 'https://example.com/webIconURL',
       });
-      const stripePlan = PlanFactory({
+      const stripePlan = StripePlanFactory({
         product: 'stringvalue',
         metadata: validMetadata,
       });
@@ -61,8 +63,8 @@ describe('StripeMapperService', () => {
       const validMetadata = StripeMetadataWithContentfulFactory({
         webIconURL: 'https://example.com/webIconURL',
       });
-      const stripePlan = PlanFactory() as Stripe.Plan;
-      stripePlan.product = ProductFactory({
+      const stripePlan = StripePlanFactory() as Stripe.Plan;
+      stripePlan.product = StripeProductFactory({
         metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
@@ -88,8 +90,8 @@ describe('StripeMapperService', () => {
       const validMetadata = StripeMetadataWithContentfulFactory({
         webIconURL: 'https://example.com/webIconURL',
       });
-      const stripePlan = PlanFactory() as Stripe.Plan;
-      stripePlan.product = ProductFactory({
+      const stripePlan = StripePlanFactory() as Stripe.Plan;
+      stripePlan.product = StripeProductFactory({
         metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
@@ -118,10 +120,10 @@ describe('StripeMapperService', () => {
       const planOverrideMetadata = StripeMetadataWithContentfulFactory({
         webIconURL: 'https://plan.override/emailIcon',
       });
-      const stripePlan = PlanFactory({
+      const stripePlan = StripePlanFactory({
         metadata: planOverrideMetadata,
       }) as Stripe.Plan;
-      stripePlan.product = ProductFactory({
+      stripePlan.product = StripeProductFactory({
         metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
@@ -145,8 +147,8 @@ describe('StripeMapperService', () => {
         productSet: 'set',
         productOrder: 'order',
       };
-      const stripePlan = PlanFactory() as Stripe.Plan;
-      stripePlan.product = ProductFactory({
+      const stripePlan = StripePlanFactory() as Stripe.Plan;
+      stripePlan.product = StripeProductFactory({
         metadata: productMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
@@ -183,16 +185,16 @@ describe('StripeMapperService', () => {
         productSet: 'set',
         productOrder: 'order',
       };
-      const product = ProductFactory({
+      const product = StripeProductFactory({
         metadata: productMetadata,
       });
-      const stripePlan1 = PlanFactory({
+      const stripePlan1 = StripePlanFactory({
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in English',
         }),
       }) as Stripe.Plan;
       stripePlan1.product = product;
-      const stripePlan2 = PlanFactory({
+      const stripePlan2 = StripePlanFactory({
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in French',
           'product:details:2': 'Detail 2 in French',
@@ -236,16 +238,16 @@ describe('StripeMapperService', () => {
         productSet: 'set',
         productOrder: 'order',
       };
-      const product = ProductFactory({
+      const product = StripeProductFactory({
         metadata: productMetadata,
       });
-      const stripePlan1 = PlanFactory({
+      const stripePlan1 = StripePlanFactory({
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in German',
         }),
       }) as Stripe.Plan;
       stripePlan1.product = product;
-      const stripePlan2 = PlanFactory({
+      const stripePlan2 = StripePlanFactory({
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in French',
           'product:details:2': 'Detail 2 in French',

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -1,17 +1,21 @@
-export { CardFactory } from './lib/factories/card.factory';
-export { CustomerFactory } from './lib/factories/customer.factory';
-export { InvoiceLineItemFactory } from './lib/factories/invoice-line-item.factory';
-export { InvoiceFactory } from './lib/factories/invoice.factory';
-export { PriceFactory } from './lib/factories/price.factory';
-export { PlanFactory } from './lib/factories/plan.factory';
-export { ProductFactory } from './lib/factories/product.factory';
 export {
-  SubscriptionFactory,
-  SubscriptionItemFactory,
-  SubscriptionListFactory,
+  StripeApiListFactory,
+  StripeResponseFactory,
+} from './lib/factories/api-list.factory';
+export { StripeCardFactory } from './lib/factories/card.factory';
+export { StripeCustomerFactory } from './lib/factories/customer.factory';
+export { StripeInvoiceLineItemFactory } from './lib/factories/invoice-line-item.factory';
+export { StripeInvoiceFactory } from './lib/factories/invoice.factory';
+export { StripePlanFactory } from './lib/factories/plan.factory';
+export { StripePriceFactory } from './lib/factories/price.factory';
+export { StripeProductFactory } from './lib/factories/product.factory';
+export {
+  StripeSubscriptionFactory,
+  StripeSubscriptionItemFactory,
 } from './lib/factories/subscription.factory';
 export * from './lib/stripe.client';
+export * from './lib/stripe.client.types';
+export * from './lib/stripe.config';
 export * from './lib/stripe.constants';
 export * from './lib/stripe.error';
 export * from './lib/stripe.manager';
-export * from './lib/stripe.client.types';

--- a/libs/payments/stripe/src/lib/factories/api-list.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/api-list.factory.ts
@@ -1,0 +1,26 @@
+import { faker } from '@faker-js/faker';
+import { StripeApiList, StripeResponse } from '../stripe.client.types';
+
+export const StripeApiListFactory = <T extends Array<any>>(
+  data: T,
+  override?: Partial<StripeApiList<T>>
+): StripeApiList<T[0]> => ({
+  object: 'list',
+  url: '/v1/subscriptions',
+  has_more: false,
+  data,
+  ...override,
+});
+
+export const StripeResponseFactory = <T>(
+  data: T,
+  override?: Partial<StripeResponse<T>>
+): StripeResponse<T> => ({
+  lastResponse: {
+    headers: {},
+    requestId: faker.string.uuid(),
+    statusCode: 200,
+  },
+  ...data,
+  ...override,
+});

--- a/libs/payments/stripe/src/lib/factories/card.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/card.factory.ts
@@ -5,7 +5,9 @@
 import { faker } from '@faker-js/faker';
 import { StripeCard } from '../stripe.client.types';
 
-export const CardFactory = (override?: Partial<StripeCard>): StripeCard => ({
+export const StripeCardFactory = (
+  override?: Partial<StripeCard>
+): StripeCard => ({
   id: 'card',
   object: 'card',
   address_city: faker.location.city(),

--- a/libs/payments/stripe/src/lib/factories/customer.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/customer.factory.ts
@@ -5,7 +5,7 @@
 import { faker } from '@faker-js/faker';
 import { StripeCustomer } from '../stripe.client.types';
 
-export const CustomerFactory = (
+export const StripeCustomerFactory = (
   override?: Partial<StripeCustomer>
 ): StripeCustomer => ({
   id: `cus_${faker.string.alphanumeric({ length: 14 })}`,

--- a/libs/payments/stripe/src/lib/factories/invoice-line-item.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/invoice-line-item.factory.ts
@@ -5,7 +5,7 @@
 import { faker } from '@faker-js/faker';
 import { StripeInvoiceLineItem } from '../stripe.client.types';
 
-export const InvoiceLineItemFactory = (
+export const StripeInvoiceLineItemFactory = (
   override?: Partial<StripeInvoiceLineItem>
 ): StripeInvoiceLineItem => ({
   id: faker.string.alphanumeric(10),

--- a/libs/payments/stripe/src/lib/factories/invoice.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/invoice.factory.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { InvoiceLineItemFactory } from './invoice-line-item.factory';
+import { StripeInvoiceLineItemFactory } from './invoice-line-item.factory';
 import { StripeInvoice } from '../stripe.client.types';
 
-export const InvoiceFactory = (
+export const StripeInvoiceFactory = (
   override?: Partial<StripeInvoice>
 ): StripeInvoice => ({
   id: `in_${faker.string.alphanumeric({ length: 24 })}`,
@@ -53,7 +53,7 @@ export const InvoiceFactory = (
   latest_revision: null,
   lines: {
     object: 'list',
-    data: [InvoiceLineItemFactory()],
+    data: [StripeInvoiceLineItemFactory()],
     has_more: false,
     url: faker.internet.url(),
   },

--- a/libs/payments/stripe/src/lib/factories/plan.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/plan.factory.ts
@@ -5,7 +5,9 @@
 import { faker } from '@faker-js/faker';
 import { StripePlan } from '../stripe.client.types';
 
-export const PlanFactory = (override?: Partial<StripePlan>): StripePlan => ({
+export const StripePlanFactory = (
+  override?: Partial<StripePlan>
+): StripePlan => ({
   id: `plan_${faker.string.alphanumeric({ length: 24 })}`,
   object: 'plan',
   active: true,

--- a/libs/payments/stripe/src/lib/factories/price.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/price.factory.ts
@@ -5,7 +5,9 @@
 import { faker } from '@faker-js/faker';
 import { StripePrice } from '../stripe.client.types';
 
-export const PriceFactory = (override?: Partial<StripePrice>): StripePrice => ({
+export const StripePriceFactory = (
+  override?: Partial<StripePrice>
+): StripePrice => ({
   id: `price_${faker.string.alphanumeric({ length: 24 })}`,
   object: 'price',
   active: true,

--- a/libs/payments/stripe/src/lib/factories/product.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/product.factory.ts
@@ -5,7 +5,7 @@
 import { faker } from '@faker-js/faker';
 import { StripeProduct } from '../stripe.client.types';
 
-export const ProductFactory = (
+export const StripeProductFactory = (
   override?: Partial<StripeProduct>
 ): StripeProduct => ({
   id: `prod_${faker.string.alphanumeric({ length: 14 })}`,

--- a/libs/payments/stripe/src/lib/factories/subscription.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/subscription.factory.ts
@@ -3,14 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { PriceFactory } from './price.factory';
+import { StripePriceFactory } from './price.factory';
 import {
-  StripeApiList,
   StripeSubscription,
   StripeSubscriptionItem,
 } from '../stripe.client.types';
 
-export const SubscriptionFactory = (
+export const StripeSubscriptionFactory = (
   override?: Partial<StripeSubscription>
 ): StripeSubscription => ({
   id: `sub_${faker.string.alphanumeric({ length: 24 })}`,
@@ -40,7 +39,7 @@ export const SubscriptionFactory = (
   ended_at: null,
   items: {
     object: 'list',
-    data: [SubscriptionItemFactory()],
+    data: [StripeSubscriptionItemFactory()],
     has_more: false,
     url: `/v1/subscription_items?subscription=sub_${faker.string.alphanumeric({
       length: 24,
@@ -67,7 +66,7 @@ export const SubscriptionFactory = (
   ...override,
 });
 
-export const SubscriptionItemFactory = (
+export const StripeSubscriptionItemFactory = (
   override?: Partial<StripeSubscriptionItem>
 ): StripeSubscriptionItem => ({
   id: `si_${faker.string.alphanumeric({ length: 14 })}`,
@@ -98,19 +97,9 @@ export const SubscriptionItemFactory = (
     trial_period_days: null,
     usage_type: 'licensed',
   },
-  price: PriceFactory(),
+  price: StripePriceFactory(),
   quantity: 1,
   subscription: `sub_${faker.string.alphanumeric({ length: 24 })}`,
   tax_rates: [],
-  ...override,
-});
-
-export const SubscriptionListFactory = (
-  override?: Partial<StripeApiList<StripeSubscription>>
-): StripeApiList<StripeSubscription> => ({
-  object: 'list',
-  url: '/v1/subscriptions',
-  has_more: false,
-  data: [SubscriptionFactory()],
   ...override,
 });

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -5,13 +5,13 @@
 import { Injectable } from '@nestjs/common';
 import { Stripe } from 'stripe';
 
-import { StripeClientConfig } from './stripe.client.config';
 import {
   StripeCustomer,
   StripeDeletedCustomer,
   StripeInvoice,
   StripeSubscription,
 } from './stripe.client.types';
+import { StripeConfig } from './stripe.config';
 
 /**
  * A wrapper for Stripe that enforces that results have deterministic typings
@@ -19,10 +19,9 @@ import {
  */
 @Injectable()
 export class StripeClient {
-  public readonly stripe: Stripe;
-
-  constructor(private stripeClientConfig: StripeClientConfig) {
-    this.stripe = new Stripe(this.stripeClientConfig.apiKey, {
+  private readonly stripe: Stripe;
+  constructor(private stripeConfig: StripeConfig) {
+    this.stripe = new Stripe(this.stripeConfig.apiKey, {
       apiVersion: '2022-11-15',
       maxNetworkRetries: 3,
     });

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -278,3 +278,5 @@ export type StripeCard = NegotiateExpanded<
 >;
 
 export type StripeApiList<T> = Stripe.ApiList<T>;
+export type StripeApiListPromise<T> = Stripe.ApiListPromise<T>;
+export type StripeResponse<T> = Stripe.Response<T>;

--- a/libs/payments/stripe/src/lib/stripe.config.ts
+++ b/libs/payments/stripe/src/lib/stripe.config.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsString } from 'class-validator';
+import { IsObject, IsString } from 'class-validator';
 
-export class StripeClientConfig {
+export class StripeConfig {
   @IsString()
   public readonly apiKey!: string;
+
+  @IsObject()
+  public readonly taxIds!: { [key: string]: string };
 }

--- a/libs/payments/stripe/src/lib/stripe.error.ts
+++ b/libs/payments/stripe/src/lib/stripe.error.ts
@@ -6,12 +6,9 @@ import { BaseError } from '@fxa/shared/error';
 
 export class StripeError extends BaseError {
   constructor(message: string, cause?: Error) {
-    super(
-      message,
-      {
-        cause,
-      },
-    );
+    super(message, {
+      cause,
+    });
   }
 }
 
@@ -27,7 +24,7 @@ export class CustomerNotFoundError extends StripeError {
   }
 }
 
-export class SubscriptionStripeError extends StripeError {
+export class StripeNoMinimumChargeAmountAvailableError extends StripeError {
   constructor() {
     super('Currency does not have a minimum charge amount available.');
   }


### PR DESCRIPTION
## This pull request

- [x] Loads tax IDs from config
- [x] Fetches tax IDs (this is simply a lookup in the stored taxId map from config)

Ref: see existing implementation in StripeHelper.getTaxIdForCustomer

## Issue that this pull request solves

Closes: FXA-8946

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.