### PR TITLE
feat(fxa-settings): Add input component with separated characters

### DIFF
--- a/packages/fxa-settings/src/components/FormVerifyTotp/en.ftl
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/en.ftl
@@ -1,0 +1,5 @@
+## FormVerifyTotp
+
+# When focused on the button, screen reader will read the action and entire number that will be submitted
+form-verify-code-submit-button =
+  .aria-label = Submit { $codeValue }

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.stories.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import FormVerifyTotp from '.';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import Subject from './mocks';
+
+export default {
+  title: 'Components/FormVerifyTotp',
+  component: FormVerifyTotp,
+  decorators: [withLocalization],
+} as Meta;
+
+export const With6DigitCode = () => <Subject />;
+
+export const With8DigitCode = () => <Subject codeLength={8} />;
+
+export const WithErrorOnSubmit = () => <Subject success={false} />;

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import React from 'react';
+import Subject from './mocks';
+import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
+
+describe('FormVerifyTotp component', () => {
+  it('renders as expected with default props', async () => {
+    renderWithLocalizationProvider(<Subject />);
+    expect(screen.getByText('Enter 6-digit code')).toBeVisible();
+    expect(screen.getAllByRole('textbox')).toHaveLength(6);
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Submit');
+  });
+
+  describe('submit button', () => {
+    it('is disabled on render', () => {
+      renderWithLocalizationProvider(<Subject />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('Submit');
+      expect(button).toBeDisabled();
+    });
+
+    it('is enabled when numbers are typed into all inputs', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('Submit');
+      expect(button).toBeDisabled();
+
+      expect(
+        screen.getByRole('textbox', { name: 'Digit 1 of 6' })
+      ).toHaveFocus();
+
+      // type in each input
+      for (let i = 1; i <= 6; i++) {
+        await waitFor(() =>
+          user.type(
+            screen.getByRole('textbox', { name: `Digit ${i} of 6` }),
+            i.toString()
+          )
+        );
+      }
+      expect(button).toBeEnabled();
+    });
+
+    it('is enabled when numbers are pasted into all inputs', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject />);
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('Submit');
+      expect(button).toBeDisabled();
+
+      await waitFor(() => {
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }));
+        user.paste('123456');
+      });
+
+      expect(button).toBeEnabled();
+    });
+  });
+
+  describe('errors', () => {
+    it('are cleared when typing in input', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(
+        <Subject initialErrorMessage="Something went wrong" />
+      );
+
+      expect(screen.getByText('Something went wrong')).toBeVisible();
+
+      await waitFor(() =>
+        user.type(screen.getByRole('textbox', { name: 'Digit 1 of 6' }), '1')
+      );
+
+      expect(
+        screen.queryByText('Something went wrong')
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useRef, useState } from 'react';
+import TotpInputGroup from '../TotpInputGroup';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import Banner, { BannerType } from '../Banner';
+
+export type CodeArray = Array<string | undefined>;
+
+export type FormVerifyTotpProps = {
+  codeLength: 6 | 8;
+  errorMessage: string;
+  localizedInputGroupLabel: string;
+  localizedSubmitButtonText: string;
+  setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
+  verifyCode: (code: string) => void;
+};
+
+const FormVerifyTotp = ({
+  codeLength,
+  errorMessage,
+  localizedInputGroupLabel,
+  localizedSubmitButtonText,
+  setErrorMessage,
+  verifyCode,
+}: FormVerifyTotpProps) => {
+  const inputRefs = useRef(
+    Array.from({ length: codeLength }, () =>
+      React.createRef<HTMLInputElement>()
+    )
+  );
+
+  const [codeArray, setCodeArray] = useState<CodeArray>(new Array(codeLength));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const stringifiedCode = codeArray.join('');
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    setIsSubmitting(true);
+    await verifyCode(stringifiedCode);
+    setIsSubmitting(false);
+  };
+
+  return (
+    <>
+      {errorMessage && <Banner type={BannerType.error}>{errorMessage}</Banner>}
+      <form
+        noValidate
+        className="flex flex-col gap-4 my-6"
+        onSubmit={handleSubmit}
+      >
+        <TotpInputGroup
+          {...{
+            codeArray,
+            codeLength,
+            inputRefs,
+            localizedInputGroupLabel,
+            setCodeArray,
+            setErrorMessage,
+            errorMessage,
+          }}
+        />
+        <FtlMsg
+          id="form-verify-code-submit-button"
+          attrs={{ ariaLabel: true }}
+          vars={{ codeValue: stringifiedCode }}
+        >
+          <button
+            type="submit"
+            className="cta-primary cta-xl"
+            disabled={isSubmitting || stringifiedCode.length < codeLength}
+            aria-label={`Submit ${stringifiedCode}`}
+          >
+            {localizedSubmitButtonText}
+          </button>
+        </FtlMsg>
+      </form>
+    </>
+  );
+};
+
+export default FormVerifyTotp;

--- a/packages/fxa-settings/src/components/FormVerifyTotp/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/mocks.tsx
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState } from 'react';
+import AppLayout from '../AppLayout';
+import FormVerifyTotp, { FormVerifyTotpProps } from '.';
+
+export const Subject = ({
+  codeLength = 6,
+  success = true,
+  initialErrorMessage = '',
+}: Partial<FormVerifyTotpProps> & {
+  success?: Boolean;
+  initialErrorMessage?: string;
+}) => {
+  const localizedInputGroupLabel = `Enter ${codeLength.toString()}-digit code`;
+  const localizedSubmitButtonText = 'Submit';
+  const [errorMessage, setErrorMessage] = useState(initialErrorMessage);
+
+  const mockVerifyCodeSuccess = useCallback(
+    (code: string) => alert(`Mock code submission with code ${code}`),
+    []
+  );
+
+  const mockVerifyCodeFail = useCallback(
+    (code: string) => setErrorMessage('Something went wrong'),
+    []
+  );
+
+  const verifyCode = success ? mockVerifyCodeSuccess : mockVerifyCodeFail;
+
+  return (
+    <AppLayout>
+      <FormVerifyTotp
+        {...{
+          codeLength,
+          errorMessage,
+          localizedInputGroupLabel,
+          localizedSubmitButtonText,
+          setErrorMessage,
+          verifyCode,
+        }}
+      />
+    </AppLayout>
+  );
+};
+
+export default Subject;

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
@@ -10,7 +10,6 @@ import { ModalVerifySession } from '.';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockSession, MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
 import { LocationProvider } from '@reach/router';
-import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 
 export default {
   title: 'Components/Settings/ModalVerifySession',

--- a/packages/fxa-settings/src/components/TotpInputGroup/en.ftl
+++ b/packages/fxa-settings/src/components/TotpInputGroup/en.ftl
@@ -1,0 +1,7 @@
+## TotpInputGroup component
+## This component is composed of 6 or 8 single digit inputs for verification codes
+
+# Screen reader only label for each single-digit input, e.g., Code digit 1 of 6
+# $inputNumber is a number from 1 to 8
+# $codeLength is a number, it represents the total length of the code
+single-char-input-label = Digit { $inputNumber } of { $codeLength }

--- a/packages/fxa-settings/src/components/TotpInputGroup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/index.stories.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import TotpInputGroup from '.';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import Subject from './mocks';
+
+export default {
+  title: 'Components/TotpInputGroup',
+  component: TotpInputGroup,
+  decorators: [withLocalization],
+} as Meta;
+
+export const With6Digits = () => <Subject />;
+
+export const With8Digits = () => <Subject codeLength={8} />;
+
+export const WithError = () => (
+  <Subject initialErrorMessage="Sample error message." />
+);

--- a/packages/fxa-settings/src/components/TotpInputGroup/index.test.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/index.test.tsx
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import Subject from './mocks';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+
+describe('TotpInputGroup component', () => {
+  it('renders as expected for 6 digit code', () => {
+    renderWithLocalizationProvider(<Subject codeLength={6} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(6);
+  });
+
+  it('renders as expected for 8 digit code', () => {
+    renderWithLocalizationProvider(<Subject codeLength={8} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(8);
+  });
+
+  it('sets focus on first input box', () => {
+    renderWithLocalizationProvider(<Subject codeLength={8} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0]).toHaveFocus();
+  });
+
+  describe('keyboard navigation', () => {
+    it('can navigate between inputs with arrow keys', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject codeLength={6} />);
+      const inputs = screen.getAllByRole('textbox');
+      expect(inputs[0]).toHaveFocus();
+
+      await waitFor(() => {
+        user.keyboard('[ArrowRight]');
+      });
+      expect(inputs[1]).toHaveFocus();
+
+      await waitFor(() => {
+        user.keyboard('[ArrowLeft]');
+      });
+      expect(inputs[0]).toHaveFocus();
+    });
+
+    it('can backspace between inputs', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject codeLength={6} />);
+      const inputs = screen.getAllByRole('textbox');
+      expect(inputs[0]).toHaveFocus();
+
+      // type in each input
+      for (let i = 1; i <= 6; i++) {
+        await waitFor(() =>
+          user.type(
+            screen.getByRole('textbox', { name: `Digit ${i} of 6` }),
+            i.toString()
+          )
+        );
+      }
+
+      // all inputs have values
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByRole('textbox', { name: `Digit ${i} of 6` })
+        ).toHaveValue(i.toString());
+      }
+
+      // focus is on last edited input
+      expect(
+        screen.getByRole('textbox', { name: 'Digit 6 of 6' })
+      ).toHaveFocus();
+
+      await waitFor(() => {
+        user.keyboard('[Backspace]');
+      });
+
+      // last input is cleared
+      expect(screen.getByRole('textbox', { name: 'Digit 6 of 6' })).toHaveValue(
+        ''
+      );
+
+      // and focus shifts to previous input
+      expect(
+        screen.getByRole('textbox', { name: 'Digit 5 of 6' })
+      ).toHaveFocus();
+    });
+
+    it('can forward delete inputs', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject codeLength={6} />);
+      const inputs = screen.getAllByRole('textbox');
+      expect(inputs[0]).toHaveFocus();
+
+      // type in each input
+      for (let i = 1; i <= 6; i++) {
+        await waitFor(() =>
+          user.type(
+            screen.getByRole('textbox', { name: `Digit ${i} of 6` }),
+            i.toString()
+          )
+        );
+      }
+
+      // all inputs have values
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByRole('textbox', { name: `Digit ${i} of 6` })
+        ).toHaveValue(i.toString());
+      }
+
+      await waitFor(() => {
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }));
+      });
+
+      await waitFor(() => {
+        user.keyboard('[Delete]');
+      });
+
+      // current input is cleared
+      expect(screen.getByRole('textbox', { name: 'Digit 1 of 6' })).toHaveValue(
+        ''
+      );
+
+      // and focus shifts to next input
+      expect(
+        screen.getByRole('textbox', { name: 'Digit 2 of 6' })
+      ).toHaveFocus();
+    });
+  });
+
+  describe('paste into inputs', () => {
+    it('distributes clipboard content to inputs', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject codeLength={6} />);
+      const inputBox1 = screen.getByRole('textbox', { name: 'Digit 1 of 6' });
+      expect(inputBox1).toHaveFocus();
+
+      // inputs initially have no value
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByRole('textbox', { name: `Digit ${i} of 6` })
+        ).toHaveValue('');
+      }
+
+      await waitFor(() => {
+        user.click(inputBox1);
+        user.paste('123456');
+      });
+
+      // clipboard values are distributed between inputs
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByRole('textbox', { name: `Digit ${i} of 6` })
+        ).toHaveValue(i.toString());
+      }
+    });
+
+    it('skips non-numeric characters in clipboard', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject codeLength={6} />);
+      const inputBox1 = screen.getByRole('textbox', { name: 'Digit 1 of 6' });
+      expect(inputBox1).toHaveFocus();
+
+      // inputs initially have no value
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByRole('textbox', { name: `Digit ${i} of 6` })
+        ).toHaveValue('');
+      }
+
+      await waitFor(() => {
+        user.click(inputBox1);
+        user.paste('1b2$3 4B5.6?');
+      });
+
+      // clipboard values are distributed between inputs
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByRole('textbox', { name: `Digit ${i} of 6` })
+        ).toHaveValue(i.toString());
+      }
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/TotpInputGroup/index.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/index.tsx
@@ -1,0 +1,253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import { CodeArray } from '../FormVerifyTotp';
+import { useFtlMsgResolver } from '../../models';
+
+export type TotpInputGroupProps = {
+  codeArray: CodeArray;
+  codeLength: 6 | 8;
+  inputRefs: React.MutableRefObject<React.RefObject<HTMLInputElement>[]>;
+  localizedInputGroupLabel: string;
+  setCodeArray: React.Dispatch<React.SetStateAction<CodeArray>>;
+  setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
+  errorMessage?: string;
+};
+
+type SingleInputProps = {
+  index: number;
+};
+
+const NUMBERS_ONLY_REGEX = /^[0-9]+$/;
+
+export const TotpInputGroup = ({
+  codeArray,
+  codeLength,
+  inputRefs,
+  localizedInputGroupLabel,
+  setCodeArray,
+  setErrorMessage,
+  errorMessage = '',
+}: TotpInputGroupProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const focusOnNextInput = (index: number) => {
+    inputRefs.current[index + 1].current?.focus();
+  };
+
+  const focusOnPreviousInput = (index: number) => {
+    inputRefs.current[index - 1].current?.focus();
+  };
+
+  const focusOnSpecifiedInput = (index: number) => {
+    inputRefs.current[index].current?.focus();
+  };
+
+  const handleBackspace = async (index: number) => {
+    const currentCodeArray = [...codeArray];
+    currentCodeArray[index] = undefined;
+    await setCodeArray(currentCodeArray);
+    if (index > 0) {
+      focusOnPreviousInput(index);
+    } else {
+      focusOnSpecifiedInput(index);
+    }
+  };
+
+  const handleDelete = async (index: number) => {
+    const currentCodeArray = [...codeArray];
+    if (currentCodeArray[index] !== undefined) {
+      currentCodeArray[index] = undefined;
+    } else {
+      currentCodeArray[index + 1] = undefined;
+    }
+    await setCodeArray(currentCodeArray);
+    if (index < codeLength - 1) {
+      focusOnNextInput(index);
+    } else {
+      focusOnSpecifiedInput(index);
+    }
+  };
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    switch (e.key) {
+      case 'Backspace':
+        e.preventDefault();
+        if (index > 0) {
+          focusOnPreviousInput(index);
+        }
+        handleBackspace(index);
+        break;
+      case 'Delete':
+        e.preventDefault();
+        if (index < codeLength) {
+          handleDelete(index);
+        }
+        break;
+      case 'ArrowRight':
+        if (index < codeLength - 1) {
+          focusOnNextInput(index);
+        }
+        break;
+      case 'ArrowLeft':
+        if (index > 0) {
+          focusOnPreviousInput(index);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleInput = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    e.preventDefault();
+    errorMessage && setErrorMessage('');
+    const currentCodeArray = [...codeArray];
+
+    const inputValue = e.target.value;
+    // we only want to check new value
+    const newInputValue = Array.from(inputValue).filter((character) => {
+      return character !== codeArray[index];
+    });
+
+    if (newInputValue.length === 1) {
+      // if the new value is a number, use it
+      if (newInputValue[0].match(NUMBERS_ONLY_REGEX)) {
+        currentCodeArray[index] = newInputValue[0];
+        await setCodeArray(currentCodeArray);
+      } else {
+        // if the new value is not a number, keep the previous value (if it exists) or clear the input box
+        currentCodeArray[index] = codeArray[index];
+        await setCodeArray(currentCodeArray);
+      }
+    }
+
+    if (currentCodeArray[index] !== undefined && index < codeLength - 1) {
+      focusOnNextInput(index);
+    } else {
+      focusOnSpecifiedInput(index);
+    }
+  };
+
+  const handlePaste = async (
+    e: React.ClipboardEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    let currentIndex = index;
+    const currentCodeArray = [...codeArray];
+    const clipboardText = e.clipboardData.getData('text');
+    let digitsOnlyArray = clipboardText
+      .split('')
+      .filter((character) => {
+        return character.match(NUMBERS_ONLY_REGEX);
+      })
+      .slice(0, codeLength - index);
+    digitsOnlyArray.forEach((character: string) => {
+      currentCodeArray[currentIndex] = character;
+      if (currentIndex < codeLength - 1) {
+        focusOnNextInput(index);
+        currentIndex++;
+      }
+    });
+    await setCodeArray(currentCodeArray);
+    // if last pasted character is on last input, focus on that input
+    // otherwise focus on next input after last pasted character
+    focusOnSpecifiedInput(currentIndex);
+  };
+
+  const SingleDigitInput = ({ index }: SingleInputProps) => {
+    const [isFocused, setIsFocused] = useState(false);
+
+    // number used for localized message starts at 1
+    const inputNumber = index + 1;
+    const localizedLabel = ftlMsgResolver.getMsg(
+      'single-char-input-label',
+      `Digit ${inputNumber} of ${codeLength}`,
+      { inputNumber, codeLength }
+    );
+    return (
+      <span
+        key={`code-box-${index}`}
+        className={classNames('flex-1 min-h-14 rounded outline-none border', {
+          'min-w-12': codeLength === 6,
+          'min-w-8': codeLength === 8,
+          'border-grey-200 ': !errorMessage && !isFocused,
+          'border-blue-400 shadow-input-blue-focus': !errorMessage && isFocused,
+          'border-red-700': errorMessage,
+          'shadow-input-red-focus': errorMessage && isFocused,
+        })}
+      >
+        <label className="sr-only" htmlFor={`code-input-${index}`}>
+          {localizedLabel}
+        </label>
+        <input
+          id={`code-input-${index}`}
+          value={codeArray[index]}
+          ref={inputRefs.current[index]}
+          type="text"
+          autoComplete="one-time-code"
+          autoFocus={index === 0 ? true : false}
+          inputMode="numeric"
+          size={1}
+          pattern="[0-9]{1}"
+          className="text-xl text-center font-mono h-full w-full rounded outline-none border-none"
+          onBlur={() => setIsFocused(false)}
+          onClick={(e: React.MouseEvent<HTMLInputElement>) => {
+            e.currentTarget.setSelectionRange(0, e.currentTarget.value.length);
+          }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            handleInput(e, index);
+          }}
+          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+            setIsFocused(true);
+            e.currentTarget.setSelectionRange(0, e.currentTarget.value.length);
+          }}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            handleKeyDown(e, index);
+          }}
+          onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+            e.preventDefault();
+            handlePaste(e, index);
+          }}
+        />
+      </span>
+    );
+  };
+
+  const getAllSingleDigitInputs = () => {
+    return [...Array(codeLength)].map((value: undefined, index: number) => {
+      return (
+        <SingleDigitInput {...{ index }} key={`single-digit-input-${index}`} />
+      );
+    });
+  };
+
+  return (
+    <fieldset>
+      <legend id="totp-input-group-label" className="text-start text-sm">
+        {localizedInputGroupLabel}
+      </legend>
+      <div
+        className={classNames(
+          // OTP code input must be displayed LTR for both LTR and RTL languages
+          // TODO in FXA-7890 verify that code is also displayed LTR in RTL emails
+          'flex my-2 rtl:flex-row-reverse',
+          codeLength === 6 && 'gap-2 mobileLandscape:gap-4',
+          codeLength === 8 && 'gap-1 mobileLandscape:gap-2'
+        )}
+        aria-describedby="totp-input-group-label totp-input-group-error"
+      >
+        {getAllSingleDigitInputs()}
+      </div>
+    </fieldset>
+  );
+};
+
+export default TotpInputGroup;

--- a/packages/fxa-settings/src/components/TotpInputGroup/mocks.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/mocks.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useRef, useState } from 'react';
+import AppLayout from '../AppLayout';
+import TotpInputGroup, { TotpInputGroupProps } from '.';
+import { CodeArray } from '../FormVerifyTotp';
+
+export const Subject = ({
+  codeLength = 6,
+  initialErrorMessage = '',
+}: Partial<TotpInputGroupProps> & { initialErrorMessage?: string }) => {
+  const [codeArray, setCodeArray] = useState<CodeArray>([]);
+  const [errorMessage, setErrorMessage] = useState(initialErrorMessage || '');
+  const inputRefs = useRef(
+    Array.from({ length: codeLength }, () =>
+      React.createRef<HTMLInputElement>()
+    )
+  );
+
+  return (
+    <TotpInputGroup
+      localizedInputGroupLabel={`Enter ${codeLength.toString()}-digit code`}
+      {...{
+        codeArray,
+        codeLength,
+        inputRefs,
+        setCodeArray,
+        errorMessage,
+        setErrorMessage,
+      }}
+    />
+  );
+};
+
+export default Subject;


### PR DESCRIPTION
## Because

* New designs for reset password with code include code inputs with individual input boxes

## This pull request

* Create a `TotpInputGroup` component that contains individual input boxes for each character, with associated methods for handling input, keyboard navigation (including arrow keys, backspace, delete), pasting content into the boxes
* Add inline error feedback below new code input component, instead of tooltip
* Create a `FormVerifyTotp` component that includes the new `TotpInputGroup` (configurable for 6 or 8 digit codes) and submission button, with pre-submission validation that code contains the expected number of digits and no other characters
* Add l10n and storybooks

## Issue that this pull request solves

Closes: #FXA-7888

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

**Storybook links:
[FormVerifyTotp with 6-digit input](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/3de4924d3a57f4f250f440081cb1fb1b6cb2e105/fxa-settings/index.html?path=/story/components-formverifytotp--with-6-digit-code)

[FormVerifyTotp with 8-digit input](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/3de4924d3a57f4f250f440081cb1fb1b6cb2e105/fxa-settings/index.html?path=/story/components-formverifytotp--with-8-digit-code)

[FormVerifyTotp with error on submit](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/3de4924d3a57f4f250f440081cb1fb1b6cb2e105/fxa-settings/index.html?path=/story/components-formverifytotp--with-error-on-submit)


## Other information (Optional)

Notes: PIN code must be displayed LTR for BOTH left-to-right and right-to-left languages

