### PR TITLE
fix(stripe-client): fix updateCustomer tax expand

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -52,7 +52,10 @@ export class StripeClient {
     customerId: string,
     params: Stripe.CustomerUpdateParams
   ) {
-    const result = await this.stripe.customers.update(customerId, params);
+    const result = await this.stripe.customers.update(customerId, {
+      ...params,
+      expand: ['tax'],
+    });
 
     return result as StripeCustomer;
   }


### PR DESCRIPTION
## Because

- Customer.tax should always be expanded.

## This pull request

- Expands Customer.tax for updateCustomer calls.