### PR TITLE
bug(auth): Fix customs checks blocking /account/credentials/status

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1757,11 +1757,8 @@ export class AccountHandler {
 
     const email = (request.payload as any).email;
     await this.customs.check(request, email, 'getCredentialsStatus');
-    const { accountRecord } = await this.signinUtils.checkCustomsAndLoadAccount(
-      request,
-      email,
-      true
-    );
+
+    const accountRecord = await this.db.accountRecord(email);
 
     if (accountRecord.disabledAt) {
       throw error.cannotLoginWithEmail();


### PR DESCRIPTION
## Because
- Calls to /account/credentials/status were getting blocked by customs
- Calls to /account/credentials/status were inadvertently triggering extra custom checks like accountLogin

## This pull request
- Fixes underlying problem by directly quering the account.
- Previously the account was loaded in a way that invoked other customs checks, and those were failing.
- We are also switch to using customs.checkIpOnly instead of customs.check, since this is actually a better / broader check.

## Issue that this pull request solves

Closes: FXA-9649, FXA-9415

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Prior to this fix, this endpoint was triggering a customs check on the accountLogin action, it's quite possible this was causing erratic behavior elsewhere since this action would have gotten hit at a higher rate than we previously saw before key stretching v2 was enabled. 

I also feel like switching customs.checkIpOnly is a better check. Any IP hammering this end point would probably be querying different emails anyways, and therefore simply rate limiting on ip seems like a bitter fit.

