### PR TITLE
feat(cart): add get cart action to pages

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/layout.tsx
@@ -5,11 +5,15 @@ import { headers } from 'next/headers';
 
 import {
   app,
+  getCartAction,
   PurchaseDetails,
   SubscriptionTitle,
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
-import { getCartData, getContentfulContent } from '../../../_lib/apiClient';
+import {
+  getFakeCartData,
+  getContentfulContent,
+} from '../../../../../_lib/apiClient';
 import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
 
 // TODO - Replace these placeholders as part of FXA-8227
@@ -45,12 +49,14 @@ export default async function RootLayout({
   //);
   const locale = headers().get('accept-language') || DEFAULT_LOCALE;
   const contentfulDataPromise = getContentfulContent(params.offeringId, locale);
-  const cartDataPromise = getCartData(params.cartId);
+  const cartDataPromise = getCartAction(params.cartId);
   const l10nPromise = app.getL10n(locale);
-  const [contentful, cart, l10n] = await Promise.all([
+  const fakeCartDataPromise = getFakeCartData(params.cartId);
+  const [contentful, cart, l10n, fakeCart] = await Promise.all([
     contentfulDataPromise,
     cartDataPromise,
     l10nPromise,
+    fakeCartDataPromise,
   ]);
 
   return (
@@ -61,7 +67,7 @@ export default async function RootLayout({
         <PurchaseDetails
           l10n={l10n}
           interval={cart.interval}
-          invoice={cart.nextInvoice}
+          invoice={fakeCart.nextInvoice}
           purchaseDetails={contentful.purchaseDetails}
         />
       </section>

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/page.tsx
@@ -5,12 +5,13 @@ import Stripe from 'stripe';
 import {
   app,
   handleStripeErrorAction,
-  getCartAction,
+  getCartOrRedirectAction,
+  SupportedPages,
 } from '@fxa/payments/ui/server';
 import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
 import { auth, signIn, signOut } from 'apps/payments/next/auth';
 import { headers } from 'next/headers';
-import { CheckoutParams } from '../../../layout';
+import { CheckoutParams } from '../layout';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,7 +25,10 @@ export default async function Checkout({ params }: { params: CheckoutParams }) {
   const locale = headers().get('accept-language') || DEFAULT_LOCALE;
   const sessionPromise = auth();
   const l10nPromise = app.getL10n(locale);
-  const cartPromise = getCartAction(params.cartId);
+  const cartPromise = getCartOrRedirectAction(
+    params.cartId,
+    SupportedPages.START
+  );
   const [session, l10n, cart] = await Promise.all([
     sessionPromise,
     l10nPromise,

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/success/page.tsx
@@ -9,11 +9,15 @@ import { formatPlanPricing } from '@fxa/payments/ui';
 import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
 
 import {
-  getCartData,
+  getFakeCartData,
   getContentfulContent,
 } from '../../../../../../_lib/apiClient';
 import circledConfirm from '../../../../../../../images/circled-confirm.svg';
-import { app } from '@fxa/payments/ui/server';
+import {
+  SupportedPages,
+  app,
+  getCartOrRedirectAction,
+} from '@fxa/payments/ui/server';
 
 export const dynamic = 'force-dynamic';
 
@@ -60,12 +64,17 @@ export default async function CheckoutSuccess({
   const locale = headers().get('accept-language') || DEFAULT_LOCALE;
 
   const contentfulDataPromise = getContentfulContent(params.offeringId, locale);
-  const cartDataPromise = getCartData(params.cartId);
+  const cartDataPromise = getCartOrRedirectAction(
+    params.cartId,
+    SupportedPages.SUCCESS
+  );
   const l10nPromise = app.getL10n(locale);
-  const [contentful, cart, l10n] = await Promise.all([
+  const fakeCartDataPromise = getFakeCartData(params.cartId);
+  const [contentful, cart, l10n, fakeCart] = await Promise.all([
     contentfulDataPromise,
     cartDataPromise,
     l10nPromise,
+    fakeCartDataPromise,
   ]);
 
   return (
@@ -85,7 +94,7 @@ export default async function CheckoutSuccess({
             {l10n.getString(
               'next-payment-confirmation-thanks-subheading',
               {
-                email: cart.email,
+                email: cart.email || '',
                 product_name: contentful.purchaseDetails.productName,
               },
               `A confirmation email has been sent to ${cart.email} with details on how to get started with ${contentful.purchaseDetails.productName}.`
@@ -101,9 +110,9 @@ export default async function CheckoutSuccess({
           detail1={l10n.getString(
             'next-payment-confirmation-invoice-number',
             {
-              invoiceNumber: cart.invoiceNumber,
+              invoiceNumber: fakeCart.invoiceNumber,
             },
-            `Invoice #${cart.invoiceNumber}`
+            `Invoice #${fakeCart.invoiceNumber}`
           )}
           detail2={l10n.getString(
             'next-payment-confirmation-invoice-date',
@@ -123,23 +132,23 @@ export default async function CheckoutSuccess({
             'next-payment-confirmation-amount',
             {
               amount: l10n.getLocalizedCurrency(
-                cart.nextInvoice.totalAmount,
-                cart.nextInvoice.currency
+                fakeCart.nextInvoice.totalAmount,
+                fakeCart.nextInvoice.currency
               ),
               interval: cart.interval,
             },
             formatPlanPricing(
-              cart.nextInvoice.totalAmount,
-              cart.nextInvoice.currency,
+              fakeCart.nextInvoice.totalAmount,
+              fakeCart.nextInvoice.currency,
               cart.interval
             )
           )}
           detail2={l10n.getString(
             'next-payment-confirmation-cc-card-ending-in',
             {
-              last4: cart.last4,
+              last4: fakeCart.last4,
             },
-            `Card ending in ${cart.last4}`
+            `Card ending in ${fakeCart.last4}`
           )}
         />
 

--- a/apps/payments/next/app/_lib/apiClient.ts
+++ b/apps/payments/next/app/_lib/apiClient.ts
@@ -4,7 +4,7 @@
 
 import { fetchCartData, fetchFromContentful } from './stubs';
 
-export async function getCartData(cartId: string) {
+export async function getFakeCartData(cartId: string) {
   return fetchCartData(cartId);
 }
 

--- a/libs/payments/ui/jest.config.ts
+++ b/libs/payments/ui/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'payments-ui',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/payments/ui',
+};

--- a/libs/payments/ui/project.json
+++ b/libs/payments/ui/project.json
@@ -11,6 +11,13 @@
       "options": {
         "lintFilePatterns": ["libs/payments/ui/**/*.{ts,tsx,js,jsx}"]
       }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/ui/jest.config.ts"
+      }
     }
   }
 }

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -5,15 +5,30 @@
 'use server';
 
 import { plainToClass } from 'class-transformer';
+import { redirect } from 'next/navigation';
 import { app } from '../nestapp/app';
 import { GetCartActionArgs } from '../nestapp/validators/GetCartActionArgs';
+import { getRedirect, validateCartState } from '../utils/get-cart';
+import { SupportedPages } from '../utils/types';
 
-export const getCartAction = async (cartId: string) => {
+/**
+ * Get Cart or Redirect if cart state does not match supported page
+ * @@param cartId - Cart ID
+ * @@param page - Page that action is being called from
+ */
+export const getCartOrRedirectAction = async (
+  cartId: string,
+  page: SupportedPages
+) => {
   const cart = await app.getActionsService().getCart(
     plainToClass(GetCartActionArgs, {
       cartId,
     })
   );
+
+  if (!validateCartState(cart.state, page)) {
+    redirect(getRedirect(cart.state));
+  }
 
   return cart;
 };

--- a/libs/payments/ui/src/lib/nestapp/validators/SetupCartActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/SetupCartActionArgs.ts
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Optional } from '@nestjs/common';
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class SetupCartActionArgs {
   @IsString()
@@ -12,18 +11,18 @@ export class SetupCartActionArgs {
   offeringConfigId!: string;
 
   @IsString()
-  @Optional()
+  @IsOptional()
   experiment?: string;
 
   @IsString()
-  @Optional()
+  @IsOptional()
   promoCode?: string;
 
   @IsString()
-  @Optional()
+  @IsOptional()
   uid?: string;
 
   @IsString()
-  @Optional()
+  @IsOptional()
   ip?: string;
 }

--- a/libs/payments/ui/src/lib/utils/get-cart.spec.ts
+++ b/libs/payments/ui/src/lib/utils/get-cart.spec.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { CartState } from '@fxa/shared/db/mysql/account';
+import { getRedirect, validateCartState } from './get-cart';
+import { SupportedPages } from './types';
+
+describe('getCart Utils', () => {
+  describe('validateCartState', () => {
+    it('should return true if state matches page', () => {
+      const expected = true;
+      const result = validateCartState(CartState.START, SupportedPages.START);
+      expect(result).toBe(expected);
+    });
+
+    it('should return false if state does not match page', () => {
+      const expected = false;
+      const result = validateCartState(
+        CartState.START,
+        SupportedPages.PROCESSING
+      );
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('getRedirect', () => {
+    it('should return correct page for redirect', () => {
+      const expected = SupportedPages.ERROR;
+      const result = getRedirect(CartState.FAIL);
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/utils/get-cart.ts
+++ b/libs/payments/ui/src/lib/utils/get-cart.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { CartState } from '@fxa/shared/db/mysql/account';
+import { SupportedPages } from './types';
+
+export const cartStateToPageMap = {
+  [CartState.START]: SupportedPages.START,
+  [CartState.PROCESSING]: SupportedPages.PROCESSING,
+  [CartState.SUCCESS]: SupportedPages.SUCCESS,
+  [CartState.FAIL]: SupportedPages.ERROR,
+};
+
+export function validateCartState(
+  cartState: CartState,
+  currentPage: SupportedPages
+) {
+  return cartStateToPageMap[cartState] === currentPage;
+}
+
+export function getRedirect(cartState: CartState) {
+  return cartStateToPageMap[cartState];
+}

--- a/libs/payments/ui/src/lib/utils/types.ts
+++ b/libs/payments/ui/src/lib/utils/types.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+export enum SupportedPages {
+  START = 'start',
+  PROCESSING = 'processing',
+  SUCCESS = 'success',
+  ERROR = 'error',
+}

--- a/libs/payments/ui/src/server.ts
+++ b/libs/payments/ui/src/server.ts
@@ -9,6 +9,8 @@ export * from './lib/config.utils';
 export * from './lib/server/purchase-details';
 export * from './lib/server/subscription-title';
 export * from './lib/server/terms-and-privacy';
+export * from './lib/utils/types';
 export { handleStripeErrorAction } from './lib/actions/handleStripeError';
 export { getCartAction } from './lib/actions/getCart';
+export { getCartOrRedirectAction } from './lib/actions/getCartOrRedirect';
 export { setupCartAction } from './lib/actions/setupCart';

--- a/libs/payments/ui/tsconfig.json
+++ b/libs/payments/ui/tsconfig.json
@@ -11,6 +11,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ],
   "extends": "../../../tsconfig.base.json"

--- a/libs/payments/ui/tsconfig.spec.json
+++ b/libs/payments/ui/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Because

- Pages were still calling mock get cart

## This pull request

- Adds getCartOrRedirect to all pages
- Redirects to appropriate page if cart.state does not much current page

## Issue that this pull request solves

Closes: #FXA-9039

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).