### PR TITLE
task(settings): Add 'mozilla account' as a common password

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
@@ -102,4 +102,18 @@ describe('FormPasswordWithBalloons component', () => {
     const imageElement = within(passwordMinCharRequirement).getByRole('img');
     expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
   });
+
+  it('disallows common passwords', async () => {
+    renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
+    const passwordField = screen.getByLabelText('Password');
+    user.type(passwordField, 'mozilla accounts');
+    await waitFor(() => screen.getByText('Password requirements'));
+    expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
+
+    const passwordNotCommonRequirement = screen.getByTestId(
+      'password-not-common-req'
+    );
+    const imageElement = within(passwordNotCommonRequirement).getByRole('img');
+    expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
+  });
 });

--- a/packages/fxa-settings/src/lib/password-validator.ts
+++ b/packages/fxa-settings/src/lib/password-validator.ts
@@ -14,6 +14,8 @@ const BANNED_SERVICE_NAMES = [
   'lockbox',
   'fxlockbox',
   'mozilla',
+  'mozilla account',
+  'mozillaaccount',
   'sumo',
   'sync',
   // These need to be sorted by length so that the largest match


### PR DESCRIPTION
Because:


This Commit:


## Because
- We should not allow obvious passwords

## This pull request

- Adds mozillaccount the BANNED_SERVICE_NAMES
- Adds mozilla account to the BAND_SERVICE_NAMES

## Issue that this pull request solves

Closes: FXA-9411

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was discovered while validating a similar change for the content server in #16574.
