### PR TITLE
refactor(functional-tests): TestAccountTracker

### DIFF
--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -74,13 +74,6 @@ export enum EmailHeader {
 }
 
 export class EmailClient {
-  static emailFromTestTitle(title: string) {
-    return `${title
-      .match(/(\w+)/g)
-      .join('_')
-      .substr(0, 20)
-      .toLowerCase()}_${Math.floor(Math.random() * 10000)}@restmail.net`;
-  }
   constructor(private readonly host: string = 'http://restmail.net') {}
 
   async waitForEmail(

--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -1,47 +1,24 @@
-import { Browser, expect, firefox, test as base } from '@playwright/test';
-import crypto from 'crypto';
-import { create, Credentials, ServerTarget, TargetName } from '../targets';
-import { EmailClient } from '../email';
-import { create as createPages } from '../../pages';
-import { BaseTarget } from '../targets/base';
-import { getCode } from 'fxa-settings/src/lib/totp';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Browser, Page, test as base, expect, firefox } from '@playwright/test';
 import { getFirefoxUserPrefs } from '../../lib/targets/firefoxUserPrefs';
+import { create as createPages } from '../../pages';
+import { ServerTarget, TargetName, create } from '../targets';
+import { BaseTarget } from '../targets/base';
+import { TestAccountTracker } from '../testAccountTracker';
 
 // The DEBUG env is used to debug without the playwright inspector, like in vscode
 // see .vscode/launch.json
 const DEBUG = !!process.env.DEBUG;
 
-export { expect };
+export { Page, expect };
 export type POMS = ReturnType<typeof createPages>;
-
-export const BLOCKED_EMAIL_PREFIX = 'blocked{id}';
-export const BOUNCED_EMAIL_PREFIX = 'bounced{id}';
-export const FORCE_PWD_EMAIL_PREFIX = 'forcepwdchange{id}';
-export const SIGNIN_EMAIL_PREFIX = 'signin{id}';
-export const SIGNUP_REACT_EMAIL_PREFIX = 'signup_react{id}';
-export const SYNC_EMAIL_PREFIX = 'sync{id}';
-type EmailPrefix =
-  | typeof BLOCKED_EMAIL_PREFIX
-  | typeof BOUNCED_EMAIL_PREFIX
-  | typeof FORCE_PWD_EMAIL_PREFIX
-  | typeof SIGNIN_EMAIL_PREFIX
-  | typeof SIGNUP_REACT_EMAIL_PREFIX
-  | typeof SYNC_EMAIL_PREFIX;
-
-export const PASSWORD = 'passwordzxcv';
-export const NEW_PASSWORD = 'new_password';
-
-type EmailFixtureOptions = {
-  prefix: EmailPrefix; // Prefix for the email address
-  password: string; // Password for the email address
-};
-
 export type TestOptions = {
   pages: POMS;
   syncBrowserPages: POMS;
-  credentials: Credentials;
-  emailOptions: EmailFixtureOptions[];
-  emails: string[];
+  testAccountTracker: TestAccountTracker;
 };
 export type WorkerOptions = { targetName: TargetName; target: ServerTarget };
 
@@ -56,70 +33,6 @@ export const test = base.extend<TestOptions, WorkerOptions>({
     { scope: 'worker', auto: true },
   ],
 
-  credentials: async ({ target }, use, testInfo) => {
-    const email = EmailClient.emailFromTestTitle(testInfo.title);
-    const password = 'passwordzxcv';
-    await target.emailClient.clear(email);
-    let credentials: Credentials;
-
-    try {
-      credentials = await target.createAccount(email, password);
-    } catch (e) {
-      const newCreds = await target.authClient.signIn(email, password);
-      await target.authClient.accountDestroy(
-        email,
-        password,
-        {},
-        newCreds.sessionToken
-      );
-      credentials = await target.createAccount(email, password);
-    }
-
-    await use(credentials);
-
-    //teardown
-    await target.emailClient.clear(email);
-
-    try {
-      // we don't know if the original session still exists
-      // the test may have called signOut()
-      const { sessionToken } = await target.authClient.signIn(
-        email,
-        credentials.password
-      );
-
-      if (credentials.secret) {
-        credentials.sessionToken = sessionToken;
-        await target.authClient.verifyTotpCode(
-          sessionToken,
-          await getCode(credentials.secret)
-        );
-      }
-
-      await target.authClient.accountDestroy(
-        email,
-        credentials.password,
-        {},
-        sessionToken
-      );
-    } catch (err) {
-      if (
-        err.message ===
-        'Sign in with this email type is not currently supported'
-      ) {
-        // The user changed their primary email, the test case must manually destroy the account
-      } else if (
-        err.message === 'The request was blocked for security reasons'
-      ) {
-        // Some accounts are always prompted to unblock their account, ie emails starting
-        // `blocked.`. These accounts need to be destroyed in the test case
-      } else if (err.message !== 'Unknown account') {
-        throw err;
-      }
-      //s'ok
-    }
-  },
-
   pages: async ({ target, page }, use) => {
     const pages = createPages(page, target);
     await use(pages);
@@ -133,7 +46,15 @@ export const test = base.extend<TestOptions, WorkerOptions>({
     await syncBrowserPages.browser?.close();
   },
 
-  storageState: async ({ target, credentials }, use) => {
+  testAccountTracker: async ({ target }, use) => {
+    const testAccountTracker = new TestAccountTracker(target);
+
+    await use(testAccountTracker);
+
+    await testAccountTracker.destroyAllAccounts();
+  },
+
+  storageState: async ({ target }, use) => {
     // This is to store our session without logging in through the ui
     await use({
       cookies: [],
@@ -142,69 +63,15 @@ export const test = base.extend<TestOptions, WorkerOptions>({
           origin: target.contentServerUrl,
           localStorage: [
             {
-              name: '__fxa_storage.currentAccountUid',
-              value: JSON.stringify(credentials.uid),
-            },
-            {
               name: '__fxa_storage.experiment.generalizedReactApp',
               value: JSON.stringify({ enrolled: false }),
-            },
-            {
-              name: '__fxa_storage.accounts',
-              value: JSON.stringify({
-                [credentials.uid]: {
-                  sessionToken: credentials.sessionToken,
-                  uid: credentials.uid,
-                },
-              }),
             },
           ],
         },
       ],
     });
   },
-
-  emailOptions: [{ prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD }], // Default options for the fixture
-
-  emails: async (
-    { target, pages: { login }, emailOptions },
-    use
-  ): Promise<void> => {
-    const emails = emailOptions.map((emailOptions) => {
-      return (
-        emailOptions.prefix.replace(
-          '{id}',
-          crypto.randomBytes(8).toString('hex') + ''
-        ) + '@restmail.net'
-      );
-    });
-    await login.clearCache(); // Clear cache for each email
-
-    // Pass the generated email to the test along with the password
-    await use(emails);
-
-    for (const [index, email] of emails.entries()) {
-      await teardownEmail(target, email, emailOptions[index]);
-    }
-  },
 });
-
-async function teardownEmail(
-  target: BaseTarget,
-  email: string,
-  emailOptions: EmailFixtureOptions
-) {
-  const accountStatus = await target.authClient.accountStatusByEmail(email);
-  if (accountStatus.exists) {
-    const creds = await target.authClient.signIn(email, emailOptions.password);
-    await target.authClient.accountDestroy(
-      email,
-      emailOptions.password,
-      {},
-      creds.sessionToken
-    );
-  }
-}
 
 export async function newPages(browser: Browser, target: BaseTarget) {
   const context = await browser.newContext();

--- a/packages/functional-tests/lib/targets/local.ts
+++ b/packages/functional-tests/lib/targets/local.ts
@@ -21,12 +21,12 @@ export class LocalTarget extends BaseTarget {
     super('http://localhost:9000', 'http://localhost:9001');
   }
 
-  async createAccount(email: string, password: string, options?: any) {
-    const result = await this.authClient.signUp(email, password, {
-      lang: 'en',
-      preVerified: 'true',
-      ...(options || {}),
-    });
+  async createAccount(
+    email: string,
+    password: string,
+    options = { lang: 'en', preVerified: 'true' }
+  ) {
+    const result = await this.authClient.signUp(email, password, options);
     await this.authClient.deviceRegister(
       result.sessionToken,
       'playwright',

--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+import { Credentials } from './targets';
+import { BaseTarget } from './targets/base';
+
+enum EmailPrefix {
+  BLOCKED = 'blocked',
+  BOUNCED = 'bounced',
+  FORCED_PWD_CHANGE = 'forcepwdchange',
+  SIGNIN = 'signin',
+  SIGNUP_REACT = 'signup_react',
+  SYNC = 'sync',
+}
+
+type AccountDetails = {
+  email: string;
+  password: string;
+};
+
+export class TestAccountTracker {
+  accounts: (AccountDetails | Credentials)[];
+  private target: BaseTarget;
+
+  constructor(target: BaseTarget) {
+    this.target = target;
+    this.accounts = [];
+  }
+
+  /**
+   * Creates a new email address with the 'blocked' prefix
+   * @returns email
+   */
+  generateBlockedEmail(): string {
+    return this.generateEmail(EmailPrefix.BLOCKED);
+  }
+
+  /**
+   * Creates a new email with the 'sync' prefix
+   * @returns email
+   */
+  generateSyncEmail(): string {
+    return this.generateEmail(EmailPrefix.SYNC);
+  }
+
+  /**
+   * Creates a new email address with a given prefix
+   * @param prefix email prefix to use when generating email
+   * @returns email
+   */
+  generateEmail(prefix: EmailPrefix = EmailPrefix.SIGNIN): string {
+    const id = crypto.randomBytes(8).toString('hex');
+    return `${prefix}${id}@restmail.net`;
+  }
+
+  /**
+   * Creates a new randomized password
+   * @returns password
+   */
+  generatePassword(): string {
+    return `${crypto.randomBytes(10).toString('hex')}`;
+  }
+
+  /**
+   * Creates a new email address with the 'bounced' prefix and a new randomized
+   * password
+   * @returns AccountDetails
+   */
+  generateBouncedAccountDetails(): AccountDetails {
+    return this.generateAccountDetails(EmailPrefix.BOUNCED);
+  }
+
+  /**
+   * Creates a new email address with the 'signup_react' prefix and a new
+   * randomized password
+   * @returns AccountDetails
+   */
+  generateSignupReactAccountDetails(): AccountDetails {
+    return this.generateAccountDetails(EmailPrefix.SIGNUP_REACT);
+  }
+
+  /**
+   * Creates a new email address with the 'sync' prefix and a new randomized
+   * password
+   * @returns AccountDetails
+   */
+  generateSyncAccountDetails(): AccountDetails {
+    return this.generateAccountDetails(EmailPrefix.SYNC);
+  }
+
+  /**
+   * Creates a new email address with a given prefix and a new randomized
+   * password
+   * @param prefix email prefix to use when generating email
+   * @returns AccountDetails
+   */
+  generateAccountDetails(
+    prefix: EmailPrefix = EmailPrefix.SIGNIN
+  ): AccountDetails {
+    const account = {
+      email: this.generateEmail(prefix),
+      password: this.generatePassword(),
+    };
+    this.accounts.push(account);
+    return account;
+  }
+
+  /**
+   * Signs up an account with the AuthClient with a new email address created
+   * with the 'blocked' prefix and a new randomized password
+   * @param options AuthClient signup options
+   * @returns Credentials
+   */
+  async signUpBlocked(options?: any): Promise<Credentials> {
+    return await this.signUp(options, EmailPrefix.BLOCKED);
+  }
+
+  /**
+   * Signs up an account with the AuthClient with a new email address created
+   * with the 'forcepwdchange' prefix and a new randomized password
+   * @param options AuthClient signup options
+   * @returns Credentials
+   */
+  async signUpForced(options?: any): Promise<Credentials> {
+    return await this.signUp(options, EmailPrefix.FORCED_PWD_CHANGE);
+  }
+
+  /**
+   * Signs up an account with the AuthClient with a new email address created
+   * with the 'sync' prefix and a new randomized password
+   * @param options AuthClient signup options
+   * @returns Credentials
+   */
+  async signUpSync(options?: any): Promise<Credentials> {
+    return await this.signUp(options, EmailPrefix.SYNC);
+  }
+
+  /**
+   * Signs up an account with the AuthClient with a new email address created
+   * with a given prefix and a new randomized password
+   * @param options AuthClient signup options
+   * @param prefix email prefix to use when generating email
+   * @returns Credentials
+   */
+  async signUp(
+    options?: any,
+    prefix: EmailPrefix = EmailPrefix.SIGNIN
+  ): Promise<Credentials> {
+    const email = this.generateEmail(prefix);
+    const password = this.generatePassword();
+    const credentials = await this.target.createAccount(
+      email,
+      password,
+      options
+    );
+    this.accounts.push(credentials);
+    return credentials;
+  }
+
+  /**
+   * Destroys all accounts tracked by this TestAccountTracker
+   */
+  async destroyAllAccounts() {
+    while (this.accounts.length > 0) {
+      const account = this.accounts.pop();
+      if (!account) {
+        continue;
+      }
+
+      const accountStatus = await this.target.authClient.accountStatusByEmail(
+        account.email
+      );
+
+      if (!accountStatus.exists) {
+        continue;
+      }
+
+      /**
+       * Troubleshooting if accounts fail to destroy:
+       *
+       * Error Message: 'Sign in with this email type is not currently supported'
+       * The primary email was most likely changed, the test case must
+       * update the account with the new email
+       *
+       * Error Message: 'The request was blocked for security reasons'
+       * Some accounts are always prompted to unblock, ie emails starting
+       * with `blocked.`. These accounts need to be destroyed in the test
+       * case
+       *
+       * Error Message: 'Unconfirmed session'
+       * The account is most likely using TOTP. Disable TOTP or remove the
+       * account in the test
+       */
+      const credentials = await this.target.authClient.signIn(
+        account.email,
+        account.password
+      );
+      await this.target.authClient.accountDestroy(
+        account.email,
+        account.password,
+        {},
+        credentials.sessionToken
+      );
+    }
+  }
+}

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -210,6 +210,7 @@ export class LoginPage extends BaseLayout {
       EmailType.verifyShortCode,
       EmailHeader.shortCode
     );
+    await this.target.emailClient.clear(email);
     await this.setCode(code);
     await this.submit(waitForNavOnSubmit);
   }
@@ -220,6 +221,7 @@ export class LoginPage extends BaseLayout {
       EmailType.verifyLoginCode,
       EmailHeader.signinCode
     );
+    await this.target.emailClient.clear(email);
     await this.setCode(code);
     await this.submit();
   }
@@ -341,6 +343,7 @@ export class LoginPage extends BaseLayout {
       EmailType.unblockCode,
       EmailHeader.unblockCode
     );
+    await this.target.emailClient.clear(email);
     await this.setCode(code);
     await this.submit();
   }

--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -7,6 +7,10 @@ export class SubscribePage extends BaseLayout {
     return this.page.getByRole('heading', { name: 'Set up your subscription' });
   }
 
+  get promoCodeAppliedHeading() {
+    return this.page.getByRole('heading', { name: 'Promo Code Applied' });
+  }
+
   async visitSignIn() {
     const link = this.page.getByText('Sign In');
     await link.click();
@@ -99,14 +103,6 @@ export class SubscribePage extends BaseLayout {
       throw new Error('Generic error, most likely rate limited');
     }
     return msg;
-  }
-
-  async discountAppliedSuccess() {
-    const discount = this.page.locator(
-      '[data-testid="coupon-component"]:has-text("Promo Code Applied")'
-    );
-    await discount.waitFor();
-    return discount.isVisible();
   }
 
   async oneTimeDiscountSuccess() {

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import {
   AvatarRow,
   ConnectedServicesRow,
@@ -97,6 +97,15 @@ export class SettingsPage extends SettingsLayout {
         })
       );
     }, creds.uid);
+  }
+
+  async disconnectTotp() {
+    await this.totp.disableButton.click();
+    await this.modalConfirmButton.click();
+
+    await expect(this.settingsHeading).toBeVisible();
+    await expect(this.alertBar).toHaveText('Two-step authentication disabled');
+    await expect(this.totp.status).toHaveText('Not Set');
   }
 
   async clickPaidSubscriptions() {

--- a/packages/functional-tests/pages/settings/recoveryKey.ts
+++ b/packages/functional-tests/pages/settings/recoveryKey.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { SettingsLayout } from './layout';
 import { DataTrioComponent } from './components/dataTrio';

--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -40,8 +40,6 @@ export class SecondaryEmailPage extends SettingsLayout {
   }
 
   async addSecondaryEmail(email: string): Promise<void> {
-    await this.target.emailClient.clear(email);
-
     await expect(this.secondaryEmailHeading).toBeVisible();
     await expect(this.step1Heading).toBeVisible();
 
@@ -52,6 +50,7 @@ export class SecondaryEmailPage extends SettingsLayout {
       EmailType.verifySecondaryCode,
       EmailHeader.verifyCode
     );
+    await this.target.emailClient.clear(email);
 
     await expect(this.step2Heading).toBeVisible();
 

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -45,6 +45,10 @@ export class TotpPage extends SettingsLayout {
     return this.page.getByTestId('submit-totp');
   }
 
+  get step1CancelButton() {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
   get step2Heading() {
     return this.page.getByRole('heading', { name: 'Step 2 of 3' });
   }

--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -104,6 +104,7 @@ export class SignupReactPage extends BaseLayout {
       EmailType.verifyShortCode,
       EmailHeader.shortCode
     );
+    await this.target.emailClient.clear(email);
 
     await expect(this.codeFormHeading).toBeVisible();
 

--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -18,9 +18,11 @@ test.describe('severity-1', () => {
   });
 
   test('prompt=consent', async ({
-    credentials,
-    pages: { page, relier, login },
-  }, { project }) => {
+    pages: { relier, login },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+
     await relier.goto('prompt=consent');
     await relier.clickEmailFirst();
     await login.login(credentials.email, credentials.password);

--- a/packages/functional-tests/tests/misc/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/misc/forceAuth.spec.ts
@@ -14,9 +14,10 @@ test.describe('severity-1 #smoke', () => {
       );
     });
     test('with a registered email, registered uid', async ({
-      credentials,
       pages: { login, forceAuth },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
       await forceAuth.open(credentials);
       await login.setPassword(credentials.password);
       await login.submit();
@@ -24,9 +25,10 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('forgot password flow via force_auth', async ({
-      credentials,
       pages: { login, resetPassword, forceAuth },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
       await forceAuth.open(credentials);
       await login.clickForgotPassword();
 
@@ -53,9 +55,10 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('form prefill information is cleared after sign in->sign out', async ({
-      credentials,
       pages: { login, forceAuth, settings },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
       await forceAuth.open(credentials);
       await login.setPassword(credentials.password);
       await login.submit();

--- a/packages/functional-tests/tests/misc/keyStretchingV2.spec.ts
+++ b/packages/functional-tests/tests/misc/keyStretchingV2.spec.ts
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
-import { Page } from '@playwright/test';
-import { SignupReactPage } from '../../pages/signupReact';
 import { LoginPage } from '../../pages/login';
-import { SettingsPage } from '../../pages/settings';
 import { ResetPasswordPage } from '../../pages/resetPassword';
 import { ResetPasswordReactPage } from '../../pages/resetPasswordReact';
-import { RecoveryKeyPage } from '../../pages/settings/recoveryKey';
+import { SettingsPage } from '../../pages/settings';
 import { ChangePasswordPage } from '../../pages/settings/changePassword';
+import { RecoveryKeyPage } from '../../pages/settings/recoveryKey';
+import { SignupReactPage } from '../../pages/signupReact';
 
 // Disable this check for these tests. We are holding assertion in shared functions due
 // to how test permutations work, and these setup falsely trips this rule.
@@ -162,10 +161,10 @@ test.describe('key-stretching-v2', () => {
     async function _changePassword(
       version: 1 | 2,
       opts: Pick<Opts, 'settings' | 'changePassword'>,
-      password: string
+      password: string,
+      newPassword: string
     ) {
       const { settings, changePassword } = opts;
-      const newPassword = 'new' + password; //TODO maybe fix fixture to use new password
       await settings.goto(version === 2 ? 'stretch=2' : '');
       await settings.clickChangePassword();
 
@@ -246,9 +245,9 @@ test.describe('key-stretching-v2', () => {
       page,
       target,
       pages: { signupReact, settings, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testSignUpAndLogin(
         1,
         1,
@@ -261,16 +260,16 @@ test.describe('key-stretching-v2', () => {
           settings,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testSignUpAndLogin(
         1,
         2,
@@ -283,16 +282,16 @@ test.describe('key-stretching-v2', () => {
           settings,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testSignUpAndLogin(
         2,
         1,
@@ -305,16 +304,16 @@ test.describe('key-stretching-v2', () => {
           settings,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testSignUpAndLogin(
         2,
         2,
@@ -327,7 +326,7 @@ test.describe('key-stretching-v2', () => {
           login,
         },
         email,
-        PASSWORD
+        password
       );
     });
 
@@ -386,9 +385,9 @@ test.describe('key-stretching-v2', () => {
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         1,
@@ -404,16 +403,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password with recovery key as v1 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         1,
@@ -429,16 +428,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password with recovery key as v2 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         2,
@@ -454,16 +453,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password with recovery key as v2 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         2,
@@ -479,16 +478,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password with recovery key as v1 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         1,
@@ -504,16 +503,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password with recovery key as v1 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         1,
@@ -529,16 +528,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password with recovery key as v2 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         2,
@@ -554,16 +553,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password with recovery key as v2 and logins as v2 ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         2,
@@ -579,16 +578,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password without recovery key as v1 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         1,
@@ -604,16 +603,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password without recovery key as v1 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         1,
@@ -629,16 +628,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password without recovery key as v2 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         2,
@@ -654,16 +653,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v1 resets password without recovery key as v2 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         1,
         2,
@@ -679,16 +678,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password without recovery key as v1 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         1,
@@ -704,16 +703,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password without recovery key as v1 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         1,
@@ -729,16 +728,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password without recovery key as v2 and logins as v1 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         2,
@@ -754,16 +753,16 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
     test(`signs up as v2 resets password without recovery key as v2 and logins as v2 for ${mode}`, async ({
       page,
       target,
       pages: { signupReact, settings, login, recoveryKey, resetPasswordReact },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       await testPasswordReset(
         2,
         2,
@@ -779,7 +778,7 @@ test.describe('key-stretching-v2', () => {
           resetPasswordReact,
         },
         email,
-        PASSWORD
+        password
       );
     });
 
@@ -798,13 +797,14 @@ test.describe('key-stretching-v2', () => {
         | 'login'
         | 'signupReact'
       >,
-      email,
-      password
+      email: string,
+      password: string,
+      newPassword: string
     ) {
       await _signUp(p1, opts, true, email, password);
       await _login(p1, opts, false, email, password);
       const keys = await _getKeys(p1, opts, email, password);
-      await _changePassword(p2, opts, password);
+      await _changePassword(p2, opts, password, newPassword);
       const keys2 = await _getKeys(p1, opts, email, password);
       expect(keys2.kB).toEqual(keys.kB);
     }
@@ -812,9 +812,10 @@ test.describe('key-stretching-v2', () => {
       page,
       target,
       pages: { settings, changePassword, signupReact, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
+      const newPassword = testAccountTracker.generatePassword();
       await testChangePasswordFromSettings(
         1,
         1,
@@ -827,16 +828,18 @@ test.describe('key-stretching-v2', () => {
           changePassword,
         },
         email,
-        PASSWORD
+        password,
+        newPassword
       );
     });
     test(`signs up as v1 changes password from settings as v2 for ${mode}`, async ({
       page,
       target,
       pages: { settings, changePassword, signupReact, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
+      const newPassword = testAccountTracker.generatePassword();
       await testChangePasswordFromSettings(
         1,
         2,
@@ -849,16 +852,18 @@ test.describe('key-stretching-v2', () => {
           changePassword,
         },
         email,
-        PASSWORD
+        password,
+        newPassword
       );
     });
     test(`signs up as v2 changes password from settings as v1 for ${mode}`, async ({
       page,
       target,
       pages: { settings, changePassword, signupReact, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
+      const newPassword = testAccountTracker.generatePassword();
       await testChangePasswordFromSettings(
         2,
         1,
@@ -871,16 +876,18 @@ test.describe('key-stretching-v2', () => {
           changePassword,
         },
         email,
-        PASSWORD
+        password,
+        newPassword
       );
     });
     test(`signs up as v2 changes password from settings as v2 for ${mode}`, async ({
       page,
       target,
       pages: { settings, changePassword, signupReact, login },
-      emails,
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
+      const newPassword = testAccountTracker.generatePassword();
       await testChangePasswordFromSettings(
         2,
         2,
@@ -893,7 +900,8 @@ test.describe('key-stretching-v2', () => {
           changePassword,
         },
         email,
-        PASSWORD
+        password,
+        newPassword
       );
     });
   });

--- a/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissions.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth permissions for trusted reliers - sign up', () => {
@@ -16,32 +16,33 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup without `prompt=consent`', async ({
-      emails,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
 
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
+      await login.fillOutFirstSignUp(email, password, { verify: false });
 
       //no permissions asked for, straight to confirm
       await expect(login.signUpCodeHeader).toBeVisible();
     });
 
     test('signup with `prompt=consent`', async ({
-      emails,
       target,
       page,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
+
       const query = { prompt: 'consent' };
       const queryParam = new URLSearchParams(query);
 
       await page.goto(`${target.relierUrl}/?${queryParam.toString()}`);
       await relier.clickEmailFirst();
-      await login.fillOutFirstSignUp(email, PASSWORD, { verify: false });
+      await login.fillOutFirstSignUp(email, password, { verify: false });
 
       //Verify permissions header
       expect(await login.permissionsHeader()).toBe(true);
@@ -60,9 +61,11 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signin without `prompt=consent`', async ({
-      credentials,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+
       await relier.goto();
       await relier.clickEmailFirst();
       await login.fillOutEmailFirstSignIn(
@@ -77,9 +80,10 @@ test.describe('severity-1 #smoke', () => {
     test('signin with `prompt=consent`', async ({
       target,
       page,
-      credentials,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
       const query = { prompt: 'consent' };
       const queryParam = new URLSearchParams(query);
 
@@ -102,9 +106,11 @@ test.describe('severity-1 #smoke', () => {
     test('signin without `prompt=consent`, then re-signin with `prompt=consent`', async ({
       target,
       page,
-      credentials,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+
       await relier.goto();
       await relier.clickEmailFirst();
       await login.fillOutEmailFirstSignIn(
@@ -132,9 +138,11 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('force_auth without `prompt=consent`', async ({
-      credentials,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+
       await relier.goto(`email=${credentials.email}`);
       await relier.clickForceAuth();
       await login.setPassword(credentials.password);
@@ -147,9 +155,11 @@ test.describe('severity-1 #smoke', () => {
     test('force_auth with `prompt=consent`', async ({
       target,
       page,
-      credentials,
       pages: { login, relier },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+
       const query = new URLSearchParams({
         prompt: 'consent',
         email: credentials.email,

--- a/packages/functional-tests/tests/oauth/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/oauth/resetPassword.spec.ts
@@ -20,9 +20,10 @@ test.describe('severity-1 #smoke', () => {
     test('reset password happy path', async ({
       target,
       page,
-      credentials,
       pages: { login, relier, resetPassword },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
       await relier.goto();
       await relier.clickEmailFirst();
       await login.setEmail(credentials.email);

--- a/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
+++ b/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
@@ -2,28 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  test,
-  expect,
-  PASSWORD,
-  SYNC_EMAIL_PREFIX,
-} from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const CODE_CHALLENGE_METHOD = 'S256';
 
 test.describe('OAuth scopeKeys', () => {
-  test.use({
-    emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
-  });
-
   test('signin in Chrome for Android, verify same browser', async ({
     target,
     page,
     pages: { login },
-    emails,
+    testAccountTracker,
   }) => {
-    const [email] = emails;
     const query = new URLSearchParams({
       client_id: '7f368c6886429f19', // eslint-disable-line camelcase
       code_challenge: CODE_CHALLENGE,
@@ -39,11 +29,11 @@ test.describe('OAuth scopeKeys', () => {
       scope: 'profile https://identity.mozilla.com/apps/notes',
       state: 'fakestate',
     });
+    const credentials = await testAccountTracker.signUpSync();
 
-    await target.createAccount(email, PASSWORD);
     await page.goto(target.contentServerUrl + `/?${query.toString()}`);
-    await login.login(email, PASSWORD);
-    await login.fillOutSignInCode(email);
+    await login.login(credentials.email, credentials.password);
+    await login.fillOutSignInCode(credentials.email);
 
     await expect(login.notesHeader).toBeVisible();
   });

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import { test, expect, PASSWORD } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth webchannel', () => {
@@ -11,14 +11,16 @@ test.describe('severity-1 #smoke', () => {
       await login.clearCache();
     });
 
-    test('signup', async ({ pages: { configPage, login, relier }, emails }) => {
+    test('signup', async ({
+      pages: { configPage, login, relier },
+      testAccountTracker,
+    }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'this test is specific to backbone, skip if seeing React version'
       );
-
-      const [email] = emails;
+      const { email, password } = testAccountTracker.generateAccountDetails();
       const customEventDetail = createCustomEventDetail(
         FirefoxCommand.FxAStatus,
         {
@@ -41,7 +43,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(login.CWTSEngineBookmarks).toBeVisible();
       await expect(login.CWTSEngineHistory).toBeVisible();
 
-      await login.fillOutFirstSignUp(email, PASSWORD, {
+      await login.fillOutFirstSignUp(email, password, {
         enterEmail: false,
         waitForNavOnSubmit: false,
       });
@@ -49,7 +51,11 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
     });
 
-    test('signin', async ({ pages: { login, relier, page }, credentials }) => {
+    test('signin', async ({
+      pages: { login, relier, page },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
       const customEventDetail = createCustomEventDetail(
         FirefoxCommand.FxAStatus,
         {

--- a/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
@@ -2,73 +2,63 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  test,
-  expect,
-  FORCE_PWD_EMAIL_PREFIX,
-  PASSWORD,
-  NEW_PASSWORD,
-} from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('post verify - force password change', () => {
-    test.use({
-      emailOptions: [
-        { prefix: FORCE_PWD_EMAIL_PREFIX, password: NEW_PASSWORD },
-      ],
-    });
-    test.beforeEach(async ({ emails, target, pages: { login } }) => {
+    test.beforeEach(async () => {
       test.slow();
     });
 
     test('navigate to page directly and can change password', async ({
       target,
-      emails,
       pages: { page, login, postVerify },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
-      await target.authClient.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
-      await login.fillOutEmailFirstSignIn(email, PASSWORD);
-      await login.fillOutSignInCode(email);
+      const credentials = await testAccountTracker.signUpForced();
+      const newPassword = testAccountTracker.generatePassword();
+
+      await page.goto(target.contentServerUrl);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
+      await login.fillOutSignInCode(credentials.email);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);
 
       //Fill out change password
-      await postVerify.fillOutChangePassword(PASSWORD, NEW_PASSWORD);
+      await postVerify.fillOutChangePassword(credentials.password, newPassword);
       await postVerify.submit();
+      credentials.password = newPassword;
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
     });
 
     test('force change password on login - oauth', async ({
-      target,
-      emails,
       pages: { login, postVerify, relier },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
-      await target.authClient.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
+      const credentials = await testAccountTracker.signUpForced();
+      const newPassword = testAccountTracker.generatePassword();
+
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.fillOutEmailFirstSignIn(email, PASSWORD);
-      await login.fillOutSignInCode(email);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
+      await login.fillOutSignInCode(credentials.email);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);
 
       //Fill out change password
-      await postVerify.fillOutChangePassword(PASSWORD, NEW_PASSWORD);
+      await postVerify.fillOutChangePassword(credentials.password, newPassword);
       await postVerify.submit();
+      credentials.password = newPassword;
 
       //Verify logged in on relier page
       expect(await relier.isLoggedIn()).toBe(true);

--- a/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
@@ -16,9 +16,11 @@ test.describe('force auth react', () => {
   test('displays signin with registered email', async ({
     page,
     target,
-    credentials,
     pages: { signinReact },
+    testAccountTracker,
   }) => {
+    const credentials = await testAccountTracker.signUp();
+
     const url = getReactFeatureFlagUrl(
       target,
       '/force_auth',

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { Page, expect, test } from '../../lib/fixtures/standard';
 import { syncMobileOAuthQueryParams } from '../../lib/query-params';
-import { LoginPage } from '../../pages/login';
-import { ResetPasswordReactPage } from '../../pages/resetPasswordReact';
 import { BaseTarget } from '../../lib/targets/base';
-import { Page } from '@playwright/test';
+import { ResetPasswordReactPage } from '../../pages/resetPasswordReact';
+import { LoginPage } from '../../pages/login';
 
 const SERVICE_NAME_123 = '123';
 const SERVICE_NAME_FIREFOX = 'Firefox';
@@ -16,18 +15,20 @@ const SERVICE_NAME_FIREFOX = 'Firefox';
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth reset password react', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
-      test.slow();
-
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
+      test.slow();
     });
 
     test('reset password', async ({
       target,
       page,
-      credentials,
       pages: { login, relier, resetPasswordReact },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
       // Make sure user is not signed in, and goes to the relier (ie 123done)
       await relier.goto('showReactApp=true');
 
@@ -47,8 +48,9 @@ test.describe('severity-1 #smoke', () => {
         credentials.email
       );
 
-      await page.goto(link, { waitUntil: 'load' });
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await page.goto(link);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now
@@ -57,6 +59,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(
         resetPasswordReact.passwordResetConfirmationHeading
       ).toBeVisible();
+      // TODO FXA-9015 we must 'refresh' the page so that the 'showReactApp' param takes effect
+      page.reload();
       await expect(
         page.getByText(new RegExp(`.*${SERVICE_NAME_123}.*`, 'i'))
       ).toBeVisible();
@@ -65,9 +69,12 @@ test.describe('severity-1 #smoke', () => {
     test('reset password through Sync mobile', async ({
       target,
       page,
-      credentials,
       pages: { login, resetPasswordReact },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
       await page.goto(
         `${
           target.contentServerUrl
@@ -88,8 +95,9 @@ test.describe('severity-1 #smoke', () => {
         credentials.email
       );
 
-      await page.goto(link, { waitUntil: 'load' });
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await page.goto(link);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now
@@ -98,6 +106,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(
         resetPasswordReact.passwordResetConfirmationHeading
       ).toBeVisible();
+      // TODO FXA-9015 we must 'refresh' the page so that the 'showReactApp' param takes effect
+      page.reload();
       await expect(
         page.getByText(new RegExp(`.*${SERVICE_NAME_FIREFOX}.*`, 'i'))
       ).toBeVisible();
@@ -106,9 +116,12 @@ test.describe('severity-1 #smoke', () => {
     test('reset password different tab', async ({
       target,
       page,
-      credentials,
       pages: { login, relier, resetPasswordReact },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
       // Make sure user is not signed in, and goes to the relier (ie 123done)
       await relier.goto('showReactApp=true');
 
@@ -131,8 +144,9 @@ test.describe('severity-1 #smoke', () => {
       // Clearing session state simulates a 'new' tab, and changes the navigation at the end of the flow.
       await page.evaluate(() => window.sessionStorage.clear());
 
-      await page.goto(link, { waitUntil: 'load' });
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await page.goto(link);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now
@@ -141,6 +155,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(
         resetPasswordReact.passwordResetConfirmationHeading
       ).toBeVisible();
+      // TODO FXA-9015 we must 'refresh' the page so that the 'showReactApp' param takes effect
+      page.reload();
       await expect(
         page.getByText(new RegExp(`.*${SERVICE_NAME_123}.*`, 'i'))
       ).toBeVisible();
@@ -149,9 +165,12 @@ test.describe('severity-1 #smoke', () => {
     test('reset password scoped keys', async ({
       target,
       page,
-      credentials,
       pages: { login, relier, resetPasswordReact },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
       // Make sure user is not signed in, and goes to the relier (ie 123done)
       await relier.goto('showReactApp=true');
 
@@ -171,8 +190,9 @@ test.describe('severity-1 #smoke', () => {
         credentials.email
       );
 
-      await page.goto(link, { waitUntil: 'load' });
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await page.goto(link);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now
@@ -181,6 +201,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(
         resetPasswordReact.passwordResetConfirmationHeading
       ).toBeVisible();
+      // TODO FXA-9015 we must 'refresh' the page so that the 'showReactApp' param takes effect
+      page.reload();
       await expect(
         page.getByText(new RegExp(`.*${SERVICE_NAME_123}.*`, 'i'))
       ).toBeVisible();
@@ -189,13 +211,16 @@ test.describe('severity-1 #smoke', () => {
     test('reset password with PKCE different tab', async ({
       target,
       page,
-      credentials,
       pages: { login, resetPasswordReact },
+      testAccountTracker,
     }) => {
       test.fixme(true, 'Fix required as of 2023/07/18 (see FXA-8006).');
       // the PKCE button is broken at the moment, so for now navigate directly to the link.
       // PKCE button doesn't appear to work at the moment locally. Some sort of cors error
       // keeps getting in the way. Just go to link directly for now.
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
       await page.goto(
         `http://localhost:3030/authorization?showReactApp=true` +
           `&access_type=offline` +
@@ -225,7 +250,8 @@ test.describe('severity-1 #smoke', () => {
       await page.evaluate(() => window.sessionStorage.clear());
 
       await page.goto(link, { waitUntil: 'load' });
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now
@@ -241,17 +267,31 @@ test.describe('severity-1 #smoke', () => {
 
     test('reset password with account recovery key', async ({
       target,
-      credentials,
-      page,
-      pages: { login, resetPasswordReact, relier, settings, recoveryKey },
+      pages: {
+        page,
+        login,
+        signinReact,
+        resetPasswordReact,
+        relier,
+        settings,
+        recoveryKey,
+      },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
+      await signinReact.goto();
+      await signinReact.fillOutEmailFirstForm(credentials.email);
+      await signinReact.fillOutPasswordForm(credentials.password);
+
       // Goes to settings and enables the account recovery key on user's account.
-      await settings.goto();
       await settings.recoveryKey.createButton.click();
       const accountRecoveryKey = await recoveryKey.createRecoveryKey(
         credentials.password,
         'hint'
       );
+      await settings.signOut();
 
       // Make sure user is not signed in, and goes to the relier (ie 123done)
       await relier.goto('showReactApp=true');
@@ -273,9 +313,9 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await page.goto(link, { waitUntil: 'load' });
-      await login.setRecoveryKey(accountRecoveryKey);
-      await login.submit();
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await resetPasswordReact.fillOutRecoveryKeyForm(accountRecoveryKey);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now
@@ -292,15 +332,29 @@ test.describe('severity-1 #smoke', () => {
 
     test('reset password with valid totp', async ({
       target,
-      credentials,
-      page,
-      pages: { login, resetPasswordReact, relier, totp, settings },
+      pages: {
+        page,
+        login,
+        signinReact,
+        resetPasswordReact,
+        relier,
+        totp,
+        settings,
+      },
+      testAccountTracker,
     }) => {
+      test.fixme(true, 'Fix required as of 2024/04/25 FXA-9513');
+
+      const credentials = await testAccountTracker.signUp();
+      const newPassword = testAccountTracker.generatePassword();
+
+      await signinReact.goto();
+      await signinReact.fillOutEmailFirstForm(credentials.email);
+      await signinReact.fillOutPasswordForm(credentials.password);
       // Goes to settings and enables totp on user's account.
-      await settings.goto();
       await settings.totp.addButton.click();
-      const { secret } = await totp.fillOutTotpForms();
-      credentials.secret = secret;
+      await totp.fillOutTotpForms();
+      await settings.signOut();
 
       // Makes sure user is not signed in, and goes to the relier (ie 123done)
       await relier.goto('showReactApp=true');
@@ -321,7 +375,8 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await page.goto(link, { waitUntil: 'load' });
-      await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
+      await resetPasswordReact.fillOutNewPasswordForm(newPassword);
+      credentials.password = newPassword;
 
       // Note: We used to redirect the user back to the relier in some cases
       // but we've decided to just show the success message for now

--- a/packages/functional-tests/tests/react-conversion/signIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signIn.spec.ts
@@ -7,9 +7,9 @@ import { test, expect } from '../../lib/fixtures/standard';
 test.describe('severity-2 #smoke', () => {
   test.describe('react signin', () => {
     test('sign in as an existing user', async ({
-      credentials,
       page,
       pages: { configPage, settings, signinReact },
+      testAccountTracker,
     }) => {
       // Ensure that the feature flag is enabled
       const config = await configPage.getConfig();
@@ -17,6 +17,7 @@ test.describe('severity-2 #smoke', () => {
         config.showReactApp.signInRoutes !== true,
         'React signInRoutes not enabled'
       );
+      const credentials = await testAccountTracker.signUp();
 
       await signinReact.goto();
       await signinReact.fillOutEmailFirstForm(credentials.email);

--- a/packages/functional-tests/tests/react-conversion/signInCached.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInCached.spec.ts
@@ -7,9 +7,9 @@ import { test, expect } from '../../lib/fixtures/standard';
 test.describe('severity-2 #smoke', () => {
   test.describe('react signin cached', () => {
     test('sign in twice, on second attempt email will be cached', async ({
-      credentials,
       page,
       pages: { configPage, settings, signinReact },
+      testAccountTracker,
     }) => {
       // Ensure that the feature flag is enabled
       const config = await configPage.getConfig();
@@ -17,6 +17,8 @@ test.describe('severity-2 #smoke', () => {
         config.showReactApp.signInRoutes !== true,
         'Skip tests if React signInRoutes not enabled'
       );
+
+      const credentials = await testAccountTracker.signUp();
 
       await signinReact.goto();
       await signinReact.fillOutEmailFirstForm(credentials.email);
@@ -30,7 +32,7 @@ test.describe('severity-2 #smoke', () => {
       // Return to sign in without signing out
       await signinReact.goto();
 
-      await expect(await signinReact.cachedSigninHeading).toBeVisible();
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
       // email is prefilled and password is not required to sign in
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signinReact.signInButton.click();

--- a/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
@@ -7,14 +7,17 @@ import { test, expect } from '../../lib/fixtures/standard';
 test.describe('severity-2 #smoke', () => {
   test.describe('connect_another_device', () => {
     test('react signin Fx Desktop, load /connect_another_device page', async ({
-      credentials,
       syncBrowserPages: { configPage, connectAnotherDevice, page, signinReact },
+      testAccountTracker,
     }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signInRoutes !== true,
         'Skip tests if React signInRoutes not enabled'
       );
+
+      const credentials = await testAccountTracker.signUp();
+
       await signinReact.goto(
         undefined,
         new URLSearchParams('context=fx_desktop_v3&service=sync&action=email')

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -10,7 +10,6 @@ test.describe('severity-1 #smoke', () => {
 
   test('react signin to sync and disconnect', async ({
     target,
-    credentials,
     syncBrowserPages: {
       configPage,
       connectAnotherDevice,
@@ -18,6 +17,7 @@ test.describe('severity-1 #smoke', () => {
       signinReact,
       settings,
     },
+    testAccountTracker,
   }) => {
     const config = await configPage.getConfig();
     test.fixme(true, 'Fix required as of 2024/04/19 (see FXA-9490)');
@@ -25,6 +25,8 @@ test.describe('severity-1 #smoke', () => {
       config.showReactApp.signInRoutes !== true,
       'Skip tests if React signInRoutes not enabled'
     );
+
+    const credentials = await testAccountTracker.signUp();
 
     await signinReact.goto(
       undefined,
@@ -57,18 +59,20 @@ test.describe('severity-1 #smoke', () => {
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293475
   test('react disconnect RP #1293475', async ({
-    credentials,
     pages: { configPage, page, relier, signinReact, settings },
+    testAccountTracker,
   }, { project }) => {
     const config = await configPage.getConfig();
-    test.skip(
-      config.showReactApp.signInRoutes !== true,
-      'Skip tests if React signInRoutes not enabled'
-    );
     test.fixme(
       project.name !== 'local',
       'FXA-9518 - Timing issue? Fails on stage with `Bad request - unknown state` on L86, unless breakpoint added on L85. Passes when restarting from breakpoint. '
     );
+    test.skip(
+      config.showReactApp.signInRoutes !== true,
+      'Skip tests if React signInRoutes not enabled'
+    );
+
+    const credentials = await testAccountTracker.signUp();
 
     await relier.goto();
     await relier.clickEmailFirst();

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -7,19 +7,22 @@ import { expect, test } from '../../lib/fixtures/standard';
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 signin react', () => {
     test('verified, does not need to confirm', async ({
-      credentials,
       syncBrowserPages: { configPage, connectAnotherDevice, signinReact },
+      testAccountTracker,
     }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signInRoutes !== true,
         'React signInRoutes not enabled'
       );
+
+      const credentials = await testAccountTracker.signUp();
+
       await signinReact.goto(
         undefined,
         new URLSearchParams('context=fx_desktop_v3&service=sync&action=email')
       );
-      await expect(await signinReact.syncSignInHeading).toBeVisible();
+      await expect(signinReact.syncSignInHeading).toBeVisible();
       await signinReact.fillOutEmailFirstForm(credentials.email);
       await signinReact.fillOutPasswordForm(credentials.password);
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();

--- a/packages/functional-tests/tests/settings/displayName.spec.ts
+++ b/packages/functional-tests/tests/settings/displayName.spec.ts
@@ -2,10 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { Page, expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { LoginPage } from '../../pages/login';
 
 test.describe('severity-2 #smoke', () => {
-  test('add the display name', async ({ pages: { settings, displayName } }) => {
+  test('add the display name', async ({
+    target,
+    pages: { page, login, settings, displayName },
+    testAccountTracker,
+  }) => {
+    await signInAccount(target, page, login, testAccountTracker);
+
     await settings.goto();
 
     await expect(settings.displayName.status).toHaveText('None');
@@ -18,8 +27,12 @@ test.describe('severity-2 #smoke', () => {
   });
 
   test('cancel add the display name', async ({
-    pages: { settings, displayName },
+    target,
+    pages: { page, login, settings, displayName },
+    testAccountTracker,
   }) => {
+    await signInAccount(target, page, login, testAccountTracker);
+
     await settings.goto();
 
     await expect(settings.displayName.status).toHaveText('None');
@@ -33,8 +46,12 @@ test.describe('severity-2 #smoke', () => {
   });
 
   test('change the display name', async ({
-    pages: { settings, displayName },
+    target,
+    pages: { page, login, settings, displayName },
+    testAccountTracker,
   }) => {
+    await signInAccount(target, page, login, testAccountTracker);
+
     await settings.goto();
 
     await expect(settings.displayName.status).toHaveText('None');
@@ -53,8 +70,12 @@ test.describe('severity-2 #smoke', () => {
   });
 
   test('remove the display name', async ({
-    pages: { settings, displayName },
+    target,
+    pages: { page, login, settings, displayName },
+    testAccountTracker,
   }) => {
+    await signInAccount(target, page, login, testAccountTracker);
+
     await settings.goto();
 
     await expect(settings.displayName.status).toHaveText('None');
@@ -72,3 +93,19 @@ test.describe('severity-2 #smoke', () => {
     await expect(settings.displayName.status).toHaveText('None');
   });
 });
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  login: LoginPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+
+  //Verify logged in on Settings page
+  expect(await login.isUserLoggedIn()).toBe(true);
+
+  return credentials;
+}

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -2,73 +2,74 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  expect,
-  test,
-  PASSWORD,
-  SIGNIN_EMAIL_PREFIX,
-} from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 import { oauthWebchannelV1 } from '../../lib/query-params';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { LoginPage } from '../../pages/login';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('fxa_status web channel message in Settings', () => {
-  test.use({
-    emailOptions: [
-      { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
-      { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
-    ],
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    // Ensure that the feature flag is enabled
+    const config = await configPage.getConfig();
+    test.skip(config.featureFlags.sendFxAStatusOnSettings !== true);
+    test.slow();
   });
-  test.beforeEach(
-    async ({
-      emails,
-      target,
-      pages: { configPage },
-      syncBrowserPages: { login },
-    }) => {
-      test.slow();
-      // Ensure that the feature flag is enabled
-      const config = await configPage.getConfig();
-      test.skip(config.featureFlags.sendFxAStatusOnSettings !== true);
-      const [email, otherEmail] = emails;
-      await target.authClient.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await target.authClient.signUp(otherEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      // First we sign the browser into an account
-      await login.goto('load', 'context=fx_desktop_v3&service=sync');
-      await login.fillOutEmailFirstSignIn(email, PASSWORD);
-      // Then, we sign into a **different** account
-      await login.goto();
-      await login.useDifferentAccountLink();
-      await login.fillOutEmailFirstSignIn(otherEmail, PASSWORD);
-    }
-  );
 
   test('message is sent when loading with context = oauth_webchannel_v1', async ({
-    emails,
-    syncBrowserPages: { settings },
+    syncBrowserPages: { page, login, settings },
+    testAccountTracker,
   }) => {
-    const [email, ,] = emails;
+    const credentials = await signInAccount(testAccountTracker, login);
+    await signInDifferentAccount(testAccountTracker, login);
+
     // We verify that even though another email is signed in, when
     // accessing the setting with a `context=oauth_webchannel_v1` the account
     // signed into the browser takes precedence
     await settings.goto(oauthWebchannelV1.toString());
-    await expect(settings.primaryEmail.status).toHaveText(email);
+    await expect(settings.primaryEmail.status).toHaveText(credentials.email);
   });
 
   test('message is not sent when loading without oauth web channel context', async ({
-    emails,
-    syncBrowserPages: { settings },
+    syncBrowserPages: { login, settings },
+    testAccountTracker,
   }) => {
-    const [, otherEmail] = emails;
+    await signInAccount(testAccountTracker, login);
+    const otherCredentials = await signInDifferentAccount(
+      testAccountTracker,
+      login
+    );
+
     // We verify that when accessing the setting without the `context=oauth_webchannel_v1`
     // the newer account takes precedence
     await settings.goto();
-    await expect(settings.primaryEmail.status).toHaveText(otherEmail);
+    await expect(settings.primaryEmail.status).toHaveText(
+      otherCredentials.email
+    );
   });
 });
+
+async function signInAccount(
+  testAccountTracker: TestAccountTracker,
+  login: LoginPage
+) {
+  const credentials = await testAccountTracker.signUp();
+  await login.goto('load', 'context=fx_desktop_v3&service=sync');
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  return credentials;
+}
+
+async function signInDifferentAccount(
+  testAccountTracker: TestAccountTracker,
+  login: LoginPage
+) {
+  const otherCredentials = await testAccountTracker.signUp();
+  await login.goto();
+  await login.useDifferentAccountLink();
+  await login.fillOutEmailFirstSignIn(
+    otherCredentials.email,
+    otherCredentials.password
+  );
+  return otherCredentials;
+}

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -2,10 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { Page, expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { LoginPage } from '../../pages/login';
 
 test.describe('severity-1 #smoke', () => {
-  test('settings help link', async ({ pages: { settings } }) => {
+  test('settings help link', async ({
+    target,
+    page,
+    pages: { login, settings },
+    testAccountTracker,
+  }) => {
+    await signInAccount(target, page, login, testAccountTracker);
+
     await settings.goto();
     const helpPage = await settings.clickHelp();
 
@@ -15,8 +25,13 @@ test.describe('severity-1 #smoke', () => {
 
 test.describe('severity-2 #smoke', () => {
   test('open and close bento drop-down menu', async ({
-    pages: { settings },
+    target,
+    page,
+    pages: { login, settings },
+    testAccountTracker,
   }) => {
+    await signInAccount(target, page, login, testAccountTracker);
+
     await settings.goto();
 
     await expect(settings.bentoDropDownMenu).toBeHidden();
@@ -30,3 +45,19 @@ test.describe('severity-2 #smoke', () => {
     await expect(settings.bentoDropDownMenu).toBeHidden();
   });
 });
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  login: LoginPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+
+  //Verify logged in on Settings page
+  expect(await login.isUserLoggedIn()).toBe(true);
+
+  return credentials;
+}

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
 import { EmailHeader, EmailType } from '../../lib/email';
+import { Page, expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { LoginPage } from '../../pages/login';
 import { SettingsPage } from '../../pages/settings';
 import { TotpCredentials, TotpPage } from '../../pages/settings/totp';
 
@@ -15,22 +18,20 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('add and remove totp', async ({
-      credentials,
-      pages: { settings, totp, login },
+      target,
+      pages: { page, settings, totp, login },
+      testAccountTracker,
     }) => {
-      await settings.goto();
-      const { secret } = await addTotp(settings, totp);
-      credentials.secret = secret;
-      await settings.totp.disableButton.click();
-      await settings.modalConfirmButton.click();
-      credentials.secret = '';
-
-      await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
-        'Two-step authentication disabled'
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
       );
-      await expect(settings.totp.status).toHaveText('Not Set');
 
+      await settings.goto();
+      await addTotp(settings, totp);
+      await settings.disconnectTotp();
       // Login to verify no prompt for code
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
@@ -38,49 +39,69 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('totp use QR code', async ({
-      credentials,
-      pages: { settings, totp },
+      target,
+      pages: { page, login, settings, totp },
+      testAccountTracker,
     }) => {
+      await signInAccount(target, page, login, testAccountTracker);
+
       await settings.goto();
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.totp.status).toHaveText('Not Set');
 
       await settings.totp.addButton.click();
-      const secret = await totp.fillOutStep1FormQR();
+      await totp.fillOutStep1FormQR();
       const recoveryCodes = await totp.fillOutStep2Form();
       await totp.fillOutStep3Form(recoveryCodes[0]);
-      credentials.secret = secret;
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toHaveText(
         'Two-step authentication enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
+
+      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('add TOTP and login', async ({
-      credentials,
-      pages: { login, settings, totp },
+      target,
+      pages: { page, settings, totp, login },
+      testAccountTracker,
     }) => {
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
+
       await settings.goto();
       const { secret } = await addTotp(settings, totp);
-      credentials.secret = secret;
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
-      await login.setTotp(credentials.secret);
+      await login.setTotp(secret);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.totp.status).toHaveText('Enabled');
+
+      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('totp invalid recovery code', async ({
-      credentials,
-      pages: { settings, totp, login },
+      target,
+      pages: { page, settings, totp, login },
+      testAccountTracker,
     }) => {
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
+
       await settings.goto();
-      const { secret } = await addTotp(settings, totp);
-      credentials.secret = secret;
+      const { recoveryCodes } = await addTotp(settings, totp);
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
       await login.clickUseRecoveryCode();
@@ -90,16 +111,27 @@ test.describe('severity-1 #smoke', () => {
       await expect(login.tooltip).toHaveText(
         'Invalid backup authentication code'
       );
+
+      // Required before teardown
+      await login.setCode(recoveryCodes[0]);
+      await login.submitButton.click();
+      await settings.disconnectTotp();
     });
 
     test('can change backup authentication codes', async ({
-      credentials,
-      page,
-      pages: { settings, totp, login },
+      target,
+      pages: { page, settings, totp, login },
+      testAccountTracker,
     }) => {
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
+
       await settings.goto();
-      const { secret, recoveryCodes } = await addTotp(settings, totp);
-      credentials.secret = secret;
+      const { recoveryCodes } = await addTotp(settings, totp);
       await settings.totp.changeButton.click();
       await settings.modalConfirmButton.click();
 
@@ -122,16 +154,24 @@ test.describe('severity-1 #smoke', () => {
       await login.submit();
 
       expect(page.url()).toContain(settings.url);
+
+      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('can get new backup authentication codes via email', async ({
       target,
-      credentials,
-      pages: { page, login, settings, totp },
+      pages: { page, settings, totp, login },
+      testAccountTracker,
     }) => {
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
+
       await settings.goto();
-      const { secret, recoveryCodes } = await addTotp(settings, totp);
-      credentials.secret = secret;
+      const { recoveryCodes } = await addTotp(settings, totp);
       await settings.signOut();
 
       for (let i = 0; i < recoveryCodes.length - 3; i++) {
@@ -157,19 +197,29 @@ test.describe('severity-1 #smoke', () => {
       await page.goto(link);
       const newCodes = await totp.getRecoveryCodes();
       expect(newCodes.length).toEqual(recoveryCodes.length);
+
+      // Disconnect totp, required before teardown
+      await totp.step1CancelButton.click();
+      await settings.disconnectTotp();
     });
 
     test('delete account with totp enabled', async ({
-      credentials,
-      page,
-      pages: { settings, totp, login, deleteAccount },
+      target,
+      pages: { page, settings, totp, login, deleteAccount },
+      testAccountTracker,
     }) => {
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
+
       await settings.goto();
       const { secret } = await addTotp(settings, totp);
-      credentials.secret = secret;
       await settings.signOut();
       await login.login(credentials.email, credentials.password);
-      await login.setTotp(credentials.secret);
+      await login.setTotp(secret);
 
       await settings.deleteAccountButton.click();
       await deleteAccount.deleteAccount(credentials.password);
@@ -180,6 +230,22 @@ test.describe('severity-1 #smoke', () => {
     });
   });
 });
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  login: LoginPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+
+  //Verify logged in on Settings page
+  expect(await login.isUserLoggedIn()).toBe(true);
+
+  return credentials;
+}
 
 async function addTotp(
   settings: SettingsPage,

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -7,10 +7,12 @@ import { expect, test } from '../../lib/fixtures/standard';
 test.describe('severity-2 #smoke', () => {
   test.describe('connect_another_device', () => {
     test('signin Fx Desktop, verify /connect_another_device page', async ({
-      credentials,
       syncBrowserPages: { connectAnotherDevice, page, login },
       target,
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -6,20 +6,14 @@ import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('redirect_to', () => {
-    test.beforeEach(
-      async ({ credentials, pages: { settings, login, configPage } }) => {
-        const config = await configPage.getConfig();
-        // NOTE: These tests pass for React when `fullProdRollout` for React Signup is set
-        // to `true`, but when we're only at 15% and the flag is "on", URLs need to have
-        // the force experiment params. Since we'll be porting these over for React, for now,
-        // skip these tests if the flag is on.
-        test.skip(config.showReactApp.signUpRoutes === true);
-
-        await settings.goto();
-        await settings.signOut();
-        await login.login(credentials.email, credentials.password);
-      }
-    );
+    test.beforeEach(async ({ pages: { configPage } }) => {
+      const config = await configPage.getConfig();
+      // NOTE: These tests pass for React when `fullProdRollout` for React Signup is set
+      // to `true`, but when we're only at 15% and the flag is "on", URLs need to have
+      // the force experiment params. Since we'll be porting these over for React, for now,
+      // skip these tests if the flag is on.
+      test.skip(config.showReactApp.signUpRoutes === true);
+    });
 
     const testCases = [
       { name: 'invalid', redirectTo: 'https://evil.com/' },
@@ -29,8 +23,15 @@ test.describe('severity-2 #smoke', () => {
       test(`prevent ${name} redirect_to parameter`, async ({
         target,
         page,
-        pages: { login },
+        pages: { login, settings },
+        testAccountTracker,
       }) => {
+        const { email, password } = testAccountTracker.generateAccountDetails();
+
+        await settings.goto();
+        await settings.signOut();
+        await login.login(email, password);
+
         await page.goto(
           `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`
         );
@@ -43,9 +44,15 @@ test.describe('severity-2 #smoke', () => {
 
     test('allows valid redirect_to parameter', async ({
       target,
-      page,
-      pages: { login },
+      pages: { page, settings, login },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await settings.goto();
+      await settings.signOut();
+      await login.login(credentials.email, credentials.password);
+
       const redirectTo = `${target.contentServerUrl}/settings`;
       await page.goto(
         `${target.contentServerUrl}/confirm_signup_code?redirect_to=${redirectTo}`

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -10,10 +10,13 @@ test.describe('severity-1 #smoke', () => {
 
   test('signin to sync and disconnect', async ({
     target,
-    credentials,
     syncBrowserPages: { page, login, settings },
+    testAccountTracker,
   }) => {
     test.fixme(true, 'Fix required as of 2024/04/19 (see FXA-9490)');
+
+    const credentials = await testAccountTracker.signUp();
+
     await page.goto(
       target.contentServerUrl +
         '?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email'
@@ -35,9 +38,11 @@ test.describe('severity-1 #smoke', () => {
   });
 
   test('disconnect RP', async ({
-    credentials,
     pages: { relier, login, settings },
+    testAccountTracker,
   }) => {
+    const credentials = await testAccountTracker.signUp();
+
     await relier.goto();
     await relier.clickEmailFirst();
     await login.login(credentials.email, credentials.password);
@@ -62,11 +67,12 @@ test.describe('severity-1 #smoke', () => {
   });
 
   test('can login to addons', async ({
-    credentials,
     pages: { page, login, settings },
+    testAccountTracker,
   }, { project }) => {
     test.skip(project.name !== 'production', 'uses prod addons site');
 
+    const credentials = await testAccountTracker.signUp();
     await page.goto('https://addons.mozilla.org/en-US/firefox/');
     await page.getByRole('link', { name: 'Log in' }).click();
     await page.waitForURL(/accounts\.firefox\.com/);
@@ -92,11 +98,15 @@ test.describe('severity-1 #smoke', () => {
     await settings.avatarMenuSignOut.click();
   });
 
-  test('can login to monitor', async ({ credentials, page, pages: { login } }, {
-    project,
-  }) => {
+  test('can login to monitor', async ({
+    page,
+    pages: { login },
+    testAccountTracker,
+  }, { project }) => {
     // This test has a history of breaking (see FXA-9140).
     test.skip(project.name !== 'production', 'uses prod monitor');
+
+    const credentials = await testAccountTracker.signUp();
 
     await page.goto('https://monitor.mozilla.org/');
     await page.getByRole('button', { name: 'Sign In' }).click();
@@ -111,10 +121,14 @@ test.describe('severity-1 #smoke', () => {
     await expect(page).toHaveURL('https://monitor.mozilla.org/');
   });
 
-  test('can login to SUMO', async ({ credentials, page, pages: { login } }, {
-    project,
-  }) => {
+  test('can login to SUMO', async ({
+    page,
+    pages: { login },
+    testAccountTracker,
+  }, { project }) => {
     test.skip(project.name !== 'production', 'uses prod monitor');
+
+    const credentials = await testAccountTracker.signUp();
 
     await page.goto('https://support.mozilla.org/');
 

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -2,72 +2,54 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page } from '@playwright/test';
-import {
-  BLOCKED_EMAIL_PREFIX,
-  PASSWORD,
-  SIGNIN_EMAIL_PREFIX,
-  expect,
-  test,
-} from '../../lib/fixtures/standard';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { Page, expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { LoginPage } from '../../pages/login';
 import { SettingsPage } from '../../pages/settings';
 import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 
 test.describe('severity-2 #smoke', () => {
-  test.beforeEach(async () => {
-    test.slow(); //This test has steps for email rendering that runs slow on stage
-  });
-
   test.describe('signin blocked', () => {
-    test.use({
-      emailOptions: [{ prefix: BLOCKED_EMAIL_PREFIX, password: PASSWORD }],
+    test.beforeEach(() => {
+      test.slow(); //This test has steps for email rendering that runs slow on stage
     });
 
     test('valid code entered', async ({
-      emails,
       target,
       page,
       pages: { login, settings, deleteAccount },
+      testAccountTracker,
     }) => {
-      const [blockedEmail] = emails;
-      await target.authClient.signUp(blockedEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await page.goto(target.contentServerUrl);
-      await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
-
-      //Verify sign in block header
-      await expect(login.signInUnblockHeader()).toBeVisible();
-      expect(await login.getUnblockEmail()).toContain(blockedEmail);
+      const credentials = await signInBlockedAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
 
       //Unblock the email
-      await login.unblock(blockedEmail);
+      await login.unblock(credentials.email);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await removeAccount(settings, deleteAccount, page);
+      await removeAccount(settings, deleteAccount, page, credentials.password);
     });
 
     test('incorrect code entered', async ({
-      emails,
       target,
       page,
       pages: { login, settings, deleteAccount },
+      testAccountTracker,
     }) => {
-      const [blockedEmail] = emails;
-      await target.authClient.signUp(blockedEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await page.goto(target.contentServerUrl);
-      await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
-
-      //Verify sign in block header
-      await expect(login.signInUnblockHeader()).toBeVisible();
-      expect(await login.getUnblockEmail()).toContain(blockedEmail);
+      const credentials = await signInBlockedAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
 
       await login.enterUnblockCode('incorrect');
 
@@ -77,32 +59,27 @@ test.describe('severity-2 #smoke', () => {
       );
 
       //Unblock the email
-      await login.unblock(blockedEmail);
+      await login.unblock(credentials.email);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await removeAccount(settings, deleteAccount, page);
+      await removeAccount(settings, deleteAccount, page, credentials.password);
     });
 
     test('resend', async ({
-      emails,
       target,
       page,
       pages: { login, resetPassword, settings, deleteAccount },
+      testAccountTracker,
     }) => {
-      const [blockedEmail] = emails;
-      await target.authClient.signUp(blockedEmail, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await page.goto(target.contentServerUrl);
-      await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
-
-      //Verify sign in block header
-      await expect(login.signInUnblockHeader()).toBeVisible();
-      expect(await login.getUnblockEmail()).toContain(blockedEmail);
+      const credentials = await signInBlockedAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
 
       //Click resend link
       await resetPassword.clickResend();
@@ -113,82 +90,76 @@ test.describe('severity-2 #smoke', () => {
       );
 
       //Unblock the email
-      await login.unblock(blockedEmail);
+      await login.unblock(credentials.email);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await removeAccount(settings, deleteAccount, page);
+      await removeAccount(settings, deleteAccount, page, credentials.password);
     });
 
     test('unverified', async ({
-      emails,
       target,
       page,
       pages: { login, settings, deleteAccount },
+      testAccountTracker,
     }) => {
       test.fixme(true, 'FXA-9226');
-      const [unverifiedEmail] = emails;
-      await target.authClient.signUp(unverifiedEmail, PASSWORD, {
+
+      const credentials = await testAccountTracker.signUp({
         lang: 'en',
         preVerified: 'false',
       });
+
       await page.goto(target.contentServerUrl);
-      await login.fillOutEmailFirstSignIn(unverifiedEmail, PASSWORD);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
 
       //Verify sign in block header
       await expect(login.signInUnblockHeader()).toBeVisible();
-      expect(await login.getUnblockEmail()).toContain(unverifiedEmail);
+      expect(await login.getUnblockEmail()).toContain(credentials.email);
 
       //Unblock the email
-      await login.unblock(unverifiedEmail);
+      await login.unblock(credentials.email);
 
       //Verify confirm code header
       await expect(login.signUpCodeHeader).toBeVisible();
 
-      await login.fillOutSignInCode(unverifiedEmail);
+      await login.fillOutSignInCode(credentials.email);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await removeAccount(settings, deleteAccount, page);
+      await removeAccount(settings, deleteAccount, page, credentials.password);
     });
-  });
 
-  test.describe('signin blocked', () => {
-    test.use({
-      emailOptions: [
-        { prefix: BLOCKED_EMAIL_PREFIX, password: PASSWORD },
-        { prefix: SIGNIN_EMAIL_PREFIX, password: PASSWORD },
-      ],
-    });
     test('with primary email changed', async ({
-      emails,
       target,
       page,
-      pages: { login, settings, deleteAccount, secondaryEmail },
+      pages: { login, settings, secondaryEmail, deleteAccount },
+      testAccountTracker,
     }) => {
-      const [blockedEmail, email] = emails;
-      await target.authClient.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
-      await page.goto(target.contentServerUrl);
-      await login.fillOutEmailFirstSignIn(email, PASSWORD);
-
-      //Verify logged in on Settings page
-      expect(await login.isUserLoggedIn()).toBe(true);
+      const blockedEmail = testAccountTracker.generateBlockedEmail();
+      const credentials = await signInAccount(
+        target,
+        page,
+        login,
+        testAccountTracker
+      );
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
       await secondaryEmail.addSecondaryEmail(blockedEmail);
       await settings.secondaryEmail.makePrimaryButton.click();
+      credentials.email = blockedEmail;
       await settings.signOut();
 
       await page.goto(target.contentServerUrl);
-      await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
+      await login.fillOutEmailFirstSignIn(blockedEmail, credentials.password);
 
       //Verify sign in block header
       await expect(login.signInUnblockHeader()).toBeVisible();
@@ -201,18 +172,52 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await removeAccount(settings, deleteAccount, page);
+      await removeAccount(settings, deleteAccount, page, credentials.password);
     });
   });
 });
 
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  login: LoginPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+
+  //Verify logged in on Settings page
+  expect(await login.isUserLoggedIn()).toBe(true);
+
+  return credentials;
+}
+
+async function signInBlockedAccount(
+  target: BaseTarget,
+  page: Page,
+  login: LoginPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUpBlocked();
+  await page.goto(target.contentServerUrl);
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+
+  //Verify sign in block header
+  await expect(login.signInUnblockHeader()).toBeVisible();
+  expect(await login.getUnblockEmail()).toContain(credentials.email);
+
+  return credentials;
+}
+
 async function removeAccount(
   settings: SettingsPage,
   deleteAccount: DeleteAccountPage,
-  page: Page
+  page: Page,
+  password: string
 ) {
   await settings.deleteAccountButton.click();
-  await deleteAccount.deleteAccount(PASSWORD);
+  await deleteAccount.deleteAccount(password);
 
   await expect(page.getByText('Account deleted successfully')).toBeVisible();
 }

--- a/packages/functional-tests/tests/stub.spec.ts
+++ b/packages/functional-tests/tests/stub.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '../lib/fixtures/standard';
 
-test('stub', async ({ credentials, page }) => {
+test('stub', async ({ page, testAccountTracker }) => {
+  const credentials = await testAccountTracker.signUp();
   console.log(credentials);
   await page.pause();
 });

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../../lib/fixtures/standard';
+import { Page, expect, test } from '../../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../../lib/targets/base';
+import { TestAccountTracker } from '../../../lib/testAccountTracker';
+import { LoginPage } from '../../../pages/login';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -13,12 +16,17 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('resubscribe successfully with the same coupon after canceling for stripe', async ({
+      target,
+      page,
       pages: { relier, subscribe, login, settings, subscriptionManagement },
+      testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
+      await signInAccount(target, page, login, testAccountTracker);
+
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -26,7 +34,7 @@ test.describe('severity-2 #smoke', () => {
       await subscribe.addCouponCode('auto10pforever');
 
       // Verify the coupon is applied successfully
-      expect(await subscribe.discountAppliedSuccess()).toBe(true);
+      await expect(subscribe.promoCodeAppliedHeading).toBeVisible();
 
       const total = await subscribe.getTotalPrice();
 
@@ -64,12 +72,17 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('update mode of payment for stripe', async ({
+      target,
+      page,
       pages: { relier, subscribe, login, settings, subscriptionManagement },
+      testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
+      await signInAccount(target, page, login, testAccountTracker);
+
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -97,3 +110,19 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  login: LoginPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+
+  //Verify logged in on Settings page
+  expect(await login.isUserLoggedIn()).toBe(true);
+
+  return credentials;
+}

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -3,57 +3,53 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import {
-  expect,
-  test,
-  PASSWORD,
-  NEW_PASSWORD,
-  SYNC_EMAIL_PREFIX,
-} from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-2 #smoke', () => {
-  test.use({
-    emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: NEW_PASSWORD }],
-  });
   test.describe('Firefox Desktop Sync v3 settings', () => {
-    test.beforeEach(
-      async ({
-        emails,
-        target,
-        syncBrowserPages: { login, connectAnotherDevice, page },
-      }) => {
-        const [email] = emails;
-        test.slow();
-        await target.authClient.signUp(email, PASSWORD, {
-          lang: 'en',
-          preVerified: 'true',
-        });
-        const customEventDetail = createCustomEventDetail(
-          FirefoxCommand.LinkAccount,
-          {
-            ok: true,
-          }
-        );
-        await page.goto(
-          `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-        );
-        await login.respondToWebChannelMessage(customEventDetail);
-        await login.fillOutEmailFirstSignIn(email, PASSWORD);
-        await expect(login.signInCodeHeader).toBeVisible();
-
-        await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
-        await login.fillOutSignInCode(email);
-        await login.checkWebChannelMessage(FirefoxCommand.Login);
-        await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
-      }
-    );
+    test.beforeEach(async () => {
+      test.slow();
+    });
 
     test('sign in, change the password', async ({
       target,
-      syncBrowserPages: { changePassword, settings, page },
+      syncBrowserPages: {
+        login,
+        changePassword,
+        connectAnotherDevice,
+        settings,
+        page,
+      },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUpSync();
+      const newPassword = testAccountTracker.generatePassword();
+      const customEventDetail = createCustomEventDetail(
+        FirefoxCommand.LinkAccount,
+        {
+          ok: true,
+        }
+      );
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await login.respondToWebChannelMessage(customEventDetail);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
+
+      await expect(login.signInCodeHeader).toBeVisible();
+
+      await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
+      await login.fillOutSignInCode(credentials.email);
+      await login.checkWebChannelMessage(FirefoxCommand.Login);
+
+      await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
+
       //Goto settings sync url
       await page.goto(
         `${target.contentServerUrl}/settings?context=fx_desktop_v3&service=sync`
@@ -61,22 +57,64 @@ test.describe('severity-2 #smoke', () => {
 
       //Change password
       await settings.password.changeButton.click();
-      await changePassword.fillOutChangePassword(PASSWORD, NEW_PASSWORD);
+      await changePassword.fillOutChangePassword(
+        credentials.password,
+        newPassword
+      );
+      credentials.password = newPassword;
 
       //Verify success message
       await expect(settings.alertBar).toHaveText('Password updated');
     });
 
     test('sign in, change the password by browsing directly to settings', async ({
-      syncBrowserPages: { login, changePassword, settings },
+      target,
+      syncBrowserPages: {
+        login,
+        changePassword,
+        connectAnotherDevice,
+        settings,
+        page,
+      },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUpSync();
+      const newPassword = testAccountTracker.generatePassword();
+      const customEventDetail = createCustomEventDetail(
+        FirefoxCommand.LinkAccount,
+        {
+          ok: true,
+        }
+      );
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await login.respondToWebChannelMessage(customEventDetail);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
+
+      await expect(login.signInCodeHeader).toBeVisible();
+
+      await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
+      await login.fillOutSignInCode(credentials.email);
+      await login.checkWebChannelMessage(FirefoxCommand.Login);
+
+      await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
+
       //Goto settings non-sync url
       await settings.goto();
 
       //Change password
       await settings.password.changeButton.click();
       await login.noSuchWebChannelMessage(FirefoxCommand.ChangePassword);
-      await changePassword.fillOutChangePassword(PASSWORD, NEW_PASSWORD);
+      await changePassword.fillOutChangePassword(
+        credentials.password,
+        newPassword
+      );
+      credentials.password = newPassword;
 
       //Verify success message
       await expect(settings.alertBar).toHaveText('Password updated');
@@ -85,21 +123,20 @@ test.describe('severity-2 #smoke', () => {
 
   test.describe('Firefox Desktop Sync v3 settings - delete account', () => {
     test('sign in, delete the account', async ({
-      emails,
       target,
       syncBrowserPages: { login, settings, deleteAccount, page },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
-      test.slow();
-      await target.authClient.signUp(email, PASSWORD, {
-        lang: 'en',
-        preVerified: 'true',
-      });
+      const credentials = await testAccountTracker.signUpSync();
+
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
-      await login.fillOutEmailFirstSignIn(email, PASSWORD);
-      await login.fillOutSignInCode(email);
+      await login.fillOutEmailFirstSignIn(
+        credentials.email,
+        credentials.password
+      );
+      await login.fillOutSignInCode(credentials.email);
 
       //Go to setting page
       await page.goto(
@@ -107,7 +144,7 @@ test.describe('severity-2 #smoke', () => {
       );
       //Click Delete account
       await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(PASSWORD);
+      await deleteAccount.deleteAccount(credentials.password);
 
       await expect(
         page.getByText('Account deleted successfully')

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -3,21 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
-import {
-  expect,
-  test,
-  PASSWORD,
-  SYNC_EMAIL_PREFIX,
-} from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
+
+const AGE_21 = '21';
 
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync v3 sign up and CWTS', () => {
-    test.use({
-      emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
-    });
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(
@@ -28,12 +22,12 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('verify with signup code and CWTS', async ({
-      emails,
       target,
-      syncBrowserPages,
+      syncBrowserPages: { login, page, connectAnotherDevice },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
-      const { login, page, connectAnotherDevice } = syncBrowserPages;
+      const { email, password } =
+        testAccountTracker.generateSyncAccountDetails();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -64,9 +58,9 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await login.clickSubmit();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
+      await login.setPassword(password);
+      await login.confirmPassword(password);
+      await login.setAge(AGE_21);
 
       // The CWTS form is on the same signup page
       await expect(login.CWTSEngineHeader).toBeVisible();
@@ -86,9 +80,13 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
-    test('verify at CWTS', async ({ emails, target, syncBrowserPages }) => {
-      const { login, page, connectAnotherDevice } = syncBrowserPages;
-      const [email] = emails;
+    test('verify at CWTS', async ({
+      target,
+      syncBrowserPages: { login, page, connectAnotherDevice },
+      testAccountTracker,
+    }) => {
+      const { email, password } =
+        testAccountTracker.generateSyncAccountDetails();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -113,9 +111,9 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await login.clickSubmit();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
+      await login.setPassword(password);
+      await login.confirmPassword(password);
+      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes
@@ -132,11 +130,12 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('engines not supported', async ({
-      emails,
       target,
       syncBrowserPages: { login, page },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } =
+        testAccountTracker.generateSyncAccountDetails();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -155,9 +154,9 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await login.clickSubmit();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
+      await login.setPassword(password);
+      await login.confirmPassword(password);
+      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes
@@ -167,11 +166,12 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('neither `creditcards` nor `addresses` supported', async ({
-      emails,
       target,
       syncBrowserPages: { login, page },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } =
+        testAccountTracker.generateSyncAccountDetails();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -193,9 +193,9 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await login.clickSubmit();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
+      await login.setPassword(password);
+      await login.confirmPassword(password);
+      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes
@@ -205,11 +205,12 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('`creditcards` and `addresses` supported', async ({
-      emails,
       target,
       syncBrowserPages: { login, page },
+      testAccountTracker,
     }) => {
-      const [email] = emails;
+      const { email, password } =
+        testAccountTracker.generateSyncAccountDetails();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
@@ -231,9 +232,9 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage('fxaccounts:fxa_status');
       await login.setEmail(email);
       await login.clickSubmit();
-      await login.setPassword(PASSWORD);
-      await login.confirmPassword(PASSWORD);
-      await login.setAge('21');
+      await login.setPassword(password);
+      await login.confirmPassword(password);
+      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes


### PR DESCRIPTION
## Because

- of test isolation issues caused by the improper cleanup of accounts and the use of a universal password

## This pull request

- consolidates account creation and destruction to a TestAccountTracker
  - this responsibility was previously spread across the credentials fixture, emails fixture, EmailClient and individual tests
  - the TestAccountTracker keeps track of accounts needing possible destruction with the `accounts` data structure
  - the TestAccountTracker generates unique email and password values to ensure future isolation of accounts between tests
- removes the assignment of '__fxa_storage.currentAccountUid' and '__fxa_storage.accounts' from storage state
  -  the 'storageState' fixture is set to 'auto: true' by default and had credentials as a dependency. As a result, every test would begin by creating and signing up a user with the AuthClient, but wouldn't necessarily use this account.
  - the PR replaces this with UI test steps, alternatively we could override the storageState fixture to include these values on the directory or module level
- removes the try/catch associated with account destruction and implements fixes so that tests cleanup, helping to assure isolation

## Issue that this pull request solves

Closes: # FXA-9517

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

- the use of TestAccountTracker unfortunately impacts almost every single test in the FxA test suite. It is recommended to focus on the changes in `packages/functional-tests/lib`, as opposed to `packages/functional-tests/pages` and `packages/functional/tests`.
- because of the ~21% local skip rate, it is possible that we may see side effects in the stage and production smoke tests upon first execution, therefore we will run smoke tests against those environments before merging
- a fixme annotation, FXA-9513, was added to `react-conversion/oauthResetPassword.spec.ts › severity-1 #smoke › oauth reset password react › reset password with valid totp`. This module was particularly impacted by the new isolation
