### PR TITLE
fix: match existing libs/ tsconfig.lib.json in vendored

### DIFF
--- a/libs/vendored/common-password-list/tsconfig.lib.json
+++ b/libs/vendored/common-password-list/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]

--- a/libs/vendored/incremental-encoder/tsconfig.lib.json
+++ b/libs/vendored/incremental-encoder/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]

--- a/libs/vendored/jwtool/tsconfig.lib.json
+++ b/libs/vendored/jwtool/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]


### PR DESCRIPTION
Because:

* We want auth-server to load libs correctly.

This commit:

* Matches the tsconfig.lib.json of other working libraries in auth-server.
