### PR TITLE
feat(payments-stripe): Create StripeManager cancelIncompleteSubscription

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -62,6 +62,25 @@ export class StripeManager {
   }
 
   /**
+   * Cancels incomplete subscription
+   */
+  async cancelIncompleteSubscriptionsToPrice(
+    customerId: string,
+    priceId: string
+  ) {
+    const subscriptions = await this.getSubscriptions(customerId);
+    const targetSubs = subscriptions.data.filter((sub) =>
+      sub.items.data.find((item) => item.price.id === priceId)
+    );
+
+    for (const sub of targetSubs) {
+      if (sub && sub.status === 'incomplete') {
+        await this.client.subscriptionsCancel(sub.id);
+      }
+    }
+  }
+
+  /**
    * Retrieves subscriptions
    */
   async getSubscriptions(customerId: string) {


### PR DESCRIPTION
## This pull request

- [x] takes customerId and priceId as arguments
- [x] cancel subscription with target priceId via StripeClient.

## Issue that this pull request solves

Closes: FXA-8948

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
