### PR TITLE
example of upgrading playwright on the fly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,9 +317,9 @@ commands:
       # image once we fix anything impacted by the new playwright version.
       #
       - run:
-        name: Test playwright upgrade
-        command: |
-          npx playwright install --with-deps
+          name: Test playwright upgrade
+          command: |
+            npx playwright install --with-deps
       - run:
           name: Running Playwright tests
           # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,23 @@ commands:
       project:
         type: string
     steps:
+      #
+      # TEMPORARY STEP!
+      #
+      # We are checking out a new playwright version with breaking changes. This is a temporary step to upgrade playwright
+      # on the fly.
+      #
+      # Eventually we want to make sure the container image already has done this, so we don't have install overhead
+      # everytime we run playwright tests.
+      #
+      # Also note that --with-deps installs firefox and chrome. We probably just need firefox. So also try this with
+      # npx playwright install firefox, and see if this works. If it does, let's just use that, and update the container
+      # image once we fix anything impacted by the new playwright version.
+      #
+      - run:
+        name: Test playwright upgrade
+        command: |
+          npx playwright install --with-deps
       - run:
           name: Running Playwright tests
           # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/


### PR DESCRIPTION
This is just an example of how to upgrade playwright on the fly. Typically playwright and its dependencies are preinstalled in our functional test executor; however, if we are validating an upgrade for potential breaking changes, we can run the install before our tests starts to make sure the latest version is used.