### PR TITLE
fix(nx): update nxignore to include build folder

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -7,3 +7,4 @@
 **/storybook-static
 **/dist/**
 external/l10n
+**/build/**


### PR DESCRIPTION
## Because

- Nx is parsing build directories

## This pull request

- Update nxignore to ignore build directories

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional information

Reason for this change, is that while investigating an issue related to `fxa-payments-server` script `build-l10n`, it was identified that the script failed with the following error.

![image](https://github.com/mozilla/fxa/assets/10620585/03ab686d-f51c-41df-a762-1d8bb765eb90)
