### PR TITLE
feat(signup): Update email newsletter name and slug

### DIFF
--- a/packages/fxa-settings/src/components/ChooseNewsletters/en.ftl
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/en.ftl
@@ -4,11 +4,12 @@
 # Prompt above a checklist of newsletters
 choose-newsletters-prompt-2 = Get more from { -brand-mozilla }:
 # Newsletter checklist item
-choose-newsletters-option-take-action-for-the-internet-2 =
-  .label = Help keep the internet healthy
-# Newsletter checklist item
 choose-newsletters-option-security-privacy =
   .label = Security & privacy news and updates
 # Newsletter checklist item
 choose-newsletters-option-test-pilot =
   .label = Early access to test new products
+# Newsletter checklist item. This for a Mozilla Foundation newsletters,
+# "Action alerts" can be interpreted as "Calls to action"
+choose-newsletters-option-reclaim-the-internet =
+  .label = Action alerts to reclaim the internet

--- a/packages/fxa-settings/src/components/ChooseNewsletters/newsletters.ts
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/newsletters.ts
@@ -26,8 +26,8 @@ export const newsletters: Newsletter[] = [
     ftlId: 'choose-newsletters-option-test-pilot',
   },
   {
-    label: 'Help keep the internet healthy',
-    slug: ['take-action-for-the-internet'],
-    ftlId: 'choose-newsletters-option-take-action-for-the-internet-2',
+    label: 'Action alerts to reclaim the internet',
+    slug: ['mozilla-foundation'],
+    ftlId: 'choose-newsletters-option-reclaim-the-internet',
   },
 ];

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -439,7 +439,7 @@ describe('Signup page', () => {
                 'security-privacy-news',
                 'mozilla-accounts',
                 'test-pilot',
-                'take-action-for-the-internet',
+                'mozilla-foundation',
               ],
               unwrapBKey: MOCK_UNWRAP_BKEY,
             },


### PR DESCRIPTION
Because:
* We want to update the newsletter option and slug displayed for new users

This commit:
* Replaces the desired newsletter name, slug, and FTL ID

closes FXA-9493

<img width="591" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/ce6325b3-5cca-48de-9037-5a18e650d0d0">
