### PR TITLE
fix(scripts): Add dynamic import for PQueue to fix module error

### DIFF
--- a/packages/fxa-auth-server/lib/routes/cloud-scheduler.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-scheduler.ts
@@ -4,18 +4,112 @@
 
 import { ConfigType } from '../../config';
 import { AuthLogger, AuthRequest } from '../types';
-// commenting this out for now because the script uses p-queue, which is pure
-// ESM since 7.x.  That won't work when nodejs try to `require` it.
-// import { processDateRange } from '../../scripts/delete-unverified-accounts';
 import {
   AccountTasks,
   AccountTasksFactory,
-  //  ReasonForDeletion,
+  ReasonForDeletion,
 } from '@fxa/shared/cloud-tasks';
 import { StatsD } from 'hot-shots';
-import error from '../error';
+import { setupAccountDatabase } from '@fxa/shared/db/mysql/account';
 
 const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Process a date range of accounts to delete.
+ *
+ * @param config
+ * @param accountTasks
+ * @param reason
+ * @param startDate
+ * @param endDate
+ * @param taskLimit
+ * @param log
+ */
+export async function processAccountDeletionInRange(
+  config: ConfigType,
+  accountTasks: AccountTasks,
+  reason: ReasonForDeletion,
+  startDate: any,
+  endDate: any,
+  taskLimit: number,
+  log?: AuthLogger
+) {
+  const PQueue = (await import('p-queue')) as any;
+  const kyselyDb = await setupAccountDatabase(config.database.mysql.auth);
+  const accounts = await kyselyDb
+    .selectFrom('accounts')
+    .where('accounts.emailVerified', '=', 0)
+    .where('accounts.createdAt', '>=', startDate)
+    .where('accounts.createdAt', '<=', endDate)
+    .leftJoin('accountCustomers', 'accounts.uid', 'accountCustomers.uid')
+    .select(['accounts.uid', 'accountCustomers.stripeCustomerId'])
+    .execute();
+
+  // Scaling suggestion is 500/5/50 rule, may start at 500/sec, and increase every 5 minutes by 50%.
+  // They also note increased latency may occur past 1000/sec, so we stop increasing as we approach that.
+  const scaleUpIntervalMins = 5;
+  let lastScaleUp = Date.now();
+  let rateLimit = taskLimit;
+
+  const queue = new PQueue({
+    interval: 1000,
+    intervalCap: rateLimit,
+    concurrency: rateLimit * 2,
+  });
+
+  if (accounts.length === 0) {
+    return 0;
+  }
+
+  for (const row of accounts) {
+    if (
+      rateLimit < 950 &&
+      Date.now() - lastScaleUp > scaleUpIntervalMins * 60 * 1000
+    ) {
+      rateLimit = Math.floor(rateLimit * 1.5);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      queue['#intervalCap'] = rateLimit; // This is private, but we need to update it
+      queue.concurrency = rateLimit * 2;
+      lastScaleUp = Date.now();
+    }
+
+    await queue.onSizeLessThan(rateLimit * 4); // Back-pressure
+
+    queue.add(async () => {
+      try {
+        const result = await accountTasks.deleteAccount({
+          uid: row.uid.toString('hex'),
+          customerId: row.stripeCustomerId || undefined,
+          reason,
+        });
+
+        if (log) {
+          log.info('Created cloud task', {
+            cloudTaskId: result,
+            reason,
+            uid: row.uid.toString('hex'),
+          });
+        } else {
+          console.log(
+            `Created cloud task ${result} for uid ${row.uid.toString('hex')}`
+          );
+        }
+      } catch (err) {
+        if (log) {
+          log.error('Errored creating task', {
+            err,
+          });
+        } else {
+          console.error('Errored creating task', err);
+        }
+      }
+    });
+  }
+  await queue.onIdle(); // Wait for the queue to empty and promises to complete
+
+  return 0;
+}
 
 export class CloudSchedulerHandler {
   private accountTasks: AccountTasks;
@@ -32,31 +126,50 @@ export class CloudSchedulerHandler {
     return new Date(Date.now() - days * MILLISECONDS_IN_A_DAY);
   }
 
+  async processAccountDeletionInRange(
+    config: ConfigType,
+    accountTasks: AccountTasks,
+    reason: ReasonForDeletion,
+    startDate: any,
+    endDate: any,
+    taskLimit: number,
+    log?: AuthLogger
+  ) {
+    return processAccountDeletionInRange(
+      config,
+      accountTasks,
+      reason,
+      startDate,
+      endDate,
+      taskLimit,
+      log
+    );
+  }
+
   async deleteUnverifiedAccounts() {
-    return error.featureNotEnabled();
+    const { sinceDays, durationDays, taskLimit } =
+      this.config.cloudScheduler.deleteUnverifiedAccounts;
+    const endDate = this.calculateDate(sinceDays);
+    const startDate = this.calculateDate(sinceDays + durationDays);
+    const reason = ReasonForDeletion.Unverified;
 
-    // const { sinceDays, durationDays, taskLimit } =
-    //   this.config.cloudScheduler.deleteUnverifiedAccounts;
-    // const endDate = this.calculateDate(sinceDays);
-    // const startDate = this.calculateDate(sinceDays + durationDays);
-    // const reason = ReasonForDeletion.Unverified;
+    this.log.info('Deleting unverified accounts', {
+      initiatedAt: new Date().toISOString(),
+      endDate: endDate.toISOString(),
+      startDate: startDate.toISOString(),
+    });
+    this.statsd.increment('cloud-scheduler.deleteUnverifiedAccounts');
+    await this.processAccountDeletionInRange(
+      this.config,
+      this.accountTasks,
+      reason,
+      startDate.getTime(),
+      endDate.getTime(),
+      taskLimit,
+      this.log
+    );
 
-    // this.log.info('Deleting unverified accounts', {
-    //   initiatedAt: new Date().toISOString(),
-    //   endDate: endDate.toISOString(),
-    //   startDate: startDate.toISOString(),
-    // });
-    // this.statsd.increment('cloud-scheduler.deleteUnverifiedAccounts');
-    // await processDateRange(
-    //   this.config,
-    //   this.accountTasks,
-    //   reason,
-    //   startDate.getTime(),
-    //   endDate.getTime(),
-    //   taskLimit
-    // );
-
-    // return {};
+    return {};
   }
 }
 

--- a/packages/fxa-auth-server/scripts/delete-unverified-accounts.ts
+++ b/packages/fxa-auth-server/scripts/delete-unverified-accounts.ts
@@ -4,12 +4,10 @@
 
 import { Command } from 'commander';
 import { StatsD } from 'hot-shots';
-import PQueue from 'p-queue';
 import { Container } from 'typedi';
+import { processAccountDeletionInRange } from '../lib/routes/cloud-scheduler';
 
-import { setupAccountDatabase } from '@fxa/shared/db/mysql/account';
-
-import appConfig, { ConfigType } from '../config';
+import appConfig from '../config';
 import * as random from '../lib/crypto/random';
 import DB from '../lib/db';
 import { setupFirestore } from '../lib/firestore-db';
@@ -21,7 +19,6 @@ import Token from '../lib/tokens';
 import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
 import { parseDryRun } from './lib/args';
 import {
-  AccountTasks,
   AccountTasksFactory,
   ReasonForDeletion,
 } from '@fxa/shared/cloud-tasks';
@@ -225,7 +222,7 @@ const init = async () => {
       return 0;
     }
 
-    await processDateRange(
+    await processAccountDeletionInRange(
       config,
       accountTasks,
       reason,
@@ -237,84 +234,6 @@ const init = async () => {
 
   return 0;
 };
-
-/**
- * Process a date range of accounts to delete.
- *
- * @param config
- * @param accountTasks
- * @param reason
- * @param startDate
- * @param endDate
- * @param taskLimit
- */
-export async function processDateRange(
-  config: ConfigType,
-  accountTasks: AccountTasks,
-  reason: ReasonForDeletion,
-  startDate: any,
-  endDate: any,
-  taskLimit: number
-) {
-  const kyselyDb = await setupAccountDatabase(config.database.mysql.auth);
-  const accounts = await kyselyDb
-    .selectFrom('accounts')
-    .where('accounts.emailVerified', '=', 0)
-    .where('accounts.createdAt', '>=', startDate)
-    .where('accounts.createdAt', '<=', endDate)
-    .leftJoin('accountCustomers', 'accounts.uid', 'accountCustomers.uid')
-    .select(['accounts.uid', 'accountCustomers.stripeCustomerId'])
-    .execute();
-
-  // Scaling suggestion is 500/5/50 rule, may start at 500/sec, and increase every 5 minutes by 50%.
-  // They also note increased latency may occur past 1000/sec, so we stop increasing as we approach that.
-  const scaleUpIntervalMins = 5;
-  let lastScaleUp = Date.now();
-  let rateLimit = taskLimit;
-  const queue = new PQueue({
-    interval: 1000,
-    intervalCap: rateLimit,
-    concurrency: rateLimit * 2,
-  });
-
-  if (accounts.length === 0) {
-    return 0;
-  }
-
-  for (const row of accounts) {
-    if (
-      rateLimit < 950 &&
-      Date.now() - lastScaleUp > scaleUpIntervalMins * 60 * 1000
-    ) {
-      rateLimit = Math.floor(rateLimit * 1.5);
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      queue['#intervalCap'] = rateLimit; // This is private, but we need to update it
-      queue.concurrency = rateLimit * 2;
-      lastScaleUp = Date.now();
-    }
-
-    await queue.onSizeLessThan(rateLimit * 4); // Back-pressure
-
-    queue.add(async () => {
-      try {
-        const result = await accountTasks.deleteAccount({
-          uid: row.uid.toString('hex'),
-          customerId: row.stripeCustomerId || undefined,
-          reason,
-        });
-        console.log(
-          `Created cloud task ${result} for uid ${row.uid.toString('hex')}`
-        );
-      } catch (err) {
-        console.error('Errored creating task', err);
-      }
-    });
-  }
-  await queue.onIdle(); // Wait for the queue to empty and promises to complete
-
-  return 0;
-}
 
 if (require.main === module) {
   init()


### PR DESCRIPTION
## Because

- We were getting an error `Error [ERR_REQUIRE_ESM]: require() of ES Module` when using PQueue

## This pull request

- Updates this to use a dynamic import of the library which works for CommonJS modules
- Moved the `processDateRange` function to the cloud scheduler route

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9644

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test:

1. From fxa-auth-server, run `yarn build`
2. Run `NODE_ENV=dev node dist/packages/fxa-auth-server/scripts/delete-unverified-accounts.js` verify scripts starts but asks for uid
3. Run `NODE_ENV=dev node dist/packages/fxa-auth-server/bin/key_server.js` verify server starts
