### PR TITLE
bug(nx): Fix nx build failures in docker

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -3,3 +3,8 @@
 **/browser_modules
 **/.vscode
 **/version.json
+**/.next
+**/storybook-static
+dist
+external/l10n
+packages/*/dist


### PR DESCRIPTION
## Because

- Builds were failing with a 'ProjectsWithConflictingNamesError: The following projects are defined in multiple locations'

## This pull request

- Adds folders that might contain rogue project.json files to the nx ignore list

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Working locally now:
![image](https://github.com/mozilla/fxa/assets/94418270/34c08ae8-0e09-4396-8277-0a9e33122cac)

## Other information (Optional)

To test locally add version.json to packages folder with this:
`{ "version": { "version": "v0.0.0" } }`

Then run `./.circleci/docker-build-fxa.sh  9624cf31-6134-4eba-bea4-1ed71f2d66d7`
