### PR TITLE
chore: refactor password.js to password.ts and async

### DIFF
--- a/libs/shared/otp/src/lib/otp.ts
+++ b/libs/shared/otp/src/lib/otp.ts
@@ -5,9 +5,9 @@
 import { timingSafeEqual, randomInt } from 'crypto';
 
 export interface OtpStorage {
-  del: (key: string) => unknown;
-  get: (key: string) => unknown;
-  set: (key: string, value: string) => unknown;
+  del: (key: string) => Promise<null>;
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string) => Promise<null>;
 }
 
 type OtpManagerOptions = {


### PR DESCRIPTION
Because:

* We want to use TypeScript and async/await.
* Otp Storage could have more precise TS definition.

This commit:

* Renames `password.js` to `password.ts`.
* Refactors promise chains in password.ts to async/await.
* Adds more precise types to `OtpStorage`.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
