### PR TITLE
fix(customs): update password otp verification rate limiting / blocking

### DIFF
--- a/packages/fxa-customs-server/lib/ip_record.js
+++ b/packages/fxa-customs-server/lib/ip_record.js
@@ -111,14 +111,14 @@ module.exports = function (limits, now) {
         (otpVerificationTime) =>
           otpVerificationTime >
           thisIsNow - limits.passwordResetOtpVerificationRateLimitWindowMs
-      ).length > limits.maxPasswordResetOtpVerificationRateLimit
+      ).length >= limits.maxPasswordResetOtpVerificationRateLimit
     );
   };
 
   IpRecord.prototype.isOverPasswordResetOtpVerificationBlockLimit =
     function () {
       this.trimPasswordResetOtpVerifications(now());
-      return this.ov.length > limits.maxPasswordResetOtpVerificationBlockLimit;
+      return this.ov.length >= limits.maxPasswordResetOtpVerificationBlockLimit;
     };
 
   IpRecord.prototype.isOverVerifyCodes = function () {
@@ -363,44 +363,33 @@ module.exports = function (limits, now) {
     }
 
     if (actions.isResetPasswordOtpVerificationAction(action)) {
-      const otpVerificationRateLimited = () =>
-        !!(
-          this.rl &&
-          now() - this.rl < limits.passwordResetOtpVerificationRateLimitWindowMs
-        );
-      const otpVerificationBlocked = () =>
-        !!(
-          this.bk &&
-          now() - this.bk < limits.passwordResetOtpVerificationBlockWindowMs
-        );
-      if (otpVerificationRateLimited() || otpVerificationBlocked()) {
-        return this.retryAfter(
-          limits.passwordResetOtpVerificationRateLimitWindowMs,
-          limits.passwordResetOtpVerificationBlockWindowMs
-        );
-      }
-
-      this.addPasswordResetOtpVerification();
-
       const shouldBlock = this.isOverPasswordResetOtpVerificationBlockLimit();
       const shouldRateLimit =
         this.isOverPasswordResetOtpVerificationRateLimit();
 
       if (shouldBlock || shouldRateLimit) {
+        const latest = this.ov[this.ov.length - 1];
+
         if (shouldBlock) {
-          this.block();
-          this.ov = [];
-          this.rl = 0;
+          return Math.ceil(
+            (latest +
+              limits.passwordResetOtpVerificationBlockWindowMs -
+              now()) /
+              1000
+          );
         }
         if (shouldRateLimit) {
-          this.rateLimit();
-          this.bk = 0;
+          return Math.ceil(
+            (latest +
+              limits.passwordResetOtpVerificationRateLimitWindowMs -
+              now()) /
+              1000
+          );
         }
-        return this.retryAfter(
-          limits.passwordResetOtpVerificationRateLimitWindowMs,
-          limits.passwordResetOtpVerificationBlockWindowMs
-        );
       }
+
+      this.addPasswordResetOtpVerification();
+      return 0;
     }
 
     return this.retryAfter();

--- a/packages/fxa-customs-server/test/local/email_record_tests.js
+++ b/packages/fxa-customs-server/test/local/email_record_tests.js
@@ -299,10 +299,17 @@ test('update works', function (t) {
   nowTimestamp = 1003;
   res = er.update('passwordForgotVerifyOtp');
   t.equal(res === 0, true, 'account is not rate limited or blocked');
+
+  // rate limited ; attempt timestamp not saved
   nowTimestamp = 2001;
   const verifyOtpRateLimitRes = er.update('passwordForgotVerifyOtp');
   t.equal(verifyOtpRateLimitRes > 0, true, 'account is rate limited');
+
+  // third attempt
   nowTimestamp = 8001;
+  er.update('passwordForgotVerifyOtp');
+
+  // blocked
   const verifyOtpBlockLimitRes = er.update('passwordForgotVerifyOtp');
   t.equal(
     verifyOtpBlockLimitRes - verifyOtpRateLimitRes > 0,

--- a/packages/fxa-customs-server/test/remote/too_many_password_reset_otp_verifications.js
+++ b/packages/fxa-customs-server/test/remote/too_many_password_reset_otp_verifications.js
@@ -65,7 +65,15 @@ test('/check passwordForgotVerifyOtp by email', async (t) => {
   t.equal(obj.retryAfter, 1, 'rate limit retry amount');
 
   // the min configurable value is a second
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+
+  // this is the third recorded attempt; the third request was rate limited
+  // thus not recorded
+  ip = testUtils.randomIp();
+  response = await client.postAsync('/check', { ip, email, action });
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, false, 'not rate limited');
 
   ip = testUtils.randomIp();
   response = await client.postAsync('/check', { ip, email, action });
@@ -108,7 +116,15 @@ test('/check passwordForgotVerifyOtp by ip address', async (t) => {
   t.equal(obj.retryAfter, 1, 'rate limit retry amount');
 
   // the min configurable value is a second
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+
+  // this is the third attempt; the third request was rate limited thus not
+  // recorded
+  email = testUtils.randomEmail();
+  response = await client.postAsync('/check', { ip, email, action });
+  [_, res, obj] = response;
+  t.equal(res.statusCode, 200, 'returns a 200');
+  t.equal(obj.block, false, 'not rate limited');
 
   email = testUtils.randomEmail();
   response = await client.postAsync('/check', { ip, email, action });


### PR DESCRIPTION
Because:
 - having the passwordForgotVerifyOtp action's rate limiting / blocking use the email/ip records' existing properties and retry after calculation was buggy, leading to unintended blocking

This commit:
 - updates passwordForgotVerifyOtp action's rate limiting / blocking so that they won't affect other actions
