### PR TITLE
feat(payments-stripe): create doesPlanMatchSubplatInterval

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -28,6 +28,7 @@ import {
   ResultAccountCustomerFactory,
   StripeClient,
   StripeManager,
+  SubplatInterval,
 } from '@fxa/payments/stripe';
 import { CheckoutService } from './checkout.service';
 
@@ -103,7 +104,7 @@ describe('CartService', () => {
       const mockAccountCustomer = ResultAccountCustomerFactory();
       const mockResultCart = ResultCartFactory();
       const args = {
-        interval: faker.string.uuid(),
+        interval: SubplatInterval.Monthly,
         offeringConfigId: faker.string.uuid(),
         experiment: faker.string.uuid(),
         promoCode: faker.word.noun(),

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -13,6 +13,7 @@ import { CartErrorReasonId, CartState } from '@fxa/shared/db/mysql/account';
 import {
   AccountCustomerManager,
   AccountCustomerNotFoundError,
+  SubplatInterval,
 } from '@fxa/payments/stripe';
 import { GeoDBManager } from '@fxa/shared/geodb';
 import { CheckoutService } from './checkout.service';
@@ -32,7 +33,7 @@ export class CartService {
    * **Note**: This method is currently a placeholder. The arguments will likely change, and the internal implementation is far from complete.
    */
   async setupCart(args: {
-    interval: string;
+    interval: SubplatInterval;
     offeringConfigId: string;
     experiment?: string;
     promoCode?: string;

--- a/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
@@ -8,6 +8,7 @@ import {
   StripeManager,
   StripePlan,
   StripePlanFactory,
+  SubplatInterval,
 } from '@fxa/payments/stripe';
 import {
   ContentfulManager,
@@ -500,13 +501,13 @@ describe('EligibilityManager', () => {
     it('returns create status when there are no overlaps', async () => {
       const mockOverlapResult = [] as OfferingOverlapProductResult[];
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockSubscribedPlans = [] as StripePlan[];
 
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         mockSubscribedPlans
       );
       expect(result).toEqual(CartEligibilityStatus.CREATE);
@@ -526,14 +527,14 @@ describe('EligibilityManager', () => {
         },
       ] as OfferingOverlapProductResult[];
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockPlan = StripePlanFactory();
       const mockSubscribedPlans = [mockPlan, mockPlan];
 
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         mockSubscribedPlans
       );
       expect(result).toEqual(CartEligibilityStatus.INVALID);
@@ -548,14 +549,14 @@ describe('EligibilityManager', () => {
         },
       ] as OfferingOverlapProductResult[];
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockPlan = StripePlanFactory();
       const mockSubscribedPlans = [mockPlan];
 
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         mockSubscribedPlans
       );
       expect(result).toEqual(CartEligibilityStatus.DOWNGRADE);
@@ -570,12 +571,12 @@ describe('EligibilityManager', () => {
         },
       ] as OfferingOverlapProductResult[];
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
 
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         []
       );
       expect(result).toEqual(CartEligibilityStatus.INVALID);
@@ -590,13 +591,13 @@ describe('EligibilityManager', () => {
         },
       ] as OfferingOverlapProductResult[];
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockPlan = StripePlanFactory();
 
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         [mockPlan]
       );
       expect(result).toEqual(CartEligibilityStatus.INVALID);
@@ -621,7 +622,7 @@ describe('EligibilityManager', () => {
         interval: 'month',
         product: mockTargetOffering.stripeProductId,
       });
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
 
       mockStripeManager.getPlanByInterval = jest
         .fn()
@@ -630,7 +631,7 @@ describe('EligibilityManager', () => {
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         [mockPlan1]
       );
       expect(result).toEqual(CartEligibilityStatus.DOWNGRADE);
@@ -648,7 +649,7 @@ describe('EligibilityManager', () => {
         interval: 'year',
         product: mockTargetOffering.stripeProductId,
       });
-      const mockInterval = 'year';
+      const interval = SubplatInterval.Yearly;
       const mockOverlapResult = [
         {
           comparison: OfferingComparison.UPGRADE,
@@ -664,7 +665,7 @@ describe('EligibilityManager', () => {
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         [mockPlan1]
       );
       expect(result).toEqual(CartEligibilityStatus.UPGRADE);
@@ -674,7 +675,7 @@ describe('EligibilityManager', () => {
       const mockTargetOffering = EligibilityContentOfferingResultFactory({
         stripeProductId: 'prod_test1',
       });
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockPlan1 = StripePlanFactory({
         interval: 'month',
         product: mockTargetOffering.stripeProductId,
@@ -698,7 +699,7 @@ describe('EligibilityManager', () => {
       const result = await manager.compareOverlap(
         mockOverlapResult,
         mockTargetOffering,
-        mockInterval,
+        interval,
         [mockPlan1]
       );
       expect(result).toEqual(CartEligibilityStatus.UPGRADE);

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -4,7 +4,11 @@
 
 import { Injectable } from '@nestjs/common';
 
-import { StripeManager, StripePlan } from '@fxa/payments/stripe';
+import {
+  StripeManager,
+  StripePlan,
+  SubplatInterval,
+} from '@fxa/payments/stripe';
 import {
   ContentfulManager,
   EligibilityContentOfferingResult,
@@ -95,7 +99,7 @@ export class EligibilityManager {
   async compareOverlap(
     overlaps: OfferingOverlapProductResult[],
     targetOffering: EligibilityContentOfferingResult,
-    interval: string,
+    interval: SubplatInterval,
     subscribedPlans: StripePlan[]
   ) {
     if (!overlaps.length) {

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -17,6 +17,7 @@ import {
   StripeCustomerFactory,
   StripeManager,
   StripeSubscriptionFactory,
+  SubplatInterval,
 } from '@fxa/payments/stripe';
 import {
   ContentfulClient,
@@ -70,11 +71,11 @@ describe('EligibilityService', () => {
 
   describe('checkEligibility', () => {
     it('returns create eligibility status for a new customer', async () => {
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockOffering = EligibilityContentOfferingResultFactory();
 
       const result = await eligibilityService.checkEligibility(
-        mockInterval,
+        interval,
         mockOffering.apiIdentifier,
         undefined
       );
@@ -84,11 +85,11 @@ describe('EligibilityService', () => {
     it('throws an error for no offering for offeringConfigId', async () => {
       const expectedError = new Error('No offering available');
       const mockCustomer = StripeCustomerFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
 
       jest
         .spyOn(contentfulManager, 'getEligibilityContentByOffering')
-        .mockResolvedValueOnce({
+        .mockResolvedValue({
           getOffering: jest.fn().mockImplementation(() => {
             throw expectedError;
           }),
@@ -96,7 +97,7 @@ describe('EligibilityService', () => {
 
       await expect(
         eligibilityService.checkEligibility(
-          mockInterval,
+          interval,
           'prod_test1',
           mockCustomer.id
         )
@@ -105,7 +106,7 @@ describe('EligibilityService', () => {
 
     it('returns eligibility status successfully', async () => {
       const mockCustomer = StripeCustomerFactory();
-      const mockInterval = 'month';
+      const interval = SubplatInterval.Monthly;
       const mockOffering = EligibilityContentOfferingResultFactory();
       const mockOverlapResult = [
         {
@@ -138,7 +139,7 @@ describe('EligibilityService', () => {
         .mockResolvedValue(EligibilityStatus.UPGRADE);
 
       await eligibilityService.checkEligibility(
-        mockInterval,
+        interval,
         mockOffering.apiIdentifier,
         mockCustomer.id
       );
@@ -156,7 +157,7 @@ describe('EligibilityService', () => {
       expect(eligibilityManager.compareOverlap).toHaveBeenCalledWith(
         mockOverlapResult,
         mockOffering,
-        mockInterval,
+        interval,
         []
       );
     });

--- a/libs/payments/eligibility/src/lib/eligibility.service.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.ts
@@ -7,6 +7,7 @@ import {
   getSubscribedPlans,
   getSubscribedProductIds,
   StripeManager,
+  SubplatInterval,
 } from '@fxa/payments/stripe';
 import { ContentfulManager } from '@fxa/shared/contentful';
 import { EligibilityManager } from './eligibility.manager';
@@ -24,7 +25,7 @@ export class EligibilityService {
    * Checks if user is eligible to subscribe to plan
    */
   async checkEligibility(
-    interval: string,
+    interval: SubplatInterval,
     offeringConfigId: string,
     stripeCustomerId?: string | null | undefined
   ) {

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -32,3 +32,4 @@ export * from './lib/stripe.error';
 export * from './lib/stripe.manager';
 export * from './lib/stripe.service';
 export * from './lib/stripe.util';
+export { SubplatInterval } from './lib/stripe.types';

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -20,6 +20,7 @@ import { StripeClient } from './stripe.client';
 import { MockStripeConfigProvider } from './stripe.config';
 import { PlanIntervalMultiplePlansError } from './stripe.error';
 import { StripeManager } from './stripe.manager';
+import { SubplatInterval } from './stripe.types';
 
 describe('StripeManager', () => {
   let stripeManager: StripeManager;
@@ -379,14 +380,19 @@ describe('StripeManager', () => {
 
   describe('getPlanByInterval', () => {
     it('returns plan that matches interval', async () => {
-      const mockPlan = StripeResponseFactory(StripePlanFactory());
-      const mockInterval = mockPlan.interval;
+      const mockPlan = StripeResponseFactory(
+        StripePlanFactory({
+          interval: 'month',
+          interval_count: 1,
+        })
+      );
+      const subplatInterval = SubplatInterval.Monthly;
 
       jest.spyOn(stripeManager, 'getPlan').mockResolvedValue(mockPlan);
 
       const result = await stripeManager.getPlanByInterval(
         [mockPlan.id],
-        mockInterval
+        subplatInterval
       );
       expect(result).toEqual(mockPlan);
     });
@@ -398,6 +404,7 @@ describe('StripeManager', () => {
       const mockPlan2 = StripePlanFactory({
         interval: 'month',
       });
+      const subplatInterval = SubplatInterval.Monthly;
 
       jest
         .spyOn(stripeManager, 'getPlan')
@@ -407,7 +414,10 @@ describe('StripeManager', () => {
         .mockResolvedValue(StripeResponseFactory(mockPlan2));
 
       await expect(
-        stripeManager.getPlanByInterval([mockPlan1.id, mockPlan2.id], 'month')
+        stripeManager.getPlanByInterval(
+          [mockPlan1.id, mockPlan2.id],
+          subplatInterval
+        )
       ).rejects.toBeInstanceOf(PlanIntervalMultiplePlansError);
     });
   });

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -6,7 +6,11 @@ import { Injectable } from '@nestjs/common';
 import { Stripe } from 'stripe';
 
 import { StripeClient } from './stripe.client';
-import { StripeCustomer, StripeSubscription } from './stripe.client.types';
+import {
+  StripeCustomer,
+  StripePlan,
+  StripeSubscription,
+} from './stripe.client.types';
 import { StripeConfig } from './stripe.config';
 import {
   MOZILLA_TAX_ID,
@@ -20,6 +24,8 @@ import {
   ProductNotFoundError,
   StripeNoMinimumChargeAmountAvailableError,
 } from './stripe.error';
+import { doesPlanMatchSubplatInterval } from './util/doesPlanMatchSubplatInterval';
+import { SubplatInterval } from './stripe.types';
 
 @Injectable()
 export class StripeManager {
@@ -183,11 +189,11 @@ export class StripeManager {
     return plan;
   }
 
-  async getPlanByInterval(planIds: string[], interval: string) {
-    const plans = [];
+  async getPlanByInterval(planIds: string[], interval: SubplatInterval) {
+    const plans: StripePlan[] = [];
     for (const planId of planIds) {
       const plan = await this.getPlan(planId);
-      if (plan.interval === interval) {
+      if (doesPlanMatchSubplatInterval(plan, interval)) {
         plans.push(plan);
       }
     }

--- a/libs/payments/stripe/src/lib/stripe.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.types.ts
@@ -11,3 +11,11 @@ export enum STRIPE_PRICE_METADATA {
 export enum STRIPE_PRODUCT_METADATA {
   PROMOTION_CODES = 'promotionCodes',
 }
+
+export enum SubplatInterval {
+  Daily = 'daily',
+  Weekly = 'weekly',
+  Monthly = 'monthly',
+  HalfYearly = 'halfyearly',
+  Yearly = 'yearly',
+}

--- a/libs/payments/stripe/src/lib/util/doesPlanMatchSubplatInterval.spec.ts
+++ b/libs/payments/stripe/src/lib/util/doesPlanMatchSubplatInterval.spec.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StripePlanFactory } from '../factories/plan.factory';
+import { SubplatInterval } from '../stripe.types';
+import { doesPlanMatchSubplatInterval } from './doesPlanMatchSubplatInterval';
+
+describe('doesPlanMatchSubplatInterval', () => {
+  it('returns true when plan matches interval', () => {
+    const plan = StripePlanFactory({
+      interval: 'week',
+      interval_count: 1,
+    });
+
+    const result = doesPlanMatchSubplatInterval(plan, SubplatInterval.Weekly);
+
+    expect(result).toEqual(true);
+  });
+
+  it('does not return plans that do not match interval', () => {
+    const plan = StripePlanFactory({
+      interval: 'week',
+      interval_count: 1,
+    });
+
+    const result = doesPlanMatchSubplatInterval(plan, SubplatInterval.Daily);
+
+    expect(result).toEqual(false);
+  });
+});

--- a/libs/payments/stripe/src/lib/util/doesPlanMatchSubplatInterval.ts
+++ b/libs/payments/stripe/src/lib/util/doesPlanMatchSubplatInterval.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StripePlan } from '../stripe.client.types';
+import { SubplatInterval } from '../stripe.types';
+
+interface Interval {
+  interval: StripePlan['interval'];
+  intervalCount: number;
+}
+
+const subplatIntervalToInterval = {
+  [SubplatInterval.Daily]: {
+    interval: 'day',
+    intervalCount: 1,
+  },
+  [SubplatInterval.Weekly]: {
+    interval: 'week',
+    intervalCount: 1,
+  },
+  [SubplatInterval.Monthly]: {
+    interval: 'month',
+    intervalCount: 1,
+  },
+  [SubplatInterval.HalfYearly]: {
+    interval: 'month',
+    intervalCount: 6,
+  },
+  [SubplatInterval.Yearly]: {
+    interval: 'year',
+    intervalCount: 1,
+  },
+} satisfies Record<SubplatInterval, Interval>;
+
+export const doesPlanMatchSubplatInterval = (
+  plan: StripePlan,
+  subplatInterval: SubplatInterval
+) => {
+  const stripeInterval = subplatIntervalToInterval[subplatInterval];
+
+  return (
+    plan.interval === stripeInterval.interval &&
+    plan.interval_count === stripeInterval.intervalCount
+  );
+};

--- a/libs/payments/ui/src/lib/nestapp/validators/SetupCartActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/SetupCartActionArgs.ts
@@ -1,11 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { SubplatInterval } from '@fxa/payments/stripe';
 import { IsOptional, IsString } from 'class-validator';
 
 export class SetupCartActionArgs {
   @IsString()
-  interval!: string;
+  interval!: SubplatInterval;
 
   @IsString()
   offeringConfigId!: string;


### PR DESCRIPTION
## Because

* We need to actually check interval_count rather than just interval

## This pull request

* Adds a handy util for doing so, and uses it within the stripe manager

## Issue that this pull request solves

Closes FXA-9536
