### PR TITLE
feat(stripe-client): add stripe typings utility type and base types

### DIFF
--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -61,10 +61,9 @@ describe('StripeMapperService', () => {
       const validMetadata = StripeMetadataWithContentfulFactory({
         webIconURL: 'https://example.com/webIconURL',
       });
-      const stripePlan = PlanFactory({
-        product: ProductFactory({
-          metadata: validMetadata,
-        }),
+      const stripePlan = PlanFactory() as Stripe.Plan;
+      stripePlan.product = ProductFactory({
+        metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
@@ -89,10 +88,9 @@ describe('StripeMapperService', () => {
       const validMetadata = StripeMetadataWithContentfulFactory({
         webIconURL: 'https://example.com/webIconURL',
       });
-      const stripePlan = PlanFactory({
-        product: ProductFactory({
-          metadata: validMetadata,
-        }),
+      const stripePlan = PlanFactory() as Stripe.Plan;
+      stripePlan.product = ProductFactory({
+        metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
@@ -121,10 +119,10 @@ describe('StripeMapperService', () => {
         webIconURL: 'https://plan.override/emailIcon',
       });
       const stripePlan = PlanFactory({
-        product: ProductFactory({
-          metadata: validMetadata,
-        }),
         metadata: planOverrideMetadata,
+      }) as Stripe.Plan;
+      stripePlan.product = ProductFactory({
+        metadata: validMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
@@ -147,10 +145,9 @@ describe('StripeMapperService', () => {
         productSet: 'set',
         productOrder: 'order',
       };
-      const stripePlan = PlanFactory({
-        product: ProductFactory({
-          metadata: productMetadata,
-        }),
+      const stripePlan = PlanFactory() as Stripe.Plan;
+      stripePlan.product = ProductFactory({
+        metadata: productMetadata,
       });
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
@@ -190,18 +187,18 @@ describe('StripeMapperService', () => {
         metadata: productMetadata,
       });
       const stripePlan1 = PlanFactory({
-        product,
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in English',
         }),
-      });
+      }) as Stripe.Plan;
+      stripePlan1.product = product;
       const stripePlan2 = PlanFactory({
-        product,
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in French',
           'product:details:2': 'Detail 2 in French',
         }),
-      });
+      }) as Stripe.Plan;
+      stripePlan2.product = product;
 
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(
@@ -243,18 +240,18 @@ describe('StripeMapperService', () => {
         metadata: productMetadata,
       });
       const stripePlan1 = PlanFactory({
-        product,
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in German',
         }),
-      });
+      }) as Stripe.Plan;
+      stripePlan1.product = product;
       const stripePlan2 = PlanFactory({
-        product,
         metadata: StripeMetadataWithContentfulFactory({
           'product:details:1': 'Detail 1 in French',
           'product:details:2': 'Detail 2 in French',
         }),
-      });
+      }) as Stripe.Plan;
+      stripePlan2.product = product;
 
       const { mappedPlans, nonMatchingPlans } =
         await stripeMapper.mapContentfulToStripePlans(

--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -208,14 +208,7 @@ describe('PaypalManager', () => {
         data: [mockPayPalSubscription],
       });
 
-      const mockCustomer = CustomerFactory({
-        subscriptions: {
-          object: 'list',
-          data: [mockPayPalSubscription],
-          has_more: true,
-          url: '/v1/customers/customer12345/subscriptions',
-        },
-      });
+      const mockCustomer = CustomerFactory();
 
       const expected = [mockPayPalSubscription];
 
@@ -224,7 +217,7 @@ describe('PaypalManager', () => {
         .mockResolvedValueOnce(mockSubscriptionList);
 
       const result = await paypalManager.getCustomerPayPalSubscriptions(
-        mockCustomer
+        mockCustomer.id
       );
       expect(result).toEqual(expected);
     });
@@ -287,7 +280,6 @@ describe('PaypalManager', () => {
       const mockInvoice = InvoiceFactory({
         amount_due: 50,
         currency: 'usd',
-        customer: mockCustomer,
       });
 
       stripeManager.fetchActiveCustomer = jest

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -14,3 +14,4 @@ export * from './lib/stripe.client';
 export * from './lib/stripe.constants';
 export * from './lib/stripe.error';
 export * from './lib/stripe.manager';
+export * from './lib/stripe.client.types';

--- a/libs/payments/stripe/src/lib/factories/card.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/card.factory.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
+import { StripeCard } from '../stripe.client.types';
 
-export const CardFactory = (override?: Partial<Stripe.Card>): Stripe.Card => ({
+export const CardFactory = (override?: Partial<StripeCard>): StripeCard => ({
   id: 'card',
   object: 'card',
   address_city: faker.location.city(),

--- a/libs/payments/stripe/src/lib/factories/customer.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/customer.factory.ts
@@ -3,17 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
-import { CardFactory } from './card.factory';
+import { StripeCustomer } from '../stripe.client.types';
 
 export const CustomerFactory = (
-  override?: Partial<Stripe.Customer>
-): Stripe.Customer => ({
+  override?: Partial<StripeCustomer>
+): StripeCustomer => ({
   id: `cus_${faker.string.alphanumeric({ length: 14 })}`,
   object: 'customer',
   balance: faker.number.int({ max: 1000 }),
   created: faker.number.int(),
-  default_source: CardFactory(),
+  tax: {
+    location: null,
+    automatic_tax: 'supported',
+    ip_address: faker.internet.ipv4(),
+  },
+  default_source: faker.string.uuid(),
   description: '',
   email: faker.internet.email(),
   invoice_settings: {

--- a/libs/payments/stripe/src/lib/factories/invoice-line-item.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/invoice-line-item.factory.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
+import { StripeInvoiceLineItem } from '../stripe.client.types';
 
 export const InvoiceLineItemFactory = (
-  override?: Partial<Stripe.InvoiceLineItem>
-): Stripe.InvoiceLineItem => ({
+  override?: Partial<StripeInvoiceLineItem>
+): StripeInvoiceLineItem => ({
   id: faker.string.alphanumeric(10),
   object: 'line_item',
   amount: faker.number.int({ max: 1000 }),

--- a/libs/payments/stripe/src/lib/factories/invoice.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/invoice.factory.ts
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
 import { InvoiceLineItemFactory } from './invoice-line-item.factory';
+import { StripeInvoice } from '../stripe.client.types';
 
 export const InvoiceFactory = (
-  override?: Partial<Stripe.Invoice>
-): Stripe.Invoice => ({
+  override?: Partial<StripeInvoice>
+): StripeInvoice => ({
   id: `in_${faker.string.alphanumeric({ length: 24 })}`,
   object: 'invoice',
   account_country: null,

--- a/libs/payments/stripe/src/lib/factories/plan.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/plan.factory.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
+import { StripePlan } from '../stripe.client.types';
 
-export const PlanFactory = (override?: Partial<Stripe.Plan>): Stripe.Plan => ({
+export const PlanFactory = (override?: Partial<StripePlan>): StripePlan => ({
   id: `plan_${faker.string.alphanumeric({ length: 24 })}`,
   object: 'plan',
   active: true,

--- a/libs/payments/stripe/src/lib/factories/price.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/price.factory.ts
@@ -3,11 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
+import { StripePrice } from '../stripe.client.types';
 
-export const PriceFactory = (
-  override?: Partial<Stripe.Price>
-): Stripe.Price => ({
+export const PriceFactory = (override?: Partial<StripePrice>): StripePrice => ({
   id: `price_${faker.string.alphanumeric({ length: 24 })}`,
   object: 'price',
   active: true,

--- a/libs/payments/stripe/src/lib/factories/product.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/product.factory.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
+import { StripeProduct } from '../stripe.client.types';
 
 export const ProductFactory = (
-  override?: Partial<Stripe.Product>
-): Stripe.Product => ({
+  override?: Partial<StripeProduct>
+): StripeProduct => ({
   id: `prod_${faker.string.alphanumeric({ length: 14 })}`,
   object: 'product',
   active: true,

--- a/libs/payments/stripe/src/lib/factories/subscription.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/subscription.factory.ts
@@ -3,12 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { Stripe } from 'stripe';
 import { PriceFactory } from './price.factory';
+import {
+  StripeApiList,
+  StripeSubscription,
+  StripeSubscriptionItem,
+} from '../stripe.client.types';
 
 export const SubscriptionFactory = (
-  override?: Partial<Stripe.Subscription>
-): Stripe.Subscription => ({
+  override?: Partial<StripeSubscription>
+): StripeSubscription => ({
   id: `sub_${faker.string.alphanumeric({ length: 24 })}`,
   object: 'subscription',
   application: null,
@@ -64,8 +68,8 @@ export const SubscriptionFactory = (
 });
 
 export const SubscriptionItemFactory = (
-  override?: Partial<Stripe.SubscriptionItem>
-): Stripe.SubscriptionItem => ({
+  override?: Partial<StripeSubscriptionItem>
+): StripeSubscriptionItem => ({
   id: `si_${faker.string.alphanumeric({ length: 14 })}`,
   object: 'subscription_item',
   billing_thresholds: null,
@@ -102,8 +106,8 @@ export const SubscriptionItemFactory = (
 });
 
 export const SubscriptionListFactory = (
-  override?: Partial<Stripe.ApiList<Stripe.Subscription>>
-): Stripe.ApiList<Stripe.Subscription> => ({
+  override?: Partial<StripeApiList<StripeSubscription>>
+): StripeApiList<StripeSubscription> => ({
   object: 'list',
   url: '/v1/subscriptions',
   has_more: false,

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -6,7 +6,17 @@ import { Injectable } from '@nestjs/common';
 import { Stripe } from 'stripe';
 
 import { StripeClientConfig } from './stripe.client.config';
+import {
+  StripeCustomer,
+  StripeDeletedCustomer,
+  StripeInvoice,
+  StripeSubscription,
+} from './stripe.client.types';
 
+/**
+ * A wrapper for Stripe that enforces that results have deterministic typings
+ * that represent their expanded/unexpanded state.
+ */
 @Injectable()
 export class StripeClient {
   public readonly stripe: Stripe;
@@ -20,9 +30,15 @@ export class StripeClient {
 
   /**
    * Retrieves a customer record directly from Stripe
+   *
+   * @param customerId The Stripe customer ID of the customer to fetch
+   * @returns The customer record for the customerId provided
    */
   async fetchCustomer(customerId: string) {
-    return this.stripe.customers.retrieve(customerId);
+    const result = await this.stripe.customers.retrieve(customerId, {
+      expand: ['tax'],
+    });
+    return result as StripeCustomer | StripeDeletedCustomer;
   }
 
   /**
@@ -36,22 +52,30 @@ export class StripeClient {
     customerId: string,
     params: Stripe.CustomerUpdateParams
   ) {
-    return this.stripe.customers.update(customerId, params);
+    const result = await this.stripe.customers.update(customerId, params);
+
+    return result as StripeCustomer;
   }
 
   /**
    * Retrieves subscriptions directly from Stripe
    */
   async fetchSubscriptions(customerId: string) {
-    return this.stripe.subscriptions.list({
+    const result = await this.stripe.subscriptions.list({
       customer: customerId,
     });
+
+    return result as Stripe.ApiList<StripeSubscription>;
   }
 
   async finalizeInvoice(
     invoiceId: string,
     params?: Stripe.InvoiceFinalizeInvoiceParams | undefined
   ) {
-    return this.stripe.invoices.finalizeInvoice(invoiceId, params);
+    const result = await this.stripe.invoices.finalizeInvoice(
+      invoiceId,
+      params
+    );
+    return result as StripeInvoice;
   }
 }

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Stripe } from 'stripe';
+
+/**
+ * Replaces types with expanded/unexpanded variants given the base Stripe type passed in.
+ */
+type NegotiateExpanded<
+  ExpandedProperties extends keyof StripeObj | never,
+  StripeObj,
+  UnexpandedProperties extends keyof StripeObj
+> = {
+  // For specified unexpanded properties
+  [key in keyof Pick<
+    StripeObj,
+    UnexpandedProperties
+  >]: StripeObj[key] extends Array<any> // Stripe types can be in the form of Array<Stripe.XYZ | string | null>
+    ? // Extract and return type Array<string | null> out of Array<Stripe.XYZ | string | null>
+      Array<Extract<StripeObj[key][0], string | null | undefined>>
+    : // Stripe types can be in the form of (Array<Stripe.XYZ | string | null> | null)
+    StripeObj[key] extends Array<any> | null
+    ? // Extract and return type (Array<string | null> | null) out of (Array<Stripe.XYZ | string | null> | null)
+      Array<
+        Extract<NonNullable<StripeObj[key]>[0], string | null | undefined>
+      > | null
+    : // Extract and return type (string | null) out of (Stripe.XYZ | string | null)
+      Extract<StripeObj[key], string | null | undefined>;
+} & {
+  // For specified unexpanded properties
+  [key in keyof Pick<
+    StripeObj,
+    ExpandedProperties
+  >]-?: StripeObj[key] extends Array<any> // Stripe types can be in the form of Array<Stripe.XYZ | string | null>
+    ? // Extract and return type Array<Stripe.XYZ | null> out of Array<Stripe.XYZ | string | null>
+      Array<Exclude<StripeObj[key][0], string>>
+    : // Stripe types can be in the form of (Array<Stripe.XYZ | string | null> | null)
+    StripeObj[key] extends Array<any> | null
+    ? // Extract and return type (Array<Stripe.XYZ | null> | null) out of (Array<Stripe.XYZ | string | null> | null)
+      Array<Exclude<NonNullable<StripeObj[key]>[0], string>> | null
+    : // Extract and return type (Stripe.XYZ | null) out of (Stripe.XYZ | string | null)
+      Exclude<StripeObj[key], string>;
+} & {
+  // All other unspecified properties return their original typing
+  [key in keyof Omit<
+    StripeObj,
+    UnexpandedProperties | ExpandedProperties
+  >]: StripeObj[key];
+};
+
+/**
+ * Replaces some properties nested inside of an object, overriding anything in the first argument with values from the second, if provided.
+ */
+type DeepOverride<BaseType, OverrideMap extends Partial<BaseType>> = {
+  // Use types from OverrideMap where present
+  [key in keyof OverrideMap]: OverrideMap[key];
+} & {
+  // Use types from BaseType only when not present in OverrideMap
+  [key in keyof Omit<BaseType, keyof OverrideMap>]: BaseType[key];
+};
+
+/**
+ * Stripe.Customer with expanded fields removed except:
+ *   - tax is always expanded
+ */
+export type StripeCustomer = NegotiateExpanded<
+  'tax',
+  DeepOverride<
+    Stripe.Customer,
+    {
+      discount?: StripeDiscount | null;
+      invoice_settings: StripeCustomerInvoiceSettings;
+    }
+  >,
+  | 'cash_balance'
+  | 'default_source'
+  | 'invoice_credit_balance'
+  | 'sources'
+  | 'subscriptions'
+  | 'tax_ids'
+  | 'test_clock'
+>;
+
+export type StripeCustomerInvoiceSettings = NegotiateExpanded<
+  never,
+  Stripe.Customer.InvoiceSettings,
+  'default_payment_method'
+>;
+
+/**
+ * Stripe.DeletedCustomer with expanded fields removed
+ */
+export type StripeDeletedCustomer = Stripe.DeletedCustomer;
+
+/**
+ * Stripe.Discount with expanded fields removed
+ */
+export type StripeDiscount = NegotiateExpanded<
+  never,
+  DeepOverride<
+    Stripe.Discount,
+    {
+      coupon: StripeCoupon;
+    }
+  >,
+  'customer' | 'promotion_code'
+>;
+
+/**
+ * Stripe.StripeTaxRate with expanded fields removed
+ */
+export type StripeTaxRate = Stripe.TaxRate;
+
+/**
+ * Stripe.StripeTaxRate with expanded fields removed
+ */
+export type StripeInvoiceLineItemTaxAmount = NegotiateExpanded<
+  never,
+  Stripe.InvoiceLineItem.TaxAmount,
+  'tax_rate'
+>;
+
+/**
+ * Stripe.InvoiceLineItem with expanded fields removed
+ */
+export type StripeInvoiceLineItem = NegotiateExpanded<
+  never,
+  DeepOverride<
+    Stripe.InvoiceLineItem,
+    {
+      discount_amounts: Array<
+        NegotiateExpanded<
+          never,
+          Stripe.InvoiceLineItem.DiscountAmount,
+          'discount'
+        >
+      > | null;
+      price: StripePrice | null;
+      tax_amounts?: Array<StripeInvoiceLineItemTaxAmount>;
+    }
+  >,
+  'discounts' | 'invoice_item' | 'subscription' | 'subscription_item'
+>;
+
+/**
+ * Stripe.Invoice with expanded fields removed
+ */
+export type StripeInvoice = NegotiateExpanded<
+  never,
+  DeepOverride<
+    Stripe.Invoice,
+    {
+      lines: Stripe.ApiList<StripeInvoiceLineItem>;
+      discount: StripeDiscount | null;
+    }
+  >,
+  | 'charge'
+  | 'customer'
+  | 'payment_intent'
+  | 'subscription'
+  | 'account_tax_ids'
+  | 'application'
+  | 'default_payment_method'
+  | 'default_source'
+  | 'discounts'
+  | 'latest_revision'
+  | 'on_behalf_of'
+  | 'quote'
+  | 'test_clock'
+>;
+
+export type StripeSubscriptionItem = Stripe.SubscriptionItem;
+
+/**
+ * Stripe.Subscription with expanded fields removed
+ */
+export type StripeSubscription = NegotiateExpanded<
+  never,
+  Stripe.Subscription,
+  | 'customer'
+  | 'default_payment_method'
+  | 'latest_invoice'
+  | 'pending_setup_intent'
+  | 'application'
+  | 'default_source'
+  | 'on_behalf_of'
+  | 'schedule'
+  | 'test_clock'
+>;
+
+/**
+ * Stripe.Plan with expanded fields removed
+ */
+export type StripePlan = NegotiateExpanded<
+  never,
+  Stripe.Plan,
+  'product' | 'tiers'
+>;
+
+/**
+ * Stripe.Price with expanded fields removed
+ */
+export type StripePrice = NegotiateExpanded<
+  never,
+  Stripe.Price,
+  'product' | 'currency_options' | 'tiers'
+>;
+
+/**
+ * Stripe.Price with expanded fields removed
+ */
+export type StripeProduct = NegotiateExpanded<
+  never,
+  Stripe.Product,
+  'default_price' | 'tax_code'
+>;
+
+/**
+ * Stripe.PromotionCode with expanded fields removed
+ */
+export type StripePromotionCode = NegotiateExpanded<
+  never,
+  Stripe.PromotionCode,
+  'customer'
+>;
+
+/**
+ * Stripe.Coupon with expanded fields removed
+ */
+export type StripeCoupon = NegotiateExpanded<
+  never,
+  Stripe.Coupon,
+  'applies_to' | 'currency_options'
+>;
+
+/**
+ * Stripe.CreditNote with expanded fields removed
+ */
+export type StripeCreditNote = NegotiateExpanded<
+  never,
+  DeepOverride<
+    Stripe.CreditNote,
+    {
+      lines: Stripe.ApiList<StripeCreditNoteLineItem>;
+    }
+  >,
+  'invoice' | 'customer' | 'customer_balance_transaction' | 'refund'
+>;
+
+/**
+ * Stripe.CreditNoteLineItem with expanded fields removed
+ */
+export type StripeCreditNoteLineItem = NegotiateExpanded<
+  never,
+  DeepOverride<
+    Stripe.CreditNoteLineItem,
+    {
+      discount_amounts: Array<
+        NegotiateExpanded<
+          never,
+          Stripe.CreditNoteLineItem.DiscountAmount,
+          'discount'
+        >
+      >;
+    }
+  >,
+  never
+>;
+
+/**
+ * Stripe.Card with expanded fields removed
+ */
+export type StripeCard = NegotiateExpanded<
+  never,
+  Stripe.Card,
+  'customer' | 'account'
+>;
+
+export type StripeApiList<T> = Stripe.ApiList<T>;

--- a/libs/payments/stripe/src/lib/stripe.constants.ts
+++ b/libs/payments/stripe/src/lib/stripe.constants.ts
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Stripe } from 'stripe';
+import { StripeSubscription } from './stripe.client.types';
 
 /** Represents all subscription statuses that are considered active for a PayPal customer */
-export const ACTIVE_SUBSCRIPTION_STATUSES: Stripe.Subscription['status'][] = [
+export const ACTIVE_SUBSCRIPTION_STATUSES: StripeSubscription['status'][] = [
   'active',
   'past_due',
   'trialing',

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -86,14 +86,7 @@ describe('StripeManager', () => {
         data: [mockSubscription],
       });
 
-      const mockCustomer = CustomerFactory({
-        subscriptions: {
-          object: 'list',
-          data: [mockSubscription],
-          has_more: true,
-          url: '/v1/customers/customer12345/subscriptions',
-        },
-      });
+      const mockCustomer = CustomerFactory();
 
       const expected = mockSubscriptionList;
 
@@ -107,14 +100,6 @@ describe('StripeManager', () => {
   });
 
   describe('isCustomerStripeTaxEligible', () => {
-    it('should throw an error if no tax in customer', async () => {
-      const mockCustomer = CustomerFactory();
-
-      expect(manager.isCustomerStripeTaxEligible(mockCustomer)).rejects.toThrow(
-        'customer.tax is not present'
-      );
-    });
-
     it('should return true for a taxable customer', async () => {
       const mockCustomer = CustomerFactory({
         tax: {

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
-import { Stripe } from 'stripe';
 
 import { StripeClient } from './stripe.client';
 import {
@@ -15,6 +14,7 @@ import {
   CustomerNotFoundError,
   SubscriptionStripeError,
 } from './stripe.error';
+import { StripeCustomer } from './stripe.client.types';
 
 @Injectable()
 export class StripeManager {
@@ -62,15 +62,10 @@ export class StripeManager {
    * Creating a subscription with automatic_tax enabled requires a customer with an address
    * that is in a recognized location with an active tax registration.
    */
-  async isCustomerStripeTaxEligible(customer: Stripe.Customer) {
-    if (!customer.tax) {
-      // TODO: FXA-8891
-      throw new Error('customer.tax is not present');
-    }
-
+  async isCustomerStripeTaxEligible(customer: StripeCustomer) {
     return (
-      customer.tax?.automatic_tax === 'supported' ||
-      customer.tax?.automatic_tax === 'not_collecting'
+      customer.tax.automatic_tax === 'supported' ||
+      customer.tax.automatic_tax === 'not_collecting'
     );
   }
 


### PR DESCRIPTION
## Because

- We want to override Stripe's types with our own to provide more predictability. See ADR for more details.

## This pull request

- Adds a generic that helps break down required/optional properties, while still allowing us to use Stripe's original types (for nice LSP passthrough!).

## Issue that this pull request solves

Closes: FXA-8891
