### PR TITLE
feat(payments-stripe): add cancelSubscription to stripe manager

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -122,6 +122,18 @@ describe('StripeManager', () => {
     });
   });
 
+  describe('cancelSubscription', () => {
+    it('calls stripeclient', async () => {
+      const mockSubscription = StripeSubscriptionFactory();
+
+      mockClient.subscriptionsCancel = jest
+        .fn()
+        .mockResolvedValueOnce(undefined);
+
+      await manager.cancelSubscription(mockSubscription.id);
+    });
+  });
+
   describe('isCustomerStripeTaxEligible', () => {
     it('should return true for a taxable customer', async () => {
       const mockCustomer = StripeCustomerFactory({

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -70,6 +70,10 @@ export class StripeManager {
     });
   }
 
+  async cancelSubscription(subscriptionId: string) {
+    return this.client.subscriptionsCancel(subscriptionId);
+  }
+
   /**
    * Check if customer's automatic tax status indicates that they're eligible for automatic tax.
    * Creating a subscription with automatic_tax enabled requires a customer with an address


### PR DESCRIPTION
## Because

* We want to be able to cancel subscriptions from non-stripe lib

## This pull request

* Adds a stripe manager method to do so

## Issue that this pull request solves

Closes FXA-9027