### PR TITLE
fix(react): Handle 2FA required error, enable React inline 2FA setup under signin flag

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -5,7 +5,6 @@
 // Shared implementation of `signIn` view method
 
 import AuthErrors from '../../lib/auth-errors';
-import GeneralizedReactAppExperimentMixin from '../../lib/generalized-react-app-experiment-mixin';
 import GleanMetrics from '../../lib/glean';
 import OAuthErrors from '../../lib/oauth-errors';
 import NavigateBehavior from '../behaviors/navigate';
@@ -15,11 +14,7 @@ import VerificationReasons from '../../lib/verification-reasons';
 import PushLoginExperiment from './push-login-experiment-mixin';
 
 export default {
-  dependsOn: [
-    GeneralizedReactAppExperimentMixin,
-    ResumeTokenMixin,
-    PushLoginExperiment,
-  ],
+  dependsOn: [ResumeTokenMixin, PushLoginExperiment],
 
   /**
    * Sign in a user
@@ -137,14 +132,6 @@ export default {
           AuthErrors.is(err, 'INSUFFICIENT_ACR_VALUES') ||
           OAuthErrors.is(err, 'MISMATCH_ACR_VALUES')
         ) {
-          if (
-            this.isInReactExperiment() &&
-            this.config?.showReactApp?.inlineTotpRoutes
-          ) {
-            return this.window.location.assign(
-              `/inline_totp_setup${this.window.location.search}`
-            );
-          }
           return this.navigate('inline_totp_setup', {
             account: account,
             onSubmitComplete: this.onSignInSuccess.bind(this),

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -81,7 +81,6 @@ const settingsConfig = {
   showReactApp: {
     signUpRoutes: config.get('showReactApp.signUpRoutes'),
     signInRoutes: config.get('showReactApp.signInRoutes'),
-    inlineTotpRoutes: config.get('showReactApp.inlineTotpRoutes'),
   },
   rolloutRates: {
     keyStretchV2: config.get('rolloutRates.keyStretchV2'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -288,12 +288,6 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'REACT_CONVERSION_WEB_CHANNEL_EXAMPLE_ROUTES',
     },
-    inlineTotpRoutes: {
-      default: false,
-      doc: 'Enable users to visit the "inline" 2fa setup routes',
-      format: Boolean,
-      env: 'REACT_CONVERSION_INLINE_TOTP_ROUTES',
-    },
   },
   brandMessagingMode: {
     default: 'none',

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -76,6 +76,8 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signin_unblock',
         'force_auth',
         'signin_recovery_code',
+        'inline_totp_setup',
+        'inline_recovery_setup',
       ]),
       fullProdRollout: false,
     },
@@ -123,15 +125,6 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
     webChannelExampleRoutes: {
       featureFlagOn: showReactApp.webChannelExampleRoutes,
       routes: reactRoute.getRoutes(['web_channel_example']),
-      fullProdRollout: false,
-    },
-
-    inlineTotpRoutes: {
-      featureFlagOn: showReactApp.inlineTotpRoutes,
-      routes: reactRoute.getRoutes([
-        'inline_totp_setup',
-        'inline_recovery_setup',
-      ]),
       fullProdRollout: false,
     },
   };

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -57,7 +57,6 @@ type ShowReactApp = {
   postVerifyCADViaQRRoutes: boolean;
   postVerifyThirdPartyAuthRoutes: boolean;
   webChannelExampleRoutes: boolean;
-  inlineTotpRoutes: boolean;
 };
 
 export interface ReactRouteGroups {

--- a/packages/fxa-content-server/tests/server/routes/react-app.js
+++ b/packages/fxa-content-server/tests/server/routes/react-app.js
@@ -40,7 +40,6 @@ const showReactAppAll = {
   pairRoutes: true,
   postVerifyOtherRoutes: true,
   postVerifyCADViaQRRoutes: true,
-  inlineTotpRoutes: true,
 };
 
 function getEmptyClientReactRouteGroups(showReactApp = showReactAppAll) {

--- a/packages/fxa-settings/src/components/DataBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.stories.tsx
@@ -5,7 +5,8 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import DataBlock from './index';
+import { Subject } from './mocks';
+import DataBlock from '.';
 
 export default {
   title: 'Components/DataBlock',
@@ -13,20 +14,14 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const SingleCodeInlineCopy = () => (
-  <DataBlock value="ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F" isInline />
-);
+export const SingleCodeInlineCopy = () => <Subject isInline />;
 
-export const SingleCode = () => (
-  <DataBlock value="ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F" />
-);
+export const SingleCode = () => <Subject />;
 
-export const SingleCodeOnIOS = () => (
-  <DataBlock value="ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F" isIOS />
-);
+export const SingleCodeOnIOS = () => <Subject isIOS />;
 
 export const MultipleCodes = () => (
-  <DataBlock
+  <Subject
     value={[
       'C1OFZW7R04',
       'XVKRLKERT4',

--- a/packages/fxa-settings/src/components/DataBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.test.tsx
@@ -5,10 +5,8 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import { Account, AppContext } from '../../models';
-import DataBlock from './index';
 import { act } from 'react-dom/test-utils';
-import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
+import { Subject } from './mocks';
 
 const singleValue = 'ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F';
 
@@ -23,41 +21,25 @@ const multiValue = [
   'D4J6KY8FL4',
 ];
 
-const account = {
-  ...MOCK_ACCOUNT,
-} as unknown as Account;
-
 Object.defineProperty(window.navigator, 'clipboard', {
   value: { writeText: jest.fn() },
 });
 window.URL.createObjectURL = jest.fn();
 
 it('can render single values', () => {
-  renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock value={singleValue} />
-    </AppContext.Provider>
-  );
+  renderWithLocalizationProvider(<Subject />);
   expect(screen.getByText(singleValue)).toBeInTheDocument();
 });
 
 it('can render multiple values', () => {
-  renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock value={multiValue} />
-    </AppContext.Provider>
-  );
+  renderWithLocalizationProvider(<Subject value={multiValue} />);
   multiValue.forEach((value) => {
     expect(screen.getByText(value)).toBeInTheDocument();
   });
 });
 
 it('can apply spacing to multiple values', () => {
-  renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock value={multiValue} separator=" " />
-    </AppContext.Provider>
-  );
+  renderWithLocalizationProvider(<Subject value={multiValue} separator=" " />);
 
   expect(screen.getByTestId('datablock').textContent?.trim()).toEqual(
     multiValue.join(' ')
@@ -66,9 +48,7 @@ it('can apply spacing to multiple values', () => {
 
 it('displays only Copy icon in iOS', () => {
   renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock value={multiValue} separator=" " isIOS />
-    </AppContext.Provider>
+    <Subject value={multiValue} separator=" " isIOS />
   );
 
   expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
@@ -81,11 +61,7 @@ it('displays only Copy icon in iOS', () => {
 });
 
 it('displays a tooltip on action', async () => {
-  renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock value={multiValue} />
-    </AppContext.Provider>
-  );
+  renderWithLocalizationProvider(<Subject value={multiValue} />);
   await act(async () => {
     fireEvent.click(await screen.findByTestId('databutton-copy'));
   });
@@ -96,12 +72,7 @@ it('displays a tooltip on action', async () => {
 
 it('sets download file name', async () => {
   renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock
-        value={multiValue}
-        contentType="Firefox account recovery key"
-      />
-    </AppContext.Provider>
+    <Subject value={multiValue} contentType="Firefox account recovery key" />
   );
   let element = await screen.findByTestId('databutton-download');
   expect(element).toBeInTheDocument();
@@ -111,11 +82,7 @@ it('sets download file name', async () => {
 });
 
 it('sets has fallback download file name', async () => {
-  renderWithLocalizationProvider(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <DataBlock value={multiValue} />
-    </AppContext.Provider>
-  );
+  renderWithLocalizationProvider(<Subject value={multiValue} />);
   const element = await screen.findByTestId('databutton-download');
   expect(element).toBeInTheDocument();
   expect(element.getAttribute('download')).toContain('Firefox.txt');

--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -29,6 +29,7 @@ export type DataBlockProps = {
   onAction?: actionFn;
   isIOS?: boolean;
   isInline?: boolean;
+  email: string;
 };
 
 export const DataBlock = ({
@@ -40,6 +41,7 @@ export const DataBlock = ({
   onAction = () => {},
   isIOS = false,
   isInline = false,
+  email,
 }: DataBlockProps) => {
   const valueIsArray = Array.isArray(value);
   const [performedAction, setPerformedAction] = useState<actions>();
@@ -95,18 +97,24 @@ export const DataBlock = ({
         )}
         {isInline && (
           <GetDataCopySingletonInline
-            {...{ value, onAction: actionCb, setTooltipVisible }}
+            {...{ value, onAction: actionCb, setTooltipVisible, email }}
           />
         )}
       </div>
       {isIOS && !isInline && (
         <GetDataCopySingleton
-          {...{ value, onAction: actionCb, setTooltipVisible }}
+          {...{ value, onAction: actionCb, setTooltipVisible, email }}
         />
       )}
       {!isIOS && !isInline && (
         <GetDataTrio
-          {...{ value, contentType, onAction: actionCb, setTooltipVisible }}
+          {...{
+            value,
+            contentType,
+            onAction: actionCb,
+            setTooltipVisible,
+            email,
+          }}
         />
       )}
     </div>

--- a/packages/fxa-settings/src/components/DataBlock/mocks.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/mocks.tsx
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import DataBlock, { DataBlockProps } from '.';
+import { MOCK_EMAIL } from '../../pages/mocks';
+
+export const Subject = ({
+  value = 'ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F',
+  ...props // overrides
+}: Partial<DataBlockProps> = {}) => (
+  <DataBlock email={MOCK_EMAIL} {...{ value, ...props }} />
+);

--- a/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
@@ -9,6 +9,7 @@ import GetDataTrio, {
   GetDataCopySingletonInline,
 } from './index';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MOCK_EMAIL } from '../../pages/mocks';
 
 export default {
   title: 'Components/GetDataTrio',
@@ -20,7 +21,11 @@ export const Default = () => {
   const [, setTooltipVisible] = useState(false);
   return (
     <div className="p-10 max-w-xs">
-      <GetDataTrio value="Copy that" {...{ setTooltipVisible }} />
+      <GetDataTrio
+        value="Copy that"
+        email={MOCK_EMAIL}
+        {...{ setTooltipVisible }}
+      />
     </div>
   );
 };
@@ -29,7 +34,11 @@ export const SingleCopyButton = () => {
   const [, setTooltipVisible] = useState(false);
   return (
     <div className="p-10 max-w-xs">
-      <GetDataCopySingleton value="Copy that" {...{ setTooltipVisible }} />
+      <GetDataCopySingleton
+        value="Copy that"
+        email={MOCK_EMAIL}
+        {...{ setTooltipVisible }}
+      />
     </div>
   );
 };
@@ -40,6 +49,7 @@ export const SingleCopyButtonInline = () => {
     <div className="p-10 max-w-xs">
       <GetDataCopySingletonInline
         value="Copy that"
+        email={MOCK_EMAIL}
         {...{ setTooltipVisible }}
       />
     </div>

--- a/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
@@ -5,23 +5,22 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import { Account, AppContext } from '../../models';
 import GetDataTrio from './index';
-import { MOCK_ACCOUNT } from '../../models/mocks';
+import { MOCK_EMAIL } from '../../pages/mocks';
 
 const contentType = 'Firefox account recovery key';
 const value = 'Sun Tea';
 const url = 'https://mozilla.org';
 
-const account = { ...MOCK_ACCOUNT } as unknown as Account;
 const setTooltipVisible = jest.fn();
 
 it('renders Trio as expected', () => {
   window.URL.createObjectURL = jest.fn();
   renderWithLocalizationProvider(
-    <AppContext.Provider value={{ account }}>
-      <GetDataTrio {...{ value, contentType, url, setTooltipVisible }} />
-    </AppContext.Provider>
+    <GetDataTrio
+      {...{ value, contentType, url, setTooltipVisible }}
+      email={MOCK_EMAIL}
+    />
   );
   expect(screen.getByTestId('databutton-download')).toBeInTheDocument();
   expect(screen.getByTestId('databutton-download')).toHaveAttribute(
@@ -35,9 +34,10 @@ it('renders Trio as expected', () => {
 it('renders single Copy button as expected', () => {
   window.URL.createObjectURL = jest.fn();
   renderWithLocalizationProvider(
-    <AppContext.Provider value={{ account }}>
-      <GetDataTrio {...{ value, contentType, url, setTooltipVisible }} />
-    </AppContext.Provider>
+    <GetDataTrio
+      {...{ value, contentType, url, setTooltipVisible }}
+      email={MOCK_EMAIL}
+    />
   );
   expect(screen.getByTestId('databutton-copy')).toBeInTheDocument();
 });

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as CopyIcon } from './copy.svg';
 import { ReactComponent as InlineCopyIcon } from './copy-inline.svg';
 import { ReactComponent as DownloadIcon } from './download.svg';
 import { ReactComponent as PrintIcon } from './print.svg';
-import { useAccount, useFtlMsgResolver } from '../../models';
+import { useFtlMsgResolver } from '../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
 export type DownloadContentType =
@@ -28,6 +28,7 @@ export type GetDataTrioProps = {
   contentType?: DownloadContentType;
   onAction?: (type: 'download' | 'copy' | 'print') => void;
   setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  email: string;
 };
 
 export const GetDataCopySingleton = ({
@@ -115,6 +116,7 @@ export const GetDataTrio = ({
   contentType,
   onAction,
   setTooltipVisible,
+  email,
 }: GetDataTrioProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
 
@@ -135,7 +137,6 @@ export const GetDataTrio = ({
     printWindow.print();
     printWindow.close();
   }, [value, pageTitle]);
-  const { primaryEmail } = useAccount();
 
   return (
     <div className="flex justify-between w-4/5 max-w-48">
@@ -150,7 +151,7 @@ export const GetDataTrio = ({
               type: 'text/plain',
             })
           )}
-          download={`${primaryEmail.email} ${contentType}.txt`}
+          download={`${email} ${contentType}.txt`}
           data-testid="databutton-download"
           className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
           onClick={() => {
@@ -170,7 +171,9 @@ export const GetDataTrio = ({
         </a>
       </FtlMsg>
 
-      <GetDataCopySingleton {...{ onAction, value, setTooltipVisible }} />
+      <GetDataCopySingleton
+        {...{ onAction, value, setTooltipVisible, email }}
+      />
 
       {/** This only opens the page that is responsible
        *   for triggering the print screen.

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.stories.tsx
@@ -8,6 +8,7 @@ import { Meta } from '@storybook/react';
 import { useFtlMsgResolver } from '../../../models';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { MOCK_RECOVERY_KEY_VALUE } from './mocks';
+import { MOCK_EMAIL } from '../../../pages/mocks';
 
 export default {
   title: 'Components/Settings/FlowRecoveryKeyDownload',
@@ -44,7 +45,9 @@ export const Default = () => {
         navigateBackward,
         navigateForward,
         viewName,
+        email: MOCK_EMAIL,
       }}
+      email={MOCK_EMAIL}
       recoveryKeyValue={MOCK_RECOVERY_KEY_VALUE}
     />
   );

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -8,6 +8,7 @@ import { logViewEvent } from '../../../lib/metrics';
 import FlowRecoveryKeyDownload from './';
 import { renderWithRouter } from '../../../models/mocks';
 import { MOCK_RECOVERY_KEY_VALUE } from './mocks';
+import { MOCK_EMAIL } from '../../../pages/mocks';
 
 const localizedBackButtonTitle = 'Back to settings';
 const localizedPageTitle = 'Account Recovery Key';
@@ -40,6 +41,7 @@ const renderFlowPage = () => {
         navigateBackward,
         viewName,
       }}
+      email={MOCK_EMAIL}
       recoveryKeyValue={MOCK_RECOVERY_KEY_VALUE}
     />
   );

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
@@ -34,6 +34,7 @@ export type FlowRecoveryKeyDownloadProps = {
   navigateForward: () => void;
   recoveryKeyValue: string;
   viewName: string;
+  email: string;
 };
 
 export const FlowRecoveryKeyDownload = ({
@@ -43,6 +44,7 @@ export const FlowRecoveryKeyDownload = ({
   navigateForward,
   recoveryKeyValue,
   viewName,
+  email,
 }: FlowRecoveryKeyDownloadProps) => {
   return (
     <FlowContainer
@@ -75,6 +77,7 @@ export const FlowRecoveryKeyDownload = ({
             logViewEvent(`flow.${viewName}`, `recovery-key.copy-option`)
           }
           isInline
+          {...{ email }}
         />
         <div className="bg-grey-10 p-4 rounded-lg text-grey-400 text-sm">
           <FtlMsg id="flow-recovery-key-download-storage-ideas-heading-v2">

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -146,6 +146,7 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
                   separator=" "
                   onCopy={copyRecoveryCodes}
                   contentType="Backup authentication codes"
+                  email={account.email}
                 />
               ) : (
                 <LoadingSpinner />

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -25,7 +25,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   usePageViewEvent(viewName);
   const location = useLocation();
 
-  const { recoveryKey } = useAccount();
+  const { recoveryKey, email } = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
   const navigate = useNavigate();
 
@@ -93,7 +93,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
       {/* Download recovery key */}
       {currentStep === 3 && (
         <FlowRecoveryKeyDownload
-          {...{ ...sharedStepProps }}
+          {...{ ...sharedStepProps, email }}
           recoveryKeyValue={formattedRecoveryKey}
         />
       )}

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -322,7 +322,8 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 onAction={logDataTrioActionEvent}
                 onCopy={copyRecoveryCodes}
                 contentType="Backup authentication codes"
-              ></DataBlock>
+                email={account.email}
+              />
             </div>
           </div>
           <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/en.ftl
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/en.ftl
@@ -19,6 +19,7 @@ inline-recovery-continue-button = Continue
 # This button allows user to verify one of their recovery codes to show they downloaded them
 inline-recovery-confirm-button = Confirm
 inline-recovery-back-link = Back
+inline-recovery-cancel-setup = Cancel setup
 # Label describing a text input where the user can enter one of their new authentication codes to prove they downloaded them
 inline-recovery-backup-authentication-code = Backup authentication code
 inline-recovery-confirmation-description = To ensure that you will be able to regain access to your account, in the event of a lost device, please enter one of your saved backup authentication codes.
@@ -29,3 +30,4 @@ inline-recovery-confirmation-header-default = Confirm backup authentication code
 # If more appropriate in a locale, the string within the <span>, "to continue to { $serviceName }" can stand alone as "Continue to { $serviceName }"
 # $serviceName - the name of the service which is using Mozilla accounts to authenticate
 inline-recovery-confirmation-header = Confirm backup authentication code <span>to continue to { $serviceName }</span>
+inline-recovery-2fa-enabled = Two-step authentication enabled

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import InlineRecoverySetup, { InlineRecoverySetupProps } from '.';
+import InlineRecoverySetup from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { MOCK_RECOVERY_CODES, MOCK_SERVICE_NAME } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { InlineRecoverySetupProps } from './interfaces';
+import { MOCK_EMAIL } from '../mocks';
 
 export default {
   title: 'Pages/InlineRecoverySetup',
@@ -38,7 +40,10 @@ export const Default = () => (
     cancelSetupHandler={cancelSetupHandler}
     verifyTotpHandler={verifyTotpHandler}
     successfulSetupHandler={successfulSetupHandler}
+    email={MOCK_EMAIL}
   />
 );
 
-export const WithServiceName = () => <ComponentWithRouter {...props} />;
+export const WithServiceName = () => (
+  <ComponentWithRouter {...props} email={MOCK_EMAIL} />
+);

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
@@ -5,11 +5,10 @@
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import InlineRecoverySetup from '.';
-import { REACT_ENTRYPOINT } from '../../constants';
-import { usePageViewEvent } from '../../lib/metrics';
 import { MozServices } from '../../lib/types';
 import { renderWithRouter } from '../../models/mocks';
 import { MOCK_RECOVERY_CODES, MOCK_SERVICE_NAME } from './mocks';
+import { MOCK_EMAIL } from '../mocks';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -37,7 +36,7 @@ describe('InlineRecoverySetup', () => {
   });
 
   it('renders default content as expected', () => {
-    renderWithRouter(<InlineRecoverySetup {...props} />);
+    renderWithRouter(<InlineRecoverySetup {...props} email={MOCK_EMAIL} />);
     screen.getByRole('heading', {
       name: `Save backup authentication codes to continue to ${MozServices.Default}`,
     });
@@ -56,7 +55,11 @@ describe('InlineRecoverySetup', () => {
 
   it('renders as expected with a custom service name', () => {
     renderWithRouter(
-      <InlineRecoverySetup serviceName={MOCK_SERVICE_NAME} {...props} />
+      <InlineRecoverySetup
+        serviceName={MOCK_SERVICE_NAME}
+        email={MOCK_EMAIL}
+        {...props}
+      />
     );
     screen.getByRole('heading', {
       name: `Save backup authentication codes to continue to ${MOCK_SERVICE_NAME}`,
@@ -64,7 +67,7 @@ describe('InlineRecoverySetup', () => {
   });
 
   it('renders "showConfirmation" content as expected', async () => {
-    renderWithRouter(<InlineRecoverySetup {...props} />);
+    renderWithRouter(<InlineRecoverySetup email={MOCK_EMAIL} {...props} />);
 
     await act(
       async () =>
@@ -83,7 +86,11 @@ describe('InlineRecoverySetup', () => {
 
   it('renders "showConfirmation" content as expected with a custom service name', async () => {
     renderWithRouter(
-      <InlineRecoverySetup serviceName={MOCK_SERVICE_NAME} {...props} />
+      <InlineRecoverySetup
+        email={MOCK_EMAIL}
+        serviceName={MOCK_SERVICE_NAME}
+        {...props}
+      />
     );
     await act(
       async () =>
@@ -96,7 +103,11 @@ describe('InlineRecoverySetup', () => {
 
   it('shows an error on incorrect recovery code submission', async () => {
     renderWithRouter(
-      <InlineRecoverySetup serviceName={MOCK_SERVICE_NAME} {...props} />
+      <InlineRecoverySetup
+        email={MOCK_EMAIL}
+        serviceName={MOCK_SERVICE_NAME}
+        {...props}
+      />
     );
     await act(
       async () =>
@@ -122,6 +133,7 @@ describe('InlineRecoverySetup', () => {
     renderWithRouter(
       <InlineRecoverySetup
         serviceName={MOCK_SERVICE_NAME}
+        email={MOCK_EMAIL}
         {...props}
         {...{ verifyTotpHandler, successfulSetupHandler }}
       />
@@ -153,6 +165,7 @@ describe('InlineRecoverySetup', () => {
     const successfulSetupHandler = jest.fn();
     renderWithRouter(
       <InlineRecoverySetup
+        email={MOCK_EMAIL}
         serviceName={MOCK_SERVICE_NAME}
         {...props}
         {...{ verifyTotpHandler, successfulSetupHandler }}

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -4,7 +4,6 @@
 
 import React, { useCallback, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
 import DataBlock from '../../components/DataBlock';
@@ -18,14 +17,7 @@ import {
   AuthUiErrors,
   composeAuthUiErrorTranslationId,
 } from '../../lib/auth-errors/auth-errors';
-
-export type InlineRecoverySetupProps = {
-  recoveryCodes: Array<string>;
-  serviceName?: MozServices;
-  cancelSetupHandler: () => void;
-  verifyTotpHandler: () => Promise<boolean>;
-  successfulSetupHandler: () => void;
-};
+import { InlineRecoverySetupProps } from './interfaces';
 
 const InlineRecoverySetup = ({
   recoveryCodes,
@@ -33,6 +25,7 @@ const InlineRecoverySetup = ({
   cancelSetupHandler,
   verifyTotpHandler,
   successfulSetupHandler,
+  email,
 }: InlineRecoverySetupProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedIncorrectBackupCodeError = ftlMsgResolver.getMsg(
@@ -55,8 +48,8 @@ const InlineRecoverySetup = ({
         <Banner type={BannerType.success}>
           <p>
             {ftlMsgResolver.getMsg(
-              'postAddTwoStepAuthentication-title-2',
-              'You turned on two-step authentication'
+              'inline-recovery-2fa-enabled',
+              'Two-step authentication enabled'
             )}
           </p>
         </Banner>
@@ -199,7 +192,8 @@ const InlineRecoverySetup = ({
               separator=" "
               onCopy={copyRecoveryCodes}
               contentType="Backup authentication codes"
-            ></DataBlock>
+              {...{ email }}
+            />
             <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">
               <FtlMsg id="inline-recovery-cancel-button">
                 <button

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/interfaces.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MozServices } from '../../lib/types';
+import { SigninLocationState, TotpToken } from './../Signin/interfaces';
+
+export type SigninRecoveryLocationState = SigninLocationState & {
+  totp: TotpToken;
+};
+
+export interface InlineRecoverySetupProps {
+  recoveryCodes: Array<string>;
+  serviceName?: MozServices;
+  cancelSetupHandler: () => void;
+  verifyTotpHandler: () => Promise<boolean>;
+  successfulSetupHandler: () => void;
+  email: string;
+}

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
@@ -40,3 +40,6 @@ inline-totp-setup-on-completion-description = Once complete, it will begin gener
 
 # The "authentication code" here refers to the code provided by an authentication app.
 inline-totp-setup-security-code-placeholder = Authentication code
+# The "authentication code" here refers to the code provided by an authentication app.
+inline-totp-setup-code-required-error = Authentication code required
+tfa-qr-code-alt = Use the code { $code } to set up two-step authentication in supported applications.

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -4,25 +4,15 @@
 
 import React, { useState, useCallback } from 'react';
 import classNames from 'classnames';
-import { MozServices } from '../../lib/types';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { Account, useFtlMsgResolver } from '../../models';
+import { useFtlMsgResolver } from '../../models';
 import { TwoFactorAuthImage } from '../../components/images';
 import CardHeader from '../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode from '../../components/FormVerifyCode';
 import AppLayout from '../../components/AppLayout';
 import Banner, { BannerType } from '../../components/Banner';
-
-export type TotpToken = Awaited<ReturnType<Account['createTotp']>>;
-
-type InlineTotpSetupProps = {
-  totp: TotpToken;
-  email: string;
-  serviceName?: MozServices;
-  cancelSetupHandler: () => void;
-  verifyCodeHandler: (code: string) => void;
-};
+import { InlineTotpSetupProps } from './interfaces';
 
 export const InlineTotpSetup = ({
   totp,

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MozServices } from '../../lib/types';
+import { TotpToken } from '../Signin/interfaces';
+
+export interface InlineTotpSetupProps {
+  totp: TotpToken;
+  email: string;
+  serviceName?: MozServices;
+  cancelSetupHandler: () => void;
+  verifyCodeHandler: (code: string) => void;
+}

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
@@ -1,6 +1,29 @@
-export const MOCK_EMAIL = 'example@example.com';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MOCK_SESSION_TOKEN, MOCK_UID } from '../mocks';
+
 export const MOCK_TOTP_TOKEN = {
   secret: '1234567890',
   qrCodeUrl: 'data:image/png;base64,pewpewpew',
   recoveryCodes: ['recoveryCode1', 'recoveryCode2'],
+};
+export const MOCK_QUERY_PARAMS = {
+  client_id: 'dcdb5ae7add825d2',
+  pkce_client_id: '38a6b9b3a65a1871',
+  redirect_uri: 'http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth',
+  scope: 'profile%20openid',
+  acr_values: 'AAL2',
+};
+export const MOCK_EMAIL = 'nomannisanislandexcepttheisleofmann@example.gg';
+export const MOCK_SIGNIN_LOCATION_STATE = {
+  email: MOCK_EMAIL,
+  sessionToken: MOCK_SESSION_TOKEN,
+  uid: MOCK_UID,
+  verified: true,
+};
+export const MOCK_SIGNIN_RECOVERY_LOCATION_STATE = {
+  ...MOCK_SIGNIN_LOCATION_STATE,
+  totp: MOCK_TOTP_TOKEN,
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -11,7 +11,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useMutation } from '@apollo/client';
 import { CONSUME_RECOVERY_CODE_MUTATION } from './gql';
 import { useCallback } from 'react';
-import { getStoredAccountInfo, handleGQLError } from '../utils';
+import { getSigninState, handleGQLError } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
@@ -41,12 +41,7 @@ export const SigninRecoveryCodeContainer = ({
   const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
   const { redirectTo } = queryParamModel;
 
-  const signinLocationState =
-    location.state && location.state.sessionToken
-      ? location.state
-      : getStoredAccountInfo();
-
-  const { sessionToken } = signinLocationState;
+  const signinState = getSigninState(location.state);
 
   const [consumeRecoveryCode] = useMutation<ConsumeRecoveryCodeResponse>(
     CONSUME_RECOVERY_CODE_MUTATION
@@ -82,7 +77,7 @@ export const SigninRecoveryCodeContainer = ({
     );
   }
 
-  if (!sessionToken) {
+  if (!signinState) {
     hardNavigateToContentServer(`/${location.search}`);
     return <LoadingSpinner fullScreen />;
   }
@@ -94,7 +89,7 @@ export const SigninRecoveryCodeContainer = ({
         integration,
         redirectTo,
         serviceName,
-        signinLocationState,
+        signinState,
         submitRecoveryCode,
       }}
     />

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
@@ -43,7 +43,7 @@ export const Default = () => (
   <SigninRecoveryCode
     finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
     integration={mockWebIntegration}
-    signinLocationState={mockSigninLocationState}
+    signinState={mockSigninLocationState}
     submitRecoveryCode={mockSubmitSuccess}
   />
 );
@@ -53,7 +53,7 @@ export const WithServiceName = () => (
     serviceName={MozServices.MozillaVPN}
     finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
     integration={mockWebIntegration}
-    signinLocationState={mockSigninLocationState}
+    signinState={mockSigninLocationState}
     submitRecoveryCode={mockSubmitSuccess}
   />
 );
@@ -62,7 +62,7 @@ export const WithCodeErrorOnSubmit = () => (
   <SigninRecoveryCode
     finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
     integration={mockWebIntegration}
-    signinLocationState={mockSigninLocationState}
+    signinState={mockSigninLocationState}
     submitRecoveryCode={mockCodeError}
   />
 );
@@ -71,7 +71,7 @@ export const WithBannerErrorOnSubmit = () => (
   <SigninRecoveryCode
     finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
     integration={mockWebIntegration}
-    signinLocationState={mockSigninLocationState}
+    signinState={mockSigninLocationState}
     submitRecoveryCode={mockOtherError}
   />
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -42,7 +42,7 @@ describe('PageSigninRecoveryCode', () => {
         <SigninRecoveryCode
           finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
           integration={mockIntegration}
-          signinLocationState={mockSigninLocationState}
+          signinState={mockSigninLocationState}
           submitRecoveryCode={mockSubmitRecoveryCode}
         />
       </LocationProvider>
@@ -74,7 +74,7 @@ describe('PageSigninRecoveryCode', () => {
         <SigninRecoveryCode
           finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
           integration={mockIntegration}
-          signinLocationState={mockSigninLocationState}
+          signinState={mockSigninLocationState}
           submitRecoveryCode={mockSubmitRecoveryCode}
           serviceName={MozServices.MozillaVPN}
         />
@@ -94,7 +94,7 @@ describe('PageSigninRecoveryCode', () => {
           <SigninRecoveryCode
             finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
             integration={mockIntegration}
-            signinLocationState={mockSigninLocationState}
+            signinState={mockSigninLocationState}
             submitRecoveryCode={mockSubmitRecoveryCode}
           />
         </LocationProvider>
@@ -111,7 +111,7 @@ describe('PageSigninRecoveryCode', () => {
           <SigninRecoveryCode
             finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
             integration={mockIntegration}
-            signinLocationState={mockSigninLocationState}
+            signinState={mockSigninLocationState}
             submitRecoveryCode={mockSubmitRecoveryCode}
           />
         </LocationProvider>
@@ -141,7 +141,7 @@ describe('PageSigninRecoveryCode', () => {
           <SigninRecoveryCode
             finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
             integration={mockIntegration}
-            signinLocationState={mockSigninLocationState}
+            signinState={mockSigninLocationState}
             submitRecoveryCode={mockSubmitRecoveryCode}
           />
         </LocationProvider>
@@ -164,7 +164,7 @@ describe('PageSigninRecoveryCode', () => {
           <SigninRecoveryCode
             finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
             integration={mockIntegration}
-            signinLocationState={mockSigninLocationState}
+            signinState={mockSigninLocationState}
             submitRecoveryCode={mockSubmitRecoveryCodeWithError}
           />
         </LocationProvider>
@@ -191,7 +191,7 @@ describe('PageSigninRecoveryCode', () => {
           <SigninRecoveryCode
             finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
             integration={mockIntegration}
-            signinLocationState={mockSigninLocationState}
+            signinState={mockSigninLocationState}
             submitRecoveryCode={mockSubmitRecoveryCodeWithError}
           />
         </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -3,12 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  Link,
-  RouteComponentProps,
-  useLocation,
-  useNavigate,
-} from '@reach/router';
+import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
 import { RecoveryCodesImage } from '../../../components/images';
@@ -35,7 +30,7 @@ const SigninRecoveryCode = ({
   integration,
   redirectTo,
   serviceName,
-  signinLocationState,
+  signinState,
   submitRecoveryCode,
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
   useEffect(() => {
@@ -50,7 +45,6 @@ const SigninRecoveryCode = ({
     'Backup authentication code required'
   );
   const location = useLocation();
-  const navigate = useNavigate();
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-recovery-code-input-label',
@@ -69,7 +63,7 @@ const SigninRecoveryCode = ({
     verificationReason,
     keyFetchToken,
     unwrapBKey,
-  } = signinLocationState;
+  } = signinState;
 
   const onSuccessNavigate = useCallback(() => {
     const navigationOptions = {
@@ -89,7 +83,7 @@ const SigninRecoveryCode = ({
       queryParams: location.search,
     };
 
-    handleNavigation(navigationOptions, navigate);
+    handleNavigation(navigationOptions);
   }, [
     email,
     integration,
@@ -97,7 +91,6 @@ const SigninRecoveryCode = ({
     keyFetchToken,
     location.search,
     redirectTo,
-    navigate,
     sessionToken,
     verificationMethod,
     verificationReason,
@@ -184,7 +177,7 @@ const SigninRecoveryCode = ({
         <FtlMsg id="signin-recovery-code-back-link">
           <Link
             to={`/signin_totp_code${location.search || ''}`}
-            state={signinLocationState}
+            state={signinState}
           >
             Back
           </Link>

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -15,7 +15,7 @@ export type SigninRecoveryCodeProps = {
   integration: SigninIntegration;
   redirectTo?: string;
   serviceName?: MozServices;
-  signinLocationState: SigninLocationState;
+  signinState: SigninLocationState;
   submitRecoveryCode: SubmitRecoveryCode;
 };
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -14,7 +14,7 @@ import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import AppLayout from '../../../components/AppLayout';
 import CardHeader from '../../../components/CardHeader';
 import { SigninLocationState } from '../interfaces';
-import { getStoredAccountInfo } from '../utils';
+import { getSigninState } from '../utils';
 
 // The email with token code (verifyLoginCodeEmail) is sent on `/signin`
 // submission if conditions are met.
@@ -29,10 +29,7 @@ const SigninTokenCodeContainer = ({
     state?: SigninLocationState;
   };
 
-  const signinState =
-    location.state && Object.keys(location.state).length > 0
-      ? location.state
-      : getStoredAccountInfo();
+  const signinState = getSigninState(location.state);
 
   const authClient = useAuthClient();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
@@ -44,7 +41,7 @@ const SigninTokenCodeContainer = ({
   const { data: totpData, loading: totpLoading } =
     useQuery<TotpStatusResponse>(GET_TOTP_STATUS);
 
-  if (Object.keys(signinState).length < 1) {
+  if (!signinState) {
     hardNavigateToContentServer(`/${location.search || ''}`);
     return <LoadingSpinner fullScreen />;
   }

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -25,6 +25,7 @@ import {
 import { createMockSigninLocationState } from './mocks';
 import VerificationReasons from '../../../constants/verification-reasons';
 import firefox from '../../../lib/channels/firefox';
+import { navigate } from '@reach/router';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -50,12 +51,11 @@ function applyDefaultMocks() {
   mockReactUtilsModule();
 }
 
-const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => {
   return {
     __esModule: true,
     ...jest.requireActual('@reach/router'),
-    useNavigate: () => mockNavigate,
+    navigate: jest.fn(),
     useLocation: () => () => {},
   };
 });
@@ -270,7 +270,7 @@ describe('SigninTokenCode page', () => {
         submitCode();
 
         await expectSuccessGleanEvents();
-        expect(mockNavigate).toHaveBeenCalledWith('/settings');
+        expect(navigate).toHaveBeenCalledWith('/settings');
       });
       it('when verificationReason is a force password change', async () => {
         session = mockSession();

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver, useSession } from '../../../models';
 import { usePageViewEvent } from '../../../lib/metrics';
@@ -39,7 +39,6 @@ const SigninTokenCode = ({
 }: SigninTokenCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const session = useSession();
-  const navigate = useNavigate();
   const location = useLocation();
 
   const {
@@ -167,7 +166,7 @@ const SigninTokenCode = ({
         };
 
         await GleanMetrics.isDone();
-        await handleNavigation(navigationOptions, navigate);
+        await handleNavigation(navigationOptions);
       } catch (error) {
         const localizedErrorMessage = getLocalizedErrorMessage(
           ftlMsgResolver,
@@ -191,7 +190,6 @@ const SigninTokenCode = ({
       keyFetchToken,
       localizedInvalidCode,
       location.search,
-      navigate,
       session,
       sessionToken,
       uid,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -10,7 +10,7 @@ import { useMutation } from '@apollo/client';
 import { MozServices } from '../../../lib/types';
 import VerificationMethods from '../../../constants/verification-methods';
 import { VERIFY_TOTP_CODE_MUTATION } from './gql';
-import { getStoredAccountInfo, handleGQLError } from '../utils';
+import { getSigninState, handleGQLError } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { Integration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
@@ -38,10 +38,7 @@ export const SigninTotpCodeContainer = ({
     state: SigninLocationState;
   };
 
-  const signinLocationState =
-    location.state && Object.keys(location.state).length > 0
-      ? location.state
-      : getStoredAccountInfo();
+  const signinState = getSigninState(location.state);
 
   const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
   const { redirectTo, service } = queryParamModel;
@@ -84,9 +81,9 @@ export const SigninTotpCodeContainer = ({
   }
 
   if (
-    !(Object.keys(signinLocationState).length > 0) ||
-    (signinLocationState.verificationMethod &&
-      signinLocationState.verificationMethod !== VerificationMethods.TOTP_2FA)
+    !signinState ||
+    (signinState.verificationMethod &&
+      signinState.verificationMethod !== VerificationMethods.TOTP_2FA)
   ) {
     hardNavigateToContentServer(`/${location.search ? location.search : ''}`);
     return <LoadingSpinner fullScreen />;
@@ -98,7 +95,7 @@ export const SigninTotpCodeContainer = ({
         finishOAuthFlowHandler,
         integration,
         redirectTo,
-        signinLocationState,
+        signinState,
         submitTotpCode,
         serviceName,
       }}

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -24,6 +24,7 @@ import { SigninIntegration } from '../interfaces';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import firefox from '../../../lib/channels/firefox';
 import * as utils from 'fxa-react/lib/utils';
+import { navigate } from '@reach/router';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -46,10 +47,10 @@ const mockLocation = () => {
     pathname: '/signin_totp_cpde',
   };
 };
-const mockNavigate = jest.fn();
+
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
-  useNavigate: () => mockNavigate,
+  navigate: jest.fn(),
   useLocation: () => mockLocation(),
 }));
 
@@ -144,7 +145,7 @@ describe('Sign in with TOTP code page', () => {
       expect(GleanMetrics.totpForm.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).toHaveBeenCalledWith('/settings');
+      expect(navigate).toHaveBeenCalledWith('/settings');
     });
 
     // When CAD is converted to React, just test navigation since CAD will handle fxaLogin
@@ -191,7 +192,7 @@ describe('Sign in with TOTP code page', () => {
       expect(GleanMetrics.totpForm.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(0);
-      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
     });
 
     it('shows general error on unexpected error', async () => {
@@ -204,7 +205,7 @@ describe('Sign in with TOTP code page', () => {
       expect(GleanMetrics.totpForm.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(0);
-      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
     });
 
     describe('with OAuth integration', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -3,12 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useState } from 'react';
-import {
-  Link,
-  RouteComponentProps,
-  useLocation,
-  useNavigate,
-} from '@reach/router';
+import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
 import { logViewEvent } from '../../../lib/metrics';
@@ -42,7 +37,7 @@ export type SigninTotpCodeProps = {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
   redirectTo?: string;
-  signinLocationState: SigninLocationState;
+  signinState: SigninLocationState;
   // TODO: Switch to gql error shaped object
   submitTotpCode: (
     totpCode: string
@@ -56,12 +51,11 @@ export const SigninTotpCode = ({
   finishOAuthFlowHandler,
   integration,
   redirectTo,
-  signinLocationState,
+  signinState,
   submitTotpCode,
   serviceName,
 }: SigninTotpCodeProps & RouteComponentProps) => {
   const location = useLocation();
-  const navigate = useNavigate();
 
   const [success, setSuccess] = useState<boolean>(false);
   const [generalError, setGeneralError] = useState<string>('');
@@ -76,7 +70,7 @@ export const SigninTotpCode = ({
     verificationReason,
     keyFetchToken,
     unwrapBKey,
-  } = signinLocationState;
+  } = signinState;
 
   const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
     'signin-totp-code-required-error',
@@ -145,7 +139,7 @@ export const SigninTotpCode = ({
         queryParams: location.search,
       };
 
-      await handleNavigation(navigationOptions, navigate, true);
+      await handleNavigation(navigationOptions, true);
     }
   };
 
@@ -193,7 +187,7 @@ export const SigninTotpCode = ({
           <FtlMsg id="signin-totp-code-recovery-code-link">
             <Link
               to={`/signin_recovery_code${location.search}`}
-              state={signinLocationState}
+              state={signinState}
               className="text-end"
             >
               Trouble entering code?

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -48,7 +48,7 @@ export const Subject = ({
   finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   integration = mockWebIntegration,
   serviceName = MozServices.Default,
-  signinLocationState = MOCK_TOTP_LOCATION_STATE,
+  signinState = MOCK_TOTP_LOCATION_STATE,
   submitTotpCode = mockSubmitTotpCode,
 }: Partial<SigninTotpCodeProps>) => {
   return (
@@ -58,7 +58,7 @@ export const Subject = ({
           finishOAuthFlowHandler,
           integration,
           serviceName,
-          signinLocationState,
+          signinState,
           submitTotpCode,
         }}
       />

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -17,6 +17,7 @@ import {
 } from '../mocks';
 import GleanMetrics from '../../../lib/glean';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { handleNavigation } from '../utils';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -37,6 +38,10 @@ const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../utils', () => ({
+  handleNavigation: jest.fn(),
 }));
 
 const email = MOCK_EMAIL;
@@ -220,7 +225,7 @@ describe('SigninUnblock', () => {
       await waitFor(() => {
         expect(signinWithUnblockCode).toHaveBeenCalledTimes(1);
       });
-      expect(mockNavigate).toHaveBeenCalled();
+      expect(handleNavigation).toHaveBeenCalled();
     });
 
     it('emits expected metrics events', async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -133,7 +133,7 @@ const SigninUnblock = ({
         queryParams: location.search,
       };
 
-      await handleNavigation(navigationOptions, navigate);
+      await handleNavigation(navigationOptions, true);
     }
     if (error) {
       const localizedErrorMessage = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -405,7 +405,7 @@ describe('signin container', () => {
       render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith(
-          `/signup?email=${MOCK_QUERY_PARAM_EMAIL}&emailStatusChecked=true`
+          `/signup?email=from%40queryparams.com&emailStatusChecked=true`
         );
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -162,6 +162,7 @@ const SigninContainer = ({
 
   useEffect(() => {
     (async () => {
+      const queryParams = new URLSearchParams(location.search);
       // Tweak this once index page is converted to React
       if (!validationError && email) {
         // if you directly hit /signin with email param or we read from localstorage
@@ -178,7 +179,9 @@ const SigninContainer = ({
             if (!exists) {
               // For now, just pass back emailStatusChecked. When we convert the Index page
               // we'll want to read from router state.
-              navigate(`/signup?email=${email}&emailStatusChecked=true`);
+              queryParams.set('email', email);
+              queryParams.set('emailStatusChecked', 'true');
+              navigate(`/signup?${queryParams}`);
             } else {
               // TODO: in FXA-9177, also set hasLinkedAccount and hasPassword in Apollo cache
               setAccountStatus({
@@ -187,11 +190,12 @@ const SigninContainer = ({
               });
             }
           } catch (error) {
-            hardNavigateToContentServer(`/?prefillEmail=${email}`);
+            queryParams.set('prefillEmail', email);
+            hardNavigateToContentServer(`/?${queryParams}`);
           }
         }
       } else {
-        hardNavigateToContentServer('/');
+        hardNavigateToContentServer(`/?${queryParams}`);
       }
     })();
     // Only run this on initial render
@@ -437,7 +441,7 @@ const SigninContainer = ({
           AuthenticationMethods.OTP
         );
         if (totpIsActive) {
-          // Cache this for /signin_token_code and /settings
+          // Cache this for subsequent requests
           cache.modify({
             id: cache.identify({ __typename: 'Account' }),
             fields: {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -133,7 +133,7 @@ const Signin = ({
           queryParams: location.search,
         };
 
-        await handleNavigation(navigationOptions, navigate);
+        await handleNavigation(navigationOptions);
       }
       if (error) {
         const localizedErrorMessage = getLocalizedErrorMessage(
@@ -143,13 +143,6 @@ const Signin = ({
         if (error.errno === AuthUiErrors.SESSION_EXPIRED.errno) {
           isPasswordNeededRef.current = true;
         }
-        if (
-          error.errno === AuthUiErrors.TOTP_REQUIRED.errno ||
-          error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
-        ) {
-          navigate('/inline_totp_setup');
-          return;
-        }
         setLocalizedBannerMessage(localizedErrorMessage);
         setSigninLoading(false);
       }
@@ -158,7 +151,6 @@ const Signin = ({
       cachedSigninHandler,
       email,
       ftlMsgResolver,
-      navigate,
       setLocalizedBannerMessage,
       integration,
       finishOAuthFlowHandler,
@@ -197,7 +189,7 @@ const Signin = ({
           queryParams: location.search,
         };
 
-        await handleNavigation(navigationOptions, navigate, true);
+        await handleNavigation(navigationOptions, true);
       }
       if (error) {
         GleanMetrics.login.error({ reason: error.message });
@@ -243,10 +235,6 @@ const Signin = ({
             case AuthUiErrors.EMAIL_HARD_BOUNCE.errno:
             case AuthUiErrors.EMAIL_SENT_COMPLAINT.errno:
               navigate('/signin_bounced');
-              break;
-            case AuthUiErrors.TOTP_REQUIRED.errno:
-            case AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno:
-              navigate('/inline_totp_setup');
               break;
             default:
               setLocalizedBannerMessage(localizedErrorMessage);

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -8,7 +8,7 @@ import { AuthUiError } from '../../lib/auth-errors/auth-errors';
 import { AccountAvatar } from '../../lib/interfaces';
 import { FinishOAuthFlowHandler } from '../../lib/oauth/hooks';
 import { MozServices } from '../../lib/types';
-import { Integration } from '../../models';
+import { Account, Integration } from '../../models';
 
 export interface AvatarResponse {
   account: {
@@ -187,3 +187,5 @@ export interface SigninLocationState {
   keyFetchToken?: hexstring;
   unwrapBKey?: hexstring;
 }
+
+export type TotpToken = Awaited<ReturnType<Account['createTotp']>>;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -173,7 +173,13 @@ const ConfirmSignupCode = ({
 
         // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
-          hardNavigateToContentServer(`oauth/signin${location.search}`);
+          // Remove the 'email' query param because this should be read from
+          // local storage on the next screen. Once the index page has been converted
+          // to React and we no longer need to pass 'email' we can improve this.
+          const queryParams = new URLSearchParams(location.search);
+          queryParams.delete('email');
+          queryParams.delete('emailStatusChecked');
+          hardNavigateToContentServer(`oauth/signin?${queryParams}`);
           return;
         } else {
           const { redirect, code, state } = await finishOAuthFlowHandler(


### PR DESCRIPTION
Because:
* Signin flows requiring 2FA before continuing (currently only AMO) would error out in React
* We prefer to keep these two pages under 'signin' feature flag to stick with current test/rollout plans

This commit:
* Removes new inline feature flags, places 'inline_totp_setup' and 'inline_recovery_setup' under the signin feature flag
* Adds try/catch around oauth handler in signin utils and navigates to the inline page, removes 'navigate' from signin utils and uses direct import instead
* Adds sync handling to 'signin_unblock_code' by setting temp parameter to true when calling signin navigation handler
* Updates signinLocationState references to signinState as we may also grab values from local storage
* Refactors state in inline pages to match other signin pages, fixes problems using useAccount in these pages/DataBlock
* Adds missing l10n strings

closes FXA-9325