### PR TITLE
feat(payments-next): Add SignIn button

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/en.ftl
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/en.ftl
@@ -1,3 +1,4 @@
-## Component - PaymentConsentCheckbox
-
+## Page
+next-new-user-step-1-2 = 1. Create a { -product-mozilla-account }
+next-new-user-sign-in-link-2 = Already have a { -product-mozilla-account }? <a>Sign in</a>
 next-payment-confirm-with-legal-links-static-3 = I authorize { -brand-mozilla } to charge my payment method for the amount shown, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/page.tsx
@@ -50,9 +50,47 @@ export default async function Checkout({ params }: { params: CheckoutParams }) {
   return (
     <>
       <section
-        className="h-min-[640px] flex flex-col items-center justify-center"
+        className="h-min-[640px]"
         aria-label="Section under construction"
       >
+        {!session && (
+          <>
+            <h4 className="font-semibold text-grey-600 text-lg">
+              {l10n.getString(
+                'next-new-user-step-1-2',
+                '1. Create a Mozilla account'
+              )}
+            </h4>
+
+            <form
+              action={async () => {
+                'use server';
+                await signIn('fxa');
+              }}
+            >
+              <div className="text-grey-400 text-sm">
+                {l10n.getFragmentWithSource(
+                  'next-new-user-sign-in-link-2',
+                  {
+                    elems: {
+                      a: (
+                        <button className="underline text-grey-400 hover:text-grey-400">
+                          Sign in
+                        </button>
+                      ),
+                    },
+                  },
+                  <button className="underline text-grey-400 hover:text-grey-400">
+                    Sign in
+                  </button>
+                )}
+              </div>
+            </form>
+
+            <hr className="mx-auto my-4 w-full border-grey-200" />
+          </>
+        )}
+
         <section className="flex flex-col gap-2 mb-8">
           <div>
             <h3 className="text-xl">Temporary L10n Section</h3>

--- a/apps/payments/next/app/styles/global.css
+++ b/apps/payments/next/app/styles/global.css
@@ -29,7 +29,7 @@ body {
 }
 
 .page-title-container {
-  @apply bg-white shadow-sm shadow-grey-300 text-center mt-0 mb-auto pt-5 px-4 pb-px tablet:mx-0;
+  @apply bg-white shadow-sm shadow-grey-300 text-center my-0 pt-5 px-4 pb-px tablet:mx-0;
 }
 
 /* error, success pages */


### PR DESCRIPTION
## This pull request

- [x] Adds in the Sign In button
   - [x] Gets user session using NextAuth - auth function
   - [x] Adds JSX to display the following if there is no user session or session indicates user is not signedIn
         1. Create a Mozilla account header
         Already have a Mozilla account? 
 
Note: as the Sign In button is currently not used anywhere else, it will be added directly to the page for now

## Issue that this pull request solves

Closes: FXA-7521

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="961" alt="Screenshot 2024-04-30 at 11 00 38 AM" src="https://github.com/mozilla/fxa/assets/28129806/39cbc362-0f66-428e-8e3a-ae253b0f741a">
<img width="958" alt="Screenshot 2024-04-30 at 11 01 12 AM" src="https://github.com/mozilla/fxa/assets/28129806/6fdc4a1c-e12d-42e9-905a-12eb72bc7718">

## Other information
Included an update to the stylesheet in this PR to eliminate gap seen below:
<img width="962" alt="Screenshot 2024-04-30 at 10 59 18 AM" src="https://github.com/mozilla/fxa/assets/28129806/3084dd66-82d9-44a8-bf89-1c46bd10881f">
