### PR TITLE
fix(auth): support no geo present on request

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -195,7 +195,7 @@ module.exports = (log, config, glean) => {
   };
 
   function emitActivityEvent(event, request, data) {
-    const { location } = request.app.geo;
+    const location = request.app.geo?.location;
     data = Object.assign(
       {
         country: location && location.country,
@@ -217,7 +217,7 @@ module.exports = (log, config, glean) => {
       return Promise.resolve();
     }
 
-    const { location } = request.app.geo;
+    const location = request.app.geo?.location;
     return request
       .gatherMetricsContext({
         country: location && location.country,


### PR DESCRIPTION
## Because

* Geo is not always guaranteed to be present on request.

## This pull request

* Fixes an issue with typing in a JS file related to geo not being present.

## Issue that this pull request solves

Closes FXA-8571