### PR TITLE
chore(deps): Use the p-queue-compat library instead of p-queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "node-fetch": "^2.6.7",
     "nps": "^5.10.0",
     "objection": "^3.1.3",
-    "p-queue": "^8.0.1",
     "passport": "^0.7.0",
     "passport-http-bearer": "^1.0.1",
     "passport-jwt": "^4.0.1",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -118,7 +118,7 @@
     "node-zendesk": "^2.2.0",
     "nodemailer": "^6.9.9",
     "otplib": "^11.0.1",
-    "p-queue": "^8.0.1",
+    "p-queue-compat": "^1.0.225",
     "p-retry": "^4.2.0",
     "poolee": "^1.0.1",
     "punycode.js": "2.3.0",

--- a/packages/fxa-auth-server/scripts/cancel-subscriptions-to-plan/cancel-subscriptions-to-plan.ts
+++ b/packages/fxa-auth-server/scripts/cancel-subscriptions-to-plan/cancel-subscriptions-to-plan.ts
@@ -6,7 +6,7 @@ import Stripe from 'stripe';
 import { Firestore } from '@google-cloud/firestore';
 import Container from 'typedi';
 import fs from 'fs';
-import PQueue from 'p-queue';
+import PQueue from 'p-queue-compat';
 
 import { AppConfig, AuthFirestore } from '../../lib/types';
 import { ConfigType } from '../../config';

--- a/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/scripts/convert-customers-to-stripe-automatic-tax/convert-customers-to-stripe-automatic-tax.ts
@@ -7,7 +7,7 @@ import { Firestore } from '@google-cloud/firestore';
 import Container from 'typedi';
 import fs from 'fs';
 import GeoDB from 'fxa-geodb';
-import PQueue from 'p-queue';
+import PQueue from 'p-queue-compat';
 
 import { AppConfig, AuthFirestore } from '../../lib/types';
 import { ConfigType } from '../../config';

--- a/packages/fxa-auth-server/scripts/move-customers-to-new-plan/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/move-customers-to-new-plan/move-customers-to-new-plan.ts
@@ -6,7 +6,7 @@ import Stripe from 'stripe';
 import { Firestore } from '@google-cloud/firestore';
 import Container from 'typedi';
 import fs from 'fs';
-import PQueue from 'p-queue';
+import PQueue from 'p-queue-compat';
 
 import { AppConfig, AuthFirestore } from '../../lib/types';
 import { ConfigType } from '../../config';

--- a/packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap/set-subscription-purchases-apple-iap.ts
+++ b/packages/fxa-auth-server/scripts/set-subscription-purchases-apple-iap/set-subscription-purchases-apple-iap.ts
@@ -5,7 +5,7 @@
 import { Firestore } from '@google-cloud/firestore';
 import { PurchaseManager } from 'fxa-shared/payments/iap/apple-app-store/purchase-manager';
 import { AppStoreSubscriptionPurchase } from 'fxa-shared/payments/iap/apple-app-store/subscription-purchase';
-import PQueue from 'p-queue';
+import PQueue from 'p-queue-compat';
 import Container from 'typedi';
 
 import { ConfigType } from '../../config';

--- a/packages/fxa-auth-server/scripts/update-subscriptions-to-new-plan/update-subscriptions-to-new-plan.ts
+++ b/packages/fxa-auth-server/scripts/update-subscriptions-to-new-plan/update-subscriptions-to-new-plan.ts
@@ -6,7 +6,7 @@ import Stripe from 'stripe';
 import { Firestore } from '@google-cloud/firestore';
 import Container from 'typedi';
 import fs from 'fs';
-import PQueue from 'p-queue';
+import PQueue from 'p-queue-compat';
 
 import { AppConfig, AuthFirestore } from '../../lib/types';
 import { ConfigType } from '../../config';

--- a/yarn.lock
+++ b/yarn.lock
@@ -35542,6 +35542,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:5.x, eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^3.1.0":
   version: 3.1.2
   resolution: "eventemitter3@npm:3.1.2"
@@ -35553,13 +35560,6 @@ __metadata:
   version: 4.0.4
   resolution: "eventemitter3@npm:4.0.4"
   checksum: 7afb1cd851d19898bc99cc55ca894fe18cb1f8a07b0758652830a09bd6f36082879a25345be6219b81d74764140688b1a8fa75bcd1073d96b9a6661e444bc2ea
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "eventemitter3@npm:5.0.1"
-  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
   languageName: node
   linkType: hard
 
@@ -37912,7 +37912,7 @@ fsevents@~2.1.1:
     nx: 18.3.1
     nyc: ^15.1.0
     otplib: ^11.0.1
-    p-queue: ^8.0.1
+    p-queue-compat: ^1.0.225
     p-retry: ^4.2.0
     pm2: ^5.3.0
     poolee: ^1.0.1
@@ -38895,7 +38895,6 @@ fsevents@~2.1.1:
     nx: 18.3.1
     nx-cloud: 18.0.0
     objection: ^3.1.3
-    p-queue: ^8.0.1
     passport: ^0.7.0
     passport-http-bearer: ^1.0.1
     passport-jwt: ^4.0.1
@@ -52376,13 +52375,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"p-queue@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "p-queue@npm:8.0.1"
+"p-queue-compat@npm:^1.0.225":
+  version: 1.0.225
+  resolution: "p-queue-compat@npm:1.0.225"
   dependencies:
-    eventemitter3: ^5.0.1
-    p-timeout: ^6.1.2
-  checksum: 84a27a5b1faf2dcc96b8c0e423c34b5984b241acc07353d3cc6d8d3d1dadefb250b4ec84ce278cb1c946466999c6bf2a36ff718a75810bad8e11c7ca47ce80f5
+    eventemitter3: 5.x
+    p-timeout-compat: ^1.0.3
+  checksum: dc35ea412ff7ba8a7ecd2057d8fd94d5efe0e75769bbc18894614b42c23cdc65d2a1e6bb92476a695b3acdaaf47dc8b7c97587cc55326a1fd06622fc11235c5e
   languageName: node
   linkType: hard
 
@@ -52403,6 +52402,13 @@ fsevents@~2.1.1:
     "@types/retry": 0.12.0
     retry: ^0.13.1
   checksum: 45c270bfddaffb4a895cea16cb760dcc72bdecb6cb45fef1971fa6ea2e91ddeafddefe01e444ac73e33b1b3d5d29fb0dd18a7effb294262437221ddc03ce0f2e
+  languageName: node
+  linkType: hard
+
+"p-timeout-compat@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "p-timeout-compat@npm:1.0.4"
+  checksum: c55421977a2b73a7419ebb437dc16690bbf0eb99ce688d7f23749093c0c5b4ce08a5236b3d83483dacce594fb98c111d36bc3916e2463ef78e7a339bf0e95d5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- We were still having issues with p-queue library and esm

## This pull request

- uses the `p-queue-compat` library

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9719

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Will have to be a point release to enable cloud scheduler
