### PR TITLE
fix(auth): setup paypalClient credentials for cancel-subscriptions-to-plan

### DIFF
--- a/packages/fxa-auth-server/scripts/cancel-subscriptions-to-plan.ts
+++ b/packages/fxa-auth-server/scripts/cancel-subscriptions-to-plan.ts
@@ -6,8 +6,11 @@ import program from 'commander';
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
 import { PlanCanceller } from './cancel-subscriptions-to-plan/cancel-subscriptions-to-plan';
 import { PayPalHelper } from '../lib/payments/paypal';
+import { PayPalClient } from '@fxa/payments/paypal';
+import { Container } from 'typedi';
 
 const pckg = require('../package.json');
+const config = require('../config').default.getProperties();
 
 const parseBatchSize = (batchSize: string | number) => {
   return parseInt(batchSize.toString(), 10);
@@ -65,6 +68,11 @@ async function init() {
   const { stripeHelper, database, log } = await setupProcessingTaskObjects(
     'cancel-subscriptions-to-plan'
   );
+
+  const paypalClient = new PayPalClient(
+    config.subscriptions.paypalNvpSigCredentials
+  );
+  Container.set(PayPalClient, paypalClient);
 
   const paypalHelper = new PayPalHelper({
     log,


### PR DESCRIPTION
## Because

- cancel-subscriptions-to-plan currently fails to refund paypal subs

## This pull request

- Sets up credentials for PaypalClient in cancel-subscriptions-to-plan script

## Issue that this pull request solves

Closes: No relevant issue