### PR TITLE
task(functional): Modify syncV3 tests not use target.auth.signUp

### DIFF
--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -37,27 +37,22 @@ test.describe('severity-2 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
 
-    // TODO in FXA-8973 - use sign in not sign up flow
     test('verified, resend', async ({ emails, target, syncBrowserPages }) => {
-      const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
+      const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
 
-      const config = await configPage.getConfig();
       const [email] = emails;
-      test.fixme(
-        config.showReactApp.signUpRoutes,
-        'this test goes through the signup flow instead of sign in, skipping for react'
-      );
+
+      target.auth.signUp(email, PASSWORD, { service: 'sync', keys: true });
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
+
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
-      await login.submit();
+      await login.clickSubmit();
 
       // Click resend link
       await signinTokenCode.resendLink.click();
@@ -76,40 +71,30 @@ test.describe('severity-2 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    // TODO in FXA-8973 - use sign in not sign up flow
     test('verified - invalid code', async ({
       emails,
       target,
       syncBrowserPages,
     }) => {
-      const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
-        syncBrowserPages;
+      const { page, login, signinTokenCode } = syncBrowserPages;
 
-      const config = await configPage.getConfig();
       const [email] = emails;
-      test.fixme(
-        config.showReactApp.signUpRoutes,
-        'this test goes through the signup flow instead of sign in, skipping for react'
-      );
+
+      target.auth.signUp(email, PASSWORD, { service: 'sync', keys: true });
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
+
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
-      await login.submit();
+      await login.clickSubmit();
 
       // Input invalid code and verify the tooltip error
       await signinTokenCode.input.fill('000000');
       await signinTokenCode.submit.click();
-      await expect(signinTokenCode.tooltip).toContainText('Invalid or expired');
-
-      //Input Valid code and verify the success
-      await login.fillOutSignUpCode(email);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+      await expect(signinTokenCode.tooltip).toBeVisible();
     });
 
     test('verified, blocked', async ({ emails, target, syncBrowserPages }) => {


### PR DESCRIPTION
## Because

- The tests were manually going through a sign up flow
- Doing so messed with react conversion testing, since the sign up could vary depending on react rollout rate

## This pull request

- Uses target.auth.signUp to generate a sign up operation thereby isolating the test
- Stops `verified - invalid code` at check for invalid code message.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We now stop the `verified - invalid code` a bit earlier. There are two reasons for this. First we already verify that a valid code works, so doing this again is redundant. Second, since we directly signup via `target.auth.signUp` the sending of the initial signup email appears to be bypassed. 
