### PR TITLE
test(functional-tests): audit signin

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -218,7 +218,7 @@ export async function newPages(browser: Browser, target: BaseTarget) {
 // `identity.fxaccounts.lastSignedInUserHash` to the last
 // user signed in. On subsequent login to Sync, a dialog is prompted for the user
 // to confirm. Playwright does not have functionality to click browser ui.
-export async function newPagesForSync(target: BaseTarget) {
+async function newPagesForSync(target: BaseTarget) {
   const browser = await firefox.launch({
     args: DEBUG ? ['-start-debugger-server'] : undefined,
     firefoxUserPrefs: getFirefoxUserPrefs(target.name, DEBUG),

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -8,8 +8,7 @@ test.describe('severity-1 #smoke', () => {
   // Slowing down test, was timing out on credentials teardown
   test.slow();
 
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293471
-  test('react signin to sync and disconnect #1293471', async ({
+  test('react signin to sync and disconnect', async ({
     target,
     credentials,
     syncBrowserPages: {
@@ -21,6 +20,7 @@ test.describe('severity-1 #smoke', () => {
     },
   }) => {
     const config = await configPage.getConfig();
+    test.fixme(true, 'Fix required as of 2024/04/19 (see FXA-9490)');
     test.skip(
       config.showReactApp.signInRoutes !== true,
       'Skip tests if React signInRoutes not enabled'

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('connect_another_device', () => {
@@ -12,10 +12,8 @@ test.describe('severity-2 #smoke', () => {
       target,
     }) => {
       await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-        { waitUntil: 'load' }
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
-
       await login.fillOutEmailFirstSignIn(
         credentials.email,
         credentials.password

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -14,6 +14,7 @@ test.describe('severity-2 #smoke', () => {
     test.use({
       emailOptions: [{ prefix: SYNC_EMAIL_PREFIX, password: PASSWORD }],
     });
+
     test('signin verified with incorrect password, click `forgot password?`', async ({
       target,
       page,
@@ -33,7 +34,7 @@ test.describe('severity-2 #smoke', () => {
       await login.clickForgotPassword();
 
       //Verify reset password header
-      await resetPassword.resetPasswordHeader();
+      expect(await resetPassword.resetPasswordHeader()).toBe(true);
     });
 
     test('signin with email with leading/trailing whitespace on the email', async ({
@@ -99,7 +100,6 @@ test.describe('severity-2 #smoke', () => {
 
       // Sign out
       await settings.signOut();
-
       // Login as existing user
       await login.setEmail(credentials.email);
       await login.clickSubmit();
@@ -140,6 +140,7 @@ test.describe('severity-2 #smoke', () => {
 
       //Verify sign in bounced header
       expect(await login.isSigninBouncedHeader()).toBe(true);
+
       await login.clickBouncedCreateAccount();
 
       //Verify user redirected to login page

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -2,13 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Page } from '@playwright/test';
 import {
-  test,
-  expect,
+  BLOCKED_EMAIL_PREFIX,
   PASSWORD,
   SIGNIN_EMAIL_PREFIX,
-  BLOCKED_EMAIL_PREFIX,
+  expect,
+  test,
 } from '../../lib/fixtures/standard';
+import { SettingsPage } from '../../pages/settings';
+import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 
 test.describe('severity-2 #smoke', () => {
   test.beforeEach(async () => {
@@ -31,9 +34,7 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: 'true',
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
 
       //Verify sign in block header
@@ -47,12 +48,7 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(PASSWORD);
-
-      await expect(
-        page.getByText('Account deleted successfully')
-      ).toBeVisible();
+      await removeAccount(settings, deleteAccount, page);
     });
 
     test('incorrect code entered', async ({
@@ -66,14 +62,13 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: 'true',
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
 
       //Verify sign in block header
       await expect(login.signInUnblockHeader()).toBeVisible();
       expect(await login.getUnblockEmail()).toContain(blockedEmail);
+
       await login.enterUnblockCode('incorrect');
 
       //Verify tooltip error
@@ -88,12 +83,7 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(PASSWORD);
-
-      await expect(
-        page.getByText('Account deleted successfully')
-      ).toBeVisible();
+      await removeAccount(settings, deleteAccount, page);
     });
 
     test('resend', async ({
@@ -107,9 +97,7 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: 'true',
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
 
       //Verify sign in block header
@@ -131,12 +119,7 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(PASSWORD);
-
-      await expect(
-        page.getByText('Account deleted successfully')
-      ).toBeVisible();
+      await removeAccount(settings, deleteAccount, page);
     });
 
     test('unverified', async ({
@@ -151,9 +134,7 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: 'false',
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(unverifiedEmail, PASSWORD);
 
       //Verify sign in block header
@@ -172,12 +153,7 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(PASSWORD);
-
-      await expect(
-        page.getByText('Account deleted successfully')
-      ).toBeVisible();
+      await removeAccount(settings, deleteAccount, page);
     });
   });
 
@@ -199,9 +175,7 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: 'true',
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(email, PASSWORD);
 
       //Verify logged in on Settings page
@@ -213,9 +187,7 @@ test.describe('severity-2 #smoke', () => {
       await settings.secondaryEmail.makePrimaryButton.click();
       await settings.signOut();
 
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(blockedEmail, PASSWORD);
 
       //Verify sign in block header
@@ -229,12 +201,18 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.isUserLoggedIn()).toBe(true);
 
       //Delete blocked account, the fixture teardown doesn't work in this case
-      await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(PASSWORD);
-
-      await expect(
-        page.getByText('Account deleted successfully')
-      ).toBeVisible();
+      await removeAccount(settings, deleteAccount, page);
     });
   });
 });
+
+async function removeAccount(
+  settings: SettingsPage,
+  deleteAccount: DeleteAccountPage,
+  page: Page
+) {
+  await settings.deleteAccountButton.click();
+  await deleteAccount.deleteAccount(PASSWORD);
+
+  await expect(page.getByText('Account deleted successfully')).toBeVisible();
+}

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -30,19 +30,17 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: true,
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       await login.clearSessionStorage();
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
+
       expect(await login.getPrefilledEmail()).toContain(syncEmail);
+
       await login.clickSignIn();
 
       //Verify logged in on Settings page
@@ -59,22 +57,19 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: true,
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       await login.clearSessionStorage();
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.denormalizeStoredEmail(syncEmail);
       await page.reload();
 
       expect(await login.getPrefilledEmail()).toContain(syncEmail);
+
       await login.clickSignIn();
 
       //Verify logged in on Settings page
@@ -94,21 +89,18 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: true,
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
       await login.destroySession(syncEmail);
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
 
       //Check prefilled email
       expect(await login.getPrefilledEmail()).toContain(syncEmail);
+
       await login.setPassword(PASSWORD);
       await login.clickSubmit();
 
@@ -126,17 +118,13 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: true,
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
 
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
 
       //Check prefilled email
       expect(await login.getPrefilledEmail()).toContain(syncEmail);
@@ -148,6 +136,7 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.signInError()).toContain(
         'Session expired. Sign in to continue.'
       );
+
       await login.setPassword(PASSWORD);
       await login.clickSubmit();
 
@@ -165,18 +154,17 @@ test.describe('severity-2 #smoke', () => {
         lang: 'en',
         preVerified: 'false',
       });
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      await page.goto(target.contentServerUrl);
       await login.fillOutEmailFirstSignIn(email_unverified, PASSWORD);
 
       //Verify sign up code header is visible
       await expect(login.signUpCodeHeader).toBeVisible();
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+
+      await page.goto(target.contentServerUrl);
+
       //Check prefilled email
       expect(await login.getPrefilledEmail()).toContain(email_unverified);
+
       await login.clickSignIn();
 
       //Cached login should still go to email confirmation screen for unverified accounts
@@ -201,6 +189,7 @@ test.describe('severity-2 #smoke', () => {
         target,
         syncBrowserPages: { page, login },
       }) => {
+        const [email, syncEmail] = emails;
         await Promise.all(
           emails.map(async (email) => {
             await target.authClient.signUp(email, PASSWORD, {
@@ -209,19 +198,17 @@ test.describe('severity-2 #smoke', () => {
             });
           })
         );
-        const [email, syncEmail] = emails;
-        await page.goto(target.contentServerUrl, {
-          waitUntil: 'load',
-        });
+        await page.goto(target.contentServerUrl);
         await login.fillOutEmailFirstSignIn(syncEmail, PASSWORD);
 
         //Verify logged in on Settings page
         expect(await login.isUserLoggedIn()).toBe(true);
-        await page.goto(target.contentServerUrl, {
-          waitUntil: 'load',
-        });
+
+        await page.goto(target.contentServerUrl);
+
         //Check prefilled email
         expect(await login.getPrefilledEmail()).toContain(syncEmail);
+
         await login.useDifferentAccountLink();
         await login.fillOutEmailFirstSignIn(email, PASSWORD);
 
@@ -229,9 +216,8 @@ test.describe('severity-2 #smoke', () => {
         expect(await login.isUserLoggedIn()).toBe(true);
 
         // testing to make sure cached signin comes back after a refresh
-        await page.goto(target.contentServerUrl, {
-          waitUntil: 'load',
-        });
+        await page.goto(target.contentServerUrl);
+
         //Check prefilled email
         expect(await login.getPrefilledEmail()).toContain(email);
       });


### PR DESCRIPTION
## Because

* we want to promote stability and sustainability in the functional-tests

## This pull request

* fixes linting errors and formatting
* removes the fixme from 'relyingParties.spec.ts > severity-1 #smoke > can login to addons'
* fixes 'relyingParties.spec.ts > severity-1 #smoke > can login to monitor'
* removes outdated testrail links
* propogates syncBrowserPages fixture

Closes: #FXA-8962

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

- A follow-up task was created to address the remaining playwright/no-wait-for-timeout linter errors and the flake that they cause(see FXA-9490)
