### PR TITLE
test(functional): add auto retrying assertion

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -232,14 +232,12 @@ export class LoginPage extends BaseLayout {
     return emailHeader.isVisible();
   }
 
-  async cannotCreateAccountHeader() {
-    const header = this.page.locator(selectors.COPPA_HEADER);
-    await header.waitFor({ state: 'visible' });
-    return header.isVisible();
+  cannotCreateAccountHeader() {
+    return this.page.locator(selectors.COPPA_HEADER);
   }
 
-  async confirmEmail() {
-    return this.page.innerText(selectors.CONFIRM_EMAIL);
+  getConfirmEmail() {
+    return this.page.locator(selectors.CONFIRM_EMAIL);
   }
 
   setEmail(email: string) {
@@ -333,8 +331,8 @@ export class LoginPage extends BaseLayout {
     return this.page.click(selectors.LINK_CHANGE_EMAIL);
   }
 
-  async getTooltipError() {
-    return this.page.locator(selectors.TOOLTIP).innerText();
+  getTooltipError() {
+    return this.page.locator(selectors.TOOLTIP);
   }
 
   async unblock(email: string) {
@@ -401,10 +399,8 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.SUBMIT).click();
   }
 
-  async isSyncConnectedHeader() {
-    return this.page.isVisible(selectors.SYNC_CONNECTED_HEADER, {
-      timeout: 100,
-    });
+  isSyncConnectedHeader() {
+    return this.page.locator(selectors.SYNC_CONNECTED_HEADER);
   }
 
   async enterPasswordHeader() {
@@ -457,8 +453,8 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.EMAIL).inputValue();
   }
 
-  async getPasswordInput() {
-    return this.page.locator(selectors.PASSWORD).inputValue();
+  getPasswordInput() {
+    return this.page.locator(selectors.PASSWORD);
   }
 
   async isCachedLogin() {
@@ -477,8 +473,8 @@ export class LoginPage extends BaseLayout {
     await this.page.waitForURL(/appleid\.apple\.com/);
   }
 
-  async getErrorMessage() {
-    return this.page.locator(selectors.ERROR).innerText();
+  getErrorMessage() {
+    return this.page.locator(selectors.ERROR);
   }
 
   async getStorage() {

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -14,7 +14,9 @@ test.describe('severity-2 #smoke', () => {
       await relier.goto(`email=${invalidEmail}`);
       await relier.clickEmailFirst();
 
-      expect(await login.getTooltipError()).toContain('Valid email required');
+      await expect(login.getTooltipError()).toContainText(
+        'Valid email required'
+      );
     });
 
     test('login_hint specified by relier, not registered', async ({

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -9,7 +9,6 @@ test.describe('severity-1 #smoke', () => {
   test.slow();
 
   test('react signin to sync and disconnect', async ({
-    target,
     syncBrowserPages: {
       configPage,
       connectAnotherDevice,
@@ -20,7 +19,6 @@ test.describe('severity-1 #smoke', () => {
     testAccountTracker,
   }) => {
     const config = await configPage.getConfig();
-    test.fixme(true, 'Fix required as of 2024/04/19 (see FXA-9490)');
     test.skip(
       config.showReactApp.signInRoutes !== true,
       'Skip tests if React signInRoutes not enabled'
@@ -40,24 +38,14 @@ test.describe('severity-1 #smoke', () => {
 
     await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     await connectAnotherDevice.notNowButton.click();
-
-    await expect(page).toHaveURL(/settings/);
-
-    // Normally we wouldn't need this delay, but because we will be
-    // disconnecting the sync service, we need to ensure that the device
-    // record and web channels have been sent and created.
-    await page.waitForTimeout(1000);
+    await expect(page).toHaveURL(/settings/, { timeout: 1000 });
 
     await settings.disconnectSync(credentials);
 
-    // See above, we need to wait for disconnect to complete
-    await page.waitForTimeout(1000);
-
     // confirm left settings and back at sign in
-    expect(page.url()).toBe(`${target.contentServerUrl}/`);
+    await page.waitForURL('**/signin', { timeout: 1000 });
   });
 
-  // https://testrail.stage.mozaws.net/index.php?/cases/view/1293475
   test('react disconnect RP #1293475', async ({
     pages: { configPage, page, relier, signinReact, settings },
     testAccountTracker,

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -21,12 +21,12 @@ test.describe('severity-2 #smoke', () => {
       pages: { login },
     }) => {
       await page.goto(`${target.contentServerUrl}?email=invalid`);
-      expect(await login.getErrorMessage()).toContain(
+      await expect(login.getErrorMessage()).toContainText(
         'Invalid parameter: email'
       );
 
       await page.goto(`${target.contentServerUrl}?email=`);
-      expect(await login.getErrorMessage()).toContain(
+      await expect(login.getErrorMessage()).toContainText(
         'Invalid parameter: email'
       );
     });
@@ -46,7 +46,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Verify the confirm code header and the email
       await expect(login.signUpCodeHeader).toBeVisible();
-      expect(await login.confirmEmail()).toContain(email);
+      await expect(login.getConfirmEmail()).toHaveValue(email);
     });
 
     test('signup with email with trailing whitespace on the email', async ({
@@ -63,7 +63,7 @@ test.describe('severity-2 #smoke', () => {
         verify: false,
       });
       await expect(login.signUpCodeHeader).toBeVisible();
-      expect(await login.confirmEmail()).toContain(email);
+      await expect(login.getConfirmEmail()).toHaveValue(email);
     });
 
     test('signup with invalid email address', async ({
@@ -76,7 +76,9 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSubmit();
 
       // Verify the error
-      expect(await login.getTooltipError()).toContain('Valid email required');
+      await expect(login.getTooltipError()).toContainText(
+        'Valid email required'
+      );
     });
 
     test('coppa is empty and too young', async ({
@@ -96,7 +98,7 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSubmit();
 
       // Verify the error
-      expect(await login.getTooltipError()).toContain(
+      await expect(login.getTooltipError()).toContainText(
         'You must enter your age to sign up'
       );
 
@@ -105,7 +107,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Verify navigated to the cannot create account page
       await page.waitForURL(/cannot_create_account/);
-      expect(await login.cannotCreateAccountHeader()).toBe(true);
+      await expect(login.cannotCreateAccountHeader()).toBeVisible();
     });
 
     test('sign up with non matching passwords', async ({
@@ -125,7 +127,9 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSubmit();
 
       // Verify the error
-      expect(await login.getTooltipError()).toContain('Passwords do not match');
+      await expect(login.getTooltipError()).toContainText(
+        'Passwords do not match'
+      );
     });
 
     test('signup via relier page and redirect after confirm', async ({
@@ -165,7 +169,7 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSubmit();
 
       // check the password was cleared
-      expect(await login.getPasswordInput()).toContain('');
+      await expect(login.getPasswordInput()).toHaveValue('');
     });
 
     test('signup, verify and sign out of two accounts, all in the same tab, then sign in to the first account', async ({

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -13,8 +13,6 @@ test.describe('severity-1 #smoke', () => {
     syncBrowserPages: { page, login, settings },
     testAccountTracker,
   }) => {
-    test.fixme(true, 'Fix required as of 2024/04/19 (see FXA-9490)');
-
     const credentials = await testAccountTracker.signUp();
 
     await page.goto(
@@ -23,18 +21,12 @@ test.describe('severity-1 #smoke', () => {
     );
     await login.login(credentials.email, credentials.password);
 
-    expect(await login.isSyncConnectedHeader()).toBe(true);
+    await expect(login.isSyncConnectedHeader()).toBeVisible({ timeout: 1000 });
 
-    // Normally we wouldn't need this delay, but because we will be
-    // disconnecting the sync service, we need to ensure that the device
-    // record and web channels have been sent and created (FXA-9490).
-    await page.waitForTimeout(1000);
     await settings.disconnectSync(credentials);
-    // See above, we need to wait for disconnect to complete (FXA-9490).
-    await page.waitForTimeout(1000);
 
     // confirm left settings and back at sign in
-    expect(page.url()).toBe(login.url);
+    await page.waitForURL('**/signin', { timeout: 1000 });
   });
 
   test('disconnect RP', async ({

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -24,7 +24,7 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSubmit();
 
       // Verify the error
-      expect(await login.getTooltipError()).toContain('Incorrect password');
+      await expect(login.getTooltipError()).toContainText('Incorrect password');
 
       //Click forgot password link
       await login.clickForgotPassword();
@@ -80,7 +80,7 @@ test.describe('severity-2 #smoke', () => {
       await login.clickSubmit();
 
       // Verify the error
-      expect(await login.getTooltipError()).toContain('Incorrect password');
+      await expect(login.getTooltipError()).toContainText('Incorrect password');
     });
 
     test('login as an existing user', async ({

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -54,7 +54,7 @@ test.describe('severity-2 #smoke', () => {
       await login.enterUnblockCode('incorrect');
 
       //Verify tooltip error
-      expect(await login.getTooltipError()).toContain(
+      await expect(login.getTooltipError()).toContainText(
         'Invalid authorization code'
       );
 

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -259,7 +259,9 @@ test.describe('severity-2 #smoke', () => {
             '?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email'
         );
         await login.login(credentials.email, credentials.password);
-        expect(await login.isSyncConnectedHeader()).toBe(true);
+        await expect(login.isSyncConnectedHeader()).toBeVisible({
+          timeout: 1000,
+        });
 
         await relier.goto();
         await relier.clickEmailFirst();

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -76,7 +76,7 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     await login.clickSubmit();
 
     // Verify the error
-    expect(await login.getTooltipError()).toContain(
+    await expect(login.getTooltipError()).toContainText(
       'Enter a valid email address. firefox.com does not offer email.'
     );
   });


### PR DESCRIPTION
## Because

- The relying party and sign up tests were flaky

## This pull request

- Adds auto retrying assertions in places where flakiness was detected.

## Issue that this pull request solves

Closes: FXA-9386 FXA-9490

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

After the changes, ran the tests for local, stage and Prod on CI and it passed (the failures are for just coupon tests in Stage):
<img width="1460" alt="Screenshot 2024-05-16 at 2 35 38 PM" src="https://github.com/mozilla/fxa/assets/62558650/e97814e4-21db-4d61-9a60-9fb131255851">


And ran the tests separately in local, Stage and prod locally several times and it didn't flake:
Stage:
<img width="1370" alt="Screenshot 2024-05-16 at 2 46 14 PM" src="https://github.com/mozilla/fxa/assets/62558650/426e2302-3c6d-47a2-86bc-eba3fec9400d">

Prod:
<img width="1379" alt="Screenshot 2024-05-16 at 2 43 33 PM" src="https://github.com/mozilla/fxa/assets/62558650/bf350741-b557-409a-8791-bd6dcc7a60e9">






