### PR TITLE
feat(payments-stripe): add new stripe methods and update naming

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -24,8 +24,10 @@ const mockStripeCustomersUpdate =
   mockJestFnGenerator<typeof Stripe.prototype.customers.update>();
 const mockStripeRetrieveUpcomingInvoice =
   mockJestFnGenerator<typeof Stripe.prototype.invoices.retrieveUpcoming>();
-const mockStripeFinalizeInvoice =
+const mockStripeInvoicesFinalizeInvoice =
   mockJestFnGenerator<typeof Stripe.prototype.invoices.finalizeInvoice>();
+const mockStripeInvoicesRetrieve =
+  mockJestFnGenerator<typeof Stripe.prototype.invoices.retrieve>();
 const mockStripeSubscriptionsList =
   mockJestFnGenerator<typeof Stripe.prototype.subscriptions.list>();
 
@@ -37,8 +39,9 @@ jest.mock('stripe', () => ({
         update: mockStripeCustomersUpdate,
       },
       invoices: {
+        retrieve: mockStripeInvoicesRetrieve,
         retrieveUpcoming: mockStripeRetrieveUpcomingInvoice,
-        finalizeInvoice: mockStripeFinalizeInvoice,
+        finalizeInvoice: mockStripeInvoicesFinalizeInvoice,
       },
       subscriptions: {
         list: mockStripeSubscriptionsList,
@@ -61,23 +64,19 @@ describe('StripeClient', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
-    expect(mockClient).toBeDefined();
-  });
-
-  describe('fetchCustomer', () => {
+  describe('customersRetrieve', () => {
     it('returns an existing customer from Stripe', async () => {
       const mockCustomer = StripeCustomerFactory();
       const mockResponse = StripeResponseFactory(mockCustomer);
 
       mockStripeCustomersRetrieve.mockResolvedValueOnce(mockResponse);
 
-      const result = await mockClient.fetchCustomer(mockCustomer.id);
+      const result = await mockClient.customersRetrieve(mockCustomer.id);
       expect(result).toEqual(mockResponse);
     });
   });
 
-  describe('updateCustomer', () => {
+  describe('customersUpdate', () => {
     it('updates an existing customer from Stripe', async () => {
       const mockCustomer = StripeCustomerFactory();
       const mockUpdatedCustomer = StripeCustomerFactory();
@@ -85,7 +84,7 @@ describe('StripeClient', () => {
 
       mockStripeCustomersUpdate.mockResolvedValueOnce(mockResponse);
 
-      const result = await mockClient.updateCustomer(mockCustomer.id, {
+      const result = await mockClient.customersUpdate(mockCustomer.id, {
         balance: mockUpdatedCustomer.balance,
       });
 
@@ -93,7 +92,7 @@ describe('StripeClient', () => {
     });
   });
 
-  describe('fetchSubscriptions', () => {
+  describe('subscriptionsList', () => {
     it('returns subscriptions from Stripe', async () => {
       const mockCustomer = StripeCustomerFactory();
       const mockSubscriptionList = StripeResponseFactory(
@@ -102,14 +101,14 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsList.mockResolvedValue(mockSubscriptionList);
 
-      const result = await mockClient.fetchSubscriptions({
+      const result = await mockClient.subscriptionsList({
         customer: mockCustomer.id,
       });
       expect(result).toEqual(mockSubscriptionList);
     });
   });
 
-  describe('retrieveUpcomingInvoice', () => {
+  describe('invoicesRetrieveUpcoming', () => {
     it('calls stripe successfully', async () => {
       const mockCustomer = StripeCustomerFactory();
       const mockInvoice = StripeUpcomingInvoiceFactory();
@@ -117,7 +116,7 @@ describe('StripeClient', () => {
 
       mockStripeRetrieveUpcomingInvoice.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.retrieveUpcomingInvoice({
+      const result = await mockClient.invoicesRetrieveUpcoming({
         customer: mockCustomer.id,
       });
 
@@ -125,18 +124,31 @@ describe('StripeClient', () => {
     });
   });
 
-  describe('finalizeInvoice', () => {
+  describe('invoicesFinalizeInvoice', () => {
     it('works successfully', async () => {
       const mockInvoice = StripeInvoiceFactory({
         auto_advance: false,
       });
       const mockResponse = StripeResponseFactory(mockInvoice);
 
-      mockStripeFinalizeInvoice.mockResolvedValue(mockResponse);
+      mockStripeInvoicesFinalizeInvoice.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.finalizeInvoice(mockInvoice.id, {
+      const result = await mockClient.invoicesFinalizeInvoice(mockInvoice.id, {
         auto_advance: false,
       });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('invoicesRetrieve', () => {
+    it('works successfully', async () => {
+      const mockInvoice = StripeInvoiceFactory();
+      const mockResponse = StripeResponseFactory(mockInvoice);
+
+      mockStripeInvoicesRetrieve.mockResolvedValue(mockResponse);
+
+      const result = await mockClient.invoicesRetrieve(mockInvoice.id);
 
       expect(result).toEqual(mockResponse);
     });

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -9,6 +9,7 @@ import {
   StripeCustomer,
   StripeDeletedCustomer,
   StripeInvoice,
+  StripePaymentMethod,
   StripeSubscription,
   StripeUpcomingInvoice,
 } from './stripe.client.types';
@@ -17,6 +18,14 @@ import { StripeConfig } from './stripe.config';
 /**
  * A wrapper for Stripe that enforces that results have deterministic typings
  * that represent their expanded/unexpanded state.
+ *
+ * Naming for methods within this file should follow the way the corresponding Stripe method is named:
+ *
+ * this.stripe.aBC.xYZ should be wrapped in a method named aBCxYZ
+ *
+ * For example:
+ * this.stripe.customers.retrieve is wrapped in a method named retrieveCustomer
+ *
  */
 @Injectable()
 export class StripeClient {
@@ -34,7 +43,7 @@ export class StripeClient {
    * @param customerId The Stripe customer ID of the customer to fetch
    * @returns The customer record for the customerId provided
    */
-  async fetchCustomer(
+  async customersRetrieve(
     customerId: string,
     params?: Stripe.CustomerRetrieveParams
   ) {
@@ -52,7 +61,7 @@ export class StripeClient {
    * @param params Values to be updated in customer object
    * @returns The updated customer object or throws an error if paramaters are invalid
    */
-  async updateCustomer(
+  async customersUpdate(
     customerId: string,
     params?: Stripe.CustomerUpdateParams
   ) {
@@ -67,7 +76,7 @@ export class StripeClient {
   /**
    * Retrieves subscriptions directly from Stripe
    */
-  async fetchSubscriptions(params?: Stripe.SubscriptionListParams) {
+  async subscriptionsList(params?: Stripe.SubscriptionListParams) {
     const result = await this.stripe.subscriptions.list({
       ...params,
       expand: undefined,
@@ -76,7 +85,9 @@ export class StripeClient {
     return result as Stripe.ApiList<StripeSubscription>;
   }
 
-  async retrieveUpcomingInvoice(params?: Stripe.InvoiceRetrieveUpcomingParams) {
+  async invoicesRetrieveUpcoming(
+    params?: Stripe.InvoiceRetrieveUpcomingParams
+  ) {
     const result = await this.stripe.invoices.retrieveUpcoming({
       ...params,
       expand: undefined,
@@ -84,11 +95,33 @@ export class StripeClient {
     return result as StripeUpcomingInvoice;
   }
 
-  async finalizeInvoice(
+  async invoicesFinalizeInvoice(
     invoiceId: string,
     params?: Stripe.InvoiceFinalizeInvoiceParams
   ) {
     const result = await this.stripe.invoices.finalizeInvoice(invoiceId, {
+      ...params,
+      expand: undefined,
+    });
+    return result as StripeInvoice;
+  }
+
+  async paymentMethodsAttach(
+    id: string,
+    params: Stripe.PaymentMethodAttachParams
+  ) {
+    const result = await this.stripe.paymentMethods.attach(id, {
+      ...params,
+      expand: undefined,
+    });
+    return result as StripePaymentMethod;
+  }
+
+  async invoicesRetrieve(
+    id: string,
+    params?: Stripe.PaymentMethodAttachParams
+  ) {
+    const result = await this.stripe.invoices.retrieve(id, {
       ...params,
       expand: undefined,
     });

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -304,6 +304,12 @@ export type StripeCard = NegotiateExpanded<
   'customer' | 'account'
 >;
 
+export type StripePaymentMethod = NegotiateExpanded<
+  never,
+  Stripe.PaymentMethod,
+  'customer'
+>;
+
 export type StripeApiList<T> = Stripe.ApiList<T>;
 export type StripeApiListPromise<T> = Stripe.ApiListPromise<T>;
 export type StripeResponse<T> = Stripe.Response<T>;

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -49,7 +49,9 @@ describe('StripeManager', () => {
     it('returns an existing customer from Stripe', async () => {
       const mockCustomer = StripeCustomerFactory();
 
-      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+      mockClient.customersRetrieve = jest
+        .fn()
+        .mockResolvedValueOnce(mockCustomer);
 
       const result = await manager.fetchActiveCustomer(mockCustomer.id);
       expect(result).toEqual(mockCustomer);
@@ -62,7 +64,7 @@ describe('StripeManager', () => {
         auto_advance: false,
       });
 
-      mockClient.finalizeInvoice = jest.fn().mockResolvedValueOnce({});
+      mockClient.invoicesFinalizeInvoice = jest.fn().mockResolvedValueOnce({});
 
       const result = await manager.finalizeInvoiceWithoutAutoAdvance(
         mockInvoice.id
@@ -111,7 +113,7 @@ describe('StripeManager', () => {
 
       const expected = mockSubscriptionList;
 
-      mockClient.fetchSubscriptions = jest
+      mockClient.subscriptionsList = jest
         .fn()
         .mockResolvedValueOnce(mockSubscriptionList);
 
@@ -159,7 +161,9 @@ describe('StripeManager', () => {
         },
       });
 
-      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+      mockClient.customersRetrieve = jest
+        .fn()
+        .mockResolvedValueOnce(mockCustomer);
 
       const result = await manager.getCustomerTaxId(mockCustomer.id);
 
@@ -169,7 +173,9 @@ describe('StripeManager', () => {
     it('returns undefined when customer tax id not found', async () => {
       const mockCustomer = StripeCustomerFactory();
 
-      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+      mockClient.customersRetrieve = jest
+        .fn()
+        .mockResolvedValueOnce(mockCustomer);
 
       const result = await manager.getCustomerTaxId(mockCustomer.id);
 
@@ -187,9 +193,11 @@ describe('StripeManager', () => {
         },
       });
 
-      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+      mockClient.customersRetrieve = jest
+        .fn()
+        .mockResolvedValueOnce(mockCustomer);
 
-      mockClient.updateCustomer = jest
+      mockClient.customersUpdate = jest
         .fn()
         .mockResolvedValueOnce(mockUpdatedCustomer);
 
@@ -208,7 +216,9 @@ describe('StripeManager', () => {
         },
       });
 
-      mockClient.fetchCustomer = jest.fn().mockResolvedValueOnce(mockCustomer);
+      mockClient.customersRetrieve = jest
+        .fn()
+        .mockResolvedValueOnce(mockCustomer);
 
       const result = await manager.setCustomerTaxId(
         mockCustomer.id,

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -47,7 +47,7 @@ export class StripeManager {
    * Retrieves a customer record
    */
   async fetchActiveCustomer(customerId: string) {
-    const customer = await this.client.fetchCustomer(customerId);
+    const customer = await this.client.customersRetrieve(customerId);
     if (customer.deleted) throw new CustomerDeletedError();
     return customer;
   }
@@ -56,7 +56,7 @@ export class StripeManager {
    * Finalizes an invoice and marks auto_advance as false.
    */
   async finalizeInvoiceWithoutAutoAdvance(invoiceId: string) {
-    return this.client.finalizeInvoice(invoiceId, {
+    return this.client.invoicesFinalizeInvoice(invoiceId, {
       auto_advance: false,
     });
   }
@@ -65,7 +65,7 @@ export class StripeManager {
    * Retrieves subscriptions
    */
   async getSubscriptions(customerId: string) {
-    return this.client.fetchSubscriptions({
+    return this.client.subscriptionsList({
       customer: customerId,
     });
   }
@@ -93,7 +93,7 @@ export class StripeManager {
     const customerTaxId = await this.getCustomerTaxId(customerId);
 
     if (!customerTaxId || customerTaxId !== taxId) {
-      return await this.client.updateCustomer(customerId, {
+      return await this.client.customersUpdate(customerId, {
         invoice_settings: {
           custom_fields: [{ name: MOZILLA_TAX_ID, value: taxId }],
         },
@@ -110,7 +110,7 @@ export class StripeManager {
    * @returns The tax ID of customer or undefined if not found
    */
   async getCustomerTaxId(customerId: string) {
-    const customer = await this.client.fetchCustomer(customerId);
+    const customer = await this.client.customersRetrieve(customerId);
 
     if (!customer) throw new CustomerNotFoundError();
     if (customer.deleted) throw new CustomerDeletedError();


### PR DESCRIPTION
## Because

* Our naming in our client needlessly renamed Stripe methods making it a little harder to understand what is going on

## This pull request

* Updates our naming to match what Stripe has, so that it's easier to look stuff up.

## Issue that this pull request solves

Closes FXA-9019