### PR TITLE
fix(tests): Add expect.assertions for tests with `.rejects`

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.manager.in.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.in.spec.ts
@@ -133,7 +133,7 @@ describe('PaypalManager', () => {
       );
       expect(result).toEqual(mockNewBillingAgreement.BILLINGAGREEMENTID);
       expect(paypalClient.createBillingAgreement).toBeCalledWith({
-        token
+        token,
       });
     });
 
@@ -297,6 +297,7 @@ describe('PaypalManager', () => {
         .fn()
         .mockResolvedValueOnce([mockPayPalCustomer1, mockPayPalCustomer2]);
 
+      expect.assertions(1);
       expect(
         paypalManager.getCustomerBillingAgreementId(mockStripeCustomer.id)
       ).rejects.toBeInstanceOf(PaypalCustomerMultipleRecordsError);

--- a/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.manager.in.spec.ts
+++ b/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.manager.in.spec.ts
@@ -49,6 +49,7 @@ describe('PaypalCustomerManager', () => {
         billingAgreementId: 'NOT VALID LONG STRING TO CAUSE ERROR',
       });
 
+      expect.assertions(0);
       expect(
         paypalCustomerManager.createPaypalCustomer(paypalCustomer)
       ).rejects.toBeInstanceOf(PaypalCustomerNotCreatedError);
@@ -74,6 +75,7 @@ describe('PaypalCustomerManager', () => {
     it('throws a PaypalCustomerNotFoundError when paypalCustomer does not exist', async () => {
       const paypalCustomer = CreatePaypalCustomerFactory();
 
+      expect.assertions(0);
       expect(
         paypalCustomerManager.fetchPaypalCustomer(
           paypalCustomer.uid,
@@ -161,10 +163,13 @@ describe('PaypalCustomerManager', () => {
       const paypalCustomer = CreatePaypalCustomerFactory();
 
       await paypalCustomerManager.createPaypalCustomer(paypalCustomer);
+
       const updatedPaypalCustomer = {
         ...paypalCustomer,
         billingAgreementId: 'NOT VALID LONG STRING TO CAUSE ERROR',
       };
+
+      expect.assertions(0);
       expect(
         paypalCustomerManager.updatePaypalCustomer(
           paypalCustomer.uid,
@@ -197,6 +202,7 @@ describe('PaypalCustomerManager', () => {
 
       await paypalCustomerManager.deletePaypalCustomer(resultPaypalCustomer);
 
+      expect.assertions(0);
       // Customer is already deleted, this should now throw
       expect(
         paypalCustomerManager.deletePaypalCustomer(resultPaypalCustomer)

--- a/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.manager.in.spec.ts
+++ b/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.manager.in.spec.ts
@@ -51,6 +51,7 @@ describe('AccountCustomer Manager', () => {
         stripeCustomerId: faker.string.alphanumeric({ length: 50 }),
       });
 
+      expect.assertions(0);
       expect(
         accountCustomerManager.createAccountCustomer(mockAccountCustomer)
       ).rejects.toBeInstanceOf(AccountCustomerNotCreatedError);
@@ -76,6 +77,7 @@ describe('AccountCustomer Manager', () => {
     it('throws an AccountCustomerNotFoundError when accountCustomer does not exist', async () => {
       const mockAccountCustomer = CreateAccountCustomerFactory();
 
+      expect.assertions(0);
       expect(
         accountCustomerManager.getAccountCustomerByUid(mockAccountCustomer.uid)
       ).rejects.toBeInstanceOf(AccountCustomerNotFoundError);
@@ -103,6 +105,7 @@ describe('AccountCustomer Manager', () => {
 
     it('throws an AccountCustomerNotUpdatedError when accountCustomer does not exist', async () => {
       const mockAccountCustomer = CreateAccountCustomerFactory();
+
       await accountCustomerManager.createAccountCustomer(mockAccountCustomer);
 
       const mockUpdatedAccountCustomer = {
@@ -110,6 +113,7 @@ describe('AccountCustomer Manager', () => {
         stripeCustomerId: faker.string.alphanumeric({ length: 50 }),
       };
 
+      expect.assertions(0);
       expect(
         accountCustomerManager.updateAccountCustomer(
           mockAccountCustomer.uid,
@@ -139,6 +143,7 @@ describe('AccountCustomer Manager', () => {
 
       await accountCustomerManager.deleteAccountCustomer(resultAccountCustomer);
 
+      expect.assertions(0);
       // Customer is already deleted, this should now throw
       expect(
         accountCustomerManager.deleteAccountCustomer(resultAccountCustomer)

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -178,6 +178,10 @@ describe('StripeManager', () => {
         .mockResolvedValueOnce(undefined);
 
       await manager.cancelSubscription(mockSubscription.id);
+
+      expect(mockClient.subscriptionsCancel).toBeCalledWith(
+        mockSubscription.id
+      );
     });
   });
 
@@ -322,8 +326,10 @@ describe('StripeManager', () => {
 
     it('should throw error if no plan exists', async () => {
       const mockPlan = StripePlanFactory();
+
       mockClient.plansRetrieve = jest.fn().mockResolvedValueOnce(undefined);
 
+      expect.assertions(1);
       expect(manager.getPlan(mockPlan.id)).rejects.toBeInstanceOf(
         PlanNotFoundError
       );
@@ -352,7 +358,11 @@ describe('StripeManager', () => {
         interval: 'month',
       });
 
-      expect(
+      manager.getPlan = jest.fn().mockResolvedValue(mockPlan1);
+      manager.getPlan = jest.fn().mockResolvedValue(mockPlan2);
+
+      expect.assertions(1);
+      await expect(
         manager.getPlanByInterval([mockPlan1.id, mockPlan2.id], 'month')
       ).rejects.toBeInstanceOf(PlanIntervalMultiplePlansError);
     });

--- a/libs/shared/account/account/src/lib/account.manager.in.spec.ts
+++ b/libs/shared/account/account/src/lib/account.manager.in.spec.ts
@@ -50,7 +50,10 @@ describe('accountManager', () => {
 
     it('should throw an error if the email already exists', async () => {
       const email = faker.internet.email();
+
       await accountManager.createAccountStub(email, 1, 'en-US');
+
+      expect.assertions(1);
       await expect(
         accountManager.createAccountStub(email, 1, 'en-US')
       ).rejects.toBeInstanceOf(AccountAlreadyExistsError);


### PR DESCRIPTION
## This pull request

- [https://jestjs.io/docs/tutorial-async#error-handling](https://jestjs.io/docs/tutorial-async#error-handling)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.