### PR TITLE
task(cirrus): Setup cirrus container

### DIFF
--- a/_dev/pm2/infrastructure.config.js
+++ b/_dev/pm2/infrastructure.config.js
@@ -60,5 +60,11 @@ module.exports = {
       autorestart: false,
       kill_timeout: 20000,
     },
+    {
+      name: 'cirrus',
+      script: '_scripts/cirrus.sh',
+      autorestart: false,
+      kill_timeout: 20000,
+    },
   ],
 };

--- a/_scripts/check-ports.sh
+++ b/_scripts/check-ports.sh
@@ -7,6 +7,7 @@ PORTS=(
   8085 # google-pubsub-emulator
   9090 # google-firestore-emulator
   5000 # sync server
+  8001 # cirrus (experimenter)
   8000 # auth-server db mysql
   9000 # auth-server key server
   3030 # content-server

--- a/_scripts/cirrus.sh
+++ b/_scripts/cirrus.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+echo -e "Starting cirrus experimenter."
+
+docker run --rm --name cirrus \
+  --net fxa \
+  --mount type=bind,source=$(pwd)/_scripts/configs/cirrus.env.sample,target=/cirrus/.env \
+  --mount type=bind,source=$(pwd)/_scripts/configs/cirrus.fml.yml,target=/cirrus/feature_manifest/fml.yml \
+  -p 8001:8001 \
+  mozilla/cirrus:latest

--- a/_scripts/configs/cirrus.env.sample
+++ b/_scripts/configs/cirrus.env.sample
@@ -1,0 +1,10 @@
+CIRRUS_REMOTE_SETTING_URL=https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/nimbus-web-experiments/records
+CIRRUS_REMOTE_SETTING_REFRESH_RATE_IN_SECONDS=10
+CIRRUS_APP_ID=test_app_id
+CIRRUS_APP_NAME=test_app_name
+CIRRUS_CHANNEL=release
+CIRRUS_FML_PATH=/cirrus/feature_manifest/sample.yml
+# CIRRUS_SENTRY_DSN=dsn_url
+CIRRUS_INSTANCE_NAME=cirrus_pod_app_v1
+CIRRUS_ENV_NAME=test_app_stage
+CIRRUS_GLEAN_MAX_EVENTS_BUFFER=10

--- a/_scripts/configs/cirrus.fml.yml
+++ b/_scripts/configs/cirrus.fml.yml
@@ -1,0 +1,26 @@
+about:
+  description: Nimbus Feature Manifest for Python Testing
+channels:
+  - beta
+  - release
+features:
+  example-feature:
+    description: An example feature
+    variables:
+      enabled:
+        description: If the feature is enabled
+        type: Boolean
+        default: false
+      something:
+        description: Another variable
+        type: Option<String>
+        default: null
+    defaults:
+      - channel: beta
+        value: { "enabled": true }
+      - channel: release
+        value: { "something": "wicked" }
+
+types:
+  objects: {}
+  enums: {}


### PR DESCRIPTION
## Because

- We want to create a cirrus container that we can interact with 
- We want this to become part of the fxa local development stack

## This pull request

- Adds a cirrus container
- Adds two other support containers, autograph, and kinto
- Add necessary configuration file
- Adds pm2 startup commands

## Issue that this pull request solves

Closes: FXA-9704

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To validate the container is accepting requests:
-  `yarn start infrastructure`
-  Once complete run `yarn pm2 status` and validate that cirrus, autograph and kinto services exist.
-  Check the logs of each of the services.


The following curl command can also be issued, to validate that cirrus is accepting requests, and picking up the `cirrus.fml.yml` files configuration settings.

```
curl \
 -H 'Content-Type: application/json' \
 --request POST \
 --data '{ "client_id": "4a1d71ab-29a2-4c5f-9e1d-9d9df2e6e449", "context": { "language": "en" } }' \
 http://localhost:8001/v1/features/
```

Also, we typically squash our PR commits, but @jonalmeida and I paired on this. So I'm leaving the commit history for now. 
