### PR TITLE
fix: switch signer to typescript

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -232,7 +232,10 @@ async function run(config) {
         })
       : null,
   };
-  const signer = require('../lib/signer')(config.secretKeyFile, config.domain);
+  const signer = require('../lib/signer').default(
+    config.secretKeyFile,
+    config.domain
+  );
   const Password = require('../lib/crypto/password')(log, config);
   const customs = new Customs(config.customsUrl, log, error, statsd);
   const zendeskClient = require('../lib/zendesk-client').createZendeskClient(

--- a/packages/fxa-auth-server/lib/signer.ts
+++ b/packages/fxa-auth-server/lib/signer.ts
@@ -2,15 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
+import { JWTool, PrivateJWK } from '@fxa/vendored/jwtool';
 
-const { JWTool } = require('@fxa/vendored/jwtool');
-
-module.exports = function (secretKeyFile, domain) {
-  const key = JWTool.JWK.fromFile(secretKeyFile, { iss: domain });
+export default function (secretKeyFile: string, domain: string) {
+  const key = JWTool.JWK.fromFile(secretKeyFile, { iss: domain }) as PrivateJWK;
 
   return {
-    sign: async function (data) {
+    sign: async function (data: any) {
       const now = Date.now();
       const cert = await key.sign({
         'public-key': data.publicKey,
@@ -32,4 +30,4 @@ module.exports = function (secretKeyFile, domain) {
       return { cert };
     },
   };
-};
+}


### PR DESCRIPTION
Because:

* Typescript path aliases aren't applied to JS files, resulting in them not being loadable in production.

This commit:

* Moves signer.js to a TypeScript file so the TS alias is resolved.

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
