### PR TITLE
bug(gql): Follow fix for ignoring known auth server errors in graphql-api

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/sentry.interceptor.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.interceptor.ts
@@ -15,7 +15,11 @@ import {
 import * as Sentry from '@sentry/node';
 import { Transaction } from '@sentry/types';
 
-import { isApolloError, processException } from './reporting';
+import {
+  isApolloError,
+  processException,
+  isAuthServerError,
+} from './reporting';
 
 @Injectable()
 export class SentryInterceptor implements NestInterceptor {
@@ -45,6 +49,10 @@ export class SentryInterceptor implements NestInterceptor {
               return;
             }
           }
+
+          // Skip known auth-server errors
+          if (isAuthServerError(exception)) return;
+
           // Skip ApolloErrors
           if (isApolloError(exception)) return;
 


### PR DESCRIPTION
## Because:

- We are still seeing the 'The authentication token could not be found' sentry issue.
- GQL is using fxa-shared not libs!

## This pull request

- Fixes a bug where the isAuthServerError wasn't added to the sentry.interceptor in fxa-shared as well.


## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

