### PR TITLE
fix(css): Margin-top tweak for desktop Settings nav

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.tsx
@@ -135,7 +135,7 @@ export const Nav = ({
   return (
     <nav
       // top-[7.69rem] allows the sticky nav header to align exactly with first section heading
-      className="font-header fixed bg-white w-full inset-0 mt-19 desktop:mt-24 me-24 desktop:mt-0 desktop:sticky desktop:top-[7.69rem] desktop:bg-transparent text-xl desktop:text-base"
+      className="font-header fixed bg-white w-full inset-0 mt-19 desktop:mt-0 desktop:sticky desktop:top-[7.69rem] desktop:bg-transparent text-xl desktop:text-base"
       data-testid="nav"
     >
       <ul className="px-6 py-8 tablet:px-8 desktop:p-0 text-start">


### PR DESCRIPTION
Because:
* There's too much margin-top in desktop

This commit:
* Tweaks the margin-top classes

---

You can see on stage there's too much margin-top here and with this tweak it aligns "Settings" with "Profile". Not sure how I let this slip when I repushed to that previous branch/PR heh. Screenshot with this PR:

<img width="721" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/f34dad28-fc15-453e-94fe-76778118748a">
