### PR TITLE
feat(hawk): Add auth strategy for Hawk and FxA Bearer token support

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.js
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const AppError = require('../../error');
+const Boom = require('@hapi/boom');
+
+// The following regexes and Hawk header parsing are taken from the Hawk library.
+// See https://github.com/mozilla/hawk/blob/01f3d35479fe76654bb50f2886b37310555d088e/lib/utils.js#L126
+const authHeaderRegex = /^(\w+)(?:\s+(.*))?$/; // Header: scheme[ something]
+const attributeRegex = /^[ \w!#$%&'()*+,\-./:;<=>?@[\]^`{|}~]+$/; // !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
+function parseAuthorizationHeader(header, keys) {
+  keys = keys || ['id', 'ts', 'nonce', 'hash', 'ext', 'mac', 'app', 'dlg'];
+
+  if (!header) {
+    throw Boom.unauthorized(null, 'Hawk');
+  }
+
+  if (header.length > 4096) {
+    throw Boom.badRequest('Header length too long');
+  }
+
+  const headerParts = header.match(authHeaderRegex);
+  if (!headerParts) {
+    throw Boom.badRequest('Invalid header syntax');
+  }
+
+  const scheme = headerParts[1];
+  if (scheme.toLowerCase() !== 'hawk') {
+    throw Boom.unauthorized(null, 'Hawk');
+  }
+
+  const attributesString = headerParts[2];
+  if (!attributesString) {
+    throw Boom.badRequest('Invalid header syntax');
+  }
+
+  const attributes = {};
+  let errorMessage = '';
+  const verify = attributesString.replace(
+    /(\w+)="([^"\\]*)"\s*(?:,\s*|$)/g,
+    ($0, $1, $2) => {
+      // Check valid attribute names
+      if (keys.indexOf($1) === -1) {
+        errorMessage = 'Unknown attribute: ' + $1;
+        return;
+      }
+
+      // Allowed attribute value characters
+      if ($2.match(attributeRegex) === null) {
+        errorMessage = 'Bad attribute value: ' + $1;
+        return;
+      }
+
+      // Check for duplicates
+      // eslint-disable-next-line no-prototype-builtins
+      if (attributes.hasOwnProperty($1)) {
+        errorMessage = 'Duplicate attribute: ' + $1;
+        return;
+      }
+
+      attributes[$1] = $2;
+      return '';
+    }
+  );
+
+  if (verify !== '') {
+    throw Boom.badRequest(errorMessage || 'Bad header format');
+  }
+
+  return attributes;
+}
+
+/**
+ * This function defines the authentication strategy for `hawk-fxa-token`.
+ * This auth strategy supports Hawk token and FxA token (Session, KeyFetch, PasswordForgotToken) for authentication as a Bearer token.
+ * This strategy will be used to slowly phase out the usage of Hawk tokens, see https://github.com/mozilla/fxa/blob/main/docs/adr/0022-deprecate-hawk.md
+ * @param {Function} getCredentialsFunc - The function to get the credentials.
+ * @returns {Function}
+ */
+function strategy(getCredentialsFunc) {
+  return function (server, options) {
+    return {
+      authenticate: async function (req, h) {
+        const auth = req.headers.authorization;
+
+        if (!auth) {
+          if (req.auth.mode === 'optional') {
+            return h.continue;
+          }
+
+          const error = AppError.unauthorized('Token not found');
+          error.isMissing = true;
+          throw error;
+        }
+
+        if (auth.toLowerCase().indexOf('hawk') > -1) {
+          // If a Hawk token is found, lets parse it and get the token's id
+          const parsedHeader = parseAuthorizationHeader(auth);
+          const token = await getCredentialsFunc(parsedHeader.id);
+
+          // If a token isn't found, this means it doesn't exist or expired and
+          // was removed from database
+          if (!token) {
+            const error = AppError.unauthorized('Token not found');
+            error.isMissing = true;
+            throw error;
+          }
+
+          return h.authenticated({
+            credentials: token,
+          });
+        }
+
+        // TODO: Fix in follow up PR, there are conflicts with the refreshToken
+        // ref: https://mozilla-hub.atlassian.net/browse/FXA-9392
+        // strategy that need to also fixed
+        // if (auth.indexOf('Bearer') > -1) {
+        //   const tokenId = auth.split(' ')[1];
+        //   try {
+        //     const token = await getCredentialsFunc(tokenId);
+        //     return h.authenticated({
+        //       credentials: token,
+        //     });
+        //   } catch (err) {}
+        // }
+
+        const error = AppError.unauthorized('Token not found');
+        error.isMissing = true;
+        throw error;
+      },
+      payload: async function (req, h) {
+        // Since we skip Hawk header validation, we don't need to perform payload validation either...
+        // unless the route requires it.
+        if (req.route.settings.auth.payload === 'required' && !req.payload) {
+          throw AppError.invalidSignature('Payload is required');
+        }
+        return h.continue;
+      },
+    };
+  };
+}
+
+module.exports = {
+  strategy,
+};

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -69,7 +69,6 @@
     "@google-cloud/tasks": "^4.0.1",
     "@googlemaps/google-maps-services-js": "^3.3.16",
     "@hapi/hapi": "^20.2.1",
-    "@hapi/hawk": "^8.0.0",
     "@hapi/hoek": "^11.0.2",
     "@mozilla/glean": "^4.0.0",
     "@types/convict": "5.2.2",

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -8,7 +8,6 @@ module.exports = (config) => {
   const EventEmitter = require('events').EventEmitter;
   const util = require('util');
 
-  const hawk = require('@hapi/hawk');
   const request = require('request');
 
   const tokens = require('../../lib/tokens')({ trace: function () {} }, config);
@@ -34,7 +33,7 @@ module.exports = (config) => {
     if (offset) {
       verify.localtimeOffsetMsec = offset;
     }
-    return hawk.client.header(url, method, verify).header;
+    return `Hawk id="${verify.credentials.id}"`;
   }
 
   ClientApi.prototype.doRequest = function (
@@ -1382,19 +1381,14 @@ module.exports = (config) => {
   };
 
   ClientApi.prototype.stubAccount = function (email, clientId) {
-    return this.doRequest(
-      'POST',
-      `${this.baseURL}/account/stub`,
-      null,
-      {
-        email,
-        clientId,
-        wantsSetupToken: true
-      }
-    );
-  }
+    return this.doRequest('POST', `${this.baseURL}/account/stub`, null, {
+      email,
+      clientId,
+      wantsSetupToken: true,
+    });
+  };
 
-  ClientApi.prototype.finishAccountSetup = async function(
+  ClientApi.prototype.finishAccountSetup = async function (
     token,
     email,
     authPW,
@@ -1414,10 +1408,10 @@ module.exports = (config) => {
         wrapKb,
         authPWVersion2,
         wrapKbVersion2,
-        clientSalt
+        clientSalt,
       }
     );
-  }
+  };
 
   ClientApi.heartbeat = function (origin) {
     return new ClientApi(origin).doRequest('GET', `${origin}/__heartbeat__`);

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/hawk-fxa-token.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/hawk-fxa-token.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const AppError = require('../../../../lib/error');
+const {
+  strategy,
+} = require('../../../../lib/routes/auth-schemes/hawk-fxa-token');
+
+const HAWK_HEADER = 'Hawk id="123", ts="123", nonce="123", mac="123"';
+
+describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
+  it('should throw an error if no authorization header is provided', async () => {
+    const getCredentialsFunc = sinon.fake.resolves(null);
+    const authStrategy = strategy(getCredentialsFunc)();
+
+    const request = { headers: {}, auth: { mode: 'required' } };
+    const h = { continue: Symbol('continue') };
+
+    try {
+      await authStrategy.authenticate(request, h);
+      assert.fail('Should have thrown an error');
+    } catch (err) {
+      assert.instanceOf(err, AppError);
+      const errorResponse = err.output.payload;
+      assert.equal(errorResponse.code, 401);
+      assert.equal(errorResponse.errno, 110);
+      assert.equal(errorResponse.message, 'Unauthorized for route');
+      assert.equal(errorResponse.detail, 'Token not found');
+    }
+  });
+
+  it('should authenticate with parsable Hawk header and valid token', async () => {
+    const getCredentialsFunc = sinon.fake.resolves({ id: 'validToken' });
+    const authStrategy = strategy(getCredentialsFunc)();
+
+    const request = {
+      headers: { authorization: HAWK_HEADER },
+      auth: { mode: 'required' },
+    };
+    const h = { authenticated: sinon.fake() };
+
+    await authStrategy.authenticate(request, h);
+    assert.isTrue(
+      h.authenticated.calledOnceWith({ credentials: { id: 'validToken' } })
+    );
+  });
+
+  it('should not authenticate with parsable Hawk header and invalid token', async () => {
+    const getCredentialsFunc = sinon.fake.resolves(null);
+    const authStrategy = strategy(getCredentialsFunc)();
+
+    const request = {
+      headers: { authorization: HAWK_HEADER },
+      auth: { mode: 'required' },
+    };
+    const h = { continue: Symbol('continue') };
+
+    try {
+      await authStrategy.authenticate(request, h);
+      assert.fail('Should have thrown an error');
+    } catch (err) {
+      assert.instanceOf(err, AppError);
+      const errorResponse = err.output.payload;
+      assert.equal(errorResponse.code, 401);
+      assert.equal(errorResponse.errno, 110);
+      assert.equal(errorResponse.message, 'Unauthorized for route');
+      assert.equal(errorResponse.detail, 'Token not found');
+    }
+  });
+
+  it('should not authenticate with unparseable Hawk header', async () => {
+    const getCredentialsFunc = sinon.fake.resolves(null);
+    const authStrategy = strategy(getCredentialsFunc)();
+
+    const request = {
+      headers: { authorization: 'Invalid Hawk Header' },
+      auth: { mode: 'required' },
+    };
+    const h = { continue: Symbol('continue') };
+
+    try {
+      await authStrategy.authenticate(request, h);
+      assert.fail('Should have thrown an error');
+    } catch (err) {
+      const errorResponse = err.output.payload;
+      assert.equal(errorResponse.statusCode, 401);
+      assert.equal(errorResponse.message, 'Unauthorized');
+    }
+  });
+});

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -9,7 +9,6 @@ const ROOT_DIR = '../..';
 const { assert } = require('chai');
 const EndpointError = require('poolee/lib/error')(require('util').inherits);
 const error = require(`${ROOT_DIR}/lib/error`);
-const hawk = require('@hapi/hawk');
 const knownIpLocation = require('../known-ip-location');
 const mocks = require('../mocks');
 const proxyquire = require('proxyquire');
@@ -669,17 +668,7 @@ describe('lib/server', () => {
         describe('authenticated request, session token not expired:', () => {
           beforeEach(() => {
             response = 'ok';
-            const auth = hawk.client.header(
-              `${config.publicUrl}account/status`,
-              'GET',
-              {
-                credentials: {
-                  id: 'deadbeef',
-                  key: 'baadf00d',
-                  algorithm: 'sha256',
-                },
-              }
-            );
+            const auth = { header: `Hawk id="deadbeef"` };
             return instance.inject({
               headers: {
                 authorization: auth.header,
@@ -720,17 +709,9 @@ describe('lib/server', () => {
           .then((s) => {
             instance = s;
             return instance.start().then(() => {
-              const auth = hawk.client.header(
-                `${config.publicUrl}account/status`,
-                'GET',
-                {
-                  credentials: {
-                    id: 'deadbeef',
-                    key: 'baadf00d',
-                    algorithm: 'sha256',
-                  },
-                }
-              );
+              const auth = {
+                header: `Hawk id="deadbeef"`,
+              };
               return instance.inject({
                 headers: {
                   authorization: auth.header,

--- a/packages/fxa-auth-server/test/remote/misc_tests.js
+++ b/packages/fxa-auth-server/test/remote/misc_tests.js
@@ -9,284 +9,285 @@ const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
 const superagent = require('superagent');
-const hawk = require('@hapi/hawk');
 
 const config = require('../../config').default.getProperties();
 
-[{version:""},{version:"V2"}].forEach((testOptions) => {
-
-describe(`#integration${testOptions.version} - remote misc`, function () {
-  this.timeout(15000);
-  let server;
-  before(() => {
-    return TestServer.start(config).then((s) => {
-      server = s;
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - remote misc`, function () {
+    this.timeout(15000);
+    let server;
+    before(() => {
+      return TestServer.start(config).then((s) => {
+        server = s;
+      });
     });
-  });
 
-  function testVersionRoute(route) {
-    return () => {
-      return superagent.get(config.publicUrl + route).then((res) => {
-        const json = res.body;
-        assert.deepEqual(Object.keys(json), ['version', 'commit', 'source']);
-        assert.equal(
-          json.version,
-          require('../../package.json').version,
-          'package version'
-        );
-        assert.ok(
-          json.source && json.source !== 'unknown',
-          'source repository'
-        );
+    function testVersionRoute(route) {
+      return () => {
+        return superagent.get(config.publicUrl + route).then((res) => {
+          const json = res.body;
+          assert.deepEqual(Object.keys(json), ['version', 'commit', 'source']);
+          assert.equal(
+            json.version,
+            require('../../package.json').version,
+            'package version'
+          );
+          assert.ok(
+            json.source && json.source !== 'unknown',
+            'source repository'
+          );
 
-        // check that the git hash just looks like a hash
-        assert.ok(
-          json.commit.match(/^[0-9a-f]{40}$/),
-          'The git hash actually looks like one'
-        );
-      });
-    };
-  }
-
-  function testCORSHeader(withAllowedOrigin) {
-    const randomAllowedOrigin =
-      config.corsOrigin[Math.floor(Math.random() * config.corsOrigin.length)];
-    const expectedOrigin = withAllowedOrigin ? randomAllowedOrigin : undefined;
-
-    return () => {
-      const get = superagent.get(`${config.publicUrl}/`);
-      if (withAllowedOrigin !== undefined) {
-        get.set(
-          'Origin',
-          withAllowedOrigin ? randomAllowedOrigin : 'http://notallowed'
-        );
-      }
-      return get.then((res) => {
-        assert.equal(
-          res.headers['access-control-allow-origin'],
-          expectedOrigin,
-          'Access-Control-Allow-Origin header was set correctly'
-        );
-      });
-    };
-  }
-
-  it('unsupported api version', () => {
-    return superagent
-      .get(`${config.publicUrl}/v0/account/create`)
-      .ok((res) => res.statusCode === 410)
-      .then((res) => {
-        assert.equal(res.statusCode, 410, 'http gone');
-      });
-  });
-
-  it('/__heartbeat__ returns a 200 OK', () => {
-    return superagent.get(`${config.publicUrl}/__heartbeat__`).then((res) => {
-      assert.equal(res.statusCode, 200, 'http ok');
-    });
-  });
-
-  it('/__lbheartbeat__ returns a 200 OK', () => {
-    return superagent.get(`${config.publicUrl}/__lbheartbeat__`).then((res) => {
-      assert.equal(res.statusCode, 200, 'http ok');
-    });
-  });
-
-  it('/ returns version, git hash and source repo', testVersionRoute('/'));
-
-  it(
-    '/__version__ returns version, git hash and source repo',
-    testVersionRoute('/__version__')
-  );
-
-  it(
-    'returns no Access-Control-Allow-Origin with no Origin set',
-    testCORSHeader(undefined)
-  );
-
-  it(
-    'returns correct Access-Control-Allow-Origin with whitelisted Origin',
-    testCORSHeader(true)
-  );
-
-  it(
-    'returns no Access-Control-Allow-Origin with not whitelisted Origin',
-    testCORSHeader(false)
-  );
-
-  it('/verify_email redirects', () => {
-    const path = '/v1/verify_email?code=0000&uid=0000';
-    return superagent
-      .get(config.publicUrl + path)
-      .redirects(0)
-      .ok((res) => res.statusCode === 302)
-      .then((res) => {
-        assert.equal(res.statusCode, 302, 'redirected');
-        //assert.equal(res.headers.location, config.contentServer.url + path)
-      });
-  });
-
-  it('/complete_reset_password redirects', () => {
-    const path = '/v1/complete_reset_password?code=0000&email=a@b.c&token=0000';
-    return superagent
-      .get(config.publicUrl + path)
-      .redirects(0)
-      .ok((res) => res.statusCode === 302)
-      .then((res) => {
-        assert.equal(res.statusCode, 302, 'redirected');
-        //assert.equal(res.headers.location, config.contentServer.url + path)
-      });
-  });
-
-  it('timestamp header', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let url = null;
-    let client = null;
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    )
-      .then((c) => {
-        client = c;
-        return client.login();
-      })
-      .then(() => {
-        url = `${client.api.baseURL}/account/keys`;
-        return client.api.Token.KeyFetchToken.fromHex(client.getState().keyFetchToken);
-      })
-      .then((token) => {
-        const method = 'GET';
-        const verify = {
-          credentials: token,
-          timestamp: Math.floor(Date.now() / 1000),
-        };
-        return superagent
-          .get(url)
-          .set('Authorization', hawk.client.header(url, method, verify).header)
-          .then((res) => {
-            const now = +new Date() / 1000;
-            assert.ok(res.headers.timestamp > now - 60, 'has timestamp header');
-            assert.ok(res.headers.timestamp < now + 60, 'has timestamp header');
-          });
-      });
-  });
-
-  it('Strict-Transport-Security header', () => {
-    return superagent.get(`${config.publicUrl}/`).then((res) => {
-      assert.equal(
-        res.headers['strict-transport-security'],
-        'max-age=31536000; includeSubDomains'
-      );
-    });
-  });
-
-  it('oversized payload', () => {
-    const client = new Client(config.publicUrl, testOptions);
-    return client.api
-      .doRequest(
-        'POST',
-        `${client.api.baseURL}/get_random_bytes`,
-        null,
-        // See payload.maxBytes in ../../server/server.js
-        { big: Buffer.alloc(8192).toString('hex') }
-      )
-      .then(
-        (body) => {
-          assert(false, 'request should have failed');
-        },
-        (err) => {
-          if (err.errno) {
-            assert.equal(err.errno, 113, 'payload too large');
-          } else {
-            // nginx returns an html response
-            assert.ok(
-              /413 Request Entity Too Large/.test(err),
-              'payload too large'
-            );
-          }
-        }
-      );
-  });
-
-  it('random bytes', () => {
-    const client = new Client(config.publicUrl, testOptions);
-    return client.api.getRandomBytes().then((x) => {
-      assert.equal(x.data.length, 64);
-    });
-  });
-
-  it('fetch /.well-known/browserid support document', () => {
-    const client = new Client(config.publicUrl, testOptions);
-    function fetch(url) {
-      return client.api.doRequest('GET', config.publicUrl + url);
+          // check that the git hash just looks like a hash
+          assert.ok(
+            json.commit.match(/^[0-9a-f]{40}$/),
+            'The git hash actually looks like one'
+          );
+        });
+      };
     }
-    return fetch('/.well-known/browserid').then((doc) => {
-      assert.ok(doc.hasOwnProperty('public-key'), 'doc has public key');
-      assert.ok(/^[0-9]+$/.test(doc['public-key'].n), 'n is base 10');
-      assert.ok(/^[0-9]+$/.test(doc['public-key'].e), 'e is base 10');
-      assert.ok(doc.hasOwnProperty('authentication'), 'doc has auth page');
-      assert.ok(
-        doc.hasOwnProperty('provisioning'),
-        'doc has provisioning page'
-      );
-      assert.equal(doc.keys.length, 1);
-      return doc;
+
+    function testCORSHeader(withAllowedOrigin) {
+      const randomAllowedOrigin =
+        config.corsOrigin[Math.floor(Math.random() * config.corsOrigin.length)];
+      const expectedOrigin = withAllowedOrigin
+        ? randomAllowedOrigin
+        : undefined;
+
+      return () => {
+        const get = superagent.get(`${config.publicUrl}/`);
+        if (withAllowedOrigin !== undefined) {
+          get.set(
+            'Origin',
+            withAllowedOrigin ? randomAllowedOrigin : 'http://notallowed'
+          );
+        }
+        return get.then((res) => {
+          assert.equal(
+            res.headers['access-control-allow-origin'],
+            expectedOrigin,
+            'Access-Control-Allow-Origin header was set correctly'
+          );
+        });
+      };
+    }
+
+    it('unsupported api version', () => {
+      return superagent
+        .get(`${config.publicUrl}/v0/account/create`)
+        .ok((res) => res.statusCode === 410)
+        .then((res) => {
+          assert.equal(res.statusCode, 410, 'http gone');
+        });
+    });
+
+    it('/__heartbeat__ returns a 200 OK', () => {
+      return superagent.get(`${config.publicUrl}/__heartbeat__`).then((res) => {
+        assert.equal(res.statusCode, 200, 'http ok');
+      });
+    });
+
+    it('/__lbheartbeat__ returns a 200 OK', () => {
+      return superagent
+        .get(`${config.publicUrl}/__lbheartbeat__`)
+        .then((res) => {
+          assert.equal(res.statusCode, 200, 'http ok');
+        });
+    });
+
+    it('/ returns version, git hash and source repo', testVersionRoute('/'));
+
+    it(
+      '/__version__ returns version, git hash and source repo',
+      testVersionRoute('/__version__')
+    );
+
+    it(
+      'returns no Access-Control-Allow-Origin with no Origin set',
+      testCORSHeader(undefined)
+    );
+
+    it(
+      'returns correct Access-Control-Allow-Origin with whitelisted Origin',
+      testCORSHeader(true)
+    );
+
+    it(
+      'returns no Access-Control-Allow-Origin with not whitelisted Origin',
+      testCORSHeader(false)
+    );
+
+    it('/verify_email redirects', () => {
+      const path = '/v1/verify_email?code=0000&uid=0000';
+      return superagent
+        .get(config.publicUrl + path)
+        .redirects(0)
+        .ok((res) => res.statusCode === 302)
+        .then((res) => {
+          assert.equal(res.statusCode, 302, 'redirected');
+          //assert.equal(res.headers.location, config.contentServer.url + path)
+        });
+    });
+
+    it('/complete_reset_password redirects', () => {
+      const path =
+        '/v1/complete_reset_password?code=0000&email=a@b.c&token=0000';
+      return superagent
+        .get(config.publicUrl + path)
+        .redirects(0)
+        .ok((res) => res.statusCode === 302)
+        .then((res) => {
+          assert.equal(res.statusCode, 302, 'redirected');
+          //assert.equal(res.headers.location, config.contentServer.url + path)
+        });
+    });
+
+    it('timestamp header', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let url = null;
+      let client = null;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      )
+        .then((c) => {
+          client = c;
+          return client.login();
+        })
+        .then(() => {
+          url = `${client.api.baseURL}/account/keys`;
+          return client.api.Token.KeyFetchToken.fromHex(
+            client.getState().keyFetchToken
+          );
+        })
+        .then((token) => {
+          const verify = {
+            credentials: token,
+            timestamp: Math.floor(Date.now() / 1000),
+          };
+          return superagent
+            .get(url)
+            .set('Authorization', `Hawk id="${verify.credentials.id}"`)
+            .then((res) => {
+              const now = +new Date() / 1000;
+              assert.ok(
+                res.headers.timestamp > now - 60,
+                'has timestamp header'
+              );
+              assert.ok(
+                res.headers.timestamp < now + 60,
+                'has timestamp header'
+              );
+            });
+        });
+    });
+
+    it('Strict-Transport-Security header', () => {
+      return superagent.get(`${config.publicUrl}/`).then((res) => {
+        assert.equal(
+          res.headers['strict-transport-security'],
+          'max-age=31536000; includeSubDomains'
+        );
+      });
+    });
+
+    it('oversized payload', () => {
+      const client = new Client(config.publicUrl, testOptions);
+      return client.api
+        .doRequest(
+          'POST',
+          `${client.api.baseURL}/get_random_bytes`,
+          null,
+          // See payload.maxBytes in ../../server/server.js
+          { big: Buffer.alloc(8192).toString('hex') }
+        )
+        .then(
+          (body) => {
+            assert(false, 'request should have failed');
+          },
+          (err) => {
+            if (err.errno) {
+              assert.equal(err.errno, 113, 'payload too large');
+            } else {
+              // nginx returns an html response
+              assert.ok(
+                /413 Request Entity Too Large/.test(err),
+                'payload too large'
+              );
+            }
+          }
+        );
+    });
+
+    it('random bytes', () => {
+      const client = new Client(config.publicUrl, testOptions);
+      return client.api.getRandomBytes().then((x) => {
+        assert.equal(x.data.length, 64);
+      });
+    });
+
+    it('fetch /.well-known/browserid support document', () => {
+      const client = new Client(config.publicUrl, testOptions);
+      function fetch(url) {
+        return client.api.doRequest('GET', config.publicUrl + url);
+      }
+      return fetch('/.well-known/browserid').then((doc) => {
+        assert.ok(doc.hasOwnProperty('public-key'), 'doc has public key');
+        assert.ok(/^[0-9]+$/.test(doc['public-key'].n), 'n is base 10');
+        assert.ok(/^[0-9]+$/.test(doc['public-key'].e), 'e is base 10');
+        assert.ok(doc.hasOwnProperty('authentication'), 'doc has auth page');
+        assert.ok(
+          doc.hasOwnProperty('provisioning'),
+          'doc has provisioning page'
+        );
+        assert.equal(doc.keys.length, 1);
+        return doc;
+      });
+    });
+
+    it('ignores fail on hawk payload mismatch', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      let url = null;
+      let client = null;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      )
+        .then((c) => {
+          client = c;
+          return client.api.Token.SessionToken.fromHex(client.sessionToken);
+        })
+        .then((token) => {
+          url = `${client.api.baseURL}/account/device`;
+          const payload = {
+            name: 'my cool device',
+            type: 'desktop',
+          };
+          const verify = {
+            credentials: token, // Token must be valid
+            payload: JSON.stringify(payload),
+            timestamp: Math.floor(Date.now() / 1000),
+          };
+          payload.name = 'my stealthily-changed device name';
+          return superagent
+            .post(url)
+            .set('Authorization', `Hawk id="${verify.credentials.id}"`)
+            .send(payload)
+            .then((res) => {
+              assert.equal(res.statusCode, 200, 'the request was accepted');
+            });
+        });
+    });
+
+    after(() => {
+      return TestServer.stop(server);
     });
   });
-
-  it('fail on hawk payload mismatch', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    let url = null;
-    let client = null;
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    )
-      .then((c) => {
-        client = c;
-        return client.api.Token.SessionToken.fromHex(client.sessionToken);
-      })
-      .then((token) => {
-        url = `${client.api.baseURL}/account/device`;
-        const method = 'POST';
-        const payload = {
-          name: 'my cool device',
-          type: 'desktop',
-        };
-        const verify = {
-          credentials: token,
-          payload: JSON.stringify(payload),
-          timestamp: Math.floor(Date.now() / 1000),
-        };
-        payload.name = 'my stealthily-changed device name';
-        return superagent
-          .post(url)
-          .set('Authorization', hawk.client.header(url, method, verify).header)
-          .send(payload)
-          .ok((res) => res.statusCode === 401)
-          .then((res) => {
-            const body = res.body;
-            assert.equal(res.statusCode, 401, 'the request was rejected');
-            assert.equal(
-              body.errno,
-              109,
-              'the errno indicates an invalid signature'
-            );
-          });
-      });
-  });
-
-  after(() => {
-    return TestServer.stop(server);
-  });
-});
-
 });

--- a/packages/fxa-auth-server/test/remote/oauth_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.js
@@ -23,403 +23,409 @@ const JWT_ACCESS_TOKEN_SECRET =
 
 const { decodeJWT } = testUtils;
 
-[{version:""},{version:"V2"}].forEach((testOptions) => {
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - /oauth/ routes`, function () {
+    this.timeout(15000);
+    let client;
+    let email;
+    let password;
+    let server;
 
-describe(`#integration${testOptions.version} - /oauth/ routes`, function () {
-  this.timeout(15000);
-  let client;
-  let email;
-  let password;
-  let server;
-
-  before(async () => {
-    testUtils.disableLogs();
-    server = await TestServer.start(config, false);
-  });
-
-  after(async () => {
-    await TestServer.stop(server);
-    testUtils.restoreStdoutWrite();
-  });
-
-  beforeEach(async () => {
-    email = server.uniqueEmail();
-    password = 'test password';
-    client = await Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    );
-  });
-
-  it('successfully grants an authorization code', async () => {
-    const res = await client.createAuthorizationCode({
-      client_id: PUBLIC_CLIENT_ID,
-      scope: 'abc',
-      state: 'xyz',
-      code_challenge: MOCK_CODE_CHALLENGE,
-      code_challenge_method: 'S256',
+    before(async () => {
+      testUtils.disableLogs();
+      server = await TestServer.start(config, false);
     });
-    assert.ok(res.redirect);
-    assert.ok(res.code);
-    assert.equal(res.state, 'xyz');
-  });
 
-  it('rejects `assertion` parameter in /authorization request', async () => {
-    try {
-      await client.createAuthorizationCode({
-        client_id: PUBLIC_CLIENT_ID,
-        state: 'xyz',
-        assertion: 'a~b',
-      });
-      assert.fail('should have thrown');
-    } catch (err) {
-      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
-      assert.equal(
-        err.validation.keys[0],
-        'assertion',
-        'assertion param caught in validation'
+    after(async () => {
+      await TestServer.stop(server);
+      testUtils.restoreStdoutWrite();
+    });
+
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      password = 'test password';
+      client = await Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
       );
-    }
-  });
+    });
 
-  it('rejects `resource` parameter in /authorization request', async () => {
-    try {
-      await client.createAuthorizationCode({
+    it('successfully grants an authorization code', async () => {
+      const res = await client.createAuthorizationCode({
         client_id: PUBLIC_CLIENT_ID,
+        scope: 'abc',
         state: 'xyz',
         code_challenge: MOCK_CODE_CHALLENGE,
         code_challenge_method: 'S256',
-        resource: 'https://resource.server.com',
       });
-      assert.fail('should have thrown');
-    } catch (err) {
-      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
-      assert.equal(
-        err.validation.keys[0],
-        'resource',
-        'resource param caught in validation'
-      );
-    }
-  });
-
-  it('successfully grants tokens from sessionToken and notifies user', async () => {
-    const SCOPE = OAUTH_SCOPE_OLD_SYNC;
-
-    let devices = await client.devices();
-    assert.equal(devices.length, 0, 'no devices yet');
-
-    const res = await client.grantOAuthTokensFromSessionToken({
-      grant_type: 'fxa-credentials',
-      client_id: PUBLIC_CLIENT_ID,
-      access_type: 'offline',
-      scope: SCOPE,
+      assert.ok(res.redirect);
+      assert.ok(res.code);
+      assert.equal(res.state, 'xyz');
     });
 
-    assert.ok(res.access_token);
-    assert.ok(res.refresh_token);
-    assert.equal(res.scope, SCOPE);
-    assert.ok(res.auth_at);
-    assert.ok(res.expires_in);
-    assert.ok(res.token_type);
-
-    // added a new device
-    devices = await client.devicesWithRefreshToken(res.refresh_token);
-    assert.equal(devices.length, 1, 'new device');
-    assert.equal(devices[0].name, OAUTH_CLIENT_NAME);
-  });
-
-  it('successfully grants tokens via authentication code flow, and refresh token flow', async () => {
-    const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
-
-    let devices = await client.devices();
-    assert.equal(devices.length, 0, 'no devices yet');
-
-    let res = await client.createAuthorizationCode({
-      client_id: PUBLIC_CLIENT_ID,
-      state: 'abc',
-      code_challenge: MOCK_CODE_CHALLENGE,
-      code_challenge_method: 'S256',
-      scope: SCOPE,
-      access_type: 'offline',
-    });
-    assert.ok(res.code);
-
-    devices = await client.devices();
-    assert.equal(devices.length, 0, 'no devices yet');
-
-    res = await client.grantOAuthTokens({
-      client_id: PUBLIC_CLIENT_ID,
-      code: res.code,
-      code_verifier: MOCK_CODE_VERIFIER,
-    });
-    assert.ok(res.access_token);
-    assert.ok(res.refresh_token);
-    assert.ok(res.id_token);
-    assert.equal(res.scope, SCOPE);
-    assert.ok(res.auth_at);
-    assert.ok(res.expires_in);
-    assert.ok(res.token_type);
-
-    const idToken = decodeJWT(res.id_token);
-    assert.strictEqual(idToken.claims.aud, PUBLIC_CLIENT_ID);
-
-    devices = await client.devices();
-    assert.equal(devices.length, 1, 'has a new device after the code grant');
-
-    const res2 = await client.grantOAuthTokens({
-      client_id: PUBLIC_CLIENT_ID,
-      grant_type: 'refresh_token',
-      refresh_token: res.refresh_token,
-    });
-    assert.ok(res2.access_token);
-    assert.notOk(res2.id_token);
-    assert.equal(res2.scope, OAUTH_SCOPE_OLD_SYNC);
-    assert.ok(res2.expires_in);
-    assert.ok(res2.token_type);
-    assert.notEqual(res.access_token, res2.access_token);
-
-    devices = await client.devices();
-    assert.equal(
-      devices.length,
-      1,
-      'still only one device after a refresh_token grant'
-    );
-  });
-
-  it('successfully propagates `resource` and `clientId` in the ID token `aud` claim', async () => {
-    const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
-
-    let devices = await client.devices();
-    assert.equal(devices.length, 0, 'no devices yet');
-
-    let res = await client.createAuthorizationCode({
-      client_id: PUBLIC_CLIENT_ID,
-      state: 'abc',
-      code_challenge: MOCK_CODE_CHALLENGE,
-      code_challenge_method: 'S256',
-      scope: SCOPE,
-      access_type: 'offline',
-    });
-    assert.ok(res.code);
-
-    devices = await client.devices();
-    assert.equal(devices.length, 0, 'no devices yet');
-
-    res = await client.grantOAuthTokens({
-      client_id: PUBLIC_CLIENT_ID,
-      code: res.code,
-      code_verifier: MOCK_CODE_VERIFIER,
-      resource: 'https://resource.server.com',
-    });
-    assert.ok(res.access_token);
-    assert.ok(res.refresh_token);
-    assert.ok(res.id_token);
-    assert.equal(res.scope, SCOPE);
-    assert.ok(res.auth_at);
-    assert.ok(res.expires_in);
-    assert.ok(res.token_type);
-
-    const idToken = decodeJWT(res.id_token);
-    assert.deepEqual(idToken.claims.aud, [
-      PUBLIC_CLIENT_ID,
-      'https://resource.server.com',
-    ]);
-  });
-
-  it('successfully grants JWT access tokens via authentication code flow, and refresh token flow', async () => {
-    const SCOPE = 'openid';
-
-    const codeRes = await client.createAuthorizationCode({
-      client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
-      state: 'abc',
-      scope: SCOPE,
-      access_type: 'offline',
-    });
-    assert.ok(codeRes.code);
-    const tokenRes = await client.grantOAuthTokens({
-      client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
-      client_secret: JWT_ACCESS_TOKEN_SECRET,
-      code: codeRes.code,
-      ppid_seed: 100,
-    });
-    assert.ok(tokenRes.access_token);
-    assert.ok(tokenRes.refresh_token);
-    assert.ok(tokenRes.id_token);
-    assert.equal(tokenRes.scope, SCOPE);
-    assert.ok(tokenRes.auth_at);
-    assert.ok(tokenRes.expires_in);
-    assert.ok(tokenRes.token_type);
-    const tokenJWT = decodeJWT(tokenRes.access_token);
-    assert.ok(tokenJWT.claims.sub);
-    assert.strictEqual(tokenJWT.claims.aud, JWT_ACCESS_TOKEN_CLIENT_ID);
-
-    const refreshTokenRes = await client.grantOAuthTokens({
-      client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
-      client_secret: JWT_ACCESS_TOKEN_SECRET,
-      refresh_token: tokenRes.refresh_token,
-      grant_type: 'refresh_token',
-      ppid_seed: 100,
-      resource: 'https://resource.server1.com',
-      scope: SCOPE,
-    });
-    assert.ok(refreshTokenRes.access_token);
-    assert.notOk(refreshTokenRes.id_token);
-    assert.equal(refreshTokenRes.scope, '');
-    assert.ok(refreshTokenRes.expires_in);
-    assert.ok(refreshTokenRes.token_type);
-
-    const refreshTokenJWT = decodeJWT(refreshTokenRes.access_token);
-
-    assert.equal(tokenJWT.claims.sub, refreshTokenJWT.claims.sub);
-    assert.deepEqual(refreshTokenJWT.claims.aud, [
-      JWT_ACCESS_TOKEN_CLIENT_ID,
-      'https://resource.server1.com',
-    ]);
-
-    const clientRotatedRes = await client.grantOAuthTokens({
-      client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
-      client_secret: JWT_ACCESS_TOKEN_SECRET,
-      refresh_token: tokenRes.refresh_token,
-      grant_type: 'refresh_token',
-      ppid_seed: 101,
-      scope: SCOPE,
-    });
-    assert.ok(clientRotatedRes.access_token);
-    assert.notOk(clientRotatedRes.id_token);
-    assert.equal(clientRotatedRes.scope, '');
-    assert.ok(clientRotatedRes.expires_in);
-    assert.ok(clientRotatedRes.token_type);
-
-    const clientRotatedJWT = decodeJWT(clientRotatedRes.access_token);
-    assert.notEqual(tokenJWT.claims.sub, clientRotatedJWT.claims.sub);
-  });
-
-  it('successfully revokes access tokens, and refresh tokens', async () => {
-    let res = await client.createAuthorizationCode({
-      client_id: PUBLIC_CLIENT_ID,
-      state: 'abc',
-      code_challenge: MOCK_CODE_CHALLENGE,
-      code_challenge_method: 'S256',
-      scope: 'profile openid',
-      access_type: 'offline',
-    });
-    assert.ok(res.code);
-
-    res = await client.grantOAuthTokens({
-      client_id: PUBLIC_CLIENT_ID,
-      code: res.code,
-      code_verifier: MOCK_CODE_VERIFIER,
-    });
-    assert.ok(res.access_token);
-    assert.ok(res.refresh_token);
-
-    let tokenStatus = await client.api.introspect(res.access_token);
-    assert.equal(tokenStatus.active, true);
-
-    await client.revokeOAuthToken({
-      client_id: PUBLIC_CLIENT_ID,
-      token: res.access_token,
+    it('rejects `assertion` parameter in /authorization request', async () => {
+      try {
+        await client.createAuthorizationCode({
+          client_id: PUBLIC_CLIENT_ID,
+          state: 'xyz',
+          assertion: 'a~b',
+        });
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+        assert.equal(
+          err.validation.keys[0],
+          'assertion',
+          'assertion param caught in validation'
+        );
+      }
     });
 
-    tokenStatus = await client.api.introspect(res.access_token);
-    assert.equal(tokenStatus.active, false);
-
-    const res2 = await client.grantOAuthTokens({
-      client_id: PUBLIC_CLIENT_ID,
-      grant_type: 'refresh_token',
-      refresh_token: res.refresh_token,
+    it('rejects `resource` parameter in /authorization request', async () => {
+      try {
+        await client.createAuthorizationCode({
+          client_id: PUBLIC_CLIENT_ID,
+          state: 'xyz',
+          code_challenge: MOCK_CODE_CHALLENGE,
+          code_challenge_method: 'S256',
+          resource: 'https://resource.server.com',
+        });
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+        assert.equal(
+          err.validation.keys[0],
+          'resource',
+          'resource param caught in validation'
+        );
+      }
     });
-    assert.ok(res2.access_token);
-    assert.notExists(res2.refresh_token);
 
-    tokenStatus = await client.api.introspect(res.refresh_token);
-    assert.equal(tokenStatus.active, true);
+    it('successfully grants tokens from sessionToken and notifies user', async () => {
+      const SCOPE = OAUTH_SCOPE_OLD_SYNC;
 
-    await client.revokeOAuthToken({
-      client_id: PUBLIC_CLIENT_ID,
-      token: res.refresh_token,
+      let devices = await client.devices();
+      assert.equal(devices.length, 0, 'no devices yet');
+
+      const res = await client.grantOAuthTokensFromSessionToken({
+        grant_type: 'fxa-credentials',
+        client_id: PUBLIC_CLIENT_ID,
+        access_type: 'offline',
+        scope: SCOPE,
+      });
+
+      assert.ok(res.access_token);
+      assert.ok(res.refresh_token);
+      assert.equal(res.scope, SCOPE);
+      assert.ok(res.auth_at);
+      assert.ok(res.expires_in);
+      assert.ok(res.token_type);
+
+      // added a new device
+      devices = await client.devicesWithRefreshToken(res.refresh_token);
+      assert.equal(devices.length, 1, 'new device');
+      assert.equal(devices[0].name, OAUTH_CLIENT_NAME);
     });
 
-    try {
-      await client.grantOAuthTokens({
+    it('successfully grants tokens via authentication code flow, and refresh token flow', async () => {
+      const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
+
+      let devices = await client.devices();
+      assert.equal(devices.length, 0, 'no devices yet');
+
+      let res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        state: 'abc',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: SCOPE,
+        access_type: 'offline',
+      });
+      assert.ok(res.code);
+
+      devices = await client.devices();
+      assert.equal(devices.length, 0, 'no devices yet');
+
+      res = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      assert.ok(res.access_token);
+      assert.ok(res.refresh_token);
+      assert.ok(res.id_token);
+      assert.equal(res.scope, SCOPE);
+      assert.ok(res.auth_at);
+      assert.ok(res.expires_in);
+      assert.ok(res.token_type);
+
+      const idToken = decodeJWT(res.id_token);
+      assert.strictEqual(idToken.claims.aud, PUBLIC_CLIENT_ID);
+
+      devices = await client.devices();
+      assert.equal(devices.length, 1, 'has a new device after the code grant');
+
+      const res2 = await client.grantOAuthTokens({
         client_id: PUBLIC_CLIENT_ID,
         grant_type: 'refresh_token',
         refresh_token: res.refresh_token,
       });
-      assert.fail('should have thrown');
-    } catch (err) {
-      assert.equal(err.errno, error.ERRNO.INVALID_TOKEN);
-    }
-  });
+      assert.ok(res2.access_token);
+      assert.notOk(res2.id_token);
+      assert.equal(res2.scope, OAUTH_SCOPE_OLD_SYNC);
+      assert.ok(res2.expires_in);
+      assert.ok(res2.token_type);
+      assert.notEqual(res.access_token, res2.access_token);
 
-  it('successfully revokes JWT access tokens', async () => {
-    const codeRes = await client.createAuthorizationCode({
-      client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
-      state: 'abc',
-      scope: 'openid',
+      devices = await client.devices();
+      assert.equal(
+        devices.length,
+        1,
+        'still only one device after a refresh_token grant'
+      );
     });
-    assert.ok(codeRes.code);
-    const token = (
-      await client.grantOAuthTokens({
+
+    it('successfully propagates `resource` and `clientId` in the ID token `aud` claim', async () => {
+      const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
+
+      let devices = await client.devices();
+      assert.equal(devices.length, 0, 'no devices yet');
+
+      let res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        state: 'abc',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: SCOPE,
+        access_type: 'offline',
+      });
+      assert.ok(res.code);
+
+      devices = await client.devices();
+      assert.equal(devices.length, 0, 'no devices yet');
+
+      res = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+        resource: 'https://resource.server.com',
+      });
+      assert.ok(res.access_token);
+      assert.ok(res.refresh_token);
+      assert.ok(res.id_token);
+      assert.equal(res.scope, SCOPE);
+      assert.ok(res.auth_at);
+      assert.ok(res.expires_in);
+      assert.ok(res.token_type);
+
+      const idToken = decodeJWT(res.id_token);
+      assert.deepEqual(idToken.claims.aud, [
+        PUBLIC_CLIENT_ID,
+        'https://resource.server.com',
+      ]);
+    });
+
+    it('successfully grants JWT access tokens via authentication code flow, and refresh token flow', async () => {
+      const SCOPE = 'openid';
+
+      const codeRes = await client.createAuthorizationCode({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        state: 'abc',
+        scope: SCOPE,
+        access_type: 'offline',
+      });
+      assert.ok(codeRes.code);
+      const tokenRes = await client.grantOAuthTokens({
         client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
         client_secret: JWT_ACCESS_TOKEN_SECRET,
         code: codeRes.code,
         ppid_seed: 100,
-      })
-    ).access_token;
-    assert.ok(token);
+      });
+      assert.ok(tokenRes.access_token);
+      assert.ok(tokenRes.refresh_token);
+      assert.ok(tokenRes.id_token);
+      assert.equal(tokenRes.scope, SCOPE);
+      assert.ok(tokenRes.auth_at);
+      assert.ok(tokenRes.expires_in);
+      assert.ok(tokenRes.token_type);
+      const tokenJWT = decodeJWT(tokenRes.access_token);
+      assert.ok(tokenJWT.claims.sub);
+      assert.strictEqual(tokenJWT.claims.aud, JWT_ACCESS_TOKEN_CLIENT_ID);
 
-    const tokenJWT = decodeJWT(token);
-    assert.ok(tokenJWT.claims.sub);
+      const refreshTokenRes = await client.grantOAuthTokens({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        refresh_token: tokenRes.refresh_token,
+        grant_type: 'refresh_token',
+        ppid_seed: 100,
+        resource: 'https://resource.server1.com',
+        scope: SCOPE,
+      });
+      assert.ok(refreshTokenRes.access_token);
+      assert.notOk(refreshTokenRes.id_token);
+      assert.equal(refreshTokenRes.scope, '');
+      assert.ok(refreshTokenRes.expires_in);
+      assert.ok(refreshTokenRes.token_type);
 
-    await client.revokeOAuthToken({
-      client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
-      client_secret: JWT_ACCESS_TOKEN_SECRET,
-      token,
+      const refreshTokenJWT = decodeJWT(refreshTokenRes.access_token);
+
+      assert.equal(tokenJWT.claims.sub, refreshTokenJWT.claims.sub);
+      assert.deepEqual(refreshTokenJWT.claims.aud, [
+        JWT_ACCESS_TOKEN_CLIENT_ID,
+        'https://resource.server1.com',
+      ]);
+
+      const clientRotatedRes = await client.grantOAuthTokens({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        refresh_token: tokenRes.refresh_token,
+        grant_type: 'refresh_token',
+        ppid_seed: 101,
+        scope: SCOPE,
+      });
+      assert.ok(clientRotatedRes.access_token);
+      assert.notOk(clientRotatedRes.id_token);
+      assert.equal(clientRotatedRes.scope, '');
+      assert.ok(clientRotatedRes.expires_in);
+      assert.ok(clientRotatedRes.token_type);
+
+      const clientRotatedJWT = decodeJWT(clientRotatedRes.access_token);
+      assert.notEqual(tokenJWT.claims.sub, clientRotatedJWT.claims.sub);
+    });
+
+    it('successfully revokes access tokens, and refresh tokens', async () => {
+      let res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        state: 'abc',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: 'profile openid',
+        access_type: 'offline',
+      });
+      assert.ok(res.code);
+
+      res = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      assert.ok(res.access_token);
+      assert.ok(res.refresh_token);
+
+      let tokenStatus = await client.api.introspect(res.access_token);
+      assert.equal(tokenStatus.active, true);
+
+      await client.revokeOAuthToken({
+        client_id: PUBLIC_CLIENT_ID,
+        token: res.access_token,
+      });
+
+      tokenStatus = await client.api.introspect(res.access_token);
+      assert.equal(tokenStatus.active, false);
+
+      const res2 = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: res.refresh_token,
+      });
+      assert.ok(res2.access_token);
+      assert.notExists(res2.refresh_token);
+
+      tokenStatus = await client.api.introspect(res.refresh_token);
+      assert.equal(tokenStatus.active, true);
+
+      await client.revokeOAuthToken({
+        client_id: PUBLIC_CLIENT_ID,
+        token: res.refresh_token,
+      });
+
+      try {
+        await client.grantOAuthTokens({
+          client_id: PUBLIC_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: res.refresh_token,
+        });
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.INVALID_TOKEN);
+      }
+    });
+
+    it('successfully revokes JWT access tokens', async () => {
+      const codeRes = await client.createAuthorizationCode({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        state: 'abc',
+        scope: 'openid',
+      });
+      assert.ok(codeRes.code);
+      const token = (
+        await client.grantOAuthTokens({
+          client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+          client_secret: JWT_ACCESS_TOKEN_SECRET,
+          code: codeRes.code,
+          ppid_seed: 100,
+        })
+      ).access_token;
+      assert.ok(token);
+
+      const tokenJWT = decodeJWT(token);
+      assert.ok(tokenJWT.claims.sub);
+
+      await client.revokeOAuthToken({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        token,
+      });
+    });
+
+    it('sees correct keyRotationTimestamp after password change and password reset', async () => {
+      const keyData1 = (
+        await client.getScopedKeyData({
+          client_id: PUBLIC_CLIENT_ID,
+          scope: OAUTH_SCOPE_OLD_SYNC,
+        })
+      )[OAUTH_SCOPE_OLD_SYNC];
+
+      await client.changePassword('new password');
+      await server.mailbox.waitForEmail(email);
+      // eslint-disable-next-line require-atomic-updates
+      client = await Client.login(
+        config.publicUrl,
+        email,
+        'new password',
+        testOptions
+      );
+      await server.mailbox.waitForEmail(email);
+
+      const keyData2 = (
+        await client.getScopedKeyData({
+          client_id: PUBLIC_CLIENT_ID,
+          scope: OAUTH_SCOPE_OLD_SYNC,
+        })
+      )[OAUTH_SCOPE_OLD_SYNC];
+
+      assert.equal(
+        keyData1.keyRotationTimestamp,
+        keyData2.keyRotationTimestamp
+      );
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await client.verifyPasswordResetCode(code);
+      await client.resetPassword(password, {});
+      await server.mailbox.waitForEmail(email);
+
+      const keyData3 = (
+        await client.getScopedKeyData({
+          client_id: PUBLIC_CLIENT_ID,
+          scope: OAUTH_SCOPE_OLD_SYNC,
+        })
+      )[OAUTH_SCOPE_OLD_SYNC];
+
+      assert.ok(keyData2.keyRotationTimestamp < keyData3.keyRotationTimestamp);
     });
   });
-
-  it('sees correct keyRotationTimestamp after password change and password reset', async () => {
-    const keyData1 = (
-      await client.getScopedKeyData({
-        client_id: PUBLIC_CLIENT_ID,
-        scope: OAUTH_SCOPE_OLD_SYNC,
-      })
-    )[OAUTH_SCOPE_OLD_SYNC];
-
-    await client.changePassword('new password');
-    await server.mailbox.waitForEmail(email);
-    // eslint-disable-next-line require-atomic-updates
-    client = await Client.login(config.publicUrl, email, 'new password', testOptions);
-    await server.mailbox.waitForEmail(email);
-
-    const keyData2 = (
-      await client.getScopedKeyData({
-        client_id: PUBLIC_CLIENT_ID,
-        scope: OAUTH_SCOPE_OLD_SYNC,
-      })
-    )[OAUTH_SCOPE_OLD_SYNC];
-
-    assert.equal(keyData1.keyRotationTimestamp, keyData2.keyRotationTimestamp);
-
-    await client.forgotPassword();
-    const code = await server.mailbox.waitForCode(email);
-    await client.verifyPasswordResetCode(code);
-    await client.resetPassword(password, {});
-    await server.mailbox.waitForEmail(email);
-
-    const keyData3 = (
-      await client.getScopedKeyData({
-        client_id: PUBLIC_CLIENT_ID,
-        scope: OAUTH_SCOPE_OLD_SYNC,
-      })
-    )[OAUTH_SCOPE_OLD_SYNC];
-
-    assert.ok(keyData2.keyRotationTimestamp < keyData3.keyRotationTimestamp);
-  });
-});
-
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10376,19 +10376,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hapi/hawk@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@hapi/hawk@npm:8.0.0"
-  dependencies:
-    "@hapi/b64": 5.x.x
-    "@hapi/boom": 9.x.x
-    "@hapi/cryptiles": 5.x.x
-    "@hapi/hoek": 9.x.x
-    "@hapi/sntp": 4.x.x
-  checksum: 71b46194845d819c561f83a9d1e68f2e20d586700a1a21f5701511da3786f3b64d7edea7b145c5b6285a6ed884a1f15e279ca0370e4d6f7f6e3e8e5d384ce42b
-  languageName: node
-  linkType: hard
-
 "@hapi/heavy@npm:^7.0.1":
   version: 7.0.1
   resolution: "@hapi/heavy@npm:7.0.1"
@@ -10513,18 +10500,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hapi/sntp@npm:4.x.x":
-  version: 4.0.0
-  resolution: "@hapi/sntp@npm:4.0.0"
-  dependencies:
-    "@hapi/boom": 9.x.x
-    "@hapi/bounce": 2.x.x
-    "@hapi/hoek": 9.x.x
-    "@hapi/teamwork": 4.x.x
-  checksum: 4bab7212e747748ffaee23598b76570f75cd05627e2fabd0e31e740316009283e22f67be672ff3406b809ff91a0701533581caeeea3a2d6f39132473ad0a6b2e
-  languageName: node
-  linkType: hard
-
 "@hapi/somever@npm:^3.0.0":
   version: 3.0.1
   resolution: "@hapi/somever@npm:3.0.1"
@@ -10562,13 +10537,6 @@ __metadata:
     "@hapi/pez": ^5.0.1
     "@hapi/wreck": 17.x.x
   checksum: f10702ba7ab931752ee360c05d66586ed9ef3e1c77e2cb19532146e20843407b9014e3a064c0ce388683fcf99a1e9107b2a1cbf033fda3d7a02fae7c633a848b
-  languageName: node
-  linkType: hard
-
-"@hapi/teamwork@npm:4.x.x":
-  version: 4.0.0
-  resolution: "@hapi/teamwork@npm:4.0.0"
-  checksum: e23f66c52dd1abac855f0f60357d500274e3dea5dc2c473deaf84b9d23b27b00d653a70aab3a05359f1b34520e9bc71c533b36ceb90d486ee9e2770fad379651
   languageName: node
   linkType: hard
 
@@ -37986,7 +37954,6 @@ fsevents@~2.1.1:
     "@google-cloud/tasks": ^4.0.1
     "@googlemaps/google-maps-services-js": ^3.3.16
     "@hapi/hapi": ^20.2.1
-    "@hapi/hawk": ^8.0.0
     "@hapi/hoek": ^11.0.2
     "@mozilla/glean": ^4.0.0
     "@storybook/addon-controls": ^7.4.6


### PR DESCRIPTION
## Because

- We are planning on phasing out support for Hawk authentication
- We want our internal services to talk to each other by sending a Hawk like token

## This pull request

- Adds a new authentication stragey `hawk-fxa-token`, this checks for a Hawk like token ie `Hawk id="<token id>"`, extracts the id and then does the token lookup
- Does not validate the Hawk header
- Removes the Hawk library from fxa-auth-server
- Updates test

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9282

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
