### PR TITLE
feat(cartService): update total in `CartService.setupCart`

### DIFF
--- a/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.factories.ts
+++ b/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.factories.ts
@@ -17,9 +17,7 @@ export const ResultAccountCustomerFactory = (
     prefix: '',
     casing: 'lower',
   }),
-  stripeCustomerId: faker.string.alphanumeric({
-    length: 14,
-  }),
+  stripeCustomerId: `cus_${faker.string.alphanumeric({ length: 14 })}`,
   createdAt: faker.date.recent().getTime(),
   updatedAt: faker.date.recent().getTime(),
   ...override,

--- a/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
+++ b/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
@@ -48,6 +48,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
       discountAmount:
         mockUpcomingInvoice.discount &&
         mockUpcomingInvoice.total_discount_amounts?.[0].amount,
+      subTotal: mockUpcomingInvoice.subtotal,
     });
   });
 });

--- a/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
+++ b/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
@@ -30,5 +30,6 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
     totalAmount: invoice.total,
     taxAmounts,
     discountAmount,
+    subTotal: invoice.subtotal,
   };
 }


### PR DESCRIPTION
## Because

- We want to remove skeleton placeholders and replace with actual values.

## This pull request

- Calls `stripeManager.previewInvoice` using priceId obtained from calling `contentfulService.retrieveStripePlanId`, and replaces the amount placeholder with `totalAmount`.

## Issue that this pull request solves

Closes FXA-8896

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
