### PR TITLE
fix(functional-test): update failing coupon tests

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -11,8 +11,12 @@ export class SubscribePage extends BaseLayout {
     return this.page.getByRole('heading', { name: 'Promo Code Applied' });
   }
 
-  async getCouponStatusByDataTestId(dataTestId: string) {
-    return this.page.locator(`[data-testid="${dataTestId}"]`);
+  get couponError() {
+    return this.page.getByTestId('coupon-error');
+  }
+
+  get removeCouponButton() {
+    return this.page.getByTestId('coupon-remove-button');
   }
 
   async visitSignIn() {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -26,10 +26,8 @@ test.describe('severity-2 #smoke', () => {
       // 'autoexpired' coupon is an expired coupon for a 6mo plan
       await subscribe.addCouponCode('autoexpired');
 
-      await expect(
-        await subscribe.getCouponStatusByDataTestId('coupon-error')
-      ).toBeVisible({
-        timeout: 5000,
+      await expect(subscribe.couponError).toBeVisible({
+        timeout: 10000,
       });
 
       // Verifying the correct error message
@@ -52,10 +50,8 @@ test.describe('severity-2 #smoke', () => {
       // But valid for a 12mo plan
       await subscribe.addCouponCode('autoinvalid');
 
-      await expect(
-        await subscribe.getCouponStatusByDataTestId('coupon-error')
-      ).toBeVisible({
-        timeout: 5000,
+      await expect(subscribe.couponError).toBeVisible({
+        timeout: 10000,
       });
 
       // Asserting that the code is invalid for a 6mo plan
@@ -228,10 +224,8 @@ test.describe('severity-2 #smoke', () => {
       await subscribe.addCouponCode('auto50ponetime');
 
       // Verify the coupon is applied successfully
-      await expect(
-        await subscribe.getCouponStatusByDataTestId('coupon-remove-button')
-      ).toBeVisible({
-        timeout: 5000,
+      await expect(subscribe.removeCouponButton).toBeVisible({
+        timeout: 10000,
       });
       expect(await subscribe.oneTimeDiscountSuccess()).toBe(true);
 


### PR DESCRIPTION
## Because

- We are aiming to make stage and prod deployments all green.
- There is still flakiness.

## This pull request

- Updates tests to add a longer timeout to page locators.
- Follow up to #16983.

## Issue that this pull request solves

Closes FXA-9689

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
