### PR TITLE
fix(setting): Fix 500 error and infinite spinner on redirects from reset password with code

### DIFF
--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -16,31 +16,23 @@ export function hardNavigate(
   includeCurrentQueryParams = false
 ) {
   // If there are any query params in the href, we automatically include them in the new url.
-  let searchParams = new URLSearchParams();
-  if (href.includes('?')) {
-    searchParams = new URLSearchParams(href.substring(href.indexOf('?')));
-  }
+  const url = new URL(href, window.location.origin);
 
   if (includeCurrentQueryParams) {
     const currentSearchParams = new URLSearchParams(window.location.search);
     currentSearchParams.forEach((value, key) => {
-      if (!searchParams.has(key)) {
-        searchParams.append(key, value);
+      if (!url.searchParams.has(key)) {
+        url.searchParams.append(key, value);
       }
     });
   }
 
-  if (additionalQueryParams) {
-    const additionalSearchParams = new URLSearchParams(additionalQueryParams);
-    additionalSearchParams.forEach((value, key) => {
-      searchParams.append(key, value);
-    });
-  }
+  const additionalSearchParams = new URLSearchParams(additionalQueryParams);
+  additionalSearchParams.forEach((value, key) => {
+    url.searchParams.append(key, value);
+  });
 
-  if (href.includes('?')) {
-    href = href.substring(0, href.indexOf('?'));
-  }
-  window.location.href = `${href}?${searchParams.toString()}`;
+  window.location.href = url.href;
 }
 
 export enum LocalizedDateOptions {

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.test.tsx
@@ -43,7 +43,7 @@ describe('LinkRememberPassword', () => {
     expect(screen.getByRole('link', { name: 'Sign in' })).toBeVisible();
   });
 
-  it('links to signin and appends parameters', async () => {
+  it('links to index and appends parameters', async () => {
     renderWithLocalizationProvider(<Subject />);
 
     const rememberPasswordLink = screen.getByRole('link', {
@@ -52,7 +52,7 @@ describe('LinkRememberPassword', () => {
 
     expect(rememberPasswordLink).toHaveAttribute(
       'href',
-      `/signin?client_id=123&email=${encodeURIComponent(MOCK_EMAIL)}`
+      `/?client_id=123&prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
     );
   });
 });

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
@@ -17,8 +17,10 @@ const LinkRememberPassword = ({ email }: LinkRememberPasswordProps) => {
   const params = new URLSearchParams(location.search);
   let linkHref: string;
   if (email && isEmailValid(email)) {
-    params.set('email', email);
-    linkHref = `/signin?${params}`;
+    params.set('prefillEmail', email);
+    // react and backbone signin handle email/prefill params differently so
+    // go back to index - any errors (like throttling) will be shown there on submit
+    linkHref = `/?${params}`;
   } else {
     linkHref = params.size > 0 ? `/?${params}` : '/';
   }

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.test.tsx
@@ -66,7 +66,7 @@ describe('CompleteResetPassword page', () => {
       expect(link).toBeVisible();
       expect(link).toHaveAttribute(
         'href',
-        `/signin?email=${encodeURIComponent(MOCK_EMAIL)}`
+        `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
       );
     });
 
@@ -111,7 +111,7 @@ describe('CompleteResetPassword page', () => {
       expect(link).toBeVisible();
       expect(link).toHaveAttribute(
         'href',
-        `/signin?email=${encodeURIComponent(MOCK_EMAIL)}`
+        `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
       );
     });
 

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import ConfirmResetPassword from '.';
 import {
   ConfirmResetPasswordLocationState,
@@ -27,6 +26,12 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
 
   const { email, metricsContext } =
     (location.state as ConfirmResetPasswordLocationState) || {};
+
+  useEffect(() => {
+    if (!email || !metricsContext) {
+      navigate(`/reset_password${location.search}`);
+    }
+  });
 
   const handleNavigation = (
     code: string,
@@ -119,11 +124,6 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
       return false;
     }
   };
-
-  if (!email) {
-    navigate(`/reset_password${location.search}`);
-    return <LoadingSpinner fullScreen />;
-  }
 
   return (
     <ConfirmResetPassword

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
@@ -38,6 +38,7 @@ const ConfirmResetPassword = ({
   const spanElement = <span className="font-bold">{email}</span>;
 
   const handleResend = async () => {
+    setResendStatus(ResendStatus['not sent']);
     const result = await resendCode();
     if (result === true) {
       setResendStatus(ResendStatus.sent);

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/container.tsx
@@ -26,6 +26,12 @@ const ResetPasswordContainer = ({
 
   let localizedErrorMessage = '';
 
+  console.log(
+    queryParamsToMetricsContext(
+      flowQueryParams as unknown as Record<string, string>
+    )
+  );
+
   const requestResetPasswordCode = async (email: string) => {
     const metricsContext = queryParamsToMetricsContext(
       flowQueryParams as unknown as Record<string, string>

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -67,6 +67,7 @@ import { QueryParams } from '../..';
 import { queryParamsToMetricsContext } from '../../lib/metrics';
 import OAuthDataError from '../../components/OAuthDataError';
 import { MetricsContext } from 'fxa-auth-client/browser';
+import { isEmailValid } from 'fxa-shared/email/helpers';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -179,11 +180,22 @@ const SigninContainer = ({
               });
             }
           } catch (error) {
-            queryParams.set('prefillEmail', email);
+            // Passing back the 'email' param causes various behaviors in
+            // content-server since it marks the email as "coming from a RP".
+            queryParams.delete('email');
+            if (isEmailValid(email)) {
+              queryParams.set('prefillEmail', email);
+            }
             hardNavigate(`/?${queryParams}`);
           }
         }
       } else {
+        // Passing back the 'email' param causes various behaviors in
+        // content-server since it marks the email as "coming from a RP".
+        queryParams.delete('email');
+        if (email && isEmailValid(email)) {
+          queryParams.set('prefillEmail', email);
+        }
         const optionalParams = queryParams.size > 0 ? `?${queryParams}` : '';
         hardNavigate(`/${optionalParams}`);
       }


### PR DESCRIPTION
## Because

* If an email was blocked, following the "Remember your password? Sign in" would result in a 500 error
* Trying to reach confirm_reset_password directly without required location state would result in an infinite loading spinner
* Hard navigating from React to Backbone without search params, a stray ? was included in href

## This pull request

* Use the prefillEmail param instead of email when using the "Remember your password? Sign in" link
* When hard navigating, only include the ? if there are params to include
* If confirm_reset_password is accessed without required state, return to index

## Issue that this pull request solves

Closes: #FXA-9722

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The initial error from this ticket only occurs when requests are throttled. To enable throttling locally, temporarily set auth-server config for `customsUrl` to `"customsUrl":"http://localhost:7000"` in `config/dev.json`.