### PR TITLE
fix(metrics): Metrics tweaks for React signup events

### DIFF
--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -351,6 +351,7 @@ module.exports = function (
             // The `marketingOptIn` is safe to remove after train-167+
             marketingOptIn: isA.boolean().optional(),
             newsletters: validators.newsletters,
+            metricsContext: METRICS_CONTEXT_SCHEMA,
           }),
         },
       },

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -363,7 +363,7 @@ const AuthAndAccountSetupRoutes = ({
       <CannotCreateAccount path="/cannot_create_account/*" />
       <ConfirmSignupCodeContainer
         path="/confirm_signup_code/*"
-        {...{ integration }}
+        {...{ integration, flowQueryParams }}
       />
       <SignupContainer
         path="/oauth/signup/*"

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -20,6 +20,7 @@ import SignupConfirmCodeContainer from './container';
 import { Integration } from '../../../models';
 import {
   MOCK_EMAIL,
+  MOCK_FLOW_ID,
   MOCK_KEY_FETCH_TOKEN,
   MOCK_SESSION_TOKEN,
   MOCK_UID,
@@ -136,6 +137,7 @@ async function render() {
       {...{
         integration,
       }}
+      flowQueryParams={{ flowId: MOCK_FLOW_ID }}
     />
   );
 }

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -15,6 +15,7 @@ import { GetEmailBounceStatusResponse, LocationState } from './interfaces';
 import { useQuery } from '@apollo/client';
 import { EMAIL_BOUNCE_STATUS_QUERY } from './gql';
 import OAuthDataError from '../../../components/OAuthDataError';
+import { QueryParams } from '../../..';
 
 export const POLL_INTERVAL = 5000;
 
@@ -38,8 +39,10 @@ function getAccountInfo(
 
 const SignupConfirmCodeContainer = ({
   integration,
+  flowQueryParams,
 }: {
   integration: Integration;
+  flowQueryParams: QueryParams;
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const location = useLocation() as ReturnType<typeof useLocation> & {
@@ -148,6 +151,7 @@ const SignupConfirmCodeContainer = ({
         declinedSyncEngines,
         keyFetchToken,
         unwrapBKey,
+        flowQueryParams,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -32,6 +32,7 @@ import { OAUTH_ERRORS } from '../../../lib/oauth';
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
+  queryParamsToMetricsContext: jest.fn(),
   logViewEventOnce: jest.fn(),
   useMetrics: () => ({
     usePageViewEvent: jest.fn(),

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -11,7 +11,11 @@ import {
   getErrorFtlId,
   getLocalizedErrorMessage,
 } from '../../../lib/auth-errors/auth-errors';
-import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
+import {
+  logViewEvent,
+  queryParamsToMetricsContext,
+  usePageViewEvent,
+} from '../../../lib/metrics';
 import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import {
   useAlertBar,
@@ -55,6 +59,7 @@ const ConfirmSignupCode = ({
   declinedSyncEngines,
   keyFetchToken,
   unwrapBKey,
+  flowQueryParams,
 }: ConfirmSignupCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -130,6 +135,9 @@ const ConfirmSignupCode = ({
           scopes: integration.getPermissions(),
         }),
         ...(service !== MozServices.Default && { service }),
+        metricsContext: queryParamsToMetricsContext(
+          flowQueryParams as unknown as Record<string, string>
+        ),
       };
 
       await session.verifySession(code, options);

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -13,6 +13,7 @@ import {
   OAuthIntegrationData,
 } from '../../../models';
 import { StoredAccountData } from '../../../lib/storage-utils';
+import { QueryParams } from '../../..';
 
 export type LocationState = {
   origin: 'signup' | undefined;
@@ -40,6 +41,7 @@ export type ConfirmSignupCodeProps = {
   newsletterSlugs?: string[];
   offeredSyncEngines?: string[];
   declinedSyncEngines?: string[];
+  flowQueryParams: QueryParams;
 } & Pick<LocationState, 'keyFetchToken' | 'unwrapBKey'> &
   RouteComponentProps;
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -8,6 +8,7 @@ import ConfirmSignupCode from '.';
 import { IntegrationType } from '../../../models';
 import {
   MOCK_EMAIL,
+  MOCK_FLOW_ID,
   MOCK_KEY_FETCH_TOKEN,
   MOCK_REDIRECT_URI,
   MOCK_SERVICE,
@@ -72,6 +73,7 @@ export const Subject = ({
           newsletterSlugs,
           finishOAuthFlowHandler,
         }}
+        flowQueryParams={{ flowId: MOCK_FLOW_ID }}
         email={MOCK_EMAIL}
         keyFetchToken={MOCK_KEY_FETCH_TOKEN}
         sessionToken={MOCK_SESSION_TOKEN}


### PR DESCRIPTION
Because:
* reg_complete is not logging the flow id

This commit:
* For reg_complete, adds metricsContext to session/verify call on front-end in ConfirmSignupCode, update expected payload on backend

fixes FXA-9656

---

To verify the `reg_complete` fix, register for an account and grep the auth-server logs for `reg_complete`. See the missing flow ID. In this branch you'll see the flow ID now attached to the event. (Yes, adding `metricsContext` to the expected payload in auth-server is needed or it's still empty.)

--

**Edit: I investigated `reg_view` as part of the ticket but it does appear to be coming through? We might need another PR to fix it if it's a problem but I'll leave my note below, and will repush to update my actual commit message mentioning `reg_view` after r+ in case of nits.**

Currently, I'm not sure why `reg_view` is returning null. The setup looks right and the events look the same when I check in React and Backbone. I went through the flow at least 5 times and could not see a missing flow ID. It's possible we're still having some Glean init issues where the ping tries to get sent before initialization but it's just a hunch. I saw some interesting rerendering [here](https://github.com/mozilla/fxa/blob/main/packages/fxa-settings/src/components/App/index.tsx#L106-L107) but need to circle back on it.
<img width="443" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/0cf68e14-f59e-4ec0-b415-4e0b320f4524">

