### PR TITLE
fix(signup): Disallow space-only passwords for React signup

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -296,7 +296,10 @@ export const FormPasswordWithBalloons = ({
               inputRef={register({
                 required: true,
                 validate: {
-                  length: (value: string) => value.length > 7,
+                  // TODO in FXA-7482, review our password requirements and best way to display them
+                  // For now, this most closely matches parity to Backbone for a space-only password
+                  length: (value: string) =>
+                    value.length > 7 && value.trim() !== '',
                   notEmail: (value: string) => {
                     return !passwordValidator.isSameAsEmail(
                       value.toLowerCase()


### PR DESCRIPTION
Because:
* We want to disallow space-only passwords

This commit:
* Includes a bandaid fix for React signup to disallow this by showing the "password must be at least 8 characters" error message. This is to meet parity with Backbone and we will revisit PW requirements in FXA-7482

closes FXA-9301

---

See [this thread in Slack](https://mozilla.slack.com/archives/C04LVV8V8BA/p1711643764605569). In Backbone this shows up as a tooltip after the user submits but here it will show in the PW balloon until we've decided how we want to do this. Backbone doesn't do a `trim()` option (it allows a trailing space at the end of a 7-character input, making it 8) but the check for a full empty PW does get converted to an empty string at some point during submit validation.

<img width="500" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/632e21f5-0d7b-45a6-915e-0d41cc544596">
