### PR TITLE
fix(signup): Add newsletter slug to backend whitelist

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -848,6 +848,7 @@ module.exports.newsletters = isA
       .valid(
         'firefox-accounts-journey',
         'knowledge-is-power',
+        'mozilla-foundation',
         'take-action-for-the-internet',
         'test-pilot',
         'mozilla-and-you',

--- a/packages/fxa-auth-server/test/local/routes/newsletters.js
+++ b/packages/fxa-auth-server/test/local/routes/newsletters.js
@@ -28,7 +28,7 @@ const uid = 'uid';
 const newsletters = [
   'firefox-accounts-journey',
   'knowledge-is-power',
-  'take-action-for-the-internet',
+  'mozilla-foundation',
   'test-pilot',
 ];
 


### PR DESCRIPTION
Because:
* Users are prevented from signing up when they select our new newsletter since it's considered an invalid slug

This commit:
* Adds the slug to our BE whitelist

fixes FXA-9655

---

You can test this locally by going through the entire flow, the newsletter list is sent up on `ConfirmSignupCode`.