### PR TITLE
fix(metrics): add email to account.deleted activity event

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1847,9 +1847,6 @@ export class AccountHandler {
       accountRecord.uid,
       ReasonForDeletion.UserRequested
     );
-    await request.emitMetricsEvent('account.deleted', {
-      uid: accountRecord.uid,
-    });
 
     if (this.accountTasks.queueEnabled) {
       const result = await getAccountCustomerByUid(accountRecord.uid);

--- a/packages/fxa-auth-server/test/local/account-delete.js
+++ b/packages/fxa-auth-server/test/local/account-delete.js
@@ -51,7 +51,7 @@ describe('AccountDeleteManager', function () {
 
     sandbox.reset();
     mockFxaDb = {
-      ...mocks.mockDB({ email: email, uid: uid }),
+      ...mocks.mockDB({ email: email, emailVerified: true, uid: uid }),
       fetchAccountSubscriptions: sinon.spy(
         async (uid) => expectedSubscriptions
       ),
@@ -188,6 +188,8 @@ describe('AccountDeleteManager', function () {
       sinon.assert.calledOnceWithExactly(mockOAuthDb.removeTokensAndCodes, uid);
       sinon.assert.calledOnceWithExactly(mockLog.activityEvent, {
         uid,
+        email,
+        emailVerified: true,
         event: 'account.deleted',
       });
     });

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3829,14 +3829,6 @@ describe('/account/destroy', () => {
 
     return runTest(route, mockRequest, () => {
       sinon.assert.calledOnceWithExactly(mockDB.accountRecord, email);
-      sinon.assert.calledOnceWithExactly(mockLog.activityEvent, {
-        country: 'United States',
-        event: 'account.deleted',
-        region: 'California',
-        service: undefined,
-        userAgent: 'test user-agent',
-        uid: uid,
-      });
 
       sinon.assert.calledOnceWithExactly(
         mockAccountQuickDelete,
@@ -3861,14 +3853,6 @@ describe('/account/destroy', () => {
 
     return runTest(route, mockRequest, () => {
       sinon.assert.calledOnceWithExactly(mockDB.accountRecord, email);
-      sinon.assert.calledOnceWithExactly(mockLog.activityEvent, {
-        country: 'United States',
-        event: 'account.deleted',
-        region: 'California',
-        service: undefined,
-        userAgent: 'test user-agent',
-        uid: uid,
-      });
       sinon.assert.calledOnceWithExactly(mockAccountTasksDeleteAccount, {
         uid,
         customerId: 'customer123',


### PR DESCRIPTION
Because:
 - we need to know whose account we deleted

This commit:
 - adds the account's primary email address and verified status to the 'account.deleted' activity event
 - simplifies the logging by having it in one place

