### PR TITLE
fix(sync): Send 'service' option with submission on ConfirmSignupCode for React sync

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -32,7 +32,7 @@ import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
 import { MailImage } from '../../../components/images';
-import { ResendStatus } from 'fxa-settings/src/lib/types';
+import { MozServices, ResendStatus } from 'fxa-settings/src/lib/types';
 import {
   isOAuthIntegration,
   isSyncDesktopV3Integration,
@@ -125,13 +125,14 @@ const ConfirmSignupCode = ({
     GleanMetrics.signupConfirmation.submit();
     try {
       const hasSelectedNewsletters = newsletters && newsletters.length > 0;
+      const service = integration.getService();
 
       const options = {
         ...(hasSelectedNewsletters && { ...{ newsletters } }),
         ...(isOAuthIntegration(integration) && {
           scopes: integration.getPermissions(),
-          service: integration.getService(),
         }),
+        ...(service !== MozServices.Default && { service }),
       };
 
       await session.verifySession(code, options);

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -5,6 +5,7 @@
 import { RouteComponentProps } from '@reach/router';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
+  BaseIntegration,
   BaseIntegrationData,
   Integration,
   IntegrationType,
@@ -52,6 +53,7 @@ export interface ConfirmSignupCodeBaseIntegration {
     uid: BaseIntegrationData['uid'];
     redirectTo: BaseIntegrationData['redirectTo'];
   };
+  getService: BaseIntegration['getService'];
 }
 
 export interface ConfirmSignupCodeOAuthIntegration {

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -22,6 +22,7 @@ import {
   ConfirmSignupCodeOAuthIntegration,
 } from './interfaces';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { MozServices } from '../../../lib/types';
 
 export const MOCK_AUTH_ERROR = {
   errno: 999,
@@ -36,6 +37,7 @@ export function createMockWebIntegration({
   return {
     type: IntegrationType.Web,
     data: { uid: MOCK_UID, redirectTo },
+    getService: () => MozServices.Default,
   };
 }
 


### PR DESCRIPTION
Because:
* Users are not receiving the welcome email after confirming their account through Sync

This commit:
* Moves the 'service' option from OAuth-only to always be included if the service is not the default

fixes FXA-9527

---

You can test this by launching `fxa-dev-launcher` and seeing before this patch, the [welcome email](https://storage.googleapis.com/mozilla-storybooks-fxa/commits/latest/fxa-auth-server/index.html?path=/story/fxa-emails-templates-postverify--post-verify-desktop-tablet) does not come through when [signing up through Sync in React](http://localhost:3030?context=fx_desktop_v3&entrypoint=preferences&action=email&service=sync&forceExperiment=generalizedReactApp&forceExperimentGroup=react). With this patch, it does.