### PR TITLE
refactor(functional-tests): move createEmail from login to email fixture

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -492,13 +492,6 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.ERROR).innerText();
   }
 
-  createEmail(template?: string) {
-    if (!template) {
-      template = 'signin{id}';
-    }
-    return template.replace('{id}', Math.random() + '') + '@restmail.net';
-  }
-
   async getStorage() {
     await this.goto();
     return this.page.evaluate(() => {

--- a/packages/functional-tests/pages/settings/deleteAccount.ts
+++ b/packages/functional-tests/pages/settings/deleteAccount.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { SettingsLayout } from './layout';
 
 export class DeleteAccountPage extends SettingsLayout {
@@ -42,19 +43,16 @@ export class DeleteAccountPage extends SettingsLayout {
     }
   }
 
-  clickContinue() {
-    return this.page.click('button[data-testid=continue-button]');
-  }
+  async deleteAccount(password: string) {
+    await expect(this.deleteAccountHeading).toBeVisible();
+    await expect(this.step1Heading).toBeVisible();
 
-  setPassword(password: string) {
-    return this.page.fill('input[type=password]', password);
-  }
+    await this.checkAllBoxes();
+    await this.continueButton.click();
 
-  submit() {
-    return this.page.click('[data-testid="delete-account-button"]');
-  }
+    await expect(this.step2Heading).toBeVisible();
 
-  success() {
-    return this.page.locator('.success');
+    await this.passwordTextbox.fill(password);
+    await this.deleteButton.click();
   }
 }

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  PASSWORD,
+  SIGNIN_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('OAuth `login_hint` and `email` param', () => {
@@ -20,8 +25,9 @@ test.describe('severity-2 #smoke', () => {
       page,
       pages: { login, relier },
       target,
+      emails,
     }) => {
-      const email = login.createEmail();
+      const [email] = emails;
       await relier.goto(`login_hint=${email}`);
       await relier.clickEmailFirst();
 
@@ -68,15 +74,22 @@ test.describe('severity-2 #smoke', () => {
       // Email first page has email input prefilled
       await expect(await login.getEmailInput()).toEqual(credentials.email);
     });
+  });
 
+  test.describe('OAuth `login_hint` and `email` param', () => {
+    test.use({
+      emailOptions: [
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+      ],
+    });
     test('cached credentials, login_hint specified by relier', async ({
       target,
       pages: { login, relier },
+      emails,
     }) => {
-      const email = login.createEmail();
+      const [email, loginHintEmail] = emails;
       await target.createAccount(email, PASSWORD);
-
-      const loginHintEmail = login.createEmail();
       await target.createAccount(loginHintEmail, PASSWORD);
 
       // Create a cached login

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -6,7 +6,6 @@ import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth permissions for trusted reliers - sign up', () => {
-    test.use({ emailOptions: [{ PASSWORD }] });
     test.beforeEach(async ({ pages: { configPage, login } }) => {
       const config = await configPage.getConfig();
       test.skip(

--- a/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
+++ b/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
@@ -2,18 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  PASSWORD,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const CODE_CHALLENGE_METHOD = 'S256';
 
 test.describe('OAuth scopeKeys', () => {
+  test.use({
+    emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
+  });
   test('signin in Chrome for Android, verify same browser', async ({
     target,
     page,
     pages: { login },
+    emails,
   }) => {
-    const email = login.createEmail('sync{id}');
+    const [email] = emails;
     await target.createAccount(email, PASSWORD);
 
     const query = new URLSearchParams({

--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -2,27 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  SIGNIN_EMAIL_PREFIX,
+  BOUNCED_EMAIL_PREFIX,
+  PASSWORD,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
-  test.describe('Oauth sign up', () => {
-    test.use({
-      emailOptions: [{ PASSWORD }, { prefix: 'bounced{id}', PASSWORD }],
-    });
-    test.beforeEach(async ({ pages: { configPage, login } }) => {
-      const config = await configPage.getConfig();
-      if (config.showReactApp.signUpRoutes === true) {
-        test.skip(
-          true,
-          'this test is specific to backbone, skip if serving react'
-        );
-      } else {
-        test.slow();
-      }
-    });
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'this test is specific to backbone, skip if serving react'
+    );
+    test.slow();
+  });
 
+  test.describe('Oauth sign up', () => {
     test('sign up', async ({ emails, pages: { login, relier } }) => {
-      const [email, ,] = emails;
+      const [email] = emails;
       await relier.goto();
       await relier.clickEmailFirst();
       await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
@@ -35,7 +35,15 @@ test.describe('severity-1 #smoke', () => {
       //Verify logged in on relier page
       expect(await relier.isLoggedIn()).toBe(true);
     });
+  });
 
+  test.describe('Oauth sign up', () => {
+    test.use({
+      emailOptions: [
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+        { prefix: BOUNCED_EMAIL_PREFIX, password: PASSWORD },
+      ],
+    });
     test('signup, bounce email, allow user to restart flow but force a different email', async ({
       emails,
       target,

--- a/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
+++ b/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
@@ -3,11 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { EmailHeader, EmailType } from '../../lib/email';
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  PASSWORD,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('OAuth signin token code', () => {
-    test.use({ emailOptions: [{ prefix: 'sync{id}', PASSWORD }] });
     function toQueryString(obj) {
       return Object.entries(obj)
         .map((x) => `${x[0]}=${x[1]}`)
@@ -29,18 +33,18 @@ test.describe('severity-2 #smoke', () => {
     };
     /* eslint-enable camelcase */
 
-    test.beforeEach(async ({ target, emails }, { project }) => {
-      // The `sync` prefix is needed to force confirmation.
-      const [syncEmail] = emails;
-      await target.createAccount(syncEmail, PASSWORD);
+    test.use({
+      emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
     });
-
     test('verified - invalid token', async ({
+      target,
       emails,
       page,
       pages: { login, relier, signinTokenCode },
     }) => {
+      // The `sync` prefix is needed to force confirmation.
       const [syncEmail] = emails;
+      await target.createAccount(syncEmail, PASSWORD);
       await relier.goto(toQueryString(queryParameters));
 
       // Click the Email First flow, which should direct to the sign in page
@@ -61,12 +65,14 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('verified - valid code', async ({
-      emails,
       target,
+      emails,
       page,
       pages: { login, relier, signinTokenCode },
     }) => {
+      // The `sync` prefix is needed to force confirmation.
       const [syncEmail] = emails;
+      await target.createAccount(syncEmail, PASSWORD);
       await relier.goto(toQueryString(queryParameters));
 
       // Click the Email First flow, which should direct to the sign in page

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  expect,
+  test,
+  PASSWORD,
+  SIGNIN_EMAIL_PREFIX,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.beforeEach(() => {
@@ -11,7 +17,10 @@ test.describe('severity-1 #smoke', () => {
 
   test.describe('signin with OAuth after Sync', () => {
     test.use({
-      emailOptions: [{ PASSWORD }, { prefix: 'sync{id}', PASSWORD }],
+      emailOptions: [
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+        { prefix: SYNC_EMAIL_PREFIX, password: PASSWORD },
+      ],
     });
     test('signin to OAuth with Sync creds', async ({
       emails,
@@ -50,7 +59,7 @@ test.describe('severity-1 #smoke', () => {
 
   test.describe('signin to Sync after OAuth', () => {
     test.use({
-      emailOptions: [{ prefix: 'sync{id}', PASSWORD }],
+      emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
     });
     test('email-first Sync signin', async ({
       emails,

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -11,7 +11,7 @@ test.describe('severity-1 #smoke', () => {
       await login.clearCache();
     });
 
-    test('signup', async ({ pages: { configPage, login, relier } }) => {
+    test('signup', async ({ pages: { configPage, login, relier }, emails }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
@@ -28,7 +28,7 @@ test.describe('severity-1 #smoke', () => {
           signedInUser: null,
         }
       );
-      const email = login.createEmail();
+      const [email] = emails;
 
       await relier.goto('context=oauth_webchannel_v1&automatedBrowser=true');
       await relier.clickEmailFirst();

--- a/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
@@ -5,38 +5,32 @@
 import {
   test,
   expect,
+  FORCE_PWD_EMAIL_PREFIX,
   PASSWORD,
   NEW_PASSWORD,
 } from '../../lib/fixtures/standard';
-
-let emailUserCreds;
 
 test.describe('severity-2 #smoke', () => {
   test.describe('post verify - force password change', () => {
     test.use({
       emailOptions: [
-        {
-          prefix: 'forcepwdchange{id}',
-          PASSWORD,
-          NEW_PASSWORD,
-        },
+        { prefix: FORCE_PWD_EMAIL_PREFIX, password: NEW_PASSWORD },
       ],
     });
     test.beforeEach(async ({ emails, target, pages: { login } }) => {
       test.slow();
+    });
+
+    test('navigate to page directly and can change password', async ({
+      target,
+      emails,
+      pages: { page, login, postVerify },
+    }) => {
       const [email] = emails;
       await target.auth.signUp(email, PASSWORD, {
         lang: 'en',
         preVerified: 'true',
       });
-    });
-
-    test('navigate to page directly and can change password', async ({
-      emails,
-      target,
-      pages: { page, login, postVerify },
-    }) => {
-      const [email] = emails;
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -55,10 +49,15 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('force change password on login - oauth', async ({
+      target,
       emails,
       pages: { login, postVerify, relier },
     }) => {
       const [email] = emails;
+      await target.auth.signUp(email, PASSWORD, {
+        lang: 'en',
+        preVerified: 'true',
+      });
       await relier.goto();
       await relier.clickEmailFirst();
       await login.fillOutEmailFirstSignIn(email, PASSWORD);

--- a/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
@@ -7,27 +7,26 @@ import {
   test,
   PASSWORD,
   NEW_PASSWORD,
+  FORCE_PWD_EMAIL_PREFIX,
 } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('post verify - force password change sync', () => {
     test.use({
-      emailOptions: [{ prefix: 'forcepwdchange{id}', PASSWORD, NEW_PASSWORD }],
+      emailOptions: [
+        { prefix: FORCE_PWD_EMAIL_PREFIX, password: NEW_PASSWORD },
+      ],
     });
-    test.beforeEach(async ({ emails, target, syncBrowserPages: { login } }) => {
-      const [email] = emails;
-      await target.auth.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-    });
-
     test('force change password on login - sync', async ({
       emails,
       target,
       syncBrowserPages,
     }) => {
       const [email] = emails;
+      await target.auth.signUp(email, PASSWORD, {
+        lang: 'en',
+        preVerified: 'true',
+      });
       const { page, login, postVerify, connectAnotherDevice } =
         syncBrowserPages;
       await page.goto(

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -3,7 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import { expect, test } from '../../lib/fixtures/standard';
+import {
+  SIGNUP_REACT_EMAIL_PREFIX,
+  expect,
+  test,
+} from '../../lib/fixtures/standard';
 import { PASSWORD } from '../../lib/fixtures/standard';
 
 import {
@@ -22,6 +26,10 @@ const eventDetailLinkAccount = createCustomEventDetail(
 );
 
 test.describe('severity-1 #smoke', () => {
+  test.use({
+    emailOptions: [{ prefix: SIGNUP_REACT_EMAIL_PREFIX, password: PASSWORD }],
+  });
+
   test.beforeEach(async ({ pages: { configPage } }) => {
     test.slow();
     // Ensure that the feature flag is enabled
@@ -32,7 +40,6 @@ test.describe('severity-1 #smoke', () => {
   });
 
   test.describe('signup react', () => {
-    test.use({ emailOptions: [{ prefix: 'signup_react{id}', PASSWORD }] });
     test('signup web', async ({
       page,
       pages: { settings, signupReact },
@@ -214,7 +221,6 @@ test.describe('severity-1 #smoke', () => {
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signup react', () => {
-    test.use({ emailOptions: [{ prefix: 'signup_react{id}', PASSWORD }] });
     test('signup invalid email', async ({ page, pages: { signupReact } }) => {
       const invalidEmail = 'invalid';
 

--- a/packages/functional-tests/tests/settings/deleteAccount.spec.ts
+++ b/packages/functional-tests/tests/settings/deleteAccount.spec.ts
@@ -50,17 +50,7 @@ test.describe('severity-1 #smoke', () => {
     await settings.goto();
 
     await settings.deleteAccountButton.click();
-
-    await expect(deleteAccount.deleteAccountHeading).toBeVisible();
-    await expect(deleteAccount.step1Heading).toBeVisible();
-
-    await deleteAccount.checkAllBoxes();
-    await deleteAccount.continueButton.click();
-
-    await expect(deleteAccount.step2Heading).toBeVisible();
-
-    await deleteAccount.passwordTextbox.fill(credentials.password);
-    await deleteAccount.deleteButton.click();
+    await deleteAccount.deleteAccount(credentials.password);
 
     await expect(page.getByText('Account deleted successfully')).toBeVisible();
   });

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -2,13 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  expect,
+  test,
+  PASSWORD,
+  SIGNIN_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 import { oauthWebchannelV1 } from '../../lib/query-params';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('fxa_status web channel message in Settings', () => {
-  test.use({ emailOptions: [{ PASSWORD }, { PASSWORD }] });
+  test.use({
+    emailOptions: [
+      { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+      { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+    ],
+  });
   test.beforeEach(
     async ({
       emails,
@@ -18,9 +28,9 @@ test.describe('fxa_status web channel message in Settings', () => {
     }) => {
       test.slow();
       // Ensure that the feature flag is enabled
-      const [email, otherEmail] = emails;
       const config = await configPage.getConfig();
       test.skip(config.featureFlags.sendFxAStatusOnSettings !== true);
+      const [email, otherEmail] = emails;
       await target.auth.signUp(email, PASSWORD, {
         lang: 'en',
         preVerified: 'true',

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -172,17 +172,7 @@ test.describe('severity-1 #smoke', () => {
       await login.setTotp(credentials.secret);
 
       await settings.deleteAccountButton.click();
-
-      await expect(deleteAccount.deleteAccountHeading).toBeVisible();
-      await expect(deleteAccount.step1Heading).toBeVisible();
-
-      await deleteAccount.checkAllBoxes();
-      await deleteAccount.continueButton.click();
-
-      await expect(deleteAccount.step2Heading).toBeVisible();
-
-      await deleteAccount.passwordTextbox.fill(credentials.password);
-      await deleteAccount.deleteButton.click();
+      await deleteAccount.deleteAccount(credentials.password);
 
       await expect(
         page.getByText('Account deleted successfully')

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -2,21 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  SIGNIN_EMAIL_PREFIX,
+  PASSWORD,
+} from '../../lib/fixtures/standard';
 
 const password = 'password12345678';
 
 test.describe('severity-2 #smoke', () => {
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
+    test.skip(
+      config.showReactApp.signUpRoutes === true,
+      'these tests are specific to backbone, skip if serving React version'
+    );
+    test.slow();
+  });
   test.describe('signup here', () => {
-    test.beforeEach(async ({ pages: { configPage } }) => {
-      const config = await configPage.getConfig();
-      test.skip(
-        config.showReactApp.signUpRoutes === true,
-        'these tests are specific to backbone, skip if serving React version'
-      );
-      test.slow();
-    });
-
     test('with an invalid email, empty email query query param', async ({
       target,
       page,
@@ -33,14 +37,14 @@ test.describe('severity-2 #smoke', () => {
       );
     });
 
-    test('signup with email with leading/trailing whitespace on the email', async ({
+    test('signup with email with leading whitespace on the email', async ({
       target,
       page,
       pages: { login },
+      emails,
     }) => {
-      let email = login.createEmail();
-      let emailWithoutSpace = email;
-      let emailWithSpace = '   ' + email;
+      const [emailWithoutSpace] = emails;
+      const emailWithSpace = '   ' + emailWithoutSpace;
       await page.goto(target.contentServerUrl);
       await login.fillOutFirstSignUp(emailWithSpace, password, {
         verify: false,
@@ -49,14 +53,17 @@ test.describe('severity-2 #smoke', () => {
       // Verify the confirm code header and the email
       await expect(login.signUpCodeHeader()).toBeVisible();
       expect(await login.confirmEmail()).toContain(emailWithoutSpace);
+    });
 
-      // Need to clear the cache to get the new email
-      await login.clearCache();
-
+    test('signup with email with trailing whitespace on the email', async ({
+      target,
+      page,
+      pages: { login },
+      emails,
+    }) => {
+      const [emailWithoutSpace] = emails;
+      const emailWithSpace = emailWithoutSpace + ' ';
       await page.goto(target.contentServerUrl);
-      email = login.createEmail();
-      emailWithoutSpace = email;
-      emailWithSpace = email + ' ';
       await login.fillOutFirstSignUp(emailWithSpace, password, {
         verify: false,
       });
@@ -81,8 +88,9 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { login },
+      emails,
     }) => {
-      const email = login.createEmail();
+      const [email] = emails;
       await page.goto(target.contentServerUrl);
       await login.setEmail(email);
       await login.clickSubmit();
@@ -108,8 +116,9 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { login },
+      emails,
     }) => {
-      const email = login.createEmail();
+      const [email] = emails;
       await page.goto(target.contentServerUrl);
       await login.setEmail(email);
       await login.clickSubmit();
@@ -122,12 +131,33 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.getTooltipError()).toContain('Passwords do not match');
     });
 
+    test('signup via relier page and redirect after confirm', async ({
+      pages: { login, relier },
+      emails,
+    }) => {
+      const [email] = emails;
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await login.fillOutFirstSignUp(email, password);
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+  });
+
+  test.describe('signup here', () => {
+    test.use({
+      emailOptions: [
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+      ],
+    });
+
     test('form prefill information is cleared after signup->sign out', async ({
       target,
       page,
       pages: { login, settings },
+      emails,
     }) => {
-      const email = login.createEmail();
+      const [email, secondEmail] = emails;
       await page.goto(target.contentServerUrl);
       await login.fillOutFirstSignUp(email, password);
 
@@ -140,30 +170,20 @@ test.describe('severity-2 #smoke', () => {
       await login.waitForEmailHeader();
       expect(await login.getEmailInput()).toContain('');
 
-      await login.setEmail(login.createEmail());
+      await login.setEmail(secondEmail);
       await login.clickSubmit();
 
       // check the password was cleared
       expect(await login.getPasswordInput()).toContain('');
     });
 
-    test('signup via relier page and redirect after confirm', async ({
-      pages: { login, relier },
-    }) => {
-      const email = login.createEmail();
-      await relier.goto();
-      await relier.clickEmailFirst();
-      await login.fillOutFirstSignUp(email, password);
-      expect(await relier.isLoggedIn()).toBe(true);
-    });
-
     test('signup, verify and sign out of two accounts, all in the same tab, then sign in to the first account', async ({
       target,
       page,
       pages: { login, settings },
+      emails,
     }) => {
-      const email = login.createEmail();
-      const secondEmail = login.createEmail();
+      const [email, secondEmail] = emails;
       await page.goto(target.contentServerUrl);
       await login.fillOutFirstSignUp(email, password);
 

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -6,7 +6,6 @@ import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sign up with code', () => {
-    test.use({ emailOptions: [{ PASSWORD }] });
     test.beforeEach(async ({ pages: { configPage, login } }) => {
       const config = await configPage.getConfig();
       test.skip(

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -2,10 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  PASSWORD,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signin here', () => {
+    test.use({
+      emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
+    });
     test('signin verified with incorrect password, click `forgot password?`', async ({
       target,
       page,
@@ -106,13 +114,14 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { configPage, login },
+      emails,
     }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'bounced email functionality does not currently work for react'
       );
-      const email = login.createEmail('sync{id}');
+      const [email] = emails;
       const creds = await target.createAccount(email, PASSWORD);
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -2,43 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  test,
+  expect,
+  PASSWORD,
+  SIGNIN_EMAIL_PREFIX,
+  BLOCKED_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
+  test.beforeEach(async () => {
+    test.slow(); //This test has steps for email rendering that runs slow on stage
+  });
+
   test.describe('signin blocked', () => {
     test.use({
-      emailOptions: [
-        { PASSWORD },
-        { prefix: 'blocked{id}', PASSWORD },
-        { prefix: 'blocked{id}', PASSWORD },
-        { prefix: 'blocked{id}', PASSWORD },
-      ],
-    });
-
-    test.beforeEach(async ({ emails, target, pages: { login } }) => {
-      test.slow(); //This test has steps for email rendering that runs slow on stage
-      const [email, blockedEmail, , unverifiedEmail] = emails;
-      await target.auth.signUp(blockedEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await target.auth.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await target.auth.signUp(unverifiedEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'false',
-      });
+      emailOptions: [{ prefix: BLOCKED_EMAIL_PREFIX, password: PASSWORD }],
     });
 
     test('valid code entered', async ({
       emails,
       target,
       page,
-      pages: { login },
+      pages: { login, settings, deleteAccount },
     }) => {
-      const [, blockedEmail, ,] = emails;
+      const [blockedEmail] = emails;
+      await target.auth.signUp(blockedEmail, PASSWORD, {
+        lang: 'en',
+        preVerified: 'true',
+      });
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -53,15 +45,27 @@ test.describe('severity-2 #smoke', () => {
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
+
+      //Delete blocked account, the fixture teardown doesn't work in this case
+      await settings.deleteAccountButton.click();
+      await deleteAccount.deleteAccount(PASSWORD);
+
+      await expect(
+        page.getByText('Account deleted successfully')
+      ).toBeVisible();
     });
 
     test('incorrect code entered', async ({
       emails,
       target,
       page,
-      pages: { login },
+      pages: { login, settings, deleteAccount },
     }) => {
-      const [, blockedEmail, ,] = emails;
+      const [blockedEmail] = emails;
+      await target.auth.signUp(blockedEmail, PASSWORD, {
+        lang: 'en',
+        preVerified: 'true',
+      });
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -82,15 +86,27 @@ test.describe('severity-2 #smoke', () => {
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
+
+      //Delete blocked account, the fixture teardown doesn't work in this case
+      await settings.deleteAccountButton.click();
+      await deleteAccount.deleteAccount(PASSWORD);
+
+      await expect(
+        page.getByText('Account deleted successfully')
+      ).toBeVisible();
     });
 
     test('resend', async ({
       emails,
       target,
       page,
-      pages: { login, resetPassword },
+      pages: { login, resetPassword, settings, deleteAccount },
     }) => {
-      const [, blockedEmail, ,] = emails;
+      const [blockedEmail] = emails;
+      await target.auth.signUp(blockedEmail, PASSWORD, {
+        lang: 'en',
+        preVerified: 'true',
+      });
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -113,48 +129,28 @@ test.describe('severity-2 #smoke', () => {
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
+
+      //Delete blocked account, the fixture teardown doesn't work in this case
+      await settings.deleteAccountButton.click();
+      await deleteAccount.deleteAccount(PASSWORD);
+
+      await expect(
+        page.getByText('Account deleted successfully')
+      ).toBeVisible();
     });
 
-    test('with primary email changed', async ({
+    test('unverified', async ({
       emails,
       target,
       page,
-      pages: { login, settings, secondaryEmail },
+      pages: { login, settings, deleteAccount },
     }) => {
-      const [email, , newEmail] = emails;
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
-      await login.fillOutEmailFirstSignIn(email, PASSWORD);
-
-      //Verify logged in on Settings page
-      expect(await login.isUserLoggedIn()).toBe(true);
-
-      await settings.goto();
-      await settings.secondaryEmail.addButton.click();
-      await secondaryEmail.addSecondaryEmail(newEmail);
-      await settings.secondaryEmail.makePrimaryButton.click();
-      await settings.signOut();
-
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
-      await login.fillOutEmailFirstSignIn(newEmail, PASSWORD);
-
-      //Verify sign in block header
-      await expect(login.signInUnblockHeader()).toBeVisible();
-      expect(await login.getUnblockEmail()).toContain(newEmail);
-
-      //Unblock the email
-      await login.unblock(newEmail);
-
-      //Verify logged in on Settings page
-      expect(await login.isUserLoggedIn()).toBe(true);
-    });
-
-    test('unverified', async ({ emails, target, page, pages: { login } }) => {
       test.fixme(true, 'FXA-9226');
-      const [, , , unverifiedEmail] = emails;
+      const [unverifiedEmail] = emails;
+      await target.auth.signUp(unverifiedEmail, PASSWORD, {
+        lang: 'en',
+        preVerified: 'false',
+      });
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -174,6 +170,71 @@ test.describe('severity-2 #smoke', () => {
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
+
+      //Delete blocked account, the fixture teardown doesn't work in this case
+      await settings.deleteAccountButton.click();
+      await deleteAccount.deleteAccount(PASSWORD);
+
+      await expect(
+        page.getByText('Account deleted successfully')
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('signin blocked', () => {
+    test.use({
+      emailOptions: [
+        { prefix: BLOCKED_EMAIL_PREFIX, password: PASSWORD },
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+      ],
+    });
+    test('with primary email changed', async ({
+      emails,
+      target,
+      page,
+      pages: { login, settings, deleteAccount, secondaryEmail },
+    }) => {
+      const [blockedEmail, email] = emails;
+      await target.auth.signUp(email, PASSWORD, {
+        lang: 'en',
+        preVerified: 'true',
+      });
+      await page.goto(target.contentServerUrl, {
+        waitUntil: 'load',
+      });
+      await login.fillOutEmailFirstSignIn(email, PASSWORD);
+
+      //Verify logged in on Settings page
+      expect(await login.isUserLoggedIn()).toBe(true);
+
+      await settings.goto();
+      await settings.secondaryEmail.addButton.click();
+      await secondaryEmail.addSecondaryEmail(blockedEmail);
+      await settings.secondaryEmail.makePrimaryButton.click();
+      await settings.signOut();
+
+      await page.goto(target.contentServerUrl, {
+        waitUntil: 'load',
+      });
+      await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
+
+      //Verify sign in block header
+      await expect(login.signInUnblockHeader()).toBeVisible();
+      expect(await login.getUnblockEmail()).toContain(blockedEmail);
+
+      //Unblock the email
+      await login.unblock(blockedEmail);
+
+      //Verify logged in on Settings page
+      expect(await login.isUserLoggedIn()).toBe(true);
+
+      //Delete blocked account, the fixture teardown doesn't work in this case
+      await settings.deleteAccountButton.click();
+      await deleteAccount.deleteAccount(PASSWORD);
+
+      await expect(
+        page.getByText('Account deleted successfully')
+      ).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -8,15 +8,16 @@ import {
   test,
   PASSWORD,
   NEW_PASSWORD,
+  SYNC_EMAIL_PREFIX,
 } from '../../lib/fixtures/standard';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-2 #smoke', () => {
+  test.use({
+    emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: NEW_PASSWORD }],
+  });
   test.describe('Firefox Desktop Sync v3 settings', () => {
-    test.use({
-      emailOptions: [{ prefix: 'sync{id}', PASSWORD, NEW_PASSWORD }],
-    });
     test.beforeEach(
       async ({
         emails,
@@ -83,10 +84,6 @@ test.describe('severity-2 #smoke', () => {
   });
 
   test.describe('Firefox Desktop Sync v3 settings - delete account', () => {
-    test.use({
-      emailOptions: [{ prefix: 'sync{id}', PASSWORD }],
-    });
-
     test('sign in, delete the account', async ({
       emails,
       target,
@@ -110,14 +107,11 @@ test.describe('severity-2 #smoke', () => {
       );
       //Click Delete account
       await settings.deleteAccountButton.click();
-      await deleteAccount.checkAllBoxes();
-      await deleteAccount.clickContinue();
+      await deleteAccount.deleteAccount(PASSWORD);
 
-      //Enter password
-      await deleteAccount.setPassword(PASSWORD);
-      await deleteAccount.submit();
-
-      await expect(deleteAccount.success()).toBeVisible();
+      await expect(
+        page.getByText('Account deleted successfully')
+      ).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  expect,
+  test,
+  PASSWORD,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 const incorrectPassword = 'password123';
 
@@ -10,7 +15,9 @@ test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 sign up', () => {
-    test.use({ emailOptions: [{ prefix: 'sync{id}', PASSWORD }] });
+    test.use({
+      emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
+    });
 
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -3,14 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  expect,
+  test,
+  PASSWORD,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync v3 sign up and CWTS', () => {
-    test.use({ emailOptions: [{ prefix: 'sync{id}', PASSWORD }] });
+    test.use({
+      emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
+    });
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -2,24 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  expect,
+  test,
+  PASSWORD,
+  SIGNIN_EMAIL_PREFIX,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('sync signin cached', () => {
     test.use({
-      emailOptions: [{ PASSWORD }, { prefix: 'sync{id}', PASSWORD }],
+      emailOptions: [
+        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
+        { prefix: SYNC_EMAIL_PREFIX, password: PASSWORD },
+      ],
     });
-    test.beforeEach(async ({ emails, target }) => {
+    test.beforeEach(async () => {
       test.slow(); //This test has steps for email rendering that runs slow on stage
-      const [email, syncEmail] = emails;
-      await target.auth.signUp(syncEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await target.auth.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
     });
 
     test('sign in on desktop then specify a different email on query parameter continues to cache desktop signin', async ({
@@ -27,8 +27,16 @@ test.describe('severity-2 #smoke', () => {
       target,
       syncBrowserPages: { page, login, connectAnotherDevice },
     }) => {
-      const [email, syncEmail] = emails;
       test.fixme(true, 'test to be fixed, see FXA-9194');
+      await Promise.all(
+        emails.map(async (email) => {
+          await target.auth.signUp(email, PASSWORD, {
+            lang: 'en',
+            preVerified: 'true',
+          });
+        })
+      );
+      const [email, syncEmail] = emails;
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`
       );
@@ -71,8 +79,16 @@ test.describe('severity-2 #smoke', () => {
       target,
       syncBrowserPages: { page, login },
     }) => {
-      const [email, syncEmail] = emails;
       test.fixme(true, 'test to be fixed, see FXA-9194');
+      await Promise.all(
+        emails.map(async (email) => {
+          await target.auth.signUp(email, PASSWORD, {
+            lang: 'en',
+            preVerified: 'true',
+          });
+        })
+      );
+      const [email, syncEmail] = emails;
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync`
       );

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -2,12 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test, PASSWORD } from '../../lib/fixtures/standard';
+import {
+  expect,
+  test,
+  PASSWORD,
+  SYNC_EMAIL_PREFIX,
+} from '../../lib/fixtures/standard';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('Firefox Desktop Sync v3 email first', () => {
-  test.use({ emailOptions: [{ prefix: 'sync{id}', PASSWORD }] });
+  test.use({
+    emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
+  });
   test.beforeEach(async () => {
     test.slow();
   });
@@ -18,12 +25,12 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     target,
     syncBrowserPages: { page, login },
   }) => {
-    const [email] = emails;
     const config = await configPage.getConfig();
     test.fixme(
       config.showReactApp.signUpRoutes === true,
       'Not currently supported in React Signup FXA-8973'
     );
+    const [email] = emails;
     await page.goto(
       `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,
       { waitUntil: 'load' }


### PR DESCRIPTION
## Because

* we want to assure that all emails are created and removed in a re-usable and consistent way

## This pull request

* updates tests to use the email fixture when creating emails
* standardizes email prefix strings into constants
* re-structures some test modules to only create the emails needed for tests
* isolates email logic by removing references from test.beforeEach
* cleans up linter errors
* fixes cleanup of blocked emails
  * a workaround deleting accounts from the settings page was applied to the impacted 8 test cases, rather than the fixture, since not having `Page` dependencies is necessary for planned fixture improvements 

## Issue that this pull request solves

Closes: # FXA-9359

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

- I suggest to 'Hide Whitespace' during review, since there are changes in indentation that are a bit noisy 
