### PR TITLE
task(functional): Modify syncV3 tests not use target.auth.signUp

### DIFF
--- a/packages/functional-tests/pages/baseTokenCode.ts
+++ b/packages/functional-tests/pages/baseTokenCode.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseLayout } from './layout';
+
+export abstract class BaseTokenCodePage extends BaseLayout {
+  get tooltip() {
+    this.checkPath();
+    return this.page.locator('.tooltip');
+  }
+
+  get successMessage() {
+    this.checkPath();
+    return this.page.locator('.success');
+  }
+
+  get input() {
+    this.checkPath();
+    return this.page.locator('input[type=text]');
+  }
+
+  get submit() {
+    this.checkPath();
+    return this.page.locator('button[type=submit]');
+  }
+}

--- a/packages/functional-tests/pages/confirmSignupCodePage.ts
+++ b/packages/functional-tests/pages/confirmSignupCodePage.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseTokenCodePage } from './baseTokenCode';
+
+export class ConfirmSignupCodePage extends BaseTokenCodePage {
+  readonly path = '/confirm_signup_code';
+}

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -14,7 +14,10 @@ import { RelierPage } from './relier';
 import { SecondaryEmailPage } from './settings/secondaryEmail';
 import { SettingsPage } from './settings';
 import { SignInPage } from './signin';
-import { SigninTokenCodePage } from './signinTokenCode';
+import { SigninTokenCodePage } from './signinTokenCode.ts';
+import { SigninTotpCodePage } from './signinTotpCode.ts';
+import { SigninUnblockPage } from './signinUnblock.ts';
+import { ConfirmSignupCodePage } from './confirmSignupCodePage.ts';
 import { SubscribePage } from './products';
 import { TotpPage } from './settings/totp';
 import { SubscriptionManagementPage } from './products/subscriptionManagement';
@@ -28,6 +31,7 @@ import { SignupReactPage } from './signupReact';
 import { ConfigPage } from './config';
 import { PrivacyPage } from './privacy';
 import { TermsOfService } from './termsOfService';
+
 export function create(page: Page, target: BaseTarget) {
   return {
     avatar: new AvatarPage(page, target),
@@ -46,6 +50,9 @@ export function create(page: Page, target: BaseTarget) {
     settings: new SettingsPage(page, target),
     signIn: new SignInPage(page, target),
     signinTokenCode: new SigninTokenCodePage(page, target),
+    signinTotpCode: new SigninTotpCodePage(page, target),
+    signinUnblock: new SigninUnblockPage(page, target),
+    confirmSignupCode: new ConfirmSignupCodePage(page, target),
     subscribe: new SubscribePage(page, target),
     totp: new TotpPage(page, target),
     subscriptionManagement: new SubscriptionManagementPage(page, target),

--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -7,7 +7,12 @@ import { BaseTarget } from '../lib/targets/base';
 import { CustomEventDetail } from '../lib/channels';
 
 export abstract class BaseLayout {
-  readonly path?: string;
+  /**
+   * The expected path of the current page. This works with checkPath(). If left empty,
+   * checkPath will always pass. If defined, checkPass will enforce that this value is
+   * in the URL.
+   */
+  abstract get path(): string;
 
   constructor(public page: Page, protected readonly target: BaseTarget) {}
 
@@ -17,6 +22,23 @@ export abstract class BaseLayout {
 
   get url() {
     return `${this.baseUrl}/${this.path}`;
+  }
+
+  /**
+   * Checks that the current path maps to the POM's expected path. This can be called before querying for locators in
+   * child classes to make locators more robust and avoid false positives. If the current path does not exist in the URL,
+   * an error will be thrown.
+   */
+  checkPath() {
+    if (this.path) {
+      if (this.page.url().indexOf(this.path) < 0) {
+        throw new Error(
+          `Invalid page state detected! Expected ${
+            this.path
+          } to be in url, ${this.page.url()}`
+        );
+      }
+    }
   }
 
   goto(

--- a/packages/functional-tests/pages/signinTotpCode.ts
+++ b/packages/functional-tests/pages/signinTotpCode.ts
@@ -4,16 +4,11 @@
 
 import { BaseTokenCodePage } from './baseTokenCode';
 
-export class SigninTokenCodePage extends BaseTokenCodePage {
-  readonly path = '/signin_token_code';
+export class SigninTotpCodePage extends BaseTokenCodePage {
+  readonly path = '/signin_totp_code';
 
-  get tokenCodeHeader() {
+  get input() {
     this.checkPath();
-    return this.page.locator('#fxa-signin-code-header');
-  }
-
-  get resendLink() {
-    this.checkPath();
-    return this.page.locator('#resend');
+    return this.page.locator('input[type=number]');
   }
 }

--- a/packages/functional-tests/pages/signinUnblock.ts
+++ b/packages/functional-tests/pages/signinUnblock.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseTokenCodePage } from './baseTokenCode';
+
+export class SigninUnblockPage extends BaseTokenCodePage {
+  readonly path = '/signin_unblock';
+}

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -66,7 +66,7 @@ test.describe('severity-1 #smoke', () => {
       });
       await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
       await login.setCode('1234');
-      await signinTokenCode.clickSubmitButton();
+      await signinTokenCode.submit.click();
       expect(await login.getTooltipError()).toContain(
         'Invalid or expired confirmation code'
       );

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { sign } from 'crypto';
 import { EmailHeader, EmailType } from '../../lib/email';
 import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import { getCode } from 'fxa-settings/src/lib/totp';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -20,129 +22,186 @@ test.describe('severity-2 #smoke', () => {
       test.slow();
     });
 
-    test('verified, does not need to confirm', async ({
+    test('verified email, does not need to confirm', async ({
       target,
       credentials,
       syncBrowserPages,
     }) => {
       const email = credentials.email;
-      const { page, login, connectAnotherDevice, signinTokenCode } =
-        syncBrowserPages;
+      const { page, login, connectAnotherDevice } = syncBrowserPages;
+
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
-      await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
-      await login.setPassword(PASSWORD);
-      await login.submit();
+      await login.login(email, PASSWORD);
+
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
 
-    test('verified, resend', async ({ emails, target, syncBrowserPages }) => {
-      const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
+    test('verified email with signin verification, can ask to resend code', async ({
+      emails,
+      target,
+      syncBrowserPages,
+    }) => {
+      const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
+
       const [email] = emails;
-      const config = await configPage.getConfig();
-      test.fixme(
-        config.showReactApp.signUpRoutes,
-        'this test goes through the signup flow instead of sign in, skipping for react, see FXA-8973'
-      );
+
+      // Simulate a new sign up that requires a signin verification code.
+      target.auth.signUp(email, PASSWORD, {
+        service: 'sync',
+        preVerified: 'true',
+      });
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
-      await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
-      await login.submit();
+      await login.login(email, PASSWORD);
 
       // Click resend link
       await signinTokenCode.resendLink.click();
-      await signinTokenCode.successMessage.waitFor({ state: 'visible' });
       await expect(signinTokenCode.successMessage).toBeVisible();
       await expect(signinTokenCode.successMessage).toContainText(
         /Email re-?sent/
       );
       const code = await target.email.waitForEmail(
         email,
-        EmailType.verifyShortCode,
-        EmailHeader.shortCode
+        EmailType.verifyLoginCode,
+        EmailHeader.signinCode
       );
       await signinTokenCode.input.fill(code);
-      await login.submit();
+      await signinTokenCode.submit.click();
+
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('verified - invalid code', async ({
+    test('verified email with signin verification, accepts valid sign in code', async ({
       emails,
       target,
       syncBrowserPages,
     }) => {
-      const { configPage, page, login, connectAnotherDevice, signinTokenCode } =
+      const { page, login, connectAnotherDevice, signinTokenCode } =
         syncBrowserPages;
+
       const [email] = emails;
-      const config = await configPage.getConfig();
-      test.fixme(
-        config.showReactApp.signUpRoutes,
-        'this test goes through the signup flow instead of sign in, skipping for react, see FXA-8973'
-      );
+
+      // Simulate a new sign up that requires a signin verification code.
+      target.auth.signUp(email, PASSWORD, {
+        service: 'sync',
+        preVerified: 'true',
+      });
+
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
-      await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
-      await login.submit();
+      await login.login(email, PASSWORD);
+
+      const code = await target.email.waitForEmail(
+        email,
+        EmailType.verifyLoginCode,
+        EmailHeader.signinCode
+      );
+      await signinTokenCode.input.fill(code);
+      await signinTokenCode.submit.click();
+
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+    });
+
+    test('verified email with signin verification, rejects invalid signin code', async ({
+      emails,
+      target,
+      syncBrowserPages,
+    }) => {
+      const { page, login, connectAnotherDevice, signinTokenCode } =
+        syncBrowserPages;
+
+      const [email] = emails;
+
+      // Simulate a new sign up that requires a signin verification code.
+      target.auth.signUp(email, PASSWORD, {
+        service: 'sync',
+        preVerified: 'true',
+      });
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await login.login(email, PASSWORD);
 
       // Input invalid code and verify the tooltip error
       await signinTokenCode.input.fill('000000');
       await signinTokenCode.submit.click();
+
+      await expect(signinTokenCode.tooltip).toBeVisible();
       await expect(signinTokenCode.tooltip).toContainText('Invalid or expired');
 
-      //Input Valid code and verify the success
-      await login.fillOutSignUpCode(email);
+      const code = await target.email.waitForEmail(
+        email,
+        EmailType.verifyLoginCode,
+        EmailHeader.signinCode
+      );
+      await signinTokenCode.input.fill(code);
+      await signinTokenCode.submit.click();
+
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('verified, blocked', async ({ emails, target, syncBrowserPages }) => {
-      const { page, login, connectAnotherDevice, signinTokenCode } =
+    test('verified email, in blocked state', async ({
+      emails,
+      target,
+      syncBrowserPages,
+    }) => {
+      const { page, login, signinUnblock, connectAnotherDevice } =
         syncBrowserPages;
       const [, blockedEmail] = emails;
       await target.auth.signUp(blockedEmail, PASSWORD, {
+        service: 'sync',
         lang: 'en',
         preVerified: 'true',
       });
+
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`
       );
-      await login.setEmail(blockedEmail);
-      await signinTokenCode.clickSubmitButton();
-      await login.setPassword(PASSWORD);
-      await login.submit();
-      await login.unblock(blockedEmail);
+      await login.login(blockedEmail, PASSWORD);
+
+      const code = await target.email.waitForEmail(
+        blockedEmail,
+        EmailType.unblockCode,
+        EmailHeader.unblockCode
+      );
+      await signinUnblock.input.fill(code);
+      await signinUnblock.submit.click();
+
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('unverified', async ({ emails, target, syncBrowserPages }) => {
-      const { page, login, connectAnotherDevice, signinTokenCode } =
+    test('unverified email', async ({ emails, target, syncBrowserPages }) => {
+      const { page, login, connectAnotherDevice, confirmSignupCode } =
         syncBrowserPages;
       const [email] = emails;
+
       await target.auth.signUp(email, PASSWORD, {
+        service: 'sync',
         lang: 'en',
         preVerified: 'false',
       });
+
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
-      await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
-      await login.setPassword(PASSWORD);
-      await login.submit();
-      await login.fillOutSignInCode(email);
+      await login.login(email, PASSWORD);
+
+      // Since the account is not verified yet, we'd expect to see the signup code confirmation
+      const code = await target.email.waitForEmail(
+        email,
+        EmailType.verifyLoginCode,
+        EmailHeader.signinCode
+      );
+      await confirmSignupCode.input.fill(code);
+      await confirmSignupCode.submit.click();
+
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
@@ -151,8 +210,14 @@ test.describe('severity-2 #smoke', () => {
       target,
       syncBrowserPages,
     }) => {
-      const { page, login, connectAnotherDevice, settings, totp } =
-        syncBrowserPages;
+      const {
+        page,
+        login,
+        connectAnotherDevice,
+        settings,
+        totp,
+        signinTotpCode,
+      } = syncBrowserPages;
 
       await settings.goto();
       await settings.totp.clickAdd();
@@ -160,13 +225,17 @@ test.describe('severity-2 #smoke', () => {
       credentials.secret = secret;
       await settings.signOut();
 
-      // Sync sign in
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`,
         { waitUntil: 'load' }
       );
+
       await login.login(credentials.email, credentials.password);
-      await login.setTotp(credentials.secret);
+
+      const code = await getCode(credentials.secret);
+      await signinTotpCode.input.fill(code);
+      await signinTotpCode.submit.click();
+
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
   });

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -22,15 +22,14 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('sync sign up', async ({ emails, target, syncBrowserPages }) => {
-      const { page, login, connectAnotherDevice, signinTokenCode } =
-        syncBrowserPages;
+      const { page, login, connectAnotherDevice } = syncBrowserPages;
       const [email] = emails;
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
         { waitUntil: 'load' }
       );
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
 
       // Verify the email is correct
       expect(await login.getPrefilledEmail()).toMatch(email);
@@ -39,7 +38,7 @@ test.describe('severity-1 #smoke', () => {
       await login.setPassword(PASSWORD);
       await login.confirmPassword(incorrectPassword);
       await login.setAge('21');
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
 
       // Verify the error message
       expect(await login.getTooltipError()).toContain('Passwords do not match');

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -26,8 +26,7 @@ test.describe('severity-1 #smoke', () => {
       syncBrowserPages,
     }) => {
       const [email] = emails;
-      const { login, page, signinTokenCode, connectAnotherDevice } =
-        syncBrowserPages;
+      const { login, page, connectAnotherDevice } = syncBrowserPages;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -57,7 +56,7 @@ test.describe('severity-1 #smoke', () => {
       await login.respondToWebChannelMessage(eventDetailLinkAccount);
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
       await login.confirmPassword(PASSWORD);
       await login.setAge('21');
@@ -74,15 +73,14 @@ test.describe('severity-1 #smoke', () => {
       // Uncheck the passwords and history engines
       await login.CWTSEngineHistory.click();
       await login.CWTSEnginePasswords.click();
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
       await login.fillOutSignUpCode(email);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
     test('verify at CWTS', async ({ emails, target, syncBrowserPages }) => {
-      const { login, page, signinTokenCode, connectAnotherDevice } =
-        syncBrowserPages;
+      const { login, page, connectAnotherDevice } = syncBrowserPages;
       const [email] = emails;
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
@@ -107,7 +105,7 @@ test.describe('severity-1 #smoke', () => {
       await login.respondToWebChannelMessage(eventDetailStatus);
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
       await login.confirmPassword(PASSWORD);
       await login.setAge('21');
@@ -120,7 +118,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(login.CWTSEngineCreditCards).toBeHidden();
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
       await login.noSuchWebChannelMessage(FirefoxCommand.Login);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.fillOutSignUpCode(email);
       await login.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
@@ -129,7 +127,7 @@ test.describe('severity-1 #smoke', () => {
     test('engines not supported', async ({
       emails,
       target,
-      syncBrowserPages: { login, page, signinTokenCode },
+      syncBrowserPages: { login, page },
     }) => {
       const [email] = emails;
       const query = new URLSearchParams({
@@ -149,7 +147,7 @@ test.describe('severity-1 #smoke', () => {
       await login.respondToWebChannelMessage(eventDetailStatus);
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
       await login.confirmPassword(PASSWORD);
       await login.setAge('21');
@@ -164,7 +162,7 @@ test.describe('severity-1 #smoke', () => {
     test('neither `creditcards` nor `addresses` supported', async ({
       emails,
       target,
-      syncBrowserPages: { login, page, signinTokenCode },
+      syncBrowserPages: { login, page },
     }) => {
       const [email] = emails;
       const query = new URLSearchParams({
@@ -187,7 +185,7 @@ test.describe('severity-1 #smoke', () => {
       await login.respondToWebChannelMessage(eventDetailStatus);
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
       await login.confirmPassword(PASSWORD);
       await login.setAge('21');
@@ -202,7 +200,7 @@ test.describe('severity-1 #smoke', () => {
     test('`creditcards` and `addresses` supported', async ({
       emails,
       target,
-      syncBrowserPages: { login, page, signinTokenCode },
+      syncBrowserPages: { login, page },
     }) => {
       const [email] = emails;
       const query = new URLSearchParams({
@@ -225,7 +223,7 @@ test.describe('severity-1 #smoke', () => {
       await login.respondToWebChannelMessage(eventDetailStatus);
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
-      await signinTokenCode.clickSubmitButton();
+      await login.clickSubmit();
       await login.setPassword(PASSWORD);
       await login.confirmPassword(PASSWORD);
       await login.setAge('21');

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -70,14 +70,14 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
 
   test('enter a firefox.com address', async ({
     target,
-    syncBrowserPages: { login, page, signinTokenCode },
+    syncBrowserPages: { login, page },
   }) => {
     await page.goto(
       `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'load' }
     );
     await login.setEmail('testuser@firefox.com');
-    await signinTokenCode.clickSubmitButton();
+    await login.clickSubmit();
 
     // Verify the error
     expect(await login.getTooltipError()).toContain(


### PR DESCRIPTION
## Because

- The tests were manually going through a sign up flow
- Doing so messed with react conversion testing, since the sign up implementation could vary
- Depending on react rollout rate. i.e Sometimes the the app would route an end user through
- Backbone, and sometimes it would route an end user through react.
- There were also some potential improvements that may improve clarity of these tests.

## This pull request
- Uses target.auth.signUp, which uses the auth-client to generate a signup, thereby isolating the sync sign in tests and fixing the issue with react react rollout.
- Cleans up tests by:
  - Renaming some tests to make their intent more clear.
  - Introducing a BaseTokenCode page that facilitates code reuse across pages that require a token code.
  - Adding a 'checkUrlPath' method to BaseTokenCode. This lets us ensure that the POM object we are interacting with is actually on the expected page, and is now being used in the ‘TokenCode’ pages.
  - Introducing a signinTotpCode page and using it to make the tests more clear.
  - Introducing a signinUnblockCode page and using it to make the tests more clear.
  - Introducing a singupTokenCode page  and using it to make the tests more clear.

## Issue that this pull request solves

Closes: FXA-8973

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Part of these code changes are an attempt to do a little cleanup and make the tests read a bit more clearly. This is mostly accomplished by using new more targeted, smaller POMs. Please have a look at this and decide if we want to continue with this pattern, or simply use the login page for these interactions. In my opinion using smaller POMs for these sign in code steps improved a couple things. 

- It ensures that we are actually on the page we think we are. This is enforced by calling the checkPath().
- The smaller classes are easier to understand
- When reading the actual test case, it's very clear what page and action is being conducted. 

I've left some comments in this PR calling out key aspects of these changes.

