### PR TITLE
Add `provision` back to docker building steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,6 +474,7 @@ jobs:
     steps:
       - checkout
       - cache-restore-yarn
+      - provision
       - setup_remote_docker:
           docker_layer_caching: true
       - run:


### PR DESCRIPTION
We're not sure what was going on with https://github.com/mozilla/fxa/commit/06c207480cf849539ad3f95c6dc25113c64cd39f but we think this is breaking stuff.

## Because
