### PR TITLE
task(content,payments,settings): Enable sentry INP

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/sentry.js
+++ b/packages/fxa-content-server/app/scripts/lib/sentry.js
@@ -135,7 +135,11 @@ function SentryMetrics(config) {
     Sentry.init({
       ...opts,
       instrumenter: 'otel',
-      integrations: [new Sentry.BrowserTracing()],
+      integrations: [
+        Sentry.browserTracingIntegration({
+          enableInp: true,
+        }),
+      ],
       beforeSend(event) {
         event = tagFxaName(event, opts.clientName);
         event = beforeSend(event);

--- a/packages/fxa-payments-server/src/lib/sentry.js
+++ b/packages/fxa-payments-server/src/lib/sentry.js
@@ -140,7 +140,11 @@ SentryMetrics.prototype = {
 
       Sentry.init({
         ...opts,
-        integrations: [new Sentry.BrowserTracing()],
+        integrations: [
+          Sentry.browserTracingIntegration({
+            enableInp: true,
+          }),
+        ],
         beforeSend(event) {
           event = tagCriticalEvent(event);
           event = tagFxaName(event, opts.clientName);

--- a/packages/fxa-shared/sentry/browser.ts
+++ b/packages/fxa-shared/sentry/browser.ts
@@ -163,11 +163,14 @@ function configure(config: SentryConfigOpts, log?: ILogger) {
   disable();
 
   const opts = buildSentryConfig(config, log);
-
   try {
     Sentry.init({
       ...opts,
-      integrations: [new Sentry.BrowserTracing()],
+      integrations: [
+        Sentry.browserTracingIntegration({
+          enableInp: true,
+        }),
+      ],
       beforeSend: function (event: Sentry.Event, hint?: any) {
         return beforeSend(opts, event, hint);
       },


### PR DESCRIPTION
## Because

- FID (First Input Delay) metric is going away

## This pull request

- Turns on INP (Interaction to Next Paint) in the sentry's browser tracing integration

## Issue that this pull request solves

Closes: FXA-9278

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

We can now see INP metrics in sentry! (Note, I've set the environment to local and created this metrics by running fxa locally)
![image](https://github.com/mozilla/fxa/assets/94418270/bd64079f-b4a6-44f4-b12b-85f5fa983d68)


## Other information (Optional)

Turns out INP is not currently supported by firefox  :cry:... So when testing this locally I had to use chrome.
![image](https://github.com/mozilla/fxa/assets/94418270/25526f21-b5a7-4e6e-a67e-d1d35cb6234b)

