### PR TITLE
fix(customs): save ip record after password reset

### DIFF
--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -680,7 +680,7 @@ module.exports = async function createServer(config, log) {
       emailRecord.passwordReset();
 
       try {
-        await setRecords(emailRecord);
+        await setRecords(ipRecord, emailRecord);
         return {};
       } catch (err) {
         logError(err);


### PR DESCRIPTION
Because:
 - we need to clean out password reset OTP related timestamps after a successful password reset

This commit:
 - saves the ip record after a password reset
