### PR TITLE
feat(react): Full prod rollout of React signup

### DIFF
--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -25,15 +25,21 @@ export class SignupReactPage extends BaseLayout {
   }
 
   get passwordTextbox() {
-    return this.page.getByTestId('new-password-input-field');
+    return this.page
+      .getByLabel('Password', { exact: true }) // React
+      .or(this.page.getByPlaceholder('Password', { exact: true })); // Backbone
   }
 
   get verifyPasswordTextbox() {
-    return this.page.getByTestId('verify-password-input-field');
+    return this.page
+      .getByLabel('Repeat password', { exact: true }) // React
+      .or(this.page.getByPlaceholder('Repeat password', { exact: true })); // Backbone
   }
 
   get ageTextbox() {
-    return this.page.getByTestId('age-input-field');
+    return this.page
+      .getByLabel('How old are you?') // React
+      .or(this.page.getByPlaceholder('How old are you?')); // Backbone
   }
 
   get createAccountButton() {
@@ -45,7 +51,9 @@ export class SignupReactPage extends BaseLayout {
   }
 
   get codeTextbox() {
-    return this.page.getByTestId('confirm-signup-code-input-field');
+    return this.page
+      .getByLabel('Enter 6-digit code') // React
+      .or(this.page.getByPlaceholder('Enter 6-digit code')); // Backbone
   }
 
   get confirmButton() {
@@ -82,6 +90,12 @@ export class SignupReactPage extends BaseLayout {
     await this.verifyPasswordTextbox.fill(password);
     await this.ageTextbox.fill(age);
     await this.createAccountButton.click();
+  }
+
+  async fillOutFirstSignUp(email: string, password: string, age: string) {
+    await this.fillOutEmailForm(email);
+    await this.fillOutSignupForm(password, age);
+    await this.fillOutCodeForm(email);
   }
 
   async fillOutCodeForm(email: string) {

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -10,6 +10,8 @@ import {
   SYNC_EMAIL_PREFIX,
 } from '../../lib/fixtures/standard';
 
+const AGE_21 = '21';
+
 test.describe('severity-1 #smoke', () => {
   test.beforeEach(() => {
     test.slow();
@@ -26,7 +28,13 @@ test.describe('severity-1 #smoke', () => {
     test('signin to OAuth with Sync creds', async ({
       emails,
       target,
-      syncBrowserPages: { page, login, connectAnotherDevice, relier },
+      syncBrowserPages: {
+        page,
+        login,
+        connectAnotherDevice,
+        relier,
+        signupReact,
+      },
     }) => {
       const [email, syncEmail] = emails;
       await target.createAccount(syncEmail, PASSWORD);
@@ -42,7 +50,8 @@ test.describe('severity-1 #smoke', () => {
       await relier.goto();
       await relier.clickEmailFirst();
       await login.useDifferentAccountLink();
-      await login.fillOutFirstSignUp(email, PASSWORD);
+
+      await signupReact.fillOutFirstSignUp(email, PASSWORD, AGE_21);
 
       // RP is logged in, logout then back in again
       expect(await relier.isLoggedIn()).toBe(true);
@@ -67,12 +76,19 @@ test.describe('severity-1 #smoke', () => {
     test('email-first Sync signin', async ({
       emails,
       target,
-      syncBrowserPages: { page, login, connectAnotherDevice, relier },
+      syncBrowserPages: {
+        page,
+        login,
+        connectAnotherDevice,
+        relier,
+        signupReact,
+      },
     }) => {
       const [syncEmail] = emails;
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.fillOutFirstSignUp(syncEmail, PASSWORD);
+
+      await signupReact.fillOutFirstSignUp(syncEmail, PASSWORD, AGE_21);
 
       expect(await relier.isLoggedIn()).toBe(true);
 

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -92,7 +92,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'signup_verified',
         'oauth/signup',
       ]),
-      fullProdRollout: false,
+      fullProdRollout: true,
     },
 
     pairRoutes: {


### PR DESCRIPTION
Because:
* React Signup is looking good in prod at 15%, and we want to totally roll signup out

This commit:
* Sets 'fullProdRollout' for React signup to 'true'
* Updates necessary functional tests

fixes FXA-9470