### PR TITLE
chore(routes): Add config to disable certificate sign route by user email

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1975,7 +1975,12 @@ const convictConf = convict({
       format: String,
     },
   },
-
+  certificateSignDisableRolloutRate: {
+    default: 0,
+    doc: 'Rollout rate for disabling certificate signing, in the range 0 .. 1',
+    env: 'CERTIFICATE_SIGN_DISABLE_ROLLOUT_RATE',
+    format: Number,
+  },
   contentful: {
     cdnUrl: {
       doc: 'Base URL for Content Delivery API (https://www.contentful.com/developers/docs/references/content-delivery-api/)',

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -514,6 +514,15 @@ AppError.gone = function () {
   });
 };
 
+AppError.goneFourOhFour = function () {
+  return new AppError({
+    code: 404,
+    error: 'Gone',
+    errno: ERRNO.ENDPOINT_NOT_SUPPORTED,
+    message: 'This endpoint is no longer supported',
+  });
+};
+
 AppError.mustResetAccount = function (email) {
   return new AppError(
     {

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -143,7 +143,14 @@ module.exports = function (
     customs,
     glean
   );
-  const sign = require('./sign')(log, signer, db, config.domain, devicesImpl);
+  const sign = require('./sign')(
+    log,
+    signer,
+    db,
+    config.domain,
+    devicesImpl,
+    config
+  );
   const unblockCodes = require('./unblock-codes')(
     log,
     db,

--- a/packages/fxa-auth-server/test/local/routes/sign.js
+++ b/packages/fxa-auth-server/test/local/routes/sign.js
@@ -354,6 +354,56 @@ describe('/certificate/sign', () => {
     );
   });
 
+  describe('disable certification sign endpoint', () => {
+    it('with rollout 0 (0%)', async () => {
+      return runTest(
+        {
+          devices: mockDevices,
+          log: mockLog,
+          config: {
+            certificateSignDisableRolloutRate: 0,
+          },
+        },
+        mockRequest,
+        (res) => {
+          assert.equal(
+            mockDevices.upsert.callCount,
+            1,
+            'devices.upsert was called once'
+          );
+          assert.equal(
+            mockLog.activityEvent.callCount,
+            1,
+            'log.activityEvent was called once'
+          );
+        },
+        (e) => {
+          assert.fail('should have succeeded');
+        }
+      );
+    });
+
+    it('with rollout 1 (100%)', async () => {
+      return runTest(
+        {
+          devices: mockDevices,
+          log: mockLog,
+          config: {
+            certificateSignDisableRolloutRate: 1,
+          },
+        },
+        mockRequest,
+        (res) => {
+          assert.fail('should have failed succeeded');
+        },
+        (err) => {
+          assert.equal(err.output.statusCode, 404);
+          assert.equal(err.errno, 116);
+        }
+      );
+    });
+  });
+
   function runTest(options, request, onSuccess, onError) {
     return new Promise((resolve, reject) => {
       try {
@@ -389,7 +439,8 @@ describe('/certificate/sign', () => {
         updateLocale: function () {},
       },
       options.domain || 'wibble',
-      options.devices
+      options.devices,
+      options.config || {}
     );
   }
 });


### PR DESCRIPTION
## Because

- We no longer support browserid and want to start disabling this route

## This pull request

- Adds a config to specify a disable rollout rate
- Based on our content server experiment enrollment function (hash user constant value, convert to 0-1 value, check if lower than rollout rate)

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9394

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

