### PR TITLE
switch fixme to skip for tests that will be modified or created for reset pwd with code

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -62,7 +62,7 @@ test.describe('severity-2 #smoke', () => {
       testAccountTracker,
     }) => {
       const config = await configPage.getConfig();
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -60,7 +60,7 @@ test.describe('severity-2 #smoke', () => {
       testAccountTracker,
     }) => {
       const config = await configPage.getConfig();
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -17,7 +17,7 @@ test.describe('severity-1 #smoke', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -13,7 +13,7 @@ test.describe('severity-1 #smoke', () => {
       // Ensure that the react reset password route feature flag is enabled
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -11,7 +11,7 @@ test.describe('severity-1 #smoke', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
@@ -11,7 +11,7 @@ test.describe('severity-1 #smoke', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -171,7 +171,7 @@ test.describe('severity-1 #smoke', () => {
       testAccountTracker,
     }) => {
       const config = await configPage.getConfig();
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -16,7 +16,7 @@ test.describe('severity-2 #smoke', () => {
       testAccountTracker,
     }) => {
       const config = await configPage.getConfig();
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );


### PR DESCRIPTION
The tests that were marked as fixme for `FXA-9612` should be marked as skipped instead, they are not broken just skipped based on feature flag.