### PR TITLE
feat(next): use next 14.2 instrumentation

### DIFF
--- a/apps/payments/next/app/%5F_lbheartbeat__/route.ts
+++ b/apps/payments/next/app/%5F_lbheartbeat__/route.ts
@@ -4,11 +4,8 @@
 
 import { NextResponse } from 'next/server';
 
-import { app } from '@fxa/payments/ui/server';
-
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
-  await app.initialize();
   return NextResponse.json({});
 }

--- a/apps/payments/next/instrumentation.ts
+++ b/apps/payments/next/instrumentation.ts
@@ -1,0 +1,7 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { app } = await import('@fxa/payments/ui/server');
+
+    await app.initialize();
+  }
+}

--- a/apps/payments/next/next.config.js
+++ b/apps/payments/next/next.config.js
@@ -17,6 +17,7 @@ const nextConfig = {
     svgr: false,
   },
   experimental: {
+    instrumentationHook: true,
     serverComponentsExternalPackages: [
       '@nestjs/core',
       '@nestjs/common',
@@ -27,7 +28,6 @@ const nextConfig = {
       'kysely',
       'mysql2',
       'nest-typed-config',
-      'rxjs',
     ],
   },
   images: {

--- a/libs/payments/ui/src/lib/nestapp/app.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.ts
@@ -22,9 +22,7 @@ class AppSingleton {
     }
   }
 
-  async getL10n(acceptLanguage: string) {
-    // Temporary until Next.js canary lands
-    await this.initialize();
+  getL10n(acceptLanguage: string) {
     const localizerRscFactory = this.app.get(LocalizerRscFactory);
     return localizerRscFactory.createLocalizerRsc(acceptLanguage);
   }
@@ -33,9 +31,7 @@ class AppSingleton {
    * This method should be used in any server action wishing to call a server-side module.
    * Do not add individual services/managers/clients to this singleton, rather to NextJSActionsService.
    */
-  async getActionsService() {
-    // Temporary until Next.js canary lands
-    await this.initialize();
+  getActionsService() {
     return this.app.get(NextJSActionsService);
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "mysql2": "^3.9.1",
     "nest-typed-config": "^2.9.2",
     "nest-winston": "^1.9.4",
-    "next": "^14.1.1",
+    "next": "14.2.0",
     "next-auth": "beta",
     "node-fetch": "^2.6.7",
     "nps": "^5.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12659,10 +12659,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/env@npm:14.1.1"
-  checksum: 9714e716ca26dd024b1680ca9c17be60adf4228a2bd7a1a9f71752cfd8989f005e805477453200cad0a5ed85439161563a248235fc897dc42f762cba742ec62a
+"@next/env@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/env@npm:14.2.0"
+  checksum: c99722ed9cbd977aa714d767b928bb6bd84e97bdab09966c07b69dda8c87edbea69b8d2024d36285128ab46ea4b629fdba53f7928bf5043b47d2da85d1016ccc
   languageName: node
   linkType: hard
 
@@ -12675,65 +12675,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-darwin-arm64@npm:14.1.1"
+"@next/swc-darwin-arm64@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-darwin-arm64@npm:14.2.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-darwin-x64@npm:14.1.1"
+"@next/swc-darwin-x64@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-darwin-x64@npm:14.2.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-linux-arm64-gnu@npm:14.1.1"
+"@next/swc-linux-arm64-gnu@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-linux-arm64-musl@npm:14.1.1"
+"@next/swc-linux-arm64-musl@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-linux-arm64-musl@npm:14.2.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-linux-x64-gnu@npm:14.1.1"
+"@next/swc-linux-x64-gnu@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-linux-x64-gnu@npm:14.2.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-linux-x64-musl@npm:14.1.1"
+"@next/swc-linux-x64-musl@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-linux-x64-musl@npm:14.2.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-win32-arm64-msvc@npm:14.1.1"
+"@next/swc-win32-arm64-msvc@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-win32-ia32-msvc@npm:14.1.1"
+"@next/swc-win32-ia32-msvc@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@next/swc-win32-x64-msvc@npm:14.1.1"
+"@next/swc-win32-x64-msvc@npm:14.2.0":
+  version: 14.2.0
+  resolution: "@next/swc-win32-x64-msvc@npm:14.2.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -20792,19 +20792,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/counter@npm:^0.1.2":
+"@swc/counter@npm:^0.1.2, @swc/counter@npm:^0.1.3":
   version: 0.1.3
   resolution: "@swc/counter@npm:0.1.3"
   checksum: df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@swc/helpers@npm:0.5.2"
+"@swc/helpers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@swc/helpers@npm:0.5.5"
   dependencies:
+    "@swc/counter": ^0.1.3
     tslib: ^2.4.0
-  checksum: 51d7e3d8bd56818c49d6bfbd715f0dbeedc13cf723af41166e45c03e37f109336bbcb57a1f2020f4015957721aeb21e1a7fff281233d797ff7d3dd1f447fa258
+  checksum: d4f207b191e54b29460804ddf2984ba6ece1d679a0b2f6a9c765dcf27bba92c5769e7965668a4546fb9f1021eaf0ff9be4bf5c235ce12adcd65acdfe77187d11
   languageName: node
   linkType: hard
 
@@ -38824,7 +38825,7 @@ fsevents@~2.1.1:
     mysql2: ^3.9.1
     nest-typed-config: ^2.9.2
     nest-winston: ^1.9.4
-    next: ^14.1.1
+    next: 14.2.0
     next-auth: beta
     node-fetch: ^2.6.7
     nps: ^5.10.0
@@ -50489,21 +50490,21 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"next@npm:^14.1.1":
-  version: 14.1.1
-  resolution: "next@npm:14.1.1"
+"next@npm:14.2.0":
+  version: 14.2.0
+  resolution: "next@npm:14.2.0"
   dependencies:
-    "@next/env": 14.1.1
-    "@next/swc-darwin-arm64": 14.1.1
-    "@next/swc-darwin-x64": 14.1.1
-    "@next/swc-linux-arm64-gnu": 14.1.1
-    "@next/swc-linux-arm64-musl": 14.1.1
-    "@next/swc-linux-x64-gnu": 14.1.1
-    "@next/swc-linux-x64-musl": 14.1.1
-    "@next/swc-win32-arm64-msvc": 14.1.1
-    "@next/swc-win32-ia32-msvc": 14.1.1
-    "@next/swc-win32-x64-msvc": 14.1.1
-    "@swc/helpers": 0.5.2
+    "@next/env": 14.2.0
+    "@next/swc-darwin-arm64": 14.2.0
+    "@next/swc-darwin-x64": 14.2.0
+    "@next/swc-linux-arm64-gnu": 14.2.0
+    "@next/swc-linux-arm64-musl": 14.2.0
+    "@next/swc-linux-x64-gnu": 14.2.0
+    "@next/swc-linux-x64-musl": 14.2.0
+    "@next/swc-win32-arm64-msvc": 14.2.0
+    "@next/swc-win32-ia32-msvc": 14.2.0
+    "@next/swc-win32-x64-msvc": 14.2.0
+    "@swc/helpers": 0.5.5
     busboy: 1.6.0
     caniuse-lite: ^1.0.30001579
     graceful-fs: ^4.2.11
@@ -50511,6 +50512,7 @@ fsevents@~2.1.1:
     styled-jsx: 5.1.1
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
     react: ^18.2.0
     react-dom: ^18.2.0
     sass: ^1.3.0
@@ -50536,11 +50538,13 @@ fsevents@~2.1.1:
   peerDependenciesMeta:
     "@opentelemetry/api":
       optional: true
+    "@playwright/test":
+      optional: true
     sass:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 58c17bf9520648cb79c3341a0a011ce19e8e5368f23be7415b4a35787b3562519cfd0dd8e008a1ce0b49dfe79e4ab89127f412cf039cb854b35f79a457a9be22
+  checksum: 390f72a3465030a75e03f45fc0779d19d5b755c12b57f0352606b576ee1c106c917036183ece0fbb8c424a7aefb6afc12614106da891016a9ced41f4feb7cfa2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- Want to use Next.js instrumentation featuer to start NestApp on Next.js server startup.

## This pull request

- Upgrades Next.js to version 14.2 which includes intrumentation fixes.
- Adds instrumentation logic.

## Issue that this pull request solves

Closes: # (issue number)

Co-authored-by: @bbangert 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).