### PR TITLE
bug: Use docker command to check if mysql db is alive

### DIFF
--- a/_scripts/check-mysql.sh
+++ b/_scripts/check-mysql.sh
@@ -1,16 +1,17 @@
 #!/bin/bash -e
-
-PORT=${1:-3306}
-HOST=${2:-localhost}
 RETRY=60
+CONTAINER_NAME="mydb"
+
 for i in $(eval echo "{1..$RETRY}"); do
-  if echo PING | nc "$HOST" "$PORT" | grep -q 'mysql'; then
+  if DOCKER_CLI_HINTS=false docker exec -it $CONTAINER_NAME /bin/bash -c 'mysqladmin ping' > /dev/null; then
+    echo "MySQL DB is ready"
     exit 0
   else
     if [ "$i" -lt $RETRY ]; then
+      echo "MySQL DB could not be reached, trying again"
       sleep 1
     fi
   fi
 done
-
+echo "MySQL DB Could not be reached, please double check your docker setup"
 exit 1


### PR DESCRIPTION
## Because

- I couldn't use the latest version of Docker with FxA and builds kept failing

## This pull request

- Changes how we ping the MySQL container by executing `mysqladmin ping` on it.
- I'm not sure why we were using netcat and echoing a `PING` into it before, and why that was not working properly in later versions of docker

With this PR, I can now build FxA using the latest version of Docker (4.29.0)

**Someone else should verify that using the latest version of docker, builds work OK for others**

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
