### PR TITLE
chore(functional-tests): update the playwright config file to use defineConfig method

### DIFF
--- a/packages/functional-tests/README.md
+++ b/packages/functional-tests/README.md
@@ -37,7 +37,13 @@ test('mocha tests', async ({ target, page }, info) => {
 
 ## Creating new tests
 
-`yarn record` is a convenient script to start with when creating a new test. It starts playwright in debug mode and runs the `tests/stub.spec.ts` test which creates a new account and prints the credentials to the terminal. From there you can use the Playwright inspector to record your test and copy the command output to your test file.
+`codegen` is a convenient way to start with when creating a new test. Using the codegen command runs the test generator followed by the URL of the website you want to generate tests for. It opens up two windows, a browser window where you interact with the website you wish to test and the Playwright Inspector window where you can record your tests and then copy them into your editor. More info on `codegen` and other options to start with a new test can be found [here](https://playwright.dev/docs/codegen#generate-tests-with-the-playwright-inspector)
+
+Example:
+
+```ts
+npx playwright codegen localhost:3030
+```
 
 ## Fixtures
 

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
-    "record": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=stub --debug",
     "test": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local",
     "test-local": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local",
     "test-stage": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=stage",

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -1,8 +1,9 @@
-import { PlaywrightTestConfig, Project } from '@playwright/test';
-import * as path from 'path';
-import { TargetNames } from './lib/targets';
-import { TestOptions, WorkerOptions } from './lib/fixtures/standard';
 import { getFirefoxUserPrefs } from './lib/targets/firefoxUserPrefs';
+import type { Project } from '@playwright/test';
+import { PlaywrightTestConfig, defineConfig } from '@playwright/test';
+import * as path from 'path';
+import { TestOptions, WorkerOptions } from './lib/fixtures/standard';
+import { TargetNames } from './lib/targets';
 
 const CI = !!process.env.CI;
 
@@ -22,7 +23,7 @@ if (CI) {
   maxFailures = retries * workers * 2;
 }
 
-const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
+export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
   outputDir: path.resolve(__dirname, '../../artifacts/functional'),
   forbidOnly: CI,
   retries,
@@ -35,7 +36,6 @@ const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
       (name) =>
         ({
           name,
-          testIgnore: 'stub.spec.ts',
           use: {
             browserName: 'firefox',
             targetName: name,
@@ -49,19 +49,6 @@ const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
           },
         } as Project)
     ),
-    {
-      name: 'stub',
-      testMatch: 'stub.spec.ts',
-      use: {
-        browserName: 'firefox',
-        targetName: 'local',
-        launchOptions: {
-          args: DEBUG ? ['-start-debugger-server'] : undefined,
-          firefoxUserPrefs: getFirefoxUserPrefs('local', DEBUG),
-          headless: !DEBUG,
-        },
-      },
-    },
   ],
   reporter: CI
     ? [
@@ -79,6 +66,4 @@ const config: PlaywrightTestConfig<TestOptions, WorkerOptions> = {
     : 'list',
   workers,
   maxFailures,
-};
-
-export default config;
+});

--- a/packages/functional-tests/tests/stub.spec.ts
+++ b/packages/functional-tests/tests/stub.spec.ts
@@ -1,7 +1,0 @@
-import { test } from '../lib/fixtures/standard';
-
-test('stub', async ({ page, testAccountTracker }) => {
-  const credentials = await testAccountTracker.signUp();
-  console.log(credentials);
-  await page.pause();
-});


### PR DESCRIPTION
## Because

- The Playwright version 1.31.1 introduced new method defineConfig to be used in the Playwright config file.
- New property [testProject.dependencies](https://playwright.dev/docs/api/class-testproject#test-project-dependencies) to configure dependencies between projects.
- [Release notes](https://playwright.dev/docs/release-notes#new-apis-8)

## This pull request

- Uses new method defineConfig in the config file.
- Removes the `stub.spec.ts` file as well as it's reference from the Playwright config file as it doesn't seem useful anymore and was created with an intent of helping when writing new tests but we already have 300+ tests now and don't need it anymore

## Issue that this pull request solves

Closes: FXA-9242

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

