### PR TITLE
fix(react): Address inline TOTP setup issues

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -386,7 +386,7 @@ const AuthAndAccountSetupRoutes = ({
       <InlineTotpSetupContainer
         path="/inline_totp_setup/*"
         integration={integration as OAuthIntegration}
-        {...{ isSignedIn, serviceName }}
+        {...{ isSignedIn, serviceName, flowQueryParams }}
       />
       <InlineRecoverySetupContainer
         path="/inline_recovery_setup/*"

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -21,7 +21,11 @@ import {
 } from './mocks';
 import { screen, waitFor } from '@testing-library/react';
 import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
-import { MOCK_NO_TOTP, MOCK_TOTP_STATUS_VERIFIED } from '../Signin/mocks';
+import {
+  MOCK_FLOW_ID,
+  MOCK_NO_TOTP,
+  MOCK_TOTP_STATUS_VERIFIED,
+} from '../Signin/mocks';
 import { SigninLocationState } from '../Signin/interfaces';
 
 const mockLocationHook = (
@@ -102,7 +106,13 @@ const defaultProps = {
 function render(props = {}) {
   renderWithLocalizationProvider(
     <LocationProvider>
-      <InlineTotpSetupContainer {...{ ...defaultProps, ...props }} />
+      <InlineTotpSetupContainer
+        {...{
+          ...defaultProps,
+          ...props,
+          flowQueryParams: { flowId: MOCK_FLOW_ID },
+        }}
+      />
     </LocationProvider>
   );
 }


### PR DESCRIPTION
Because:
* The inline TOTP setup flow is being blocked by customs on stage
* This flow can also encounter a "token already exists" error in some cases

This commit:
* Adds metricsContext to the request for customs
* Does not rerun the TOTP create request if a totp token already exists

fixes FXA-9435

---

You can access this flow in React by going to 123done and clicking "Sign in (2FA required)", adding the React experiment params, then either signing up for an account or signing into an account. You should be redirected back to signin with a cached view, then on click of signin, you should be taken to the inline TOTP setup page.

Vijay flagged in the comments of this ticket that the flow wasn't working as expected (note, QA's comment/gif is not applicable to this issue). I did some investigation and fixed a couple of issues I saw when going through the flow locally, though, it's worth noting the flow ID fix is a best guess to what I'm seeing on staging (request blocked for security reasons), I could not seem to trigger this state locally.