### PR TITLE
fix(sync): Send Fx desktop context=oauth_webchannel_v1 users to CAD after login

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -14,6 +14,7 @@ import OAuthRedirectAuthenticationBroker from './oauth-redirect';
 import ScopedKeys from 'lib/crypto/scoped-keys';
 import WebChannel from '../../lib/channels/web';
 import SyncEngines from '../sync-engines';
+import ConnectAnotherDeviceBehavior from '../../views/behaviors/connect-another-device';
 
 const ALLOWED_LOGIN_FIELDS = ['email', 'sessionToken', 'uid', 'verified'];
 
@@ -79,9 +80,12 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
   },
 
   afterSignIn(account) {
-    return this._notifyRelierOfLogin(account).then(() =>
-      proto.afterSignIn.call(this, account)
-    );
+    return this._notifyRelierOfLogin(account).then(() => {
+      // Take user to CAD, or enact default behavior if ineligible
+      return new ConnectAnotherDeviceBehavior(
+        proto.afterSignIn.call(this, account)
+      );
+    });
   },
 
   afterSignUpConfirmationPoll(account) {

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -105,7 +105,8 @@ export default {
     const isNotActionEmail = this.relier.get('action') !== 'email';
     if (
       this.isDefault() &&
-      context === Constants.FX_DESKTOP_V3_CONTEXT &&
+      (context === Constants.FX_DESKTOP_V3_CONTEXT ||
+        context === Constants.OAUTH_WEBCHANNEL_CONTEXT) &&
       (entrypoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT ||
         (isNotActionEmail &&
           [

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -108,20 +108,35 @@ describe('views/connect_another_device', () => {
         beforeEach(() => {
           sinon.stub(view, '_isSignedIn').callsFake(() => true);
           relier.set('entrypoint', entrypoint);
-          relier.set('context', 'fx_desktop_v3');
           sinon.spy(view, 'navigate');
-
           windowMock.navigator.userAgent =
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+        });
 
-          return view.render().then(() => {
-            view.afterVisible();
+        describe('with fx_desktop_v3 context', () => {
+          beforeEach(() => {
+            relier.set('context', 'fx_desktop_v3');
+            return view.render().then(() => {
+              view.afterVisible();
+            });
+          });
+          it('redirects and shows pairing', () => {
+            assert.isTrue(view._isSignedIn.called);
+            assert.isTrue(view.navigate.calledWith('/pair'));
           });
         });
 
-        it('redirects and shows pairing', () => {
-          assert.isTrue(view._isSignedIn.called);
-          assert.isTrue(view.navigate.calledWith('/pair'));
+        describe('with oauth_webchannel_v1 context', () => {
+          beforeEach(() => {
+            relier.set('context', 'oauth_webchannel_v1');
+            return view.render().then(() => {
+              view.afterVisible();
+            });
+          });
+          it('redirects and shows pairing', () => {
+            assert.isTrue(view._isSignedIn.called);
+            assert.isTrue(view.navigate.calledWith('/pair'));
+          });
         });
       });
     });


### PR DESCRIPTION
…fter login

Because:
* This is the behavior for desktop v3 which we want to mimic; otherwise the behavior halts on signin

This commit:
* Updates afterSignIn method for oauth-webchannel-v1 broker

fixes FXA-9100

---

This appears to work as expected for me with React.

Testing locally:
* Update your configs (auth-server and content-server) to [match this diff](https://github.com/mozilla/fxa/commit/96c6b297c1731d0571c09395dbe128040fa20c85). Restart the stack
* Run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 yarn start` in dev launcher, (make sure FF is latest), change `identity.fxaccounts.oauth.enabled` to `true` and set `identity.fxaccounts.contextParam` to `oauth_webchannel_v1`
* Sign in with Sync, try React (with params) and Backbone signin. See Sync signin is successful and CAD is shown