### PR TITLE
bug(auth): Regression in reporting known errors to sentry

### DIFF
--- a/packages/fxa-auth-server/lib/monitoring.js
+++ b/packages/fxa-auth-server/lib/monitoring.js
@@ -41,6 +41,15 @@ const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
  * @param {Sentry.Event} event
  */
 function filterSentryEvent(event, hint) {
+  // This flag indicates the error was captured by us. Without this, we were seeing
+  // errors propagate from instrumentation libraries, thereby creating duplicates
+  // and create errors without expected context. This appeared to start happening
+  // when we enabled tracing. See the reportError function if you are curious about
+  // how this gets set, and wired into hapi's error handling.
+  if (event.extra?.report !== true) {
+    return null;
+  }
+
   // If we encounter a WError, we likely want to filter it out. These errors are
   // intentionally relayed to the client, and don't constitute unexpected errors.
   // Note, that these might arrive here from our reportSentryError function, or


### PR DESCRIPTION
## Because

- We were seeing errors show up in Sentry that would typically be ignored.
- We were seeing errors show up in Sentry that lacked extra context set by our reportError function
- We were able to determine that instrumentations libraries that appear to have show up around the time we added tracing started propagating errors.

## This pull request
- Adds an extra flag to our errors we capture
- Ignores errors that aren't being captured by our code (ie errors being captured by instrumentation libraries).

## Issue that this pull request solves

Closes: FXA-9252

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
