### PR TITLE
feat(payments-ui): add checkoutCartWithStripe action

### DIFF
--- a/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { plainToClass } from 'class-transformer';
+import { app } from '../nestapp/app';
+import { CheckoutCartWithStripeActionArgs } from '../nestapp/validators/CheckoutCartWithStripeActionArgs';
+
+export const checkoutCartWithStripe = async (
+  cartId: string,
+  version: number,
+  paymentMethodId: string
+) => {
+  await app.getActionsService().checkoutCartWithStripe(
+    plainToClass(CheckoutCartWithStripeActionArgs, {
+      cartId,
+      version,
+      paymentMethodId,
+    })
+  );
+};

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -13,6 +13,7 @@ import { Validator } from 'class-validator';
 import { SetupCartActionArgs } from './validators/SetupCartActionArgs';
 import { FinalizeCartWithErrorArgs } from './validators/FinalizeCartWithErrorArgs';
 import { CheckoutCartWithPaypalActionArgs } from './validators/CheckoutCartWithPaypalActionArgs';
+import { CheckoutCartWithStripeActionArgs } from './validators/CheckoutCartWithStripeActionArgs';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -87,6 +88,16 @@ export class NextJSActionsService {
       args.cartId,
       args.version,
       args.token
+    );
+  }
+
+  async checkoutCartWithStripe(args: CheckoutCartWithStripeActionArgs) {
+    new Validator().validateOrReject(args);
+
+    await this.cartService.checkoutCartWithStripe(
+      args.cartId,
+      args.version,
+      args.paymentMethodId
     );
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithStripeActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithStripeActionArgs.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsNumber, IsString } from 'class-validator';
+
+export class CheckoutCartWithStripeActionArgs {
+  @IsString()
+  cartId!: string;
+
+  @IsNumber()
+  version!: number;
+
+  @IsString()
+  paymentMethodId!: string;
+}


### PR DESCRIPTION
Because:

* We want to be able to checkout with Stripe from payments-next

This commit:

* Adds a server action to do so

Closes FXA-8950