### PR TITLE
task(ci): update funcitonal test executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ executors:
   # step, and the saving the initial a workspace state.
   build-executor:
     docker:
-      - image: mozilla/fxa-circleci:ci-builder-v2
+      - image: mozilla/fxa-circleci:ci-builder-v3
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
@@ -99,7 +99,7 @@ executors:
         default: medium
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-test-runner-v2
+      - image: mozilla/fxa-circleci:ci-test-runner-v3
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
@@ -115,7 +115,7 @@ executors:
         default: large
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-test-runner-v2
+      - image: mozilla/fxa-circleci:ci-test-runner-v3
       - image: cimg/mysql:8.0
         command: --default-authentication-plugin=mysql_native_password
       - image: jdlk7/firestore-emulator
@@ -139,7 +139,7 @@ executors:
         default: large
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-functional-test-runner-v2
+      - image: mozilla/fxa-circleci:ci-functional-test-runner-v3
       - image: redis
       - image: memcached
       - image: pafortin/goaws
@@ -180,7 +180,7 @@ executors:
         default: medium+
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-functional-test-runner-v2
+      - image: mozilla/fxa-circleci:ci-functional-test-runner-v3
     environment:
       NODE_ENV: development
       CUSTOMS_SERVER_URL: none
@@ -435,7 +435,7 @@ commands:
             docker build . \
                 -f ./project/_dev/docker/ci/Dockerfile \
                 --target << parameters.target >> \
-                -t mozilla/fxa-circleci:ci-<< parameters.target >>-v2
+                -t mozilla/fxa-circleci:ci-<< parameters.target >>-v3
 
   create-fxa-ci-images:
     # Build CI images. Images are built on top of each other. Each is optimized for a specific task.
@@ -464,10 +464,10 @@ commands:
           name: Push CI Images and Extract Yarn Cache
           command: |
             docker login -u $DOCKER_USER_fxa_circleci -p $DOCKER_PASS_fxa_circleci
-            .circleci/docker-copy-cache.sh mozilla/fxa-circleci:ci-builder-v2
-            docker push mozilla/fxa-circleci:ci-test-runner-v2
-            docker push mozilla/fxa-circleci:ci-functional-test-runner-v2
-            docker push mozilla/fxa-circleci:ci-builder-v2
+            .circleci/docker-copy-cache.sh mozilla/fxa-circleci:ci-builder-v3
+            docker push mozilla/fxa-circleci:ci-test-runner-v3
+            docker push mozilla/fxa-circleci:ci-functional-test-runner-v3
+            docker push mozilla/fxa-circleci:ci-builder-v3
             wait
 
 jobs:
@@ -476,7 +476,6 @@ jobs:
     steps:
       - checkout
       - cache-restore-yarn
-      - provision
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -861,6 +860,7 @@ workflows:
               only:
                 - main
                 - chore/update-tsconfig-for-node-20
+                - update-functional-test-executor
             tags:
               ignore: /.*/
           force-deploy: << pipeline.parameters.force-deploy-fxa-ci-images >>

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "@playwright/test": "^1.38.1",
+    "@playwright/test": "^1.43.1",
     "@types/eslint": "^8",
     "@types/upng-js": "^2",
     "eslint": "^8.56.0",

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "^1.38.1",
     "@types/eslint": "^8",
     "@types/upng-js": "^2",
     "eslint": "^8.56.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14290,7 +14290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.38.1":
+"@playwright/test@npm:^1.43.1":
   version: 1.43.1
   resolution: "@playwright/test@npm:1.43.1"
   dependencies:
@@ -37308,7 +37308,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "functional-tests@workspace:packages/functional-tests"
   dependencies:
-    "@playwright/test": ^1.38.1
+    "@playwright/test": ^1.43.1
     "@types/eslint": ^8
     "@types/upng-js": ^2
     eslint: ^8.56.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -14290,19 +14290,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.35.1":
-  version: 1.35.1
-  resolution: "@playwright/test@npm:1.35.1"
+"@playwright/test@npm:^1.38.1":
+  version: 1.43.1
+  resolution: "@playwright/test@npm:1.43.1"
   dependencies:
-    "@types/node": "*"
-    fsevents: 2.3.2
-    playwright-core: 1.35.1
-  dependenciesMeta:
-    fsevents:
-      optional: true
+    playwright: 1.43.1
   bin:
     playwright: cli.js
-  checksum: 3509d2f2c7397f9b0d4f49088cab8625f17d186f7e9b3389ddebf7c52ee8aae6407eab48f66b300b7bf6a33f6e3533fd5951e72bfdb001b68838af98596d5a53
+  checksum: f9db387b488a03125e5dc22dd7ffed9c661d1f2428188912a35a2235b3bd9d826b390e7600d04998639994f5a96695b9dc9034ca9cb59e261d2fdee93a60df3f
   languageName: node
   linkType: hard
 
@@ -37313,7 +37308,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "functional-tests@workspace:packages/functional-tests"
   dependencies:
-    "@playwright/test": ^1.35.1
+    "@playwright/test": ^1.38.1
     "@types/eslint": ^8
     "@types/upng-js": ^2
     eslint: ^8.56.0
@@ -53011,12 +53006,27 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.35.1":
-  version: 1.35.1
-  resolution: "playwright-core@npm:1.35.1"
+"playwright-core@npm:1.43.1":
+  version: 1.43.1
+  resolution: "playwright-core@npm:1.43.1"
   bin:
     playwright-core: cli.js
-  checksum: 179abc0051f00474e528935b507fa8cedc986b2803b020d7679878ba28cdd7036ad5a779792aad2ad281f8dc625eb1d2fb77663cb8de0d20c7ffbda7c18febdd
+  checksum: 7c96b3a4a4bce2ee22c3cd680c9b0bb9e4bf07ee4b51d1e9a7f47a6489c7b0b960d4b550e530b8f41d1ffeadd26c7c6bb626ae8689dfd90dce1cb8e35ae78ff7
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.43.1":
+  version: 1.43.1
+  resolution: "playwright@npm:1.43.1"
+  dependencies:
+    fsevents: 2.3.2
+    playwright-core: 1.43.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: de9db021f93018a18275bbb5af09ebf1804aa0534f47578b35b440064abc774509740205802824afc94a99fc84dd55ffe9e215718ad3ecc691b251ab3882b096
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- To keep up with the latest version and new updates, upgrading the Playwright version to the latest 1.43.1.

## This pull request

- Updates the functional-test-runner images
- Upgrades Playwright version to 1.43.1

## Issue that this pull request solves

Closes: FXA-9135 FXA-9358

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Typically we do this for node versions, but it should also work for playwright versions. See docs here: https://mozilla.github.io/ecosystem-platform/how-tos/ci-guidelines#updating-ci-runner-images 
