### PR TITLE
refactor(signin): Check for matching cached account if 'email' is provided

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -267,7 +267,6 @@ describe('signin container', () => {
       it('can be set from query param', async () => {
         mockUseValidateModule();
         render([mockGqlAvatarUseQuery()]);
-        expect(CacheModule.currentAccount).not.toBeCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
         });
@@ -277,7 +276,6 @@ describe('signin container', () => {
         mockUseValidateModule();
         mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
         render([mockGqlAvatarUseQuery()]);
-        expect(CacheModule.currentAccount).not.toBeCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
         });
@@ -287,12 +285,30 @@ describe('signin container', () => {
         mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
         render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
-          expect(CacheModule.currentAccount).not.toBeCalled();
+          expect(currentSigninProps?.email).toBe(MOCK_ROUTER_STATE_EMAIL);
         });
-        expect(currentSigninProps?.email).toBe(MOCK_ROUTER_STATE_EMAIL);
         expect(SigninModule.default).toBeCalled();
       });
-      it('is read from localStorage if email is not provided via query param or router state', async () => {
+      it('if it matches email in local storage, session token in local storage is used', async () => {
+        const storedAccount = {
+          ...MOCK_STORED_ACCOUNT,
+          email: MOCK_QUERY_PARAM_EMAIL,
+          sessionToken: 'blabadee',
+        };
+        mockCurrentAccount(storedAccount);
+        mockUseValidateModule();
+        render([mockGqlAvatarUseQuery()]);
+        await waitFor(() => {
+          expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
+        });
+        await waitFor(() => {
+          expect(currentSigninProps?.sessionToken).toBe(
+            storedAccount.sessionToken
+          );
+        });
+        expect(SigninModule.default).toBeCalled();
+      });
+      it('uses local storage value if email is not provided via query param or router state', async () => {
         mockCurrentAccount(MOCK_STORED_ACCOUNT);
         render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).toBeCalled();

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -89,11 +89,13 @@ function getAccountInfo(nonCachedEmail?: string) {
   let email = nonCachedEmail;
   let sessionToken: hexstring | undefined;
   let uid: hexstring | undefined;
-  // only read from local storage if email isn't provided via query param or router state
-  if (!nonCachedEmail) {
-    const storedLocalAccount = currentAccount();
-    email = storedLocalAccount?.email;
+
+  const storedLocalAccount = currentAccount();
+  // Try to use local storage values if email is not provided or if email
+  // is provided and matches the email in local storage
+  if (!nonCachedEmail || storedLocalAccount?.email === nonCachedEmail) {
     sessionToken = storedLocalAccount?.sessionToken;
+    email = storedLocalAccount?.email;
     uid = storedLocalAccount?.uid;
   }
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -173,13 +173,7 @@ const ConfirmSignupCode = ({
 
         // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
-          // Remove the 'email' query param because this should be read from
-          // local storage on the next screen. Once the index page has been converted
-          // to React and we no longer need to pass 'email' we can improve this.
-          const queryParams = new URLSearchParams(location.search);
-          queryParams.delete('email');
-          queryParams.delete('emailStatusChecked');
-          hardNavigateToContentServer(`oauth/signin?${queryParams}`);
+          hardNavigateToContentServer(`oauth/signin${location.search}`);
           return;
         } else {
           const { redirect, code, state } = await finishOAuthFlowHandler(


### PR DESCRIPTION
Because:
* We should check local storage to see if an account already has an existing session token if the email is given via query param or router state

This commit:
* Removes newly added temp code that removes the 'email' param before navigating to this page during the inline TOTP flow, as it was a bandaid
* Always reads from local storage in Signin, because if the email is provided we want to see if a session token already exists for cached view and otherwise we want to use the account in local storage

fixes FXA-9435

---

I mentioned [here](https://github.com/mozilla/fxa/pull/16665#issuecomment-2047859197) that this was causing 15 test failures but that's not correct, seems like a lot of them were coming from `fxa-shared` needing to be rebuilt.

You can test this (basically checking we didn't regress) by going to "sign in (2FA required)" in 123done and signing up for an account in the React version, you shouldn't be prompted for a password after sign up.