### PR TITLE
fix(unblock): Use correct authPW when user is blocked

### DIFF
--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -91,6 +91,15 @@ export class TestAccountTracker {
   }
 
   /**
+   * Creates a new email address with the 'blocked' prefix and a new randomized
+   * password
+   * @returns AccountDetails
+   */
+  generateBlockedAccountDetails(): AccountDetails {
+    return this.generateAccountDetails(EmailPrefix.BLOCKED);
+  }
+
+  /**
    * Creates a new email address with a given prefix and a new randomized
    * password
    * @param prefix email prefix to use when generating email

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -6,7 +6,6 @@ import { useMutation } from '@apollo/client';
 import { RouteComponentProps, useLocation } from '@reach/router';
 
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-import { KeyStretchExperiment } from '../../../models/experiments/key-stretch-experiment';
 
 import VerificationMethods from '../../../constants/verification-methods';
 import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
@@ -15,24 +14,11 @@ import {
   isOAuthIntegration,
   useAuthClient,
   useFtlMsgResolver,
-  useConfig,
 } from '../../../models';
 
 // using default signin handlers
-import {
-  BEGIN_SIGNIN_MUTATION,
-  CREDENTIAL_STATUS_MUTATION,
-  GET_ACCOUNT_KEYS_MUTATION,
-  PASSWORD_CHANGE_FINISH_MUTATION,
-  PASSWORD_CHANGE_START_MUTATION,
-} from '../gql';
-import {
-  BeginSigninResponse,
-  CredentialStatusResponse,
-  GetAccountKeysResponse,
-  PasswordChangeFinishResponse,
-  PasswordChangeStartResponse,
-} from '../interfaces';
+import { BEGIN_SIGNIN_MUTATION } from '../gql';
+import { BeginSigninResponse } from '../interfaces';
 
 import SigninUnblock from '.';
 import {
@@ -47,9 +33,6 @@ import { MozServices } from '../../../lib/types';
 import { QueryParams } from '../../..';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import OAuthDataError from '../../../components/OAuthDataError';
-import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
-import { trySignIn, tryKeyStretchingUpgrade } from '../container';
-import { getCredentials } from 'fxa-auth-client/browser';
 
 const SigninUnblockContainer = ({
   integration,
@@ -60,14 +43,11 @@ const SigninUnblockContainer = ({
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
-  const config = useConfig();
-  const keyStretchExp = useValidatedQueryParams(KeyStretchExperiment);
 
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: SigninUnblockLocationState;
   };
-  const { email, hasLinkedAccount, hasPassword, password } =
-    location.state || {};
+  const { email, authPW, hasLinkedAccount, hasPassword } = location.state || {};
 
   const wantsTwoStepAuthentication =
     isOAuthIntegration(integration) && integration.wantsTwoStepAuthentication();
@@ -75,22 +55,6 @@ const SigninUnblockContainer = ({
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
     integration
-  );
-
-  const [credentialStatus] = useMutation<CredentialStatusResponse>(
-    CREDENTIAL_STATUS_MUTATION
-  );
-
-  const [passwordChangeStart] = useMutation<PasswordChangeStartResponse>(
-    PASSWORD_CHANGE_START_MUTATION
-  );
-
-  const [passwordChangeFinish] = useMutation<PasswordChangeFinishResponse>(
-    PASSWORD_CHANGE_FINISH_MUTATION
-  );
-
-  const [getWrappedKeys] = useMutation<GetAccountKeysResponse>(
-    GET_ACCOUNT_KEYS_MUTATION
   );
 
   const [beginSignin] = useMutation<BeginSigninResponse>(BEGIN_SIGNIN_MUTATION);
@@ -110,31 +74,15 @@ const SigninUnblockContainer = ({
     };
 
     try {
-      const { error, unverifiedAccount, v1Credentials, v2Credentials } =
-        await tryKeyStretchingUpgrade(
-          email,
-          password,
-          keyStretchExp.queryParamModel.isV2(config),
-          credentialStatus,
-          passwordChangeStart,
-          getWrappedKeys,
-          passwordChangeFinish
-        );
-
-      return await trySignIn(
-        email,
-        v1Credentials,
-        error ? undefined : v2Credentials,
-        unverifiedAccount,
-        beginSignin,
-        options,
-        async (correctedEmail: string) => {
-          return {
-            v1Credentials: await getCredentials(correctedEmail, password),
-            v2Credentials,
-          };
-        }
-      );
+      return beginSignin({
+        variables: {
+          input: {
+            email,
+            authPW,
+            options,
+          },
+        },
+      });
     } catch (error) {
       return getHandledError(error);
     }
@@ -161,7 +109,7 @@ const SigninUnblockContainer = ({
     return <OAuthDataError error={oAuthDataError} />;
   }
 
-  if (!email || !password) {
+  if (!email || !authPW) {
     hardNavigate('/', {}, true);
     return <LoadingSpinner fullScreen />;
   }

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
@@ -9,7 +9,7 @@ export interface SigninUnblockLocationState {
   email: string;
   hasLinkedAccount: boolean;
   hasPassword: boolean;
-  password: string;
+  authPW: string;
 }
 
 export interface SigninUnblockProps {

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -23,6 +23,7 @@ import {
   MOCK_SESSION_TOKEN,
   MOCK_UID,
   MOCK_UNWRAP_BKEY,
+  MOCK_AUTHPW,
 } from '../mocks';
 import { MozServices } from '../../lib/types';
 import * as utils from 'fxa-react/lib/utils';
@@ -507,9 +508,9 @@ describe('Signin', () => {
           expect(mockNavigate).toHaveBeenCalledWith('/signin_unblock', {
             state: {
               email: MOCK_EMAIL,
+              authPW: MOCK_AUTHPW,
               hasLinkedAccount: false,
               hasPassword: true,
-              password: MOCK_PASSWORD,
             },
           });
         });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -32,6 +32,7 @@ import {
 import { SigninFormData, SigninProps } from './interfaces';
 import { handleNavigation } from './utils';
 import { useWebRedirect } from '../../lib/hooks/useWebRedirect';
+import { getCredentials } from 'fxa-auth-client/lib/crypto';
 
 export const viewName = 'signin';
 
@@ -230,11 +231,15 @@ const Signin = ({
                 setSigninLoading(false);
                 break;
               }
+
+              // Fallback to using v1 creds for signin unblock and don't
+              // upgrade user to v2 keys
+              const v1Credentials = await getCredentials(email, password);
               // navigate only if sending the unblock code email is successful
               navigate('/signin_unblock', {
                 state: {
                   email,
-                  password,
+                  authPW: v1Credentials.authPW,
                   // TODO: in FXA-9177, remove hasLinkedAccount and hasPassword from state
                   // will be stored in Apollo cache at the container level
                   hasPassword,

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -21,6 +21,8 @@ export const MOCK_KEY_FETCH_TOKEN_2 = 'keyFetchToken2';
 export const MOCK_RESET_TOKEN = 'mockResetToken';
 export const MOCK_AUTH_AT = 12345;
 export const MOCK_PASSWORD = 'notYourAveragePassW0Rd';
+export const MOCK_AUTHPW =
+  'b5a61d1f7a6b1b762539bd85f783b65f635def1025c3f66fc51a438a68a77d6d';
 export const MOCK_UNBLOCK_CODE = 'A1B2C3D4';
 export const MOCK_RECOVERY_CODE = 'a1b2c3d4e5';
 export const MOCK_AVATAR_NON_DEFAULT = {


### PR DESCRIPTION
## Because

- After a getting blocked, the user would not be able to correctly signin after enter an unblock code

## This pull request

- Don't upgrade the user creds to v2 if they get blocked
- Fallback to v1 creds

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9661

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
