### PR TITLE
test(functional): add fixme to failing coupon tests

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -16,6 +16,10 @@ test.describe('severity-2 #smoke', () => {
     test('apply an expired coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/05/13 (see FXA-9665).'
+      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
@@ -35,6 +39,10 @@ test.describe('severity-2 #smoke', () => {
     test('apply an invalid coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/05/13 (see FXA-9665).'
+      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
@@ -204,6 +212,10 @@ test.describe('severity-2 #smoke', () => {
     test('remove a coupon and verify', async ({
       pages: { relier, subscribe, login },
     }, { project }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/05/13 (see FXA-9689).'
+      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'


### PR DESCRIPTION
## Because

- 3 Coupon tests were failing in Stage. 2 were due to a customs failure issue and the third one because of a locator not visible issue.

## This pull request

- Adds fixme to all the 2 failing coupon tests with appropriate ticket mentioned.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
