### PR TITLE
feat(customs): rate limit / block on password reset OTP verification

### DIFF
--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -142,9 +142,12 @@ class CustomsClient {
     });
   }
 
-  async reset(email) {
+  async reset(request, email) {
     await this.makeRequest('/passwordReset', {
-      ...this.sanitizePayload({ email }),
+      ...this.sanitizePayload({
+        ip: request.app.clientAddress,
+        email,
+      }),
     });
   }
 

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1593,7 +1593,7 @@ export class AccountHandler {
           generation: account.verifierSetAt,
         }),
         this.oauth.removeTokensAndCodes(account.uid),
-        this.customs.reset(account.email),
+        this.customs.reset(request, account.email),
       ]);
     };
 

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -584,11 +584,14 @@ module.exports = function (
         // glean.resetPassword.otpEmailSent(request);
 
         await request.emitMetricsEvent('password.forgot.send_otp.completed');
-        recordSecurityEvent('account.password_reset_otp_sent', {
-          db,
-          request,
-          account: { uid: account.uid },
-        });
+
+        // This was commented out because the call fails when there is no token id in the call.
+        // recordSecurityEvent('account.password_reset_otp_sent', {
+        //   db,
+        //   request,
+        //   account: { uid: account.uid },
+        // });
+
         statsd.increment('otp.passwordForgot.sent');
 
         return {};
@@ -622,33 +625,29 @@ module.exports = function (
         await request.emitMetricsEvent('password.forgot.verify_otp.start');
         statsd.increment('otp.passwordForgot.attempt');
 
-        // TODO FXA-9487
-        // await customs.check(request, email, 'passwordForgotVerifyOtp');
+        const { email, code } = request.payload;
+        await customs.check(request, email, 'passwordForgotVerifyOtp');
 
         request.validateMetricsContext();
 
-        const { email, code } = request.payload;
         const account = await db.accountRecord(email);
         const isValidCode = await otpManager.isValid(account.uid, code);
 
         if (!isValidCode) {
-          // TODO FXA-9487
-          // increment failed attempt
-
           throw error.invalidVerificationCode();
         }
-
-        // TODO FXA-9486
-        // glean.resetPassword.otpVerified(request);
 
         const passwordForgotToken = await db.createPasswordForgotToken(account);
 
         await request.emitMetricsEvent('password.forgot.verify_otp.completed');
-        recordSecurityEvent('account.password_reset_otp_verified', {
-          db,
-          request,
-          account: { uid: account.uid },
-        });
+
+        // This was commented out because the call fails when there is no token id in the call.
+        // recordSecurityEvent('account.password_reset_otp_verified', {
+        //   db,
+        //   request,
+        //   account: { uid: account.uid },
+        // });
+
         statsd.increment('otp.passwordForgot.verified');
 
         return {

--- a/packages/fxa-auth-server/test/local/customs.js
+++ b/packages/fxa-auth-server/test/local/customs.js
@@ -81,7 +81,7 @@ describe('Customs', () => {
         );
       })
       .then(() => {
-        return customsNoUrl.reset(email);
+        return customsNoUrl.reset(request, email);
       })
       .then((result) => {
         assert.equal(
@@ -170,6 +170,7 @@ describe('Customs', () => {
             assert.deepEqual(
               body,
               {
+                ip: request.app.clientAddress,
                 email: email,
               },
               'first call to /passwordReset had expected request params'
@@ -177,7 +178,7 @@ describe('Customs', () => {
             return true;
           })
           .reply(200, {});
-        return customsWithUrl.reset(email);
+        return customsWithUrl.reset(request, email);
       })
       .then((result) => {
         assert.equal(
@@ -384,7 +385,7 @@ describe('Customs', () => {
           );
         }),
 
-      customsInvalidUrl.reset(email).then(assert.fail, (err) => {
+      customsInvalidUrl.reset(request, email).then(assert.fail, (err) => {
         assert.equal(
           err.errno,
           error.ERRNO.BACKEND_SERVICE_FAILURE,

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -160,6 +160,12 @@ describe('/password', () => {
           1,
           'validateMetricsContext was called'
         );
+        sinon.assert.calledOnceWithExactly(
+          mockCustoms.check,
+          mockRequest,
+          TEST_EMAIL,
+          'passwordForgotSendOtp'
+        );
 
         sinon.assert.calledOnce(mockMailer.sendPasswordForgotOtpEmail);
 
@@ -310,6 +316,13 @@ describe('/password', () => {
           mockRequest.validateMetricsContext.callCount,
           1,
           'validateMetricsContext was called'
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          mockCustoms.check,
+          mockRequest,
+          TEST_EMAIL,
+          'passwordForgotVerifyOtp'
         );
 
         sinon.assert.callCount(mockStatsd.increment, 2);

--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -65,6 +65,9 @@ const SMS_SENDING_ACTION = {
 const ACCOUNT_ACCESS_ACTION = new Set(['consumeSigninCode']);
 
 const RESET_PASSWORD_OTP_SENDING_ACTION = { passwordForgotSendOtp: true };
+const RESET_PASSWORD_OTP_VERIFICATION_ACTION = {
+  passwordForgotVerifyOtp: true,
+};
 
 module.exports = {
   isPasswordCheckingAction: function (action) {
@@ -93,5 +96,9 @@ module.exports = {
 
   isResetPasswordOtpSendingAction(action) {
     return RESET_PASSWORD_OTP_SENDING_ACTION[action];
+  },
+
+  isResetPasswordOtpVerificationAction(action) {
+    return RESET_PASSWORD_OTP_VERIFICATION_ACTION[action];
   },
 };

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -192,6 +192,30 @@ module.exports = function (fs, path, url, convict) {
           format: 'nat',
           env: 'PASSWORD_RESET_OTP_EMAIL_RATE_LIMIT_SECONDS',
         },
+        maxPasswordResetOtpVerificationRateLimit: {
+          doc: 'Number of OTP verification for an account email or from an IP can request before rate limiting for passwordResetOtpVerificationLimitIntervalSeconds',
+          default: 5,
+          format: 'nat',
+          env: 'PASSWORD_RESET_OTP_VERIFICATION_RATE_LIMIT',
+        },
+        passwordResetOtpVerificationLimitIntervalSeconds: {
+          doc: 'Number of seconds to wait until password reset OTP verification is allowed again',
+          default: 600,
+          format: 'nat',
+          env: 'PASSWORD_RESET_OTP_VERIFICATION_RATE_LIMIT_SECONDS',
+        },
+        maxPasswordResetOtpVerificationBlockLimit: {
+          doc: 'Number of OTP verification for an account email or from an IP can request before blocking for passwordResetOtpVerificationBlockWindowSeconds',
+          default: 10,
+          format: 'nat',
+          env: 'PASSWORD_RESET_OTP_VERIFICATION_BLOCK_LIMIT',
+        },
+        passwordResetOtpVerificationBlockWindowSeconds: {
+          doc: 'Number of seconds when the max number of OTP verification is allowed',
+          default: 86400,
+          format: 'nat',
+          env: 'PASSWORD_RESET_OTP_VERIFICATION_WINDOW_SECONDS',
+        },
       },
     },
     cache: {

--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -663,6 +663,7 @@ module.exports = async function createServer(config, log) {
     method: 'POST',
     path: '/passwordReset',
     handler: async (req, h) => {
+      const ip = req.payload.ip;
       var email = req.payload.email;
       if (!email) {
         const err = {
@@ -674,7 +675,8 @@ module.exports = async function createServer(config, log) {
       }
       email = normalizedEmail(email);
 
-      const { emailRecord } = await fetchRecords({ email });
+      const { ipRecord, emailRecord } = await fetchRecords({ ip, email });
+      ipRecord.passwordReset();
       emailRecord.passwordReset();
 
       try {

--- a/packages/fxa-customs-server/lib/settings/limits.js
+++ b/packages/fxa-customs-server/lib/settings/limits.js
@@ -55,6 +55,16 @@ module.exports = (config, Settings, log) => {
       this.passwordResetOtpEmailRateLimitIntervalMs =
         settings.passwordResetOtpLimits
           .passwordResetOtpRateLimitIntervalSeconds * 1000;
+      this.maxPasswordResetOtpVerificationRateLimit =
+        settings.passwordResetOtpLimits.maxPasswordResetOtpVerificationRateLimit;
+      this.passwordResetOtpVerificationRateLimitWindowMs =
+        settings.passwordResetOtpLimits
+          .passwordResetOtpVerificationLimitIntervalSeconds * 1000;
+      this.maxPasswordResetOtpVerificationBlockLimit =
+        settings.passwordResetOtpLimits.maxPasswordResetOtpVerificationBlockLimit;
+      this.passwordResetOtpVerificationBlockWindowMs =
+        settings.passwordResetOtpLimits
+          .passwordResetOtpVerificationBlockWindowSeconds * 1000;
 
       return this;
     }

--- a/packages/fxa-customs-server/test/cache-helper.js
+++ b/packages/fxa-customs-server/test/cache-helper.js
@@ -49,6 +49,17 @@ var config = {
         600,
       passwordResetOtpRateLimitIntervalSeconds:
         Number(process.env.PASSWORD_RESET_OTP_EMAIL_RATE_LIMIT_SECONDS) || 1800,
+      maxPasswordResetOtpVerificationRateLimit:
+        Number(process.env.PASSWORD_RESET_OTP_VERIFICATION_RATE_LIMIT) || 5,
+      passwordResetOtpVerificationLimitIntervalSeconds:
+        Number(
+          process.env.PASSWORD_RESET_OTP_VERIFICATION_RATE_LIMIT_SECONDS
+        ) || 600,
+      maxPasswordResetOtpVerificationBlockLimit:
+        Number(process.env.PASSWORD_RESET_OTP_VERIFICATION_BLOCK_LIMIT) || 10,
+      passwordResetOtpVerificationBlockWindowSeconds:
+        Number(process.env.PASSWORD_RESET_OTP_VERIFICATION_WINDOW_SECONDS) ||
+        86400,
     },
   },
   requestChecks: {

--- a/packages/fxa-customs-server/test/remote/email_normalization.js
+++ b/packages/fxa-customs-server/test/remote/email_normalization.js
@@ -91,7 +91,7 @@ test('too many failed logins using different capitalizations', function (t) {
 
 test('failed logins are cleared', function (t) {
   return client
-    .postAsync('/passwordReset', { email: 'tEst@example.com' })
+    .postAsync('/passwordReset', { ip: TEST_IP, email: 'tEst@example.com' })
     .spread(function (req, res, obj) {
       t.equal(res.statusCode, 200, 'request returns a 200');
       t.ok(obj, 'got an obj, make jshint happy');

--- a/packages/fxa-customs-server/test/remote/password_reset_tests.js
+++ b/packages/fxa-customs-server/test/remote/password_reset_tests.js
@@ -8,6 +8,7 @@ var mcHelper = require('../cache-helper');
 const { randomEmail } = require('../utils');
 
 var TEST_EMAIL = randomEmail();
+const TEST_IP = '192.0.2.1';
 
 const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
@@ -32,7 +33,7 @@ var client = restifyClients.createJsonClient({
 test('well-formed request', function (t) {
   client.post(
     '/passwordReset',
-    { email: TEST_EMAIL },
+    { ip: TEST_IP, email: TEST_EMAIL },
     function (err, req, res, obj) {
       t.notOk(err, 'good request is successful');
       t.equal(res.statusCode, 200, 'good request returns a 200');
@@ -43,7 +44,7 @@ test('well-formed request', function (t) {
 });
 
 test('missing email', function (t) {
-  client.post('/passwordReset', {}, function (err, req, res, obj) {
+  client.post('/passwordReset', { ip: TEST_IP }, function (err, req, res, obj) {
     t.equal(res.statusCode, 400, 'bad request returns a 400');
     t.type(obj.code, 'string', 'bad request returns an error code');
     t.type(obj.message, 'string', 'bad request returns an error message');

--- a/packages/fxa-customs-server/test/remote/too_many_password_reset_otp_verifications.js
+++ b/packages/fxa-customs-server/test/remote/too_many_password_reset_otp_verifications.js
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const test = require('tap').test;
+const TestServer = require('../test_server');
+const Promise = require('bluebird');
+const restifyClients = Promise.promisifyAll(require('restify-clients'));
+const mcHelper = require('../cache-helper');
+const testUtils = require('../utils');
+
+const config = require('../../lib/config').getProperties();
+config.limits.rateLimitIntervalSeconds = 1;
+config.limits.ipRateLimitIntervalSeconds = 1;
+config.limits.passwordResetOtpLimits.maxPasswordResetOtpVerificationRateLimit = 2;
+config.limits.passwordResetOtpLimits.passwordResetOtpVerificationLimitIntervalSeconds = 1;
+config.limits.passwordResetOtpLimits.maxPasswordResetOtpVerificationBlockLimit = 3;
+config.limits.passwordResetOtpLimits.passwordResetOtpVerificationBlockWindowSeconds = 3;
+
+const testServer = new TestServer(config);
+
+const client = restifyClients.createJsonClient({
+  url: 'http://localhost:' + config.listen.port,
+});
+
+const action = 'passwordForgotVerifyOtp';
+
+Promise.promisifyAll(client, { multiArgs: true });
+
+test('startup', async function (t) {
+  await testServer.start();
+  t.type(testServer.server, 'object', 'test server was started');
+  t.end();
+});
+
+test('clear everything', function (t) {
+  mcHelper.clearEverything(function (err) {
+    t.notOk(err, 'no errors were returned');
+    t.end();
+  });
+});
+
+test('/check passwordForgotVerifyOtp by email', async (t) => {
+  const email = testUtils.randomEmail();
+  let ip = testUtils.randomIp();
+
+  let response = await client.postAsync('/check', { ip, email, action });
+  let [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, false, 'not rate limited');
+
+  // same email different ip
+  ip = testUtils.randomIp();
+  response = await client.postAsync('/check', { ip, email, action });
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, false, 'not rate limited');
+
+  ip = testUtils.randomIp();
+  response = await client.postAsync('/check', { ip, email, action });
+  // eslint-disable-next-line no-unused-vars
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, true, 'rate limited');
+  t.equal(obj.retryAfter, 1, 'rate limit retry amount');
+
+  // the min configurable value is a second
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  ip = testUtils.randomIp();
+  response = await client.postAsync('/check', { ip, email, action });
+  // eslint-disable-next-line no-unused-vars
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, true, 'blocked');
+  t.equal(obj.retryAfter, 3, 'blocked retry amount');
+});
+
+test('clear everything', function (t) {
+  mcHelper.clearEverything(function (err) {
+    t.notOk(err, 'no errors were returned');
+    t.end();
+  });
+});
+
+test('/check passwordForgotVerifyOtp by ip address', async (t) => {
+  const ip = testUtils.randomIp();
+  let email = testUtils.randomEmail();
+
+  let response = await client.postAsync('/check', { ip, email, action });
+  let [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, false, 'not rate limited');
+
+  // same ip different email
+  email = testUtils.randomEmail();
+  response = await client.postAsync('/check', { ip, email, action });
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, false, 'not rate limited');
+
+  email = testUtils.randomEmail();
+  response = await client.postAsync('/check', { ip, email, action });
+  // eslint-disable-next-line no-unused-vars
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, true, 'rate limited');
+  t.equal(obj.retryAfter, 1, 'rate limit retry amount');
+
+  // the min configurable value is a second
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  email = testUtils.randomEmail();
+  response = await client.postAsync('/check', { ip, email, action });
+  // eslint-disable-next-line no-unused-vars
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, true, 'blocked');
+  t.equal(obj.retryAfter, 3, 'blocked retry amount');
+});
+
+test('teardown', async function (t) {
+  await testServer.stop();
+  t.end();
+});


### PR DESCRIPTION
Because:
 - we need to rate limit requests to verify password reset OTPs

This commit:
 - updates customs server to rate limit and block with IP address or account email address for password reset OTP verification requests
