### PR TITLE
feat(metrics): add reg_success_view frontend Glean event

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -166,8 +166,8 @@ const SigninTokenCode = ({
           queryParams: location.search,
         };
 
+        await GleanMetrics.isDone();
         await handleNavigation(navigationOptions, navigate);
-        GleanMetrics.isDone();
       } catch (error) {
         const localizedErrorMessage = getLocalizedErrorMessage(
           ftlMsgResolver,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -42,7 +42,16 @@ jest.mock('@reach/router', () => ({
 
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
-  default: { signupConfirmation: { view: jest.fn(), submit: jest.fn() } },
+  default: {
+    registration: {
+      complete: jest.fn(),
+    },
+    signupConfirmation: {
+      view: jest.fn(),
+      submit: jest.fn(),
+    },
+    isDone: jest.fn(),
+  },
 }));
 
 jest.mock('../../../lib/hooks/useWebRedirect');
@@ -212,6 +221,7 @@ describe('ConfirmSignupCode page', () => {
       submit();
 
       await waitFor(() => {
+        expect(GleanMetrics.registration.complete).toHaveBeenCalledTimes(1);
         expect(hardNavigateSpy).toHaveBeenCalledWith(redirectTo);
       });
     });
@@ -235,6 +245,7 @@ describe('ConfirmSignupCode page', () => {
       submit();
 
       await waitFor(() => {
+        expect(GleanMetrics.registration.complete).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('/settings', {
           replace: true,
         });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -142,6 +142,11 @@ const ConfirmSignupCode = ({
         REACT_ENTRYPOINT
       );
 
+      GleanMetrics.registration.complete();
+      // since many of the branches below lead to a redirect, we'll wait for
+      // the Glean requests
+      await GleanMetrics.isDone();
+
       storeAccountData({
         sessionToken,
         email,

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -31,6 +31,7 @@ export const eventsMap = {
     engage: 'reg_engage',
     submit: 'reg_submit',
     success: 'reg_submit_success',
+    complete: 'reg_success_view',
   },
 
   signupConfirmation: {


### PR DESCRIPTION
Because:
 - we want a frontend Glean event for successful registration

This commit:
 - adds the event and emit it when the user successfully verify their signup code
