### PR TITLE
chore(functional-tests): change retries from 3 to 1 on CI

### DIFF
--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -13,23 +13,29 @@ const DEBUG = !!process.env.DEBUG;
 const SLOWMO = parseInt(process.env.PLAYWRIGHT_SLOWMO || '0');
 const NUM_WORKERS = parseInt(process.env.PLAYWRIGHT_WORKERS || '16');
 
-let retries = 0,
-  workers = NUM_WORKERS || 2,
+let workers = NUM_WORKERS || 2,
   maxFailures = 0;
 if (CI) {
-  // Overall maxFailures is now dependent on the number of retries, workers
-  retries = 3;
+  // Overall maxFailures is dependent on the number of workers
   workers = 2;
-  maxFailures = retries * workers * 2;
+  maxFailures = workers * 2;
 }
 
 export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
   outputDir: path.resolve(__dirname, '../../artifacts/functional'),
-  forbidOnly: CI,
-  retries,
+
+  // Look for test files in the "tests" directory, relative to this configuration file.
   testDir: 'tests',
+
   // Run all tests in parallel.
   fullyParallel: true,
+
+  // Fail the build on CI if you accidentally left test.only in the source code.
+  forbidOnly: CI,
+
+  // Retry on CI only.
+  retries: CI ? 1 : 0,
+
   use: {
     viewport: { width: 1280, height: 720 },
   },

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -60,8 +60,15 @@ test.describe('severity-2 #smoke', () => {
         resetPasswordReact,
       },
       testAccountTracker,
-    }) => {
+    }, { project }) => {
       const config = await configPage.getConfig();
+      test.fixme(
+        project.name !== 'local' &&
+          signup.version === 1 &&
+          reset.version === 2 &&
+          signin.version === 1,
+        'FXA-9742'
+      );
       test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'

--- a/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
@@ -38,7 +38,13 @@ test.describe('severity-2 #smoke', () => {
         deleteAccount,
       },
       testAccountTracker,
-    }) => {
+    }, { project }) => {
+      test.fixme(
+        project.name !== 'local' &&
+          signup.version === 1 &&
+          signin.version === 2,
+        'FXA-9734'
+      );
       const { email, password } =
         testAccountTracker.generateBlockedAccountDetails();
       await page.goto(


### PR DESCRIPTION
## Because

- we want to reduce the impact on execution time when tests fail and address issues of flake

## This pull request

- reduces the available retires in functional tests on CI from 3 to 1
- add a fixme annotation for the `severity-2 #smoke › signs up as v1, rate limited, unblocked, signs in as v2` test
- add a fixme annotation for the `severity-2 #smoke › signs up as v1 resets password with recovery key as v2 and signs in as v1` test

## Issue that this pull request solves

Closes: # FXA-9390

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

Repeated flake has been detected for the following tests on Stage, but I'm hoping they are addressed by https://github.com/mozilla/fxa/pull/17021
 - `severity-2 #smoke › subscription › subscribe with credit card and login to product`
 - `severity-2 #smoke › Flow, acquisition and new user checkout funnel metrics › New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics`

For reference: [Playwright Test Configuration](https://playwright.dev/docs/test-configuration)

After consulting with @jrbenny35, it's come to my attention that a rerun/retry standard of 1 has been set for the Nimbus test suites. Ref: https://github.com/mozilla/experimenter/blob/main/.circleci/config.yml#L174
They track reruns with Sentry https://mozilla.sentry.io/issues/5132907827/?alert_rule_id=13422918&alert_type=issue&notification_uuid=f14412ce-8af6-4147-bf78-b741aa9e6943&project=4504493871071232&referrer=slack, something we could also look into.
