### PR TITLE
task(auth, graphql-api, admin-server): Update event-broker's profileDataChange data schema and remove the metrics-change event

### DIFF
--- a/libs/shared/notifier/src/lib/notifier.service.ts
+++ b/libs/shared/notifier/src/lib/notifier.service.ts
@@ -8,8 +8,8 @@ import { SNS, AWSError } from 'aws-sdk';
 import { NotifierSnsService } from './notifier.sns.provider';
 import { ConfigService } from '@nestjs/config';
 import { NotifierSnsConfig } from './notifier.sns.config';
-import { MozLoggerService } from '@fxa/shared/mozlog';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 @Injectable()
 export class NotifierService {
@@ -19,22 +19,18 @@ export class NotifierService {
     configService: ConfigService,
     private readonly log: MozLoggerService,
     @Inject(NotifierSnsService) private readonly sns: SNS,
-    @Inject(StatsDService) private readonly statsd: StatsD
+    @Inject(StatsDService) private readonly statsd: StatsD | undefined
   ) {
     const config = configService.get<NotifierSnsConfig>('notifier.sns');
     if (config == null) {
       throw new Error('Could not locate sns.notifier config');
     }
 
-    this.log.error('Creating notifier service', {
-      config: JSON.stringify(config),
-    });
-
     if (!config.snsTopicArn) {
-      throw new Error('Config error snsTopicArnMissing');
+      this.log.warn('', { message: 'snsTopicArn missing!' });
     }
     if (!config.snsTopicEndpoint) {
-      throw new Error('Config error notifierSnsTopicEndpoint missing');
+      this.log.warn('', { message: 'snsTopicEndpoint missing!' });
     }
 
     this.config = config;

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -30,6 +30,8 @@ import { GqlModule } from './gql/gql.module';
 import { NewslettersModule } from './newsletters/newsletters.module';
 import { SubscriptionModule } from './subscriptions/subscriptions.module';
 
+import { NotifierSnsFactory, NotifierService } from '@fxa/shared/notifier';
+
 const version = getVersionInfo(__dirname);
 
 @Module({
@@ -90,6 +92,8 @@ const version = getVersionInfo(__dirname);
       useClass: UserGroupGuard,
     },
     SentryPlugin,
+    NotifierSnsFactory,
+    NotifierService,
   ],
 })
 export class AppModule {}

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -586,6 +586,22 @@ const conf = convict({
     },
   },
   cloudTasks: CloudTasksConvictConfigFactory(),
+  notifier: {
+    sns: {
+      snsTopicArn: {
+        doc: 'Amazon SNS topic on which to send account event notifications. Set to "disabled" to turn off the notifier',
+        format: String,
+        env: 'SNS_TOPIC_ARN',
+        default: '',
+      },
+      snsTopicEndpoint: {
+        doc: 'Amazon SNS topic endpoint',
+        format: String,
+        env: 'SNS_TOPIC_ENDPOINT',
+        default: undefined,
+      },
+    },
+  },
 });
 
 const configDir = __dirname;

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -17,8 +17,10 @@
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index"],
       "@fxa/shared/log": ["libs/shared/log/src/index"],
       "@fxa/shared/metrics/statsd": ["libs/shared/metrics/statsd/src/index"],
-      "@fxa/shared/pem-jwk": ["libs/shared/pem-jwk/src/index.ts"],
-      "@fxa/vendored/typesafe-node-firestore": ["libs/vendored/typesafe-node-firestore/src/index"]
+      "@fxa/shared/pem-jwk": ["libs/shared/pem-jwk/src/index"],
+      "@fxa/vendored/typesafe-node-firestore": ["libs/vendored/typesafe-node-firestore/src/index"],
+      "@fxa/shared/notifier": ["libs/shared/notifier/src/index"],
+      "@fxa/shared/mozlog": ["libs/shared/mozlog/src/index"]
     }
   }
 }

--- a/packages/fxa-auth-server/lib/profile/updates.js
+++ b/packages/fxa-auth-server/lib/profile/updates.js
@@ -9,6 +9,10 @@ module.exports = function (log) {
     async function handleProfileUpdated(message) {
       const uid = message && message.uid;
 
+      if (!uid) {
+        throw new Error('uid missing from profile update message.');
+      }
+
       log.info('handleProfileUpdated', { uid, action: 'notify' });
 
       try {
@@ -24,6 +28,12 @@ module.exports = function (log) {
           {},
           {
             uid,
+            email: message.email,
+            locale: message.locale,
+            metricsEnabled: message.metricsEnabled,
+            totpEnabled: message.totpEnabled,
+            accountDisabled: message.accountDisabled,
+            accountLocked: message.accountLocked,
           }
         );
       } catch (err) {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -242,6 +242,16 @@ export class AccountHandler {
       uid: account.uid,
       userAgent: userAgentString,
     });
+    await this.log.notifyAttachedServices('profileDataChange', request, {
+      uid: account.uid,
+      email: email,
+      locale: locale,
+      totpEnabled: false,
+      metricsEnabled: true,
+      accountDisabled: false,
+      accountLocked: false,
+    });
+
     return { password, password2, account };
   }
 
@@ -1591,6 +1601,10 @@ export class AccountHandler {
         this.log.notifyAttachedServices('reset', request, {
           uid: account.uid,
           generation: account.verifierSetAt,
+        }),
+        this.log.notifyAttachedServices('profileDataChange', request, {
+          uid: account.uid,
+          accountLocked: false,
         }),
         this.oauth.removeTokensAndCodes(account.uid),
         this.customs.reset(request, account.email),

--- a/packages/fxa-auth-server/lib/routes/sign.js
+++ b/packages/fxa-auth-server/lib/routes/sign.js
@@ -176,6 +176,14 @@ module.exports = (log, signer, db, domain, devices, config) => {
               locale: request.app.acceptLanguage,
             });
             db.updateLocale(sessionToken.uid, request.app.acceptLanguage);
+            log.notifyAttachedServices(
+              'profileDataChange',
+              {},
+              {
+                uid: sessionToken.uid,
+                locale: request.app.acceptLanguage,
+              }
+            );
             // meh on the result
           } else {
             // We're seeing a surprising number of accounts that don't get

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -155,9 +155,14 @@ module.exports = (log, db, mailer, customs, config, glean) => {
         // See #5154.
         await db.verifyTokensWithMethod(sessionToken.id, 'email-2fa');
 
-        await log.notifyAttachedServices('profileDataChange', request, {
-          uid,
-        });
+        await log.notifyAttachedServices(
+          'profileDataChange',
+          {},
+          {
+            uid,
+            totpEnabled: false,
+          }
+        );
 
         if (hasEnabledToken) {
           const account = await db.account(uid);
@@ -304,6 +309,7 @@ module.exports = (log, db, mailer, customs, config, glean) => {
 
           await log.notifyAttachedServices('profileDataChange', request, {
             uid: sessionToken.uid,
+            totpEnabled: true,
           });
         }
 

--- a/packages/fxa-auth-server/test/local/profile/updates.js
+++ b/packages/fxa-auth-server/test/local/profile/updates.js
@@ -54,11 +54,23 @@ describe('profile updates', () => {
   it('should send notifications', () => {
     const log = mockLog();
     const uid = '1e2122ba';
+    const email = 'foo@mozilla.com';
+    const locale = 'en-US';
+    const metricsEnabled = true;
+    const totpEnabled = false;
+    const accountDisabled = false;
+    const accountLocked = false;
 
     return mockProfileUpdates(log)
       .handleProfileUpdated(
         mockMessage({
           uid: uid,
+          email,
+          locale,
+          metricsEnabled,
+          totpEnabled,
+          accountDisabled,
+          accountLocked,
         })
       )
       .then(() => {
@@ -71,7 +83,15 @@ describe('profile updates', () => {
           log.notifyAttachedServices.calledWithExactly(
             'profileDataChange',
             {},
-            { uid }
+            {
+              uid,
+              email,
+              locale,
+              metricsEnabled,
+              totpEnabled,
+              accountDisabled,
+              accountLocked,
+            }
           )
         );
       });

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -893,10 +893,10 @@ describe('/account/create', () => {
 
       assert.equal(
         mockLog.notifier.send.callCount,
-        1,
+        2,
         'an sqs event was logged'
       );
-      const eventData = mockLog.notifier.send.getCall(0).args[0];
+      let eventData = mockLog.notifier.send.getCall(0).args[0];
       assert.equal(eventData.event, 'login', 'it was a login event');
       assert.equal(eventData.data.service, 'sync', 'it was for sync');
       assert.equal(
@@ -934,6 +934,16 @@ describe('/account/create', () => {
         },
         'it contained the correct metrics context metadata'
       );
+
+      eventData = mockLog.notifier.send.getCall(1).args[0];
+      assert.equal(eventData.event, 'profileDataChange');
+      assert.equal(eventData.data.uid, uid);
+      assert.equal(eventData.data.email, 'foo@gmail.com');
+      assert.equal(eventData.data.locale, 'en-US');
+      assert.equal(eventData.data.totpEnabled, false);
+      assert.equal(eventData.data.metricsEnabled, true);
+      assert.equal(eventData.data.accountDisabled, false);
+      assert.equal(eventData.data.accountLocked, false);
 
       assert.equal(
         mockLog.activityEvent.callCount,
@@ -1136,16 +1146,25 @@ describe('/account/create', () => {
     return runTest(route, mockRequest, () => {
       assert.equal(
         mockLog.notifier.send.callCount,
-        1,
+        2,
         'an sqs event was logged'
       );
-      const eventData = mockLog.notifier.send.getCall(0).args[0];
+      let eventData = mockLog.notifier.send.getCall(0).args[0];
       assert.equal(eventData.event, 'login', 'it was a login event');
       assert.equal(
         eventData.data.service,
         'foo',
         'it was for the expected service'
       );
+      eventData = mockLog.notifier.send.getCall(1).args[0];
+      assert.equal(eventData.event, 'profileDataChange');
+      assert.equal(eventData.data.uid, uid);
+      assert.equal(eventData.data.email, 'foo@gmail.com');
+      assert.equal(eventData.data.locale, 'en-US');
+      assert.equal(eventData.data.totpEnabled, false);
+      assert.equal(eventData.data.metricsEnabled, true);
+      assert.equal(eventData.data.accountDisabled, false);
+      assert.equal(eventData.data.accountLocked, false);
 
       assert.equal(
         mockLog.activityEvent.callCount,

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -137,12 +137,8 @@ describe('totp', () => {
           'profileDataChange',
           'first argument was event name'
         );
-        assert.equal(args[1], request, 'second argument was request object');
-        assert.equal(
-          args[2].uid,
-          'uid',
-          'third argument was event data with a uid'
-        );
+        assert.equal(args[2].uid, 'uid');
+        assert.equal(args[2].totpEnabled, false);
 
         assert.equal(
           db.verifyTokensWithMethod.callCount,

--- a/packages/fxa-event-broker/src/jwtset/jwtset.service.spec.ts
+++ b/packages/fxa-event-broker/src/jwtset/jwtset.service.spec.ts
@@ -11,9 +11,8 @@ import {
   PROFILE_CHANGE_EVENT,
   SUBSCRIPTION_UPDATE_EVENT,
   DELETE_EVENT,
-  METRICS_CHANGE_EVENT,
 } from '../queueworker/sqs.dto';
-import { METRICS_CHANGE_EVENT_ID, PROFILE_EVENT_ID } from './set.interface';
+import { PROFILE_EVENT_ID } from './set.interface';
 
 const TEST_KEY = {
   d: 'nvfTzcMqVr8fa-b3IIFBk0J69sZQsyhKc3jYN5pPG7FdJyA-D5aPNv5zsF64JxNJetAS44cAsGAKN3Kh7LfjvLCtV56Ckg2tkBMn3GrbhE1BX6ObYvMuOBz5FJ9GmTOqSCxotAFRbR6AOBd5PCw--Rls4MylX393TFg6jJTGLkuYGuGHf8ILWyb17hbN0iyT9hME-cgLW1uc_u7oZ0vK9IxGPTblQhr82RBPQDTvZTM4s1wYiXzbJNrI_RGTAhdbwXuoXKiBN4XL0YRDKT0ENVqQLMiBwfdT3sW-M0L6kIv-L8qX3RIhbM3WA_a_LjTOM3WwRcNanSGiAeJLHwE5cQ',
@@ -63,7 +62,6 @@ describe('JwtsetService', () => {
       password: [PASSWORD_CHANGE_EVENT, 'generatePasswordSET'],
       profile: [PROFILE_CHANGE_EVENT, 'generateProfileSET'],
       delete: [DELETE_EVENT, 'generateDeleteSET'],
-      metrics: [METRICS_CHANGE_EVENT, 'generateMetricsChangeSET'],
     };
 
     async function checkSet(event: string, method: string) {
@@ -73,6 +71,11 @@ describe('JwtsetService', () => {
         event,
         uid: 'uid1234',
         email: 'test@mozilla.com',
+        locale: 'en-US',
+        totpEnabled: false,
+        metricsEnabled: true,
+        accountDisabled: false,
+        accountLocked: false,
       };
       const token = await (service as any)[method](evt);
       const payload = await PUBLIC_JWT.verify(token);
@@ -81,6 +84,11 @@ describe('JwtsetService', () => {
       expect(payload.iss).toBe('test');
       if (event === PROFILE_CHANGE_EVENT) {
         expect(payload.events[PROFILE_EVENT_ID].email).toBe('test@mozilla.com');
+        expect(payload.events[PROFILE_EVENT_ID].locale).toBe('en-US');
+        expect(payload.events[PROFILE_EVENT_ID].totpEnabled).toBe(false);
+        expect(payload.events[PROFILE_EVENT_ID].metricsEnabled).toBe(true);
+        expect(payload.events[PROFILE_EVENT_ID].accountDisabled).toBe(false);
+        expect(payload.events[PROFILE_EVENT_ID].accountLocked).toBe(false);
       }
     }
 
@@ -105,21 +113,6 @@ describe('JwtsetService', () => {
       expect(payload.aud).toBe(TEST_CLIENT_ID);
       expect(payload.sub).toBe('uid1234');
       expect(payload.iss).toBe('test');
-    });
-
-    it('metrics change SET', async () => {
-      const event = {
-        clientId: TEST_CLIENT_ID,
-        event: METRICS_CHANGE_EVENT,
-        uid: 'uid1234',
-        enabled: false,
-      };
-      const token = await service.generateMetricsChangeSET(event);
-      const payload = await PUBLIC_JWT.verify(token);
-      expect(payload.aud).toBe(TEST_CLIENT_ID);
-      expect(payload.sub).toBe('uid1234');
-      expect(payload.iss).toBe('test');
-      expect(payload.events[METRICS_CHANGE_EVENT_ID].enabled).toBe(false);
     });
   });
 });

--- a/packages/fxa-event-broker/src/jwtset/jwtset.service.ts
+++ b/packages/fxa-event-broker/src/jwtset/jwtset.service.ts
@@ -77,6 +77,11 @@ export class JwtsetService {
       events: {
         [set.PROFILE_EVENT_ID]: {
           email: proEvent.email,
+          locale: proEvent.locale,
+          metricsEnabled: proEvent.metricsEnabled,
+          totpEnabled: proEvent.totpEnabled,
+          accountDisabled: proEvent.accountDisabled,
+          accountLocked: proEvent.accountLocked,
         },
       },
       uid: proEvent.uid,
@@ -133,18 +138,6 @@ export class JwtsetService {
           success: appleMigrationEvent.success,
           err: appleMigrationEvent.err,
           uid: appleMigrationEvent.uid,
-        },
-      },
-    });
-  }
-
-  public generateMetricsChangeSET(event: set.metricsChangeEvent) {
-    return this.generateSET({
-      uid: event.uid,
-      clientId: event.clientId,
-      events: {
-        [set.METRICS_CHANGE_EVENT_ID]: {
-          enabled: event.enabled,
         },
       },
     });

--- a/packages/fxa-event-broker/src/jwtset/set.interface.ts
+++ b/packages/fxa-event-broker/src/jwtset/set.interface.ts
@@ -13,8 +13,6 @@ export const SUBSCRIPTION_STATE_EVENT_ID =
   'https://schemas.accounts.firefox.com/event/subscription-state-change';
 export const APPLE_USER_MIGRATION_ID =
   'https://schemas.accounts.firefox.com/event/apple-user-migration';
-export const METRICS_CHANGE_EVENT_ID =
-  'https://schemas.accounts.firefox.com/event/metrics-change';
 
 export type deleteEvent = {
   clientId: string;
@@ -30,7 +28,12 @@ export type passwordEvent = {
 export type profileEvent = {
   clientId: string;
   uid: string;
-  email: string;
+  email?: string;
+  locale?: string;
+  totpEnabled?: boolean;
+  accountDisabled?: boolean;
+  accountLocked?: boolean;
+  metricsEnabled?: boolean;
 };
 
 export type securityEvent = {
@@ -59,10 +62,4 @@ export type appleMigrationEvent = {
   transferSub: string;
   success: boolean;
   err: string;
-};
-
-export type metricsChangeEvent = {
-  uid: string;
-  clientId: string;
-  enabled: boolean;
 };

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
@@ -57,6 +57,11 @@ const createValidProfileMessage = (): string => {
     JSON.stringify({
       event: dto.PROFILE_CHANGE_EVENT,
       uid: 'uid1234',
+      locale: 'en-us',
+      totpEnabled: false,
+      accountDisabled: false,
+      accountLocked: false,
+      metricsEnabled: true,
     })
   ).toString('base64');
 };
@@ -67,16 +72,6 @@ const createValidPasswordMessage = (): string => {
       changeTime: CHANGE_TIME,
       event: dto.PASSWORD_CHANGE_EVENT,
       uid: 'uid1234',
-    })
-  ).toString('base64');
-};
-
-const createValidMetricsChangeMessage = (): string => {
-  return Buffer.from(
-    JSON.stringify({
-      event: dto.METRICS_CHANGE_EVENT,
-      uid: 'uid1234',
-      enabled: false,
     })
   ).toString('base64');
 };
@@ -101,7 +96,6 @@ describe('PubsubProxy Controller', () => {
       generatePasswordSET: jest.fn().mockResolvedValue(TEST_TOKEN),
       generateProfileSET: jest.fn().mockResolvedValue(TEST_TOKEN),
       generateSubscriptionSET: jest.fn().mockResolvedValue(TEST_TOKEN),
-      generateMetricsChangeSET: jest.fn().mockResolvedValue(TEST_TOKEN),
     };
     logger = { debug: jest.fn(), error: jest.fn() };
     const MockMetrics: Provider = {
@@ -190,10 +184,6 @@ describe('PubsubProxy Controller', () => {
       delete: [createValidDeleteMessage, 'generateDeleteSET'],
       password: [createValidPasswordMessage, 'generatePasswordSET'],
       profile: [createValidProfileMessage, 'generateProfileSET'],
-      metricsChange: [
-        createValidMetricsChangeMessage,
-        'generateMetricsChangeSET',
-      ],
     };
 
     async function notifiesSuccessfully(

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
@@ -197,6 +197,11 @@ export class PubsubProxyController {
           clientId,
           uid: message.uid,
           email: message.email,
+          locale: message.locale,
+          metricsEnabled: message.metricsEnabled,
+          totpEnabled: message.totpEnabled,
+          accountDisabled: message.accountDisabled,
+          accountLocked: message.accountLocked,
         });
       }
       case dto.APPLE_USER_MIGRATION_EVENT: {
@@ -208,13 +213,6 @@ export class PubsubProxyController {
           transferSub: message.transferSub,
           success: message.success,
           err: message.error,
-        });
-      }
-      case dto.METRICS_CHANGE_EVENT: {
-        return await this.jwtset.generateMetricsChangeSET({
-          clientId,
-          uid: message.uid,
-          enabled: message.enabled,
         });
       }
       default:

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -51,12 +51,6 @@ const baseSubscriptionUpdateMessage = {
   productName: undefined,
 };
 
-const baseMetricsChangeMessage = {
-  ...baseMessage,
-  event: 'metricsChange',
-  enabled: true,
-};
-
 const baseDeleteMessage = {
   ...baseMessage,
   event: 'delete',
@@ -306,7 +300,6 @@ describe('QueueworkerService', () => {
       'primary email message': basePrimaryEmailMessage,
       'profile change message': baseProfileMessage,
       'subscription message': baseSubscriptionUpdateMessage,
-      'metrics change message': baseMetricsChangeMessage,
     };
 
     // Ensure that all our message types can be handled without error.

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -176,8 +176,7 @@ export class QueueworkerService
       | dto.deleteSchema
       | dto.profileSchema
       | dto.passwordSchema
-      | dto.appleUserMigrationSchema
-      | dto.metricsChangeSchema,
+      | dto.appleUserMigrationSchema,
     eventType: string
   ) {
     this.metrics.increment('message.type', { eventType });
@@ -353,10 +352,6 @@ export class QueueworkerService
       }
       case dto.APPLE_USER_MIGRATION_EVENT: {
         await this.handleAppleUserMigrationEvent(message);
-        break;
-      }
-      case dto.METRICS_CHANGE_EVENT: {
-        await this.handleMessageFanout(message, 'metricsOptIn');
         break;
       }
       default:

--- a/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
+++ b/packages/fxa-event-broker/src/queueworker/service-notification.interface.ts
@@ -14,7 +14,6 @@ export type ServiceNotification =
   | dto.profileSchema
   | dto.subscriptionUpdateSchema
   | dto.appleUserMigrationSchema
-  | dto.metricsChangeSchema
   | undefined;
 
 interface SchemaTable {
@@ -31,7 +30,6 @@ const eventSchemas = {
   [dto.PASSWORD_CHANGE_EVENT]: dto.PASSWORD_CHANGE_SCHEMA,
   [dto.PASSWORD_RESET_EVENT]: dto.PASSWORD_CHANGE_SCHEMA,
   [dto.APPLE_USER_MIGRATION_EVENT]: dto.APPLE_USER_MIGRATION_SCHEMA,
-  [dto.METRICS_CHANGE_EVENT]: dto.METRICS_CHANGE_SCHEMA,
 };
 
 /**

--- a/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
+++ b/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import joi from 'joi';
-import { METRICS_CHANGE_EVENT_ID } from '../jwtset/set.interface';
 
 // Event strings
 export const DELETE_EVENT = 'delete';
@@ -13,7 +12,6 @@ export const PRIMARY_EMAIL_EVENT = 'primaryEmailChanged';
 export const PROFILE_CHANGE_EVENT = 'profileDataChange';
 export const SUBSCRIPTION_UPDATE_EVENT = 'subscription:update';
 export const APPLE_USER_MIGRATION_EVENT = 'appleUserMigration';
-export const METRICS_CHANGE_EVENT = 'metricsChange';
 
 // Message schemas
 export const CLIENT_ID = joi.string().regex(/[a-z0-9]{16}/);
@@ -105,18 +103,6 @@ export const APPLE_USER_MIGRATION_SCHEMA = joi
   .unknown(true)
   .required();
 
-export const METRICS_CHANGE_SCHEMA = joi
-  .object()
-  .keys({
-    event: joi.string().valid(METRICS_CHANGE_EVENT),
-    timestamp: joi.number().optional(),
-    ts: joi.number().required(),
-    uid: joi.string().required(),
-    enabled: joi.boolean().required(),
-  })
-  .unknown(true)
-  .required();
-
 export type deleteSchema = {
   event: typeof DELETE_EVENT;
   timestamp?: number;
@@ -149,6 +135,11 @@ export type profileSchema = {
   ts: number;
   uid: string;
   email?: string;
+  locale?: string;
+  metricsEnabled?: boolean;
+  totpEnabled?: boolean;
+  accountDisabled?: boolean;
+  accountLocked?: boolean;
 };
 
 export type productCapability = string;
@@ -173,12 +164,4 @@ export type appleUserMigrationSchema = {
   transferSub: string;
   success: boolean;
   err: string;
-};
-
-export type metricsChangeSchema = {
-  event: typeof METRICS_CHANGE_EVENT;
-  timestamp?: number;
-  ts: number;
-  uid: string;
-  enabled: boolean;
 };

--- a/packages/fxa-graphql-api/src/database/database.service.spec.ts
+++ b/packages/fxa-graphql-api/src/database/database.service.spec.ts
@@ -8,6 +8,7 @@ import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Account } from 'fxa-shared/db/models/auth';
 import { MozLoggerService } from '@fxa/shared/mozlog';
+import { StatsDService } from '@fxa/shared/metrics/statsd';
 
 describe('#integration - DatabaseService', () => {
   let service: DatabaseService;
@@ -44,12 +45,17 @@ describe('#integration - DatabaseService', () => {
       provide: 'METRICS',
       useFactory: () => undefined,
     };
+    const MockStatsd: Provider = {
+      provide: StatsDService,
+      useValue: undefined,
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DatabaseService,
         MockConfig,
         MockMozLogger,
         MockMetricsFactory,
+        MockStatsd,
       ],
     }).compile();
 

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -485,9 +485,10 @@ describe('#integration - AccountResolver', () => {
           clientMutationId: 'testid',
         });
         expect(notifierService.send).toBeCalledWith({
-          event: 'metricsOptOut',
+          event: 'profileDataChange',
           data: {
             uid: USER_1.uid,
+            metricsEnabled: false,
           },
         });
       });
@@ -503,9 +504,10 @@ describe('#integration - AccountResolver', () => {
           clientMutationId: 'testid',
         });
         expect(notifierService.send).toBeCalledWith({
-          event: 'metricsOptIn',
+          event: 'profileDataChange',
           data: {
             uid: USER_1.uid,
+            metricsEnabled: true,
           },
         });
       });
@@ -1002,7 +1004,8 @@ describe('#integration - AccountResolver', () => {
         });
         expect(authClient.getRecoveryKey).toBeCalledWith(
           'cooltokenyo',
-          'recoveryKeyId'
+          'recoveryKeyId',
+          expect.any(Object)
         );
         expect(result).toStrictEqual({
           recoveryData: 'recoveryData',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -457,15 +457,15 @@ export class AccountResolver {
 
     if (!['in', 'out'].includes(input.state)) {
       throw new Error(
-        `Invalid state. Expected 'in' or 'out'. But recieved: ${input.state}`
+        `Invalid metrics opt state! State must be in or out, but recieved ${input.state}.`
       );
     }
 
     await this.notifier.send({
-      event: 'metricsChange',
+      event: 'profileDataChange',
       data: {
         uid,
-        enabled: input.state === 'in',
+        metricsEnabled: input.state === 'in',
       },
     });
 


### PR DESCRIPTION
## Because

- In a previous PR, a new event type was created, but we should have repurposed the profileDataChange event type
- During the previous deployment it was noted that there are different ways to configure sns, and that a topic arn and/or topic endpoint might not be required

## This pull request

- Relaxes requirements for notifier service.
  - Makes snsTopicEndpoint optional
  - Makes snsTopicArn optional
- Removes the `metricsChange` event type
- Augments the `profileDataChange` type schema to support, locale, metricsEnabled, totpEnabled, accountDisabled, and accountLocked states.
- Emmits the `profileDataChange` whenever corresponding account data is mutated.

## Issue that this pull request solves

Closes: FXA-9412

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The eco systems docs will also need to be updated to reflect this new state. It's also worth noting that on account creation, there is now an initial `profileDataChange` event sent out with the full state.
