### PR TITLE
refactor: parallelize customs redis hit

### DIFF
--- a/packages/fxa-customs-server/lib/cache.js
+++ b/packages/fxa-customs-server/lib/cache.js
@@ -25,6 +25,17 @@ class Cache {
       return {};
     }
   }
+
+  async getMultiAsync(keys) {
+    const values = await this.client.redis.mget(keys);
+    return values.map((value) => {
+      try {
+        return JSON.parse(value);
+      } catch (err) {
+        return {};
+      }
+    });
+  }
 }
 
 module.exports = Cache;

--- a/packages/fxa-customs-server/lib/records.js
+++ b/packages/fxa-customs-server/lib/records.js
@@ -47,30 +47,56 @@ module.exports = function (
 
     const { ip, email, phoneNumber, uid } = config;
 
+    const recordFetches = [];
     if (ip) {
-      records.ipRecord = await fetchRecord(ip, IpRecord.parse);
+      recordFetches.push({
+        field: 'ipRecord',
+        key: ip,
+        parser: IpRecord.parse,
+      });
       records.reputation = await reputationService.get(ip);
     }
 
     // The /checkIpOnly endpoint has no email (or phoneNumber)
     if (email) {
-      records.emailRecord = await fetchRecord(email, EmailRecord.parse);
+      recordFetches.push({
+        field: 'emailRecord',
+        key: email,
+        parser: EmailRecord.parse,
+      });
     }
 
     if (ip && email) {
-      records.ipEmailRecord = await fetchRecord(
-        ip + email,
-        IpEmailRecord.parse
-      );
+      recordFetches.push({
+        field: 'ipEmailRecord',
+        key: ip + email,
+        parser: IpEmailRecord.parse,
+      });
     }
 
     // Check against SMS records to make sure that this request can send to this phone number
     if (phoneNumber) {
-      records.smsRecord = await fetchRecord(phoneNumber, SmsRecord.parse);
+      recordFetches.push({
+        field: 'smsRecord',
+        key: phoneNumber,
+        parser: SmsRecord.parse,
+      });
     }
 
     if (uid) {
-      records.uidRecord = await fetchRecord(uid, UidRecord.parse);
+      recordFetches.push({
+        field: 'uidRecord',
+        key: uid,
+        parser: UidRecord.parse,
+      });
+    }
+
+    const redisResults = await mc.getMultiAsync(
+      recordFetches.map((r) => r.key)
+    );
+    for (const [index, { field, key, parser }] of recordFetches.entries()) {
+      records[field] = parser(redisResults[index]);
+      records[field].key = key;
     }
 
     statsd.timing('record_request', performance.now() - startTime, 1);

--- a/packages/fxa-customs-server/test/local/records_tests.js
+++ b/packages/fxa-customs-server/test/local/records_tests.js
@@ -8,6 +8,7 @@ const { test } = require('tap');
 const sandbox = sinon.createSandbox();
 
 const mc = {
+  getMultiAsync: sandbox.spy(() => Promise.resolve({})),
   getAsync: sandbox.spy(() => Promise.resolve({})),
   setAsync: sandbox.spy(() => Promise.resolve()),
 };
@@ -39,12 +40,13 @@ test('fetchRecords', function (t) {
     phoneNumber: 'phone number',
     uid: 'uid',
   }).then((records) => {
-    assert.strictEqual(mc.getAsync.callCount, 5);
-    assert.strictEqual(mc.getAsync.args[0][0], 'ip address');
-    assert.strictEqual(mc.getAsync.args[1][0], 'email address');
-    assert.strictEqual(mc.getAsync.args[2][0], 'ip addressemail address');
-    assert.strictEqual(mc.getAsync.args[3][0], 'phone number');
-    assert.strictEqual(mc.getAsync.args[4][0], 'uid');
+    assert.strictEqual(mc.getMultiAsync.callCount, 1);
+    const keys = mc.getMultiAsync.args[0][0];
+    assert.strictEqual(keys[0], 'ip address');
+    assert.strictEqual(keys[1], 'email address');
+    assert.strictEqual(keys[2], 'ip addressemail address');
+    assert.strictEqual(keys[3], 'phone number');
+    assert.strictEqual(keys[4], 'uid');
 
     assert.lengthOf(Object.keys(records), 6);
     assert.isObject(records.ipRecord);


### PR DESCRIPTION
Because:

* It's more efficient to run a single multi-key get with redis than serial key fetches.

This commit:

* Uses a single multi-key get to fetch all redis records.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

