### PR TITLE
feat(content): Add feature flag for password reset with code

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -56,6 +56,7 @@
     "signInRoutes": true
   },
   "featureFlags": {
-    "sendFxAStatusOnSettings": true
+    "sendFxAStatusOnSettings": true,
+    "resetPasswordWithCode": false
   }
 }

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -87,6 +87,7 @@ const settingsConfig = {
   },
   featureFlags: {
     keyStretchV2: config.get('featureFlags.keyStretchV2'),
+    resetPasswordWithCode: config.get('featureFlags.resetPasswordWithCode'),
   },
 };
 

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -226,6 +226,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_KEY_STRETCH_V2',
     },
+    resetPasswordWithCode: {
+      default: false,
+      doc: 'Enables using confirmation codes instead of links for password reset',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_RESET_PWD_WITH_CODE',
+    },
   },
   showReactApp: {
     simpleRoutes: {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -87,6 +87,7 @@ export interface Config {
   };
   featureFlags?: {
     keyStretchV2?: boolean;
+    resetPasswordWithCode?: boolean;
   };
 }
 
@@ -160,6 +161,9 @@ export function getDefault() {
     showReactApp: {
       signUpRoutes: false,
       signInRoutes: false,
+    },
+    featureFlags: {
+      resetPasswordWithCode: false,
     },
   } as Config;
 }


### PR DESCRIPTION
## Because

* We want to be able to switch the reset password with code functionality on/off with a feature flag

## This pull request

* Add a `resetPasswordWithCode`/`FEATURE_FLAGS_RESET_PWD_WITH_CODE` feature flag and make it available in fxa-settings with default set to false

## Issue that this pull request solves

Closes: #FXA-7909

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
