### PR TITLE
fix(content): Missing argument in createEventFn causing ts compilation issue

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -233,7 +233,7 @@ const createEventFn =
       await populateMetrics(properties);
 
       // recording the event metric triggers the event ping because Glean is initialized with `maxEvents: 1`
-      recordEventMetric(eventName);
+      recordEventMetric(eventName, properties);
 
       accountsEvents.submit();
     };


### PR DESCRIPTION
## Because

- PRs were failing CircleCI on the fxa-content-server compilation step

## This pull request

- Adds missing properties argument in Glean createEventFn

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
