### PR TITLE
test(functional-tests): add fixme annotation to cookies disabled › visit verify page with localStorage disabled

### DIFF
--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -71,6 +71,7 @@ test.describe('cookies disabled', () => {
     page,
     pages: { cookiesDisabled, login },
   }) => {
+    test.fixme(true, 'Fix required as of 2024/03/22 (see FXA-9323).');
     //Goto cookies enabled url
     await page.goto(
       `${target.contentServerUrl}/verify_email?disable_local_storage=1&uid=240103bbecd645848103021e7d245bcb&code=fc46f44802b2a2ce979f39b2187aa1c0`,


### PR DESCRIPTION
## Because

- The 'cookies disabled › visit verify page with localStorage disabled' test is flaking

## This pull request

- Adds a fixme annotation until the cause can be diagnosed and fixed

## Issue that this pull request solves

Relates To: #FXA-9323

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
