### PR TITLE
feat(payments-ui): add restartCart server action

### DIFF
--- a/libs/payments/ui/src/lib/actions/restartCart.ts
+++ b/libs/payments/ui/src/lib/actions/restartCart.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { plainToClass } from 'class-transformer';
+import { app } from '../nestapp/app';
+import { RestartCartActionArgs } from '../nestapp/validators/RestartCartActionArgs';
+
+export const restartCartAction = async (cartId: string) => {
+  const actionsService = app.getActionsService();
+
+  const cart = await actionsService.restartCart(
+    plainToClass(RestartCartActionArgs, {
+      cartId,
+    })
+  );
+
+  return cart;
+};

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -5,8 +5,9 @@
 import { CartService } from '@fxa/payments/cart';
 import { Injectable } from '@nestjs/common';
 import { GetCartActionArgs } from './validators/GetCartActionArgs';
-import { Validator } from 'class-validator';
+import { RestartCartActionArgs } from './validators/RestartCartActionArgs';
 import { UpdateCartActionArgs } from './validators/UpdateCartActionArgs';
+import { Validator } from 'class-validator';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -33,5 +34,13 @@ export class NextJSActionsService {
       args.version,
       args.cartDetails
     );
+  }
+
+  async restartCart(args: RestartCartActionArgs) {
+    new Validator().validateOrReject(args);
+
+    const cart = await this.cartService.restartCart(args.cartId);
+
+    return cart;
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/RestartCartActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RestartCartActionArgs.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class RestartCartActionArgs {
+  @IsString()
+  cartId!: string;
+}


### PR DESCRIPTION
## Because

- We need a server action to restart the cart.

## This pull request

- Adds a simple server action to restart the cart.

## Issue that this pull request solves

Closes FXA-8899

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Relates to: https://github.com/mozilla/fxa/pull/16684