### PR TITLE
fix(git): Ignore shared-contentful generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,7 @@ configs/gql/allowlist
 
 
 tmp
+
+# shared-contentful
+libs/shared/contentful/src/__generated__/graphql.d.ts
+libs/shared/contentful/src/__generated__/graphql.js


### PR DESCRIPTION
## This pull request

- adds the following files to gitignore:
   - libs/shared/contentful/src/__generated__/graphql.d.ts
   - libs/shared/contentful/src/__generated__/graphql.js
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.