### PR TITLE
feat(payments,shared): Add ContentfulService to Nest.js AppSingleton

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/layout.tsx
@@ -5,15 +5,13 @@ import { headers } from 'next/headers';
 
 import {
   app,
+  fetchContentfulData,
   getCartAction,
   PurchaseDetails,
   SubscriptionTitle,
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
-import {
-  getFakeCartData,
-  getContentfulContent,
-} from '../../../../../_lib/apiClient';
+import { getFakeCartData } from '../../../../../_lib/apiClient';
 import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
 
 // TODO - Replace these placeholders as part of FXA-8227
@@ -48,7 +46,7 @@ export default async function RootLayout({
   //  headers().get('accept-language')
   //);
   const locale = headers().get('accept-language') || DEFAULT_LOCALE;
-  const contentfulDataPromise = getContentfulContent(params.offeringId, locale);
+  const contentfulDataPromise = fetchContentfulData(params.offeringId, locale);
   const cartDataPromise = getCartAction(params.cartId);
   const l10nPromise = app.getL10n(locale);
   const fakeCartDataPromise = getFakeCartData(params.cartId);
@@ -68,7 +66,7 @@ export default async function RootLayout({
           l10n={l10n}
           interval={cart.interval}
           invoice={fakeCart.nextInvoice}
-          purchaseDetails={contentful.purchaseDetails}
+          purchaseDetails={contentful.defaultPurchase.purchaseDetails}
         />
       </section>
 
@@ -78,7 +76,7 @@ export default async function RootLayout({
           l10n={l10n}
           {...cart}
           {...contentful.commonContent}
-          {...contentful.purchaseDetails}
+          {...contentful.defaultPurchase.purchaseDetails}
           showFXALinks={true}
         />
       </div>

--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/success/page.tsx
@@ -6,18 +6,16 @@ import { headers } from 'next/headers';
 import Image from 'next/image';
 
 import { formatPlanPricing } from '@fxa/payments/ui';
-import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
-
-import {
-  getFakeCartData,
-  getContentfulContent,
-} from '../../../../../../_lib/apiClient';
-import circledConfirm from '../../../../../../../images/circled-confirm.svg';
 import {
   SupportedPages,
   app,
+  fetchContentfulData,
   getCartOrRedirectAction,
 } from '@fxa/payments/ui/server';
+import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
+
+import { getFakeCartData } from '../../../../../../_lib/apiClient';
+import circledConfirm from '../../../../../../../images/circled-confirm.svg';
 
 export const dynamic = 'force-dynamic';
 
@@ -63,7 +61,7 @@ export default async function CheckoutSuccess({
   //);
   const locale = headers().get('accept-language') || DEFAULT_LOCALE;
 
-  const contentfulDataPromise = getContentfulContent(params.offeringId, locale);
+  const contentfulDataPromise = fetchContentfulData(params.offeringId, locale);
   const cartDataPromise = getCartOrRedirectAction(
     params.cartId,
     SupportedPages.SUCCESS
@@ -95,9 +93,10 @@ export default async function CheckoutSuccess({
               'next-payment-confirmation-thanks-subheading',
               {
                 email: cart.email || '',
-                product_name: contentful.purchaseDetails.productName,
+                product_name:
+                  contentful.defaultPurchase.purchaseDetails.productName,
               },
-              `A confirmation email has been sent to ${cart.email} with details on how to get started with ${contentful.purchaseDetails.productName}.`
+              `A confirmation email has been sent to ${cart.email} with details on how to get started with ${contentful.defaultPurchase.purchaseDetails.productName}.`
             )}
           </p>
         </div>

--- a/libs/payments/ui/src/lib/actions/fetchContentfulData.ts
+++ b/libs/payments/ui/src/lib/actions/fetchContentfulData.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { plainToClass } from 'class-transformer';
+import { app } from '../nestapp/app';
+import { FetchContentfulDataArgs } from '../nestapp/validators/FetchContentfulDataArgs';
+
+export const fetchContentfulData = (
+  offeringId: string,
+  acceptLanguage: string
+) => {
+  return app.getActionsService().fetchContentfulData(
+    plainToClass(FetchContentfulDataArgs, {
+      offeringId,
+      acceptLanguage,
+    })
+  );
+};

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -2,35 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Module } from '@nestjs/common';
 import { TypedConfigModule } from 'nest-typed-config';
 
 import { CartManager, CartService } from '@fxa/payments/cart';
-import { AccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
-import { Module } from '@nestjs/common';
-
-import { RootConfig } from './config';
-import { LocalizerRscFactoryProvider } from '@fxa/shared/l10n/server';
-import {
-  AccountCustomerManager,
-  StripeClient,
-  StripeManager,
-} from '@fxa/payments/stripe';
-import { NextJSActionsService } from './nextjs-actions.service';
-import { GeoDBManager, GeoDBNestFactory } from '@fxa/shared/geodb';
-import { validate } from '../config.utils';
 import {
   EligibilityManager,
   EligibilityService,
 } from '@fxa/payments/eligibility';
-import { CheckoutService } from 'libs/payments/cart/src/lib/checkout.service';
-import { ContentfulClient, ContentfulManager } from '@fxa/shared/contentful';
 import {
   PayPalClient,
   PayPalManager,
   PaypalCustomerManager,
 } from '@fxa/payments/paypal';
+import {
+  AccountCustomerManager,
+  StripeClient,
+  StripeManager,
+} from '@fxa/payments/stripe';
+import {
+  ContentfulClient,
+  ContentfulManager,
+  ContentfulService,
+} from '@fxa/shared/contentful';
 import { FirestoreProvider } from '@fxa/shared/db/firestore';
+import { AccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
+import { GeoDBManager, GeoDBNestFactory } from '@fxa/shared/geodb';
+import { LocalizerRscFactoryProvider } from '@fxa/shared/l10n/server';
 import { StatsDProvider } from '@fxa/shared/metrics/statsd';
+
+import { RootConfig } from './config';
+import { NextJSActionsService } from './nextjs-actions.service';
+import { validate } from '../config.utils';
+import { CheckoutService } from 'libs/payments/cart/src/lib/checkout.service';
 
 @Module({
   imports: [
@@ -59,6 +63,7 @@ import { StatsDProvider } from '@fxa/shared/metrics/statsd';
     CheckoutService,
     ContentfulClient,
     ContentfulManager,
+    ContentfulService,
     StripeManager,
     StripeClient,
     PayPalClient,

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -2,18 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Injectable } from '@nestjs/common';
+import { Validator } from 'class-validator';
+
 import { CartService } from '@fxa/payments/cart';
 import { PayPalManager } from '@fxa/payments/paypal';
-import { Injectable } from '@nestjs/common';
+import { ContentfulService } from '@fxa/shared/contentful';
+
+import { CheckoutCartWithPaypalActionArgs } from './validators/CheckoutCartWithPaypalActionArgs';
+import { CheckoutCartWithStripeActionArgs } from './validators/CheckoutCartWithStripeActionArgs';
+import { FetchContentfulDataArgs } from './validators/FetchContentfulDataArgs';
+import { FinalizeCartWithErrorArgs } from './validators/FinalizeCartWithErrorArgs';
 import { GetCartActionArgs } from './validators/GetCartActionArgs';
 import { GetPayPalCheckoutTokenArgs } from './validators/GetPayPalCheckoutTokenArgs';
 import { RestartCartActionArgs } from './validators/RestartCartActionArgs';
-import { UpdateCartActionArgs } from './validators/UpdateCartActionArgs';
-import { Validator } from 'class-validator';
 import { SetupCartActionArgs } from './validators/SetupCartActionArgs';
-import { FinalizeCartWithErrorArgs } from './validators/FinalizeCartWithErrorArgs';
-import { CheckoutCartWithPaypalActionArgs } from './validators/CheckoutCartWithPaypalActionArgs';
-import { CheckoutCartWithStripeActionArgs } from './validators/CheckoutCartWithStripeActionArgs';
+import { UpdateCartActionArgs } from './validators/UpdateCartActionArgs';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -24,6 +28,7 @@ import { CheckoutCartWithStripeActionArgs } from './validators/CheckoutCartWithS
 export class NextJSActionsService {
   constructor(
     private cartService: CartService,
+    private contentfulService: ContentfulService,
     private paypalManager: PayPalManager
   ) {}
 
@@ -99,5 +104,16 @@ export class NextJSActionsService {
       args.version,
       args.paymentMethodId
     );
+  }
+
+  async fetchContentfulData(args: FetchContentfulDataArgs) {
+    new Validator().validateOrReject(args);
+
+    const offering = await this.contentfulService.fetchContentfulData(
+      args.offeringId,
+      args.acceptLanguage
+    );
+
+    return offering;
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/FetchContentfulDataArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/FetchContentfulDataArgs.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class FetchContentfulDataArgs {
+  @IsString()
+  offeringId!: string;
+
+  @IsString()
+  acceptLanguage!: string;
+}

--- a/libs/payments/ui/src/lib/server/purchase-details.tsx
+++ b/libs/payments/ui/src/lib/server/purchase-details.tsx
@@ -54,7 +54,7 @@ type PurchaseDetailsProps = {
   invoice: Invoice;
   purchaseDetails: {
     details: string[];
-    subtitle?: string;
+    subtitle: string | null;
     productName: string;
     webIcon: string;
   };

--- a/libs/payments/ui/src/server.ts
+++ b/libs/payments/ui/src/server.ts
@@ -10,6 +10,7 @@ export * from './lib/server/purchase-details';
 export * from './lib/server/subscription-title';
 export * from './lib/server/terms-and-privacy';
 export * from './lib/utils/types';
+export { fetchContentfulData } from './lib/actions/fetchContentfulData';
 export { handleStripeErrorAction } from './lib/actions/handleStripeError';
 export { getCartAction } from './lib/actions/getCart';
 export { getCartOrRedirectAction } from './lib/actions/getCartOrRedirect';

--- a/libs/shared/contentful/src/index.ts
+++ b/libs/shared/contentful/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/contentful.client';
 export * from './lib/contentful.client.config';
 export * from './lib/contentful.error';
 export * from './lib/contentful.manager';
+export * from './lib/contentful.service';
 export * from './lib/factories';
 export * from './lib/queries/capability-service-by-plan-ids';
 export * from './lib/queries/eligibility-content-by-offering';

--- a/libs/shared/contentful/src/lib/contentful.service.spec.ts
+++ b/libs/shared/contentful/src/lib/contentful.service.spec.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Test } from '@nestjs/testing';
+
+import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
+import { ContentfulClient } from './contentful.client';
+import { ContentfulClientConfig } from './contentful.client.config';
+import { ContentfulManager } from './contentful.manager';
+import { ContentfulService } from './contentful.service';
+
+import {
+  PageContentForOfferingResultUtil,
+  PageContentOfferingTransformedFactory,
+} from './queries/page-content-for-offering';
+
+describe('ContentfulService', () => {
+  let contentfulManager: ContentfulManager;
+  let contentfulService: ContentfulService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ContentfulClientConfig,
+        ContentfulClient,
+        ContentfulManager,
+        ContentfulService,
+        MockFirestoreProvider,
+        MockStatsDProvider,
+      ],
+    }).compile();
+
+    contentfulService = moduleRef.get(ContentfulService);
+    contentfulManager = moduleRef.get(ContentfulManager);
+  });
+
+  describe('fetchContentfulData', () => {
+    it('fetches Contentful data successfully', async () => {
+      const mockOffering = PageContentOfferingTransformedFactory();
+
+      jest
+        .spyOn(contentfulManager, 'getPageContentForOffering')
+        .mockResolvedValue({
+          getOffering: jest.fn().mockResolvedValue(mockOffering),
+        } as unknown as PageContentForOfferingResultUtil);
+
+      const result = await contentfulService.fetchContentfulData(
+        mockOffering.apiIdentifier,
+        'en'
+      );
+
+      expect(result).toEqual(mockOffering);
+    });
+  });
+});

--- a/libs/shared/contentful/src/lib/contentful.service.ts
+++ b/libs/shared/contentful/src/lib/contentful.service.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable } from '@nestjs/common';
+import { ContentfulManager } from './contentful.manager';
+
+@Injectable()
+export class ContentfulService {
+  constructor(private contentfulManager: ContentfulManager) {}
+
+  async fetchContentfulData(offeringId: string, acceptLanguage: string) {
+    const offeringResult =
+      await this.contentfulManager.getPageContentForOffering(
+        offeringId,
+        acceptLanguage
+      );
+
+    return offeringResult.getOffering();
+  }
+}


### PR DESCRIPTION
## This pull request

- [x] Create ContentfulService
- [x] Add ContentfulService to `app.module.ts`
- [x] Add ContentfulService to NextJSActionsService
- [x] Add Server Action to fetch contentful data and return it to the page.
- [x] On the Checkout page, replace stubbed contentful data call with with Server Action to fetch Contentful data

## Issue that this pull request solves

Closes: FXA-7513

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.