### PR TITLE
feat(stripe): polish pr to update `prePaySteps` and `createPlainCustomer`

### DIFF
--- a/libs/payments/stripe/src/lib/stripe.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.spec.ts
@@ -96,22 +96,11 @@ describe('StripeManager', () => {
   });
 
   describe('createPlainCustomer', () => {
-    it('create a stub customer from Stripe', async () => {
-      const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
-
-      jest
-        .spyOn(stripeClient, 'customersCreate')
-        .mockResolvedValue(mockCustomer);
-
-      const result = await stripeManager.createPlainCustomer({});
-
-      expect(result).toEqual(mockCustomer);
-    });
-
-    it('create a stub customer with args from Stripe', async () => {
+    it('creates a plain customer from Stripe', async () => {
       const taxAddress = TaxAddressFactory();
       const mockCustomer = StripeResponseFactory(
         StripeCustomerFactory({
+          name: faker.person.fullName(),
           shipping: {
             name: '',
             address: {
@@ -131,7 +120,9 @@ describe('StripeManager', () => {
         .mockResolvedValue(mockCustomer);
 
       const result = await stripeManager.createPlainCustomer({
+        uid: faker.string.uuid(),
         email: faker.internet.email(),
+        displayName: faker.person.fullName(),
         taxAddress: taxAddress,
       });
 

--- a/libs/payments/stripe/src/lib/stripe.manager.ts
+++ b/libs/payments/stripe/src/lib/stripe.manager.ts
@@ -76,20 +76,36 @@ export class StripeManager {
   /**
    * Create customer stub account
    */
-  async createPlainCustomer(args: { email?: string; taxAddress?: TaxAddress }) {
-    if (args.taxAddress) {
-      return this.client.customersCreate({
-        shipping: {
-          name: args.email || '',
-          address: {
-            country: args.taxAddress.countryCode,
-            postal_code: args.taxAddress.postalCode,
-          },
-        },
-      });
-    }
+  async createPlainCustomer(args: {
+    uid: string;
+    email: string;
+    displayName?: string;
+    taxAddress?: TaxAddress;
+  }) {
+    const { uid, email, displayName, taxAddress } = args;
 
-    return this.client.customersCreate();
+    const shipping = taxAddress
+      ? {
+          name: email,
+          address: {
+            country: taxAddress.countryCode,
+            postal_code: taxAddress.postalCode,
+          },
+        }
+      : undefined;
+
+    const stripeCustomer = await this.client.customersCreate({
+      email,
+      name: displayName || '',
+      description: uid,
+      metadata: {
+        userid: uid,
+        geoip_date: new Date().toString(),
+      },
+      shipping,
+    });
+
+    return stripeCustomer;
   }
 
   /**


### PR DESCRIPTION
## Because

- We want to clean up our code and make sure our methods are created and updated appropriately.

## This pull request

- Is a follow up to https://github.com/mozilla/fxa/pull/16924 comments and Slack messages between the SubPlat SWEs.
- Updates `StripeManager.createPlainCustomer`.
- Updates `CheckoutService.prePaySteps` to add `AccountCustomerManager.createAccountCustomer`.
- Updates all applicable tests.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
