### PR TITLE
feat(payments-stripe): Add updateSubscription to StripeManager

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -185,6 +185,26 @@ describe('StripeManager', () => {
     });
   });
 
+  describe('updateSubscription', () => {
+    it('calls stripeclient', async () => {
+      const mockParams = {
+        description: 'This is an updated subscription',
+      };
+      const mockSubscription = StripeSubscriptionFactory(mockParams);
+
+      mockClient.subscriptionsUpdate = jest
+        .fn()
+        .mockResolvedValueOnce(mockSubscription);
+
+      await manager.updateSubscription(mockSubscription.id, mockParams);
+
+      expect(mockClient.subscriptionsUpdate).toBeCalledWith(
+        mockSubscription.id,
+        mockParams
+      );
+    });
+  });
+
   describe('isCustomerStripeTaxEligible', () => {
     it('should return true for a taxable customer', async () => {
       const mockCustomer = StripeCustomerFactory({

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
+import { Stripe } from 'stripe';
 
 import { StripeClient } from './stripe.client';
 import { StripeCustomer, StripeSubscription } from './stripe.client.types';
@@ -93,6 +94,13 @@ export class StripeManager {
 
   async cancelSubscription(subscriptionId: string) {
     return this.client.subscriptionsCancel(subscriptionId);
+  }
+
+  async updateSubscription(
+    subscriptionId: string,
+    params?: Stripe.SubscriptionUpdateParams
+  ) {
+    return this.client.subscriptionsUpdate(subscriptionId, params);
   }
 
   /**


### PR DESCRIPTION
## This pull request

- Adds `StripeManager.updateSubscription`
- Should accept any valid subscription update options that Stripe supports
- Passes call through to subscriptions update method in the stripe client.
- Add test to verify pass-through of call

## Issue that this pull request solves

Closes: FXA-9453

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
