### PR TITLE
fix(tests): Re-added fixmes as prior solution did not work

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/coupon.spec.ts
@@ -16,6 +16,10 @@ test.describe('severity-2 #smoke', () => {
     test('apply an expired coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/05/13 (see FXA-9689).'
+      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
@@ -41,6 +45,10 @@ test.describe('severity-2 #smoke', () => {
     test('apply an invalid coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/05/13 (see FXA-9689).'
+      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
@@ -216,6 +224,10 @@ test.describe('severity-2 #smoke', () => {
     test('remove a coupon and verify', async ({
       pages: { relier, subscribe, login },
     }, { project }) => {
+      test.fixme(
+        project.name !== 'local',
+        'Fix required as of 2024/05/13 (see FXA-9689).'
+      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'


### PR DESCRIPTION
## Because

- We want to reduce our failure rate on tests.

## This pull request

- Re-adds fixmes removed in https://github.com/mozilla/fxa/pull/16983.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
