### PR TITLE
fix(payments-next): Page - Revise checkout layout

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/error/page.tsx
@@ -6,16 +6,10 @@ import { headers } from 'next/headers';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { PurchaseDetails, TermsAndPrivacy } from '@fxa/payments/ui/server';
 import { getBundle, getLocaleFromRequest } from '@fxa/shared/l10n';
 
-import {
-  getCartData,
-  getContentfulContent,
-} from '../../../../../../_lib/apiClient';
-import checkLogo from '../../../../../../../images/check.svg';
+import { getCartData } from '../../../../../../_lib/apiClient';
 import errorIcon from '../../../../../../../images/error.svg';
-// import { app } from '../../_nestapp/app';
 
 // forces dynamic rendering
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
@@ -43,9 +37,8 @@ export default async function CheckoutError({
     demoSupportedLanguages
   );
 
-  const contentfulData = getContentfulContent(params.offeringId, locale);
   const cartData = getCartData(params.cartId);
-  const [contentful, cart] = await Promise.all([contentfulData, cartData]);
+  const [cart] = await Promise.all([cartData]);
   /* eslint-disable @typescript-eslint/no-unused-vars */
   // const cartService = await app.getCartService();
 
@@ -73,63 +66,27 @@ export default async function CheckoutError({
 
   return (
     <>
-      <header className="page-title-container">
-        <h1 className="page-header">
-          {l10n.getMessage('subscription-error-title')?.value?.toString() ||
-            'Error confirming subscription…'}
-        </h1>
-        <div className="page-subheader">
-          <Image src={checkLogo} alt="" />
-          <span className="page-subheader-text">
-            {l10n.getMessage('sub-guarantee')?.value?.toString() ||
-              '30-day money-back guarantee'}
-          </span>
-        </div>
-      </header>
-
       <section
-        className="payment-panel hidden tablet:block"
-        aria-label="Purchase details"
+        className="page-message-container h-[640px]"
+        aria-label="Payment error"
       >
-        <PurchaseDetails
-          locale={locale}
-          interval={cart.interval}
-          invoice={cart.nextInvoice}
-          purchaseDetails={contentful.purchaseDetails}
-        />
-      </section>
+        <Image src={errorIcon} alt="" className="mt-16 mb-10" />
+        <p className="page-message px-7 py-0 mb-4 ">
+          {l10n
+            .getMessage(getErrorReason(cart.errorReasonId).messageFtl)
+            ?.value?.toString() || getErrorReason(cart.errorReasonId).message}
+        </p>
 
-      <div className="page-body rounded-t-none tablet:rounded-t-long">
-        <section
-          className="page-message-container h-[640px]"
-          aria-label="Payment error"
+        <Link
+          className="page-button"
+          href={`/${params.offeringId}/checkout?interval=monthly`}
         >
-          <Image src={errorIcon} alt="" className="mt-16 mb-10" />
-          <p className="page-message px-7 py-0 mb-4 ">
-            {l10n
-              .getMessage(getErrorReason(cart.errorReasonId).messageFtl)
-              ?.value?.toString() || getErrorReason(cart.errorReasonId).message}
-          </p>
-
-          <Link
-            className="page-button"
-            href={`/${params.offeringId}/checkout?interval=monthly`}
-          >
-            {l10n
-              .getMessage(getErrorReason(cart.errorReasonId).buttonFtl)
-              ?.value?.toString() ||
-              getErrorReason(cart.errorReasonId).buttonLabel}
-          </Link>
-        </section>
-
-        <TermsAndPrivacy
-          locale={locale}
-          {...cart}
-          {...contentful.commonContent}
-          {...contentful.purchaseDetails}
-          showFXALinks={true}
-        />
-      </div>
+          {l10n
+            .getMessage(getErrorReason(cart.errorReasonId).buttonFtl)
+            ?.value?.toString() ||
+            getErrorReason(cart.errorReasonId).buttonLabel}
+        </Link>
+      </section>
     </>
   );
 }

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/page.tsx
@@ -2,111 +2,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { PurchaseDetails, TermsAndPrivacy } from '@fxa/payments/ui/server';
-import {
-  getCartData,
-  getContentfulContent,
-} from '../../../../../_lib/apiClient';
 import { app } from '@fxa/payments/ui/server';
-import { headers } from 'next/headers';
-import { getLocaleFromRequest } from '@fxa/shared/l10n';
 import { auth, signIn, signOut } from 'apps/payments/next/auth';
 
 export const dynamic = 'force-dynamic';
 
-interface CheckoutParams {
-  cartId: string;
-  locale: string;
-  interval: string;
-  offeringId: string;
-}
-
-export default async function Checkout({ params }: { params: CheckoutParams }) {
-  const headersList = headers();
-  const locale = getLocaleFromRequest(
-    params,
-    headersList.get('accept-language')
-  );
-
-  const contentfulData = getContentfulContent(params.offeringId, locale);
-  const cartData = getCartData(params.cartId);
-  const [contentful, cart] = await Promise.all([contentfulData, cartData]);
+export default async function Checkout() {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const cartService = await app.getCartService();
   const session = await auth();
 
   return (
     <>
-      <header className="page-title-container">
-        <h1 className="page-header">Under Construction</h1>
-      </header>
-
-      <section className="payment-panel" aria-label="Purchase details">
-        <PurchaseDetails
-          interval={cart.interval}
-          locale={locale}
-          invoice={cart.nextInvoice}
-          purchaseDetails={contentful.purchaseDetails}
-        />
-      </section>
-
-      <div className="page-body rounded-t-lg tablet:rounded-t-none">
-        <section
-          className="h-[640px] flex items-center justify-center"
-          aria-label="Section under construction"
-        >
-          {/*
+      <section
+        className="h-[640px] flex items-center justify-center"
+        aria-label="Section under construction"
+      >
+        {/*
             Temporary section to test NextAuth prompt/no prompt signin
             To be deleted as part of FXA-7521/FXA-7523 if not sooner where necessary
           */}
-          {!session ? (
-            <div className="flex flex-col gap-4">
-              <form
-                action={async () => {
-                  'use server';
-                  await signIn('fxa');
-                }}
-              >
-                <button className="flex items-center justify-center bg-blue-500 font-semibold h-12 rounded-md text-white w-full p-4">
-                  <div className="block">Sign In - Login</div>
-                </button>
-              </form>
-              <form
-                action={async () => {
-                  'use server';
-                  await signIn('fxa', undefined, { prompt: 'none' });
-                }}
-              >
-                <button className="flex items-center justify-center bg-blue-500 font-semibold h-12 rounded-md text-white w-full p-4">
-                  <div className="block">Sign In - No Prompt</div>
-                </button>
-              </form>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center gap-4">
-              <p>Hello {session?.user?.id}</p>
-              <form
-                action={async () => {
-                  'use server';
-                  await signOut();
-                }}
-              >
-                <button className="flex items-center justify-center bg-blue-500 font-semibold h-12 rounded-md text-white w-full p-4">
-                  <div className="block">Sign Out</div>
-                </button>
-              </form>
-            </div>
-          )}
-        </section>
-
-        <TermsAndPrivacy
-          locale={locale}
-          {...cart}
-          {...contentful.commonContent}
-          {...contentful.purchaseDetails}
-          showFXALinks={true}
-        />
-      </div>
+        {!session ? (
+          <div className="flex flex-col gap-4">
+            <form
+              action={async () => {
+                'use server';
+                await signIn('fxa');
+              }}
+            >
+              <button className="flex items-center justify-center bg-blue-500 font-semibold h-12 rounded-md text-white w-full p-4">
+                <div className="block">Sign In - Login</div>
+              </button>
+            </form>
+            <form
+              action={async () => {
+                'use server';
+                await signIn('fxa', undefined, { prompt: 'none' });
+              }}
+            >
+              <button className="flex items-center justify-center bg-blue-500 font-semibold h-12 rounded-md text-white w-full p-4">
+                <div className="block">Sign In - No Prompt</div>
+              </button>
+            </form>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4">
+            <p>Hello {session?.user?.id}</p>
+            <form
+              action={async () => {
+                'use server';
+                await signOut();
+              }}
+            >
+              <button className="flex items-center justify-center bg-blue-500 font-semibold h-12 rounded-md text-white w-full p-4">
+                <div className="block">Sign Out</div>
+              </button>
+            </form>
+          </div>
+        )}
+      </section>
     </>
   );
 }

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/success/page.tsx
@@ -2,15 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { PurchaseDetails, TermsAndPrivacy } from '@fxa/payments/ui/server';
-import {
-  getCartData,
-  getContentfulContent,
-} from '../../../../../../_lib/apiClient';
 import { headers } from 'next/headers';
 import Image from 'next/image';
-import checkLogo from '../../../../../../../images/check.svg';
-import circledConfirm from '../../../../../../../images/circled-confirm.svg';
+
 import { formatPlanPricing } from '@fxa/payments/ui';
 import {
   getBundle,
@@ -20,7 +14,12 @@ import {
   getLocalizedDate,
   getLocalizedDateString,
 } from '@fxa/shared/l10n';
-// import { app } from '../../_nestapp/app';
+
+import {
+  getCartData,
+  getContentfulContent,
+} from '../../../../../../_lib/apiClient';
+import circledConfirm from '../../../../../../../images/circled-confirm.svg';
 
 export const dynamic = 'force-dynamic';
 
@@ -84,125 +83,92 @@ export default async function CheckoutSuccess({
 
   return (
     <>
-      <header className="page-title-container">
-        <h1 className="page-header">
-          {l10n.getMessage('subscription-success-title')?.value?.toString() ||
-            'Subscription confirmation'}
-        </h1>
-        <div className="page-subheader">
-          <Image src={checkLogo} alt="" />
-          <span className="page-subheader-text">
-            {l10n.getMessage('sub-guarantee')?.value?.toString() ||
-              '30-day money-back guarantee'}
-          </span>
+      <section className="h-[640px]" aria-label="Payment confirmation">
+        <div className="page-message-container row-divider-grey-200">
+          <Image src={circledConfirm} alt="" className="w-16 h-16" />
+
+          <h4 className="text-xl font-normal mx-0 mt-6 mb-3">
+            {l10n
+              .getMessage('payment-confirmation-thanks-heading')
+              ?.value?.toString() || 'Thank you!'}
+          </h4>
+
+          <p className="page-message">
+            {getFormattedMsg(
+              l10n,
+              'payment-confirmation-thanks-subheading',
+              `A confirmation email has been sent to ${cart.email} with details on how to get started with ${contentful.purchaseDetails.productName}.`,
+              {
+                email: cart.email,
+                product_name: contentful.purchaseDetails.productName,
+              }
+            )}
+          </p>
         </div>
-      </header>
 
-      <section className="payment-panel" aria-label="Purchase details">
-        <PurchaseDetails
-          locale={locale}
-          interval={cart.interval}
-          invoice={cart.nextInvoice}
-          purchaseDetails={contentful.purchaseDetails}
+        <ConfirmationDetail
+          title={
+            l10n
+              .getMessage('payment-confirmation-order-heading')
+              ?.value?.toString() || 'Order details'
+          }
+          detail1={getFormattedMsg(
+            l10n,
+            'payment-confirmation-invoice-number',
+            `Invoice #${cart.invoiceNumber}`,
+            {
+              invoiceNumber: cart.invoiceNumber,
+            }
+          )}
+          detail2={getFormattedMsg(
+            l10n,
+            'payment-confirmation-invoice-date',
+            getLocalizedDateString(date),
+            {
+              invoiceDate: getLocalizedDate(date),
+            }
+          )}
         />
+
+        <ConfirmationDetail
+          title={
+            l10n
+              .getMessage('payment-confirmation-details-heading-2')
+              ?.value?.toString() || 'Payment information'
+          }
+          detail1={getFormattedMsg(
+            l10n,
+            'payment-confirmation-amount',
+            planPrice,
+            {
+              amount: getLocalizedCurrency(
+                cart.nextInvoice.totalAmount,
+                cart.nextInvoice.currency
+              ),
+              interval: cart.interval,
+            }
+          )}
+          detail2={getFormattedMsg(
+            l10n,
+            'payment-confirmation-cc-card-ending-in',
+            `Card ending in ${cart.last4}`,
+            {
+              last4: cart.last4,
+            }
+          )}
+        />
+
+        <a
+          className="page-button"
+          href={contentful.commonContent.successActionButtonUrl}
+        >
+          {contentful.commonContent.successActionButtonLabel ||
+            l10n
+              .getMessage('payment-confirmation-download-button ')
+              ?.value?.toString() ||
+            'Continue to download'}
+        </a>
       </section>
-
-      <div className="page-body rounded-t-lg tablet:rounded-t-none">
-        <section className="h-[640px]" aria-label="Payment confirmation">
-          <div className="page-message-container row-divider-grey-200">
-            <Image src={circledConfirm} alt="" className="w-16 h-16" />
-
-            <h4 className="text-xl font-normal mx-0 mt-6 mb-3">
-              {l10n
-                .getMessage('payment-confirmation-thanks-heading')
-                ?.value?.toString() || 'Thank you!'}
-            </h4>
-
-            <p className="page-message">
-              {getFormattedMsg(
-                l10n,
-                'payment-confirmation-thanks-subheading',
-                `A confirmation email has been sent to ${cart.email} with details on how to get started with ${contentful.purchaseDetails.productName}.`,
-                {
-                  email: cart.email,
-                  product_name: contentful.purchaseDetails.productName,
-                }
-              )}
-            </p>
-          </div>
-
-          <ConfirmationDetail
-            title={
-              l10n
-                .getMessage('payment-confirmation-order-heading')
-                ?.value?.toString() || 'Order details'
-            }
-            detail1={getFormattedMsg(
-              l10n,
-              'payment-confirmation-invoice-number',
-              `Invoice #${cart.invoiceNumber}`,
-              {
-                invoiceNumber: cart.invoiceNumber,
-              }
-            )}
-            detail2={getFormattedMsg(
-              l10n,
-              'payment-confirmation-invoice-date',
-              getLocalizedDateString(date),
-              {
-                invoiceDate: getLocalizedDate(date),
-              }
-            )}
-          />
-
-          <ConfirmationDetail
-            title={
-              l10n
-                .getMessage('payment-confirmation-details-heading-2')
-                ?.value?.toString() || 'Payment information'
-            }
-            detail1={getFormattedMsg(
-              l10n,
-              'payment-confirmation-amount',
-              planPrice,
-              {
-                amount: getLocalizedCurrency(
-                  cart.nextInvoice.totalAmount,
-                  cart.nextInvoice.currency
-                ),
-                interval: cart.interval,
-              }
-            )}
-            detail2={getFormattedMsg(
-              l10n,
-              'payment-confirmation-cc-card-ending-in',
-              `Card ending in ${cart.last4}`,
-              {
-                last4: cart.last4,
-              }
-            )}
-          />
-
-          <a
-            className="page-button"
-            href={contentful.commonContent.successActionButtonUrl}
-          >
-            {contentful.commonContent.successActionButtonLabel ||
-              l10n
-                .getMessage('payment-confirmation-download-button ')
-                ?.value?.toString() ||
-              'Continue to download'}
-          </a>
-        </section>
-
-        <TermsAndPrivacy
-          locale={locale}
-          {...cart}
-          {...contentful.commonContent}
-          {...contentful.purchaseDetails}
-          showFXALinks={true}
-        />
-      </div>
     </>
   );
 }

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/layout.tsx
@@ -2,21 +2,72 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { headers } from 'next/headers';
+
+import { PurchaseDetails, TermsAndPrivacy } from '@fxa/payments/ui/server';
+import { getLocaleFromRequest } from '@fxa/shared/l10n';
+
+import { getCartData, getContentfulContent } from '../../../_lib/apiClient';
+
 // TODO - Replace these placeholders as part of FXA-8227
 export const metadata = {
   title: 'Mozilla accounts',
   description: 'Mozilla accounts',
 };
 
+interface CheckoutParams {
+  cartId: string;
+  locale: string;
+  interval: string;
+  offeringId: string;
+}
+
 export interface CheckoutSearchParams {
   experiment?: string;
   promotion_code?: string;
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: CheckoutParams;
 }) {
-  return <>{children}</>;
+  const headersList = headers();
+  const locale = getLocaleFromRequest(
+    params,
+    headersList.get('accept-language')
+  );
+  const contentfulData = getContentfulContent(params.offeringId, locale);
+  const cartData = getCartData(params.cartId);
+  const [contentful, cart] = await Promise.all([contentfulData, cartData]);
+
+  return (
+    <>
+      <header className="page-title-container">
+        <h1 className="page-header">Under Construction</h1>
+      </header>
+
+      <section className="payment-panel" aria-label="Purchase details">
+        <PurchaseDetails
+          interval={cart.interval}
+          locale={locale}
+          invoice={cart.nextInvoice}
+          purchaseDetails={contentful.purchaseDetails}
+        />
+      </section>
+
+      <div className="page-body rounded-t-lg tablet:rounded-t-none">
+        {children}
+        <TermsAndPrivacy
+          locale={locale}
+          {...cart}
+          {...contentful.commonContent}
+          {...contentful.purchaseDetails}
+          showFXALinks={true}
+        />
+      </div>
+    </>
+  );
 }

--- a/libs/shared/l10n/src/lib/determine-locale.ts
+++ b/libs/shared/l10n/src/lib/determine-locale.ts
@@ -1,12 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { DEFAULT_LOCALE } from './l10n';
 import { parseAcceptLanguage } from './parse-accept-language';
 
 /**
  * Get the best fitting locale, prioritizing request search params, followed by request header AcceptLanguage and DEFAULT_LOCALE as default
- * @param searchParams - Search parameters of the request
+ * @param params - parameters of the request
  * @param acceptLanguage - Accept language from request header
  * @returns The best fitting locale
  */


### PR DESCRIPTION
## This pull request

- [x] Revises layout.tsx to the checkout folder so that it’s applied to all checkout pages
- [x] Add PurchaseDetails, TermsAndService and SubscriptionTitle components to the new layout.tsx
- [x] Remove PurchaseDetails, TermsAndService and SubscriptionTitle from the checkout, success, and error pages

## Issue that this pull request solves

Closes: FXA-9038

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.