### PR TITLE
bug(event-broker): Make sure errors are sent to sentry

### DIFF
--- a/packages/fxa-event-broker/src/client-capability/client-capability.service.spec.ts
+++ b/packages/fxa-event-broker/src/client-capability/client-capability.service.spec.ts
@@ -5,6 +5,7 @@ import { Provider } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { Test, TestingModule } from '@nestjs/testing';
+import Sentry from '@sentry/node';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { ClientCapabilityService } from './client-capability.service';
@@ -16,6 +17,10 @@ const baseClients = [
     capabilities: ['testCapability2', 'testCapability3'],
   },
 ];
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
 
 describe('ClientCapabilityService', () => {
   let service: ClientCapabilityService;
@@ -106,6 +111,7 @@ describe('ClientCapabilityService', () => {
       (service as any).axiosInstance = { get: mockUpdate };
       await service.updateCapabilities();
       expect((service as any).log.error).toBeCalledTimes(1);
+      expect(Sentry.captureException).toBeCalledTimes(1);
     });
   });
 });

--- a/packages/fxa-event-broker/src/client-capability/client-capability.service.ts
+++ b/packages/fxa-event-broker/src/client-capability/client-capability.service.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import Sentry from '@sentry/node';
+
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { ExtendedError } from 'fxa-shared/nestjs/error';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
@@ -58,6 +60,7 @@ export class ClientCapabilityService
           : undefined,
         message: 'Error fetching client capabilities.',
       });
+      Sentry.captureException(err);
       return;
     }
     this.log.debug('updateCapabilities', { clientCapabilities: result.data });

--- a/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.spec.ts
+++ b/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.spec.ts
@@ -7,6 +7,11 @@ import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { FirestoreService } from '../firestore/firestore.service';
 import { ClientWebhooksService } from './client-webhooks.service';
+import Sentry from '@sentry/node';
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
 
 describe('ClientWebhooksService', () => {
   let service: ClientWebhooksService;
@@ -116,6 +121,7 @@ describe('ClientWebhooksService', () => {
       triggerError(new Error('oops'));
       expect(mockExit).toBeCalledTimes(1);
       expect(log.error).toBeCalledTimes(1);
+      expect(Sentry.captureException).toBeCalledTimes(1);
     });
   });
 });

--- a/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.ts
+++ b/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.ts
@@ -6,6 +6,7 @@ import {
   OnApplicationBootstrap,
   OnApplicationShutdown,
 } from '@nestjs/common';
+import Sentry from '@sentry/node';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { FirestoreService } from '../firestore/firestore.service';
@@ -55,6 +56,7 @@ export class ClientWebhooksService
       },
       (err) => {
         this.log.error('listenForClientIdWebhooks', { err });
+        Sentry.captureException(err);
         process.exit(1);
       }
     );

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
@@ -4,6 +4,7 @@
 import { Provider } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import Sentry from '@sentry/node';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import nock from 'nock';
 
@@ -11,6 +12,10 @@ import { ClientWebhooksService } from '../client-webhooks/client-webhooks.servic
 import { JwtsetService } from '../jwtset/jwtset.service';
 import * as dto from '../queueworker/sqs.dto';
 import { PubsubProxyController } from './pubsub-proxy.controller';
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
 
 const TEST_TOKEN =
   'eyJhbGciOiJSUzI1NiIsImtpZCI6IjdkNjgwZDhjNzBkNDRlOTQ3MTMzY2JkNDk5ZWJjMWE2MWMzZDVhYmMiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2V4YW1wbGUuY29tIiwiYXpwIjoiMTEzNzc0MjY0NDYzMDM4MzIxOTY0IiwiZW1haWwiOiJnYWUtZ2NwQGFwcHNwb3QuZ3NlcnZpY2VhY2NvdW50LmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJleHAiOjE1NTAxODU5MzUsImlhdCI6MTU1MDE4MjMzNSwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTEzNzc0MjY0NDYzMDM4MzIxOTY0In0.QVjyqpmadTyDZmlX2u3jWd1kJ68YkdwsRZDo-QxSPbxjug4ucLBwAs2QePrcgZ6hhkvdc4UHY4YF3fz9g7XHULNVIzX5xh02qXEH8dK6PgGndIWcZQzjSYfgO-q-R2oo2hNM5HBBsQN4ARtGK_acG-NGGWM3CQfahbEjZPAJe_B8M7HfIu_G5jOLZCw2EUcGo8BvEwGcLWB2WqEgRM0-xt5-UPzoa3-FpSPG7DHk7z9zRUeq6eB__ldb-2o4RciJmjVwHgnYqn3VvlX9oVKEgXpNFhKuYA-mWh5o7BCwhujSMmFoBOh6mbIXFcyf5UiVqKjpqEbqPGo_AvKvIQ9VTQ';
@@ -222,7 +227,7 @@ describe('PubsubProxy Controller', () => {
 
   it('logs an error on invalid message payloads', async () => {
     const message = Buffer.from('invalid payload').toString('base64');
-    expect.assertions(2);
+    expect.assertions(3);
     let err: { getStatus: () => number } | undefined = undefined;
     try {
       await controller.proxy(
@@ -238,6 +243,7 @@ describe('PubsubProxy Controller', () => {
 
     expect(err?.getStatus()).toBe(400);
     expect(logger.error).toBeCalledTimes(1);
+    expect(Sentry.captureException).toBeCalledTimes(1);
   });
 
   it('proxies an error code back', async () => {

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
@@ -16,6 +16,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { Request } from 'express';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { StatsD } from 'hot-shots';
+import Sentry from '@sentry/node';
 import { ExtendedError } from 'fxa-shared/nestjs/error';
 
 import { GoogleJwtAuthGuard } from '../auth/google-jwt-auth.guard';
@@ -98,6 +99,7 @@ export class PubsubProxyController {
         message: 'Failure to load message payload',
         err,
       });
+      Sentry.captureException(err);
       throw new BadRequestException('Invalid message');
     }
   }
@@ -147,6 +149,7 @@ export class PubsubProxyController {
         return err.response;
       } else {
         this.log.error('proxyDeliverError', { err });
+        Sentry.captureException(err);
         throw ExtendedError.withCause('Proxy delivery error', err);
       }
     }
@@ -204,7 +207,7 @@ export class PubsubProxyController {
           appleEmail: message.appleEmail,
           transferSub: message.transferSub,
           success: message.success,
-          err: message.error
+          err: message.error,
         });
       }
       default:

--- a/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
+++ b/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
@@ -66,11 +66,11 @@ export const ServiceNotification = {
         return validMessage;
       }
     } catch (err) {
-      Sentry.captureException(err);
       logger.error('from.sqsMessage', {
         message: 'Invalid message',
         err,
       });
+      Sentry.captureException(err);
     }
     return;
   },


### PR DESCRIPTION
## Because

- Errors used be captured by calling this.log.error, but aren't anymore.
- Seems like queue processing errors aren't showing up in Sentry

## This pull request

- Calls Sentry.captureError anywhere log.error is invoked. 


## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was mentioned in passing while discussing while discussing event broker changes for opt in metrics. 
