### PR TITLE
fix(settings): Make nav sticky and highlight based on section in viewport

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -20,6 +20,7 @@ module.exports = {
       },
       margin: {
         18: '4.5rem',
+        19: '4.75rem',
       },
       flex: {
         2: '2',

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -91,6 +91,15 @@ const updatedFlowQueryParams = {
   flowId: FLOW_ID,
 };
 
+beforeEach(() => {
+  const mockIntersectionObserver = jest.fn();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    disconnect: () => null,
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
+});
+
 describe('metrics', () => {
   let flowInit: jest.SpyInstance;
 

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import { ApolloError } from '@apollo/client';
 import groupBy from 'lodash.groupby';
 import { LinkExternal } from 'fxa-react/components/LinkExternal';
@@ -50,7 +50,7 @@ export function sortAndFilterConnectedClients(
   return { groupedByName, sortedAndUniqueClients };
 }
 
-export const ConnectedServices = () => {
+export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
   const alertBar = useAlertBar();
   const account = useAccount();
   const attachedClients = account.attachedClients;
@@ -188,7 +188,12 @@ export const ConnectedServices = () => {
   }, [clearDisconnectingState, hideAdviceModal]);
 
   return (
-    <section className="mt-11" data-testid="settings-connected-services">
+    <section
+      className="mt-11"
+      data-testid="settings-connected-services"
+      id="connected-services-section"
+      {...{ ref }}
+    >
       <h2 className="font-header font-bold mobileLandscape:ltr:ml-6 mobileLandscape:rtl:ml-6 ltr:ml-4 rtl:mr-4 mb-4 relative">
         <span id="connected-services" className="nav-anchor"></span>
         <Localized id="cs-heading">Connected Services</Localized>
@@ -449,6 +454,6 @@ export const ConnectedServices = () => {
       </div>
     </section>
   );
-};
+});
 
 export default ConnectedServices;

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.tsx
@@ -5,12 +5,12 @@
 import { Localized, useLocalization } from '@fluent/react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import Switch from '../Switch';
-import React, { useCallback, useState } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import { useAlertBar } from '../../../models';
 import { useAccount } from '../../../models';
 import { setEnabled } from '../../../lib/metrics';
 
-export const DataCollection = () => {
+export const DataCollection = forwardRef<HTMLDivElement>((_, ref) => {
   const account = useAccount();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const alertBar = useAlertBar();
@@ -53,7 +53,12 @@ export const DataCollection = () => {
   }, [account, alertBar, l10n, setIsSubmitting]);
 
   return (
-    <section className="mt-11" data-testid="settings-data-collection">
+    <section
+      className="mt-11"
+      data-testid="settings-data-collection"
+      id="data-collection-section"
+      {...{ ref }}
+    >
       <h2 className="font-header font-bold mobileLandscape:ltr:ml-6 mobileLandscape:rtl:ml-6 ltr:ml-4 rtl:mr-4 mb-4 relative">
         <span id="data-collection" className="nav-anchor" />
         {localizedHeader}
@@ -97,6 +102,6 @@ export const DataCollection = () => {
       </div>
     </section>
   );
-};
+});
 
 export default DataCollection;

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.tsx
@@ -2,19 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { useAccount } from '../../../models';
 import { Localized } from '@fluent/react';
 import { LinkedAccount } from './LinkedAccount';
 
-export const LinkedAccounts = () => {
+export const LinkedAccounts = forwardRef<HTMLDivElement>((_, ref) => {
   const account = useAccount();
   const linkedAccounts = account.linkedAccounts;
 
   return (
     <>
       {!!linkedAccounts.length && (
-        <section className="mt-11" data-testid="settings-linked-accounts">
+        <section
+          className="mt-11"
+          data-testid="settings-linked-accounts"
+          id="linked-accounts-section"
+          {...{ ref }}
+        >
           <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4 relative">
             <span id="linked-accounts" className="nav-anchor"></span>
             <Localized id="la-heading">Linked Accounts</Localized>
@@ -42,6 +47,6 @@ export const LinkedAccounts = () => {
       )}
     </>
   );
-};
+});
 
 export default LinkedAccounts;

--- a/packages/fxa-settings/src/components/Settings/Nav/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.test.tsx
@@ -17,6 +17,15 @@ const account = {
   linkedAccounts: [],
 } as unknown as Account;
 
+beforeEach(() => {
+  const mockIntersectionObserver = jest.fn();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    disconnect: () => null,
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
+});
+
 describe('Nav', () => {
   it('renders as expected', () => {
     renderWithLocalizationProvider(

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
@@ -11,6 +11,15 @@ import * as Metrics from '../../../lib/metrics';
 jest.spyOn(Metrics, 'setProperties');
 jest.spyOn(Metrics, 'usePageViewEvent');
 
+beforeEach(() => {
+  const mockIntersectionObserver = jest.fn();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    disconnect: () => null,
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
+});
+
 it('renders without imploding', async () => {
   renderWithRouter(<PageSettings />);
   expect(screen.getByTestId('settings-profile')).toBeInTheDocument();

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import Nav from '../Nav';
 import Security from '../Security';
@@ -25,17 +25,32 @@ export const PageSettings = (_: RouteComponentProps) => {
   });
   Metrics.usePageViewEvent(Metrics.settingsViewName);
 
+  // Scroll to effect
+  const profileRef = useRef<HTMLDivElement>(null);
+  const securityRef = useRef<HTMLDivElement>(null);
+  const connectedServicesRef = useRef<HTMLDivElement>(null);
+  const linkedAccountsRef = useRef<HTMLDivElement>(null);
+  const dataCollectionRef = useRef<HTMLDivElement>(null);
+
   return (
     <div id="fxa-settings" className="flex">
       <div className="hidden desktop:block desktop:flex-2">
-        <Nav />
+        <Nav
+          {...{
+            profileRef,
+            securityRef,
+            connectedServicesRef,
+            linkedAccountsRef,
+            dataCollectionRef,
+          }}
+        />
       </div>
       <div className="flex-7 max-w-full">
-        <Profile />
-        <Security />
-        <ConnectedServices />
-        <LinkedAccounts />
-        <DataCollection />
+        <Profile ref={profileRef} />
+        <Security ref={securityRef} />
+        <ConnectedServices ref={connectedServicesRef} />
+        <LinkedAccounts ref={linkedAccountsRef} />
+        <DataCollection ref={dataCollectionRef} />
         <div className="flex mx-4 tablet:mx-0" id="delete-account">
           <Localized id="delete-account-link">
             <Link

--- a/packages/fxa-settings/src/components/Settings/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Profile/index.tsx
@@ -2,18 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { useAccount } from '../../../models';
 import { UnitRow } from '../UnitRow';
 import { UnitRowSecondaryEmail } from '../UnitRowSecondaryEmail';
 import { HomePath } from '../../../constants';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
-export const Profile = () => {
+export const Profile = forwardRef<HTMLDivElement>((_, ref) => {
   const { avatar, primaryEmail, displayName } = useAccount();
 
   return (
-    <section className="mt-11" data-testid="settings-profile">
+    <section
+      className="mt-11"
+      data-testid="settings-profile"
+      {...{ ref }}
+      id="profile-section"
+    >
       <h2 className="font-header font-bold mobileLandscape:ltr:ml-6 mobileLandscape:rtl:ml-6 ltr:ml-4 rtl:mr-4 mb-4 relative">
         <span id="profile" className="nav-anchor"></span>
         <FtlMsg id="profile-heading">Profile</FtlMsg>
@@ -62,4 +67,4 @@ export const Profile = () => {
       </div>
     </section>
   );
-};
+});

--- a/packages/fxa-settings/src/components/Settings/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Localized, useLocalization } from '@fluent/react';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import UnitRowRecoveryKey from '../UnitRowRecoveryKey';
 import UnitRowTwoStepAuth from '../UnitRowTwoStepAuth';
 import { UnitRow } from '../UnitRow';
@@ -36,13 +36,18 @@ const PwdDate = ({ passwordCreated }: { passwordCreated: number }) => {
   );
 };
 
-export const Security = () => {
+export const Security = forwardRef<HTMLDivElement>((_, ref) => {
   const { passwordCreated, hasPassword } = useAccount();
   const { l10n } = useLocalization();
   const localizedNotSet = l10n.getString('security-not-set', null, 'Not Set');
 
   return (
-    <section className="mt-11" data-testid="settings-security">
+    <section
+      className="mt-11"
+      data-testid="settings-security"
+      {...{ ref }}
+      id="security-section"
+    >
       <h2 className="font-header font-bold mobileLandscape:ltr:ml-6 mobileLandscape:rtl:ml-6 ltr:ml-4 rtl:mr-4 mb-4 relative">
         <span id="security" className="nav-anchor"></span>
         <Localized id="security-heading">Security</Localized>
@@ -103,6 +108,6 @@ export const Security = () => {
       </div>
     </section>
   );
-};
+});
 
 export default Security;

--- a/packages/fxa-settings/src/styles/tailwind.css
+++ b/packages/fxa-settings/src/styles/tailwind.css
@@ -22,6 +22,11 @@ body {
   @apply absolute -top-20;
 }
 
+/* Abstracted because we directly edit the element's classList */
+.nav-active {
+  @apply font-bold text-blue-500 rounded-sm bg-grey-50;
+}
+
 progress {
   -webkit-appearance: none;
   -moz-appearance: none;


### PR DESCRIPTION
Because:
* This is the intended behavior of our settings nav

This commit:
* Includes CSS tweaks to make the nav sticky on scroll
* Adds an intersection observer and refs for sections and links and conditionally adds our active nav classes on the appropriate link

fixes FXA-9314

---

Note, this is not perfect, but I had to timebox myself on it. With more time I could probably improve the approach but as it stands, I tried various thresholds and checking options that IntersectionObserver gives us out of the box and I think it's in an acceptable state now, but LMK if you like something better when reviewing. I did not add new unit tests since I'm not sure they're worth the effort, but sure I could create fake refs and check we call `observe` on them if we wanted.

Please check in Settings locally and the "completely filled out" Settings in storybook.
![sticky-nav2](https://github.com/mozilla/fxa/assets/13018240/253abe0f-9ddf-42e1-bc99-300d3d221e3a)

### notes from before my latest push:
I'm going to see what I can do about:
* Two anchor links being highlighted at once, but not sure there is much to do because when "Data Collection and Use" is in view, so is a short connected services or linked accounts link
  * UPDATE: yeah, not much can be done here. Users can be "in between" sections or be viewing two sections at once. 
* A long connected services list doesn't highlight properly (check fully filled out Settings in Storybook)
  * UPDATE: did fix. 

