### PR TITLE
refactor(react): Handle finishOAuthFlowHandler errors, improve other handling, allow l10n on OAuth errors

### DIFF
--- a/packages/fxa-settings/src/components/OAuthDataError/en.ftl
+++ b/packages/fxa-settings/src/components/OAuthDataError/en.ftl
@@ -1,0 +1,2 @@
+# Users will see this heading when the URL or network request is malformed, e.g. a query parameter is required and is invalid
+error-bad-request = Bad Request

--- a/packages/fxa-settings/src/components/OAuthDataError/index.tsx
+++ b/packages/fxa-settings/src/components/OAuthDataError/index.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AuthError } from '../../lib/oauth';
+import AppLayout from '../AppLayout';
+import Banner, { BannerType } from '../Banner';
+import CardHeader from '../CardHeader';
+
+const OAuthDataError = ({ error }: { error: AuthError }) => {
+  return (
+    <AppLayout>
+      <CardHeader
+        headingText="Bad Request"
+        headingTextFtlId="error-bad-request"
+      />
+      {/* TODO Localize this, FXA-9502, and account for potential errno
+        overlaps with AuthErrors (see ticket). */}
+      <Banner type={BannerType.error}>{error.message}</Banner>
+    </AppLayout>
+  );
+};
+
+export default OAuthDataError;

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -16,7 +16,7 @@ import Banner, { BannerType } from '../../Banner';
 import {
   AuthUiErrorNos,
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from '../../../lib/auth-errors/auth-errors';
 import classNames from 'classnames';
 
@@ -105,15 +105,12 @@ export const FlowRecoveryKeyHint = ({
         } catch (e) {
           let localizedError: string;
           if (e.errno && AuthUiErrorNos[e.errno]) {
-            localizedError = ftlMsgResolver.getMsg(
-              composeAuthUiErrorTranslationId(e),
-              e.message
-            );
+            localizedError = ftlMsgResolver.getMsg(getErrorFtlId(e), e.message);
           } else {
             // Any errors that aren't matched to a known error are reported to the user as an unexpected error
             const unexpectedError = AuthUiErrors.UNEXPECTED_ERROR;
             localizedError = ftlMsgResolver.getMsg(
-              composeAuthUiErrorTranslationId(unexpectedError),
+              getErrorFtlId(unexpectedError),
               unexpectedError.message
             );
           }

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
@@ -11,7 +11,7 @@ import { useAccount, useSession } from '../../../models';
 import { Localized, useLocalization } from '@fluent/react';
 import {
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 
 type ModalProps = {
@@ -49,7 +49,7 @@ export const ModalVerifySession = ({
       } catch (e) {
         if (e.errno === AuthUiErrors.INVALID_EXPIRED_SIGNUP_CODE.errno) {
           const errorText = l10n.getString(
-            composeAuthUiErrorTranslationId(e),
+            getErrorFtlId(e),
             null,
             AuthUiErrors.INVALID_EXPIRED_SIGNUP_CODE.message
           );

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
@@ -15,7 +15,7 @@ import { useAccount, useAlertBar } from '../../../models';
 import FlowContainer from '../FlowContainer';
 import {
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from '../../../lib/auth-errors/auth-errors';
 import { useLocalization, Localized } from '@fluent/react';
 import FormPassword from '../../FormPassword';
@@ -65,9 +65,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
     async ({ oldPassword, newPassword }: FormData) => {
       if (oldPassword === newPassword) {
         const localizedError = l10n.getString(
-          composeAuthUiErrorTranslationId(
-            AuthUiErrors.PASSWORDS_MUST_BE_DIFFERENT
-          ),
+          getErrorFtlId(AuthUiErrors.PASSWORDS_MUST_BE_DIFFERENT),
           null,
           AuthUiErrors.PASSWORDS_MUST_BE_DIFFERENT.message
         );
@@ -80,7 +78,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
         alertSuccessAndGoHome();
       } catch (e) {
         const localizedError = l10n.getString(
-          composeAuthUiErrorTranslationId(AuthUiErrors.INCORRECT_PASSWORD),
+          getErrorFtlId(AuthUiErrors.INCORRECT_PASSWORD),
           null,
           AuthUiErrors.INCORRECT_PASSWORD.message
         );

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -27,7 +27,7 @@ import { useLocalization } from '@fluent/react';
 import { Localized } from '@fluent/react';
 import {
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from '../../../lib/auth-errors/auth-errors';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
@@ -149,7 +149,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
         hardNavigateToContentServer(`${ROOTPATH}?delete_account_success=true`);
       } catch (e) {
         const localizedError = l10n.getString(
-          composeAuthUiErrorTranslationId(AuthUiErrors.INCORRECT_PASSWORD),
+          getErrorFtlId(AuthUiErrors.INCORRECT_PASSWORD),
           null,
           AuthUiErrors.INCORRECT_PASSWORD.message
         );

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -10,7 +10,7 @@ import { isEmailMask, isEmailValid } from 'fxa-shared/email/helpers';
 import { useAccount, useAlertBar } from 'fxa-settings/src/models';
 import {
   AuthUiErrorNos,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 
 export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
@@ -40,7 +40,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
       } catch (e) {
         if (e.errno) {
           const errorText = l10n.getString(
-            composeAuthUiErrorTranslationId(e),
+            getErrorFtlId(e),
             { retryAfter: e.retryAfterLocalized },
             AuthUiErrorNos[e.errno].message
           );

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -10,7 +10,7 @@ import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { useForm } from 'react-hook-form';
 import {
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 
 type FormData = {
@@ -63,7 +63,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
       } catch (e) {
         if (e.errno) {
           const errorText = l10n.getString(
-            composeAuthUiErrorTranslationId(e),
+            getErrorFtlId(e),
             null,
             AuthUiErrors.INVALID_VERIFICATION_CODE.message
           );

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -17,7 +17,7 @@ import { logViewEvent, useMetrics } from '../../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
 import {
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
 } from '../../../lib/auth-errors/auth-errors';
 import { useAsync } from 'react-async-hook';
 
@@ -95,7 +95,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
         if (e.errno === AuthUiErrors.TOTP_TOKEN_NOT_FOUND.errno) {
           setRecoveryCodeError(
             l10n.getString(
-              composeAuthUiErrorTranslationId(e),
+              getErrorFtlId(e),
               null,
               AuthUiErrors.TOTP_TOKEN_NOT_FOUND.message
             )

--- a/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
@@ -9,17 +9,14 @@ import {
   useFtlMsgResolver,
 } from '../../../models';
 import { useLocation } from '@reach/router';
-import {
-  AuthUiErrors,
-  composeAuthUiErrorTranslationId,
-} from '../../auth-errors/auth-errors';
+import { AuthUiErrors, getErrorFtlId } from '../../auth-errors/auth-errors';
 
 /*
  * Check if the integration contains a valid `redirectTo` based on
  * a whitelist maintained in the config.
  *
  * At the time of writing, this is only valid for web integrations.
- * OAuth integrations must derive keys before redirecting.
+ * OAuth integrations should check against clientInfo.redirectUri.
  */
 export function useWebRedirect(redirectTo: BaseIntegrationData['redirectTo']) {
   const config = useConfig();
@@ -33,7 +30,7 @@ export function useWebRedirect(redirectTo: BaseIntegrationData['redirectTo']) {
 
   const getLocalizedErrorMessage = () =>
     ftlMsgResolver.getMsg(
-      composeAuthUiErrorTranslationId(AuthUiErrors.INVALID_REDIRECT_TO),
+      getErrorFtlId(AuthUiErrors.INVALID_REDIRECT_TO),
       AuthUiErrors.INVALID_REDIRECT_TO.message
     );
 

--- a/packages/fxa-settings/src/lib/oauth/en.ftl
+++ b/packages/fxa-settings/src/lib/oauth/en.ftl
@@ -1,0 +1,1 @@
+oauth-error-1000 = Something went wrong. Please close this tab and try again.

--- a/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
+++ b/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
@@ -7,11 +7,12 @@ export type AuthError = {
   message: string;
   response_error_code?: string;
   interpolate?: boolean;
+  version?: number;
 };
 
 export const UNEXPECTED_ERROR = 'Unexpected error';
 
-export const ERRORS: Record<string, AuthError> = {
+export const OAUTH_ERRORS: Record<string, AuthError> = {
   UNKNOWN_CLIENT: {
     errno: 101,
     message: 'Unknown client',
@@ -43,6 +44,7 @@ export const ERRORS: Record<string, AuthError> = {
   INVALID_PARAMETER: {
     errno: 109,
     message: 'Invalid OAuth parameter: %(param)s',
+    interpolate: true,
   },
   INVALID_RESPONSE_TYPE: {
     errno: 110,
@@ -179,15 +181,16 @@ export const ERRORS: Record<string, AuthError> = {
 };
 
 export class OAuthError extends Error {
+  public errno: number;
   constructor(
     public readonly error: string | number,
     public readonly params?: Record<string, string>
   ) {
     const err =
       typeof error === 'string'
-        ? ERRORS[error]
+        ? OAUTH_ERRORS[error]
         : typeof error === 'number'
-        ? Object.values(ERRORS).find((x) => x.errno === error)
+        ? Object.values(OAUTH_ERRORS).find((x) => x.errno === error)
         : null;
     let msg = err != null ? err.message : UNEXPECTED_ERROR;
     if (err?.interpolate) {
@@ -195,6 +198,8 @@ export class OAuthError extends Error {
     }
 
     super(msg);
+    this.name = 'OAuthError';
+    this.errno = err?.errno || OAUTH_ERRORS.UNEXPECTED_ERROR.errno;
   }
 }
 

--- a/packages/fxa-settings/src/models/integrations/oauth-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-integration.ts
@@ -12,7 +12,7 @@ import {
 } from './base-integration';
 import { ModelDataStore, bind, KeyTransforms as T } from '../../lib/model-data';
 import { Constants } from '../../lib/constants';
-import { ERRORS, OAuthError } from '../../lib/oauth';
+import { OAUTH_ERRORS, OAuthError } from '../../lib/oauth';
 import { IntegrationFlags } from '../../lib/integrations';
 import { BaseIntegrationData } from './web-integration';
 import {
@@ -195,7 +195,9 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
   }
 
   getRedirectUri() {
-    return this.data.redirectUri;
+    // clientInfo.redirectUri holds the validated redirect URI. We check that this
+    // value exists and throw an error before a call to this function can be made.
+    return this.clientInfo?.redirectUri || '';
   }
 
   getRedirectToRPUrl(
@@ -378,7 +380,9 @@ export class OAuthIntegration extends BaseIntegration<OAuthIntegrationFeatures> 
     }
 
     if (!permissions.length) {
-      throw new OAuthError(ERRORS.INVALID_PARAMETER.errno, { params: 'scope' });
+      throw new OAuthError(OAUTH_ERRORS.INVALID_PARAMETER.errno, {
+        params: 'scope',
+      });
     }
 
     return permissions;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
@@ -9,6 +9,7 @@ import { MozServices } from '../../lib/types';
 import { renderWithRouter } from '../../models/mocks';
 import { MOCK_RECOVERY_CODES, MOCK_SERVICE_NAME } from './mocks';
 import { MOCK_EMAIL } from '../mocks';
+import { OAUTH_ERRORS, OAuthError } from '../../lib/oauth';
 
 jest.mock('../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
@@ -18,6 +19,7 @@ const cancelSetupHandler = jest.fn();
 const verifyTotpHandler = jest.fn();
 const successSetupHandler = jest.fn();
 const props = {
+  oAuthError: undefined,
   recoveryCodes: MOCK_RECOVERY_CODES,
   cancelSetupHandler: cancelSetupHandler,
   verifyTotpHandler: verifyTotpHandler,
@@ -125,6 +127,23 @@ describe('InlineRecoverySetup', () => {
         await user.click(screen.getByRole('button', { name: 'Confirm' }))
     );
     await screen.findByText('Incorrect backup authentication code');
+  });
+
+  it('shows an error when oAuthError is passed', async () => {
+    renderWithRouter(
+      <InlineRecoverySetup
+        {...props}
+        email={MOCK_EMAIL}
+        oAuthError={new OAuthError('TRY_AGAIN')}
+      />
+    );
+    await act(
+      async () =>
+        await user.click(screen.getByRole('button', { name: 'Continue' }))
+    );
+    await waitFor(() => {
+      screen.getByText(OAUTH_ERRORS.TRY_AGAIN.message);
+    });
   });
 
   it('calls the successful setup callback on correct recovery code', async () => {

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -15,11 +15,13 @@ import { copyRecoveryCodes } from '../../lib/totp';
 import FormVerifyCode from '../../components/FormVerifyCode';
 import {
   AuthUiErrors,
-  composeAuthUiErrorTranslationId,
+  getErrorFtlId,
+  getLocalizedErrorMessage,
 } from '../../lib/auth-errors/auth-errors';
 import { InlineRecoverySetupProps } from './interfaces';
 
 const InlineRecoverySetup = ({
+  oAuthError,
   recoveryCodes,
   serviceName,
   cancelSetupHandler,
@@ -44,7 +46,7 @@ const InlineRecoverySetup = ({
 
   const showBannerSuccess = useCallback(
     () =>
-      successfulTotpSetup ? (
+      successfulTotpSetup && (
         <Banner type={BannerType.success}>
           <p>
             {ftlMsgResolver.getMsg(
@@ -53,8 +55,17 @@ const InlineRecoverySetup = ({
             )}
           </p>
         </Banner>
-      ) : null,
+      ),
     [ftlMsgResolver, successfulTotpSetup]
+  );
+  const showBannerError = useCallback(
+    () =>
+      oAuthError && (
+        <Banner type={BannerType.error}>
+          <p>{getLocalizedErrorMessage(ftlMsgResolver, oAuthError)}</p>
+        </Banner>
+      ),
+    [ftlMsgResolver, oAuthError]
   );
 
   const continueSetup = useCallback(() => {
@@ -88,7 +99,7 @@ const InlineRecoverySetup = ({
         if (error.errno === AuthUiErrors.TOTP_TOKEN_NOT_FOUND.errno) {
           setRecoveryCodeError(
             ftlMsgResolver.getMsg(
-              composeAuthUiErrorTranslationId(error),
+              getErrorFtlId(error),
               AuthUiErrors.TOTP_TOKEN_NOT_FOUND.message
             )
           );
@@ -122,6 +133,7 @@ const InlineRecoverySetup = ({
             {...{ serviceName }}
           />
           {showBannerSuccess()}
+          {showBannerError()}
           <section>
             <div>
               <RecoveryCodesImage className="mx-auto" />

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/interfaces.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { FinishOAuthFlowHandlerResult } from '../../lib/oauth/hooks';
 import { MozServices } from '../../lib/types';
 import { SigninLocationState, TotpToken } from './../Signin/interfaces';
 
@@ -10,6 +11,7 @@ export type SigninRecoveryLocationState = SigninLocationState & {
 };
 
 export interface InlineRecoverySetupProps {
+  oAuthError?: FinishOAuthFlowHandlerResult['error'];
   recoveryCodes: Array<string>;
   serviceName?: MozServices;
   cancelSetupHandler: () => void;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -11,14 +11,13 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useMutation } from '@apollo/client';
 import { CONSUME_RECOVERY_CODE_MUTATION } from './gql';
 import { useCallback } from 'react';
-import { getSigninState, handleGQLError } from '../utils';
+import { getSigninState, getHandledError } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { SigninQueryParams } from '../../../models/pages/signin';
 import { ConsumeRecoveryCodeResponse, SubmitRecoveryCode } from './interfaces';
-import AppLayout from '../../../components/AppLayout';
-import CardHeader from '../../../components/CardHeader';
+import OAuthDataError from '../../../components/OAuthDataError';
 
 export type SigninRecoveryCodeContainerProps = {
   integration: Integration;
@@ -59,22 +58,14 @@ export const SigninRecoveryCodeContainer = ({
 
         return { data };
       } catch (error) {
-        return handleGQLError(error);
+        return getHandledError(error);
       }
     },
     [consumeRecoveryCode]
   );
 
-  // TODO: UX for this, FXA-8106
   if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
+    return <OAuthDataError error={oAuthDataError} />;
   }
 
   if (!signinState) {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -65,7 +65,7 @@ const SigninRecoveryCode = ({
     unwrapBKey,
   } = signinState;
 
-  const onSuccessNavigate = useCallback(() => {
+  const onSuccessNavigate = useCallback(async () => {
     const navigationOptions = {
       email,
       signinData: {
@@ -83,7 +83,10 @@ const SigninRecoveryCode = ({
       queryParams: location.search,
     };
 
-    handleNavigation(navigationOptions);
+    const { error } = await handleNavigation(navigationOptions);
+    if (error) {
+      setBannerErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, error));
+    }
   }, [
     email,
     integration,
@@ -96,6 +99,7 @@ const SigninRecoveryCode = ({
     verificationReason,
     uid,
     unwrapBKey,
+    ftlMsgResolver,
   ]);
 
   const onSubmit = async (code: string) => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -11,10 +11,9 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import { Integration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import AppLayout from '../../../components/AppLayout';
-import CardHeader from '../../../components/CardHeader';
 import { SigninLocationState } from '../interfaces';
 import { getSigninState } from '../utils';
+import OAuthDataError from '../../../components/OAuthDataError';
 
 // The email with token code (verifyLoginCodeEmail) is sent on `/signin`
 // submission if conditions are met.
@@ -57,16 +56,8 @@ const SigninTokenCodeContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
-  // TODO: UX for this, FXA-8106
   if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
+    return <OAuthDataError error={oAuthDataError} />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -166,7 +166,18 @@ const SigninTokenCode = ({
         };
 
         await GleanMetrics.isDone();
-        await handleNavigation(navigationOptions);
+
+        const { error: navError } = await handleNavigation(navigationOptions);
+        if (navError) {
+          const localizedError = getLocalizedErrorMessage(
+            ftlMsgResolver,
+            navError
+          );
+          setBanner({
+            type: BannerType.error,
+            children: <p>{localizedError}</p>,
+          });
+        }
       } catch (error) {
         const localizedErrorMessage = getLocalizedErrorMessage(
           ftlMsgResolver,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -10,14 +10,13 @@ import { useMutation } from '@apollo/client';
 import { MozServices } from '../../../lib/types';
 import VerificationMethods from '../../../constants/verification-methods';
 import { VERIFY_TOTP_CODE_MUTATION } from './gql';
-import { getSigninState, handleGQLError } from '../utils';
+import { getSigninState, getHandledError } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { Integration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import AppLayout from '../../../components/AppLayout';
-import CardHeader from '../../../components/CardHeader';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import OAuthDataError from '../../../components/OAuthDataError';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
@@ -63,21 +62,12 @@ export const SigninTotpCodeContainer = ({
 
       return { status: false };
     } catch (error) {
-      const gqlError = handleGQLError(error);
-      return { error: gqlError.error, status: false };
+      return { error: getHandledError(error).error, status: false };
     }
   };
 
-  // TODO: UX for this, FXA-8106
   if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
+    return <OAuthDataError error={oAuthDataError} />;
   }
 
   if (

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -27,14 +27,13 @@ import {
   ResendUnblockCodeHandler,
   SigninUnblockLocationState,
 } from './interfaces';
-import { handleGQLError } from '../utils';
+import { getHandledError } from '../utils';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import AppLayout from '../../../components/AppLayout';
-import CardHeader from '../../../components/CardHeader';
 import { MozServices } from '../../../lib/types';
 import { QueryParams } from '../../..';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
+import OAuthDataError from '../../../components/OAuthDataError';
 
 const SigninUnblockContainer = ({
   integration,
@@ -88,8 +87,7 @@ const SigninUnblockContainer = ({
       });
       return { data };
     } catch (error) {
-      // TODO consider additional error handling - any non-gql errors will return an unexpected error
-      return handleGQLError(error);
+      return getHandledError(error);
     }
   };
 
@@ -110,16 +108,8 @@ const SigninUnblockContainer = ({
     }
   };
 
-  // TODO: UX for this, FXA-8106
   if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
+    return <OAuthDataError error={oAuthDataError} />;
   }
 
   if (!email || !password) {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -133,7 +133,15 @@ const SigninUnblock = ({
         queryParams: location.search,
       };
 
-      await handleNavigation(navigationOptions, true);
+      const { error: navError } = await handleNavigation(
+        navigationOptions,
+        true
+      );
+      if (navError) {
+        setBannerErrorMessage(
+          getLocalizedErrorMessage(ftlMsgResolver, navError)
+        );
+      }
     }
     if (error) {
       const localizedErrorMessage = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -60,14 +60,13 @@ import AuthenticationMethods from '../../constants/authentication-methods';
 import { KeyStretchExperiment } from '../../models/experiments';
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
 import * as Sentry from '@sentry/browser';
-import { handleGQLError } from './utils';
+import { getHandledError } from './utils';
 import { useFinishOAuthFlowHandler } from '../../lib/oauth/hooks';
-import AppLayout from '../../components/AppLayout';
-import CardHeader from '../../components/CardHeader';
 import { setCurrentAccount } from '../../lib/storage-utils';
 import { searchParams } from '../../lib/utilities';
 import { QueryParams } from '../..';
 import { queryParamsToMetricsContext } from '../../lib/metrics';
+import OAuthDataError from '../../components/OAuthDataError';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -253,7 +252,7 @@ const SigninContainer = ({
           Sentry.captureMessage(
             'Failure to finish v2 upgrade. Could not fetch credential status.'
           );
-          return handleGQLError(error);
+          return getHandledError(error);
         }
 
         // We might have to upgrade the credentials in place.
@@ -280,7 +279,7 @@ const SigninContainer = ({
             Sentry.captureMessage(
               'Failure to finish v2 upgrade. Could not start password change.'
             );
-            return handleGQLError(error);
+            return getHandledError(error);
           }
 
           // Determine wrapKb.
@@ -294,7 +293,7 @@ const SigninContainer = ({
               });
               wrapKb = keysResponse.data?.wrappedAccountKeys.wrapKB || '';
             } catch (error) {
-              const uiError = handleGQLError(error);
+              const uiError = getHandledError(error);
               if (uiError.error.errno === 104) {
                 // NOOP - If the account is simply 'unverified', then go through normal flow.
                 // The password upgrade can occur later.
@@ -303,7 +302,7 @@ const SigninContainer = ({
                 Sentry.captureMessage(
                   'Failure to finish v2 upgrade. Could not get wrapped keys.'
                 );
-                return handleGQLError(error);
+                return getHandledError(error);
               }
             }
           }
@@ -342,7 +341,7 @@ const SigninContainer = ({
               Sentry.captureMessage(
                 'Failure to finish v2 upgrade. Could not finish password change.'
               );
-              return handleGQLError(error);
+              return getHandledError(error);
             }
           }
         } else if (credentialStatusData.data?.credentialStatus.clientSalt) {
@@ -378,7 +377,7 @@ const SigninContainer = ({
             }
             return { data: undefined };
           } catch (error) {
-            return handleGQLError(error);
+            return getHandledError(error);
           }
         } else if (unverifiedAccount === false) {
           // Something went wrong, don't fail, so user can still log in, but DO report it to sentry;
@@ -412,8 +411,7 @@ const SigninContainer = ({
         }
         return { data: undefined };
       } catch (error) {
-        // TODO consider additional error handling - any non-gql errors will return an unexpected error
-        return handleGQLError(error);
+        return getHandledError(error);
       }
     },
     [
@@ -516,16 +514,9 @@ const SigninContainer = ({
     },
     [authClient, flowQueryParams, ftlMsgResolver]
   );
-  // TODO: UX for this, FXA-8106
+
   if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
+    return <OAuthDataError error={oAuthDataError} />;
   }
 
   // TODO: if validationError is 'email', in content-server we show "Bad request email param"

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -684,33 +684,33 @@ describe('with sessionToken', () => {
         const beginSigninHandler = jest
           .fn()
           .mockReturnValueOnce(signinResponse);
-        const finishOAuthFlowHandler = jest.fn().mockImplementationOnce(() => {
-          throw AuthUiErrors.TOTP_REQUIRED;
-        });
+        const finishOAuthFlowHandler = jest.fn().mockImplementationOnce(() => ({
+          error: AuthUiErrors.TOTP_REQUIRED,
+        }));
         const integration = createMockSigninOAuthIntegration();
         render({ finishOAuthFlowHandler, integration, beginSigninHandler });
 
         enterPasswordAndSubmit();
         await waitFor(() => {
-          expect(navigate).toHaveBeenCalledWith('/inline_totp_setup', {
-            state: {
-              email: MOCK_EMAIL,
-              keyFetchToken: signinResponse.data.signIn.keyFetchToken,
-              sessionToken: signinResponse.data.signIn.sessionToken,
-              uid: signinResponse.data.signIn.uid,
-              unwrapBKey: signinResponse.data.unwrapBKey,
-              verificationMethod: signinResponse.data.signIn.verificationMethod,
-              verificationReason: signinResponse.data.signIn.verificationReason,
-              verified: signinResponse.data.signIn.verified,
-            },
-          });
+          expect(GleanMetrics.login.submit).toHaveBeenCalledTimes(1);
         });
-        // TODO, follow up needed for better handling...
-        // expect(GleanMetrics.login.submit).toHaveBeenCalledTimes(1);
-        // expect(GleanMetrics.login.error).toHaveBeenCalledWith({
-        //   reason: AuthUiErrors.TOTP_REQUIRED.message,
-        // });
-        // expect(GleanMetrics.login.error).toHaveBeenCalledTimes(1);
+        expect(GleanMetrics.login.error).toHaveBeenCalledWith({
+          event: { reason: AuthUiErrors.TOTP_REQUIRED.message },
+        });
+        expect(GleanMetrics.login.error).toHaveBeenCalledTimes(1);
+
+        expect(navigate).toHaveBeenCalledWith('/inline_totp_setup', {
+          state: {
+            email: MOCK_EMAIL,
+            keyFetchToken: signinResponse.data.signIn.keyFetchToken,
+            sessionToken: signinResponse.data.signIn.sessionToken,
+            uid: signinResponse.data.signIn.uid,
+            unwrapBKey: signinResponse.data.unwrapBKey,
+            verificationMethod: signinResponse.data.signIn.verificationMethod,
+            verificationReason: signinResponse.data.signIn.verificationReason,
+            verified: signinResponse.data.signIn.verified,
+          },
+        });
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -63,7 +63,7 @@ const Signin = ({
   const navigate = useNavigate();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const [localizedBannerMessage, setLocalizedBannerMessage] = useState(
+  const [bannerError, setBannerError] = useState(
     localizedErrorFromLocationState || ''
   );
   const [passwordTooltipErrorText, setPasswordTooltipErrorText] =
@@ -133,17 +133,16 @@ const Signin = ({
           queryParams: location.search,
         };
 
-        await handleNavigation(navigationOptions);
+        const { error: navError } = await handleNavigation(navigationOptions);
+        if (navError) {
+          setBannerError(getLocalizedErrorMessage(ftlMsgResolver, navError));
+        }
       }
       if (error) {
-        const localizedErrorMessage = getLocalizedErrorMessage(
-          ftlMsgResolver,
-          error
-        );
+        setBannerError(getLocalizedErrorMessage(ftlMsgResolver, error));
         if (error.errno === AuthUiErrors.SESSION_EXPIRED.errno) {
           isPasswordNeededRef.current = true;
         }
-        setLocalizedBannerMessage(localizedErrorMessage);
         setSigninLoading(false);
       }
     },
@@ -151,7 +150,7 @@ const Signin = ({
       cachedSigninHandler,
       email,
       ftlMsgResolver,
-      setLocalizedBannerMessage,
+      setBannerError,
       integration,
       finishOAuthFlowHandler,
       location.search,
@@ -189,7 +188,13 @@ const Signin = ({
           queryParams: location.search,
         };
 
-        await handleNavigation(navigationOptions, true);
+        const { error: navError } = await handleNavigation(
+          navigationOptions,
+          true
+        );
+        if (navError) {
+          setBannerError(getLocalizedErrorMessage(ftlMsgResolver, navError));
+        }
       }
       if (error) {
         GleanMetrics.login.error({ event: { reason: error.message } });
@@ -204,7 +209,7 @@ const Signin = ({
           errno === AuthUiErrors.PASSWORD_REQUIRED.errno ||
           errno === AuthUiErrors.INCORRECT_PASSWORD.errno
         ) {
-          setLocalizedBannerMessage('');
+          setBannerError('');
           setPasswordTooltipErrorText(localizedErrorMessage);
         } else {
           switch (errno) {
@@ -216,7 +221,7 @@ const Signin = ({
                 // Sending the unblock email could itself be rate limited.
                 // If it is, the error should be displayed on this screen
                 // and the user shouldn't even have the chance to continue.
-                setLocalizedBannerMessage(unblockErrorMessage);
+                setBannerError(unblockErrorMessage);
                 setSigninLoading(false);
                 break;
               }
@@ -237,7 +242,7 @@ const Signin = ({
               navigate('/signin_bounced');
               break;
             default:
-              setLocalizedBannerMessage(localizedErrorMessage);
+              setBannerError(localizedErrorMessage);
               setSigninLoading(false);
               break;
           }
@@ -252,7 +257,7 @@ const Signin = ({
       hasPassword,
       navigate,
       sendUnblockEmailHandler,
-      setLocalizedBannerMessage,
+      setBannerError,
       finishOAuthFlowHandler,
       integration,
       location.search,
@@ -298,9 +303,9 @@ const Signin = ({
           {...{ clientId, serviceName }}
         />
       )}
-      {localizedBannerMessage && (
+      {bannerError && (
         <Banner type={BannerType.error}>
-          <p>{localizedBannerMessage}</p>
+          <p>{bannerError}</p>
         </Banner>
       )}
       <div className="mt-9">

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -272,13 +272,14 @@ describe('confirm-signup-container', () => {
                   };
                 }
               ),
-            oAuthDataError: new Error('BOOM'),
+            oAuthDataError: { message: 'BOOM', errno: 1 },
           };
         });
       render();
       await waitFor(() =>
-        expect(screen.getByText('Unexpected error')).toBeInTheDocument()
+        expect(screen.getByText('Bad Request')).toBeInTheDocument()
       );
+      expect(screen.getByText('BOOM')).toBeInTheDocument();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -7,14 +7,13 @@ import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import { currentAccount } from '../../../lib/cache';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { Integration, useAuthClient } from '../../../models';
-import AppLayout from '../../../components/AppLayout';
-import CardHeader from '../../../components/CardHeader';
 import ConfirmSignupCode from '.';
 import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { GetEmailBounceStatusResponse, LocationState } from './interfaces';
 import { useQuery } from '@apollo/client';
 import { EMAIL_BOUNCE_STATUS_QUERY } from './gql';
+import OAuthDataError from '../../../components/OAuthDataError';
 
 export const POLL_INTERVAL = 5000;
 
@@ -131,16 +130,8 @@ const SignupConfirmCodeContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
-  // TODO: UX for this, FXA-8106
   if (oAuthDataError) {
-    return (
-      <AppLayout>
-        <CardHeader
-          headingText="Unexpected error"
-          headingTextFtlId="auth-error-999"
-        />
-      </AppLayout>
-    );
+    return <OAuthDataError error={oAuthDataError} />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -66,6 +66,7 @@ export interface ConfirmSignupCodeOAuthIntegration {
     OAuthIntegration['wantsTwoStepAuthentication']
   >;
   isSync: () => ReturnType<OAuthIntegration['isSync']>;
+  getPermissions: () => ReturnType<OAuthIntegration['getPermissions']>;
 }
 
 export type ConfirmSignupCodeIntegration =

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -9,6 +9,8 @@ import { IntegrationType } from '../../../models';
 import {
   MOCK_EMAIL,
   MOCK_KEY_FETCH_TOKEN,
+  MOCK_REDIRECT_URI,
+  MOCK_SERVICE,
   MOCK_SESSION_TOKEN,
   MOCK_UID,
   MOCK_UNWRAP_BKEY,
@@ -17,7 +19,9 @@ import {
 import {
   ConfirmSignupCodeBaseIntegration,
   ConfirmSignupCodeIntegration,
+  ConfirmSignupCodeOAuthIntegration,
 } from './interfaces';
+import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 
 export const MOCK_AUTH_ERROR = {
   errno: 999,
@@ -35,12 +39,28 @@ export function createMockWebIntegration({
   };
 }
 
+export function createMockOAuthIntegration(
+  serviceName = MOCK_SERVICE
+): ConfirmSignupCodeOAuthIntegration {
+  return {
+    type: IntegrationType.OAuth,
+    data: { uid: MOCK_UID, redirectTo: undefined },
+    getRedirectUri: () => MOCK_REDIRECT_URI,
+    getService: () => serviceName,
+    wantsTwoStepAuthentication: () => false,
+    getPermissions: () => [],
+    isSync: () => false,
+  };
+}
+
 export const Subject = ({
   integration = createMockWebIntegration(),
   newsletterSlugs,
+  finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
 }: {
   integration?: ConfirmSignupCodeIntegration;
   newsletterSlugs?: string[];
+  finishOAuthFlowHandler?: FinishOAuthFlowHandler;
 }) => {
   return (
     <LocationProvider>
@@ -48,9 +68,9 @@ export const Subject = ({
         {...{
           integration,
           newsletterSlugs,
+          finishOAuthFlowHandler,
         }}
         email={MOCK_EMAIL}
-        finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
         keyFetchToken={MOCK_KEY_FETCH_TOKEN}
         sessionToken={MOCK_SESSION_TOKEN}
         uid={MOCK_UID}

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -249,7 +249,8 @@ const SignupContainer = ({
           };
         } else return { data: undefined };
       } catch (error) {
-        // TODO consider additional error handling - any non-gql errors will return an unexpected error
+        // TODO tweak this if we ever use auth-client here, any
+        // non-gql errors will return an unexpected error
         return handleGQLError(error);
       }
     },

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -41,6 +41,7 @@ export const MOCK_OAUTH_FLOW_HANDLER_RESPONSE = {
   redirect: 'someUri',
   code: 'someCode',
   state: 'someState',
+  error: undefined,
 };
 export const mockFinishOAuthFlowHandler = () =>
   Promise.resolve(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);


### PR DESCRIPTION
Because:
* Our OAuth-related errors were not being handled well

This commit:
* Includes better handling of invalid OAuth data errors, creates OAuthDataError component and l10n, and returns it when there is an oAuthDataError
* Allows OAuth errors to be localized, renames composeAuthUiErrorTranslationId to getErrorFtlId
* Handles finishOAuthFlowHandler API call errors and returns the "Try again" error as a catch-all, adds back Glean login error for TOTP required
* Better handles signin cases where error could be an AuthError or GQLError
* Removes duplicate `<main>` from SigninTotpCode

closes FXA-9235, closes FXA-8106

---

FXA-9235 mentions using `returnOnError` if `prompt=none`. Searching the codebase for `redirectWithErrorCode`, in Backbone we account for this in `inline_recovery_setup`, `inline_totp_setup`, and `authorization`. We're only missing this in `authorization` which has its own ticket that we'll do in the future.

We may want a follow up ticket to check for `oAuthDataError` and return the `OAuthDataError` component in `App` instead of in our individual container components. Right now, if the `client_id` param is invalid for example, we wait until the user hits the page we're checking this in instead of just immediately erroring out like Backbone does. This is most noticeable in Signup where we don't error until reaching `ConfirmSignupCode`.  That would mean doing this...

```
  const authClient = useAuthClient();
  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
    authClient,
    integration
  );
```
... in our `AuthAndAccountSetupRoutes`, and passing at least `finishOAuthFlowHandler` into each container component if not also `authClient`. This would have taken more refactoring and test updates so I didn't do that here.