### PR TITLE
bug(auth): RP service / client_id not being recorded

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -216,6 +216,7 @@ export class AccountHandler {
 
     this.glean.registration.accountCreated(request, {
       uid: account.uid,
+      service,
     });
 
     const geoData = request.app.geo;
@@ -379,6 +380,7 @@ export class AccountHandler {
         });
         this.glean.registration.confirmationEmailSent(request, {
           uid: account.uid,
+          service: form.service || query.service,
         });
       }
 

--- a/packages/fxa-auth-server/lib/routes/utils/signup.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signup.js
@@ -48,8 +48,8 @@ module.exports = (log, db, mailer, push, verificationReminders, glean) => {
           uid,
         }),
 
-        glean.registration.accountVerified(request, { uid }),
-        glean.registration.complete(request, { uid }),
+        glean.registration.accountVerified(request, { uid, service }),
+        glean.registration.complete(request, { uid, service }),
 
         // Verification reminders can *only* be used in email links. We currently don't
         // support them for email codes.

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -398,10 +398,12 @@ describe('Glean server side events', () => {
     describe('accountVerified', () => {
       it('logs a "reg_acc_verified" event', async () => {
         const glean = gleanMetrics(config);
-        await glean.registration.accountVerified(request);
+        await glean.registration.accountVerified(request, { service: 'sync' });
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
         assert.equal(metrics['event_name'], 'reg_acc_verified');
+        assert.equal(metrics['relying_party_oauth_client_id'], '');
+        assert.equal(metrics['relying_party_service'], 'sync');
         sinon.assert.calledOnce(recordRegAccVerifiedStub);
       });
     });
@@ -409,10 +411,17 @@ describe('Glean server side events', () => {
     describe('reg_complete', () => {
       it('logs a "reg_complete" event', async () => {
         const glean = gleanMetrics(config);
-        await glean.registration.complete(request);
+        await glean.registration.complete(request, {
+          service: 'dcdb5ae7add825d2',
+        });
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
         assert.equal(metrics['event_name'], 'reg_complete');
+        assert.equal(
+          metrics['relying_party_oauth_client_id'],
+          'dcdb5ae7add825d2'
+        );
+        assert.equal(metrics['relying_party_service'], 'dcdb5ae7add825d2');
         sinon.assert.calledOnce(recordRegCompleteStub);
       });
     });


### PR DESCRIPTION
## Because

- It appears the relying_party_oauth_client_id was being lost for registration events
- It appears the relying_party_service was being lost for registration events

## This pull request

- Extends the metricsData with an optional service field, that houses the either/or the service name or oauth client service id.
- Passes in the 'service' provided to these endpoints into this metrics data field.

## Issue that this pull request solves

Closes: FXA-9712

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I've mostly validated this manually by going through a signup flow from sync and from 123done and watching the metrics being produced. 
