### PR TITLE
task(auth): Convert metricsCache.js to typescript

### DIFF
--- a/packages/fxa-auth-server/lib/metricsCache.ts
+++ b/packages/fxa-auth-server/lib/metricsCache.ts
@@ -33,13 +33,10 @@ export type MetricsRedisConfig = {
 export class MetricsRedis extends RedisShared {
   private enabled: boolean;
   private lifetime: number;
-  private prefix: string;
 
   constructor(config: MetricsRedisConfig) {
     super(config.redis.metrics, resolveLogger(), resolveMetrics());
     this.enabled = config.redis.metrics.enabled || false;
-    // TBD - Assigned but not used?
-    this.prefix = config.redis.metrics.prefix || 'metrics:';
     this.lifetime = config.redis.metrics.lifetime || 7200;
   }
 


### PR DESCRIPTION
## Because

- Auth server failed to start

## This pull request

- Converts metricsCache.js to typescript, which supports the export syntax

## Issue that this pull request solves

Closes: FXA-9372

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This can be validated by locally by doing the following from the root of the mono repo.


`nx build fxa-auth-server`
`cd packages/fxa-auth-server/dist/packages/fxa-auth-server`
`NODE_ENV=dev node bin/key_server.js`

Observe that server starts up cleanly. If you were to do the same thing on main, the following error would occur on startup:

```
3
export class MetricsRedis extends RedisShared {
^^^^^^

SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:77:18)
    at wrapSafe (node:internal/modules/cjs/loader:1288:20)
    at Module._compile (node:internal/modules/cjs/loader:1340:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/Users/dschomburg/Documents/code/mozilla/project/packages/fxa-auth-server/dist/packages/fxa-auth-server/lib/metrics/context.js:11:26)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/Users/dschomburg/Documents/code/mozilla/project/packages/fxa-auth-server/dist/packages/fxa-auth-server/lib/routes/account.js:33:32)
```
