### PR TITLE
task(auth-client, gql): Create auth client mode where headers are required and provide headers in gql

### DIFF
--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as assert from 'assert';
+import AuthClient from '../server';
+
+describe('lib/client', () => {
+  let client: AuthClient;
+
+  before(() => {
+    client = new AuthClient('http://localhost:9000', {
+      requireHeaders: true,
+    });
+  });
+
+  it('fails without headers', async () => {
+    client = new AuthClient('http://localhost:9000', {
+      requireHeaders: true,
+    });
+
+    try {
+      // check that general requests require header
+      await client.accountStatus('0123456789abcdef');
+      assert.fail();
+    } catch (e) {
+      assert.equal(e.message, 'extraHeaders missing!');
+    }
+
+    try {
+      // check that session requests require header
+      await client.sessionStatus('0123456789abcdef');
+      assert.fail();
+    } catch (e) {
+      assert.equal(e.message, 'extraHeaders missing!');
+    }
+  });
+});

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1545,10 +1545,7 @@ const Account = Backbone.Model.extend(
     async consumeRecoveryCode(code) {
       const response = await this._fxaClient.consumeRecoveryCode(
         this.get('sessionToken'),
-        code,
-        {
-          metricsContext: this._metrics.getFlowEventMetadata(),
-        }
+        code
       );
       this.set('verified', true);
       return response;

--- a/packages/fxa-graphql-api/src/backend/auth-client.service.ts
+++ b/packages/fxa-graphql-api/src/backend/auth-client.service.ts
@@ -15,7 +15,16 @@ export const AuthClientFactory: Provider = {
       'authServer'
     ) as AppConfig['authServer'];
 
-    return new AuthClient(authServerConfig.url, { keyStretchVersion: 2 });
+    return new AuthClient(authServerConfig.url, {
+      keyStretchVersion: 2,
+      // Important! This flag will result in auth client failing
+      // hard if headers are not provided! We've trouble in the
+      // with headers not being relayed for cross services calls.
+      // When this happens, debugging the source can be a bit
+      // nebulous, so we'd rather fail upfront and catch the problems
+      // in test.
+      requireHeaders: true,
+    });
   },
   inject: [ConfigService],
 };

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
@@ -10,6 +10,9 @@ import { ProfileClientService } from './profile-client.service';
 import { ConfigService } from '@nestjs/config';
 
 describe('ProfileClientService', () => {
+  const headers = new Headers({
+    'x-forwarded-for': '123.123.123.123',
+  });
   let service: ProfileClientService;
   let authClient: any;
   const profileUrl = 'https://test.com';
@@ -58,7 +61,7 @@ describe('ProfileClientService', () => {
         set: jest.fn().mockResolvedValue({ text: '{}' }),
       }),
     });
-    const result = await service.updateDisplayName('token', 'name');
+    const result = await service.updateDisplayName('token', 'name', headers);
     expect(result).toBe(true);
   });
 
@@ -73,7 +76,12 @@ describe('ProfileClientService', () => {
         }),
       }),
     });
-    const result = await service.avatarUpload('token', 'app/json', 'somefile');
+    const result = await service.avatarUpload(
+      'token',
+      'app/json',
+      'somefile',
+      headers
+    );
     expect(result.url).toBe('testurl');
   });
 
@@ -84,7 +92,7 @@ describe('ProfileClientService', () => {
     (jest.spyOn(superagent, 'get') as jest.Mock).mockReturnValueOnce({
       set: jest.fn().mockResolvedValue({ text: '{"avatar":"x"}' }),
     });
-    const result = await service.getProfile('token');
+    const result = await service.getProfile('token', headers);
     expect(result).toStrictEqual({ avatar: 'x' });
   });
 });

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.ts
@@ -27,13 +27,14 @@ export class ProfileClientService {
     this.profileServerUrl = profileConfig.url;
   }
 
-  private async fetchToken(token: string) {
+  private async fetchToken(token: string, headers: Headers) {
     const result = await this.authAPI.createOAuthToken(
       token,
       this.oauthClientId,
       {
         scope: 'profile:write clients:write',
-      }
+      },
+      headers
     );
     return result.access_token;
   }
@@ -41,28 +42,39 @@ export class ProfileClientService {
   private async profilePostRequest(
     token: string,
     path: string,
-    data: object
+    data: object,
+    headers: Headers
   ): Promise<superagent.Response> {
-    const accessToken = await this.fetchToken(token);
+    const accessToken = await this.fetchToken(token, headers);
     return superagent
       .post(this.profileServerUrl + path)
       .send(data)
       .set('Authorization', 'Bearer ' + accessToken);
   }
 
-  public async updateDisplayName(token: string, name: string) {
-    const result = await this.profilePostRequest(token, '/display_name', {
-      displayName: name,
-    });
+  public async updateDisplayName(
+    token: string,
+    name: string,
+    headers: Headers
+  ) {
+    const result = await this.profilePostRequest(
+      token,
+      '/display_name',
+      {
+        displayName: name,
+      },
+      headers
+    );
     return result.text === '{}';
   }
 
   public async avatarUpload(
     token: string,
     contentType: string,
-    file: any
+    file: any,
+    headers: Headers
   ): Promise<Avatar> {
-    const accessToken = await this.fetchToken(token);
+    const accessToken = await this.fetchToken(token, headers);
     const result = await superagent
       .post(this.profileServerUrl + '/avatar/upload')
       .set('Content-Type', contentType)
@@ -71,8 +83,12 @@ export class ProfileClientService {
     return result.body;
   }
 
-  public async avatarDelete(token: string, id?: string) {
-    const accessToken = await this.fetchToken(token);
+  public async avatarDelete(
+    token: string,
+    id: string | undefined,
+    headers: Headers
+  ) {
+    const accessToken = await this.fetchToken(token, headers);
     const result = await superagent
       .delete(this.profileServerUrl + '/avatar/' + id)
       .set('Authorization', 'Bearer ' + accessToken);
@@ -80,8 +96,8 @@ export class ProfileClientService {
     return result.text === '{}';
   }
 
-  public async getProfile(token: string) {
-    const accessToken = await this.fetchToken(token);
+  public async getProfile(token: string, headers: Headers) {
+    const accessToken = await this.fetchToken(token, headers);
     const result = await superagent
       .get(this.profileServerUrl + '/profile')
       .set('Authorization', 'Bearer ' + accessToken);

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -24,6 +24,9 @@ let USER_1: any;
 let SESSION_1: any;
 
 describe('#integration - AccountResolver', () => {
+  const headers = new Headers({
+    'x-forwarded-for': '123.123.123.123',
+  });
   let resolver: AccountResolver;
   let logger: any;
   let knex: Knex;
@@ -149,7 +152,7 @@ describe('#integration - AccountResolver', () => {
         authClient.account = jest
           .fn()
           .mockResolvedValue({ subscriptions: [{ key: 1, key_two: 2 }] });
-        const result = await resolver.subscriptions('token');
+        const result = await resolver.subscriptions('token', headers);
         expect(result).toStrictEqual([{ key: 1, keyTwo: 2 }]);
       });
 
@@ -157,19 +160,19 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryKeyExists = jest
           .fn()
           .mockResolvedValue({ exists: true });
-        const result = await resolver.recoveryKey('token');
+        const result = await resolver.recoveryKey('token', headers);
         expect(result).toBeTruthy();
       });
 
       it('resolves totp', async () => {
         authClient.checkTotpTokenExists = jest.fn().mockResolvedValue(true);
-        const result = await resolver.totp('token');
+        const result = await resolver.totp('token', headers);
         expect(result).toBeTruthy();
       });
 
       it('resolves attachedClients', async () => {
         authClient.attachedClients = jest.fn().mockResolvedValue(true);
-        const result = await resolver.attachedClients('token');
+        const result = await resolver.attachedClients('token', headers);
         expect(result).toBeTruthy();
       });
 
@@ -222,10 +225,7 @@ describe('#integration - AccountResolver', () => {
           recoveryCodes: ['test1', 'test2'],
           secret: 'secretData',
         });
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.createTotp(headers, 'token', {
+        const result = await resolver.createTotp('token', headers, {
           metricsContext: { deviceId: 'device1', flowBeginTime: 4238248 },
           clientMutationId: 'testid',
         });
@@ -243,10 +243,7 @@ describe('#integration - AccountResolver', () => {
         authClient.verifyTotpCode = jest
           .fn()
           .mockResolvedValue({ success: true });
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.verifyTotp(headers, 'token', {
+        const result = await resolver.verifyTotp('token', headers, {
           code: 'code1234',
           clientMutationId: 'testid',
         });
@@ -262,11 +259,7 @@ describe('#integration - AccountResolver', () => {
         authClient.deleteTotpToken = jest
           .fn()
           .mockResolvedValue({ success: true });
-
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.deleteTotp(headers, 'token', {
+        const result = await resolver.deleteTotp('token', headers, {
           clientMutationId: 'testid',
         });
         expect(authClient.deleteTotpToken).toBeCalledTimes(1);
@@ -279,10 +272,7 @@ describe('#integration - AccountResolver', () => {
     describe('deleteRecoveryKey', () => {
       it('succeeds', async () => {
         authClient.deleteRecoveryKey = jest.fn().mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.deleteRecoveryKey(headers, 'token', {
+        const result = await resolver.deleteRecoveryKey('token', headers, {
           clientMutationId: 'testid',
         });
         expect(authClient.deleteRecoveryKey).toBeCalledTimes(1);
@@ -297,10 +287,7 @@ describe('#integration - AccountResolver', () => {
         authClient.replaceRecoveryCodes = jest
           .fn()
           .mockResolvedValue({ recoveryCodes: ['test1', 'test2'] });
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.changeRecoveryCodes(headers, 'token', {
+        const result = await resolver.changeRecoveryCodes('token', headers, {
           clientMutationId: 'testid',
         });
         expect(authClient.replaceRecoveryCodes).toBeCalledTimes(1);
@@ -314,7 +301,7 @@ describe('#integration - AccountResolver', () => {
     describe('updateDisplayName', () => {
       it('succeeds', async () => {
         profileClient.updateDisplayName = jest.fn().mockResolvedValue(true);
-        const result = await resolver.updateDisplayName('token', {
+        const result = await resolver.updateDisplayName('token', headers, {
           clientMutationId: 'testid',
           displayName: 'fred',
         });
@@ -329,7 +316,7 @@ describe('#integration - AccountResolver', () => {
     describe('deleteAvatar', () => {
       it('succeeds', async () => {
         profileClient.avatarDelete = jest.fn().mockResolvedValue(true);
-        await resolver.deleteAvatar('token', {
+        await resolver.deleteAvatar('token', headers, {
           clientMutationId: 'testid',
           id: 'blah',
         });
@@ -346,10 +333,7 @@ describe('#integration - AccountResolver', () => {
     describe('createSecondaryEmail', () => {
       it('succeeds', async () => {
         authClient.recoveryEmailCreate = jest.fn().mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.createSecondaryEmail(headers, 'token', {
+        const result = await resolver.createSecondaryEmail('token', headers, {
           clientMutationId: 'testid',
           email: 'test@example.com',
         });
@@ -365,12 +349,9 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSecondaryResendCode = jest
           .fn()
           .mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         const result = await resolver.resendSecondaryEmailCode(
-          headers,
           'token',
+          headers,
           {
             clientMutationId: 'testid',
             email: 'test@example.com',
@@ -388,10 +369,7 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSecondaryVerifyCode = jest
           .fn()
           .mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.verifySecondaryEmail(headers, 'token', {
+        const result = await resolver.verifySecondaryEmail('token', headers, {
           clientMutationId: 'testid',
           email: 'test@example.com',
           code: 'ABCD1234',
@@ -406,10 +384,7 @@ describe('#integration - AccountResolver', () => {
     describe('deleteSecondaryEmail', () => {
       it('succeeds', async () => {
         authClient.recoveryEmailDestroy = jest.fn().mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.deleteSecondaryEmail(headers, 'token', {
+        const result = await resolver.deleteSecondaryEmail('token', headers, {
           clientMutationId: 'testid',
           email: 'test@example.com',
         });
@@ -425,10 +400,7 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSetPrimaryEmail = jest
           .fn()
           .mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
-        const result = await resolver.updatePrimaryEmail(headers, 'token', {
+        const result = await resolver.updatePrimaryEmail('token', headers, {
           clientMutationId: 'testid',
           email: 'test@example.com',
         });
@@ -442,12 +414,9 @@ describe('#integration - AccountResolver', () => {
     describe('attachedClientDisconnect', () => {
       it('succeeds', async () => {
         authClient.attachedClientDestroy = jest.fn().mockResolvedValue(true);
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         const result = await resolver.attachedClientDisconnect(
-          headers,
           'token',
+          headers,
           {
             clientMutationId: 'testid',
             clientId: 'client1234',
@@ -465,13 +434,10 @@ describe('#integration - AccountResolver', () => {
 
     describe('sendSessionVerificationCode', () => {
       it('succeeds', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         authClient.sessionResendVerifyCode = jest.fn().mockResolvedValue(true);
         const result = await resolver.sendSessionVerificationCode(
-          headers,
           'token',
+          headers,
           {
             clientMutationId: 'testid',
           }
@@ -489,11 +455,8 @@ describe('#integration - AccountResolver', () => {
 
     describe('verifySession', () => {
       it('succeeds', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         authClient.sessionVerifyCode = jest.fn().mockResolvedValue(true);
-        const result = await resolver.verifySession(headers, 'token', {
+        const result = await resolver.verifySession('token', headers, {
           clientMutationId: 'testid',
           code: 'ABCD1234',
         });
@@ -561,9 +524,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('passwordForgotSendCode', () => {
       it('succeeds', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         authClient.passwordForgotSendCode = jest.fn().mockResolvedValue({
           clientMutationId: 'testid',
           passwordForgotToken: 'cooltokenyo',
@@ -581,9 +541,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('passwordForgotVerifyCode', () => {
       it('succeeds', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         authClient.passwordForgotVerifyCode = jest.fn().mockResolvedValue({
           clientMutationId: 'testid',
           accountResetToken: 'cooltokenyo',
@@ -613,9 +570,6 @@ describe('#integration - AccountResolver', () => {
           tries: 1,
           ttl: 2,
         });
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         const result = await resolver.passwordForgotCodeStatus(headers, {
           token: 'passwordforgottoken',
         });
@@ -630,9 +584,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('accountReset', () => {
       it('succeeds', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         const now = Date.now();
         authClient.accountResetAuthPW = jest.fn().mockResolvedValue({
           clientMutationId: 'testid',
@@ -659,9 +610,6 @@ describe('#integration - AccountResolver', () => {
       });
 
       it('succeeds for v2', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         const now = Date.now();
         authClient.accountResetAuthPW = jest.fn().mockResolvedValue({
           clientMutationId: 'testid',
@@ -698,7 +646,6 @@ describe('#integration - AccountResolver', () => {
     describe('signUp', () => {
       it('calls auth-client and proxy the result', async () => {
         const now = Date.now();
-        const headers = new Headers();
         const mockRespPayload = {
           clientMutationId: 'testid',
           uid: '1337',
@@ -727,7 +674,6 @@ describe('#integration - AccountResolver', () => {
 
       it('calls auth-client and proxy the result with V2 password', async () => {
         const now = Date.now();
-        const headers = new Headers();
         const mockRespPayload = {
           clientMutationId: 'testid',
           uid: '1337',
@@ -770,7 +716,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('finishSetup', () => {
       it('calls auth-client and proxy the result', async () => {
-        const headers = new Headers();
         const mockRespPayload = {
           clientMutationId: 'testid',
           uid: '1337',
@@ -795,7 +740,6 @@ describe('#integration - AccountResolver', () => {
       });
 
       it('calls auth-client and proxy the result with V2 password', async () => {
-        const headers = new Headers();
         const mockRespPayload = {
           clientMutationId: 'testid',
           uid: '1337',
@@ -836,7 +780,6 @@ describe('#integration - AccountResolver', () => {
     describe('signIn', () => {
       it('calls auth-client and proxy the result', async () => {
         const now = Date.now();
-        const headers = new Headers();
         const mockRespPayload = {
           clientMutationId: 'testid',
           uid: '1337',
@@ -866,7 +809,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('credentialSet', () => {
       it('calls auth-client and proxy the result', async () => {
-        const headers = new Headers();
         const mockRespPayload = {
           version: 'v2',
           upgradeNeeded: false,
@@ -893,7 +835,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('password start', () => {
       it('calls auth-client and proxies result', async () => {
-        const headers = new Headers();
         const mockRespPayload = {
           keyFetchToken: '123456789abcdef',
           passwordChangeToken: '23456789abcdef1',
@@ -920,7 +861,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('password finish', () => {
       it('calls auth-client and proxies result', async () => {
-        const headers = new Headers();
         const mockRespPayload = {
           keyFetchToken: '123456789abcdef',
           passwordChangeToken: '23456789abcdef1',
@@ -961,7 +901,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('wrapped keys', () => {
       it('calls auth-client and proxies result', async () => {
-        const headers = new Headers();
         const mockRespPayload = {
           kA: '123456789abcdef',
           wrapKB: '23456789abcdef1',
@@ -1034,9 +973,6 @@ describe('#integration - AccountResolver', () => {
 
     describe('emailVerifyCode', () => {
       it('succeeds', async () => {
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
-        });
         authClient.verifyCode = jest.fn().mockResolvedValue({
           uid: 'cooltokenyo',
           code: 'coolcode',
@@ -1059,9 +995,6 @@ describe('#integration - AccountResolver', () => {
       it('succeeds', async () => {
         authClient.getRecoveryKey = jest.fn().mockResolvedValue({
           recoveryData: 'recoveryData',
-        });
-        const headers = new Headers({
-          'x-forwarded-for': '123.123.123.123',
         });
         const result = await resolver.getRecoveryKeyBundle(headers, {
           accountResetToken: 'cooltokenyo',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -152,14 +152,18 @@ export class AccountResolver {
   })
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async createTotp(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => CreateTotpInput })
     input: CreateTotpInput
   ): Promise<CreateTotpPayload> {
-    const result = await this.authAPI.createTotpToken(token, {
-      metricsContext: input.metricsContext,
-    });
+    const result = await this.authAPI.createTotpToken(
+      token,
+      {
+        metricsContext: input.metricsContext,
+      },
+      headers
+    );
     return {
       clientMutationId: input.clientMutationId,
       ...result,
@@ -173,15 +177,16 @@ export class AccountResolver {
   @UseGuards(UnverifiedSessionGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifyTotp(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => VerifyTotpInput })
     input: VerifyTotpInput
   ): Promise<VerifyTotpPayload> {
     const result = await this.authAPI.verifyTotpCode(
       token,
       input.code,
-      input.service ? { service: input.service } : undefined
+      input.service ? { service: input.service } : undefined,
+      headers
     );
     return {
       clientMutationId: input.clientMutationId,
@@ -195,12 +200,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteTotp(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => DeleteTotpInput })
     input: DeleteTotpInput
   ): Promise<BasicPayload> {
-    await this.authAPI.deleteTotpToken(token);
+    await this.authAPI.deleteTotpToken(token, headers);
     return {
       clientMutationId: input.clientMutationId,
     };
@@ -212,12 +217,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteRecoveryKey(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => DeleteRecoveryKeyInput })
     input: DeleteRecoveryKeyInput
   ): Promise<BasicPayload> {
-    await this.authAPI.deleteRecoveryKey(token);
+    await this.authAPI.deleteRecoveryKey(token, headers);
     return {
       clientMutationId: input.clientMutationId,
     };
@@ -230,12 +235,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async changeRecoveryCodes(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => ChangeRecoveryCodesInput })
     input: ChangeRecoveryCodesInput
   ): Promise<ChangeRecoveryCodesPayload> {
-    const result = await this.authAPI.replaceRecoveryCodes(token);
+    const result = await this.authAPI.replaceRecoveryCodes(token, headers);
     return {
       clientMutationId: input.clientMutationId,
       recoveryCodes: result.recoveryCodes,
@@ -249,12 +254,14 @@ export class AccountResolver {
   @CatchGatewayError
   public async updateDisplayName(
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => UpdateDisplayNameInput })
     input: UpdateDisplayNameInput
   ): Promise<UpdateDisplayNamePayload> {
     const result = await this.profileAPI.updateDisplayName(
       token,
-      input.displayName
+      input.displayName,
+      headers
     );
     return {
       clientMutationId: input.clientMutationId,
@@ -292,9 +299,10 @@ export class AccountResolver {
   @CatchGatewayError
   public async deleteAvatar(
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => DeleteAvatarInput }) input: DeleteAvatarInput
   ): Promise<BasicPayload> {
-    await this.profileAPI.avatarDelete(token, input.id);
+    await this.profileAPI.avatarDelete(token, input.id, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -304,13 +312,18 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async createSecondaryEmail(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailCreate(token, input.email, {
-      verificationMethod: 'email-otp',
-    });
+    await this.authAPI.recoveryEmailCreate(
+      token,
+      input.email,
+      {
+        verificationMethod: 'email-otp',
+      },
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -320,11 +333,15 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async resendSecondaryEmailCode(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailSecondaryResendCode(token, input.email);
+    await this.authAPI.recoveryEmailSecondaryResendCode(
+      token,
+      input.email,
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -334,14 +351,15 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifySecondaryEmail(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => VerifyEmailInput }) input: VerifyEmailInput
   ) {
     await this.authAPI.recoveryEmailSecondaryVerifyCode(
       token,
       input.email,
-      input.code
+      input.code,
+      headers
     );
     return { clientMutationId: input.clientMutationId };
   }
@@ -352,11 +370,11 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async deleteSecondaryEmail(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailDestroy(token, input.email);
+    await this.authAPI.recoveryEmailDestroy(token, input.email, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -367,11 +385,15 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async updatePrimaryEmail(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailSetPrimaryEmail(token, input.email);
+    await this.authAPI.recoveryEmailSetPrimaryEmail(
+      token,
+      input.email,
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -382,12 +404,12 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async attachedClientDisconnect(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => AttachedClientDisconnectInput })
     input: AttachedClientDisconnectInput
   ) {
-    await this.authAPI.attachedClientDestroy(token, input);
+    await this.authAPI.attachedClientDestroy(token, input, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -397,8 +419,8 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async sendSessionVerificationCode(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => SendSessionVerificationInput })
     input: SendSessionVerificationInput
   ) {
@@ -412,8 +434,8 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   @CatchGatewayError
   public async verifySession(
-    @GqlXHeaders() headers: Headers,
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => VerifySessionInput }) input: VerifySessionInput
   ) {
     await this.authAPI.sessionVerifyCode(token, input.code, undefined, headers);
@@ -521,7 +543,7 @@ export class AccountResolver {
     @Args('input', { type: () => PasswordForgotCodeStatusInput })
     input: PasswordForgotCodeStatusInput
   ) {
-    return this.authAPI.passwordForgotStatus(input.token);
+    return this.authAPI.passwordForgotStatus(input.token, headers);
   }
 
   @Mutation((returns) => AccountResetPayload, {
@@ -694,7 +716,8 @@ export class AccountResolver {
   ): Promise<RecoveryKeyBundlePayload> {
     const { recoveryData } = await this.authAPI.getRecoveryKey(
       input.accountResetToken,
-      input.recoveryKeyId
+      input.recoveryKeyId,
+      headers
     );
 
     return { recoveryData };
@@ -719,6 +742,7 @@ export class AccountResolver {
   @ResolveField()
   public async avatar(
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Parent() account: Account
   ) {
     try {
@@ -727,7 +751,7 @@ export class AccountResolver {
         return avatar;
       }
 
-      const profile = await this.profileAPI.getProfile(token);
+      const profile = await this.profileAPI.getProfile(token, headers);
       const url = profile.avatar;
       return {
         id: `default-${url[url.length - 1]}`,
@@ -768,25 +792,41 @@ export class AccountResolver {
   }
 
   @ResolveField()
-  public async subscriptions(@GqlSessionToken() token: string) {
-    const account = await this.authAPI.account(token);
+  public async subscriptions(
+    @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers
+  ) {
+    const account = await this.authAPI.account(token, headers);
     return account.subscriptions.map(snakeToCamelObject);
   }
 
   @ResolveField()
-  public async recoveryKey(@GqlSessionToken() token: string) {
-    const result = await this.authAPI.recoveryKeyExists(token);
+  public async recoveryKey(
+    @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers
+  ) {
+    const result = await this.authAPI.recoveryKeyExists(
+      token,
+      undefined,
+      headers
+    );
     return result.exists;
   }
 
   @ResolveField()
-  public totp(@GqlSessionToken() token: string) {
-    return this.authAPI.checkTotpTokenExists(token);
+  public totp(
+    @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers
+  ) {
+    return this.authAPI.checkTotpTokenExists(token, headers);
   }
 
   @ResolveField()
-  public attachedClients(@GqlSessionToken() token: string) {
-    return this.authAPI.attachedClients(token);
+  public attachedClients(
+    @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers
+  ) {
+    return this.authAPI.attachedClients(token, headers);
   }
 
   @ResolveField()

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -41,10 +41,11 @@ export class SessionResolver {
   @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async destroySession(
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => DestroySessionInput })
     input: DestroySessionInput
   ): Promise<BasicPayload> {
-    await this.authAPI.sessionDestroy(token);
+    await this.authAPI.sessionDestroy(token, undefined, headers);
     return {
       clientMutationId: input.clientMutationId,
     };
@@ -135,10 +136,15 @@ export class SessionResolver {
   @CatchGatewayError
   public async consumeRecoveryCode(
     @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => ConsumeRecoveryCodeInput })
     input: ConsumeRecoveryCodeInput
   ): Promise<ConsumeRecoveryCodePayload> {
-    const result = await this.authAPI.consumeRecoveryCode(token, input.code);
+    const result = await this.authAPI.consumeRecoveryCode(
+      token,
+      input.code,
+      headers
+    );
     return {
       clientMutationId: input.clientMutationId,
       ...result,


### PR DESCRIPTION

## Because
- We have scenarios where headers are not being forwarded between the graphql-api and auth-server
- This means the client IP isn’t forwarded properly, and customs may block requests

## This pull request
- Creates mode in authClient that fails hard / fast when headers are not provided
- Uses this mode for the authClient instance in our graphql api
- Ensures that headers are always provided to the auth client

## Issue that this pull request solves

Closes: FXA-9678

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

