### PR TITLE
feat(next): add `Localization` wrapper client

### DIFF
--- a/libs/payments/ui/src/index.ts
+++ b/libs/payments/ui/src/index.ts
@@ -6,3 +6,4 @@
 
 export * from './lib/utils/helpers';
 export * from './lib/client/components/StripeWrapper';
+export * from './lib/client/components/Providers';

--- a/libs/payments/ui/src/lib/client/components/FluentLocalizationProvider.tsx
+++ b/libs/payments/ui/src/lib/client/components/FluentLocalizationProvider.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { ReactLocalization, LocalizationProvider } from '@fluent/react';
+import {
+  LocalizerClient,
+  LocalizerBindingsClient,
+} from '@fxa/shared/l10n/client';
+
+export function FluentLocalizationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [l10n, setL10n] = useState<ReactLocalization>();
+
+  useEffect(() => {
+    const setLocalization = async () => {
+      const locale = navigator.language;
+      const bindings = new LocalizerBindingsClient();
+      const localizerClient = new LocalizerClient(bindings);
+      const { l10n } = await localizerClient.setupReactLocalization(locale);
+
+      setL10n(l10n);
+    };
+
+    setLocalization();
+  }, []);
+
+  if (!l10n) {
+    return;
+  }
+
+  return <LocalizationProvider l10n={l10n}>{children}</LocalizationProvider>;
+}

--- a/libs/payments/ui/src/lib/client/components/Providers.tsx
+++ b/libs/payments/ui/src/lib/client/components/Providers.tsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import { FluentLocalizationProvider } from './FluentLocalizationProvider';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <FluentLocalizationProvider>{children}</FluentLocalizationProvider>;
+}

--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 'use client';
 
+import { Localized } from '@fluent/react';
 import { loadStripe, StripeElementsOptions } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 import { CheckoutForm } from './CheckoutForm';
+import { Providers } from './Providers';
 
 interface StripeWrapperProps {
   amount: number;
@@ -57,8 +59,11 @@ export function StripeWrapper({ amount, currency, cart }: StripeWrapperProps) {
   };
 
   return (
-    <Elements stripe={stripePromise} options={options}>
-      <CheckoutForm cart={cart} />
-    </Elements>
+    <Providers>
+      <Localized id="next-pay-with-heading-card-only"></Localized>
+      <Elements stripe={stripePromise} options={options}>
+        <CheckoutForm cart={cart} />
+      </Elements>
+    </Providers>
   );
 }

--- a/libs/shared/l10n/src/lib/localizer/localizer.client.bindings.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.client.bindings.ts
@@ -10,7 +10,7 @@ export class LocalizerBindingsClient implements ILocalizerBindings {
     this.opts = Object.assign(
       {
         translations: {
-          basePath: './locales',
+          basePath: '/locales',
         },
       },
       opts


### PR DESCRIPTION
## Because

- We want to localize client components using the Fluent/react library.

## This pull request

- Adds component FluentLocalizationProvider that initializes and wraps `children` in Fluent `<LocalizationProvider>`.
- Adds a test string to `Checkout` page as a means to test the client component localization works as expected.

## Issue that this pull request solves

Closes: #FXA-7827

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Pay with card in English
![image](https://github.com/mozilla/fxa/assets/10620585/61a968ff-459a-4df6-ada4-2362cb507767)

In German
![image](https://github.com/mozilla/fxa/assets/10620585/6c67cfe4-86a7-48d5-80fb-3ef303102249)

