### PR TITLE
feat(l10n): add localizer client

### DIFF
--- a/libs/shared/l10n/src/index.ts
+++ b/libs/shared/l10n/src/index.ts
@@ -12,3 +12,5 @@ export * from './lib/other-languages';
 export * from './lib/parse-accept-language';
 export { default as supportedLanguages } from './lib/supported-languages.json';
 export * from './lib/localizer/localizer.base';
+export * from './lib/localizer/localizer.client';
+export * from './lib/localizer/localizer.client.bindings';

--- a/libs/shared/l10n/src/lib/localizer/localizer.base.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.base.ts
@@ -40,7 +40,7 @@ export class LocalizerBase {
   }
 
   protected createBundleGenerator(fetched: Record<string, string>) {
-    async function* generateBundles(currentLocales: string[]) {
+    function* generateBundles(currentLocales: string[]) {
       for (const locale of currentLocales) {
         const source = fetched[locale];
         if (source) {

--- a/libs/shared/l10n/src/lib/localizer/localizer.client.bindings.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.client.bindings.ts
@@ -1,0 +1,23 @@
+import type { LocalizerOpts } from './localizer.models';
+import { ILocalizerBindings } from './localizer.interfaces';
+
+export class LocalizerBindingsClient implements ILocalizerBindings {
+  readonly opts: LocalizerOpts;
+  constructor(opts?: LocalizerOpts) {
+    this.opts = Object.assign(
+      {
+        translations: {
+          basePath: './locales',
+        },
+      },
+      opts
+    );
+  }
+
+  async fetchResource(path: string): Promise<string> {
+    const response = await fetch(path);
+    const messages = await response.text();
+
+    return messages;
+  }
+}

--- a/libs/shared/l10n/src/lib/localizer/localizer.client.spec.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.client.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { LocalizerClient } from './localizer.client';
+import { ILocalizerBindings } from './localizer.interfaces';
+
+describe('LocalizerClient', () => {
+  let localizer: LocalizerClient;
+  const supportedLocales = ['en', 'fr'];
+  const bindings: ILocalizerBindings = {
+    opts: {
+      translations: {
+        basePath: '',
+      },
+    },
+    fetchResource: async (filePath) => {
+      const locale = filePath.split('/')[1];
+      switch (locale) {
+        case supportedLocales[0]:
+          return 'test-id = Test';
+        case supportedLocales[1]:
+          return 'test-id = Test Fr';
+        default:
+          throw new Error('Could not find locale');
+      }
+    },
+  };
+
+  beforeEach(async () => {
+    localizer = new LocalizerClient(bindings);
+  });
+
+  it('should be defined', () => {
+    expect(localizer).toBeDefined();
+    expect(localizer).toBeInstanceOf(LocalizerClient);
+  });
+
+  describe('setupReactLocalization', () => {
+    it('should successfully create instance of ReactLocalization', async () => {
+      const acceptLanguage = 'en,fr';
+      const { l10n, selectedLocale } = await localizer.setupReactLocalization(
+        acceptLanguage
+      );
+
+      expect(selectedLocale).toBe('en');
+      // Check that bundles exist for supported locales
+      for (const bundle of l10n['bundles']) {
+        expect(supportedLocales).toContainEqual(bundle.locales[0]);
+      }
+    });
+
+    it('reports error for invalid id', async () => {
+      const reportError = jest.fn();
+      const { l10n } = await localizer.setupReactLocalization(
+        'en',
+        reportError
+      );
+      l10n.getString('invalid_id');
+      expect(reportError).toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/shared/l10n/src/lib/localizer/localizer.client.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.client.ts
@@ -1,0 +1,27 @@
+import { ReactLocalization } from '@fluent/react';
+import { determineLocale } from '../determine-locale';
+import { parseAcceptLanguage } from '../parse-accept-language';
+import { LocalizerBase } from './localizer.base';
+import { ILocalizerBindings } from './localizer.interfaces';
+
+export class LocalizerClient extends LocalizerBase {
+  constructor(bindings: ILocalizerBindings) {
+    super(bindings);
+  }
+
+  async setupReactLocalization(
+    acceptLanguage: string,
+    reportError?: (error: Error) => void
+  ) {
+    const currentLocales = parseAcceptLanguage(acceptLanguage);
+    const selectedLocale = determineLocale(acceptLanguage);
+    const messages = await this.fetchMessages(currentLocales);
+    const generateBundles = this.createBundleGenerator(messages);
+    const l10n = new ReactLocalization(
+      generateBundles(currentLocales),
+      undefined,
+      reportError
+    );
+    return { l10n, selectedLocale };
+  }
+}

--- a/libs/shared/l10n/src/lib/localizer/localizer.provider.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.provider.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Provider } from '@nestjs/common';
-import { LocalizerBindingsServer, LocalizerServer } from './localizer.server';
+import { LocalizerServer } from './localizer.server';
+import { LocalizerBindingsServer } from './localizer.server.bindings';
 
 export const LocalizerServerFactory: Provider<LocalizerServer> = {
   provide: LocalizerServer,

--- a/libs/shared/l10n/src/lib/localizer/localizer.server.bindings.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.server.bindings.ts
@@ -1,0 +1,33 @@
+import { promises as fsPromises, existsSync } from 'fs';
+import { join } from 'path';
+import type { LocalizerOpts } from './localizer.models';
+import { ILocalizerBindings } from './localizer.interfaces';
+
+export class LocalizerBindingsServer implements ILocalizerBindings {
+  readonly opts: LocalizerOpts;
+  constructor(opts?: LocalizerOpts) {
+    this.opts = Object.assign(
+      {
+        translations: {
+          basePath: join(__dirname, '../../public/locales'),
+        },
+      },
+      opts
+    );
+
+    // Make sure config is legit
+    this.validateConfig();
+  }
+
+  protected async validateConfig() {
+    if (!existsSync(this.opts.translations.basePath)) {
+      throw new Error('Invalid ftl translations basePath');
+    }
+  }
+
+  async fetchResource(path: string): Promise<string> {
+    return fsPromises.readFile(path, {
+      encoding: 'utf8',
+    });
+  }
+}

--- a/libs/shared/l10n/src/lib/localizer/localizer.server.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.server.ts
@@ -3,38 +3,6 @@ import { LocalizerBase } from './localizer.base';
 import { Injectable } from '@nestjs/common';
 import supportedLanguages from '../supported-languages.json';
 import type { ILocalizerBindings } from './localizer.interfaces';
-import { promises as fsPromises, existsSync } from 'fs';
-import { join } from 'path';
-import type { LocalizerOpts } from './localizer.models';
-
-export class LocalizerBindingsServer implements ILocalizerBindings {
-  readonly opts: LocalizerOpts;
-  constructor(opts?: LocalizerOpts) {
-    this.opts = Object.assign(
-      {
-        translations: {
-          basePath: join(__dirname, '../../public/locales'),
-        },
-      },
-      opts
-    );
-
-    // Make sure config is legit
-    this.validateConfig();
-  }
-
-  protected async validateConfig() {
-    if (!existsSync(this.opts.translations.basePath)) {
-      throw new Error('Invalid ftl translations basePath');
-    }
-  }
-
-  async fetchResource(path: string): Promise<string> {
-    return fsPromises.readFile(path, {
-      encoding: 'utf8',
-    });
-  }
-}
 
 @Injectable()
 export class LocalizerServer extends LocalizerBase {

--- a/libs/shared/l10n/src/server.ts
+++ b/libs/shared/l10n/src/server.ts
@@ -1,2 +1,3 @@
 export * from './lib/localizer/localizer.server';
+export * from './lib/localizer/localizer.server.bindings';
 export * from './lib/localizer/localizer.provider';


### PR DESCRIPTION
## Because

- Need a Localizer implementation that can be used in a react client component.

## This pull request

- Creates LocalizerClient which instantiates an instance of ReactLocalization to be used by the LocalizationProvider.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Just missing some tests currently skipped.
