### PR TITLE
fix(fxa-settings): Email shown on React Signin page should not change on submit

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -136,6 +136,8 @@ export default {
     const user = this.user;
     const account = user.getChooserAccount();
     if (this.allowSuggestedAccount(account)) {
+      // allows passing the email to react signin
+      this.user.set('emailFromIndex', account.get('email'));
       return account;
     } else {
       return user.initAccount({});


### PR DESCRIPTION
## Because

* Fix a bug where email shown on React Signin page might change on refresh or submit if session expires or local storage changes

## This pull request

* Let the email-first page choose a suggested account, do not pick an account from local storage on the sign in page
* Pass the suggested account email from email-first in query params
* Only retrieve the email on React Signin from query params or location state, otherwise redirect to email-first
* Update unit tests to reflect that we are no longer checking local storage for a recent account on signin page

## Issue that this pull request solves

Closes: #FXA-9417

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

With the changes in PR, when accessing React sign in directly without params or location state, there's a brief loading spinner while the page redirects (in the background) to `/` where the email first account chooser reads from local storage then returns to React signin with the email in params.