### PR TITLE
test(functional-tests): add fixmes to oauthsignin.spec.ts

### DIFF
--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -20,7 +20,12 @@ test.describe('severity-1 #smoke', () => {
     test('verified account, no email confirmation required', async ({
       pages: { page, relier, signinReact },
       testAccountTracker,
-    }) => {
+    }, { project }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/04/26 (see FXA-9518).'
+      );
+
       const credentials = await testAccountTracker.signUp();
 
       await relier.goto();
@@ -43,7 +48,7 @@ test.describe('severity-1 #smoke', () => {
     }, { project }) => {
       test.fixme(
         project.name !== 'local',
-        'FXA-9518 - Timing issues? Fails on stage with `Bad request - unknown state` on L54 and L74, unless breakpoint added on L53 and L72. Passes when restarting from breakpoint.'
+        'Fix required as of 2024/04/26 (see FXA-9518).'
       );
 
       const credentials = await testAccountTracker.signUp();
@@ -85,7 +90,11 @@ test.describe('severity-1 #smoke', () => {
     test('verified using a cached expired login', async ({
       pages: { page, relier, signinReact },
       testAccountTracker,
-    }) => {
+    }, { project }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/04/26 (see FXA-9518).'
+      );
       const credentials = await testAccountTracker.signUp();
 
       await relier.goto();

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -65,7 +65,7 @@ test.describe('severity-1 #smoke', () => {
     const config = await configPage.getConfig();
     test.fixme(
       project.name !== 'local',
-      'FXA-9518 - Timing issue? Fails on stage with `Bad request - unknown state` on L86, unless breakpoint added on L85. Passes when restarting from breakpoint. '
+      'Fix required as of 2024/04/26 (see FXA-9518).'
     );
     test.skip(
       config.showReactApp.signInRoutes !== true,


### PR DESCRIPTION
## Because

- We want to minimize disruption in the CI and have high trust in test results

## This pull request

- adds fixme annotations to additional impacted tests in oauthSignin.spec.ts

## Issue that this pull request solves

Relates to: #FXA-9518

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

- I've opted to shorten the descriptions in the fixme annotation, in favor of adding details to the JIRA task. Certain details, including line numbers, are likely to evolve and imo this reduces the maintenance required on comments.
