### PR TITLE
chore(metrics): add definitions of internal Glean metrics for better events ping support

### DIFF
--- a/packages/fxa-shared/metrics/glean/glean-backend-metrics-compat.yaml
+++ b/packages/fxa-shared/metrics/glean/glean-backend-metrics-compat.yaml
@@ -1,0 +1,106 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# These metrics are included for telemetry ingestion pipeline compatibility
+# reasons. They are not used here and will be removed in the future.
+# For details, see https://bugzilla.mozilla.org/show_bug.cgi?id=1874935#c14
+
+---
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+glean.client.annotation:
+  experimentation_id:
+    type: string
+    lifetime: application
+    send_in_pings:
+      - accounts-events
+    description: |
+      An experimentation identifier derived and provided by the application
+      for the purpose of experimentation enrollment.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848201#c5
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+
+glean.error:
+  invalid_value:
+    type: labeled_counter
+    description: |
+      Counts the number of times a metric was set to an invalid value.
+      The labels are the `category.name` identifier of the metric.
+    bugs:
+      - https://bugzilla.mozilla.org/1499761
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    send_in_pings:
+      - accounts-events
+    no_lint:
+      - COMMON_PREFIX
+
+  invalid_label:
+    type: labeled_counter
+    description: |
+      Counts the number of times a metric was set with an invalid label.
+      The labels are the `category.name` identifier of the metric.
+    bugs:
+      - https://bugzilla.mozilla.org/1499761
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    send_in_pings:
+      - accounts-events
+    no_lint:
+      - COMMON_PREFIX
+
+  invalid_state:
+    type: labeled_counter
+    description: |
+      Counts the number of times a timing metric was used incorrectly.
+      The labels are the `category.name` identifier of the metric.
+    bugs:
+      - https://bugzilla.mozilla.org/1566380
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1499761#c5
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    send_in_pings:
+      - accounts-events
+    no_lint:
+      - COMMON_PREFIX
+
+  invalid_overflow:
+    type: labeled_counter
+    description: |
+      Counts the number of times a metric was set a value that overflowed.
+      The labels are the `category.name` identifier of the metric.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1591912
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1591912#c3
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - glean-team@mozilla.com
+    expires: never
+    send_in_pings:
+      - accounts-events
+    no_lint:
+      - COMMON_PREFIX


### PR DESCRIPTION
## Because

- This is a follow up to https://github.com/mozilla/fxa/pull/16298 - in order for ingestion pipeline to correctly parse `accounts-events` ping after adding `events` ping, we need to add some internal metrics definitions here so probe-scraper can pick them up.

## This pull request

- Adds definitions of internal Glean metrics to unblock BQ table generation in the ingestion pipeline.

## Issue that this pull request solves

Closes: https://bugzilla.mozilla.org/show_bug.cgi?id=1874935#c14

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
