### PR TITLE
bug(settings): Handle incorrect email case in sign up

### DIFF
--- a/packages/functional-tests/pages/config.ts
+++ b/packages/functional-tests/pages/config.ts
@@ -19,7 +19,7 @@ export class ConfigPage extends BaseLayout {
       const metaConfig = page.locator('meta[name="fxa-content-server/config"]');
       const config = await metaConfig.getAttribute('content');
 
-      this.config = JSON.parse(decodeURIComponent(config));
+      this.config = JSON.parse(decodeURIComponent(config || '{}'));
 
       await page.close();
     }

--- a/packages/functional-tests/tests/react-conversion/signIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signIn.spec.ts
@@ -31,5 +31,32 @@ test.describe('severity-2 #smoke', () => {
 
       await expect(signinReact.emailFirstHeading).toBeVisible();
     });
+
+    test('sign in as an existing user with incorrect email case', async ({
+      page,
+      pages: { configPage, settings, signinReact },
+      testAccountTracker,
+    }) => {
+      // Ensure that the feature flag is enabled
+      const config = await configPage.getConfig();
+      test.skip(
+        config.showReactApp.signInRoutes !== true,
+        'React signInRoutes not enabled'
+      );
+      const credentials = await testAccountTracker.signUp();
+
+      await signinReact.goto();
+      // Note, we should automatically handle emails that are incorrectly cased
+      await signinReact.fillOutEmailFirstForm(credentials.email.toUpperCase());
+      await signinReact.fillOutPasswordForm(credentials.password);
+
+      // Verify successfully navigated to settings
+      await expect(page).toHaveURL(/settings/);
+
+      // Sign out
+      await settings.signOut();
+
+      await expect(signinReact.emailFirstHeading).toBeVisible();
+    });
   });
 });

--- a/packages/fxa-graphql-api/src/gql/lib/error.ts
+++ b/packages/fxa-graphql-api/src/gql/lib/error.ts
@@ -43,6 +43,8 @@ export function CatchGatewayError(
             code: err.code,
             errno: err.errno,
             info: err.info,
+            // Important, used for 'Incorrect email case' error
+            email: err.email,
           },
         });
       } else if (err.status && err.stack && err.response) {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -49,6 +49,7 @@ import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { trySignIn, tryKeyStretchingUpgrade } from '../container';
+import { getCredentials } from 'fxa-auth-client/browser';
 
 const SigninUnblockContainer = ({
   integration,
@@ -120,17 +121,19 @@ const SigninUnblockContainer = ({
           passwordChangeFinish
         );
 
-      if (error) {
-        return { error };
-      }
-
       return await trySignIn(
         email,
         v1Credentials,
-        v2Credentials,
+        error ? undefined : v2Credentials,
         unverifiedAccount,
         beginSignin,
-        options
+        options,
+        async (correctedEmail: string) => {
+          return {
+            v1Credentials: await getCredentials(correctedEmail, password),
+            v2Credentials,
+          };
+        }
       );
     } catch (error) {
       return getHandledError(error);

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -85,6 +85,7 @@ export interface BeginSigninError {
   verificationMethod?: VerificationMethods;
   retryAfter?: number;
   retryAfterLocalized?: string;
+  email?: string;
 }
 
 export type CachedSigninHandler = (

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -149,7 +149,10 @@ export function mockGqlAvatarUseQuery() {
   };
 }
 
-export function mockGqlBeginSigninMutation(opts: { keys: boolean }) {
+export function mockGqlBeginSigninMutation(
+  opts: { keys: boolean },
+  inputOverrides: any = {}
+) {
   const result = opts.keys
     ? createBeginSigninResponse({
         keyFetchToken: MOCK_KEY_FETCH_TOKEN,
@@ -164,6 +167,7 @@ export function mockGqlBeginSigninMutation(opts: { keys: boolean }) {
         input: {
           email: MOCK_EMAIL,
           authPW: MOCK_AUTH_PW,
+          ...inputOverrides,
           options: {
             ...opts,
             verificationMethod: VerificationMethods.EMAIL_OTP,
@@ -288,13 +292,15 @@ export function mockBeginSigninMutationWithV2Password() {
 }
 
 export function mockGqlError(
-  error: AuthUiError = AuthUiErrors.UNEXPECTED_ERROR
+  error: AuthUiError = AuthUiErrors.UNEXPECTED_ERROR,
+  extensionOverrides: any = {}
 ) {
   return new ApolloError({
     graphQLErrors: [
       new GraphQLError(error.message, {
         extensions: {
           errno: error.errno,
+          ...extensionOverrides,
         },
       }),
     ],
@@ -340,6 +346,7 @@ export function createBeginSigninResponseError({
   errno = AuthUiErrors.INCORRECT_PASSWORD.errno!,
   verificationMethod,
   verificationReason,
+  email,
 }: Partial<BeginSigninError> = {}): {
   error: BeginSigninError;
 } {
@@ -350,6 +357,7 @@ export function createBeginSigninResponseError({
       verificationMethod,
       verificationReason,
       message,
+      email,
     },
   };
 }

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -229,6 +229,10 @@ const handleGQLError = (graphQLError: GraphQLError) => {
     const uiError = {
       message: AuthUiErrorNos[errno].message,
       errno,
+      email:
+        errno === AuthUiErrors.INCORRECT_EMAIL_CASE.errno
+          ? graphQLError.extensions.email
+          : undefined,
       verificationMethod:
         (graphQLError.extensions.verificationMethod as VerificationMethods) ||
         undefined,


### PR DESCRIPTION
## Because

- We did not handle the incorrect email properly, and would just display incorrect email to the user.
- The incorrect email error contains a corrected email in the payload that should be used.


## This pull request

- Retries the login with the email provided by the incorrect email error state.
- Fixes typescript error in functional-tests/pages/config.ts.
- Adds functional test to cover this edge case.


## Issue that this pull request solves

Closes: FXA-9663

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This also impacted the sign in unblock flow and is now fixed. However, it might conflict with https://github.com/mozilla/fxa/pull/16959  :disappointed: .