### PR TITLE
test(functional): create email fixtures for hooks

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -13,10 +13,21 @@ const DEBUG = !!process.env.DEBUG;
 export { expect };
 export type POMS = ReturnType<typeof createPages>;
 
+export const PASSWORD = 'passwordzxcv';
+export const NEW_PASSWORD = 'new_password';
+
+type EmailFixtureOptions = {
+  prefix?: string; // Prefix for the email address
+  PASSWORD: string; // Password for the email address
+  NEW_PASSWORD?: string;
+};
+
 export type TestOptions = {
   pages: POMS;
   syncBrowserPages: POMS;
   credentials: Credentials;
+  emailOptions: EmailFixtureOptions[];
+  emails: string[];
 };
 export type WorkerOptions = { targetName: TargetName; target: ServerTarget };
 
@@ -138,7 +149,51 @@ export const test = base.extend<TestOptions, WorkerOptions>({
       ],
     });
   },
+
+  emailOptions: [{ prefix: '', PASSWORD }], // Default options for the fixture
+
+  emails: async (
+    { target, pages: { login }, emailOptions },
+    use
+  ): Promise<void> => {
+    const emails = await Promise.all(
+      emailOptions.map(async (emailOptions) =>
+        login.createEmail(emailOptions.prefix ?? '')
+      )
+    );
+    await login.clearCache(); // Clear cache for each email
+
+    // Pass the generated email to the test along with the password
+    await use(emails);
+    for (const [index, email] of emails.entries()) {
+      const emailExists = await target.auth.accountStatusByEmail(email);
+      if (emailExists.exists) {
+        const x = emailOptions[index];
+        await teardownEmail(target, email, x.NEW_PASSWORD ?? x.PASSWORD);
+      }
+    }
+  },
 });
+
+export async function teardownEmail(
+  target: BaseTarget,
+  email: string,
+  PASSWORD: string
+) {
+  try {
+    const creds = await target.auth.signIn(email, PASSWORD);
+    await target.auth.accountDestroy(email, PASSWORD, {}, creds.sessionToken);
+  } catch (error) {
+    // If the account is not created during the execution of the test, which
+    // can happen if the test fails prematurly, an exception will be thrown
+    // during email cleanup
+    const ERROR_1 = 'Bad Request';
+    const ERROR_2 = 'Request blocked';
+    if (!(error.error === ERROR_1) && !(error.error === ERROR_2)) {
+      throw error;
+    }
+  }
+}
 
 export async function newPages(browser: Browser, target: BaseTarget) {
   const context = await browser.newContext();

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
-
-const PASSWORD = 'passwordzxcv';
+import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('OAuth `login_hint` and `email` param', () => {

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
-
-let email;
-const password = 'passwordzxcv';
+import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth permissions for trusted reliers - sign up', () => {
+    test.use({ emailOptions: [{ PASSWORD }] });
     test.beforeEach(async ({ pages: { configPage, login } }) => {
       const config = await configPage.getConfig();
       test.skip(
@@ -16,46 +14,35 @@ test.describe('severity-1 #smoke', () => {
         'these tests are specific to backbone, skip if seeing React version'
       );
       test.slow();
-      email = login.createEmail();
-      await login.clearCache();
-    });
-
-    test.afterEach(async ({ target }) => {
-      if (email) {
-        // Cleanup any accounts created during the test
-        const credentials = await target.auth.signIn(email, password);
-        await target.auth.accountDestroy(
-          email,
-          password,
-          {},
-          credentials.sessionToken
-        );
-      }
     });
 
     test('signup without `prompt=consent`', async ({
+      emails,
       pages: { login, relier },
     }) => {
+      const [email] = emails;
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.fillOutFirstSignUp(email, password, { verify: false });
+      await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
 
       //no permissions asked for, straight to confirm
-      expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader()).toBeVisible();
     });
 
     test('signup with `prompt=consent`', async ({
+      emails,
       target,
       page,
       pages: { login, relier },
     }) => {
+      const [email] = emails;
       const query = { prompt: 'consent' };
       const queryParam = new URLSearchParams(query);
       await page.goto(`${target.relierUrl}/?${queryParam.toString()}`, {
         waitUntil: 'load',
       });
       await relier.clickEmailFirst();
-      await login.fillOutFirstSignUp(email, password, { verify: false });
+      await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
 
       //Verify permissions header
       expect(await login.permissionsHeader()).toBe(true);

--- a/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
+++ b/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
-const PASSWORD = 'passwordzxcv';
 const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const CODE_CHALLENGE_METHOD = 'S256';
 

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 let email = '';
 const AGE_21 = '21';
-const PASSWORD = 'passwordzxcv';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('OAuth signin', () => {
@@ -115,17 +114,16 @@ test.describe('severity-1 #smoke', () => {
 
       // Create unverified account
       email = login.createEmail();
-      const password = 'passwordzxcv';
 
       await relier.goto();
       await relier.clickEmailFirst();
 
       if (config.showReactApp.signUpRoutes !== true) {
         // Dont register account and attempt to login via relier
-        await login.fillOutFirstSignUp(email, password, { verify: false });
+        await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
       } else {
         await signupReact.fillOutEmailForm(email);
-        await signupReact.fillOutSignupForm(password, AGE_21);
+        await signupReact.fillOutSignupForm(PASSWORD, AGE_21);
       }
 
       await relier.goto();

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -3,9 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import { test, expect } from '../../lib/fixtures/standard';
-
-const PASSWORD = 'Password123!';
+import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth webchannel', () => {

--- a/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
@@ -2,53 +2,52 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
-let email;
-const password = 'password';
-const newPassword = 'new_password';
+import {
+  test,
+  expect,
+  PASSWORD,
+  NEW_PASSWORD,
+} from '../../lib/fixtures/standard';
+
 let emailUserCreds;
 
 test.describe('severity-2 #smoke', () => {
   test.describe('post verify - force password change', () => {
-    test.beforeEach(async ({ target, pages: { login } }) => {
+    test.use({
+      emailOptions: [
+        {
+          prefix: 'forcepwdchange{id}',
+          PASSWORD,
+          NEW_PASSWORD,
+        },
+      ],
+    });
+    test.beforeEach(async ({ emails, target, pages: { login } }) => {
       test.slow();
-      email = login.createEmail('forcepwdchange{id}');
-      emailUserCreds = await target.auth.signUp(email, password, {
+      const [email] = emails;
+      await target.auth.signUp(email, PASSWORD, {
         lang: 'en',
         preVerified: 'true',
       });
-      await login.clearCache();
-    });
-
-    test.afterEach(async ({ target }) => {
-      // Cleanup any accounts created during the test
-      try {
-        await target.auth.accountDestroy(
-          email,
-          newPassword,
-          {},
-          emailUserCreds.sessionToken
-        );
-      } catch (e) {
-        // ignore
-      }
     });
 
     test('navigate to page directly and can change password', async ({
+      emails,
       target,
       pages: { page, login, postVerify },
     }) => {
+      const [email] = emails;
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
-      await login.fillOutEmailFirstSignIn(email, password);
+      await login.fillOutEmailFirstSignIn(email, PASSWORD);
       await login.fillOutSignInCode(email);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);
 
       //Fill out change password
-      await postVerify.fillOutChangePassword(password, newPassword);
+      await postVerify.fillOutChangePassword(PASSWORD, NEW_PASSWORD);
       await postVerify.submit();
 
       //Verify logged in on Settings page
@@ -56,18 +55,20 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('force change password on login - oauth', async ({
+      emails,
       pages: { login, postVerify, relier },
     }) => {
+      const [email] = emails;
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.fillOutEmailFirstSignIn(email, password);
+      await login.fillOutEmailFirstSignIn(email, PASSWORD);
       await login.fillOutSignInCode(email);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);
 
       //Fill out change password
-      await postVerify.fillOutChangePassword(password, newPassword);
+      await postVerify.fillOutChangePassword(PASSWORD, NEW_PASSWORD);
       await postVerify.submit();
 
       //Verify logged in on relier page

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import { expect, test as base } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
+import { PASSWORD } from '../../lib/fixtures/standard';
+
 import {
   syncDesktopV3QueryParams,
   syncMobileOAuthQueryParams,
@@ -11,7 +13,6 @@ import {
 
 const AGE_12 = '12';
 const AGE_21 = '21';
-const PASSWORD = 'passwordzxcv';
 
 const eventDetailLinkAccount = createCustomEventDetail(
   FirefoxCommand.LinkAccount,
@@ -19,29 +20,6 @@ const eventDetailLinkAccount = createCustomEventDetail(
     ok: true,
   }
 );
-
-export const test = base.extend({
-  email: async ({ target, pages: { login } }, use) => {
-    const email = login.createEmail('signup_react{id}');
-    await login.clearCache();
-
-    await use(email);
-
-    try {
-      const creds = await target.auth.signIn(email, PASSWORD);
-      await target.auth.accountDestroy(email, PASSWORD, {}, creds.sessionToken);
-    } catch (error) {
-      // If the account is not created during the execution of the test, which
-      // can happen if the test fails prematurly, an exception will be thrown
-      // during email cleanup
-      const ERROR = 'Bad Request';
-      const MESSAGE = 'Unknown account';
-      if (!(error.error === ERROR && error.message == MESSAGE)) {
-        throw error;
-      }
-    }
-  },
-});
 
 test.beforeEach(async ({ pages: { configPage } }) => {
   test.slow();
@@ -54,11 +32,13 @@ test.beforeEach(async ({ pages: { configPage } }) => {
 
 test.describe('severity-1 #smoke', () => {
   test.describe('signup react', () => {
+    test.use({ emailOptions: [{ prefix: 'signup_react{id}', PASSWORD }] });
     test('signup web', async ({
       page,
       pages: { settings, signupReact },
-      email,
+      emails,
     }) => {
+      const [email] = emails;
       await signupReact.goto();
 
       await signupReact.fillOutEmailForm(email);
@@ -74,11 +54,12 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup oauth', async ({
+      emails,
       page,
       target,
       pages: { relier, signupReact },
-      email,
     }) => {
+      const [email] = emails;
       relier.goto();
 
       relier.clickEmailFirst();
@@ -104,11 +85,12 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup oauth with missing redirect_uri', async ({
+      emails,
       page,
       target,
       pages: { relier, signupReact },
-      email,
     }) => {
+      const [email] = emails;
       relier.goto();
 
       relier.clickEmailFirst();
@@ -136,9 +118,10 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup oauth webchannel - sync mobile or FF desktop 123+', async ({
+      emails,
       syncBrowserPages: { page, login, signupReact },
-      email,
     }) => {
+      const [email] = emails;
       test.fixme(true, 'Fix required as of 2024/03/18 (see FXA-9306).');
       const customEventDetail = createCustomEventDetail(
         FirefoxCommand.FxAStatus,
@@ -182,8 +165,9 @@ test.describe('severity-1 #smoke', () => {
 
     test('signup sync desktop v3, verify account', async ({
       syncBrowserPages: { page, signupReact, login },
-      email,
+      emails,
     }) => {
+      const [email] = emails;
       test.fixme(true, 'Fix required as of 2024/03/18 (see FXA-9306).');
       await signupReact.goto('/', syncDesktopV3QueryParams);
 
@@ -224,6 +208,7 @@ test.describe('severity-1 #smoke', () => {
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signup react', () => {
+    test.use({ emailOptions: [{ prefix: 'signup_react{id}', PASSWORD }] });
     test('signup invalid email', async ({ page, pages: { signupReact } }) => {
       const invalidEmail = 'invalid';
 
@@ -251,8 +236,9 @@ test.describe('severity-2 #smoke', () => {
     test('coppa is too young', async ({
       page,
       pages: { login, signupReact },
-      email,
+      emails,
     }) => {
+      const [email] = emails;
       await signupReact.goto();
 
       await signupReact.fillOutEmailForm(email);
@@ -267,8 +253,9 @@ test.describe('severity-2 #smoke', () => {
       page,
       target,
       pages: { signupReact, relier, subscribe, settings },
-      email,
+      emails,
     }, { project }) => {
+      const [email] = emails;
       test.skip(
         project.name === 'production',
         'no test products available in prod'

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -21,23 +21,6 @@ test.describe('severity-1 #smoke', () => {
       }
     );
 
-    test.afterEach(async ({ credentials, target }) => {
-      try {
-        const newCreds = await target.auth.signIn(
-          newEmail,
-          credentials.password
-        );
-        await target.auth.accountDestroy(
-          newEmail,
-          credentials.password,
-          {},
-          newCreds.sessionToken
-        );
-      } catch (err) {
-        // ignore
-      }
-    });
-
     test('change primary email and login', async ({
       credentials,
       page,
@@ -167,23 +150,6 @@ test.describe('severity-1 #smoke', () => {
         await settings.signOut();
       }
     );
-
-    test.afterEach(async ({ credentials, target }) => {
-      try {
-        const newCreds = await target.auth.signIn(
-          newEmail,
-          credentials.password
-        );
-        await target.auth.accountDestroy(
-          newEmail,
-          credentials.password,
-          {},
-          newCreds.sessionToken
-        );
-      } catch (err) {
-        // ignore
-      }
-    });
 
     test('change primary email, get blocked with invalid password, redirect enter password page', async ({
       credentials,

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -2,67 +2,63 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test } from '../../lib/fixtures/standard';
+import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
 import { oauthWebchannelV1 } from '../../lib/query-params';
 
-const password = 'passwordzxcv';
-let browserEmail: string;
-let otherEmail: string;
 let skipTest = false;
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('fxa_status web channel message in Settings', () => {
+  test.use({ emailOptions: [{ PASSWORD }, { PASSWORD }] });
   test.beforeEach(
-    async ({ target, pages: { configPage }, syncBrowserPages: { login } }) => {
+    async ({
+      emails,
+      target,
+      pages: { configPage },
+      syncBrowserPages: { login },
+    }) => {
       test.slow();
       // Ensure that the feature flag is enabled
+      const [email, otherEmail] = emails;
       const config = await configPage.getConfig();
       skipTest = config.featureFlags.sendFxAStatusOnSettings !== true;
       test.skip(skipTest);
-
-      browserEmail = login.createEmail();
-      await target.auth.signUp(browserEmail, password, {
+      await target.auth.signUp(email, PASSWORD, {
         lang: 'en',
         preVerified: 'true',
       });
-      otherEmail = login.createEmail();
-      await target.auth.signUp(otherEmail, password, {
+      await target.auth.signUp(otherEmail, PASSWORD, {
         lang: 'en',
         preVerified: 'true',
       });
       // First we sign the browser into an account
       await login.goto('load', 'context=fx_desktop_v3&service=sync');
-      await login.fillOutEmailFirstSignIn(browserEmail, password);
+      await login.fillOutEmailFirstSignIn(email, PASSWORD);
       // Then, we sign into a **different** account
       await login.goto();
       await login.useDifferentAccountLink();
-      await login.fillOutEmailFirstSignIn(otherEmail, password);
+      await login.fillOutEmailFirstSignIn(otherEmail, PASSWORD);
     }
   );
-  test.afterEach(async ({ target }) => {
-    if (!skipTest) {
-      // Cleanup any accounts created during the test
-      const credsBrowser = await target.auth.signIn(browserEmail, password);
-      const credsEmail = await target.auth.signIn(otherEmail, password);
-      await target.auth.accountDestroy(browserEmail, password, {}, credsBrowser.sessionToken);
-      await target.auth.accountDestroy(otherEmail, password, {}, credsEmail.sessionToken);
-    }
-  });
 
   test('message is sent when loading with context = oauth_webchannel_v1', async ({
+    emails,
     syncBrowserPages: { settings },
   }) => {
+    const [email, ,] = emails;
     // We verify that even though another email is signed in, when
     // accessing the setting with a `context=oauth_webchannel_v1` the account
     // signed into the browser takes precedence
     await settings.goto(oauthWebchannelV1.toString());
-    expect(await settings.primaryEmail.statusText()).toBe(browserEmail);
+    expect(await settings.primaryEmail.statusText()).toBe(email);
   });
 
   test('message is not sent when loading without oauth web channel context', async ({
+    emails,
     syncBrowserPages: { settings },
   }) => {
+    const [, otherEmail] = emails;
     // We verify that when accessing the setting without the `context=oauth_webchannel_v1`
     // the newer account takes precedence
     await settings.goto();

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signin here', () => {
@@ -113,16 +113,15 @@ test.describe('severity-2 #smoke', () => {
         'bounced email functionality does not currently work for react'
       );
       const email = login.createEmail('sync{id}');
-      const password = 'password123';
-      const creds = await target.createAccount(email, password);
+      const creds = await target.createAccount(email, PASSWORD);
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`
       );
-      await login.fillOutEmailFirstSignIn(email, password);
+      await login.fillOutEmailFirstSignIn(email, PASSWORD);
 
       // Verify the header after login
       expect(login.signInCodeHeader()).toBeVisible();
-      await target.auth.accountDestroy(email, password, {}, creds.sessionToken);
+      await target.auth.accountDestroy(email, PASSWORD, {}, creds.sessionToken);
       await page.waitForURL(/signin_bounced/);
 
       //Verify sign in bounced header

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import { expect, test } from '../../lib/fixtures/standard';
+import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
-const password = 'passwordzxcv';
 let email;
 
 test.describe.configure({ mode: 'parallel' });
@@ -21,16 +20,18 @@ test.describe('severity-1 #smoke', () => {
   });
 
   test.describe('Sync v3 sign up and CWTS', () => {
+    test.use({ emailOptions: [{ prefix: 'sync{id}', PASSWORD }] });
     test.beforeEach(async ({ syncBrowserPages: { login } }) => {
       //Sync tests run a little slower and flake
       test.slow();
-      email = login.createEmail('sync{id}');
     });
 
     test('verify with signup code and CWTS', async ({
+      emails,
       target,
       syncBrowserPages,
     }) => {
+      const [email] = emails;
       const { login, page, signinTokenCode, connectAnotherDevice } =
         syncBrowserPages;
       const query = new URLSearchParams({
@@ -63,8 +64,8 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await signinTokenCode.clickSubmitButton();
-      await login.setPassword(password);
-      await login.confirmPassword(password);
+      await login.setPassword(PASSWORD);
+      await login.confirmPassword(PASSWORD);
       await login.setAge('21');
 
       // The CWTS form is on the same signup page
@@ -85,9 +86,10 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('verify at CWTS', async ({ target, syncBrowserPages }) => {
+    test('verify at CWTS', async ({ emails, target, syncBrowserPages }) => {
       const { login, page, signinTokenCode, connectAnotherDevice } =
         syncBrowserPages;
+      const [email] = emails;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -112,8 +114,8 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await signinTokenCode.clickSubmitButton();
-      await login.setPassword(password);
-      await login.confirmPassword(password);
+      await login.setPassword(PASSWORD);
+      await login.confirmPassword(PASSWORD);
       await login.setAge('21');
       await login.submit();
 
@@ -131,9 +133,11 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('engines not supported', async ({
+      emails,
       target,
       syncBrowserPages: { login, page, signinTokenCode },
     }) => {
+      const [email] = emails;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -152,8 +156,8 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await signinTokenCode.clickSubmitButton();
-      await login.setPassword(password);
-      await login.confirmPassword(password);
+      await login.setPassword(PASSWORD);
+      await login.confirmPassword(PASSWORD);
       await login.setAge('21');
       await login.submit();
 
@@ -164,9 +168,11 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('neither `creditcards` nor `addresses` supported', async ({
+      emails,
       target,
       syncBrowserPages: { login, page, signinTokenCode },
     }) => {
+      const [email] = emails;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -188,8 +194,8 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await signinTokenCode.clickSubmitButton();
-      await login.setPassword(password);
-      await login.confirmPassword(password);
+      await login.setPassword(PASSWORD);
+      await login.confirmPassword(PASSWORD);
       await login.setAge('21');
       await login.submit();
 
@@ -200,9 +206,11 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('`creditcards` and `addresses` supported', async ({
+      emails,
       target,
       syncBrowserPages: { login, page, signinTokenCode },
     }) => {
+      const [email] = emails;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -224,8 +232,8 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await signinTokenCode.clickSubmitButton();
-      await login.setPassword(password);
-      await login.confirmPassword(password);
+      await login.setPassword(PASSWORD);
+      await login.confirmPassword(PASSWORD);
       await login.setAge('21');
       await login.submit();
 

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test } from '../../lib/fixtures/standard';
+import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
 
-const PASSWORD = 'passwordzxcv';
 let email;
 
 test.describe.configure({ mode: 'parallel' });


### PR DESCRIPTION
## Because

- we want to isolate and assure proper set up and tear down for our email/accounts

## This pull request

- refactors common code in before, after and test methods to playwright test [fixtures](https://playwright.dev/docs/test-fixtures)

## Issue that this pull request solves

Closes: [FXA-8984](https://mozilla-hub.atlassian.net/browse/FXA-8984)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a new PR for the same requirements as https://github.com/mozilla/fxa/pull/16594. All the review comments have been incorporated in this new PR from the old PR. The only reason for discarding the old PR were the merge conflicts which were not getting resolved.



[FXA-8984]: https://mozilla-hub.atlassian.net/browse/FXA-8984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ