### PR TITLE
chore(functional-tests): run fullyParallel by default

### DIFF
--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -28,6 +28,8 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
   forbidOnly: CI,
   retries,
   testDir: 'tests',
+  // Run all tests in parallel.
+  fullyParallel: true,
   use: {
     viewport: { width: 1280, height: 720 },
   },

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -7,8 +7,6 @@ import { oauthWebchannelV1 } from '../../lib/query-params';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { LoginPage } from '../../pages/login';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('fxa_status web channel message in Settings', () => {
   test.beforeEach(async ({ pages: { configPage } }) => {
     // Ensure that the feature flag is enabled

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -7,8 +7,6 @@ import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { LoginPage } from '../../../pages/login';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test', () => {
     test.beforeEach(() => {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -7,8 +7,6 @@ import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { LoginPage } from '../../../pages/login';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-2 #smoke', () => {
   test.describe('resubscription test', () => {
     test.beforeEach(() => {

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -8,8 +8,6 @@ import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { LoginPage } from '../../pages/login';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-2 #smoke', () => {
   test.describe('subscription', () => {
     test.beforeEach(() => {

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -6,8 +6,6 @@ import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox desktop user info handshake', () => {
     test.beforeEach(async () => {

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -9,8 +9,6 @@ const makeUid = () =>
     .map(() => Math.floor(Math.random() * 16).toString(16))
     .join('');
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-1 #smoke', () => {
   test.describe('Desktop Sync V3 force auth', () => {
     test.beforeEach(async () => {

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -5,8 +5,6 @@
 import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 settings', () => {
     test.beforeEach(async () => {

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -9,8 +9,6 @@ import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { LoginPage } from '../../pages/login';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-2 #smoke', () => {
   test.beforeEach(async () => {
     test.slow();

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -6,8 +6,6 @@ import { expect, test } from '../../lib/fixtures/standard';
 
 const AGE_21 = '21';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-1 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 sign up', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -8,8 +8,6 @@ import uaStrings from '../../lib/ua-strings';
 
 const AGE_21 = '21';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync v3 sign up and CWTS', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -4,8 +4,6 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Firefox Desktop Sync v3 email first', () => {
   test.beforeEach(async () => {
     test.slow();


### PR DESCRIPTION
## Because

- we want the functional test suite to execute as fast as possible

## This pull request

- set the default configuration to run 'fullyParallel' 

## Issue that this pull request solves

Closes: # FXA-9389

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

Before: 11.33 minutes
<img width="573" alt="image" src="https://github.com/mozilla/fxa/assets/3422688/f7460fa8-0853-4f08-9280-4dafb725e1f9">

After 9.52 minutes
<img width="581" alt="image" src="https://github.com/mozilla/fxa/assets/3422688/a0cf317c-053e-46ab-9799-d40990d487f4">

## Other information (Optional)

Any other information that is important to this pull request.
