### PR TITLE
task(auth): Have auth-server use cloud-tasks nx lib 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,11 +121,14 @@ executors:
       - image: jdlk7/firestore-emulator
       - image: memcached
       - image: redis
+      - image: ghcr.io/aertje/cloud-tasks-emulator:1.2.0
+        command: -queue "projects/test/locations/test/queues/delete-accounts-queue"
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
       CUSTOMS_SERVER_URL: none
       HUSKY_SKIP_INSTALL: 1
+      AUTH_CLOUDTASKS_USE_LOCAL_EMULATOR: true
 
   # For anything that needs a full stack to run and needs browsers available for
   # ui test automation. This image requires a restored workspace state.
@@ -143,6 +146,8 @@ executors:
       - image: cimg/mysql:8.0
         command: --default-authentication-plugin=mysql_native_password
       - image: jdlk7/firestore-emulator
+      - image: ghcr.io/aertje/cloud-tasks-emulator:1.2.0
+        command: -queue "projects/test/locations/test/queues/delete-accounts-queue"
     environment:
       NODE_ENV: development
       FXA_EMAIL_ENV: development
@@ -164,6 +169,7 @@ executors:
       REACT_CONVERSION_POST_VERIFY_CAD_VIA_QR_ROUTES: true
       CUSTOMS_SERVER_URL: none
       HUSKY_SKIP_INSTALL: 1
+      AUTH_CLOUDTASKS_USE_LOCAL_EMULATOR: true
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
   # automation. Perfect for running smoke tests against remote targets.

--- a/libs/shared/cloud-tasks/src/lib/account-tasks.ts
+++ b/libs/shared/cloud-tasks/src/lib/account-tasks.ts
@@ -20,7 +20,11 @@ export class AccountTasks extends CloudTasks {
     super(config, cloudTaskClient);
   }
 
-  /** Add an account to the task queue. */
+  /**
+   * Adds an account to the delete account task queue.
+   * @param deleteTask The info necessary to queue an account deletion.
+   * @returns A taskName
+   */
   public async deleteAccount(deleteTask: DeleteAccountTask) {
     try {
       const result = await this.enqueueTask({

--- a/libs/shared/cloud-tasks/src/lib/account-tasks.types.ts
+++ b/libs/shared/cloud-tasks/src/lib/account-tasks.types.ts
@@ -12,8 +12,6 @@ export type DeleteAccountCloudTaskConfig = CloudTasksConfig & {
       queueName: string;
     };
   };
-  publicUrl: string;
-  apiVersion: string;
 };
 
 /** Reasons an account can be deleted. */
@@ -28,7 +26,7 @@ export type DeleteAccountTask = {
   /** The account id */
   uid: string;
   /** The customer id, i.e. a stripe customer id if applicable */
-  customerId?: string;
+  customerId: string | undefined;
   /** Reason for deletion */
   reason: ReasonForDeletion;
 };

--- a/libs/shared/cloud-tasks/src/lib/cloud-tasks.ts
+++ b/libs/shared/cloud-tasks/src/lib/cloud-tasks.ts
@@ -6,6 +6,24 @@ import { CloudTasksConfig } from './cloud-tasks.types';
 
 /** Base class for encapsulating common cloud task operations */
 export class CloudTasks {
+  /**
+   * Indicates if a queue has been configured and is enabled.
+   */
+  public get queueEnabled() {
+    // If a keyFilename was supplied, the cloud task queue can be considered enabled.
+    if (this.config.cloudTasks.credentials.keyFilename) {
+      return true;
+    }
+
+    // If we specify a local emulator is being used, then no keyFilename is required,
+    // and the task queue can be considered enabled.
+    if (this.config.cloudTasks.useLocalEmulator) {
+      return true;
+    }
+
+    return false;
+  }
+
   protected constructor(
     protected readonly config: CloudTasksConfig,
     protected readonly client: Pick<CloudTasksClient, 'createTask' | 'getTask'>

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -37,6 +37,10 @@ const { AccountDeleteManager } = require('../lib/account-delete');
 const { gleanMetrics } = require('../lib/metrics/glean');
 const Customs = require('../lib/customs');
 const Profile = require('../lib/profile/client');
+const {
+  AccountTasks,
+  AccountTasksFactory,
+} = require('@fxa/shared/cloud-tasks');
 async function run(config) {
   Container.set(AppConfig, config);
 
@@ -176,12 +180,15 @@ async function run(config) {
 
   // The AccountDeleteManager is dependent on some of the object set into
   // Container above.
+  const accountTasks = AccountTasksFactory(config, statsd);
+  Container.set(AccountTasks, accountTasks);
+
   const accountDeleteManager = new AccountDeleteManager({
     fxaDb: database,
     oauthDb,
+    config,
     push,
     pushbox,
-    statsd,
   });
   Container.set(AccountDeleteManager, accountDeleteManager);
 

--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -4,13 +4,10 @@
 
 import {
   deleteAllPayPalBAs,
-  getAccountCustomerByUid,
   getAllPayPalBAByUid,
 } from 'fxa-shared/db/models/auth';
-import { StatsD } from 'hot-shots';
 import { Container } from 'typedi';
 
-import { CloudTasksClient } from '@google-cloud/tasks';
 import * as Sentry from '@sentry/node';
 
 import { ConfigType } from '../config';
@@ -21,10 +18,10 @@ import { AppleIAP } from './payments/iap/apple-app-store/apple-iap';
 import { PlayBilling } from './payments/iap/google-play/play-billing';
 import { PayPalHelper } from './payments/paypal/helper';
 import { StripeHelper } from './payments/stripe';
+import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 import { StripeFirestoreMultiError } from './payments/stripe-firestore';
 import pushBuilder from './push';
 import pushboxApi from './pushbox';
-import { accountDeleteCloudTaskPath } from './routes/cloud-tasks';
 import { AppConfig, AuthLogger, AuthRequest } from './types';
 
 type FxaDbDeleteAccount = Pick<
@@ -42,54 +39,17 @@ type PushForDeleteAccount = Pick<
 >;
 type Log = AuthLogger & { activityEvent: (data: Record<string, any>) => void };
 
-export const ReasonForDeletionOptions = {
-  UserRequested: 'fxa_user_requested_account_delete',
-  Unverified: 'fxa_unverified_account_delete',
-  Cleanup: 'fxa_cleanup_account_delete',
-} as const;
-export type ReasonForDeletion =
-  (typeof ReasonForDeletionOptions)[keyof typeof ReasonForDeletionOptions];
-export const ReasonForDeletionValues = Object.values(ReasonForDeletionOptions);
-
-type DeleteTask = {
-  uid: string;
-  customerId?: string;
-  reason: ReasonForDeletion;
-};
-type EnqueueByUidParam = {
-  uid: string;
-  reason: ReasonForDeletion;
-};
-type EnqueueByEmailParam = {
-  email: string;
-  reason: ReasonForDeletion;
-};
-
-const isEnqueueByUidParam = (
-  x: EnqueueByUidParam | EnqueueByEmailParam
-): x is EnqueueByUidParam => (x as EnqueueByUidParam).uid !== undefined;
-const isEnqueueByEmailParam = (
-  x: EnqueueByUidParam | EnqueueByEmailParam
-): x is EnqueueByEmailParam => (x as EnqueueByEmailParam).email !== undefined;
-
 export class AccountDeleteManager {
   private fxaDb: FxaDbDeleteAccount;
   private oauthDb: OAuthDbDeleteAccount;
   private push: PushForDeleteAccount;
   private pushbox: PushboxDeleteAccount;
-  private statsd: StatsD;
   private stripeHelper?: StripeHelper;
   private paypalHelper?: PayPalHelper;
   private appleIap?: AppleIAP;
   private playBilling?: PlayBilling;
   private log: Log;
   private config: ConfigType;
-  private tasksEnabled = false;
-  private tasksRequired = false;
-
-  private cloudTasksClient: CloudTasksClient;
-  private queueName;
-  private taskUrl;
 
   constructor({
     fxaDb,
@@ -97,21 +57,18 @@ export class AccountDeleteManager {
     config,
     push,
     pushbox,
-    statsd,
   }: {
     fxaDb: FxaDbDeleteAccount;
     oauthDb: OAuthDbDeleteAccount;
     config: ConfigType;
     push: PushForDeleteAccount;
     pushbox: PushboxDeleteAccount;
-    statsd: StatsD;
   }) {
     this.fxaDb = fxaDb;
     this.oauthDb = oauthDb;
     this.config = config;
     this.push = push;
     this.pushbox = pushbox;
-    this.statsd = statsd;
 
     if (Container.has(StripeHelper)) {
       this.stripeHelper = Container.get(StripeHelper);
@@ -125,81 +82,11 @@ export class AccountDeleteManager {
     if (Container.has(PlayBilling)) {
       this.playBilling = Container.get(PlayBilling);
     }
+
     this.log = Container.get(AuthLogger) as Log;
+
+    // Is this intentional? Config is passed in the constructor
     this.config = Container.get(AppConfig);
-    const tasksConfig = this.config.cloudTasks;
-
-    this.cloudTasksClient = new CloudTasksClient({
-      projectId: tasksConfig.projectId,
-      keyFilename: tasksConfig.credentials.keyFilename ?? undefined,
-    });
-    this.queueName = `projects/${tasksConfig.projectId}/locations/${tasksConfig.locationId}/queues/${tasksConfig.deleteAccounts.queueName}`;
-    this.taskUrl = `${this.config.publicUrl}/v${this.config.apiVersion}${accountDeleteCloudTaskPath}`;
-    this.tasksEnabled = !!tasksConfig.credentials.keyFilename;
-    this.tasksRequired = ['stage', 'prod'].includes(this.config.env);
-  }
-
-  public async enqueue(options: EnqueueByUidParam | EnqueueByEmailParam) {
-    if (isEnqueueByUidParam(options)) {
-      return this.enqueueByUid(options);
-    }
-
-    if (isEnqueueByEmailParam(options)) {
-      return this.enqueueByEmail(options);
-    }
-
-    throw new Error(
-      `Failed to enqueue account delete cloud task with ${options}.`
-    );
-  }
-
-  private async enqueueByUid(options: EnqueueByUidParam) {
-    const { stripeCustomerId } =
-      (await getAccountCustomerByUid(options.uid)) || {};
-    const task: DeleteTask = {
-      uid: options.uid,
-      customerId: stripeCustomerId,
-      reason: options.reason,
-    };
-    return this.enqueueTask(task);
-  }
-
-  private async enqueueByEmail(options: EnqueueByEmailParam) {
-    const account = await this.fxaDb.accountRecord(options.email);
-    const { stripeCustomerId } =
-      (await getAccountCustomerByUid(account.uid)) || {};
-    const task: DeleteTask = {
-      uid: account.uid,
-      customerId: stripeCustomerId,
-      reason: options.reason,
-    };
-    return this.enqueueTask(task);
-  }
-
-  private async enqueueTask(task: DeleteTask) {
-    try {
-      const taskResult = await this.cloudTasksClient.createTask({
-        parent: this.queueName,
-        task: {
-          httpRequest: {
-            url: this.taskUrl,
-            httpMethod: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: Buffer.from(JSON.stringify(task)).toString('base64'),
-            oidcToken: {
-              audience: this.config.cloudTasks.oidc.aud,
-              serviceAccountEmail:
-                this.config.cloudTasks.oidc.serviceAccountEmail,
-            },
-          },
-        },
-      });
-      this.statsd.increment('cloud-tasks.account-delete.enqueue.success');
-      return taskResult[0].name;
-    } catch (err) {
-      this.statsd.increment('cloud-tasks.account-delete.enqueue.failure');
-      throw err;
-    }
   }
 
   /**
@@ -240,7 +127,7 @@ export class AccountDeleteManager {
    * deletion.
    */
   public async quickDelete(uid: string, reason: ReasonForDeletion) {
-    if (reason !== ReasonForDeletionOptions.UserRequested) {
+    if (reason !== ReasonForDeletion.UserRequested) {
       throw new Error('quickDelete only supports user requested deletions');
     }
 
@@ -251,10 +138,6 @@ export class AccountDeleteManager {
       // If the account wasn't fully deleted, we should log the error and
       // still queue the account for cleanup.
       this.log.error('quickDelete', { uid, error });
-    }
-    // Only queue if enabled or is in stage/prod.
-    if (this.tasksEnabled || this.tasksRequired) {
-      await this.enqueueByUid({ uid, reason });
     }
   }
 
@@ -329,7 +212,7 @@ export class AccountDeleteManager {
     });
 
     // Currently only support auto refund of invoices for unverified accounts
-    if (deleteReason !== ReasonForDeletionOptions.Unverified || !customerId) {
+    if (deleteReason !== ReasonForDeletion.Unverified || !customerId) {
       return;
     }
 

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Account } from 'fxa-shared/db/models/auth';
+import { Account, getAccountCustomerByUid } from 'fxa-shared/db/models/auth';
 import {
   AppStoreSubscription,
   PlayStoreSubscription,
@@ -42,11 +42,9 @@ import requestHelper from './utils/request_helper';
 import validators from './validators';
 import { AccountEventsManager } from '../account-events';
 import { gleanMetrics } from '../metrics/glean';
-import {
-  AccountDeleteManager,
-  ReasonForDeletionOptions,
-} from '../account-delete';
+import { AccountDeleteManager } from '../account-delete';
 import { uuidTransformer } from 'fxa-shared/db/transformers';
+import { AccountTasks, ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -67,6 +65,7 @@ export class AccountHandler {
   private capabilityService: CapabilityService;
   private accountEventsManager: AccountEventsManager;
   private accountDeleteManager: AccountDeleteManager;
+  private accountTasks: AccountTasks;
 
   constructor(
     private log: AuthLogger,
@@ -82,7 +81,6 @@ export class AccountHandler {
     private subscriptionAccountReminders: any,
     private oauth: any,
     private stripeHelper: StripeHelper,
-    private pushbox: any,
     private glean: ReturnType<typeof gleanMetrics>
   ) {
     this.otpUtils = require('./utils/otp')(log, config, db);
@@ -104,6 +102,7 @@ export class AccountHandler {
     this.capabilityService = Container.get(CapabilityService);
     this.accountEventsManager = Container.get(AccountEventsManager);
     this.accountDeleteManager = Container.get(AccountDeleteManager);
+    this.accountTasks = Container.get(AccountTasks);
   }
 
   private async generateRandomValues() {
@@ -1846,11 +1845,21 @@ export class AccountHandler {
 
     await this.accountDeleteManager.quickDelete(
       accountRecord.uid,
-      ReasonForDeletionOptions.UserRequested
+      ReasonForDeletion.UserRequested
     );
     await request.emitMetricsEvent('account.deleted', {
       uid: accountRecord.uid,
     });
+
+    if (this.accountTasks.queueEnabled) {
+      const result = await getAccountCustomerByUid(accountRecord.uid);
+      await this.accountTasks.deleteAccount({
+        uid: accountRecord.uid,
+        customerId: result?.stripeCustomerId,
+        reason: ReasonForDeletion.UserRequested,
+      });
+    }
+
     return {};
   }
 
@@ -1935,7 +1944,6 @@ export const accountRoutes = (
     subscriptionAccountReminders,
     oauth,
     stripeHelper,
-    pushbox,
     glean
   );
   const routes = [

--- a/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-tasks.ts
@@ -7,19 +7,11 @@ import { Container } from 'typedi';
 
 import { ConfigType } from '../../config';
 import DESCRIPTION from '../../docs/swagger/shared/descriptions';
-import {
-  AccountDeleteManager,
-  ReasonForDeletion,
-  ReasonForDeletionValues,
-} from '../account-delete';
+import { AccountDeleteManager } from '../account-delete';
 import { AuthLogger, AuthRequest } from '../types';
 import validators from './validators';
 
-export type DeleteAccountTaskPayload = {
-  uid: string;
-  customerId?: string;
-  reason: ReasonForDeletion;
-};
+import { DeleteAccountTask } from '@fxa/shared/cloud-tasks';
 
 export class CloudTaskHandler {
   private accountDeleteManager: AccountDeleteManager;
@@ -28,7 +20,7 @@ export class CloudTaskHandler {
     this.accountDeleteManager = Container.get(AccountDeleteManager);
   }
 
-  async deleteAccount(taskPayload: DeleteAccountTaskPayload) {
+  async deleteAccount(taskPayload: DeleteAccountTask) {
     this.log.debug('Received delete account task', taskPayload);
     await this.accountDeleteManager.deleteAccount(
       taskPayload.uid,
@@ -64,14 +56,12 @@ export const cloudTaskRoutes = (log: AuthLogger, config: ConfigType) => {
               .string()
               .optional()
               .description(DESCRIPTION.customerId),
-            reason: isA.string().valid(...ReasonForDeletionValues),
+            reason: validators.reasonForAccountDeletion,
           }),
         },
       },
       handler: (request: AuthRequest) =>
-        cloudTaskHandler.deleteAccount(
-          request.payload as DeleteAccountTaskPayload
-        ),
+        cloudTaskHandler.deleteAccount(request.payload as DeleteAccountTask),
     },
   ];
 

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -35,6 +35,7 @@ const {
 const {
   VX_REGEX: CLIENT_SALT_STRING,
 } = require('../../lib/routes/utils/client-key-stretch');
+const { ReasonForDeletion } = require('@fxa/shared/cloud-tasks');
 
 // Match any non-empty hex-encoded string.
 const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
@@ -121,6 +122,9 @@ module.exports.uid = module.exports.hexString.length(32);
 module.exports.clientId = module.exports.hexString.length(16);
 module.exports.clientSecret = module.exports.hexString;
 module.exports.idToken = module.exports.jwt;
+module.exports.reasonForAccountDeletion = isA
+  .string()
+  .valid(...Object.values(ReasonForDeletion));
 module.exports.refreshToken = module.exports.hexString.length(64);
 module.exports.sessionToken = module.exports.hexString.length(64);
 module.exports.sessionTokenId = module.exports.hexString.length(64);

--- a/packages/fxa-auth-server/scripts/clean-up-partial-account-customer.ts
+++ b/packages/fxa-auth-server/scripts/clean-up-partial-account-customer.ts
@@ -3,27 +3,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Command } from 'commander';
-import { AccountCustomers } from 'fxa-shared/db/models/auth';
+import {
+  AccountCustomers,
+  getAccountCustomerByUid,
+} from 'fxa-shared/db/models/auth';
 import { StatsD } from 'hot-shots';
 import { Container } from 'typedi';
 
 import appConfig from '../config';
-import {
-  AccountDeleteManager,
-  ReasonForDeletionOptions,
-} from '../lib/account-delete';
 import * as random from '../lib/crypto/random';
 import DB from '../lib/db';
 import { setupFirestore } from '../lib/firestore-db';
 import initLog from '../lib/log';
-import oauthDb from '../lib/oauth/db';
 import { CurrencyHelper } from '../lib/payments/currencies';
 import { createStripeHelper, StripeHelper } from '../lib/payments/stripe';
-import { pushboxApi } from '../lib/pushbox';
 import initRedis from '../lib/redis';
 import Token from '../lib/tokens';
 import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
 import { parseDryRun } from './lib/args';
+import {
+  AccountTasksFactory,
+  ReasonForDeletion,
+} from '@fxa/shared/cloud-tasks';
 
 const dryRun = async (program: Command, limit: number) => {
   const countQuery = AccountCustomers.query()
@@ -66,7 +67,7 @@ const init = async () => {
   program.parse(process.argv);
   const isDryRun = parseDryRun(program.dryRun);
   const limit = program.limit ? parseInt(program.limit) : Infinity;
-  const reason = ReasonForDeletionOptions.Cleanup;
+  const reason = ReasonForDeletion.Cleanup;
 
   if (limit <= 0) {
     throw new Error('The limit should be a positive integer.');
@@ -88,7 +89,7 @@ const init = async () => {
     random.base32(config.signinUnblock.codeLength) as any // TS type inference is failing pretty hard with this
   );
   // connect to db here so the dry run could get a row count
-  const fxaDb = await db.connect(config, redis);
+  await db.connect(config, redis);
 
   if (isDryRun) {
     console.log(
@@ -98,7 +99,6 @@ const init = async () => {
     return dryRun(program, limit);
   }
 
-  const pushbox = pushboxApi(log, config, statsd);
   Container.set(AppConfig, config);
   Container.set(AuthLogger, log);
   const authFirestore = setupFirestore(config);
@@ -108,14 +108,7 @@ const init = async () => {
   const stripeHelper = createStripeHelper(log, config, statsd);
   Container.set(StripeHelper, stripeHelper);
 
-  const accountDeleteManager = new AccountDeleteManager({
-    fxaDb,
-    oauthDb,
-    config,
-    push: {} as any, // Push isn't needed for enqueuing
-    pushbox,
-    statsd,
-  });
+  const accountTasks = AccountTasksFactory(config, statsd);
 
   const query = AccountCustomers.query()
     .select({ uid: 'accountCustomers.uid' })
@@ -131,7 +124,11 @@ const init = async () => {
   const rows = await query;
 
   for (const x of rows) {
-    const result = await accountDeleteManager.enqueue({ uid: x.uid, reason });
+    const result = await accountTasks.deleteAccount({
+      uid: x.uid,
+      customerId: (await getAccountCustomerByUid(x.uid))?.stripeCustomerId,
+      reason,
+    });
     console.log(`Created cloud task ${result} for uid ${x.uid}`);
   }
 

--- a/packages/fxa-auth-server/scripts/cleanup-partial-firestore-customers.ts
+++ b/packages/fxa-auth-server/scripts/cleanup-partial-firestore-customers.ts
@@ -8,31 +8,31 @@ import { parseDryRun } from './lib/args';
 import { FieldPath, Firestore } from '@google-cloud/firestore';
 import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
 import Container from 'typedi';
-import {
-  AccountDeleteManager,
-  ReasonForDeletionOptions,
-} from '../lib/account-delete';
 import { ConfigType } from '../config';
-import oauthDb from '../lib/oauth/db';
 import { StatsD } from 'hot-shots';
-import pushboxApi from '../lib/pushbox';
 import { setupAccountDatabase } from '@fxa/shared/db/mysql/account';
 import { AccountManager } from '@fxa/shared/account/account';
 import { uuidTransformer } from 'packages/fxa-shared/db/transformers';
 import * as pckg from '../package.json';
+import {
+  AccountTasks,
+  ReasonForDeletion,
+  AccountTasksFactory,
+} from '@fxa/shared/cloud-tasks';
+import { getAccountCustomerByUid } from 'fxa-shared/db/models/auth';
 
 class CleanupFirestoreHelper {
   private firestore: Firestore;
   private log: AuthLogger;
   private config: ConfigType;
-  private accountDeleteManager: AccountDeleteManager;
+  private accountTasks: AccountTasks;
   private accountManager: AccountManager;
 
   constructor(private batchSize: number, private dryRun: boolean) {
     this.firestore = Container.get<Firestore>(AuthFirestore);
     this.log = Container.get(AuthLogger);
     this.config = Container.get(AppConfig);
-    this.accountDeleteManager = Container.get(AccountDeleteManager);
+    this.accountTasks = Container.get(AccountTasks);
     this.accountManager = Container.get(AccountManager);
   }
 
@@ -104,10 +104,11 @@ class CleanupFirestoreHelper {
     }
 
     await Promise.all(
-      uids.map((uid) =>
-        this.accountDeleteManager.enqueue({
+      uids.map(async (uid) =>
+        this.accountTasks.deleteAccount({
           uid,
-          reason: ReasonForDeletionOptions.Cleanup,
+          customerId: (await getAccountCustomerByUid(uid))?.stripeCustomerId,
+          reason: ReasonForDeletion.Cleanup,
         })
       )
     );
@@ -153,25 +154,14 @@ export async function init() {
   const batchSize = parseInt(options.batchSize);
   const isDryRun = parseDryRun(options.dryRun);
 
-  const { database: fxaDb } = await setupProcessingTaskObjects(
-    'cleanup-delete-partial-firestore'
-  );
+  // TBD, do we still need this? fxaDb is no longer referenced...
+  await setupProcessingTaskObjects('cleanup-delete-partial-firestore');
 
   const config = Container.get(AppConfig);
   const statsd = Container.get(StatsD);
-  const log = Container.get(AuthLogger);
-  const pushbox = pushboxApi(log, config, statsd);
 
-  const accountDeleteManager = new AccountDeleteManager({
-    fxaDb,
-    oauthDb,
-    config,
-    push: {} as any,
-    pushbox,
-    statsd,
-  });
-
-  Container.set(AccountDeleteManager, accountDeleteManager);
+  const accountTasks = AccountTasksFactory(config, statsd);
+  Container.set(AccountTasks, accountTasks);
 
   const accountDb = await setupAccountDatabase(config.database.mysql.auth);
   const accountManager = new AccountManager(accountDb);

--- a/packages/fxa-auth-server/scripts/delete-account.ts
+++ b/packages/fxa-auth-server/scripts/delete-account.ts
@@ -37,6 +37,10 @@ import {
   AuthLogger,
   ProfileClient,
 } from '../lib/types';
+import {
+  AccountTasks,
+  AccountTasksFactory,
+} from '../../../libs/shared/cloud-tasks/src';
 
 const config = configProperties.getProperties();
 const mailer = null;
@@ -121,13 +125,16 @@ DB.connect(config).then(async (db: any) => {
     Container.set(PayPalHelper, paypalHelper);
   }
 
+  const accountTasks = AccountTasksFactory(config, statsd);
+  Container.set(AccountTasks, accountTasks);
+
   const accountDeleteManager = new AccountDeleteManager({
     fxaDb: db,
     oauthDb: oauthDB,
+    config,
     push,
     pushbox,
-    statsd,
-  } as any);
+  });
   Container.set(AccountDeleteManager, accountDeleteManager);
 
   // Load the account-deletion route, so we can use its logic directly.

--- a/packages/fxa-auth-server/test/local/routes/cloud-tasks.js
+++ b/packages/fxa-auth-server/test/local/routes/cloud-tasks.js
@@ -8,11 +8,8 @@ const sinon = require('sinon');
 const mocks = require('../../mocks');
 const getRoute = require('../../routes_helpers').getRoute;
 const { cloudTaskRoutes } = require('../../../lib/routes/cloud-tasks');
-const {
-  AccountDeleteManager,
-  ReasonForDeletionOptions,
-} = require('../../../lib/account-delete');
-
+const { AccountDeleteManager } = require('../../../lib/account-delete');
+const { ReasonForDeletion } = require('@fxa/shared/cloud-tasks');
 const mockConfig = {
   cloudTasks: {
     deleteAccounts: { queueName: 'del-accts' },
@@ -45,7 +42,7 @@ describe('/cloud-tasks/accounts/delete', () => {
   it('should delete the account', async () => {
     try {
       const req = {
-        payload: { uid, reason: ReasonForDeletionOptions.Unverified },
+        payload: { uid, reason: ReasonForDeletion.Unverified },
       };
 
       await route.handler(req);

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -11,6 +11,7 @@ const plan1 = require('../payments/fixtures/stripe/plan1.json');
 const validProductMetadata = plan1.product.metadata;
 const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
 const { deepCopy } = require('../payments/util');
+const { ReasonForDeletion } = require('@fxa/shared/cloud-tasks');
 
 describe('lib/routes/validators:', () => {
   it('isValidEmailAddress returns true for valid email addresses', () => {
@@ -1136,6 +1137,29 @@ describe('lib/routes/validators:', () => {
     it('requires proper length', () => {
       assert.exists(validators.recoveryCode(5).validate('1234').error);
       assert.exists(validators.recoveryCode(11).validate('123456').error);
+    });
+  });
+
+  describe('reason for account deletion', () => {
+    it('validates valid reason', () => {
+      assert.notExists(
+        validators.reasonForAccountDeletion.validate(ReasonForDeletion.Cleanup)
+          .error
+      );
+      assert.notExists(
+        validators.reasonForAccountDeletion.validate(
+          ReasonForDeletion.UserRequested
+        ).error
+      );
+      assert.notExists(
+        validators.reasonForAccountDeletion.validate(
+          ReasonForDeletion.Unverified
+        ).error
+      );
+    });
+
+    it('requires valid reason', () => {
+      assert.exists(validators.reasonForAccountDeletion.validate('blah').error);
     });
   });
 });

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -19,998 +19,987 @@ const {
 } = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 // Note, intentionally not indenting for code review.
-[{version:""},{version:"V2"}].forEach((testOptions) => {
-
-
-describe(`#integration${testOptions.version} - remote account create`, function () {
-  this.timeout(50000);
-  let server;
-  before(async () => {
-    config.subscriptions = {
-      enabled: true,
-      stripeApiKey: 'fake_key',
-      paypalNvpSigCredentials: {
-        enabled: false,
-      },
-      paymentsServer: {
-        url: 'http://fakeurl.com',
-      },
-      productConfigsFirestore: { enabled: true },
-    };
-    const mockStripeHelper = {};
-    mockStripeHelper.hasActiveSubscription = async () =>
-      Promise.resolve(false);
-    mockStripeHelper.removeCustomer = async () => Promise.resolve();
-
-    Container.set(PlaySubscriptions, {});
-    Container.set(AppStoreSubscriptions, {});
-
-    server = await TestServer.start(config, false, {
-      authServerMockDependencies: {
-        '../lib/payments/stripe': {
-          StripeHelper: mockStripeHelper,
-          createStripeHelper: () => mockStripeHelper,
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - remote account create`, function () {
+    this.timeout(50000);
+    let server;
+    before(async () => {
+      config.subscriptions = {
+        enabled: true,
+        stripeApiKey: 'fake_key',
+        paypalNvpSigCredentials: {
+          enabled: false,
         },
-      },
-    });
-    return server;
-  });
+        paymentsServer: {
+          url: 'http://fakeurl.com',
+        },
+        productConfigsFirestore: { enabled: true },
+      };
+      const mockStripeHelper = {};
+      mockStripeHelper.hasActiveSubscription = async () =>
+        Promise.resolve(false);
+      mockStripeHelper.removeCustomer = async () => Promise.resolve();
 
-  it('unverified account fail when getting keys', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, testOptions)
-      .then((x) => {
-        client = x;
-        assert.ok(client.authAt, 'authAt was set');
+      Container.set(PlaySubscriptions, {});
+      Container.set(AppStoreSubscriptions, {});
+
+      server = await TestServer.start(config, false, {
+        authServerMockDependencies: {
+          '../lib/payments/stripe': {
+            StripeHelper: mockStripeHelper,
+            createStripeHelper: () => mockStripeHelper,
+          },
+        },
+      });
+      return server;
+    });
+
+    it('unverified account fail when getting keys', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then((x) => {
+          client = x;
+          assert.ok(client.authAt, 'authAt was set');
+        })
+        .then(() => {
+          return client.keys();
+        })
+        .then(
+          (keys) => {
+            assert(false, 'got keys before verifying email');
+          },
+          (err) => {
+            assert.equal(err.errno, 104, 'Unverified account error code');
+            assert.equal(
+              err.message,
+              'Unconfirmed account',
+              'Unverified account error message'
+            );
+          }
+        );
+    });
+
+    it('create and verify sync account', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, {
+        ...testOptions,
+        service: 'sync',
       })
-      .then(() => {
-        return client.keys();
+        .then((x) => {
+          client = x;
+          assert.ok(client.authAt, 'authAt was set');
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, false);
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(emailData.headers['x-mailer'], undefined);
+          assert.equal(emailData.headers['x-template-name'], 'verify');
+          return emailData.headers['x-verify-code'];
+        })
+        .then((verifyCode) => {
+          return client.verifyEmail(verifyCode, { service: 'sync' });
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(
+            emailData.headers['x-link'].indexOf(config.smtp.syncUrl),
+            0,
+            'sync url present'
+          );
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, true);
+        });
+    });
+
+    it('create account with service identifier and resume', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      return Client.create(config.publicUrl, email, password, {
+        ...testOptions,
+        service: 'abcdef',
+        resume: 'foo',
       })
-      .then(
-        (keys) => {
-          assert(false, 'got keys before verifying email');
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(emailData.headers['x-service-id'], 'abcdef');
+          assert.ok(emailData.headers['x-link'].indexOf('resume=foo') > -1);
+        });
+    });
+
+    it('create account allows localization of emails', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then((x) => {
+          client = x;
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.include(emailData.text, 'Confirm account', 'en-US');
+          // TODO: reinstate after translations catch up
+          //assert.notInclude(emailData.text, 'Ativar agora', 'not pt-BR');
+          return client.destroyAccount();
+        })
+        .then(() => {
+          return Client.create(config.publicUrl, email, password, {
+            ...testOptions,
+            lang: 'pt-br',
+          });
+        })
+        .then((x) => {
+          client = x;
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.notInclude(emailData.text, 'Confirm email', 'not en-US');
+          // TODO: reinstate after translations catch up
+          //assert.include(emailData.text, 'Ativar agora', 'is pt-BR');
+          return client.destroyAccount();
+        });
+    });
+
+    it('Unknown account should not exist', () => {
+      const client = new Client(config.publicUrl, testOptions);
+      client.email = server.uniqueEmail();
+      client.authPW = crypto.randomBytes(32);
+      client.authPWVersion2 = crypto.randomBytes(32);
+      return client.auth().then(
+        () => {
+          assert(false, 'account should not exist');
         },
         (err) => {
-          assert.equal(err.errno, 104, 'Unverified account error code');
-          assert.equal(
-            err.message,
-            'Unconfirmed account',
-            'Unverified account error message'
-          );
+          assert.equal(err.errno, 102, 'account does not exist');
         }
       );
-  });
+    });
 
-  it('create and verify sync account', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, {
-      ...testOptions,
-      service: 'sync',
-    })
-      .then((x) => {
-        client = x;
-        assert.ok(client.authAt, 'authAt was set');
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, false);
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(emailData.headers['x-mailer'], undefined);
-        assert.equal(emailData.headers['x-template-name'], 'verify');
-        return emailData.headers['x-verify-code'];
-      })
-      .then((verifyCode) => {
-        return client.verifyEmail(verifyCode, { service: 'sync' });
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(
-          emailData.headers['x-link'].indexOf(config.smtp.syncUrl),
-          0,
-          'sync url present'
-        );
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, true);
-      });
-  });
-
-  it('create account with service identifier and resume', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    return Client.create(config.publicUrl, email, password, {
-      ...testOptions,
-      service: 'abcdef',
-      resume: 'foo',
-    })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(emailData.headers['x-service-id'], 'abcdef');
-        assert.ok(emailData.headers['x-link'].indexOf('resume=foo') > -1);
-      });
-  });
-
-  it('create account allows localization of emails', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, testOptions)
-      .then((x) => {
-        client = x;
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.include(emailData.text, 'Confirm account', 'en-US');
-        // TODO: reinstate after translations catch up
-        //assert.notInclude(emailData.text, 'Ativar agora', 'not pt-BR');
-        return client.destroyAccount();
-      })
-      .then(() => {
-        return Client.create(config.publicUrl, email, password, {
-          ...testOptions,
-          lang: 'pt-br',
-        });
-      })
-      .then((x) => {
-        client = x;
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.notInclude(emailData.text, 'Confirm email', 'not en-US');
-        // TODO: reinstate after translations catch up
-        //assert.include(emailData.text, 'Ativar agora', 'is pt-BR');
-        return client.destroyAccount();
-      });
-  });
-
-  it('Unknown account should not exist', () => {
-    const client = new Client(config.publicUrl, testOptions);
-    client.email = server.uniqueEmail();
-    client.authPW = crypto.randomBytes(32);
-    client.authPWVersion2 = crypto.randomBytes(32);
-    return client.auth().then(
-      () => {
-        assert(false, 'account should not exist');
-      },
-      (err) => {
-        assert.equal(err.errno, 102, 'account does not exist');
-      }
-    );
-  });
-
-  it('stubs account and finishes setup', async () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    const client = new Client(config.publicUrl, testOptions);
-    await client.setupCredentials(email, password);
-
-    if (testOptions.version === "V2") {
-      await client.setupCredentialsV2(email, password);
-    }
-
-    // Stub account for 123Done
-    const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
-    assert.exists(stubResponse.setup_token);
-
-    // Finish the setup.
-    const response = await client.finishAccountSetup(stubResponse.setup_token)
-    assert.exists(response.uid);
-    assert.exists(response.sessionToken);
-    assert.exists(response.verified);
-    assert.isFalse(response.verified);
-
-    // Now a client should be able login
-    const client2 = await Client.login(config.publicUrl, email, password, testOptions);
-    assert.exists(client2.sessionToken)
-  })
-
-  it('cannot stub the same account twice', async () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    const stub = async () => {
+    it('stubs account and finishes setup', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
       const client = new Client(config.publicUrl, testOptions);
       await client.setupCredentials(email, password);
 
-      if (testOptions.version === "V2") {
+      if (testOptions.version === 'V2') {
+        await client.setupCredentialsV2(email, password);
+      }
+
+      // Stub account for 123Done
+      const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
+      assert.exists(stubResponse.setup_token);
+
+      // Finish the setup.
+      const response = await client.finishAccountSetup(
+        stubResponse.setup_token
+      );
+      assert.exists(response.uid);
+      assert.exists(response.sessionToken);
+      assert.exists(response.verified);
+      assert.isFalse(response.verified);
+
+      // Now a client should be able login
+      const client2 = await Client.login(
+        config.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      assert.exists(client2.sessionToken);
+    });
+
+    it('cannot stub the same account twice', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const stub = async () => {
+        const client = new Client(config.publicUrl, testOptions);
+        await client.setupCredentials(email, password);
+
+        if (testOptions.version === 'V2') {
+          await client.setupCredentialsV2(email, password);
+        }
+
+        const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
+        assert.exists(stubResponse.setup_token);
+      };
+
+      // The second attempt to stub should fail, because the email has already been
+      // stubbed
+      await stub();
+      assert.isRejected(stub());
+    });
+
+    it('fails to create account with a corrupt setup token', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(config.publicUrl, testOptions);
+      await client.setupCredentials(email, password);
+
+      if (testOptions.version === 'V2') {
         await client.setupCredentialsV2(email, password);
       }
 
       const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
       assert.exists(stubResponse.setup_token);
-    };
 
-    // The second attempt to stub should fail, because the email has already been
-    // stubbed
-    await stub();
-    assert.isRejected(stub());
-  })
+      // modify the setup token and make sure it fails
+      stubResponse.setup_token = stubResponse.setup_token
+        .toString()
+        .substring(2);
 
-  it('fails to create account with a corrupt setup token', async () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    const client = new Client(config.publicUrl, testOptions);
-    await client.setupCredentials(email, password);
-
-    if (testOptions.version === "V2") {
-      await client.setupCredentialsV2(email, password);
-    }
-
-    const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
-    assert.exists(stubResponse.setup_token);
-
-    // modify the setup token and make sure it fails
-    stubResponse.setup_token = stubResponse.setup_token.toString().substring(2);
-
-    // Finish the setup. Should fail because the setup token is bad
-    assert.isRejected(client.finishAccountSetup(stubResponse.setup_token))
-  })
-
-  it('fails to call finish setup again', async () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    const client = new Client(config.publicUrl, testOptions);
-    await client.setupCredentials(email, password);
-
-    if (testOptions.version === "V2") {
-      await client.setupCredentialsV2(email, password);
-    }
-
-    const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
-    await client.finishAccountSetup(stubResponse.setup_token);
-
-    //Should fail because finish account setup was already called
-    assert.isRejected(client.finishAccountSetup(stubResponse.setup_token));
-  })
-
-  it('/account/create works with proper data', () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    let client;
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    )
-      .then((x) => {
-        client = x;
-        assert.ok(client.uid, 'account created');
-      })
-      .then(() => {
-        return client.login();
-      })
-      .then(() => {
-        assert.ok(client.sessionToken, 'client can login');
-      });
-  });
-
-  it('/account/create returns a sessionToken', () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    const client = new Client(config.publicUrl, testOptions);
-    return client.setupCredentials(email, password).then((c) => {
-      return c.api.accountCreate(c.email, c.authPW).then((response) => {
-        assert.ok(response.sessionToken, 'has a sessionToken');
-        assert.equal(
-          response.keyFetchToken,
-          undefined,
-          'no keyFetchToken without keys=true'
-        );
-      });
+      // Finish the setup. Should fail because the setup token is bad
+      assert.isRejected(client.finishAccountSetup(stubResponse.setup_token));
     });
-  });
 
-  it('/account/create returns a keyFetchToken when keys=true', () => {
-    const email = server.uniqueEmail();
-    const password = 'ilikepancakes';
-    const client = new Client(config.publicUrl, testOptions);
-    return client.setupCredentials(email, password).then((c) => {
-      return c.api
-        .accountCreate(c.email, c.authPW, { keys: true })
-        .then((response) => {
-          assert.ok(response.sessionToken, 'has a sessionToken');
-          assert.ok(response.keyFetchToken, 'keyFetchToken with keys=true');
-        });
+    it('fails to call finish setup again', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(config.publicUrl, testOptions);
+      await client.setupCredentials(email, password);
+
+      if (testOptions.version === 'V2') {
+        await client.setupCredentialsV2(email, password);
+      }
+
+      const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
+      await client.finishAccountSetup(stubResponse.setup_token);
+
+      //Should fail because finish account setup was already called
+      assert.isRejected(client.finishAccountSetup(stubResponse.setup_token));
     });
-  });
 
-  it('signup with same email, different case', () => {
-    const email = server.uniqueEmail();
-    const email2 = email.toUpperCase();
-    const password = 'abcdef';
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    )
-      .then((c) => {
-        return Client.create(config.publicUrl, email2, password, testOptions);
-      })
-      .then(assert.fail, (err) => {
-        assert.equal(err.code, 400);
-        assert.equal(err.errno, 101, 'Account already exists');
-        assert.equal(
-          err.email,
-          email,
-          'The existing email address is returned'
-        );
-      });
-  });
-
-  it('re-signup against an unverified email', () => {
-    const email = server.uniqueEmail();
-    const password = 'abcdef';
-    return Client.create(config.publicUrl, email, password, testOptions)
-      .then(() => {
-        // delete the first verification email
-        return server.mailbox.waitForEmail(email);
-      })
-      .then(() => {
-        return Client.createAndVerify(
-          config.publicUrl,
-          email,
-          password,
-          server.mailbox,
-          testOptions
-        );
-      })
-      .then((client) => {
-        assert.ok(client.uid, 'account created');
-      });
-  });
-
-  it('invalid redirectTo', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      redirectTo: 'http://accounts.firefox.com.evil.us',
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => {
-        assert.equal(err.errno, 107, 'bad redirectTo rejected');
-      })
-      .then(() => {
-        return api.passwordForgotSendCode(email, options);
-      })
-      .then(assert.fail, (err) => {
-        assert.equal(err.errno, 107, 'bad redirectTo rejected');
-      });
-  });
-
-  it('another invalid redirectTo', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      redirectTo: 'https://www.fake.com/.firefox.com',
-    };
-
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => {
-        assert.equal(err.errno, 107, 'bad redirectTo rejected');
-      })
-      .then(() => {
-        return api.passwordForgotSendCode(email, {
-          redirectTo: 'https://fakefirefox.com',
-        });
-      })
-      .then(assert.fail, (err) => {
-        assert.equal(err.errno, 107, 'bad redirectTo rejected');
-      });
-  });
-
-  it('valid metricsContext', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: 'bar',
-        utmContent: 'baz',
-        utmMedium: 'qux',
-        utmSource: 'wibble',
-        utmTerm: 'blee',
-      },
-    };
-    return api.accountCreate(email, authPW, options);
-  });
-
-  it('empty metricsContext', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {},
-    };
-    return api.accountCreate(email, authPW, options);
-  });
-
-  it('invalid entrypoint', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: ';',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: 'foo',
-        utmContent: 'bar',
-        utmMedium: 'baz',
-        utmSource: 'qux',
-        utmTerm: 'wibble',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid entrypointExperiment', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: ';',
-        entrypointVariation: 'var',
-        utmCampaign: 'bar',
-        utmContent: 'baz',
-        utmMedium: 'qux',
-        utmSource: 'wibble',
-        utmTerm: 'blee',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid entrypointVariation', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: ';',
-        utmCampaign: 'bar',
-        utmContent: 'baz',
-        utmMedium: 'qux',
-        utmSource: 'wibble',
-        utmTerm: 'blee',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid utmCampaign', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: ';',
-        utmContent: 'bar',
-        utmMedium: 'baz',
-        utmSource: 'qux',
-        utmTerm: 'wibble',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid utmContent', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: 'bar',
-        utmContent: ';',
-        utmMedium: 'baz',
-        utmSource: 'qux',
-        utmTerm: 'wibble',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid utmMedium', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: 'bar',
-        utmContent: 'baz',
-        utmMedium: ';',
-        utmSource: 'qux',
-        utmTerm: 'wibble',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid utmSource', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: 'bar',
-        utmContent: 'baz',
-        utmMedium: 'qux',
-        utmSource: ';',
-        utmTerm: 'wibble',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('invalid utmTerm', () => {
-    const api = new Client.Api(config.publicUrl, testOptions);
-    const email = server.uniqueEmail();
-    const authPW =
-      '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
-    const options = {
-      ...testOptions,
-      metricsContext: {
-        entrypoint: 'foo',
-        entrypointExperiment: 'exp',
-        entrypointVariation: 'var',
-        utmCampaign: 'bar',
-        utmContent: 'baz',
-        utmMedium: 'qux',
-        utmSource: 'wibble',
-        utmTerm: ';',
-      },
-    };
-    return api
-      .accountCreate(email, authPW, options)
-      .then(assert.fail, (err) => assert.equal(err.errno, 107));
-  });
-
-  it('create account with service query parameter', () => {
-    const email = server.uniqueEmail();
-    return Client.create(config.publicUrl, email, 'foo', {
-      ...testOptions,
-      serviceQuery: 'bar',
-    })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(
-          emailData.headers['x-service-id'],
-          'bar',
-          'service query parameter was propagated'
-        );
-      });
-  });
-
-  it('account creation works with unicode email address', () => {
-    const email = server.uniqueUnicodeEmail();
-    return Client.create(config.publicUrl, email, 'foo', testOptions)
-      .then((client) => {
-        assert.ok(client, 'created account');
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.ok(emailData, 'received email');
-      });
-  });
-
-  it('account creation fails with invalid metricsContext flowId', () => {
-    const email = server.uniqueEmail();
-    return Client.create(config.publicUrl, email, 'foo', {
-      ...testOptions,
-      metricsContext: {
-        flowId: 'deadbeefbaadf00ddeadbeefbaadf00d',
-        flowBeginTime: 1,
-      },
-    }).then(
-      () => {
-        assert(false, 'account creation should have failed');
-      },
-      (err) => {
-        assert.ok(err, 'account creation failed');
-      }
-    );
-  });
-
-  it('account creation fails with invalid metricsContext flowBeginTime', () => {
-    const email = server.uniqueEmail();
-    return Client.create(config.publicUrl, email, 'foo', {
-      ...testOptions,
-      metricsContext: {
-        flowId:
-          'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
-        flowBeginTime: 0,
-      },
-    }).then(
-      () => {
-        assert(false, 'account creation should have failed');
-      },
-      (err) => {
-        assert.ok(err, 'account creation failed');
-      }
-    );
-  });
-
-  it('account creation works with maximal metricsContext metadata', () => {
-    const email = server.uniqueEmail();
-    const options = {
-      ...testOptions,
-      metricsContext: mocks.generateMetricsContext(),
-    };
-    return Client.create(config.publicUrl, email, 'foo', options)
-      .then((client) => {
-        assert.ok(client, 'created account');
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(
-          emailData.headers['x-flow-begin-time'],
-          options.metricsContext.flowBeginTime,
-          'flow begin time set'
-        );
-        assert.equal(
-          emailData.headers['x-flow-id'],
-          options.metricsContext.flowId,
-          'flow id set'
-        );
-      });
-  });
-
-  it('account creation works with empty metricsContext metadata', () => {
-    const email = server.uniqueEmail();
-    return Client.create(config.publicUrl, email, 'foo', {
-      ...testOptions,
-      metricsContext: {},
-    }).then((client) => {
-      assert.ok(client, 'created account');
-    });
-  });
-
-  it('account creation fails with missing flowBeginTime', () => {
-    const email = server.uniqueEmail();
-    return Client.create(config.publicUrl, email, 'foo', {
-      ...testOptions,
-      metricsContext: {
-        flowId:
-          'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
-      },
-    }).then(
-      () => {
-        assert(false, 'account creation should have failed');
-      },
-      (err) => {
-        assert.ok(err, 'account creation failed');
-      }
-    );
-  });
-
-  it('account creation fails with missing flowId', () => {
-    const email = server.uniqueEmail();
-    return Client.create(config.publicUrl, email, 'foo', {
-      ...testOptions,
-      metricsContext: {
-        flowBeginTime: Date.now(),
-      },
-    }).then(
-      () => {
-        assert(false, 'account creation should have failed');
-      },
-      (err) => {
-        assert.ok(err, 'account creation failed');
-      }
-    );
-  });
-
-  it('create account for non-sync service, gets generic sign-up email and does not get post-verify email', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, testOptions)
-      .then((x) => {
-        client = x;
-        assert.ok('account was created');
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(emailData.headers['x-template-name'], 'verify');
-        return emailData.headers['x-verify-code'];
-      })
-      .then((verifyCode) => {
-        return client.verifyEmail(verifyCode, { service: 'testpilot' });
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, true);
-      })
-      .then(() => {
-        // It's hard to test for "an email didn't arrive.
-        // Instead trigger sending of another email and test
-        // that there wasn't anything in the queue before it.
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email);
-      })
-      .then((code) => {
-        assert.ok(
-          code,
-          'the next email was reset-password, not post-verify'
-        );
-      });
-  });
-
-  it('create account for unspecified service does not get create sync email and no post-verify email', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, testOptions)
-      .then((x) => {
-        client = x;
-        assert.ok('account was created');
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(emailData.headers['x-template-name'], 'verify');
-        return emailData.headers['x-verify-code'];
-      })
-      .then((verifyCode) => {
-        return client.verifyEmail(verifyCode, {}); // no 'service' param
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, true);
-      })
-      .then(() => {
-        // It's hard to test for "an email didn't arrive.
-        // Instead trigger sending of another email and test
-        // that there wasn't anything in the queue before it.
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email);
-      })
-      .then((code) => {
-        assert.ok(
-          code,
-          'the next email was reset-password, not post-verify'
-        );
-      });
-  });
-
-  it('create account and subscribe to newsletters', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, {
-      ...testOptions,
-      service: 'sync',
-    })
-      .then((x) => {
-        client = x;
-        assert.ok('account was created');
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        return emailData.headers['x-verify-code'];
-      })
-      .then((verifyCode) => {
-        return client.verifyEmail(verifyCode, {
-          service: 'sync',
-          newsletters: ['test-pilot'],
-        });
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, true);
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(emailData.headers['x-template-name'], 'postVerify');
-      });
-  });
-
-
-  it('maintains single kB value for account create with V1 & V2 credentials', async function () {
-
-    if (testOptions.version !== "V2") {
-      return this.skip();
-    }
-
-    const email = server.uniqueEmail();
-    const password = 'F00BAR';
-
-    const client = await Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      {
-        ...testOptions,
-        keys: true,
-        service: 'sync',
-      }
-    );
-
-    await client.getKeysV1();
-    await client.getKeysV2();
-    const originalKb = client.kB;
-    const clientSalt = await client.getClientSalt();
-
-    // Log in with new clients and grab kbs
-    const clientV1 = await login(email, password);
-    await clientV1.getKeysV1();
-    const kB1 = clientV1.kB;
-
-    const clientV2 = await login(email, password, "V2");
-    await clientV2.getKeysV2();
-    const kB2 = clientV2.kB;
-
-    assert.exists(originalKb);
-    assert.isTrue(
-      clientSalt.startsWith(
-        'identity.mozilla.com/picl/v1/quickStretchV2:'
+    it('/account/create works with proper data', () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      let client;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
       )
-    );
-    assert.equal(kB1, originalKb);
-    assert.equal(kB2, originalKb);
-  });
+        .then((x) => {
+          client = x;
+          assert.ok(client.uid, 'account created');
+        })
+        .then(() => {
+          return client.login();
+        })
+        .then(() => {
+          assert.ok(client.sessionToken, 'client can login');
+        });
+    });
 
-  it('maintains single kB value after account password upgrade from V1 to V2', async function () {
+    it('/account/create returns a sessionToken', () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(config.publicUrl, testOptions);
+      return client.setupCredentials(email, password).then((c) => {
+        return c.api.accountCreate(c.email, c.authPW).then((response) => {
+          assert.ok(response.sessionToken, 'has a sessionToken');
+          assert.equal(
+            response.keyFetchToken,
+            undefined,
+            'no keyFetchToken without keys=true'
+          );
+        });
+      });
+    });
 
-    if (testOptions.version !== "V2") {
-      return this.skip();
-    }
+    it('/account/create returns a keyFetchToken when keys=true', () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(config.publicUrl, testOptions);
+      return client.setupCredentials(email, password).then((c) => {
+        return c.api
+          .accountCreate(c.email, c.authPW, { keys: true })
+          .then((response) => {
+            assert.ok(response.sessionToken, 'has a sessionToken');
+            assert.ok(response.keyFetchToken, 'keyFetchToken with keys=true');
+          });
+      });
+    });
 
-    const email = server.uniqueEmail();
-    const password = 'F00BAR';
+    it('signup with same email, different case', () => {
+      const email = server.uniqueEmail();
+      const email2 = email.toUpperCase();
+      const password = 'abcdef';
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      )
+        .then((c) => {
+          return Client.create(config.publicUrl, email2, password, testOptions);
+        })
+        .then(assert.fail, (err) => {
+          assert.equal(err.code, 400);
+          assert.equal(err.errno, 101, 'Account already exists');
+          assert.equal(
+            err.email,
+            email,
+            'The existing email address is returned'
+          );
+        });
+    });
 
-    const client = await Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      {
+    it('re-signup against an unverified email', () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then(() => {
+          // delete the first verification email
+          return server.mailbox.waitForEmail(email);
+        })
+        .then(() => {
+          return Client.createAndVerify(
+            config.publicUrl,
+            email,
+            password,
+            server.mailbox,
+            testOptions
+          );
+        })
+        .then((client) => {
+          assert.ok(client.uid, 'account created');
+        });
+    });
+
+    it('invalid redirectTo', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
         ...testOptions,
-        keys: true,
+        redirectTo: 'http://accounts.firefox.com.evil.us',
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => {
+          assert.equal(err.errno, 107, 'bad redirectTo rejected');
+        })
+        .then(() => {
+          return api.passwordForgotSendCode(email, options);
+        })
+        .then(assert.fail, (err) => {
+          assert.equal(err.errno, 107, 'bad redirectTo rejected');
+        });
+    });
+
+    it('another invalid redirectTo', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        redirectTo: 'https://www.fake.com/.firefox.com',
+      };
+
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => {
+          assert.equal(err.errno, 107, 'bad redirectTo rejected');
+        })
+        .then(() => {
+          return api.passwordForgotSendCode(email, {
+            redirectTo: 'https://fakefirefox.com',
+          });
+        })
+        .then(assert.fail, (err) => {
+          assert.equal(err.errno, 107, 'bad redirectTo rejected');
+        });
+    });
+
+    it('valid metricsContext', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: 'qux',
+          utmSource: 'wibble',
+          utmTerm: 'blee',
+        },
+      };
+      return api.accountCreate(email, authPW, options);
+    });
+
+    it('empty metricsContext', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {},
+      };
+      return api.accountCreate(email, authPW, options);
+    });
+
+    it('invalid entrypoint', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: ';',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'foo',
+          utmContent: 'bar',
+          utmMedium: 'baz',
+          utmSource: 'qux',
+          utmTerm: 'wibble',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid entrypointExperiment', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: ';',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: 'qux',
+          utmSource: 'wibble',
+          utmTerm: 'blee',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid entrypointVariation', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: ';',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: 'qux',
+          utmSource: 'wibble',
+          utmTerm: 'blee',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid utmCampaign', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: ';',
+          utmContent: 'bar',
+          utmMedium: 'baz',
+          utmSource: 'qux',
+          utmTerm: 'wibble',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid utmContent', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: ';',
+          utmMedium: 'baz',
+          utmSource: 'qux',
+          utmTerm: 'wibble',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid utmMedium', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: ';',
+          utmSource: 'qux',
+          utmTerm: 'wibble',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid utmSource', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: 'qux',
+          utmSource: ';',
+          utmTerm: 'wibble',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('invalid utmTerm', () => {
+      const api = new Client.Api(config.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: 'qux',
+          utmSource: 'wibble',
+          utmTerm: ';',
+        },
+      };
+      return api
+        .accountCreate(email, authPW, options)
+        .then(assert.fail, (err) => assert.equal(err.errno, 107));
+    });
+
+    it('create account with service query parameter', () => {
+      const email = server.uniqueEmail();
+      return Client.create(config.publicUrl, email, 'foo', {
+        ...testOptions,
+        serviceQuery: 'bar',
+      })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(
+            emailData.headers['x-service-id'],
+            'bar',
+            'service query parameter was propagated'
+          );
+        });
+    });
+
+    it('account creation works with unicode email address', () => {
+      const email = server.uniqueUnicodeEmail();
+      return Client.create(config.publicUrl, email, 'foo', testOptions)
+        .then((client) => {
+          assert.ok(client, 'created account');
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.ok(emailData, 'received email');
+        });
+    });
+
+    it('account creation fails with invalid metricsContext flowId', () => {
+      const email = server.uniqueEmail();
+      return Client.create(config.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {
+          flowId: 'deadbeefbaadf00ddeadbeefbaadf00d',
+          flowBeginTime: 1,
+        },
+      }).then(
+        () => {
+          assert(false, 'account creation should have failed');
+        },
+        (err) => {
+          assert.ok(err, 'account creation failed');
+        }
+      );
+    });
+
+    it('account creation fails with invalid metricsContext flowBeginTime', () => {
+      const email = server.uniqueEmail();
+      return Client.create(config.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {
+          flowId:
+            'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+          flowBeginTime: 0,
+        },
+      }).then(
+        () => {
+          assert(false, 'account creation should have failed');
+        },
+        (err) => {
+          assert.ok(err, 'account creation failed');
+        }
+      );
+    });
+
+    it('account creation works with maximal metricsContext metadata', () => {
+      const email = server.uniqueEmail();
+      const options = {
+        ...testOptions,
+        metricsContext: mocks.generateMetricsContext(),
+      };
+      return Client.create(config.publicUrl, email, 'foo', options)
+        .then((client) => {
+          assert.ok(client, 'created account');
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(
+            emailData.headers['x-flow-begin-time'],
+            options.metricsContext.flowBeginTime,
+            'flow begin time set'
+          );
+          assert.equal(
+            emailData.headers['x-flow-id'],
+            options.metricsContext.flowId,
+            'flow id set'
+          );
+        });
+    });
+
+    it('account creation works with empty metricsContext metadata', () => {
+      const email = server.uniqueEmail();
+      return Client.create(config.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {},
+      }).then((client) => {
+        assert.ok(client, 'created account');
+      });
+    });
+
+    it('account creation fails with missing flowBeginTime', () => {
+      const email = server.uniqueEmail();
+      return Client.create(config.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {
+          flowId:
+            'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+        },
+      }).then(
+        () => {
+          assert(false, 'account creation should have failed');
+        },
+        (err) => {
+          assert.ok(err, 'account creation failed');
+        }
+      );
+    });
+
+    it('account creation fails with missing flowId', () => {
+      const email = server.uniqueEmail();
+      return Client.create(config.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {
+          flowBeginTime: Date.now(),
+        },
+      }).then(
+        () => {
+          assert(false, 'account creation should have failed');
+        },
+        (err) => {
+          assert.ok(err, 'account creation failed');
+        }
+      );
+    });
+
+    it('create account for non-sync service, gets generic sign-up email and does not get post-verify email', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then((x) => {
+          client = x;
+          assert.ok('account was created');
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(emailData.headers['x-template-name'], 'verify');
+          return emailData.headers['x-verify-code'];
+        })
+        .then((verifyCode) => {
+          return client.verifyEmail(verifyCode, { service: 'testpilot' });
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, true);
+        })
+        .then(() => {
+          // It's hard to test for "an email didn't arrive.
+          // Instead trigger sending of another email and test
+          // that there wasn't anything in the queue before it.
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email);
+        })
+        .then((code) => {
+          assert.ok(code, 'the next email was reset-password, not post-verify');
+        });
+    });
+
+    it('create account for unspecified service does not get create sync email and no post-verify email', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then((x) => {
+          client = x;
+          assert.ok('account was created');
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(emailData.headers['x-template-name'], 'verify');
+          return emailData.headers['x-verify-code'];
+        })
+        .then((verifyCode) => {
+          return client.verifyEmail(verifyCode, {}); // no 'service' param
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, true);
+        })
+        .then(() => {
+          // It's hard to test for "an email didn't arrive.
+          // Instead trigger sending of another email and test
+          // that there wasn't anything in the queue before it.
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email);
+        })
+        .then((code) => {
+          assert.ok(code, 'the next email was reset-password, not post-verify');
+        });
+    });
+
+    it('create account and subscribe to newsletters', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, {
+        ...testOptions,
         service: 'sync',
+      })
+        .then((x) => {
+          client = x;
+          assert.ok('account was created');
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          return emailData.headers['x-verify-code'];
+        })
+        .then((verifyCode) => {
+          return client.verifyEmail(verifyCode, {
+            service: 'sync',
+            newsletters: ['test-pilot'],
+          });
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, true);
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(emailData.headers['x-template-name'], 'postVerify');
+        });
+    });
+
+    it('maintains single kB value for account create with V1 & V2 credentials', async function () {
+      if (testOptions.version !== 'V2') {
+        return this.skip();
       }
-    );
 
-    await client.keys();
+      const email = server.uniqueEmail();
+      const password = 'F00BAR';
 
-    const originalKb = client.getState().kB;
-    await client.upgradeCredentials(password);
+      const client = await Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        {
+          ...testOptions,
+          keys: true,
+          service: 'sync',
+        }
+      );
 
-    // Login with two different client versions and check the kB values
-    const clientV1 = await login(email, password);
-    await clientV1.getKeysV1();
+      await client.getKeysV1();
+      await client.getKeysV2();
+      const originalKb = client.kB;
+      const clientSalt = await client.getClientSalt();
 
-    const kB1 = clientV1.kB;
+      // Log in with new clients and grab kbs
+      const clientV1 = await login(email, password);
+      await clientV1.getKeysV1();
+      const kB1 = clientV1.kB;
 
-    const clientV2 = await login(email, password, "V2");
-    await clientV2.getKeysV2();
-    const kB2 = clientV2.kB;
+      const clientV2 = await login(email, password, 'V2');
+      await clientV2.getKeysV2();
+      const kB2 = clientV2.kB;
 
-    assert.exists(originalKb);
-    assert.equal(kB1, originalKb);
-    assert.equal(kB2, originalKb);
-  });
+      assert.exists(originalKb);
+      assert.isTrue(
+        clientSalt.startsWith('identity.mozilla.com/picl/v1/quickStretchV2:')
+      );
+      assert.equal(kB1, originalKb);
+      assert.equal(kB2, originalKb);
+    });
 
+    it('maintains single kB value after account password upgrade from V1 to V2', async function () {
+      if (testOptions.version !== 'V2') {
+        return this.skip();
+      }
 
-  after(async () => {
-    await TestServer.stop(server);
-  });
+      const email = server.uniqueEmail();
+      const password = 'F00BAR';
 
-  async function login(email, password, version="") {
-    return await Client.login(
-      config.publicUrl,
-      email,
-      password,
-      {
+      const client = await Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        {
+          ...testOptions,
+          keys: true,
+          service: 'sync',
+        }
+      );
+
+      await client.keys();
+
+      const originalKb = client.getState().kB;
+      await client.upgradeCredentials(password);
+
+      // Login with two different client versions and check the kB values
+      const clientV1 = await login(email, password);
+      await clientV1.getKeysV1();
+
+      const kB1 = clientV1.kB;
+
+      const clientV2 = await login(email, password, 'V2');
+      await clientV2.getKeysV2();
+      const kB2 = clientV2.kB;
+
+      assert.exists(originalKb);
+      assert.equal(kB1, originalKb);
+      assert.equal(kB2, originalKb);
+    });
+
+    after(async () => {
+      await TestServer.stop(server);
+    });
+
+    async function login(email, password, version = '') {
+      return await Client.login(config.publicUrl, email, password, {
         ...testOptions,
         version,
         keys: true,
         service: 'sync',
-      }
-    );
-  }
-});
-
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Because
- We want to use the `cloud-tasks` nx lib that introduced last sprint

## This pull request

- Updates account end points to use the nx lib
- Updates CI to include cloud-task emulator

## Issue that this pull request solves

Closes: FXA-9270

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I'm not exactly sure what was done to test account deletion in the past. I've done my best to update existing tests and ensure that the cloud-tasks lib is under test.
