### PR TITLE
feat(cart): add util function for cart handleEligibilityStatus

### DIFF
--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -5,6 +5,7 @@ import {
   Cart,
   CartEligibilityStatus,
   CartErrorReasonId,
+  CartState,
 } from '@fxa/shared/db/mysql/account';
 
 export interface TaxAddress {
@@ -62,4 +63,10 @@ export type UpdateCart = {
   taxAddress?: TaxAddress;
   couponCode?: string;
   email?: string;
+};
+
+export type CartEligibilityDetails = {
+  eligibilityStatus: CartEligibilityStatus;
+  state: CartState;
+  errorReasonId?: CartErrorReasonId;
 };

--- a/libs/payments/cart/src/lib/cart.utils.spec.ts
+++ b/libs/payments/cart/src/lib/cart.utils.spec.ts
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { StripeError } from '@stripe/stripe-js';
 import { stripeErrorToErrorReasonId } from './cart.utils';
 import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';

--- a/libs/payments/cart/src/lib/cart.utils.ts
+++ b/libs/payments/cart/src/lib/cart.utils.ts
@@ -7,7 +7,9 @@ import { EligibilityStatus } from '@fxa/payments/eligibility';
 import {
   CartEligibilityStatus,
   CartErrorReasonId,
+  CartState,
 } from '@fxa/shared/db/mysql/account';
+import { CartEligibilityDetails } from './cart.types';
 
 export const handleEligibilityStatusMap = {
   [EligibilityStatus.BLOCKED_IAP]: CartEligibilityStatus.BLOCKED_IAP,
@@ -15,6 +17,35 @@ export const handleEligibilityStatusMap = {
   [EligibilityStatus.DOWNGRADE]: CartEligibilityStatus.DOWNGRADE,
   [EligibilityStatus.UPGRADE]: CartEligibilityStatus.UPGRADE,
   [EligibilityStatus.INVALID]: CartEligibilityStatus.INVALID,
+};
+
+export const cartEligibilityDetailsMap: Record<
+  EligibilityStatus,
+  CartEligibilityDetails
+> = {
+  [EligibilityStatus.CREATE]: {
+    eligibilityStatus: CartEligibilityStatus.CREATE,
+    state: CartState.START,
+  },
+  [EligibilityStatus.UPGRADE]: {
+    eligibilityStatus: CartEligibilityStatus.UPGRADE,
+    state: CartState.START,
+  },
+  [EligibilityStatus.DOWNGRADE]: {
+    eligibilityStatus: CartEligibilityStatus.DOWNGRADE,
+    state: CartState.FAIL,
+    errorReasonId: CartErrorReasonId.BASIC_ERROR,
+  },
+  [EligibilityStatus.BLOCKED_IAP]: {
+    eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
+    state: CartState.FAIL,
+    errorReasonId: CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT,
+  },
+  [EligibilityStatus.INVALID]: {
+    eligibilityStatus: CartEligibilityStatus.INVALID,
+    state: CartState.FAIL,
+    errorReasonId: CartErrorReasonId.Unknown,
+  },
 };
 
 export function stripeErrorToErrorReasonId(


### PR DESCRIPTION
## Because

- We want to create a util function to handle the `EligibilityStatus` and ensure that the Cart is created with the correct `CartEligibilityStatus`, `CartState` and `ErrorReasonId` (if necessary).

## This pull request

- Creates a util function in `libs/payments/cart` to handle the `EligibilityStatus` to ensure that the Cart is created with the correct `CartEligibilityStatus`, `CartState` and `ErrorReasonId` (if necessary).
- Adds a test for each state.

## Issue that this pull request solves

Closes FXA-9537

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).