### PR TITLE
task(settings): Handle account chooser edge case in react

### DIFF
--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -64,6 +64,23 @@ export function currentAccount(
   return all[uid];
 }
 
+export function lastStoredAccount() {
+  const all = accounts() || {};
+
+  let latestAccount: StoredAccountData | undefined = undefined;
+  for (const key in all) {
+    const account = all[key];
+    if (
+      account?.lastLogin != null &&
+      (latestAccount?.lastLogin == null ||
+        latestAccount.lastLogin < account.lastLogin)
+    ) {
+      latestAccount = account;
+    }
+  }
+  return latestAccount;
+}
+
 export function sessionToken(newToken?: hexstring) {
   try {
     const account = currentAccount();

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -121,6 +121,14 @@ function mockCurrentAccount(storedAccount = { uid: '123' }) {
   jest.spyOn(CacheModule, 'discardSessionToken');
 }
 
+function mockLastStoredAccount(storedAccount: {
+  uid: string;
+  email: string;
+  sessionToken: string;
+}) {
+  jest.spyOn(CacheModule, 'lastStoredAccount').mockReturnValue(storedAccount);
+}
+
 const MOCK_QUERY_PARAM_EMAIL = 'from@queryparams.com';
 let MOCK_QUERY_PARAM_MODEL = {
   email: MOCK_QUERY_PARAM_EMAIL,
@@ -289,6 +297,21 @@ describe('signin container', () => {
         expect(CacheModule.currentAccount).toBeCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_STORED_ACCOUNT.email);
+        });
+        expect(SigninModule.default).toBeCalled();
+      });
+      it('falls back to last logged in account in local storage if current local storage account does not exist', async () => {
+        const LAST_STORED_ACCOUNT = {
+          ...MOCK_STORED_ACCOUNT,
+          email: 'foo@bar.com',
+        };
+        mockCurrentAccount(undefined);
+        mockLastStoredAccount(LAST_STORED_ACCOUNT);
+        render([mockGqlAvatarUseQuery()]);
+        expect(CacheModule.currentAccount).toBeCalled();
+        expect(CacheModule.lastStoredAccount).toBeCalled();
+        await waitFor(() => {
+          expect(currentSigninProps?.email).toBe(LAST_STORED_ACCOUNT.email);
         });
         expect(SigninModule.default).toBeCalled();
       });


### PR DESCRIPTION
## Because

- We could get in a bad state when there were accounts in local storage but none matched the 'current' account.
- It's unclear if this state would actually occur, but it was observed during development.

## This pull request

- Falls back to the last logged in account and uses that which will prevent the redirect back to content-server, which proved problematic.

## Issue that this pull request solves

Closes: FXA-9084

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test do the following

Scenario 1
- On local host sign up/in for a few accounts
- Then go to local storage, and clear `__fxa_storage.uniqueUserId`
- Now go to the the sign in page `http://localhost:3030/signin?showReactApp=true&fforceExperiment=generalizedReactApp&forceExperimentGroup=react`
- You should see the email you last logged in with, and you should be in the react app.

Scenario 2
- After completing scenario 1, clear all of local storage
- Go to `http://localhost:3030/signin?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
- This should redirect you to the root index page (`http://localhost:3030/`).
- Validate local storage, you should have `__fxa_storage.experiment.generalizedReactApp = "{\"enrolled\":true}"`
- Enter your email, and press `Sign up or sign in`. Eventually you will get included in the `react` group of the experiment and directed to the react app's sign in page. Note this might take multiple attempts depending on the rollout rate for the generalizedReactApp experiment.


