### PR TITLE
feat(next): move localization provider

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/start/page.tsx
@@ -15,8 +15,6 @@ import {
   getContentfulContent,
 } from 'apps/payments/next/app/_lib/apiClient';
 import { PaymentSection } from '@fxa/payments/ui';
-import { config } from 'apps/payments/next/config';
-import { Providers } from 'libs/payments/ui/src/lib/client/providers/Providers';
 
 export const dynamic = 'force-dynamic';
 
@@ -122,17 +120,15 @@ export default async function Checkout({ params }: { params: CheckoutParams }) {
         )}
       </h3>
 
-      <Providers config={{ stripePublicApiKey: config.stripePublicApiKey }}>
-        <PaymentSection
-          cmsCommonContent={cms.commonContent}
-          paymentsInfo={{
-            amount: fakeCart.amount,
-            currency: fakeCart.nextInvoice.currency,
-          }}
-          cart={cart}
-          locale={locale}
-        />
-      </Providers>
+      <PaymentSection
+        cmsCommonContent={cms.commonContent}
+        paymentsInfo={{
+          amount: fakeCart.amount,
+          currency: fakeCart.nextInvoice.currency,
+        }}
+        cart={cart}
+        locale={locale}
+      />
     </section>
   );
 }

--- a/apps/payments/next/app/[locale]/layout.tsx
+++ b/apps/payments/next/app/[locale]/layout.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { app } from '@fxa/payments/ui/server';
+import { headers } from 'next/headers';
+import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
+import { Providers } from '@fxa/payments/ui';
+import { config } from 'apps/payments/next/config';
+
+export default async function RootProviderLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Temporarily defaulting to `accept-language`
+  // This to be updated in FXA-9404
+  //const locale = getLocaleFromRequest(
+  //  params,
+  //  headers().get('accept-language')
+  //);
+  const locale = headers().get('accept-language') || DEFAULT_LOCALE;
+  const fetchedMessages = app.getFetchedMessages(locale);
+
+  return (
+    <Providers
+      config={{ stripePublicApiKey: config.stripePublicApiKey }}
+      fetchedMessages={fetchedMessages}
+    >
+      {children}
+    </Providers>
+  );
+}

--- a/libs/payments/ui/src/index.ts
+++ b/libs/payments/ui/src/index.ts
@@ -8,3 +8,4 @@ export * from './lib/utils/helpers';
 export * from './lib/client/components/StripeWrapper';
 export * from './lib/client/components/CheckoutCheckbox';
 export * from './lib/client/components/PaymentSection';
+export * from './lib/client/providers/Providers';

--- a/libs/payments/ui/src/lib/client/components/CheckoutCheckbox.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutCheckbox.tsx
@@ -4,7 +4,7 @@
 'use client';
 
 import * as HoverCard from '@radix-ui/react-hover-card';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Localized } from '@fluent/react';
 
 interface CheckoutCheckboxProps {
@@ -20,7 +20,16 @@ export function CheckoutCheckbox({
   privacyNotice,
   notifyCheckboxChange,
 }: CheckoutCheckboxProps) {
+  // Fluent React Overlays cause hydration issues due to SSR.
+  // Using isClient along with the useEffect ensures its only run Client Side
+  // Note this currently only affects strings that make use of React Overlays.
+  // Other strings are localized in SSR as expected.
+  // - https://github.com/projectfluent/fluent.js/wiki/React-Overlays
+  // - https://nextjs.org/docs/messages/react-hydration-error
+  const [isClient, setIsClient] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
+
+  useEffect(() => setIsClient(true), []);
 
   const changeHandler = () => {
     const newValue = !isChecked;
@@ -40,10 +49,35 @@ export function CheckoutCheckbox({
             onChange={changeHandler}
           />
         </HoverCard.Trigger>
-        <Localized
-          id="next-payment-confirm-with-legal-links-static-3"
-          elems={{
-            termsOfServiceLink: (
+        {isClient && (
+          <Localized
+            id="next-payment-confirm-with-legal-links-static-3"
+            elems={{
+              termsOfServiceLink: (
+                <a
+                  href={termsOfService}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-blue-500 underline"
+                >
+                  Terms of Service
+                </a>
+              ),
+              privacyNoticeLink: (
+                <a
+                  href={privacyNotice}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-blue-500 underline"
+                >
+                  Privacy Notice
+                </a>
+              ),
+            }}
+          >
+            <span className="font-normal text-sm block">
+              I authorize Mozilla to charge my payment method for the amount
+              shown, according to{' '}
               <a
                 href={termsOfService}
                 target="_blank"
@@ -51,9 +85,8 @@ export function CheckoutCheckbox({
                 className="text-blue-500 underline"
               >
                 Terms of Service
-              </a>
-            ),
-            privacyNoticeLink: (
+              </a>{' '}
+              and{' '}
               <a
                 href={privacyNotice}
                 target="_blank"
@@ -62,32 +95,10 @@ export function CheckoutCheckbox({
               >
                 Privacy Notice
               </a>
-            ),
-          }}
-        >
-          <span className="font-normal text-sm block">
-            I authorize Mozilla to charge my payment method for the amount
-            shown, according to{' '}
-            <a
-              href={termsOfService}
-              target="_blank"
-              rel="noreferrer"
-              className="text-blue-500 underline"
-            >
-              Terms of Service
-            </a>{' '}
-            and{' '}
-            <a
-              href={privacyNotice}
-              target="_blank"
-              rel="noreferrer"
-              className="text-blue-500 underline"
-            >
-              Privacy Notice
-            </a>
-            , until I cancel my subscription.
-          </span>
-        </Localized>
+              , until I cancel my subscription.
+            </span>
+          </Localized>
+        )}
       </label>
       <HoverCard.Portal>
         <HoverCard.Content

--- a/libs/payments/ui/src/lib/client/components/Providers.tsx
+++ b/libs/payments/ui/src/lib/client/components/Providers.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import { FluentLocalizationProvider } from '../providers/FluentLocalizationProvider';
+
+export function Providers({
+  fetchedMessages,
+  children,
+}: {
+  fetchedMessages: Record<string, string>;
+  children: React.ReactNode;
+}) {
+  return (
+    <FluentLocalizationProvider fetchedMessages={fetchedMessages}>
+      {children}
+    </FluentLocalizationProvider>
+  );
+}

--- a/libs/payments/ui/src/lib/client/providers/Providers.tsx
+++ b/libs/payments/ui/src/lib/client/providers/Providers.tsx
@@ -7,16 +7,22 @@
 import { ConfigContextValues, ConfigProvider } from './ConfigProvider';
 import { FluentLocalizationProvider } from './FluentLocalizationProvider';
 
+interface ProvidersProps {
+  config: ConfigContextValues;
+  fetchedMessages: Record<string, string>;
+  children: React.ReactNode;
+}
+
 export function Providers({
   config,
+  fetchedMessages,
   children,
-}: {
-  config: ConfigContextValues;
-  children: React.ReactNode;
-}) {
+}: ProvidersProps) {
   return (
     <ConfigProvider config={config}>
-      <FluentLocalizationProvider>{children}</FluentLocalizationProvider>
+      <FluentLocalizationProvider fetchedMessages={fetchedMessages}>
+        {children}
+      </FluentLocalizationProvider>
     </ConfigProvider>
   );
 }

--- a/libs/payments/ui/src/lib/nestapp/app.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.ts
@@ -27,6 +27,11 @@ class AppSingleton {
     return localizerRscFactory.createLocalizerRsc(acceptLanguage);
   }
 
+  getFetchedMessages(acceptLanguage: string) {
+    const localizerRscFactory = this.app.get(LocalizerRscFactory);
+    return localizerRscFactory.getFetchedMessages(acceptLanguage);
+  }
+
   /**
    * This method should be used in any server action wishing to call a server-side module.
    * Do not add individual services/managers/clients to this singleton, rather to NextJSActionsService.

--- a/libs/shared/l10n/src/lib/localizer/localizer.rsc.factory.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.rsc.factory.ts
@@ -14,6 +14,7 @@ import { parseAcceptLanguage } from '../l10n.utils';
 @Injectable()
 export class LocalizerRscFactory extends LocalizerBase {
   private readonly bundles: Map<string, FluentBundle> = new Map();
+  private fetchedMessages: Record<string, string> = {};
   private document: any = null;
   constructor(bindings: ILocalizerBindings) {
     super(bindings);
@@ -25,9 +26,9 @@ export class LocalizerRscFactory extends LocalizerBase {
   }
 
   private async fetchFluentBundles() {
-    const fetchedMessages = await this.fetchMessages(supportedLanguages);
-    const bundleGenerator = this.createBundleGenerator(fetchedMessages);
-    for await (const bundle of bundleGenerator(supportedLanguages)) {
+    this.fetchedMessages = await this.fetchMessages(supportedLanguages);
+    const bundleGenerator = this.createBundleGenerator(this.fetchedMessages);
+    for (const bundle of bundleGenerator(supportedLanguages)) {
       this.bundles.set(bundle.locales[0], bundle);
     }
   }
@@ -59,5 +60,17 @@ export class LocalizerRscFactory extends LocalizerBase {
     });
 
     return new LocalizerRsc(supportedBundles, this.parseMarkup());
+  }
+
+  getFetchedMessages(acceptLanguages: string) {
+    const filteredFetchedMessages: Record<string, string> = {};
+    const currentLocales = parseAcceptLanguage(acceptLanguages);
+    currentLocales.forEach((locale) => {
+      const msgs = this.fetchedMessages[locale];
+      if (msgs) {
+        filteredFetchedMessages[locale] = msgs;
+      }
+    });
+    return filteredFetchedMessages;
   }
 }


### PR DESCRIPTION
## Because

- Fluent LocalizationProvider is currently initialized on the client causing noticable load times for client components.

## This pull request

- Initialize ReactLocalization on the server
- Wrap near root layout with LocalizationProvider as suggested by Nextjs docs.

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).