### PR TITLE
test(functional): fix unverified test

### DIFF
--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -105,9 +105,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { login, settings, deleteAccount },
       testAccountTracker,
     }) => {
-      test.fixme(true, 'FXA-9226');
-
-      const credentials = await testAccountTracker.signUp({
+      const credentials = await testAccountTracker.signUpBlocked({
         lang: 'en',
         preVerified: 'false',
       });
@@ -117,7 +115,6 @@ test.describe('severity-2 #smoke', () => {
         credentials.email,
         credentials.password
       );
-
       //Verify sign in block header
       await expect(login.signInUnblockHeader()).toBeVisible();
       expect(await login.getUnblockEmail()).toContain(credentials.email);


### PR DESCRIPTION
## Because

- Signin Blocked - unverified test was failing in Local and stage

## This pull request

- Replaces the correct sign up function to be able to navigate to the sign in blocked header

## Issue that this pull request solves

Closes: FXA-9226

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
