### PR TITLE
chore: vendor typesafe-node-firestore

### DIFF
--- a/libs/vendored/typesafe-node-firestore/.eslintrc.json
+++ b/libs/vendored/typesafe-node-firestore/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {}
+    }
+  ]
+}

--- a/libs/vendored/typesafe-node-firestore/README.md
+++ b/libs/vendored/typesafe-node-firestore/README.md
@@ -1,0 +1,11 @@
+# typesafe-node-firestore
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build typesafe-node-firestore` to build the library.
+
+## Running unit tests
+
+Run `nx test typesafe-node-firestore` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/vendored/typesafe-node-firestore/jest.config.ts
+++ b/libs/vendored/typesafe-node-firestore/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'typesafe-node-firestore',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/vendored/typesafe-node-firestore',
+};

--- a/libs/vendored/typesafe-node-firestore/package.json
+++ b/libs/vendored/typesafe-node-firestore/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fxa/vendored/typesafe-node-firestore",
+  "version": "0.0.1"
+}

--- a/libs/vendored/typesafe-node-firestore/project.json
+++ b/libs/vendored/typesafe-node-firestore/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "typesafe-node-firestore",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/vendored/typesafe-node-firestore/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/vendored/typesafe-node-firestore",
+        "tsConfig": "libs/vendored/typesafe-node-firestore/tsconfig.lib.json",
+        "packageJson": "libs/vendored/typesafe-node-firestore/package.json",
+        "main": "libs/vendored/typesafe-node-firestore/src/index.ts",
+        "assets": ["libs/vendored/typesafe-node-firestore/*.md"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/vendored/typesafe-node-firestore/jest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/vendored/typesafe-node-firestore/src/index.ts
+++ b/libs/vendored/typesafe-node-firestore/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/typesafe-node-firestore';

--- a/libs/vendored/typesafe-node-firestore/src/lib/typesafe-node-firestore.ts
+++ b/libs/vendored/typesafe-node-firestore/src/lib/typesafe-node-firestore.ts
@@ -1,0 +1,171 @@
+import * as firestore from '@google-cloud/firestore';
+
+export interface TypedDocumentData<T extends firestore.DocumentData>
+  extends firestore.DocumentData {
+  [field: string]: T;
+}
+
+export interface TypedDocumentChange<T extends firestore.DocumentData>
+  extends firestore.DocumentChange {
+  readonly doc: TypedQueryDocumentSnapshot<T>;
+
+  isEqual(other: TypedDocumentChange<T>): boolean;
+}
+
+export interface TypedDocumentReference<T extends firestore.DocumentData>
+  extends firestore.DocumentReference {
+  readonly parent: TypedCollectionReference<T>;
+  readonly path: string;
+
+  collection(collectionPath: string): TypedCollectionReference<T>;
+
+  create(data: T): Promise<firestore.WriteResult>;
+
+  isEqual(other: TypedDocumentReference<T>): boolean;
+
+  set(data: T, options?: firestore.SetOptions): Promise<firestore.WriteResult>;
+
+  update(
+    data: Partial<T>,
+    precondition?: firestore.Precondition
+  ): Promise<firestore.WriteResult>;
+
+  update(
+    field: keyof T | firestore.FieldPath,
+    value: T[keyof T],
+    ...moreFieldsAndValues: T[keyof T][]
+  ): Promise<firestore.WriteResult>;
+
+  delete(precondition?: firestore.Precondition): Promise<firestore.WriteResult>;
+
+  get(): Promise<TypedDocumentSnapshot<T>>;
+
+  onSnapshot(
+    onNext: (snapshot: TypedDocumentSnapshot<T>) => void,
+    onError?: (error: Error) => void
+  ): () => void;
+}
+
+export interface TypedDocumentSnapshot<T extends firestore.DocumentData>
+  extends firestore.DocumentSnapshot {
+  readonly ref: TypedDocumentReference<T>;
+  data(options?: firestore.QuerySnapshot): T | undefined;
+}
+
+export interface TypedQuery<T extends TypedDocumentData<T>>
+  extends firestore.Query {
+  where(
+    fieldPath: keyof T | firestore.FieldPath,
+    opStr: firestore.WhereFilterOp,
+    value: T[keyof T]
+  ): TypedQuery<T>;
+
+  where(filter: firestore.Filter): TypedQuery<T>;
+
+  orderBy(
+    fieldPath: keyof T | firestore.FieldPath,
+    directionStr?: firestore.OrderByDirection
+  ): TypedQuery<T>;
+
+  limit(limit: number): TypedQuery<T>;
+
+  offset(offset: number): TypedQuery<T>;
+
+  select(...field: (keyof T | firestore.FieldPath)[]): TypedQuery<T>;
+
+  startAt(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  startAt(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  startAfter(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  startAfter(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  endBefore(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  endBefore(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  endAt(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  endAt(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  get(): Promise<TypedQuerySnapshot<T>>;
+
+  isEqual(other: TypedQuery<T>): boolean;
+}
+
+export interface TypedQueryDocumentSnapshot<T extends firestore.DocumentData>
+  extends firestore.QueryDocumentSnapshot {
+  readonly ref: TypedDocumentReference<T>;
+  data(): T;
+}
+
+export interface TypedQuerySnapshot<T extends firestore.DocumentData>
+  extends firestore.QuerySnapshot {
+  readonly docs: TypedQueryDocumentSnapshot<T>[];
+
+  docChanges(): TypedDocumentChange<T>[];
+
+  forEach(
+    callback: (result: TypedQueryDocumentSnapshot<T>) => void,
+    thisArg?: any
+  ): void;
+
+  isEqual(other: TypedQuerySnapshot<T>): boolean;
+}
+
+export interface TypedCollectionReference<T extends firestore.DocumentData>
+  extends firestore.CollectionReference {
+  listDocuments(): Promise<TypedDocumentReference<T>[]>;
+
+  doc(): TypedDocumentReference<T>;
+
+  doc(documentPath?: string): TypedDocumentReference<T>;
+
+  add(data: T): Promise<TypedDocumentReference<T>>;
+
+  isEqual(other: TypedCollectionReference<T>): boolean;
+
+  // extends Query overrides with TypedQuery
+  where(
+    fieldPath: keyof T | firestore.FieldPath,
+    opStr: firestore.WhereFilterOp,
+    value: T[keyof T]
+  ): TypedQuery<T>;
+
+  where(filter: firestore.Filter): TypedQuery<T>;
+
+  orderBy(
+    fieldPath: keyof T | firestore.FieldPath,
+    directionStr?: firestore.OrderByDirection
+  ): TypedQuery<T>;
+
+  limit(limit: number): TypedQuery<T>;
+
+  offset(offset: number): TypedQuery<T>;
+
+  select(...field: (keyof T | firestore.FieldPath)[]): TypedQuery<T>;
+
+  startAt(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  startAt(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  startAfter(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  startAfter(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  endBefore(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  endBefore(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  endAt(snapshot: TypedDocumentSnapshot<T>): TypedQuery<T>;
+
+  endAt(...fieldValues: T[keyof T][]): TypedQuery<T>;
+
+  get(): Promise<TypedQuerySnapshot<T>>;
+
+  onSnapshot(
+    onNext: (snapshot: TypedQuerySnapshot<T>) => void,
+    onError?: (error: Error) => void
+  ): () => void;
+}

--- a/libs/vendored/typesafe-node-firestore/tsconfig.json
+++ b/libs/vendored/typesafe-node-firestore/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/vendored/typesafe-node-firestore/tsconfig.lib.json
+++ b/libs/vendored/typesafe-node-firestore/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/vendored/typesafe-node-firestore/tsconfig.spec.json
+++ b/libs/vendored/typesafe-node-firestore/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -17,7 +17,8 @@
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index"],
       "@fxa/shared/log": ["libs/shared/log/src/index"],
       "@fxa/shared/metrics/statsd": ["libs/shared/metrics/statsd/src/index"],
-      "@fxa/shared/pem-jwk": ["libs/shared/pem-jwk/src/index.ts"]
+      "@fxa/shared/pem-jwk": ["libs/shared/pem-jwk/src/index.ts"],
+      "@fxa/vendored/typesafe-node-firestore": ["libs/vendored/typesafe-node-firestore/src/index"]
     }
   }
 }

--- a/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/iap-config.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Firestore } from '@google-cloud/firestore';
 import { Container } from 'typedi';
-import { TypedCollectionReference } from 'typesafe-node-firestore';
+import { TypedCollectionReference } from '@fxa/vendored/typesafe-node-firestore';
 
 import error from '../../error';
 import { AppConfig, AuthFirestore, AuthLogger } from '../../types';

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -211,7 +211,6 @@
     "through": "2.3.8",
     "tsc-alias": "^1.8.8",
     "type-fest": "^4.18.1",
-    "typesafe-node-firestore": "^1.4.1",
     "typescript": "^5.4.2",
     "webpack": "^5.84.1",
     "webpack-watch-files-plugin": "^1.2.1",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -84,7 +84,6 @@
     "ts-jest": "^29.1.2",
     "ts-loader": "^8.4.0",
     "tsconfig-paths": "^4.2.0",
-    "typesafe-node-firestore": "^1.4.1",
     "typescript": "^5.4.2"
   },
   "jest": {

--- a/packages/fxa-event-broker/src/firestore/firestore.service.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.ts
@@ -20,7 +20,7 @@ import { ConfigService } from '@nestjs/config';
 import {
   TypedCollectionReference,
   TypedDocumentReference,
-} from 'typesafe-node-firestore';
+} from '@fxa/vendored/typesafe-node-firestore';
 
 import { AppConfig } from '../config';
 import {

--- a/packages/fxa-event-broker/tsconfig.build.json
+++ b/packages/fxa-event-broker/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "paths": {
       "@fxa/shared/pem-jwk": ["libs/shared/pem-jwk/src/index"],
-      "@fxa/vendored/jwtool": ["libs/vendored/jwtool/src/index"]
+      "@fxa/vendored/jwtool": ["libs/vendored/jwtool/src/index"],
+      "@fxa/vendored/typesafe-node-firestore": ["libs/vendored/typesafe-node-firestore/src/index"]
     }
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -324,8 +324,7 @@
     "mysql": "^2.18.1",
     "node-uap": "https://github.com/mozilla-fxa/node-uap.git#494714db3e65a4dbfae772f536c8697269174574",
     "objection": "^3.1.3",
-    "superagent": "^9.0.2",
-    "typesafe-node-firestore": "^1.4.1"
+    "superagent": "^9.0.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/fxa-shared/payments/configuration/manager.ts
+++ b/packages/fxa-shared/payments/configuration/manager.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Firestore } from '@google-cloud/firestore';
-import { TypedCollectionReference } from 'typesafe-node-firestore';
+import { TypedCollectionReference } from '@fxa/vendored/typesafe-node-firestore';
 import { PlanConfig } from '../../subscriptions/configuration/plan';
 import { ProductConfig } from '../../subscriptions/configuration/product';
 import { mergeConfigs } from '../../subscriptions/configuration/utils';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -65,7 +65,10 @@
       "@fxa/vendored/incremental-encoder": [
         "libs/vendored/incremental-encoder/src/index.ts"
       ],
-      "@fxa/vendored/jwtool": ["libs/vendored/jwtool/src/index.ts"]
+      "@fxa/vendored/jwtool": ["libs/vendored/jwtool/src/index.ts"],
+      "@fxa/vendored/typesafe-node-firestore": [
+        "libs/vendored/typesafe-node-firestore/src/index.ts"
+      ]
     },
     "typeRoots": [
       "./types",


### PR DESCRIPTION
Because:

* We don't want to maintain small external libs instead of using our monorepo.

This commit:

* Vendors in the typesafe-node-firestore typings.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
