### PR TITLE
fix(oauth/react): Avoid directly referencing integration redirectUri

### DIFF
--- a/packages/fxa-settings/src/lib/integrations/integration-factory.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.ts
@@ -25,6 +25,12 @@ import { IntegrationFlags } from './interfaces';
 import { DefaultIntegrationFlags } from '.';
 import config from '../config';
 
+/**
+ * We store a whitelist of allowed `redirectUri`s in `clientInfo.redirectUri` which
+ * can be a single value or comma-separated values for multiple allowed URIs.
+ * If the query param `redirect_uri` is provided, we must check against the whitelist
+ * to ensure a match.
+ */
 function getClientRedirect(
   clientRedirectUris: string[] | undefined,
   queryRedirectUri: string | undefined

--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -23,7 +23,9 @@ type OAuthCode = {
 const checkOAuthData = (integration: OAuthIntegration): Error | null => {
   // Ensure a redirect was provided or matched. Without this info, we can't relay the
   // oauth code and state on a redirect!
-  if (!integration.data.redirectUri && !integration.clientInfo?.redirectUri) {
+
+  // clientInfo?.redirectUri has already validated the redirect_uri query param
+  if (!integration.clientInfo?.redirectUri) {
     return new OAuthErrorInvalidRedirectUri();
   }
   if (!integration.data.clientId) {
@@ -193,9 +195,8 @@ export function useFinishOAuthFlowHandler(
         ? Constants.OAUTH_WEBCHANNEL_REDIRECT
         : constructOAuthRedirectUrl(
             oAuthCode,
-            // If the RP did not pass `redirect_uri` via query param, use clientInfo's
-            oAuthIntegration.data.redirectUri ||
-              oAuthIntegration.clientInfo?.redirectUri
+            // We know this is not falsey because this value will have already been checked
+            oAuthIntegration.clientInfo?.redirectUri!
           ).href;
 
       // Always use the state the RP passed in for OAuth Webchannel.


### PR DESCRIPTION
Because:
* We have validated clientInfo.redirectUri, but not integration.data.redirectUri, and want to "check" the clientInfo value only

This commit:
* Makes clientInfo.redirectUri the only check when referencing the redirect_uri