### PR TITLE
bug(auth): Don't notify of password change  for key stretch upgrades

### DIFF
--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -725,11 +725,15 @@ module.exports = (config, log, Token, UnblockCode = null) => {
 
   // BATCH
 
-  DB.prototype.resetAccount = async function (accountResetToken, data) {
+  DB.prototype.resetAccount = async function (
+    accountResetToken,
+    data,
+    keepSessions
+  ) {
     const { uid } = accountResetToken;
 
     log.trace('DB.resetAccount', { uid });
-    if (this.redis) {
+    if (this.redis && keepSessions !== true) {
       await this.redis.del(uid);
     }
     data.verifierSetAt = Date.now();

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -671,6 +671,19 @@ function mockDB(data, errors) {
     createPassword: sinon.spy(() => {
       return Promise.resolve(1584397692000);
     }),
+    checkPassword: sinon.spy(() => {
+      return Promise.resolve({
+        v1: data.isPasswordMatchV1 === true,
+        v2: data.isPasswordMatchV2 === true,
+      });
+    }),
+    resetAccount: sinon.spy(() => {
+      return Promise.resolve({
+        uid: data.uid,
+        verifierSetAt: Date.now(),
+        email: data.email,
+      });
+    }),
   });
 }
 


### PR DESCRIPTION
## Because

 - When auto upgrading passwords to v2 key stretching, notification emails were being sent to users
 - When auto upgrading passwords to v2 key stretching, notifications were sent to RPs

## This pull request

 - Suppresses email when we detect an v2 key stretch upgrade scenario
 - Suppresses notifications when we detect a v2 key stretch upgrade scenario
 - Reports slightly different metrics for key stretch upgrades
 
## Issue that this pull request solves

Closes: FXA-9662

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
