### PR TITLE
feat(scripts): refactor delete unverified account script to support cloud scheduler

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2046,6 +2046,44 @@ const convictConf = convict({
     },
   },
   cloudTasks: CloudTasksConvictConfigFactory(),
+  cloudScheduler: {
+    oidc: {
+      aud: {
+        default: '',
+        doc: 'The audience value of the id token payload.',
+        env: `AUTH_CLOUDSCHEDULER_OIDC_AUD`,
+        format: String,
+      },
+      serviceAccountEmail: {
+        default: '',
+        doc: 'The GCP service account email address.',
+        env: `AUTH_CLOUDSCHEDULER_OIDC_EMAIL`,
+        format: String,
+      },
+    },
+    deleteUnverifiedAccounts: {
+      sinceDays: {
+        default: 15,
+        doc: 'The time since which unverified accounts should be deleted.',
+        env: `AUTH_CLOUDSCHEDULER_DELETE_UNVERIFIED_ACCOUNTS_SINCE_DAYS`,
+        format: Number,
+      },
+      durationDays: {
+        default: 15,
+        doc:
+          'The duration to delete accounts from the since day. For example, ' +
+          'if sinceDay is 15 and duration is 15, unverified accounts created ' +
+          'between 15 and 30 days ago will be deleted.',
+        env: `AUTH_CLOUDSCHEDULER_DELETE_UNVERIFIED_ACCOUNTS_DURATION_DAYS`,
+        format: Number,
+      },
+      taskLimit: {
+        default: 200,
+        env: `AUTH_CLOUDSCHEDULER_DELETE_UNVERIFIED_ACCOUNTS_TASK_LIMIT`,
+        format: Number,
+      },
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-auth-server/lib/routes/cloud-scheduler.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-scheduler.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ConfigType } from '../../config';
+import { AuthLogger, AuthRequest } from '../types';
+import { processDateRange } from '../../scripts/delete-unverified-accounts';
+import {
+  AccountTasks,
+  AccountTasksFactory,
+  ReasonForDeletion,
+} from '@fxa/shared/cloud-tasks';
+import { StatsD } from 'hot-shots';
+
+const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
+
+export class CloudSchedulerHandler {
+  private accountTasks: AccountTasks;
+
+  constructor(
+    private log: AuthLogger,
+    private config: ConfigType,
+    private statsd: StatsD
+  ) {
+    this.accountTasks = AccountTasksFactory(this.config, this.statsd);
+  }
+
+  private calculateDate(days: number): Date {
+    return new Date(Date.now() - days * MILLISECONDS_IN_A_DAY);
+  }
+
+  async deleteUnverifiedAccounts() {
+    const { sinceDays, durationDays, taskLimit } =
+      this.config.cloudScheduler.deleteUnverifiedAccounts;
+    const endDate = this.calculateDate(sinceDays);
+    const startDate = this.calculateDate(sinceDays + durationDays);
+    const reason = ReasonForDeletion.Unverified;
+
+    this.log.info('Deleting unverified accounts', {
+      initiatedAt: new Date().toISOString(),
+      endDate: endDate.toISOString(),
+      startDate: startDate.toISOString(),
+    });
+    this.statsd.increment('cloud-scheduler.deleteUnverifiedAccounts');
+    await processDateRange(
+      this.config,
+      this.accountTasks,
+      reason,
+      startDate.getTime(),
+      endDate.getTime(),
+      taskLimit
+    );
+
+    return {};
+  }
+}
+
+export const cloudSchedulerRoutes = (
+  log: AuthLogger,
+  config: ConfigType,
+  statsd: StatsD
+) => {
+  const cloudSchedulerHandler = new CloudSchedulerHandler(log, config, statsd);
+  return [
+    {
+      method: 'POST',
+      path: '/cloud-scheduler/accounts/deleteUnverified',
+      options: {
+        auth: {
+          strategy: 'cloudSchedulerOIDC',
+          payload: false,
+        },
+      },
+      handler: (request: AuthRequest) =>
+        cloudSchedulerHandler.deleteUnverifiedAccounts(),
+    },
+  ];
+};
+
+export default cloudSchedulerRoutes;

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -206,6 +206,9 @@ module.exports = function (
   const { cloudTaskRoutes } = require('./cloud-tasks');
   const cloudTasks = cloudTaskRoutes(log, config);
 
+  const { cloudSchedulerRoutes } = require('./cloud-scheduler');
+  const cloudScheduler = cloudSchedulerRoutes(log, config, statsd);
+
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {
     basePath = '';
@@ -229,7 +232,8 @@ module.exports = function (
     subscriptions,
     newsletters,
     linkedAccounts,
-    cloudTasks
+    cloudTasks,
+    cloudScheduler
   );
 
   function optionallyIgnoreTrace(fn) {

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -442,6 +442,12 @@ async function create(log, error, config, routes, db, statsd, glean) {
   );
   server.auth.strategy('cloudTasksOIDC', 'cloudTasksOIDC');
 
+  server.auth.scheme(
+    'cloudSchedulerOIDC',
+    googleOIDC.strategy(config.cloudScheduler.oidc)
+  );
+  server.auth.strategy('cloudSchedulerOIDC', 'cloudSchedulerOIDC');
+
   // register all plugins and Swagger configuration
   await server.register([
     {

--- a/packages/fxa-auth-server/test/local/routes/cloud-scheduler.js
+++ b/packages/fxa-auth-server/test/local/routes/cloud-scheduler.js
@@ -1,0 +1,74 @@
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
+import proxyquire from 'proxyquire';
+
+describe('CloudSchedulerHandler', function () {
+  this.timeout(10000);
+
+  let cloudSchedulerHandler;
+  let config;
+  let log;
+  let statsd;
+  let AccountTasksFactory;
+  let processDateRange;
+
+  beforeEach(() => {
+    config = {
+      cloudScheduler: {
+        deleteUnverifiedAccounts: {
+          sinceDays: 7,
+          durationDays: 7,
+          taskLimit: 1000,
+        },
+      },
+    };
+    log = {
+      info: sinon.stub(),
+    };
+    statsd = {
+      increment: sinon.stub(),
+    };
+    AccountTasksFactory = sinon.stub();
+    processDateRange = sinon.stub();
+
+    const { CloudSchedulerHandler } = proxyquire(
+      '../../../lib/routes/cloud-scheduler',
+      {
+        '../../scripts/delete-unverified-accounts': {
+          processDateRange,
+        },
+        '@fxa/shared/cloud-tasks': {
+          AccountTasksFactory,
+        },
+      }
+    );
+
+    cloudSchedulerHandler = new CloudSchedulerHandler(log, config, statsd);
+  });
+
+  describe('deleteUnverifiedAccounts', () => {
+    it('should call processDateRange with correct parameters', async () => {
+      const accountTasks = AccountTasksFactory(config, statsd);
+      const { sinceDays, durationDays, taskLimit } =
+        config.cloudScheduler.deleteUnverifiedAccounts;
+      const endDate = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+      const startDate = new Date(
+        endDate.getTime() - durationDays * 24 * 60 * 60 * 1000
+      );
+      const reason = ReasonForDeletion.Unverified;
+
+      await cloudSchedulerHandler.deleteUnverifiedAccounts();
+
+      assert.calledOnceWithExactly(
+        processDateRange,
+        config,
+        accountTasks,
+        reason,
+        startDate.getTime(),
+        endDate.getTime(),
+        taskLimit
+      );
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -830,5 +830,11 @@ function getConfig() {
         serviceAccountEmail: 'testo@iam.gcp.g.co',
       },
     },
+    cloudScheduler: {
+      oidc: {
+        aud: 'cloud-scheduler',
+        serviceAccountEmail: 'testo@iam.gcp.g.co',
+      },
+    },
   };
 }


### PR DESCRIPTION
## Because

- We want to automate removal of unverified accounts

## This pull request

- Creates a new endpoint to delete unverified accounts via google cloud scheduler

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9257

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We need to update our deploy doc to add new environment variables and to have google cloud scheduler service accounts created.
