### PR TITLE
fix(fxa-settings): Fix visibility of Apple password icon in password input

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -276,11 +276,16 @@ export const FormPasswordWithBalloons = ({
   return (
     <>
       <form {...{ onSubmit }} className="flex flex-col">
-        {/* Hidden email field is to allow Fx password manager
-           to correctly save the updated password. Without it,
-           the password manager tries to save the old password
-           as the username. */}
-        <input type="email" value={email} className="hidden" readOnly />
+        {/* Hidden email field is to help password managers
+           correctly associate the email and password. Without this,
+           password managers may try to use another field as username */}
+        <input
+          type="email"
+          value={email}
+          className="hidden"
+          autoComplete="username"
+          readOnly
+        />
 
         <div className="relative mb-4" aria-atomic="true">
           <FtlMsg id={templateValues.passwordFtlId} attrs={{ label: true }}>

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -67,6 +67,7 @@ export const InputPassword = ({
         autoComplete="off"
         spellCheck={false}
         aria-describedby=""
+        isPasswordInput={true}
         {...{
           defaultValue,
           disabled,

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -38,6 +38,7 @@ export type InputTextProps = {
   inputMode?: 'text' | 'numeric' | 'tel' | 'email';
   required?: boolean;
   tooltipPosition?: 'top' | 'bottom';
+  isPasswordInput?: boolean;
 };
 
 export const InputText = ({
@@ -66,6 +67,7 @@ export const InputText = ({
   inputMode,
   required,
   tooltipPosition,
+  isPasswordInput = false,
 }: InputTextProps) => {
   const [focused, setFocused] = useState<boolean>(false);
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
@@ -132,7 +134,10 @@ export const InputText = ({
         <input
           className={classNames(
             inputOnlyClassName,
-            'pb-1 pt-5 px-3 w-full font-body rounded text-start',
+            'pb-1 pt-5 px-3 font-body rounded text-start',
+            // password specific width is to accomodate password manager icons
+            // that are otherwise hidden and inaccessible under the visibility icon
+            isPasswordInput ? 'w-[90%]' : 'w-full',
             focused ? 'outline-none border-none placeholder-grey-500' : '',
             disabled ? 'bg-grey-10 placeholder-transparent cursor-default' : ''
           )}


### PR DESCRIPTION
## Because

* Apple keychain's password suggestion button was hidden under the password visibility icon in React password inputs

## This pull request

* Adjust styling in the password input to show and enable Apple's password button
* Add autoComplete=username to the signup email input to allow correct email/password association for password managers

## Issue that this pull request solves

Closes: #FXA-9422

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://github.com/mozilla/fxa/assets/22231637/b92047c5-80f9-49be-96dc-95afef6c4dce)

After:
Note - The vertical alignment is a bit tricky because of the input's current design with nested label - opted for minimally functional fix here since we are planning to update the design in https://mozilla-hub.atlassian.net/browse/FXA-9349
![Screenshot 2024-05-01 at 2 15 40 PM](https://github.com/mozilla/fxa/assets/22231637/999b68b7-6d95-4b20-88f6-5062efa01c29)

## Other information (Optional)

To test - use **Safari on MacOS** to sign up and sign in to an account with React experiment params 
(http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react)

Use Apple's password manager tool to suggest and save the password, then use it to sign in
