### PR TITLE
feat(react): Add react navigate hook to automatically set query params on navigate

### DIFF
--- a/packages/functional-tests/tests/misc/keyStretchingV2.spec.ts
+++ b/packages/functional-tests/tests/misc/keyStretchingV2.spec.ts
@@ -187,9 +187,7 @@ test.describe('key-stretching-v2', () => {
 
       if (mode === 'react') {
         await settings.signOut();
-        await page.goto(
-          `${target.contentServerUrl}/reset_password?showReactApp=true&forceExperiment=generalizedReactApp&forceExperimentGroup=react&${stretch}`
-        );
+        await page.goto(`${target.contentServerUrl}/reset_password?${stretch}`);
         await page.waitForSelector('#root');
         await resetPasswordReact.fillOutEmailForm(email);
         const link =
@@ -197,7 +195,7 @@ test.describe('key-stretching-v2', () => {
             email,
             EmailType.recovery,
             EmailHeader.link
-          )) + `&showReactApp=true&${stretch}`;
+          )) + `&${stretch}`;
         await page.goto(link);
         await page.waitForSelector('#root');
 

--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -7,19 +7,40 @@ import { Message, Pattern } from '@fluent/bundle/esm/ast';
 import { Localized, LocalizedProps, ReactLocalization } from '@fluent/react';
 import React from 'react';
 
-// Going from react page to non-react page requires a hard navigate. This temporary
-// function is an easy way to reference what needs updating when applicable flows have
-// been fully converted - we should remove references to this function as we go and use
-// our regular navigate. We can remove this entirely when we're fully converted to React.
-export function hardNavigateToContentServer(href: string) {
-  window.location.href = href;
-}
-
 // There maybe situations where we are navigating away from the react app. For example when
-// directing back to an RP. Let's use this function to make it clear this behavior is
+// directing back to an RP or the content-server. Let's use this function to make it clear this behavior is
 // intentional.
-export function hardNavigate(href: string) {
-  window.location.href = href;
+export function hardNavigate(
+  href: string,
+  additionalQueryParams = {},
+  includeCurrentQueryParams = false
+) {
+  // If there are any query params in the href, we automatically include them in the new url.
+  let searchParams = new URLSearchParams();
+  if (href.includes('?')) {
+    searchParams = new URLSearchParams(href.substring(href.indexOf('?')));
+  }
+
+  if (includeCurrentQueryParams) {
+    const currentSearchParams = new URLSearchParams(window.location.search);
+    currentSearchParams.forEach((value, key) => {
+      if (!searchParams.has(key)) {
+        searchParams.append(key, value);
+      }
+    });
+  }
+
+  if (additionalQueryParams) {
+    const additionalSearchParams = new URLSearchParams(additionalQueryParams);
+    additionalSearchParams.forEach((value, key) => {
+      searchParams.append(key, value);
+    });
+  }
+
+  if (href.includes('?')) {
+    href = href.substring(0, href.indexOf('?'));
+  }
+  window.location.href = `${href}?${searchParams.toString()}`;
 }
 
 export enum LocalizedDateOptions {

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -239,7 +239,7 @@ describe('loading spinner states', () => {
 });
 
 describe('SettingsRoutes', () => {
-  let hardNavigateToContentServerSpy: jest.SpyInstance;
+  let hardNavigateSpy: jest.SpyInstance;
   const settingsPath = '/settings';
   jest.mock('@reach/router', () => ({
     ...jest.requireActual('@reach/router'),
@@ -251,8 +251,8 @@ describe('SettingsRoutes', () => {
   }));
 
   beforeEach(() => {
-    hardNavigateToContentServerSpy = jest
-      .spyOn(utils, 'hardNavigateToContentServer')
+    hardNavigateSpy = jest
+      .spyOn(utils, 'hardNavigate')
       .mockImplementation(() => {});
     (useInitialMetricsQueryState as jest.Mock).mockReturnValue({
       loading: false,
@@ -263,7 +263,7 @@ describe('SettingsRoutes', () => {
     });
   });
   afterEach(() => {
-    hardNavigateToContentServerSpy.mockRestore();
+    hardNavigateSpy.mockRestore();
   });
   it('redirects to /signin if isSignedIn is false', async () => {
     (useLocalSignedInQueryState as jest.Mock).mockReturnValueOnce({
@@ -292,7 +292,7 @@ describe('SettingsRoutes', () => {
     await act(() => navigateResult);
 
     await waitFor(() => {
-      expect(hardNavigateToContentServerSpy).toHaveBeenCalledWith(
+      expect(hardNavigateSpy).toHaveBeenCalledWith(
         `/?redirect_to=${encodeURIComponent(settingsPath)}`
       );
     });
@@ -331,7 +331,7 @@ describe('SettingsRoutes', () => {
     await act(() => navigateResult);
 
     await waitFor(() => {
-      expect(hardNavigateToContentServerSpy).not.toHaveBeenCalled();
+      expect(hardNavigateSpy).not.toHaveBeenCalled();
     });
     expect(screen.getByTestId('settings-profile')).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -35,7 +35,7 @@ import {
 } from '../../models/contexts/SettingsContext';
 import { CreateCompleteResetPasswordLink } from '../../models/reset-password/verification/factory';
 
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 
 import sentryMetrics from 'fxa-shared/sentry/browser';
 
@@ -223,7 +223,7 @@ const SettingsRoutes = ({
     const params = new URLSearchParams(location.search);
     params.set('redirect_to', location.pathname);
     const path = `/?${params.toString()}`;
-    hardNavigateToContentServer(path);
+    hardNavigate(path);
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/components/FormPassword/index.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.tsx
@@ -11,7 +11,7 @@ import { UseFormMethods, ValidateResult } from 'react-hook-form';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import InputPassword from '../InputPassword';
 import PasswordValidator from '../../lib/password-validator';
-import { useNavigate } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import { HomePath } from '../../constants';
 import { logViewEvent, settingsViewName } from '../../lib/metrics';
 

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/LinkedAccount.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/LinkedAccount.tsx
@@ -10,7 +10,8 @@ import { ReactComponent as AppleIcon } from './apple.svg';
 import { Modal } from '../Modal';
 import { useAccount, useFtlMsgResolver } from '../../../models';
 import { useBooleanState } from 'fxa-react/lib/hooks';
-import { useLocation, useNavigate } from '@reach/router';
+import { useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { HomePath } from '../../../constants';
 import {
   LinkedAccountProviderIds,

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/buttons.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useRef } from 'react';
 
-import { useNavigate } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { Localized, useLocalization } from '@fluent/react';
 import { useAccount, useAlertBar } from '../../../models';
 import { HomePath } from '../../../constants';

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { Localized, useLocalization } from '@fluent/react';
 import Webcam from 'react-webcam';
 import Cropper, { Area } from 'react-easy-crop';

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
@@ -4,7 +4,8 @@
 
 import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { HomePath } from '../../../constants';
 import {
   logViewEvent,

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Localized } from '@fluent/react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { HomePath } from '../../../constants';

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -4,7 +4,8 @@
 
 import React, { useCallback, useState, ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { useAccount, useAlertBar } from '../../../models';
 import InputPassword from '../../InputPassword';
 import FlowContainer from '../FlowContainer';
@@ -29,7 +30,7 @@ import {
   AuthUiErrors,
   getErrorFtlId,
 } from '../../../lib/auth-errors/auth-errors';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 
 type FormData = {
@@ -146,7 +147,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
           'flow.settings.account-delete',
           'confirm-password.success'
         );
-        hardNavigateToContentServer(`${ROOTPATH}?delete_account_success=true`);
+        hardNavigate(ROOTPATH, { delete_account_success: true }, true);
       } catch (e) {
         const localizedError = l10n.getString(
           getErrorFtlId(AuthUiErrors.INCORRECT_PASSWORD),

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
@@ -15,6 +15,17 @@ import { HomePath } from '../../../constants';
 import { Account, AppContext } from '../../../models';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
 
+let mockLocationState = {};
+const mockLocation = () => {
+  return {
+    state: mockLocationState,
+  };
+};
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useLocation: () => mockLocation(),
+}));
+
 jest.mock('../../../models/AlertBarInfo');
 const inputDisplayName = async (newName: string) => {
   await act(async () => {
@@ -71,7 +82,7 @@ it('navigates back to settings home and shows a success message on a successful 
     success: jest.fn(),
   } as any;
   const settingsContext = mockSettingsContext({ alertBarInfo });
-  renderWithRouter(
+  const { history } = renderWithRouter(
     <AppContext.Provider value={mockAppContext({ account })}>
       <SettingsContext.Provider value={settingsContext}>
         <PageDisplayName />
@@ -79,7 +90,7 @@ it('navigates back to settings home and shows a success message on a successful 
     </AppContext.Provider>
   );
   await submitDisplayName('John Hope');
-  expect(window.location.pathname).toBe(HomePath);
+  expect(history.location.pathname).toBe(HomePath);
   expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
   expect(alertBarInfo.success).toHaveBeenCalledWith('Display name updated');
 });

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from 'react';
-import { navigate, RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
 import InputText from '../../InputText';
@@ -19,7 +20,8 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const account = useAccount();
   const alertBar = useAlertBar();
   const { l10n } = useLocalization();
-  const goHome = () => navigate(HomePath + '#display-name', { replace: true });
+  const navigate = useNavigate();
+  const goHome = () => navigate(HomePath, { replace: true });
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
       l10n.getString(
@@ -28,8 +30,8 @@ export const PageDisplayName = (_: RouteComponentProps) => {
         'Display name updated'
       )
     );
-    navigate(HomePath + '#display-name', { replace: true });
-  }, [alertBar, l10n]);
+    navigate(HomePath, { replace: true });
+  }, [alertBar, l10n, navigate]);
   const initialValue = account.displayName || '';
   const { register, handleSubmit, formState, trigger } = useForm<{
     displayName: string;

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { HomePath } from '../../../constants';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { useAccount, useFtlMsgResolver } from '../../../models';
@@ -23,7 +24,6 @@ export enum RecoveryKeyAction {
 
 export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   usePageViewEvent(viewName);
-  const location = useLocation();
 
   const { recoveryKey, email } = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -48,7 +48,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   );
 
   const navigateBackward = () => {
-    navigate(`${HomePath}${location.search}`);
+    navigate(HomePath);
   };
 
   const navigateForward = (e?: React.MouseEvent<HTMLElement>) => {
@@ -56,7 +56,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
     if (currentStep + 1 <= numberOfSteps) {
       setCurrentStep(currentStep + 1);
     } else {
-      navigate(`${HomePath}${location.search}`);
+      navigate(HomePath);
     }
   };
 

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { Localized, useLocalization } from '@fluent/react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { HomePath } from '../../../constants';
 import InputText from '../../InputText';

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Localized, useLocalization } from '@fluent/react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { HomePath } from '../../../constants';
 import { logViewEvent } from '../../../lib/metrics';
 import { useAccount, useAlertBar } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
 import InputText from '../../InputText';

--- a/packages/fxa-settings/src/components/Settings/ScrollToTop/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ScrollToTop/index.tsx
@@ -4,7 +4,8 @@
 
 // See https://github.com/reach/router/issues/242 for a discussion
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { useCallback, useLayoutEffect } from 'react';
 
 export const ScrollToTop = (

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ReactNode, useCallback, useState } from 'react';
-import { useNavigate } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { useAccount, Email, useAlertBar } from '../../../models';
 import UnitRow from '../UnitRow';
 import ModalVerifySession from '../ModalVerifySession';

--- a/packages/fxa-settings/src/lib/hooks/useNavigateWithQuery/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useNavigateWithQuery/index.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useNavigate, NavigateOptions } from '@reach/router';
+
+export function useNavigateWithQuery() {
+  const navigate = useNavigate();
+
+  return (to: string, options?: NavigateOptions<{}>) => {
+    const location = window.location;
+    let path = to;
+
+    if (to.includes('?')) {
+      path = to;
+    } else if (location.search) {
+      path = `${to}${location.search}`;
+    }
+
+    if (location.hash) {
+      path = `${path}${location.hash}`;
+    }
+
+    if (options) {
+      return navigate(path, options);
+    }
+
+    return navigate(path);
+  };
+}

--- a/packages/fxa-settings/src/lib/hooks/useNavigateWithoutRerender/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useNavigateWithoutRerender/index.tsx
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useNavigate, NavigateOptions } from '@reach/router';
+import { NavigateOptions } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+
 import { useCallback } from 'react';
 
 /*

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useMutation, useQuery } from '@apollo/client';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState } from 'react';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -37,7 +37,6 @@ const mockLocationHook = (
 const mockNavigateHook = jest.fn();
 jest.mock('@reach/router', () => {
   return {
-    __esModule: true,
     ...jest.requireActual('@reach/router'),
     useNavigate: () => mockNavigateHook,
     useLocation: () => mockLocationHook(),

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState } from 'react';
 import InlineTotpSetup from '.';

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect } from 'react';
-import { Link, useNavigate } from '@reach/router';
+import { Link } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { usePageViewEvent } from '../../../lib/metrics';

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -3,12 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect } from 'react';
-import {
-  FtlMsg,
-  hardNavigate,
-  hardNavigateToContentServer,
-} from 'fxa-react/lib/utils';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import AppLayout from '../../../components/AppLayout';
 import { AUTH_PROVIDER } from 'fxa-auth-client/browser';
@@ -111,7 +108,7 @@ const ThirdPartyAuthCallback = ({
           // currently, redirect to /settings fails with an "unauthenticated" error from GQL
           // and redirects to /signin (on backbone) where ThirdPArty Auth successfully
           // navigates to /settings
-          navigate(`/settings${window.location.search}`);
+          navigate('/settings');
         }
       }
     }
@@ -158,7 +155,7 @@ const ThirdPartyAuthCallback = ({
     } else {
       // TODO validate what should happen if we hit this page
       // without the required auth params to verify the account
-      hardNavigateToContentServer('/');
+      hardNavigate('/');
     }
   }
 

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Link, useLocation, useNavigate } from '@reach/router';
+import { Link, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { logPageViewEvent, logViewEvent } from '../../../lib/metrics';
@@ -118,7 +119,7 @@ const AccountRecoveryConfirmKey = ({
         uid
       );
 
-      navigate(`/account_recovery_reset_password${window.location.search}`, {
+      navigate('/account_recovery_reset_password', {
         state: {
           accountResetToken,
           recoveryKeyId,

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -313,9 +313,7 @@ describe('AccountRecoveryResetPassword page', () => {
   it('navigates as expected without totp', async () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        `/reset_password_with_recovery_key_verified?${new URLSearchParams(
-          MOCK_SEARCH_PARAMS
-        ).toString()}`
+        `/reset_password_with_recovery_key_verified`
       );
     });
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useLocation, useNavigate } from '@reach/router';
+import { useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useForm } from 'react-hook-form';
 
@@ -255,7 +256,7 @@ const AccountRecoveryResetPassword = ({
   async function navigateAway() {
     setUserPreference('account-recovery', false);
     logViewEvent(viewName, 'recovery-key-consume.success');
-    navigate(`/reset_password_with_recovery_key_verified${location.search}`);
+    navigate('/reset_password_with_recovery_key_verified');
   }
 };
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -408,7 +408,7 @@ describe('CompleteResetPassword page', () => {
     });
 
     describe('Web integration', () => {
-      // Not needed once this page doesn't use `hardNavigateToContentServer`
+      // Not needed once this page doesn't use `hardNavigate`
       const originalWindow = window.location;
       beforeAll(() => {
         // @ts-ignore

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useState } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { POLLING_INTERVAL_MS, REACT_ENTRYPOINT } from '../../../constants';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ResendStatus } from '../../../lib/types';
@@ -18,7 +19,7 @@ import ConfirmWithLink, {
   ConfirmWithLinkPageStrings,
 } from '../../../components/ConfirmWithLink';
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import { setOriginalTabMarker } from '../../../lib/storage-utils';
 import {
   ConfirmResetPasswordIntegration,
@@ -58,7 +59,7 @@ const ConfirmResetPassword = ({
     useState<string>(passwordForgotToken);
 
   const navigateToPasswordReset = useCallback(() => {
-    navigate('reset_password?showReactApp=true', { replace: true });
+    navigate('reset_password', { replace: true });
   }, [navigate]);
 
   if (!email || !passwordForgotToken) {
@@ -73,7 +74,7 @@ const ConfirmResetPassword = ({
         currentPasswordForgotToken
       );
       if (!isValid) {
-        hardNavigateToContentServer('/signin');
+        hardNavigate('/signin', {}, false);
       } else {
         // TODO: Not sure about this. It works with the flow... but.
         setOriginalTabMarker();

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import Ready from '../../../components/Ready';

--- a/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.test.tsx
@@ -167,16 +167,13 @@ describe('PageResetPassword', () => {
       {}
     );
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/confirm_reset_password?showReactApp=true',
-      {
-        replace: true,
-        state: {
-          email: 'johndope@example.com',
-          passwordForgotToken: '123',
-        },
-      }
-    );
+    expect(mockNavigate).toHaveBeenCalledWith('/confirm_reset_password', {
+      replace: true,
+      state: {
+        email: 'johndope@example.com',
+        passwordForgotToken: '123',
+      },
+    });
   });
 
   it('submit success with trailing space in email', async () => {
@@ -204,16 +201,13 @@ describe('PageResetPassword', () => {
         { flowId: '00ff' }
       );
 
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/confirm_reset_password?showReactApp=true',
-        {
-          replace: true,
-          state: {
-            email: 'johndope@example.com',
-            passwordForgotToken: '123',
-          },
-        }
-      );
+      expect(mockNavigate).toHaveBeenCalledWith('/confirm_reset_password', {
+        replace: true,
+        state: {
+          email: 'johndope@example.com',
+          passwordForgotToken: '123',
+        },
+      });
     });
   });
 
@@ -238,16 +232,13 @@ describe('PageResetPassword', () => {
         { flowId: '00ff' }
       );
 
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/confirm_reset_password?showReactApp=true',
-        {
-          replace: true,
-          state: {
-            email: 'johndope@example.com',
-            passwordForgotToken: '123',
-          },
-        }
-      );
+      expect(mockNavigate).toHaveBeenCalledWith('/confirm_reset_password', {
+        replace: true,
+        state: {
+          email: 'johndope@example.com',
+          passwordForgotToken: '123',
+        },
+      });
     });
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
+
 import React, { useCallback, useEffect, useState } from 'react';
 import { Control, useForm, useWatch } from 'react-hook-form';
 import { REACT_ENTRYPOINT } from '../../constants';
@@ -49,7 +51,6 @@ const ResetPassword = ({
   const account = useAccount();
   const navigate = useNavigate();
   const ftlMsgResolver = useFtlMsgResolver();
-  const location = useLocation();
 
   // NOTE: This was previously part of the persistVerificationData. Let's keep these operations atomic in the new version though.
   setOriginalTabMarker();
@@ -86,14 +87,12 @@ const ResetPassword = ({
 
   const navigateToConfirmPwReset = useCallback(
     (stateData: ConfirmResetPasswordLocationState) => {
-      const searchParams = new URLSearchParams(location.search);
-      searchParams.set('showReactApp', 'true');
-      navigate(`/confirm_reset_password?${searchParams}`, {
+      navigate('/confirm_reset_password', {
         state: stateData,
         replace: true,
       });
     },
-    [location, navigate]
+    [navigate]
   );
 
   const clearError = useCallback(() => {

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.test.tsx
@@ -32,9 +32,7 @@ function mockUseValidateModule() {
 }
 
 function mockReactUtilsModule() {
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
 const mockNavigate = jest.fn();
@@ -85,8 +83,10 @@ describe('CompleteSignin container', () => {
 
       expect(screen.getByText('Validating sign-in…')).toBeInTheDocument();
       await waitFor(() => {
-        expect(ReactUtils.hardNavigateToContentServer).toHaveBeenCalledWith(
-          '/connect_another_device'
+        expect(ReactUtils.hardNavigate).toHaveBeenCalledWith(
+          '/connect_another_device',
+          {},
+          true
         );
       });
     });
@@ -113,7 +113,7 @@ describe('CompleteSignin container', () => {
         expect(
           screen.getByRole('heading', { name: 'Confirmation link expired' })
         ).toBeInTheDocument();
-        expect(ReactUtils.hardNavigateToContentServer).not.toHaveBeenCalled();
+        expect(ReactUtils.hardNavigate).not.toHaveBeenCalled();
       });
     });
   });
@@ -133,7 +133,7 @@ describe('CompleteSignin container', () => {
       expect(screen.getByText('Validating sign-in…')).toBeInTheDocument();
       await waitFor(() => {
         expect(screen.getByText('Unexpected error')).toBeInTheDocument();
-        expect(ReactUtils.hardNavigateToContentServer).not.toHaveBeenCalled();
+        expect(ReactUtils.hardNavigate).not.toHaveBeenCalled();
       });
     });
   });
@@ -155,7 +155,7 @@ describe('CompleteSignin container', () => {
       );
 
       await waitFor(() => {
-        expect(ReactUtils.hardNavigateToContentServer).not.toHaveBeenCalled();
+        expect(ReactUtils.hardNavigate).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useState } from 'react';
-import { RouteComponentProps, useLocation } from '@reach/router';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { RouteComponentProps } from '@reach/router';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { CompleteSigninQueryParams } from '../../../models/pages/signin';
 import { SigninLinkDamaged } from '../../../components/LinkDamaged';
@@ -29,7 +29,6 @@ const CompleteSigninContainer = (_: RouteComponentProps) => {
 
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
-  const location = useLocation();
 
   const [errorMessage, setErrorMessage] = useState<string>();
   const [linkExpired, setLinkExpired] = useState(false);
@@ -75,7 +74,7 @@ const CompleteSigninContainer = (_: RouteComponentProps) => {
     // TODO in FXA-9132 - Add metrics event
     // Backbone had 'verification.success' and 'signin.success';
 
-    hardNavigateToContentServer(`/connect_another_device${location.search}`);
+    hardNavigate('/connect_another_device', {}, true);
   };
 
   if (validationError) {

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useState } from 'react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import { ReportSigninQueryParams } from '../../../models/pages/signin';

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
@@ -10,11 +10,14 @@ import { MOCK_ACCOUNT, renderWithRouter } from '../../../models/mocks';
 import SigninBounced, { viewName } from '.';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
+import * as utils from '../../../../../fxa-react/lib/utils';
+import * as ReactUtils from '../../../../../fxa-react/lib/utils';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
 }));
+let hardNavigateSpy: jest.SpyInstance;
 
 describe('SigninBounced', () => {
   // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
@@ -24,21 +27,10 @@ describe('SigninBounced', () => {
   //   bundle = await getFtlBundle('settings');
   // });
 
-  // Not needed once this page doesn't use `hardNavigateToContentServer`
-  const originalWindow = window.location;
-
-  beforeAll(() => {
-    // @ts-ignore
-    delete window.location;
-    window.location = { ...originalWindow, href: '' };
-  });
-
   beforeEach(() => {
-    window.location.href = originalWindow.href;
-  });
-
-  afterAll(() => {
-    window.location = originalWindow;
+    hardNavigateSpy = jest
+      .spyOn(ReactUtils, 'hardNavigate')
+      .mockImplementationOnce(() => {});
   });
 
   it('renders default content as expected', () => {
@@ -78,8 +70,8 @@ describe('SigninBounced', () => {
     );
   });
 
-  it('pushes the user to the /signin page if there is no email address available', () => {
+  it('pushes the user to the / page if there is no email address available', () => {
     renderWithRouter(<SigninBounced />);
-    expect(window.location.href).toBe('/signin');
+    expect(hardNavigateSpy).toHaveBeenCalledWith('/', {}, true);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react';
 import { RouteComponentProps /*useNavigate*/ } from '@reach/router';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ReactComponent as EmailBounced } from './graphic_email_bounced.svg';
-import { FtlMsg, hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
 
 import AppLayout from '../../../components/AppLayout';
@@ -44,7 +44,7 @@ const SigninBounced = ({
 
   useEffect(() => {
     if (!email) {
-      hardNavigateToContentServer('/signin');
+      hardNavigate('/', {}, true);
     }
   }, [email]);
 
@@ -52,7 +52,7 @@ const SigninBounced = ({
     logViewEvent(viewName, 'link.create-account', REACT_ENTRYPOINT);
     localStorage.removeItem('__fxa_storage.accounts');
     sessionStorage.clear();
-    hardNavigateToContentServer('/signup');
+    hardNavigate('/signup', {}, true);
   };
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
@@ -73,9 +73,6 @@ function mockCache(opts: any = {}, isEmpty = false) {
 }
 
 function mockReactUtilsModule() {
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
   jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
@@ -138,21 +135,21 @@ describe('SigninRecoveryCode container', () => {
       mockReachRouter(undefined, 'signin_recovery_code');
       mockCache({}, true);
       await render([]);
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
     });
 
     it('redirects if there is no sessionToken', async () => {
       mockReachRouter(undefined, 'signin_recovery_code');
       mockCache({ sessionToken: '' });
       await render([]);
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
     });
 
     it('retrieves the session token from local storage if no location state', async () => {
       mockReachRouter(undefined, 'signin_recovery_code', {});
       mockCache(MOCK_STORED_ACCOUNT);
       await render([]);
-      expect(ReactUtils.hardNavigateToContentServer).not.toBeCalledWith('/');
+      expect(ReactUtils.hardNavigate).not.toBeCalledWith('/', {}, true);
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import { MozServices } from '../../../lib/types';
 import SigninRecoveryCode from '.';
 import { Integration, useAuthClient } from '../../../models';
@@ -69,7 +69,7 @@ export const SigninRecoveryCodeContainer = ({
   }
 
   if (!signinState) {
-    hardNavigateToContentServer(`/${location.search}`);
+    hardNavigate('/', {}, true);
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -73,9 +73,6 @@ function mockSigninTokenCodeModule() {
 }
 
 function mockReactUtilsModule() {
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
   jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
@@ -162,7 +159,7 @@ describe('SigninTokenCode container', () => {
         mockLocationState = {};
         render();
         expect(CacheModule.currentAccount).toBeCalled();
-        expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+        expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
         expect(SigninTokenCodeModule.default).not.toBeCalled();
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { TotpStatusResponse } from './interfaces';
 import SigninTokenCode from '.';
 import { useQuery } from '@apollo/client';
 import { GET_TOTP_STATUS } from '../../../components/App/gql';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import { Integration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { SigninLocationState } from '../interfaces';
@@ -41,7 +42,7 @@ const SigninTokenCodeContainer = ({
     useQuery<TotpStatusResponse>(GET_TOTP_STATUS);
 
   if (!signinState) {
-    hardNavigateToContentServer(`/${location.search || ''}`);
+    hardNavigate('/', {}, true);
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -74,9 +74,6 @@ function render(
 }
 
 function mockReactUtilsModule() {
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
   jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -76,9 +76,6 @@ function mockCache(opts: any = {}, isEmpty = false) {
 }
 
 function mockReactUtilsModule() {
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
   jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
@@ -193,20 +190,20 @@ describe('signin totp code container', () => {
     mockReachRouter();
     mockCache({}, true);
     await render(false);
-    expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+    expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
   });
 
   it('redirects if there is no sessionToken', async () => {
     mockReachRouter();
     mockCache({ sessionToken: '' });
     await render(false);
-    expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+    expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
   });
 
   it('redirects if verification method is not totp', async () => {
     mockReachRouter(MOCK_NON_TOTP_LOCATION_STATE);
     await render(false);
-    expect(ReactUtils.hardNavigateToContentServer).toBeCalledTimes(1);
-    expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+    expect(ReactUtils.hardNavigate).toBeCalledTimes(1);
+    expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -14,7 +14,7 @@ import { getSigninState, getHandledError } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { Integration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
 
@@ -75,7 +75,7 @@ export const SigninTotpCodeContainer = ({
     (signinState.verificationMethod &&
       signinState.verificationMethod !== VerificationMethods.TOTP_2FA)
   ) {
-    hardNavigateToContentServer(`/${location.search ? location.search : ''}`);
+    hardNavigate('/', {}, true);
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -41,7 +41,7 @@ import {
   SigninUnblockLocationState,
 } from './interfaces';
 import { getHandledError } from '../utils';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { MozServices } from '../../../lib/types';
 import { QueryParams } from '../../..';
@@ -159,7 +159,7 @@ const SigninUnblockContainer = ({
   }
 
   if (!email || !password) {
-    hardNavigateToContentServer('/');
+    hardNavigate('/', {}, true);
     return <LoadingSpinner fullScreen />;
   }
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -5,7 +5,8 @@
 import React, { useState } from 'react';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import CardHeader from '../../../components/CardHeader';
 import AppLayout from '../../../components/AppLayout';
@@ -150,7 +151,7 @@ const SigninUnblock = ({
       );
       switch (error.errno) {
         case AuthUiErrors.INCORRECT_PASSWORD.errno:
-          navigate(`/signin${location.search}`, {
+          navigate(`/signin`, {
             state: {
               email,
               // TODO: in FXA-9177, retrieve hasLinkedAccount and hasPassword from Apollo cache

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -193,7 +193,7 @@ function mockSigninModule() {
 
 function mockReactUtilsModule() {
   jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
+    .spyOn(ReactUtils, 'hardNavigate')
     .mockImplementation(() => {});
 }
 
@@ -303,7 +303,7 @@ describe('signin container', () => {
       it('is handled if not provided in query params or location state', async () => {
         render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).not.toBeCalled();
-        expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+        expect(ReactUtils.hardNavigate).toBeCalledWith('/');
         expect(SigninModule.default).not.toBeCalled();
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -30,7 +30,7 @@ import {
   PASSWORD_CHANGE_FINISH_MUTATION,
   PASSWORD_CHANGE_START_MUTATION,
 } from './gql';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import {
   RecoveryEmailStatusResponse,
   AvatarResponse,
@@ -180,12 +180,12 @@ const SigninContainer = ({
             }
           } catch (error) {
             queryParams.set('prefillEmail', email);
-            hardNavigateToContentServer(`/?${queryParams}`);
+            hardNavigate(`/?${queryParams}`);
           }
         }
       } else {
         const optionalParams = queryParams.size > 0 ? `?${queryParams}` : '';
-        hardNavigateToContentServer(`/${optionalParams}`);
+        hardNavigate(`/${optionalParams}`);
       }
     })();
     // Only run this on initial render
@@ -357,7 +357,7 @@ const SigninContainer = ({
   // TODO: if validationError is 'email', in content-server we show "Bad request email param"
   // For now, just redirect to index-first, until FXA-8289 is done
   if (!email || validationError) {
-    hardNavigateToContentServer(`/${location.search}`);
+    hardNavigate(`/${location.search}`);
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -757,16 +757,16 @@ describe('with sessionToken', () => {
     });
   });
 
-  describe('hardNavigateToContentServer', () => {
-    let hardNavigateToContentServerSpy: jest.SpyInstance;
+  describe('hardNavigate', () => {
+    let hardNavigateSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      hardNavigateToContentServerSpy = jest
-        .spyOn(utils, 'hardNavigateToContentServer')
+      hardNavigateSpy = jest
+        .spyOn(utils, 'hardNavigate')
         .mockImplementation(() => {});
     });
     afterEach(() => {
-      hardNavigateToContentServerSpy.mockRestore();
+      hardNavigateSpy.mockRestore();
     });
 
     it('allows users to use a different account', async () => {
@@ -779,7 +779,7 @@ describe('with sessionToken', () => {
           })
         );
       });
-      expect(hardNavigateToContentServerSpy).toHaveBeenCalledWith(
+      expect(hardNavigateSpy).toHaveBeenCalledWith(
         `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
       );
     });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -2,15 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  Link,
-  RouteComponentProps,
-  useLocation,
-  useNavigate,
-} from '@reach/router';
+import { Link, RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import classNames from 'classnames';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-import { FtlMsg, hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import AppLayout from '../../components/AppLayout';
@@ -409,7 +405,7 @@ const Signin = ({
               params.delete('hasLinkedAccount');
               params.delete('hasPassword');
               params.delete('showReactApp');
-              hardNavigateToContentServer(`/?${params.toString()}`);
+              hardNavigate(`/?${params.toString()}`);
             }}
           >
             Use a different account

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -125,9 +125,7 @@ function applyMocks() {
     });
   mockLocation();
   jest.spyOn(SentryModule.default, 'captureException');
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 
   mockEmailBounceQuery();
 }
@@ -210,7 +208,7 @@ describe('confirm-signup-container', () => {
         expect(screen.getByText('confirm signup code mock')).toBeInTheDocument()
       );
       expect(mockEmailBounceStatusQuery).toBeCalled();
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith(
+      expect(ReactUtils.hardNavigate).toBeCalledWith(
         `/?bouncedEmail=${encodeURIComponent(MOCK_EMAIL)}`
       );
     });
@@ -223,7 +221,7 @@ describe('confirm-signup-container', () => {
         expect(screen.getByText('confirm signup code mock')).toBeInTheDocument()
       );
       expect(mockEmailBounceStatusQuery).toBeCalled();
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith(
+      expect(ReactUtils.hardNavigate).toBeCalledWith(
         `/signin_bounced?bouncedEmail=${encodeURIComponent(MOCK_EMAIL)}`
       );
     });
@@ -240,7 +238,7 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(screen.getByText('loading spinner mock')).toBeInTheDocument()
       );
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith(
+      expect(ReactUtils.hardNavigate).toBeCalledWith(
         expect.stringMatching('/')
       );
     });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { currentAccount } from '../../../lib/cache';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { Integration, useAuthClient } from '../../../models';
 import ConfirmSignupCode from '.';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { GetEmailBounceStatusResponse, LocationState } from './interfaces';
 import { useQuery } from '@apollo/client';
@@ -89,7 +90,7 @@ const SignupConfirmCodeContainer = ({
       if (Array.from(params).length > 0) {
         path += `?${params.toString()}`;
       }
-      hardNavigateToContentServer(path);
+      hardNavigate(path);
     },
     [email, location.search]
   );

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useState } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import {
   AuthUiErrors,
@@ -11,11 +12,7 @@ import {
   getLocalizedErrorMessage,
 } from '../../../lib/auth-errors/auth-errors';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
-import {
-  FtlMsg,
-  hardNavigate,
-  hardNavigateToContentServer,
-} from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import {
   useAlertBar,
   useFtlMsgResolver,
@@ -162,7 +159,7 @@ const ConfirmSignupCode = ({
 
       if (isSyncDesktopV3Integration(integration)) {
         const { to } = getSyncNavigate(location.search);
-        hardNavigateToContentServer(to);
+        hardNavigate(to);
       } else if (isOAuthIntegration(integration)) {
         // Check to see if the relier wants TOTP.
         // Newly created accounts wouldn't have this so lets redirect them to signin.
@@ -174,7 +171,7 @@ const ConfirmSignupCode = ({
 
         // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
-          hardNavigateToContentServer(`oauth/signin${location.search}`);
+          hardNavigate('oauth/signin', {}, true);
           return;
         } else {
           const { redirect, code, state, error } = await finishOAuthFlowHandler(
@@ -207,7 +204,7 @@ const ConfirmSignupCode = ({
             });
             // Mobile sync will close the web view, OAuth Desktop mimics DesktopV3 behavior
             const { to } = getSyncNavigate(location.search);
-            hardNavigateToContentServer(to);
+            hardNavigate(to);
             return;
           } else {
             // Navigate to relying party
@@ -236,7 +233,7 @@ const ConfirmSignupCode = ({
               'Account confirmed successfully'
             )
           );
-          navigate(`/settings${location.search}`, { replace: true });
+          navigate('/settings', { replace: true });
         }
       }
     } catch (error) {

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -129,9 +129,7 @@ function mockReachRouterModule() {
 }
 
 function mockReactUtilsModule() {
-  jest
-    .spyOn(ReactUtils, 'hardNavigateToContentServer')
-    .mockImplementation(() => {});
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
 // TIP - Sometimes it's useful to have inner mocks. In this case, we hold a reference to
@@ -288,7 +286,7 @@ describe('sign-up-container', () => {
       await render('loading spinner mock');
 
       // TODO: Determine if email is valid: https://github.com/mozilla/fxa/pull/16131#discussion_r1418122670
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
     });
 
     it('handles empty email', async () => {
@@ -308,7 +306,7 @@ describe('sign-up-container', () => {
       await render('loading spinner mock');
 
       // TODO: Show that email is invalid: https://github.com/mozilla/fxa/pull/16131#discussion_r1418122670
-      expect(ReactUtils.hardNavigateToContentServer).toBeCalledWith('/');
+      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import {
   Integration,
   isOAuthIntegration,
@@ -13,7 +14,7 @@ import {
 import { Signup } from '.';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
 import { SignupQueryParams } from '../../models/pages/signup';
-import { hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import { useMutation } from '@apollo/client';
 import {
   BeginSignUpOptions,
@@ -127,9 +128,7 @@ const SignupContainer = ({
               },
             });
           } else {
-            hardNavigateToContentServer(
-              `/signin?email=${queryParamModel.email}`
-            );
+            hardNavigate(`/signin`, { email: queryParamModel.email }, true);
           }
         }
       }
@@ -267,7 +266,7 @@ const SignupContainer = ({
   }
 
   if (validationError) {
-    hardNavigateToContentServer('/');
+    hardNavigate('/', {}, true);
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -124,16 +124,16 @@ describe('Signup page', () => {
     expect(firefoxPrivacyLink).toHaveAttribute('href', '/legal/privacy');
   });
 
-  describe('hardNavigateToContentServer', () => {
-    let hardNavigateToContentServerSpy: jest.SpyInstance;
+  describe('hardNavigate', () => {
+    let hardNavigateSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      hardNavigateToContentServerSpy = jest
-        .spyOn(utils, 'hardNavigateToContentServer')
+      hardNavigateSpy = jest
+        .spyOn(utils, 'hardNavigate')
         .mockImplementation(() => {});
     });
     afterEach(() => {
-      hardNavigateToContentServerSpy.mockRestore();
+      hardNavigateSpy.mockRestore();
     });
 
     it('allows users to change their email', async () => {
@@ -146,7 +146,7 @@ describe('Signup page', () => {
           })
         );
       });
-      expect(hardNavigateToContentServerSpy).toHaveBeenCalledWith(
+      expect(hardNavigateSpy).toHaveBeenCalledWith(
         `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
       );
     });
@@ -329,7 +329,9 @@ describe('Signup page', () => {
         });
         expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
         expect(GleanMetrics.registration.success).not.toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith('/cannot_create_account');
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/cannot_create_account?email=johndope%40example.com'
+        );
         expect(mockBeginSignupHandler).not.toBeCalled();
       });
 

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from '@reach/router';
+import { useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import { useForm } from 'react-hook-form';
 import {
   isOAuthIntegration,
@@ -15,7 +16,7 @@ import {
   settingsViewName,
   usePageViewEvent,
 } from '../../lib/metrics';
-import { FtlMsg, hardNavigateToContentServer } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormPasswordWithBalloons from '../../components/FormPasswordWithBalloons';
 import InputText from '../../components/InputText';
@@ -271,7 +272,7 @@ export const Signup = ({
           });
         }
 
-        navigate(`/confirm_signup_code${location.search}`, {
+        navigate('/confirm_signup_code', {
           state: {
             origin: 'signup',
             selectedNewsletterSlugs,
@@ -304,7 +305,6 @@ export const Signup = ({
       selectedNewsletterSlugs,
       declinedSyncEngines,
       email,
-      location.search,
       integration,
       offeredSyncEngineConfigs,
       isSyncOAuth,
@@ -402,7 +402,7 @@ export const Signup = ({
               // for more info.
               params.delete('emailStatusChecked');
               params.delete('email');
-              hardNavigateToContentServer(`/?${params.toString()}`);
+              hardNavigate(`/?${params.toString()}`);
             }}
           >
             Change email


### PR DESCRIPTION
## Because

- We want to make sure that query params are set when a user navigates with `navigate`

## This pull request

- Adds React `useNavigateWithQueryParams` hook

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9420

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
