### PR TITLE
fix(test): fix prod oauth test

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -437,6 +437,10 @@ export class LoginPage extends BaseLayout {
     return header;
   }
 
+  waitForSigninPasswordHeader() {
+    return this.page.locator(selectors.SIGNIN_PASSWORD_HEADER);
+  }
+
   async clickSignIn() {
     return this.page.locator(selectors.SUBMIT_USER_SIGNED_IN).click();
   }
@@ -464,7 +468,7 @@ export class LoginPage extends BaseLayout {
     });
   }
 
-  async signInPasswordHeader() {
+  async enterPasswordHeader() {
     const header = this.page.locator(selectors.PASSWORD_HEADER);
     await header.waitFor();
     return header.isVisible();

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -66,8 +66,14 @@ export class RelierPage extends BaseLayout {
     return waitForNavigation;
   }
 
-  clickChooseFlow() {
-    return this.page.locator('button.sign-choose').click();
+  async clickChooseFlow() {
+    await this.page.waitForTimeout(1000); //necessary for production environment otherwise waitForURL times out
+    await this.page.locator('button.sign-choose').click();
+    // We need to add a `waitUntil` option here because the page gets redirected from
+    // /authorization to /oauth before the page is fully loaded.
+    return this.page.waitForURL(`${this.target.contentServerUrl}/oauth/**`, {
+      waitUntil: 'load',
+    });
   }
 
   async signInPromptNone() {

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -44,7 +44,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Email is prefilled
       await expect(await login.getPrefilledEmail()).toEqual(credentials.email);
-      expect(await login.signInPasswordHeader()).toEqual(true);
+      expect(await login.enterPasswordHeader()).toEqual(true);
 
       await login.useDifferentAccountLink();
 
@@ -61,7 +61,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Email is prefilled
       await expect(await login.getPrefilledEmail()).toEqual(credentials.email);
-      expect(await login.signInPasswordHeader()).toEqual(true);
+      expect(await login.enterPasswordHeader()).toEqual(true);
 
       await login.useDifferentAccountLink();
 
@@ -92,7 +92,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Email is prefilled
       await expect(await login.getPrefilledEmail()).toEqual(loginHintEmail);
-      expect(await login.signInPasswordHeader()).toEqual(true);
+      expect(await login.enterPasswordHeader()).toEqual(true);
 
       await login.useDifferentAccountLink();
 

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -172,10 +172,9 @@ test.describe('severity-1 #smoke', () => {
       // now suggest a cached login
       await relier.goto();
       await relier.clickChooseFlow();
-      await page.waitForURL(`${target.contentServerUrl}/oauth/**`);
 
       // User shown signin enter password page
-      expect(await login.signInPasswordHeader()).toEqual(true);
+      await expect(login.waitForSigninPasswordHeader()).toBeVisible();
     });
 
     test('verified, blocked', async ({ target, pages: { login, relier } }) => {
@@ -204,7 +203,7 @@ test.describe('severity-1 #smoke', () => {
       await login.unblock(blockedEmail);
 
       // After filling in the unblock code, the user is prompted again to enter password
-      expect(await login.signInPasswordHeader()).toEqual(true);
+      expect(await login.enterPasswordHeader()).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
## Because

- Prod oauth test was failing https://app.circleci.com/pipelines/github/mozilla/fxa/48563/workflows/9f57915b-6f6a-46c7-9228-795dd85e9fc5/jobs/489892/tests

## This pull request

- Replaces the wrong header function with the correct header function

## Issue that this pull request solves

Closes: FXA-9304

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I tried fixing the header function to use locator object but it was breaking around 15 tests (see the previous commit) as its been used in various places in login page object. We already have a follow up task [here](https://mozilla-hub.atlassian.net/browse/FXA-9379) to address this issue and to convert all remaining selector objects to locator objects.
