### PR TITLE
bug(graphql): Make sure Accept-Language header is forwarded

### DIFF
--- a/packages/fxa-graphql-api/src/decorators.spec.ts
+++ b/packages/fxa-graphql-api/src/decorators.spec.ts
@@ -24,11 +24,23 @@ describe('gql decorators', () => {
     });
 
     it('forwards relevant headers', () => {
+      const lang = 'en-US';
+      const traceId = '00b30317128040e29364590a05812bb0';
+      const baggage = `sentry-environment=local,sentry-release=0.0.0,sentry-public_key=adb27d09f83f43b8852e61ce4c8a487b,sentry-trace_id=${traceId}`;
+
       const headers = extractRequiredHeaders({
         ip,
-        headers: { 'user-agent': agent },
+        headers: {
+          'user-agent': agent,
+          'Accept-Language': lang,
+          'sentry-trace': traceId,
+          baggage,
+        },
       });
       expect(headers.get('user-agent')).toEqual(agent);
+      expect(headers.get('accept-language')).toEqual(lang);
+      expect(headers.get('sentry-trace')).toEqual(traceId);
+      expect(headers.get('baggage')).toEqual(baggage);
     });
 
     it('does not forward irrelevant headers', () => {


### PR DESCRIPTION
## Because

- On signup going through GQL we noticed the users language wasn't being set correctly.

## This pull request

- Makes sure the header propagates
- Also adds in sentry-trace which is useful for tracing
- Also adds baggage header which is useful for tracing

## Issue that this pull request solves

Closes: FXA-9354

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before fix: (note that accept-language is missing from auth-server request)
![image](https://github.com/mozilla/fxa/assets/94418270/c05f3e15-41cf-4b16-92df-61b1a1c6db55)
![image](https://github.com/mozilla/fxa/assets/94418270/4a3709e8-281d-4eda-b25d-8d2c9acef82f)

After fix
![image](https://github.com/mozilla/fxa/assets/94418270/aa7fd402-e93f-4650-898b-022b0d047f6a)
![image](https://github.com/mozilla/fxa/assets/94418270/9107ba1d-1437-4605-8220-8eb36cf108a2)

(Images are from wireshark captures)


## Other information (Optional)

While doing this, it became apparent the baggage and sentry-trace headers were also not being copied, which are needed to connect trace data together, so they were added as well.
