### PR TITLE
fix(functional-tests): remove fixme for missing awaits

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -132,6 +132,14 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.SUBMIT);
   }
 
+  get signUpCodeHeader() {
+    return this.page.locator(selectors.SIGN_UP_CODE_HEADER);
+  }
+
+  get signInCodeHeader() {
+    return this.page.locator(selectors.SIGN_IN_CODE_HEADER);
+  }
+
   async getUnblockEmail() {
     return this.page.locator(selectors.SIGNIN_UNBLOCK_VERIFICATION).innerText();
   }
@@ -230,14 +238,6 @@ export class LoginPage extends BaseLayout {
     const header = this.page.locator(selectors.COPPA_HEADER);
     await header.waitFor({ state: 'visible' });
     return header.isVisible();
-  }
-
-  signUpCodeHeader() {
-    return this.page.locator(selectors.SIGN_UP_CODE_HEADER);
-  }
-
-  signInCodeHeader() {
-    return this.page.locator(selectors.SIGN_IN_CODE_HEADER);
   }
 
   async confirmEmail() {

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -25,7 +25,7 @@ test.describe('severity-1 #smoke', () => {
       await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
 
       //no permissions asked for, straight to confirm
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
     });
 
     test('signup with `prompt=consent`', async ({
@@ -48,7 +48,7 @@ test.describe('severity-1 #smoke', () => {
       await login.acceptOauthPermissions();
 
       //Verify sign up code header
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
     });
   });
 

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -129,7 +129,6 @@ test.describe('severity-1 #smoke', () => {
       target,
       pages: { relier, login },
     }) => {
-      test.fixme(true, 'test to be fixed, see FXA-9194');
       const [email] = emails;
       await target.auth.signUp(email, PASSWORD, {
         lang: 'en',
@@ -141,7 +140,7 @@ test.describe('severity-1 #smoke', () => {
       await login.fillOutEmailFirstSignIn(email, PASSWORD);
 
       //Verify sign up code header
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
 
       const query = new URLSearchParams({
         login_hint: email,

--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -28,7 +28,7 @@ test.describe('severity-1 #smoke', () => {
       await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
 
       //Verify sign up code header
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
 
       await login.fillOutSignUpCode(email);
 
@@ -57,7 +57,7 @@ test.describe('severity-1 #smoke', () => {
       await login.fillOutFirstSignUp(bouncedEmail, PASSWORD, { verify: false });
 
       //Verify sign up code header
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
 
       try {
         const accounts = await page.evaluate(() => {
@@ -92,7 +92,7 @@ test.describe('severity-1 #smoke', () => {
       await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
 
       //Verify sign up code header
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
       await login.fillOutSignUpCode(email);
 
       //Verify logged in on relier page

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -51,7 +51,7 @@ test.describe('severity-2 #smoke', () => {
       });
 
       // Verify the confirm code header and the email
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
       expect(await login.confirmEmail()).toContain(emailWithoutSpace);
     });
 
@@ -67,7 +67,7 @@ test.describe('severity-2 #smoke', () => {
       await login.fillOutFirstSignUp(emailWithSpace, password, {
         verify: false,
       });
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
       expect(await login.confirmEmail()).toContain(emailWithoutSpace);
     });
 

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -129,7 +129,7 @@ test.describe('severity-2 #smoke', () => {
       await login.fillOutEmailFirstSignIn(email, PASSWORD);
 
       // Verify the header after login
-      await expect(login.signInCodeHeader()).toBeVisible();
+      await expect(login.signInCodeHeader).toBeVisible();
       await target.auth.accountDestroy(email, PASSWORD, {}, creds.sessionToken);
       await page.waitForURL(/signin_bounced/);
 

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -164,7 +164,7 @@ test.describe('severity-2 #smoke', () => {
       await login.unblock(unverifiedEmail);
 
       //Verify confirm code header
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
 
       await login.fillOutSignInCode(unverifiedEmail);
 

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -160,7 +160,6 @@ test.describe('severity-2 #smoke', () => {
       syncBrowserPages: { page, login },
       emails,
     }) => {
-      test.fixme(true, 'test to be fixed, see FXA-9194');
       const [email_unverified] = emails;
       await target.auth.signUp(email_unverified, PASSWORD, {
         lang: 'en',
@@ -172,7 +171,7 @@ test.describe('severity-2 #smoke', () => {
       await login.fillOutEmailFirstSignIn(email_unverified, PASSWORD);
 
       //Verify sign up code header is visible
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
@@ -181,7 +180,7 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSignIn();
 
       //Cached login should still go to email confirmation screen for unverified accounts
-      await expect(login.signUpCodeHeader()).toBeVisible();
+      await expect(login.signUpCodeHeader).toBeVisible();
 
       //Fill the code and submit
       await login.fillOutSignUpCode(email_unverified);

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -41,7 +41,7 @@ test.describe('severity-2 #smoke', () => {
         );
         await login.respondToWebChannelMessage(customEventDetail);
         await login.fillOutEmailFirstSignIn(email, PASSWORD);
-        await expect(login.signInCodeHeader()).toBeVisible();
+        await expect(login.signInCodeHeader).toBeVisible();
 
         await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
         await login.fillOutSignInCode(email);

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -27,7 +27,6 @@ test.describe('severity-2 #smoke', () => {
       target,
       syncBrowserPages: { page, login, connectAnotherDevice },
     }) => {
-      test.fixme(true, 'test to be fixed, see FXA-9194');
       await Promise.all(
         emails.map(async (email) => {
           await target.auth.signUp(email, PASSWORD, {
@@ -43,7 +42,7 @@ test.describe('severity-2 #smoke', () => {
       await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
       //Verify sign up code header is visible
-      await expect(login.signInCodeHeader()).toBeVisible();
+      await expect(login.signInCodeHeader).toBeVisible();
 
       const query = { email: email };
       const queryParam = new URLSearchParams(query);
@@ -79,7 +78,6 @@ test.describe('severity-2 #smoke', () => {
       target,
       syncBrowserPages: { page, login },
     }) => {
-      test.fixme(true, 'test to be fixed, see FXA-9194');
       await Promise.all(
         emails.map(async (email) => {
           await target.auth.signUp(email, PASSWORD, {
@@ -95,7 +93,7 @@ test.describe('severity-2 #smoke', () => {
       await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
       //Verify sign up code header is visible
-      await expect(login.signInCodeHeader()).toBeVisible();
+      await expect(login.signInCodeHeader).toBeVisible();
 
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',


### PR DESCRIPTION
## Because

* there were missing awaits, which were fixed in 698210b, and tests were annotated with fixme 

## This pull request

* removes the fixme annotation
* conforms the signUpCodeHeader and signInCodeHeader to accessors in login.ts

## Issue that this pull request solves

Closes: # FXA-9194

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
