### PR TITLE
bug(graphql): Prevent reporting of known auth-server errors

### DIFF
--- a/libs/shared/sentry/src/lib/nest/sentry.interceptor.ts
+++ b/libs/shared/sentry/src/lib/nest/sentry.interceptor.ts
@@ -15,7 +15,11 @@ import {
 import * as Sentry from '@sentry/node';
 import { Transaction } from '@sentry/types';
 
-import { isApolloError, processException } from '../reporting';
+import {
+  isApolloError,
+  isAuthServerError,
+  processException,
+} from '../reporting';
 
 @Injectable()
 export class SentryInterceptor implements NestInterceptor {
@@ -43,6 +47,10 @@ export class SentryInterceptor implements NestInterceptor {
               return;
             }
           }
+
+          // Skip known auth-server errors
+          if (isAuthServerError(exception)) return;
+
           // Skip ApolloErrors
           if (isApolloError(exception)) return;
 

--- a/libs/shared/sentry/src/lib/reporting.spec.ts
+++ b/libs/shared/sentry/src/lib/reporting.spec.ts
@@ -3,7 +3,55 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as uuid from 'uuid';
 import { FILTERED } from './pii/filter-actions';
-import { filterObject } from './reporting';
+import { filterObject, isAuthServerError } from './reporting';
+
+describe('detects auth server error', () => {
+  it('flags when code and errno are present', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+      extensions: {
+        code: 401,
+        errno: 101,
+      },
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  it('does not flag when code is missing', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+      extensions: {
+        errno: 101,
+      },
+    });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('does not flag when errno is missing', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+      extensions: {
+        code: 500,
+      },
+    });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('does not flag general errors', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+    });
+
+    expect(result).toBeFalsy();
+  });
+});
 
 describe('filterObject', () => {
   it('should be defined', () => {

--- a/libs/shared/sentry/src/lib/reporting.ts
+++ b/libs/shared/sentry/src/lib/reporting.ts
@@ -56,6 +56,23 @@ export function isApolloError(err: Error): boolean {
   return false;
 }
 
+/**
+ * Determine if an error originates from auth-server. Auth server responds with error
+ * codes and numbers, and client applications handle these states accordingly. These
+ * responses are not considered unhandled error states, and therefore should not
+ * be reported on.
+ * @param error - The error that has occurred
+ * @returns true if errors states appears to be a known auth server error
+ */
+export function isAuthServerError(
+  error: Error & { extensions?: { errno?: number; code?: number } }
+): boolean {
+  return (
+    typeof error.extensions?.code === 'number' &&
+    typeof error.extensions?.errno === 'number'
+  );
+}
+
 export function isOriginallyHttpError(
   error: Error & { originalError?: { status: number } }
 ): boolean {

--- a/packages/fxa-shared/nestjs/sentry/reporting.spec.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.spec.ts
@@ -3,13 +3,61 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as uuid from 'uuid';
 
-import { filterObject } from './reporting';
+import { filterObject, isAuthServerError } from './reporting';
 
 const FILTERED = '[Filtered]';
 
 function getUid() {
   return uuid.v4().replace(/-/g, '');
 }
+
+describe('detects auth server error', () => {
+  it('flags when code and errno are present', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+      extensions: {
+        code: 401,
+        errno: 101,
+      },
+    });
+
+    expect(result).toBeTruthy();
+  });
+
+  it('does not flag when code is missing', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+      extensions: {
+        errno: 101,
+      },
+    });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('does not flag when errno is missing', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+      extensions: {
+        code: 500,
+      },
+    });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('does not flag general errors', () => {
+    const result = isAuthServerError({
+      name: 'foo',
+      message: 'bar',
+    });
+
+    expect(result).toBeFalsy();
+  });
+});
 
 describe('filterObject', () => {
   it('should be defined', () => {
@@ -19,25 +67,7 @@ describe('filterObject', () => {
   // Test Sentry QueryParams filtering types
   it('should filter array of key/value arrays', () => {
     const input = {
-      extra: [
-        ['foo', getUid()],
-        ['baz', getUid()],
-        ['bar', 'fred'],
-      ],
-    };
-    const expected = {
-      extra: [
-        ['foo', FILTERED],
-        ['baz', FILTERED],
-        ['bar', 'fred'],
-      ],
-    };
-    const output = filterObject(input);
-    expect(output).toEqual(expected);
-  });
-
-  it('should filter an object of key/value pairs', () => {
-    const input = {
+      type: undefined,
       extra: {
         foo: getUid(),
         baz: getUid(),
@@ -45,6 +75,28 @@ describe('filterObject', () => {
       },
     };
     const expected = {
+      type: undefined,
+      extra: {
+        foo: FILTERED,
+        baz: FILTERED,
+        bar: 'fred',
+      },
+    };
+    const output = filterObject(input);
+    expect(output).toEqual(expected);
+  });
+
+  it('should filter an object of key/value pairs', () => {
+    const input = {
+      type: undefined,
+      extra: {
+        foo: getUid(),
+        baz: getUid(),
+        bar: 'fred',
+      },
+    };
+    const expected = {
+      type: undefined,
       extra: {
         foo: FILTERED,
         baz: FILTERED,
@@ -57,18 +109,20 @@ describe('filterObject', () => {
 
   it('should skip nested arrays that are not valid key/value arrays', () => {
     const input = {
-      extra: [
-        ['foo', getUid()],
-        ['bar', 'fred'],
-        ['fizz', 'buzz', 'parrot'],
-      ],
+      type: undefined,
+      extra: {
+        foo: getUid(),
+        bar: 'fred',
+        fizz: ['buzz', 'parrot'],
+      },
     };
     const expected = {
-      extra: [
-        ['foo', FILTERED],
-        ['bar', 'fred'],
-        ['fizz', 'buzz', 'parrot'],
-      ],
+      type: undefined,
+      extra: {
+        foo: FILTERED,
+        bar: 'fred',
+        fizz: ['buzz', 'parrot'],
+      },
     };
     const output = filterObject(input);
     expect(output).toEqual(expected);

--- a/packages/fxa-shared/nestjs/sentry/reporting.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.ts
@@ -49,6 +49,24 @@ export function isApolloError(err: Error): boolean {
   return false;
 }
 
+/**
+ * Determine if an error originates from auth-server. Auth server responds with error
+ * codes and numbers, and client applications handle these states accordingly. These
+ * responses are not considered unhandled error states, and therefore should not
+ * be reported on.
+ * @param error - The error that has occurred
+ * @returns true if errors states appears to be a known auth server error
+ */
+export function isAuthServerError(
+  error: Error & { extensions?: { errno?: number; code?: number } }
+): boolean {
+  return (
+    typeof error.extensions?.code === 'number' &&
+    typeof error.extensions?.errno === 'number' &&
+    error.extensions.errno >= 100
+  );
+}
+
 export function isOriginallyHttpError(
   error: Error & { originalError?: { status: number } }
 ): boolean {


### PR DESCRIPTION
## Because

- We were reporting known error response states that come from auth-server and were intended for flow control to Sentry

## This pull request

- Adds an extra check so we do not report these states needlessly.
- Fixes some tests so they adhere to latest sentry types.

## Issue that this pull request solves

Closes: FXA-9289

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

If a manual is desired, you can start up the stack, and run the following curl command (enable Sentry locally), and observe that the error does not propagate; yet the error, 'The authentication token could not be found', is still returned.

```
curl 'http://localhost:8290/graphql' -X POST -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0' -H 'Accept: */*' -H 'Accept-Language: en-US' -H 'Accept-Encoding: gzip, deflate, br, zstd' -H 'Referer: http://localhost:3030/' -H 'Origin: http://localhost:3030' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: no-cors' -H 'Sec-Fetch-Site: same-site' -H 'content-type: application/json' -H 'authorization: Bearer null' -H 'sentry-trace: f0a12862978a4d11a0e2b7dd630d88bb-ab78569a2d9e49fa' -H 'baggage: sentry-environment=local,sentry-release=0.0.0,sentry-public_key=adb27d09f83f43b8852e61ce4c8a487b,sentry-trace_id=f0a12862978a4d11a0e2b7dd630d88bb' -H 'Priority: u=4' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache' --data-raw '[{"operationName":"passwordForgotCodeStatus","variables":{"input":{"token":"0000000000000000000000000000000000000000000000000000000000000000"}},"query":"mutation passwordForgotCodeStatus($input: PasswordForgotCodeStatusInput!) {\n  passwordForgotCodeStatus(input: $input) {\n    tries\n    __typename\n  }\n}"}]'
```

Note, there are only a couple ways to get the `The authentication token could not be found` from known gql queries that allow a singular token field in the input, and is why the above query is a good candidate for a manual sanity check.

Also note, the logic was updated in two places, since we are currently in midst of an NX migration, and only the `fxa-graphql-api` is using the version housed in libs at the moment.
