### PR TITLE
bug(functional-tests): Skip failing smoke tests due to timing issue on redirect to Stage 123 Done

### DIFF
--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -186,7 +186,11 @@ test.describe('severity-1 #smoke', () => {
       page,
       pages: { login, relier, settings, deleteAccount },
       emails,
-    }) => {
+    }, { project }) => {
+      test.fixme(
+        project.name !== 'local',
+        'FXA-9518 - Timing issue? Fails on stage with `Bad request - unknown state` on L209, unless breakpoint added on L208. Passes when restarting from breakpoint. '
+      );
       const [blockedEmail] = emails;
 
       await target.createAccount(blockedEmail, PASSWORD);
@@ -202,6 +206,7 @@ test.describe('severity-1 #smoke', () => {
       await login.setPassword(PASSWORD);
       await login.submit();
       await login.unblock(blockedEmail);
+      await relier.isLoggedIn();
       await settings.goto();
       await settings.deleteAccountButton.click();
       await deleteAccount.deleteAccount(PASSWORD);

--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -38,7 +38,11 @@ test.describe('severity-1 #smoke', () => {
     test('verified account with cached login, no email confirmation required', async ({
       credentials,
       pages: { page, relier, signinReact },
-    }) => {
+    }, { project }) => {
+      test.fixme(
+        project.name !== 'local',
+        'FXA-9518 - Timing issues? Fails on stage with `Bad request - unknown state` on L54 and L74, unless breakpoint added on L53 and L72. Passes when restarting from breakpoint.'
+      );
       await relier.goto();
       await relier.clickEmailFirst();
       await expect(page).toHaveURL(/oauth\//);
@@ -70,7 +74,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signinReact.signInButton.click();
 
-      expect(await relier.isLoggedIn()).toBe(true);
+      await relier.isLoggedIn();
     });
 
     test('verified using a cached expired login', async ({

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -59,11 +59,15 @@ test.describe('severity-1 #smoke', () => {
   test('react disconnect RP #1293475', async ({
     credentials,
     pages: { configPage, page, relier, signinReact, settings },
-  }) => {
+  }, { project }) => {
     const config = await configPage.getConfig();
     test.skip(
       config.showReactApp.signInRoutes !== true,
       'Skip tests if React signInRoutes not enabled'
+    );
+    test.fixme(
+      project.name !== 'local',
+      'FXA-9518 - Timing issue? Fails on stage with `Bad request - unknown state` on L86, unless breakpoint added on L85. Passes when restarting from breakpoint. '
     );
 
     await relier.goto();


### PR DESCRIPTION
## Because

- Tests failed stage smoke tests
- All three tests are failing on redirect to 123Done stage with `Bad request - Unknown state`, but if a breakpoint is added on the preceding test step, the redirect works as expected and test passes on continuing from breakpoint without any code changes.

## This pull request

- Skip tests in stage and production until timing issue is fixed

## Issue that this pull request solves

Issue: # FXA-9518

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
