### PR TITLE
chore(metrics): fix schema identifier of internal Glean metrics

### DIFF
--- a/packages/fxa-shared/metrics/glean/glean-backend-metrics-compat.yaml
+++ b/packages/fxa-shared/metrics/glean/glean-backend-metrics-compat.yaml
@@ -7,7 +7,7 @@
 # For details, see https://bugzilla.mozilla.org/show_bug.cgi?id=1874935#c14
 
 ---
-$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 glean.client.annotation:
   experimentation_id:


### PR DESCRIPTION
This is a follow up to https://github.com/mozilla/fxa/pull/16864

## Because

- Metrics definitions added in https://github.com/mozilla/fxa/pull/16864 contained wrong schema identifier

## This pull request

- Fixes metrics schema identifier

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
