### PR TITLE
test(functional-tests): add fixme annotation to 'severity-2 #smoke › ui functionality › verify plan change funnel metrics & coupon feature not available when changing plans'

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -10,6 +10,7 @@ test.describe('severity-2 #smoke', () => {
     test('verify plan change funnel metrics & coupon feature not available when changing plans', async ({
       pages: { relier, subscribe },
     }, { project }) => {
+      test.fixme(true, 'Fix required as of 2024/04/16 (see FXA-9378).');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'


### PR DESCRIPTION
## Because
- we want to prevent CI disruption and promote trust in the functional test suite 

## This pull request

- adds a fixme annotation to the flaky test until it can be fixed

## Issue that this pull request solves
Relates To: #FXA-9467

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
