### PR TITLE
fix(apps,libs): Revise discountAmount and temporary page on  payments-next

### DIFF
--- a/apps/payments/next/app/page.tsx
+++ b/apps/payments/next/app/page.tsx
@@ -29,7 +29,7 @@ export default function Index() {
             <h2>VPN - Yearly</h2>
             <Link
               className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-              href="/en/vpn/checkout/yearly/landing"
+              href="/en/123donepro/checkout/yearly/landing"
             >
               Redirect
             </Link>
@@ -50,7 +50,7 @@ export default function Index() {
             <h2>VPN - Yearly</h2>
             <Link
               className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-              href="/en/vpn/checkout/yearly/new"
+              href="/en/123donepro/checkout/yearly/new"
             >
               Redirect
             </Link>

--- a/apps/payments/next/next.config.js
+++ b/apps/payments/next/next.config.js
@@ -40,6 +40,12 @@ const nextConfig = {
         port: '',
         pathname: '/product-icons/**',
       },
+      {
+        protocol: 'https',
+        hostname: '123done-stage.dev.lcip.org',
+        port: '',
+        pathname: '/img/**',
+      },
     ],
   },
 };

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -385,6 +385,7 @@ describe('CartService', () => {
     const mockPrice = StripePriceFactory();
     const mockUpcomingInvoice = StripeResponseFactory(
       StripeUpcomingInvoiceFactory({
+        discount: StripeDiscountFactory(),
         total_discount_amounts: [
           {
             amount: 500,
@@ -415,7 +416,9 @@ describe('CartService', () => {
         },
       ],
       discountAmount:
-        mockUpcomingInvoice.total_discount_amounts?.[0].amount ?? null,
+        mockUpcomingInvoice.discount &&
+        mockUpcomingInvoice.total_discount_amounts &&
+        mockUpcomingInvoice.total_discount_amounts[0].amount,
     };
 
     it('returns cart and invoicePreview', async () => {

--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -87,6 +87,7 @@ describe('StripeManager', () => {
       const mockPrice = StripePriceFactory();
       const mockUpcomingInvoice = StripeResponseFactory(
         StripeUpcomingInvoiceFactory({
+          discount: StripeDiscountFactory(),
           total_discount_amounts: [
             {
               amount: 500,
@@ -119,8 +120,8 @@ describe('StripeManager', () => {
           },
         ],
         discountAmount:
-          mockUpcomingInvoice.total_discount_amounts &&
-          mockUpcomingInvoice.total_discount_amounts[0].amount,
+          mockUpcomingInvoice.discount &&
+          mockUpcomingInvoice.total_discount_amounts?.[0].amount,
       };
 
       jest

--- a/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
+++ b/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
@@ -14,6 +14,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
   it('formats invoice', () => {
     const mockUpcomingInvoice = StripeResponseFactory(
       StripeUpcomingInvoiceFactory({
+        discount: StripeDiscountFactory(),
         total_discount_amounts: [
           {
             amount: 500,
@@ -45,7 +46,8 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
         },
       ],
       discountAmount:
-        mockUpcomingInvoice.total_discount_amounts?.[0].amount ?? null,
+        mockUpcomingInvoice.discount &&
+        mockUpcomingInvoice.total_discount_amounts?.[0].amount,
     });
   });
 });

--- a/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
+++ b/libs/payments/stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
@@ -18,7 +18,11 @@ export function stripeInvoiceToFirstInvoicePreviewDTO(
     },
   ];
 
-  const discountAmount = invoice.total_discount_amounts?.[0].amount ?? null;
+  const discountAmount =
+    (invoice.discount &&
+      invoice.total_discount_amounts &&
+      invoice.total_discount_amounts[0].amount) ??
+    null;
 
   return {
     currency: invoice.currency,


### PR DESCRIPTION
## This pull request

- [x] fixes `Error: Cannot read properties of undefined` for `discountAmount`
- [x] revises how `discountAmount` is determined [(see stripeInvoiceToFirstInvoicePreviewDTO)](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/payments/stripe-formatter.ts#L45-L47)
- [x] fixes redirect for yearly buttons on `payments-next`
- [x] adds `123done-stage.dev.lcip.org` to `next.config.js` to prevent [next/image Un-configured Host error](https://nextjs.org/docs/messages/next-image-unconfigured-host)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.