### PR TITLE
bug(auth): Accounts aren't fully deleted

### DIFF
--- a/libs/shared/cloud-tasks/src/lib/cloud-tasks.factories.ts
+++ b/libs/shared/cloud-tasks/src/lib/cloud-tasks.factories.ts
@@ -86,6 +86,7 @@ export function CloudTaskClientFactory(config: CloudTasksConfig) {
   const cloudTasksClient = new CloudTasksClient({
     projectId: config.cloudTasks.projectId,
     keyFilename: config.cloudTasks.credentials.keyFilename ?? undefined,
+    fallback: true,
   });
 
   return cloudTasksClient;

--- a/libs/shared/cloud-tasks/src/lib/cloud-tasks.ts
+++ b/libs/shared/cloud-tasks/src/lib/cloud-tasks.ts
@@ -6,24 +6,6 @@ import { CloudTasksConfig } from './cloud-tasks.types';
 
 /** Base class for encapsulating common cloud task operations */
 export class CloudTasks {
-  /**
-   * Indicates if a queue has been configured and is enabled.
-   */
-  public get queueEnabled() {
-    // If a keyFilename was supplied, the cloud task queue can be considered enabled.
-    if (this.config.cloudTasks.credentials.keyFilename) {
-      return true;
-    }
-
-    // If we specify a local emulator is being used, then no keyFilename is required,
-    // and the task queue can be considered enabled.
-    if (this.config.cloudTasks.useLocalEmulator) {
-      return true;
-    }
-
-    return false;
-  }
-
   protected constructor(
     protected readonly config: CloudTasksConfig,
     protected readonly client: Pick<CloudTasksClient, 'createTask' | 'getTask'>

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1848,14 +1848,12 @@ export class AccountHandler {
       ReasonForDeletion.UserRequested
     );
 
-    if (this.accountTasks.queueEnabled) {
-      const result = await getAccountCustomerByUid(accountRecord.uid);
-      await this.accountTasks.deleteAccount({
-        uid: accountRecord.uid,
-        customerId: result?.stripeCustomerId,
-        reason: ReasonForDeletion.UserRequested,
-      });
-    }
+    const result = await getAccountCustomerByUid(accountRecord.uid);
+    await this.accountTasks.deleteAccount({
+      uid: accountRecord.uid,
+      customerId: result?.stripeCustomerId,
+      reason: ReasonForDeletion.UserRequested,
+    });
 
     return {};
   }

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -123,7 +123,6 @@ const makeRoutes = function (options = {}, requireMocks = {}) {
   mockAccountTasksDeleteAccount = sinon.fake.resolves();
   const accountTasks = {
     deleteAccount: mockAccountTasksDeleteAccount,
-    queueEnabled: true,
   };
   Container.set(AccountTasks, accountTasks);
 


### PR DESCRIPTION
## Because

- Accounts were not being fully deleted
- Since we do not use a keyfile, the check on whether or not the queue was enabled did not pass, and the explicit check to run in stage/prod was lost in the refactor

## This pull request

- Removes the queueEnabled flag check entirely. (Now that a local emulator is present we can assume the queue should always be available.)
- Adds back in the fallback option to the CloudTasksClient, which indicates the client should use https instead of grcp, which has proven to be a more reliable setting.


## Issue that this pull request solves

Closes: FXA-9471

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

