### PR TITLE
chore(libs): restructure tests

### DIFF
--- a/libs/payments/capability/src/lib/capability.manager.spec.ts
+++ b/libs/payments/capability/src/lib/capability.manager.spec.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Test, TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 
 import {
   ContentfulManager,
@@ -12,44 +12,39 @@ import {
   CapabilityServicesResultFactory,
   ServiceResultFactory,
   ServicesWithCapabilitiesResultUtil,
+  ServicesWithCapabilitiesQueryFactory,
+  ServicesWithCapabilitiesResult,
+  ContentfulClient,
+  ContentfulClientConfig,
+  CapabilityServiceByPlanIdsQueryFactory,
+  CapabilityServiceByPlanIdsResult,
+  CapabilityPurchaseResultFactory,
 } from '@fxa/shared/contentful';
 import { CapabilityManager } from './capability.manager';
+import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
+import { MockStatsDFactory } from '@fxa/shared/metrics/statsd';
 
 describe('CapabilityManager', () => {
+  let capabilityManager: CapabilityManager;
+  let contentfulManager: ContentfulManager;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MockFirestoreProvider,
+        MockStatsDFactory,
+        ContentfulClientConfig,
+        ContentfulClient,
+        ContentfulManager,
+        CapabilityManager,
+      ],
+    }).compile();
+
+    contentfulManager = module.get(ContentfulManager);
+    capabilityManager = module.get(CapabilityManager);
+  });
+
   describe('getClients', () => {
-    let capabilityManager: CapabilityManager;
-    let mockContentfulManager: ContentfulManager;
-    let mockServicesResult: ServicesWithCapabilitiesResultUtil;
-
-    beforeEach(async () => {
-      mockServicesResult = {} as ServicesWithCapabilitiesResultUtil;
-      mockContentfulManager = {
-        getServicesWithCapabilities: jest
-          .fn()
-          .mockResolvedValueOnce(mockServicesResult),
-      } as any;
-
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          { provide: ContentfulManager, useValue: mockContentfulManager },
-          CapabilityManager,
-        ],
-      }).compile();
-
-      capabilityManager = module.get<CapabilityManager>(CapabilityManager);
-    });
-
-    it('should be defined', async () => {
-      expect(capabilityManager).toBeDefined();
-      expect(capabilityManager).toBeInstanceOf(CapabilityManager);
-    });
-
-    it('should return empty results', async () => {
-      mockServicesResult.getServices = jest.fn().mockReturnValueOnce(undefined);
-      const result = await capabilityManager.getClients();
-      expect(result).toHaveLength(0);
-    });
-
     it('should return services with capabilities', async () => {
       const clientResults = [
         ServiceResultFactory({
@@ -66,52 +61,47 @@ describe('CapabilityManager', () => {
           },
         }),
       ];
-      mockServicesResult.getServices = jest.fn().mockReturnValue(clientResults);
+      const mockServicesWithCapabilitiesQuery =
+        ServicesWithCapabilitiesQueryFactory({
+          serviceCollection: {
+            items: clientResults,
+          },
+        });
+      jest
+        .spyOn(contentfulManager, 'getServicesWithCapabilities')
+        .mockResolvedValue(
+          new ServicesWithCapabilitiesResultUtil(
+            mockServicesWithCapabilitiesQuery as ServicesWithCapabilitiesResult
+          )
+        );
+
       const result = await capabilityManager.getClients();
       expect(result.length).toBe(1);
-      expect(result[0].clientId).toBe('client1');
+      expect(result.at(0)?.clientId).toBe('client1');
 
       const actualCapabilities = clientResults[0].capabilitiesCollection.items
         .map((capability) => capability.slug)
         .sort();
 
-      expect(result[0].capabilities).toHaveLength(6);
-      expect(result[0].capabilities).toStrictEqual(actualCapabilities);
+      expect(result.at(0)?.capabilities).toHaveLength(6);
+      expect(result.at(0)?.capabilities).toStrictEqual(actualCapabilities);
     });
   });
 
   describe('planIdsToClientCapabilities', () => {
-    let capabilityManager: CapabilityManager;
-    let mockContentfulManager: ContentfulManager;
-    let mockServicesResult: CapabilityServiceByPlanIdsResultUtil;
-
-    beforeEach(async () => {
-      mockServicesResult = {} as CapabilityServiceByPlanIdsResultUtil;
-      mockContentfulManager = {
-        getPurchaseDetailsForCapabilityServiceByPlanIds: jest
-          .fn()
-          .mockResolvedValueOnce(mockServicesResult),
-      } as any;
-
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          { provide: ContentfulManager, useValue: mockContentfulManager },
-          CapabilityManager,
-        ],
-      }).compile();
-
-      capabilityManager = module.get<CapabilityManager>(CapabilityManager);
-    });
-
-    it('should be defined', async () => {
-      expect(capabilityManager).toBeDefined();
-      expect(capabilityManager).toBeInstanceOf(CapabilityManager);
-    });
-
     it('should return empty results', async () => {
-      mockServicesResult.capabilityOfferingForPlanId = jest
-        .fn()
-        .mockReturnValueOnce(undefined);
+      const mockCapabilityServiceByPlanIdsQuery =
+        CapabilityServiceByPlanIdsQueryFactory();
+      jest
+        .spyOn(
+          contentfulManager,
+          'getPurchaseDetailsForCapabilityServiceByPlanIds'
+        )
+        .mockResolvedValue(
+          new CapabilityServiceByPlanIdsResultUtil([
+            mockCapabilityServiceByPlanIdsQuery,
+          ] as CapabilityServiceByPlanIdsResult[])
+        );
       const result = await capabilityManager.planIdsToClientCapabilities([
         'planId1',
       ]);
@@ -119,14 +109,32 @@ describe('CapabilityManager', () => {
     });
 
     it('should return empty results when there are no capability collection items', async () => {
-      const offeringResult = CapabilityOfferingResultFactory({
+      const mockCapabilityOfferingResult = CapabilityOfferingResultFactory({
         capabilitiesCollection: {
           items: [],
         },
       });
-      mockServicesResult.capabilityOfferingForPlanId = jest
-        .fn()
-        .mockReturnValueOnce(offeringResult);
+      const mockCapabilityPurchaseResult = CapabilityPurchaseResultFactory({
+        offering: mockCapabilityOfferingResult,
+      });
+      const mockCapabilityServiceByPlanIdsQuery =
+        CapabilityServiceByPlanIdsQueryFactory({
+          purchaseCollection: {
+            total: 1,
+            items: [mockCapabilityPurchaseResult],
+          },
+        });
+      jest
+        .spyOn(
+          contentfulManager,
+          'getPurchaseDetailsForCapabilityServiceByPlanIds'
+        )
+        .mockResolvedValue(
+          new CapabilityServiceByPlanIdsResultUtil([
+            mockCapabilityServiceByPlanIdsQuery,
+          ] as CapabilityServiceByPlanIdsResult[])
+        );
+
       const result = await capabilityManager.planIdsToClientCapabilities([
         'planId1',
       ]);
@@ -134,7 +142,7 @@ describe('CapabilityManager', () => {
     });
 
     it('should return empty results when there are no service collection items', async () => {
-      const offeringResult = CapabilityOfferingResultFactory({
+      const mockCapabilityOfferingResult = CapabilityOfferingResultFactory({
         capabilitiesCollection: {
           items: [
             CapabilityCapabilitiesResultFactory({
@@ -146,9 +154,27 @@ describe('CapabilityManager', () => {
           ],
         },
       });
-      mockServicesResult.capabilityOfferingForPlanId = jest
-        .fn()
-        .mockReturnValueOnce(offeringResult);
+      const mockCapabilityPurchaseResult = CapabilityPurchaseResultFactory({
+        offering: mockCapabilityOfferingResult,
+      });
+      const mockCapabilityServiceByPlanIdsQuery =
+        CapabilityServiceByPlanIdsQueryFactory({
+          purchaseCollection: {
+            total: 1,
+            items: [mockCapabilityPurchaseResult],
+          },
+        });
+      jest
+        .spyOn(
+          contentfulManager,
+          'getPurchaseDetailsForCapabilityServiceByPlanIds'
+        )
+        .mockResolvedValue(
+          new CapabilityServiceByPlanIdsResultUtil([
+            mockCapabilityServiceByPlanIdsQuery,
+          ] as CapabilityServiceByPlanIdsResult[])
+        );
+
       const result = await capabilityManager.planIdsToClientCapabilities([
         'planId1',
       ]);
@@ -156,7 +182,7 @@ describe('CapabilityManager', () => {
     });
 
     it('should return planIds to client capabilities', async () => {
-      const offeringResult = CapabilityOfferingResultFactory({
+      const mockCapabilityOfferingResult = CapabilityOfferingResultFactory({
         capabilitiesCollection: {
           items: [
             CapabilityCapabilitiesResultFactory({
@@ -192,9 +218,28 @@ describe('CapabilityManager', () => {
           ],
         },
       });
-      mockServicesResult.capabilityOfferingForPlanId = jest
-        .fn()
-        .mockReturnValueOnce(offeringResult);
+      const mockCapabilityPurchaseResult = CapabilityPurchaseResultFactory({
+        stripePlanChoices: ['planId1'],
+        offering: mockCapabilityOfferingResult,
+      });
+      const mockCapabilityServiceByPlanIdsQuery =
+        CapabilityServiceByPlanIdsQueryFactory({
+          purchaseCollection: {
+            total: 1,
+            items: [mockCapabilityPurchaseResult],
+          },
+        });
+      jest
+        .spyOn(
+          contentfulManager,
+          'getPurchaseDetailsForCapabilityServiceByPlanIds'
+        )
+        .mockResolvedValue(
+          new CapabilityServiceByPlanIdsResultUtil([
+            mockCapabilityServiceByPlanIdsQuery,
+          ] as CapabilityServiceByPlanIdsResult[])
+        );
+
       const result = await capabilityManager.planIdsToClientCapabilities([
         'planId1',
       ]);

--- a/libs/payments/capability/src/lib/capability.manager.ts
+++ b/libs/payments/capability/src/lib/capability.manager.ts
@@ -14,11 +14,9 @@ export class CapabilityManager {
   constructor(private contentfulManager: ContentfulManager) {}
 
   async getClients() {
-    const clients: ServiceResult[] = (
+    const clients = (
       await this.contentfulManager.getServicesWithCapabilities()
     ).getServices();
-
-    if (!clients) return [];
 
     return clients.map((client: ServiceResult) => {
       const capabilities = client.capabilitiesCollection.items.map(
@@ -42,8 +40,6 @@ export class CapabilityManager {
   async planIdsToClientCapabilities(
     subscribedPrices: string[]
   ): Promise<Record<string, string[]>> {
-    if (!subscribedPrices.length) return {};
-
     const result: Record<string, string[]> = {};
 
     for (const subscribedPrice of subscribedPrices) {

--- a/libs/payments/cart/src/lib/cart.manager.in.spec.ts
+++ b/libs/payments/cart/src/lib/cart.manager.in.spec.ts
@@ -49,7 +49,7 @@ async function directUpdate(
     .execute();
 }
 
-describe('#payments-cart - manager', () => {
+describe('CartManager', () => {
   let db: AccountDatabase;
   let cartManager: CartManager;
   let testCart: ResultCart;

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -43,8 +43,8 @@ describe('CheckoutService', () => {
         PayPalManager,
         CheckoutService,
         PayPalClient,
-        { provide: StripeConfig, useValue: {} },
-        { provide: PaypalClientConfig, useValue: {} },
+        StripeConfig,
+        PaypalClientConfig,
         MockAccountDatabaseNestFactory,
       ],
     }).compile();
@@ -64,53 +64,44 @@ describe('CheckoutService', () => {
       })
     );
     const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
-    let fetchActiveCustomerSpy: jest.SpyInstance;
-    let isCustomerStripeTaxEligibleSpy: jest.SpyInstance;
     const mockPromotionCode = StripeResponseFactory(
       StripePromotionCodeFactory()
     );
-    let getPromotionCodeByNameSpy: jest.SpyInstance;
     const mockPaymentMethod = StripeResponseFactory(
       StripePaymentMethodFactory()
     );
-    let paymentMethodsAttachSpy: jest.SpyInstance;
-    let customersUpdateSpy: jest.SpyInstance;
     const mockSubscription = StripeResponseFactory(StripeSubscriptionFactory());
-    let subscriptionsCreateSpy: jest.SpyInstance;
     const mockInvoice = StripeResponseFactory(StripeInvoiceFactory());
-    let invoicesRetrieveSpy: jest.SpyInstance;
     const mockPaymentIntent = StripeResponseFactory(
       StripePaymentIntentFactory()
     );
-    let paymentIntentRetrieveSpy: jest.SpyInstance;
-    let cancelSubscriptionSpy: jest.SpyInstance;
 
     beforeEach(async () => {
-      fetchActiveCustomerSpy = jest
+      jest
         .spyOn(stripeManager, 'fetchActiveCustomer')
         .mockResolvedValue(mockCustomer);
-      isCustomerStripeTaxEligibleSpy = jest
+      jest
         .spyOn(stripeManager, 'isCustomerStripeTaxEligible')
         .mockReturnValue(true);
-      getPromotionCodeByNameSpy = jest
+      jest
         .spyOn(stripeManager, 'getPromotionCodeByName')
         .mockResolvedValue(mockPromotionCode);
-      paymentMethodsAttachSpy = jest
+      jest
         .spyOn(stripeClient, 'paymentMethodsAttach')
         .mockResolvedValue(mockPaymentMethod);
-      customersUpdateSpy = jest
+      jest
         .spyOn(stripeClient, 'customersUpdate')
         .mockResolvedValue(mockCustomer);
-      subscriptionsCreateSpy = jest
+      jest
         .spyOn(stripeClient, 'subscriptionsCreate')
         .mockResolvedValue(mockSubscription);
-      invoicesRetrieveSpy = jest
+      jest
         .spyOn(stripeClient, 'invoicesRetrieve')
         .mockResolvedValue(mockInvoice);
-      paymentIntentRetrieveSpy = jest
+      jest
         .spyOn(stripeClient, 'paymentIntentRetrieve')
         .mockResolvedValue(mockPaymentIntent);
-      cancelSubscriptionSpy = jest
+      jest
         .spyOn(stripeManager, 'cancelSubscription')
         .mockResolvedValue(mockSubscription);
     });
@@ -121,26 +112,26 @@ describe('CheckoutService', () => {
       });
 
       it('fetches the customer', async () => {
-        expect(fetchActiveCustomerSpy).toHaveBeenCalledWith(
+        expect(stripeManager.fetchActiveCustomer).toHaveBeenCalledWith(
           mockCart.stripeCustomerId
         );
       });
 
       it('checks if customer is eligible for automatic tax', async () => {
-        expect(isCustomerStripeTaxEligibleSpy).toHaveBeenCalledWith(
+        expect(stripeManager.isCustomerStripeTaxEligible).toHaveBeenCalledWith(
           mockCustomer
         );
       });
 
       it('fetches promotion code by name', async () => {
-        expect(getPromotionCodeByNameSpy).toHaveBeenCalledWith(
+        expect(stripeManager.getPromotionCodeByName).toHaveBeenCalledWith(
           mockCart.couponCode,
           true
         );
       });
 
       it('attaches payment method to customer', async () => {
-        expect(paymentMethodsAttachSpy).toHaveBeenCalledWith(
+        expect(stripeClient.paymentMethodsAttach).toHaveBeenCalledWith(
           mockPaymentMethod.id,
           {
             customer: mockCustomer.id,
@@ -149,15 +140,18 @@ describe('CheckoutService', () => {
       });
 
       it('updates the customer with a default payment method', async () => {
-        expect(customersUpdateSpy).toHaveBeenCalledWith(mockCustomer.id, {
-          invoice_settings: {
-            default_payment_method: mockPaymentMethod.id,
-          },
-        });
+        expect(stripeClient.customersUpdate).toHaveBeenCalledWith(
+          mockCustomer.id,
+          {
+            invoice_settings: {
+              default_payment_method: mockPaymentMethod.id,
+            },
+          }
+        );
       });
 
       it('creates the subscription', async () => {
-        expect(subscriptionsCreateSpy).toHaveBeenCalledWith({
+        expect(stripeClient.subscriptionsCreate).toHaveBeenCalledWith({
           customer: mockCustomer.id,
           automatic_tax: {
             enabled: true,
@@ -172,19 +166,19 @@ describe('CheckoutService', () => {
       });
 
       it('retrieves the lastest invoice', () => {
-        expect(invoicesRetrieveSpy).toHaveBeenCalledWith(
+        expect(stripeClient.invoicesRetrieve).toHaveBeenCalledWith(
           mockSubscription.latest_invoice
         );
       });
 
       it('retrieves the payment intent from the latest invoice', () => {
-        expect(paymentIntentRetrieveSpy).toHaveBeenCalledWith(
+        expect(stripeClient.paymentIntentRetrieve).toHaveBeenCalledWith(
           mockInvoice.payment_intent
         );
       });
 
       it('does not cancel the subscription', () => {
-        expect(cancelSubscriptionSpy).not.toHaveBeenCalled();
+        expect(stripeManager.cancelSubscription).not.toHaveBeenCalled();
       });
     });
   });
@@ -198,63 +192,47 @@ describe('CheckoutService', () => {
       })
     );
     const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
-    let fetchActiveCustomerSpy: jest.SpyInstance;
-    let isCustomerStripeTaxEligibleSpy: jest.SpyInstance;
     const mockPromotionCode = StripeResponseFactory(
       StripePromotionCodeFactory()
     );
-    let getPromotionCodeByNameSpy: jest.SpyInstance;
-    let getCustomerPayPalSubscriptionsSpy: jest.SpyInstance;
     const mockBillingAgreementId = faker.string.uuid();
-    let getOrCreateBillingAgreementIdSpy: jest.SpyInstance;
     const mockSubscription = StripeResponseFactory(StripeSubscriptionFactory());
-    let subscriptionsCreateSpy: jest.SpyInstance;
-    let deletePaypalCustomersByUidSpy: jest.SpyInstance;
     const mockPaypalCustomer = ResultPaypalCustomerFactory();
-    let createPaypalCustomerSpy: jest.SpyInstance;
     const mockInvoice = StripeResponseFactory(StripeInvoiceFactory());
-    let invoicesRetrieveSpy: jest.SpyInstance;
-    let processInvoiceSpy: jest.SpyInstance;
-    let cancelSubscriptionSpy: jest.SpyInstance;
-    let cancelBillingAgreementSpy: jest.SpyInstance;
 
     beforeEach(async () => {
-      fetchActiveCustomerSpy = jest
+      jest
         .spyOn(stripeManager, 'fetchActiveCustomer')
         .mockResolvedValue(mockCustomer);
-      isCustomerStripeTaxEligibleSpy = jest
+      jest
         .spyOn(stripeManager, 'isCustomerStripeTaxEligible')
         .mockReturnValue(true);
-      getPromotionCodeByNameSpy = jest
+      jest
         .spyOn(stripeManager, 'getPromotionCodeByName')
         .mockResolvedValue(mockPromotionCode);
-      getCustomerPayPalSubscriptionsSpy = jest
+      jest
         .spyOn(paypalManager, 'getCustomerPayPalSubscriptions')
         .mockResolvedValue([]);
-      getOrCreateBillingAgreementIdSpy = jest
+      jest
         .spyOn(paypalManager, 'getOrCreateBillingAgreementId')
         .mockResolvedValue(mockBillingAgreementId);
-      subscriptionsCreateSpy = jest
+      jest
         .spyOn(stripeClient, 'subscriptionsCreate')
         .mockResolvedValue(mockSubscription);
-      deletePaypalCustomersByUidSpy = jest
+      jest
         .spyOn(paypalCustomerManager, 'deletePaypalCustomersByUid')
         .mockResolvedValue(BigInt(1));
-      createPaypalCustomerSpy = jest
+      jest
         .spyOn(paypalCustomerManager, 'createPaypalCustomer')
         .mockResolvedValue(mockPaypalCustomer);
-      invoicesRetrieveSpy = jest
+      jest
         .spyOn(stripeClient, 'invoicesRetrieve')
         .mockResolvedValue(mockInvoice);
-      processInvoiceSpy = jest
-        .spyOn(paypalManager, 'processInvoice')
-        .mockResolvedValue();
-      cancelSubscriptionSpy = jest
+      jest.spyOn(paypalManager, 'processInvoice').mockResolvedValue();
+      jest
         .spyOn(stripeManager, 'cancelSubscription')
         .mockResolvedValue(mockSubscription);
-      cancelBillingAgreementSpy = jest
-        .spyOn(paypalManager, 'cancelBillingAgreement')
-        .mockResolvedValue();
+      jest.spyOn(paypalManager, 'cancelBillingAgreement').mockResolvedValue();
     });
 
     describe('success', () => {
@@ -263,40 +241,38 @@ describe('CheckoutService', () => {
       });
 
       it('fetches the customer', async () => {
-        expect(fetchActiveCustomerSpy).toHaveBeenCalledWith(
+        expect(stripeManager.fetchActiveCustomer).toHaveBeenCalledWith(
           mockCart.stripeCustomerId
         );
       });
 
       it('checks if customer is eligible for automatic tax', async () => {
-        expect(isCustomerStripeTaxEligibleSpy).toHaveBeenCalledWith(
+        expect(stripeManager.isCustomerStripeTaxEligible).toHaveBeenCalledWith(
           mockCustomer
         );
       });
 
       it('fetches promotion code by name', async () => {
-        expect(getPromotionCodeByNameSpy).toHaveBeenCalledWith(
+        expect(stripeManager.getPromotionCodeByName).toHaveBeenCalledWith(
           mockCart.couponCode,
           true
         );
       });
 
       it('fetches the customers paypal subscriptions', async () => {
-        expect(getCustomerPayPalSubscriptionsSpy).toHaveBeenCalledWith(
-          mockCustomer.id
-        );
+        expect(
+          paypalManager.getCustomerPayPalSubscriptions
+        ).toHaveBeenCalledWith(mockCustomer.id);
       });
 
       it('fetches/creates a billing agreement for checkout', async () => {
-        expect(getOrCreateBillingAgreementIdSpy).toHaveBeenCalledWith(
-          mockCart.uid,
-          false,
-          mockToken
-        );
+        expect(
+          paypalManager.getOrCreateBillingAgreementId
+        ).toHaveBeenCalledWith(mockCart.uid, false, mockToken);
       });
 
       it('creates the subscription', async () => {
-        expect(subscriptionsCreateSpy).toHaveBeenCalledWith({
+        expect(stripeClient.subscriptionsCreate).toHaveBeenCalledWith({
           customer: mockCustomer.id,
           automatic_tax: {
             enabled: true,
@@ -313,36 +289,38 @@ describe('CheckoutService', () => {
       });
 
       it('deletes all paypalCustomers for user by uid', () => {
-        expect(deletePaypalCustomersByUidSpy).toHaveBeenCalledWith(
-          mockCart.uid
-        );
+        expect(
+          paypalCustomerManager.deletePaypalCustomersByUid
+        ).toHaveBeenCalledWith(mockCart.uid);
       });
 
       it('creates a paypalCustomer entry for created billing agreement', () => {
-        expect(createPaypalCustomerSpy).toHaveBeenCalledWith({
-          uid: mockCart.uid,
-          billingAgreementId: mockBillingAgreementId,
-          status: 'active',
-          endedAt: null,
-        });
+        expect(paypalCustomerManager.createPaypalCustomer).toHaveBeenCalledWith(
+          {
+            uid: mockCart.uid,
+            billingAgreementId: mockBillingAgreementId,
+            status: 'active',
+            endedAt: null,
+          }
+        );
       });
 
       it('retrieves the lastest invoice', () => {
-        expect(invoicesRetrieveSpy).toHaveBeenCalledWith(
+        expect(stripeClient.invoicesRetrieve).toHaveBeenCalledWith(
           mockSubscription.latest_invoice
         );
       });
 
       it('calls to process the latest invoice', () => {
-        expect(processInvoiceSpy).toHaveBeenCalledWith(mockInvoice);
+        expect(paypalManager.processInvoice).toHaveBeenCalledWith(mockInvoice);
       });
 
       it('does not cancel the subscription', () => {
-        expect(cancelSubscriptionSpy).not.toHaveBeenCalled();
+        expect(stripeManager.cancelSubscription).not.toHaveBeenCalled();
       });
 
       it('does not cancel the billing agreement', () => {
-        expect(cancelBillingAgreementSpy).not.toHaveBeenCalled();
+        expect(paypalManager.cancelBillingAgreement).not.toHaveBeenCalled();
       });
     });
   });

--- a/libs/payments/currency/src/lib/currency.manager.spec.ts
+++ b/libs/payments/currency/src/lib/currency.manager.spec.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Test, TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 import { faker } from '@faker-js/faker';
 
 import { CurrencyManager } from './currency.manager';
@@ -16,11 +16,11 @@ describe('CurrencyManager', () => {
   let currencyManager: CurrencyManager;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const module = await Test.createTestingModule({
       providers: [CurrencyManager],
     }).compile();
 
-    currencyManager = module.get<CurrencyManager>(CurrencyManager);
+    currencyManager = module.get(CurrencyManager);
   });
 
   describe('assertCurrencyCompatibleWithCountry', () => {

--- a/libs/payments/paypal/src/lib/paypal.client.config.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.config.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Provider } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsNumber, IsString, ValidateNested } from 'class-validator';
 
@@ -32,3 +33,15 @@ export class PaypalClientConfig {
   @ValidateNested()
   public readonly retryOptions?: PaypalRetryConfig;
 }
+
+export const MockPaypalClientConfig = {
+  user: 'user',
+  sandbox: true,
+  pwd: 'pwd',
+  signature: 'sig',
+} satisfies PaypalClientConfig;
+
+export const MockPaypalClientConfigProvider = {
+  provide: PaypalClientConfig,
+  useValue: MockPaypalClientConfig,
+} satisfies Provider<PaypalClientConfig>;

--- a/libs/payments/paypal/src/lib/paypal.client.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.spec.ts
@@ -35,6 +35,8 @@ import {
   TransactionSearchOptions,
 } from './paypal.client.types';
 import { objectToNVP, toIsoString } from './util';
+import { Test } from '@nestjs/testing';
+import { MockPaypalClientConfigProvider } from './paypal.client.config';
 
 describe('PayPalClient', () => {
   const commonPayloadArgs = {
@@ -44,15 +46,14 @@ describe('PayPalClient', () => {
     VERSION: PAYPAL_VERSION,
   };
 
-  let client: PayPalClient;
+  let paypalClient: PayPalClient;
 
-  beforeEach(() => {
-    client = new PayPalClient({
-      user: 'user',
-      sandbox: true,
-      pwd: 'pwd',
-      signature: 'sig',
-    });
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [MockPaypalClientConfigProvider, PayPalClient],
+    }).compile();
+
+    paypalClient = module.get(PayPalClient);
   });
 
   afterEach(() => {
@@ -84,7 +85,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(NVPSetExpressCheckoutResponseFactory()));
 
-      await client.setExpressCheckout({
+      await paypalClient.setExpressCheckout({
         currencyCode,
       });
     });
@@ -101,7 +102,7 @@ describe('PayPalClient', () => {
         .reply(200, objectToNVP(NVPErrorResponseFactory()));
 
       try {
-        await client.setExpressCheckout({
+        await paypalClient.setExpressCheckout({
           currencyCode,
         });
         fail('Request should have thrown an error.');
@@ -131,7 +132,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.createBillingAgreement({
+      const result = await paypalClient.createBillingAgreement({
         token,
       });
 
@@ -170,7 +171,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.doReferenceTransaction(options);
+      const result = await paypalClient.doReferenceTransaction(options);
 
       expect(result).toMatchObject(response);
     });
@@ -211,7 +212,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.doReferenceTransaction(options);
+      const result = await paypalClient.doReferenceTransaction(options);
 
       expect(result).toMatchObject(response);
     });
@@ -241,7 +242,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.refundTransaction(options);
+      const result = await paypalClient.refundTransaction(options);
 
       expect(result).toMatchObject(response);
     });
@@ -267,7 +268,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.refundTransaction(options);
+      const result = await paypalClient.refundTransaction(options);
 
       expect(result).toMatchObject(response);
     });
@@ -291,7 +292,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.baUpdate(options);
+      const result = await paypalClient.baUpdate(options);
 
       expect(result).toMatchObject(response);
     });
@@ -315,7 +316,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.baUpdate(options);
+      const result = await paypalClient.baUpdate(options);
 
       expect(result).toMatchObject(response);
     });
@@ -328,7 +329,7 @@ describe('PayPalClient', () => {
       nock(PAYPAL_SANDBOX_IPN_BASE)
         .post(PAYPAL_IPN_ROUTE, verifyPayload)
         .reply(200, 'VERIFIED');
-      const result = await client.ipnVerify(message);
+      const result = await paypalClient.ipnVerify(message);
       expect(result).toEqual('VERIFIED');
     });
   });
@@ -359,7 +360,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
         .reply(200, objectToNVP(response));
 
-      const result = await client.transactionSearch(options);
+      const result = await paypalClient.transactionSearch(options);
 
       expect(result).toMatchObject(response);
     });

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -127,8 +127,8 @@ export class PayPalManager {
    */
   async getCustomerPayPalSubscriptions(customerId: string) {
     const subscriptions = await this.stripeManager.getSubscriptions(customerId);
-    if (!subscriptions.data) return [];
-    return subscriptions.data.filter(
+    if (!subscriptions) return [];
+    return subscriptions.filter(
       (sub) =>
         ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status) &&
         sub.collection_method === 'send_invoice'

--- a/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.manager.in.spec.ts
+++ b/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.manager.in.spec.ts
@@ -49,8 +49,7 @@ describe('PaypalCustomerManager', () => {
         billingAgreementId: 'NOT VALID LONG STRING TO CAUSE ERROR',
       });
 
-      expect.assertions(0);
-      expect(
+      await expect(
         paypalCustomerManager.createPaypalCustomer(paypalCustomer)
       ).rejects.toBeInstanceOf(PaypalCustomerNotCreatedError);
     });
@@ -75,8 +74,7 @@ describe('PaypalCustomerManager', () => {
     it('throws a PaypalCustomerNotFoundError when paypalCustomer does not exist', async () => {
       const paypalCustomer = CreatePaypalCustomerFactory();
 
-      expect.assertions(0);
-      expect(
+      await expect(
         paypalCustomerManager.fetchPaypalCustomer(
           paypalCustomer.uid,
           paypalCustomer.billingAgreementId
@@ -169,8 +167,7 @@ describe('PaypalCustomerManager', () => {
         billingAgreementId: 'NOT VALID LONG STRING TO CAUSE ERROR',
       };
 
-      expect.assertions(0);
-      expect(
+      await expect(
         paypalCustomerManager.updatePaypalCustomer(
           paypalCustomer.uid,
           paypalCustomer.billingAgreementId,
@@ -202,9 +199,8 @@ describe('PaypalCustomerManager', () => {
 
       await paypalCustomerManager.deletePaypalCustomer(resultPaypalCustomer);
 
-      expect.assertions(0);
       // Customer is already deleted, this should now throw
-      expect(
+      await expect(
         paypalCustomerManager.deletePaypalCustomer(resultPaypalCustomer)
       ).rejects.toBeInstanceOf(PaypalCustomerNotDeletedError);
     });

--- a/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.manager.in.spec.ts
+++ b/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.manager.in.spec.ts
@@ -51,8 +51,7 @@ describe('AccountCustomer Manager', () => {
         stripeCustomerId: faker.string.alphanumeric({ length: 50 }),
       });
 
-      expect.assertions(0);
-      expect(
+      await expect(
         accountCustomerManager.createAccountCustomer(mockAccountCustomer)
       ).rejects.toBeInstanceOf(AccountCustomerNotCreatedError);
     });
@@ -77,8 +76,7 @@ describe('AccountCustomer Manager', () => {
     it('throws an AccountCustomerNotFoundError when accountCustomer does not exist', async () => {
       const mockAccountCustomer = CreateAccountCustomerFactory();
 
-      expect.assertions(0);
-      expect(
+      await expect(
         accountCustomerManager.getAccountCustomerByUid(mockAccountCustomer.uid)
       ).rejects.toBeInstanceOf(AccountCustomerNotFoundError);
     });
@@ -113,8 +111,7 @@ describe('AccountCustomer Manager', () => {
         stripeCustomerId: faker.string.alphanumeric({ length: 50 }),
       };
 
-      expect.assertions(0);
-      expect(
+      await expect(
         accountCustomerManager.updateAccountCustomer(
           mockAccountCustomer.uid,
           mockUpdatedAccountCustomer
@@ -143,9 +140,8 @@ describe('AccountCustomer Manager', () => {
 
       await accountCustomerManager.deleteAccountCustomer(resultAccountCustomer);
 
-      expect.assertions(0);
       // Customer is already deleted, this should now throw
-      expect(
+      await expect(
         accountCustomerManager.deleteAccountCustomer(resultAccountCustomer)
       ).rejects.toBeInstanceOf(AccountCustomerNotDeletedError);
     });

--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { faker } from '@faker-js/faker';
 import { Stripe } from 'stripe';
 
 import {
@@ -17,6 +16,8 @@ import { StripePromotionCodeFactory } from './factories/promotion-code.factory';
 import { StripeSubscriptionFactory } from './factories/subscription.factory';
 import { StripeUpcomingInvoiceFactory } from './factories/upcoming-invoice.factory';
 import { StripeClient } from './stripe.client';
+import { Test } from '@nestjs/testing';
+import { MockStripeConfigProvider } from './stripe.config';
 
 const mockJestFnGenerator = <T extends (...args: any[]) => any>() => {
   return jest.fn<ReturnType<T>, Parameters<T>>();
@@ -87,13 +88,14 @@ jest.mock('stripe', () => ({
 }));
 
 describe('StripeClient', () => {
-  let mockClient: StripeClient;
+  let stripeClient: StripeClient;
 
-  beforeEach(() => {
-    mockClient = new StripeClient({
-      apiKey: faker.string.uuid(),
-      taxIds: { EUR: 'EU1234' },
-    });
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [MockStripeConfigProvider, StripeClient],
+    }).compile();
+
+    stripeClient = module.get(StripeClient);
   });
 
   afterEach(() => {
@@ -107,7 +109,7 @@ describe('StripeClient', () => {
 
       mockStripeCustomersRetrieve.mockResolvedValueOnce(mockResponse);
 
-      const result = await mockClient.customersRetrieve(mockCustomer.id);
+      const result = await stripeClient.customersRetrieve(mockCustomer.id);
       expect(result).toEqual(mockResponse);
     });
   });
@@ -119,7 +121,7 @@ describe('StripeClient', () => {
 
       mockStripeCustomersCreate.mockResolvedValueOnce(mockResponse);
 
-      const result = await mockClient.customersCreate();
+      const result = await stripeClient.customersCreate();
       expect(result).toEqual(mockResponse);
     });
   });
@@ -132,7 +134,7 @@ describe('StripeClient', () => {
 
       mockStripeCustomersUpdate.mockResolvedValueOnce(mockResponse);
 
-      const result = await mockClient.customersUpdate(mockCustomer.id, {
+      const result = await stripeClient.customersUpdate(mockCustomer.id, {
         balance: mockUpdatedCustomer.balance,
       });
 
@@ -149,7 +151,7 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsList.mockResolvedValue(mockSubscriptionList);
 
-      const result = await mockClient.subscriptionsList({
+      const result = await stripeClient.subscriptionsList({
         customer: mockCustomer.id,
       });
       expect(result).toEqual(mockSubscriptionList);
@@ -164,7 +166,7 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsCreate.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.subscriptionsCreate({
+      const result = await stripeClient.subscriptionsCreate({
         customer: mockCustomer.id,
       });
       expect(result).toEqual(mockResponse);
@@ -178,7 +180,9 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsCancel.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.subscriptionsCancel(mockSubscription.id);
+      const result = await stripeClient.subscriptionsCancel(
+        mockSubscription.id
+      );
 
       expect(result).toEqual(mockResponse);
     });
@@ -191,7 +195,7 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsRetrieve.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.subscriptionsRetrieve(
+      const result = await stripeClient.subscriptionsRetrieve(
         mockSubscription.id
       );
       expect(result).toEqual(mockResponse);
@@ -208,7 +212,9 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsUpdate.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.subscriptionsUpdate(mockSubscription.id);
+      const result = await stripeClient.subscriptionsUpdate(
+        mockSubscription.id
+      );
       expect(result.description).toEqual(mockUpdatedSubscription.description);
     });
   });
@@ -220,7 +226,7 @@ describe('StripeClient', () => {
 
       mockStripeInvoicesRetrieve.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.invoicesRetrieve(mockInvoice.id);
+      const result = await stripeClient.invoicesRetrieve(mockInvoice.id);
 
       expect(result).toEqual(mockResponse);
     });
@@ -234,7 +240,7 @@ describe('StripeClient', () => {
 
       mockStripeRetrieveUpcomingInvoice.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.invoicesRetrieveUpcoming({
+      const result = await stripeClient.invoicesRetrieveUpcoming({
         customer: mockCustomer.id,
       });
 
@@ -251,9 +257,12 @@ describe('StripeClient', () => {
 
       mockStripeInvoicesFinalizeInvoice.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.invoicesFinalizeInvoice(mockInvoice.id, {
-        auto_advance: false,
-      });
+      const result = await stripeClient.invoicesFinalizeInvoice(
+        mockInvoice.id,
+        {
+          auto_advance: false,
+        }
+      );
 
       expect(result).toEqual(mockResponse);
     });
@@ -266,7 +275,7 @@ describe('StripeClient', () => {
 
       mockStripePlansRetrieve.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.plansRetrieve(mockPlan.id);
+      const result = await stripeClient.plansRetrieve(mockPlan.id);
       expect(result).toEqual(mockResponse);
     });
   });
@@ -278,7 +287,7 @@ describe('StripeClient', () => {
 
       mockStripeProductsRetrieve.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.productsRetrieve(mockProduct.id);
+      const result = await stripeClient.productsRetrieve(mockProduct.id);
       expect(result).toEqual(mockResponse);
     });
   });
@@ -291,7 +300,7 @@ describe('StripeClient', () => {
 
       mockStripePromotionCodesList.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.promotionCodesList({
+      const result = await stripeClient.promotionCodesList({
         code: mockPromoCode.code,
       });
       expect(result).toEqual(mockResponse);
@@ -305,7 +314,9 @@ describe('StripeClient', () => {
 
       mockStripePromotionCodesRetrieve.mockResolvedValue(mockResponse);
 
-      const result = await mockClient.promotionCodesRetrieve(mockPromoCode.id);
+      const result = await stripeClient.promotionCodesRetrieve(
+        mockPromoCode.id
+      );
       expect(result).toEqual(mockResponse);
     });
   });

--- a/libs/payments/stripe/src/lib/stripe.config.ts
+++ b/libs/payments/stripe/src/lib/stripe.config.ts
@@ -4,6 +4,8 @@
 
 import { Transform } from 'class-transformer';
 import { IsObject, IsString } from 'class-validator';
+import { faker } from '@faker-js/faker';
+import { Provider } from '@nestjs/common';
 
 export class StripeConfig {
   @IsString()
@@ -16,3 +18,13 @@ export class StripeConfig {
   @IsObject()
   public readonly taxIds!: { [key: string]: string };
 }
+
+export const MockStripeConfig = {
+  apiKey: faker.string.uuid(),
+  taxIds: { EUR: 'EU1234' },
+} satisfies StripeConfig;
+
+export const MockStripeConfigProvider = {
+  provide: StripeConfig,
+  useValue: MockStripeConfig,
+} satisfies Provider<StripeConfig>;

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -73,7 +73,7 @@ export class StripeManager {
     priceId: string
   ) {
     const subscriptions = await this.getSubscriptions(customerId);
-    const targetSubs = subscriptions.data.filter((sub) =>
+    const targetSubs = subscriptions.filter((sub) =>
       sub.items.data.find((item) => item.price.id === priceId)
     );
 
@@ -88,9 +88,11 @@ export class StripeManager {
    * Retrieves subscriptions
    */
   async getSubscriptions(customerId: string) {
-    return this.client.subscriptionsList({
+    const result = await this.client.subscriptionsList({
       customer: customerId,
     });
+
+    return result.data;
   }
 
   async cancelSubscription(subscriptionId: string) {

--- a/libs/payments/stripe/src/lib/stripe.util.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.util.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { faker } from '@faker-js/faker';
 import {
   StripeApiListFactory,
   StripeResponseFactory,
@@ -36,11 +35,9 @@ describe('util', () => {
       const mockPrice = StripePriceFactory();
       const mockPromoCode = 'promo_code1';
 
-      try {
-        checkSubscriptionPromotionCodes(mockPromoCode, mockPrice, undefined);
-      } catch (error) {
-        expect(error).toBeInstanceOf(PromotionCodeNotForSubscriptionError);
-      }
+      expect(() =>
+        checkSubscriptionPromotionCodes(mockPromoCode, mockPrice, undefined)
+      ).toThrowError(PromotionCodeNotForSubscriptionError);
     });
 
     it('returns true if only subscription price provided', async () => {
@@ -88,11 +85,9 @@ describe('util', () => {
     it('throws error if there is no promotion code', async () => {
       const mockPromotionCode = StripeResponseFactory(undefined);
 
-      try {
-        checkValidPromotionCode(mockPromotionCode);
-      } catch (error) {
-        expect(error).toBeInstanceOf(PromotionCodeInvalidError);
-      }
+      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+        PromotionCodeInvalidError
+      );
     });
 
     it('throws error if the promotion code is not active', async () => {
@@ -100,11 +95,9 @@ describe('util', () => {
         active: false,
       });
 
-      try {
-        checkValidPromotionCode(mockPromotionCode);
-      } catch (error) {
-        expect(error).toBeInstanceOf(PromotionCodeInvalidError);
-      }
+      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+        PromotionCodeInvalidError
+      );
     });
 
     it('throws error if the promotion code coupon is not valid', async () => {
@@ -114,11 +107,9 @@ describe('util', () => {
         }),
       });
 
-      try {
-        checkValidPromotionCode(mockPromotionCode);
-      } catch (error) {
-        expect(error).toBeInstanceOf(PromotionCodeInvalidError);
-      }
+      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+        PromotionCodeInvalidError
+      );
     });
 
     it('throws error if the promotion code is expired', async () => {
@@ -127,11 +118,9 @@ describe('util', () => {
         expires_at: expiredTime,
       });
 
-      try {
-        checkValidPromotionCode(mockPromotionCode);
-      } catch (error) {
-        expect(error).toBeInstanceOf(PromotionCodeInvalidError);
-      }
+      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+        PromotionCodeInvalidError
+      );
     });
 
     it('returns true if the promotion code is valid', async () => {
@@ -151,16 +140,7 @@ describe('util', () => {
         price: mockPrice,
       });
       const mockSubscription = StripeSubscriptionFactory({
-        items: {
-          object: 'list',
-          data: [mockSubItem],
-          has_more: false,
-          url: `/v1/subscription_items?subscription=sub_${faker.string.alphanumeric(
-            {
-              length: 24,
-            }
-          )}`,
-        },
+        items: StripeApiListFactory([mockSubItem]),
       });
 
       const result = getSubscribedPrice(mockSubscription);
@@ -169,46 +149,24 @@ describe('util', () => {
 
     it('throws error if no subscription price exists', async () => {
       const mockSubscription = StripeSubscriptionFactory({
-        items: {
-          object: 'list',
-          data: [],
-          has_more: false,
-          url: `/v1/subscription_items?subscription=sub_${faker.string.alphanumeric(
-            {
-              length: 24,
-            }
-          )}`,
-        },
+        items: StripeApiListFactory([]),
       });
 
-      try {
-        getSubscribedPrice(mockSubscription);
-      } catch (error) {
-        expect(error).toBeInstanceOf(SubscriptionPriceUnknownError);
-      }
+      expect(() => getSubscribedPrice(mockSubscription)).toThrowError(
+        SubscriptionPriceUnknownError
+      );
     });
 
     it('throws error if multiple subscription prices exists', async () => {
       const mockSubItem1 = StripeSubscriptionItemFactory();
       const mockSubItem2 = StripeSubscriptionItemFactory();
       const mockSubscription = StripeSubscriptionFactory({
-        items: {
-          object: 'list',
-          data: [mockSubItem1, mockSubItem2],
-          has_more: false,
-          url: `/v1/subscription_items?subscription=sub_${faker.string.alphanumeric(
-            {
-              length: 24,
-            }
-          )}`,
-        },
+        items: StripeApiListFactory([mockSubItem1, mockSubItem2]),
       });
 
-      try {
-        getSubscribedPrice(mockSubscription);
-      } catch (error) {
-        expect(error).toBeInstanceOf(SubscriptionPriceUnknownError);
-      }
+      expect(() => getSubscribedPrice(mockSubscription)).toThrowError(
+        SubscriptionPriceUnknownError
+      );
     });
   });
 
@@ -219,27 +177,15 @@ describe('util', () => {
         plan: mockPlan,
       });
       const mockSubscription = StripeSubscriptionFactory({
-        items: {
-          object: 'list',
-          data: [mockSubItem],
-          has_more: false,
-          url: `/v1/subscription_items?subscription=sub_${faker.string.alphanumeric(
-            {
-              length: 24,
-            }
-          )}`,
-        },
+        items: StripeApiListFactory([mockSubItem]),
       });
-      const mockSubscriptionList = StripeApiListFactory([mockSubscription]);
 
-      const result = getSubscribedPlans(mockSubscriptionList);
+      const result = getSubscribedPlans([mockSubscription]);
       expect(result).toEqual([mockPlan]);
     });
 
     it('returns empty array if no subscriptions exist', async () => {
-      const mockSubscriptionList = StripeApiListFactory([]);
-
-      const result = getSubscribedPlans(mockSubscriptionList);
+      const result = getSubscribedPlans([]);
       expect(result).toEqual([]);
     });
   });

--- a/libs/payments/stripe/src/lib/stripe.util.ts
+++ b/libs/payments/stripe/src/lib/stripe.util.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  StripeApiList,
   StripePlan,
   StripePrice,
   StripeProduct,
@@ -68,11 +67,7 @@ export const getSubscribedPrice = (subscription: StripeSubscription) => {
 /**
  * Returns array of customer subscription plans
  */
-export const getSubscribedPlans = (
-  subscriptionList: StripeApiList<StripeSubscription>
-) => {
-  const subscriptions = subscriptionList.data;
-  if (!subscriptions) return [];
+export const getSubscribedPlans = (subscriptions: StripeSubscription[]) => {
   return subscriptions
     .flatMap((sub) => sub.items.data)
     .map((item) => item.plan);

--- a/libs/shared/account/account/src/lib/account.manager.in.spec.ts
+++ b/libs/shared/account/account/src/lib/account.manager.in.spec.ts
@@ -53,7 +53,6 @@ describe('accountManager', () => {
 
       await accountManager.createAccountStub(email, 1, 'en-US');
 
-      expect.assertions(1);
       await expect(
         accountManager.createAccountStub(email, 1, 'en-US')
       ).rejects.toBeInstanceOf(AccountAlreadyExistsError);

--- a/libs/shared/contentful/src/lib/contentful.manager.ts
+++ b/libs/shared/contentful/src/lib/contentful.manager.ts
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 
+import { StatsDService } from '@fxa/shared/metrics/statsd';
 import {
   EligibilityContentByPlanIdsQuery,
   PurchaseWithDetailsOfferingContentQuery,
@@ -40,7 +41,10 @@ import {
 
 @Injectable()
 export class ContentfulManager {
-  constructor(private client: ContentfulClient, private statsd: StatsD) {
+  constructor(
+    private client: ContentfulClient,
+    @Inject(StatsDService) private statsd: StatsD
+  ) {
     this.client.on('response', (response) => {
       const defaultTags = {
         method: response.method,

--- a/libs/shared/db/firestore/src/lib/firestore.provider.ts
+++ b/libs/shared/db/firestore/src/lib/firestore.provider.ts
@@ -41,7 +41,7 @@ export function setupFirestore(config: FirebaseFirestore.Settings) {
  * Factory for providing access to firestore
  */
 export const FirestoreService = Symbol('FIRESTORE');
-export const FirestoreFactory: Provider<Firestore> = {
+export const FirestoreProvider: Provider<Firestore> = {
   provide: FirestoreService,
   useFactory: (configService: ConfigService) => {
     const firestoreConfig = configService.get('authFirestore');
@@ -54,4 +54,16 @@ export const FirestoreFactory: Provider<Firestore> = {
     return firestore;
   },
   inject: [ConfigService],
+};
+
+/**
+ * Can be used to satisfy DI when unit testing things that should not need
+ * firestore access.
+ * Note: this will cause errors to be thrown if firestore is used
+ */
+export const MockFirestoreProvider: Provider<Firestore> = {
+  provide: FirestoreService,
+  useFactory: () => {
+    return {} as Firestore;
+  },
 };

--- a/libs/shared/geodb/src/lib/geodb.provider.ts
+++ b/libs/shared/geodb/src/lib/geodb.provider.ts
@@ -31,3 +31,13 @@ export const GeoDBNestFactory: Provider<GeoDBCityReader> = {
   },
   inject: [GeoDBConfig],
 };
+
+/**
+ * Can be used to satisfy DI when unit testing things that should not need
+ * maxmind.
+ * Note: this will cause errors to be thrown if geodb is used
+ */
+export const MockGeoDBNestFactory = {
+  provide: GeoDBProvider,
+  useFactory: () => ({} as any),
+} satisfies Provider<GeoDBCityReader>;

--- a/libs/shared/l10n/src/lib/localizer/localizer.rsc.factory.spec.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.rsc.factory.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Test, TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 import { LocalizerRscFactory } from './localizer.rsc.factory';
 import { ILocalizerBindings } from './localizer.interfaces';
 import supportedLanguages from '../supported-languages.json';
@@ -28,7 +28,7 @@ describe('LocalizerRscFactory', () => {
   };
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const module = await Test.createTestingModule({
       providers: [
         {
           provide: LocalizerRscFactory,
@@ -55,12 +55,12 @@ describe('LocalizerRscFactory', () => {
 
   describe('createLocalizerRsc', () => {
     it('should return instance of LocalizerRsc', async () => {
-      const localizerRsc = await localizer.createLocalizerRsc('en');
+      const localizerRsc = localizer.createLocalizerRsc('en');
       expect(localizerRsc).toBeInstanceOf(LocalizerRsc);
     });
 
     it('should error when document or bundles are not initialized', async () => {
-      const module: TestingModule = await Test.createTestingModule({
+      const module = await Test.createTestingModule({
         providers: [
           {
             provide: LocalizerRscFactory,
@@ -70,12 +70,7 @@ describe('LocalizerRscFactory', () => {
       }).compile();
       const emptyLocalizer = module.get(LocalizerRscFactory);
 
-      expect.assertions(1);
-      try {
-        emptyLocalizer.createLocalizerRsc('en');
-      } catch (error) {
-        expect(error).toBeDefined();
-      }
+      expect(() => emptyLocalizer.createLocalizerRsc('en')).toThrow();
     });
   });
 });

--- a/libs/shared/metrics/statsd/src/lib/statsd.provider.ts
+++ b/libs/shared/metrics/statsd/src/lib/statsd.provider.ts
@@ -18,3 +18,15 @@ export const StatsDFactory: Provider<StatsD> = {
   },
   inject: [ConfigService],
 };
+
+/**
+ * Can be used to satisfy DI when unit testing things that should not need
+ * statsd.
+ * Note: this will cause errors to be thrown if statsd is used
+ */
+export const MockStatsDFactory: Provider<StatsD> = {
+  provide: StatsDService,
+  useFactory: () => {
+    return {} as StatsD;
+  },
+};


### PR DESCRIPTION
## Because

* Many of the tests did not use NestJS test harness
* Many of the tests had poor structure
* Many of the tests did not use jest.spyOn and were not typesafe in their mocks

## This pull request

* Restructures tests within libs

## Issue that this pull request solves

Closes FXA-9540