### PR TITLE
feat(payments-stripe): Add subscriptionsUpdate method to StripeClient

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -39,6 +39,8 @@ const mockStripeSubscriptionsCreate =
   mockJestFnGenerator<typeof Stripe.prototype.subscriptions.create>();
 const mockStripeSubscriptionsCancel =
   mockJestFnGenerator<typeof Stripe.prototype.subscriptions.cancel>();
+const mockStripeSubscriptionsUpdate =
+  mockJestFnGenerator<typeof Stripe.prototype.subscriptions.update>();
 
 jest.mock('stripe', () => ({
   Stripe: function () {
@@ -60,6 +62,7 @@ jest.mock('stripe', () => ({
         create: mockStripeSubscriptionsCreate,
         cancel: mockStripeSubscriptionsCancel,
         list: mockStripeSubscriptionsList,
+        update: mockStripeSubscriptionsUpdate,
       },
     };
   },
@@ -160,6 +163,21 @@ describe('StripeClient', () => {
       const result = await mockClient.subscriptionsCancel(mockSubscription.id);
 
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('subscriptionsUpdate', () => {
+    it('updates a subscription within Stripe', async () => {
+      const mockSubscription = StripeSubscriptionFactory();
+      const mockUpdatedSubscription = StripeSubscriptionFactory({
+        description: 'This is an updated description.',
+      });
+      const mockResponse = StripeResponseFactory(mockUpdatedSubscription);
+
+      mockStripeSubscriptionsUpdate.mockResolvedValue(mockResponse);
+
+      const result = await mockClient.subscriptionsUpdate(mockSubscription.id);
+      expect(result.description).toEqual(mockUpdatedSubscription.description);
     });
   });
 

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -101,6 +101,18 @@ export class StripeClient {
     return result as StripeResponse<StripeSubscription>;
   }
 
+  async subscriptionsUpdate(
+    id: string,
+    params?: Stripe.SubscriptionUpdateParams
+  ) {
+    const result = await this.stripe.subscriptions.update(id, {
+      ...params,
+      expand: undefined,
+    });
+
+    return result as StripeResponse<StripeSubscription>;
+  }
+
   async invoicesRetrieve(
     id: string,
     params?: Stripe.PaymentMethodAttachParams


### PR DESCRIPTION
## This pull request

- Creates `subscriptionsUpdate` method in StripeClient 
- Return a subscription object of the same type as the subscriptionsCreate method.

## Issue that this pull request solves

Closes: FXA-9452

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.