### PR TITLE
feat(auth): Verify and update promotion code info on endpoint

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -180,9 +180,17 @@ const DESCRIPTIONS = {
   productMetadata:
     'Set of key-value pairs used to store additional information about the product. For more information, see [Ecosystem Platform](https://mozilla.github.io/ecosystem-platform/tutorials/subscription-platform#stripe-product-metadata)',
   productName: 'The name of the product purchased.',
+  promotionAmountOff:
+    'Amount (in the currency specified) that will be taken off the subtotal of any invoices for this customer.',
   promotionCode: 'A customer-redeemable code for a coupon.',
   promotionDuration: 'Indicates how long the coupon is valid for.',
+  promotionEnd:
+    'If the coupon has a duration of repeating, the date that this discount will end. If the coupon has a duration of once or forever, this attribute will be null.',
   promotionId: 'The id associated with the promotion code',
+  promotionName:
+    'Name of the coupon displayed to customers on for instance invoices or receipts.',
+  promotionPercentOff:
+    'Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a $100 invoice $50 instead.',
   providerUid: 'The user id associated with a particular third party provider.',
   publicKey:
     'The key to sign (run bin/generate-keypair from [**browserid-crypto**](https://github.com/mozilla/browserid-crypto)).',

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2460,10 +2460,13 @@ export class StripeHelper extends StripeHelperBase {
         subscription_id: sub.id,
         failure_code,
         failure_message,
+        promotion_amount_off: discount?.coupon?.amount_off ?? null,
         promotion_code:
           sub.metadata[SUBSCRIPTION_PROMOTION_CODE_METADATA_KEY] ?? null,
         promotion_duration: (discount?.coupon?.duration as string) ?? null,
         promotion_end: discount?.end ?? null,
+        promotion_name: discount?.coupon?.name ?? null,
+        promotion_percent_off: discount?.coupon?.percent_off ?? null,
       });
     }
     return subs;

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -440,6 +440,13 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
   subscription_id: module.exports.subscriptionsSubscriptionId
     .required()
     .description(DESCRIPTIONS.subscriptionId),
+  promotion_amount_off: isA
+    .number()
+    .integer()
+    .min(0)
+    .optional()
+    .allow(null)
+    .description(DESCRIPTIONS.promotionAmountOff),
   promotion_code: isA
     .string()
     .optional()
@@ -450,7 +457,23 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
     .optional()
     .allow(null)
     .description(DESCRIPTIONS.promotionDuration),
-  promotion_end: isA.number().optional().allow(null),
+  promotion_end: isA
+    .number()
+    .optional()
+    .allow(null)
+    .description(DESCRIPTIONS.promotionEnd),
+  promotion_name: isA
+    .string()
+    .optional()
+    .allow(null)
+    .description(DESCRIPTIONS.promotionName),
+  promotion_percent_off: isA
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .allow(null)
+    .description(DESCRIPTIONS.promotionPercentOff),
 });
 
 // This is support-panel's perspective on a subscription

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4587,9 +4587,12 @@ describe('#integration - StripeHelper', () => {
             failure_message: failedChargeCopy.failure_message,
             latest_invoice: invoice.number,
             latest_invoice_items: latestInvoiceItems,
+            promotion_amount_off: null,
             promotion_code: null,
             promotion_duration: null,
             promotion_end: null,
+            promotion_name: null,
+            promotion_percent_off: null,
           },
         ];
 
@@ -4669,9 +4672,12 @@ describe('#integration - StripeHelper', () => {
                 failure_message: undefined,
                 latest_invoice: paidInvoice.number,
                 latest_invoice_items: latestInvoiceItems,
+                promotion_amount_off: null,
                 promotion_code: null,
                 promotion_duration: null,
                 promotion_end: null,
+                promotion_name: null,
+                promotion_percent_off: null,
               },
             ];
 
@@ -4710,9 +4716,12 @@ describe('#integration - StripeHelper', () => {
                 failure_message: undefined,
                 latest_invoice: paidInvoice.number,
                 latest_invoice_items: latestInvoiceItems,
+                promotion_amount_off: null,
                 promotion_code: null,
                 promotion_duration: null,
                 promotion_end: null,
+                promotion_name: null,
+                promotion_percent_off: null,
               },
             ];
 
@@ -4746,9 +4755,12 @@ describe('#integration - StripeHelper', () => {
                 failure_message: undefined,
                 latest_invoice: paidInvoice.number,
                 latest_invoice_items: latestInvoiceItems,
+                promotion_amount_off: null,
                 promotion_code: null,
                 promotion_duration: null,
                 promotion_end: null,
+                promotion_name: null,
+                promotion_percent_off: null,
               },
             ];
 
@@ -4786,9 +4798,12 @@ describe('#integration - StripeHelper', () => {
                 failure_message: undefined,
                 latest_invoice: paidInvoice.number,
                 latest_invoice_items: latestInvoiceItems,
+                promotion_amount_off: null,
                 promotion_code: null,
                 promotion_duration: null,
                 promotion_end: null,
+                promotion_name: null,
+                promotion_percent_off: null,
               },
             ];
             const actual = await stripeHelper.subscriptionsToResponse(input);
@@ -4910,9 +4925,12 @@ describe('#integration - StripeHelper', () => {
             failure_message: undefined,
             latest_invoice: paidInvoice.number,
             latest_invoice_items: latestInvoiceItems,
+            promotion_amount_off: null,
             promotion_code: null,
             promotion_duration: null,
             promotion_end: null,
+            promotion_name: null,
+            promotion_percent_off: null,
           },
         ];
 
@@ -4947,10 +4965,15 @@ describe('#integration - StripeHelper', () => {
             failure_message: undefined,
             latest_invoice: paidInvoice.number,
             latest_invoice_items: latestInvoiceItems,
+            promotion_amount_off:
+              subscriptionCouponForever.discount.coupon.amount_off,
             promotion_code:
               subscriptionCouponForever.metadata.appliedPromotionCode,
             promotion_duration: 'forever',
             promotion_end: null,
+            promotion_name: subscriptionCouponForever.discount.coupon.name,
+            promotion_percent_off:
+              subscriptionCouponForever.discount.coupon.percent_off,
           },
         ];
 
@@ -4985,10 +5008,15 @@ describe('#integration - StripeHelper', () => {
             failure_message: undefined,
             latest_invoice: paidInvoice.number,
             latest_invoice_items: latestInvoiceItems,
+            promotion_amount_off:
+              subscriptionCouponRepeating.discount.coupon.amount_off,
             promotion_code:
               subscriptionCouponRepeating.metadata.appliedPromotionCode,
             promotion_duration: 'repeating',
             promotion_end: subscriptionCouponRepeating.discount.end,
+            promotion_name: subscriptionCouponRepeating.discount.coupon.name,
+            promotion_percent_off:
+              subscriptionCouponRepeating.discount.coupon.percent_off,
           },
         ];
 

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -165,9 +165,12 @@ export type WebSubscription = Pick<
       'incomplete' | 'incomplete_expired'
     >;
     subscription_id: Stripe.Subscription['id'];
+    promotion_amount_off?: number | null;
     promotion_code?: string;
     promotion_duration: string | null;
     promotion_end: number | null;
+    promotion_name?: string | null;
+    promotion_percent_off?: number | null;
   };
 
 export type IapSubscription = PlayStoreSubscription | AppStoreSubscription;


### PR DESCRIPTION
## This pull request

- [x] Verify promotion code is returned in the endpoint `/oauth/mozilla-subscriptions/customer/billing-and-subscriptions`
- [x] Update endpoint to return promo code name and discount information (20% off, etc)
- [x] Update tests

## Issue that this pull request solves

Closes: FXA-9456

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
