### PR TITLE
refactor(functional-tests): subscription-tests

### DIFF
--- a/packages/functional-tests/lib/paymentArtifacts.ts
+++ b/packages/functional-tests/lib/paymentArtifacts.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CreditCard } from '../pages/products/components/paymentInformation';
+
+export const BAD_CAVE_JOHNSON_CREDIT_CARD: CreditCard = {
+  name: 'Cave Johnson',
+  number: '4000000000000341',
+  expirationDate: '666',
+  cvc: '444',
+  zip: '77777',
+};
+
+export const CAVE_JOHNSON_CREDIT_CARD: CreditCard = {
+  name: 'Cave Johnson',
+  number: '4242424242424242',
+  expirationDate: '555',
+  cvc: '333',
+  zip: '66666',
+};
+
+export const TEST_USER_CREDIT_CARD: CreditCard = {
+  name: 'Test User',
+  number: '5555555555554444',
+  expirationDate: '444',
+  cvc: '777',
+  zip: '88888',
+};

--- a/packages/functional-tests/lib/paymentArtifacts.ts
+++ b/packages/functional-tests/lib/paymentArtifacts.ts
@@ -4,7 +4,7 @@
 
 import { CreditCard } from '../pages/products/components/paymentInformation';
 
-export const BAD_CAVE_JOHNSON_CREDIT_CARD: CreditCard = {
+export const INVALID_VISA: CreditCard = {
   name: 'Cave Johnson',
   number: '4000000000000341',
   expirationDate: '666',
@@ -12,7 +12,7 @@ export const BAD_CAVE_JOHNSON_CREDIT_CARD: CreditCard = {
   zip: '77777',
 };
 
-export const CAVE_JOHNSON_CREDIT_CARD: CreditCard = {
+export const VALID_VISA: CreditCard = {
   name: 'Cave Johnson',
   number: '4242424242424242',
   expirationDate: '555',
@@ -20,7 +20,7 @@ export const CAVE_JOHNSON_CREDIT_CARD: CreditCard = {
   zip: '66666',
 };
 
-export const TEST_USER_CREDIT_CARD: CreditCard = {
+export const VALID_MASTERCARD: CreditCard = {
   name: 'Test User',
   number: '5555555555554444',
   expirationDate: '444',

--- a/packages/functional-tests/lib/targets/base.ts
+++ b/packages/functional-tests/lib/targets/base.ts
@@ -11,6 +11,7 @@ export type Credentials = Awaited<ReturnType<AuthClient['signUp']>> & {
 
 interface SubConfig {
   product: string;
+  name: string;
   plan: string;
 }
 

--- a/packages/functional-tests/lib/targets/local.ts
+++ b/packages/functional-tests/lib/targets/local.ts
@@ -3,6 +3,7 @@ import { BaseTarget, Credentials } from './base';
 
 const RELIER_CLIENT_ID = 'dcdb5ae7add825d2';
 const SUB_PRODUCT = 'prod_GqM9ToKK62qjkK';
+const SUB_PRODUCT_NAME = '123Done Pro';
 const SUB_PLAN = 'plan_GqM9N6qyhvxaVk';
 
 export class LocalTarget extends BaseTarget {
@@ -14,6 +15,7 @@ export class LocalTarget extends BaseTarget {
   readonly relierClientID = RELIER_CLIENT_ID;
   readonly subscriptionConfig = {
     product: SUB_PRODUCT,
+    name: SUB_PRODUCT_NAME,
     plan: SUB_PLAN,
   };
 

--- a/packages/functional-tests/lib/targets/production.ts
+++ b/packages/functional-tests/lib/targets/production.ts
@@ -20,6 +20,7 @@ export class ProductionTarget extends RemoteTarget {
   readonly relierClientID = RELIER_CLIENT_ID;
   readonly subscriptionConfig = {
     product: '',
+    name: '',
     plan: '',
   };
 

--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -12,6 +12,7 @@ const RELIER_DOMAIN =
   process.env.RELIER_DOMAIN || 'stage-123done.herokuapp.com';
 const RELIER_CLIENT_ID = 'dcdb5ae7add825d2';
 const SUB_PRODUCT = 'prod_FfiuDs9u11ESbD';
+const SUB_PRODUCT_NAME = 'One, Two, Three Done...PRO';
 const SUB_PLAN = 'plan_FfiupsKXZ3mMZ6';
 
 export class StageTarget extends RemoteTarget {
@@ -23,6 +24,7 @@ export class StageTarget extends RemoteTarget {
   readonly relierClientID = RELIER_CLIENT_ID;
   readonly subscriptionConfig = {
     product: SUB_PRODUCT,
+    name: SUB_PRODUCT_NAME,
     plan: SUB_PLAN,
   };
 

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -27,7 +27,6 @@ import { SigninTotpCodePage } from './signinTotpCode.ts';
 import { SigninUnblockPage } from './signinUnblock.ts';
 import { SignupReactPage } from './signupReact';
 import { SubscribePage } from './products';
-import { SubscriptionManagementPage } from './products/subscriptionManagement';
 import { TermsOfService } from './termsOfService';
 import { TotpPage } from './settings/totp';
 
@@ -61,7 +60,6 @@ export function create(page: Page, target: BaseTarget) {
     signinUnblock: new SigninUnblockPage(page, target),
     signupReact: new SignupReactPage(page, target),
     subscribe: new SubscribePage(page, target),
-    subscriptionManagement: new SubscriptionManagementPage(page, target),
     termsOfService: new TermsOfService(page, target),
     totp: new TotpPage(page, target),
   };

--- a/packages/functional-tests/pages/products/components/paymentInformation.ts
+++ b/packages/functional-tests/pages/products/components/paymentInformation.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Page } from '@playwright/test';
+
+export type CreditCard = {
+  name: string;
+  number: string;
+  expirationDate: string;
+  cvc: string;
+  zip: string;
+};
+
+export class PaymentInformationPage {
+  constructor(readonly page: Page) {}
+
+  get fullNameTextbox() {
+    return this.page.getByTestId('name');
+  }
+
+  get creditCardNumber() {
+    return this.page
+      .frame({ url: /elements-inner-card/ })
+      ?.getByPlaceholder('Card number');
+  }
+
+  get creditCardExpirationDate() {
+    return this.page
+      .frame({ url: /elements-inner-card/ })
+      ?.getByPlaceholder('MM / YY');
+  }
+
+  get creditCardCVC() {
+    return this.page
+      .frame({ url: /elements-inner-card/ })
+      ?.getByPlaceholder('CVC');
+  }
+
+  get creditCardZIP() {
+    return this.page
+      .frame({ url: /elements-inner-card/ })
+      ?.getByPlaceholder('ZIP');
+  }
+
+  get updateButton() {
+    return this.page.getByTestId('submit');
+  }
+
+  get cardInfoAndLastFour() {
+    return this.page.getByTestId('card-logo-and-last-four');
+  }
+
+  async fillOutCreditCardInfo(creditCard: CreditCard) {
+    await this.fullNameTextbox.fill(creditCard.name);
+    await this.creditCardNumber?.fill(creditCard.number);
+    await this.creditCardExpirationDate?.fill(creditCard.expirationDate);
+    await this.creditCardCVC?.fill(creditCard.cvc);
+    await this.creditCardZIP?.fill(creditCard.zip);
+  }
+
+  async clickPayNow() {
+    // Start waiting for response before clicking
+    const responsePromise = this.page.waitForResponse(
+      (response) =>
+        response.request().method() === 'GET' &&
+        /\/mozilla-subscriptions\/customer\/billing-and-subscriptions$|static\/media\/error/.test(
+          response.request().url()
+        )
+    );
+    await this.page.getByTestId('submit').click();
+    await responsePromise;
+  }
+}

--- a/packages/functional-tests/pages/products/components/paymentInformation.ts
+++ b/packages/functional-tests/pages/products/components/paymentInformation.ts
@@ -18,28 +18,24 @@ export class PaymentInformationPage {
     return this.page.getByTestId('name');
   }
 
+  get _innerCardFrame() {
+    return this.page.frame({ url: /elements-inner-card/ });
+  }
+
   get creditCardNumber() {
-    return this.page
-      .frame({ url: /elements-inner-card/ })
-      ?.getByPlaceholder('Card number');
+    return this._innerCardFrame?.getByPlaceholder('Card number');
   }
 
   get creditCardExpirationDate() {
-    return this.page
-      .frame({ url: /elements-inner-card/ })
-      ?.getByPlaceholder('MM / YY');
+    return this._innerCardFrame?.getByPlaceholder('MM / YY');
   }
 
   get creditCardCVC() {
-    return this.page
-      .frame({ url: /elements-inner-card/ })
-      ?.getByPlaceholder('CVC');
+    return this._innerCardFrame?.getByPlaceholder('CVC');
   }
 
   get creditCardZIP() {
-    return this.page
-      .frame({ url: /elements-inner-card/ })
-      ?.getByPlaceholder('ZIP');
+    return this._innerCardFrame?.getByPlaceholder('ZIP');
   }
 
   get updateButton() {
@@ -61,6 +57,8 @@ export class PaymentInformationPage {
   async clickPayNow() {
     // Start waiting for response before clicking
     const responsePromise = this.page.waitForResponse(
+      // After clicking 'Pay Now' we should either see an API call to
+      // billing-and-subscriptions or an error message
       (response) =>
         response.request().method() === 'GET' &&
         /\/mozilla-subscriptions\/customer\/billing-and-subscriptions$|static\/media\/error/.test(

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -1,103 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from '@playwright/test';
 import { BaseLayout } from '../layout';
+import { PaymentInformationPage } from './components/paymentInformation';
 
 export class SubscriptionManagementPage extends BaseLayout {
   readonly path = '/subscription';
 
-  async subscriptiontHeader() {
-    const header = this.page.locator('#subscriptions-support');
-    await header.waitFor({ state: 'visible' });
-    return header.isVisible();
+  get subscriptiontHeading() {
+    return this.page.getByRole('heading', { name: 'Subscriptions' });
+  }
+
+  get contactsupportButton() {
+    return this.page.getByTestId('contact-support-button');
+  }
+
+  get ChangePaymentInformationButton() {
+    return this.page.getByTestId('reveal-payment-update-button');
+  }
+
+  get paymentInformation() {
+    return new PaymentInformationPage(this.page);
+  }
+
+  get revealCancelSubscriptionButton() {
+    return this.page.getByTestId('reveal-cancel-subscription-button');
+  }
+
+  get cancelSubscriptionHeading() {
+    return this.page.getByRole('heading', { name: 'Cancel Subscription' });
+  }
+
+  get cancelSubscriptionCheckbox() {
+    return this.page.getByTestId('confirm-cancel-subscription-checkbox');
+  }
+
+  get cancelSubscriptionButton() {
+    return this.page.getByTestId('cancel-subscription-button');
+  }
+
+  get dialogDismissHeading() {
+    return this.page.getByTestId('cancellation-message-title');
+  }
+
+  get dialogDismissButton() {
+    return this.page.getByTestId('dialog-dismiss');
+  }
+
+  get reactivateSubscriptionButton() {
+    return this.page.getByTestId('reactivate-subscription-button');
+  }
+
+  get reactivateSubscriptionDialogHeading() {
+    return this.page.getByRole('heading', { name: /^Want to keep using/ });
+  }
+
+  get reactivateSubscriptionConfirmButton() {
+    return this.page.getByTestId('reactivate-subscription-confirm-button');
+  }
+
+  get reactivateSubscriptionSuccessHeading() {
+    return this.page.getByTestId('reactivate-subscription-success');
+  }
+
+  get reactivateSubscriptionSuccessButton() {
+    return this.page.getByTestId('reactivate-subscription-success-button');
+  }
+
+  get subscriptionDetails() {
+    return this.page.getByTestId('subscription-item');
+  }
+
+  get resubscriptionPrice() {
+    return this.page.getByTestId('price-details-standalone');
   }
 
   async cancelSubscription() {
-    return Promise.all([
-      await this.page
-        .locator('[data-testid="reveal-cancel-subscription-button"]')
-        .click(),
-      await this.page
-        .locator('[data-testid="confirm-cancel-subscription-checkbox"]')
-        .click(),
-      await this.page
-        .locator('[data-testid="cancel-subscription-button"]')
-        .click(),
-      await this.page.locator('[data-testid="dialog-dismiss"]').click(),
-    ]);
-  }
+    await this.revealCancelSubscriptionButton.click();
 
-  async changeStripeCardDetails() {
-    await this.page
-      .locator('[data-testid="reveal-payment-update-button"]')
-      .click();
-    await this.page.locator('[data-testid="name"]').fill('Test User');
-    const frame = this.page.frame({ url: /elements-inner-card/ });
-    await frame.fill('.InputElement[name=cardnumber]', '');
-    await frame.fill('.InputElement[name=cardnumber]', '5555555555554444');
-    await frame.fill('.InputElement[name=exp-date]', '444');
-    await frame.fill('.InputElement[name=cvc]', '777');
-    await frame.fill('.InputElement[name=postal]', '88888');
-    await this.page.locator('[data-testid="submit"]').click();
-  }
+    await expect(this.cancelSubscriptionHeading).toBeVisible();
 
-  async fillSupportForm() {
-    await this.page.locator('[data-testid="contact-support-button"]').click();
-    await this.page.locator('#product_chosen a.chosen-single').click();
-    await this.page
-      .locator(
-        '#product_chosen ul.chosen-results li[data-option-array-index="1"]'
-      )
-      .click();
-    await this.page.locator('#topic_chosen a.chosen-single').click();
-    await this.page
-      .locator(
-        '#topic_chosen ul.chosen-results li[data-option-array-index="1"]'
-      )
-      .click();
-    await this.page.locator('#app_chosen a.chosen-single').click();
-    await this.page
-      .locator('#app_chosen ul.chosen-results li[data-option-array-index="1"]')
-      .click();
-    await this.page.locator('input[name="subject"]').fill('Test Support');
-    await this.page
-      .locator('textarea[name=message]')
-      .fill('Testing Support Form');
-  }
+    await this.cancelSubscriptionCheckbox.check();
+    await this.cancelSubscriptionButton.click();
 
-  async submitSupportForm() {
-    return await this.page.locator('button[type=submit]').click();
-  }
+    await expect(this.dialogDismissHeading).toBeVisible();
 
-  async cancelSupportForm() {
-    await this.page.locator('button.cancel').click();
-    await this.page.waitForLoadState();
+    await this.dialogDismissButton.click();
   }
 
   async resubscribe() {
-    return Promise.all([
-      await this.page
-        .locator('[data-testid="reactivate-subscription-button"]')
-        .click(),
-      await this.page
-        .locator('[data-testid="reactivate-subscription-confirm-button"]')
-        .click(),
-      await this.page
-        .locator('[data-testid="reactivate-subscription-success-button"]')
-        .click(),
-    ]);
-  }
+    await this.reactivateSubscriptionButton.click();
 
-  getCardInfo() {
-    return this.page
-      .locator('[data-testid="card-logo-and-last-four"]')
-      .textContent();
-  }
+    await expect(this.reactivateSubscriptionDialogHeading).toBeVisible();
 
-  async subscriptionDetails() {
-    return this.page.locator('[data-testid="subscription-item"]').textContent();
-  }
+    await this.reactivateSubscriptionConfirmButton.click();
 
-  getResubscriptionPrice() {
-    return this.page
-      .locator('[data-testid="price-details-standalone"]')
-      .textContent();
+    await expect(this.reactivateSubscriptionSuccessHeading).toBeVisible();
+
+    await this.reactivateSubscriptionSuccessButton.click();
   }
 }

--- a/packages/functional-tests/pages/products/support.ts
+++ b/packages/functional-tests/pages/products/support.ts
@@ -6,8 +6,8 @@ import { expect } from '@playwright/test';
 import { BaseLayout } from '../layout';
 
 export enum App {
-  Desktop = 'Desktop',
-  Mobile = 'Mobile',
+  DESKTOP = 'Desktop',
+  MOBILE = 'Mobile',
 }
 
 export enum Topic {

--- a/packages/functional-tests/pages/products/support.ts
+++ b/packages/functional-tests/pages/products/support.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from '@playwright/test';
+import { BaseLayout } from '../layout';
+
+export enum App {
+  Desktop = 'Desktop',
+  Mobile = 'Mobile',
+}
+
+export enum Topic {
+  PAYMENT_AND_BILLING = 'Payment & billing',
+  ACCOUNT_ISSUES = 'Account issues',
+  TECHNICAL_ISSUES = 'Technical issues',
+  PROVIDE_FEEDBACK_OR_REQUEST_FEATURES = 'Provide feedback / request features',
+  NOT_LISTED = 'Not listed',
+}
+
+export class SubscriptionSupportPage extends BaseLayout {
+  readonly path = '/support';
+
+  get contactUsHeading() {
+    return this.page.getByRole('heading', { name: 'Contact Us' });
+  }
+
+  get productDropdown() {
+    return this.page.locator('#product_chosen a.chosen-single');
+  }
+
+  get topicDropdown() {
+    return this.page.locator('#topic_chosen a');
+  }
+
+  get appDropDown() {
+    return this.page.locator('#app_chosen a');
+  }
+
+  get subjectTextbox() {
+    return this.page.getByRole('textbox', { name: 'subject' });
+  }
+
+  get messageTextbox() {
+    return this.page.getByLabel('Description of issue');
+  }
+
+  get cancelButton() {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
+  async fillOutSupportForm(
+    product: string,
+    topic: Topic,
+    app: App,
+    subject: string,
+    message: string
+  ) {
+    await expect(this.contactUsHeading).toBeVisible();
+
+    await this.productDropdown.click();
+    await this.page.getByRole('option', { name: product }).click();
+    await this.topicDropdown.click();
+    await this.page.getByRole('option', { name: topic }).click();
+    await this.appDropDown.click();
+    await this.page.getByRole('option', { name: app }).click();
+    await this.subjectTextbox.fill(subject);
+    await this.messageTextbox.fill(message);
+  }
+}

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -163,13 +163,8 @@ test.describe('severity-2 #smoke', () => {
       );
 
       // Click the sign in link
-      await subscribe.visitSignIn();
-
-      await signupReact.fillOutEmailForm(email);
-
-      await signupReact.fillOutSignupForm(password, AGE_21);
-
-      await signupReact.fillOutCodeForm(email);
+      await subscribe.signinLink.click();
+      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
       /*
        * We must `waitUntil: 'load'` due to redirects that occur here. Note,
        * React signup for SubPlat has one additional redirect compared to Backbone.
@@ -182,9 +177,7 @@ test.describe('severity-2 #smoke', () => {
        * Backbone signup staging goes from: 1) [stage]/confirm_signup_code ->
        * 2) [stage]/subscriptions/products -> 3) [payments-stage]/products
        * */
-      await page.waitForURL(`${target.paymentsServerUrl}/**`, {
-        waitUntil: 'load',
-      });
+      await page.waitForURL(`${target.paymentsServerUrl}/**`);
 
       await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
       await expect(settings.avatarIcon).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../../lib/fixtures/standard';
+import { Coupon } from '../../../pages/products';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test expired', () => {
@@ -23,19 +24,10 @@ test.describe('severity-2 #smoke', () => {
       );
       await relier.goto();
       await relier.clickSubscribe6Month();
+      await subscribe.addCouponCode(Coupon.AUTO_EXPIRED);
 
-      // 'autoexpired' coupon is an expired coupon for a 6mo plan
-      await subscribe.addCouponCode('autoexpired');
-
-      await expect(
-        await subscribe.getCouponStatusByDataTestId('coupon-error')
-      ).toBeVisible({
-        timeout: 5000,
-      });
-
-      // Verifying the correct error message
-      expect(await subscribe.couponErrorMessageText()).toContain(
-        'The code you entered has expired'
+      await expect(subscribe.couponErrorMessage).toHaveText(
+        'The code you entered has expired.'
       );
     });
   });

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
+import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
-import { LoginPage } from '../../../pages/login';
+import { Coupon } from '../../../pages/products';
+import { SettingsPage } from '../../../pages/settings';
+import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test forever discount', () => {
@@ -16,65 +19,95 @@ test.describe('severity-2 #smoke', () => {
     test('subscribe successfully with a forever discount coupon', async ({
       target,
       page,
-      pages: { relier, subscribe, login },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe6Month();
 
       // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
+      await subscribe.addCouponCode(Coupon.AUTO_10_PERCENT_FOREVER);
 
       // Verify the coupon is applied successfully
       await expect(subscribe.promoCodeAppliedHeading).toBeVisible();
 
       // Verify the line items after applying discount
-      expect(await subscribe.discountListPrice()).toBe(true);
-      expect(await subscribe.discountLineItem()).toBe(true);
+      await expect(subscribe.listPrice).toBeVisible();
+      await expect(subscribe.promoCode).toBeVisible();
 
       // Successfully subscribe
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.submit();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+
       expect(await relier.isPro()).toBe(true);
     });
 
     test('subscribe with credit card and use coupon', async ({
       target,
       page,
-      pages: { relier, login, subscribe },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe6Month();
 
+      await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
+
       // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.addCouponCode(Coupon.AUTO_10_PERCENT_FOREVER);
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.submit();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+
       expect(await relier.isPro()).toBe(true);
     });
   });
@@ -83,15 +116,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
+import { VALID_VISA } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
@@ -49,9 +49,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Successfully subscribe
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
@@ -93,9 +91,7 @@ test.describe('severity-2 #smoke', () => {
       // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
       await subscribe.addCouponCode(Coupon.AUTO_10_PERCENT_FOREVER);
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
+import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
-import { LoginPage } from '../../../pages/login';
+import { Coupon } from '../../../pages/products';
+import { SettingsPage } from '../../../pages/settings';
+import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test invalid', () => {
@@ -29,17 +32,11 @@ test.describe('severity-2 #smoke', () => {
 
       // 'autoinvalid' coupon is an invalid coupon for a 6mo plan
       // But valid for a 12mo plan
-      await subscribe.addCouponCode('autoinvalid');
-
-      await expect(
-        await subscribe.getCouponStatusByDataTestId('coupon-error')
-      ).toBeVisible({
-        timeout: 5000,
-      });
+      await subscribe.addCouponCode(Coupon.AUTO_INVALID);
 
       // Asserting that the code is invalid for a 6mo plan
-      expect(await subscribe.couponErrorMessageText()).toContain(
-        'The code you entered is invalid'
+      await expect(subscribe.couponErrorMessage).toHaveText(
+        'The code you entered is invalid.'
       );
 
       // Adding the same code to a 12mo plan
@@ -48,7 +45,7 @@ test.describe('severity-2 #smoke', () => {
 
       // 'autoinvalid' coupon is an invalid coupon for a 6mo plan
       // But valid for a 12mo plan
-      await subscribe.addCouponCode('autoinvalid');
+      await subscribe.addCouponCode(Coupon.AUTO_INVALID);
 
       // Verifying the coupon is valid with a discount line item
       await expect(subscribe.promoCodeAppliedHeading).toBeVisible();
@@ -57,35 +54,49 @@ test.describe('severity-2 #smoke', () => {
     test('subscribe successfully with an invalid coupon', async ({
       target,
       page,
-      pages: { relier, subscribe, login },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe6Month();
 
       // 'autoinvalid' coupon is an invalid coupon for a 6mo plan
-      await subscribe.addCouponCode('autoinvalid');
+      await subscribe.addCouponCode(Coupon.AUTO_INVALID);
 
       // Asserting that the code is invalid for a 6m plan
-      expect(await subscribe.couponErrorMessageText()).toContain(
-        'The code you entered is invalid'
+      await expect(subscribe.couponErrorMessage).toHaveText(
+        'The code you entered is invalid.'
       );
 
       // Successfully subscribe
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.submit();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+
       expect(await relier.isPro()).toBe(true);
     });
   });
@@ -94,15 +105,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
+import { VALID_VISA } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
@@ -82,9 +82,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Successfully subscribe
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
+import { VALID_VISA } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
@@ -52,9 +52,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Successfully subscribe
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
@@ -3,10 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import {
-  CAVE_JOHNSON_CREDIT_CARD,
-  TEST_USER_CREDIT_CARD,
-} from '../../../lib/paymentArtifacts';
+import { VALID_VISA, VALID_MASTERCARD } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
@@ -46,9 +43,7 @@ test.describe('severity-2 #smoke', () => {
 
       //Subscribe successfully
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
@@ -68,12 +63,12 @@ test.describe('severity-2 #smoke', () => {
       await subscriptionManagement.ChangePaymentInformationButton.click();
       //Change stripe card information
       await subscriptionManagement.paymentInformation.fillOutCreditCardInfo(
-        TEST_USER_CREDIT_CARD
+        VALID_MASTERCARD
       );
       await subscriptionManagement.paymentInformation.updateButton.click();
 
       //Verify that the card info is updated
-      const lastFour = TEST_USER_CREDIT_CARD.number.slice(-4);
+      const lastFour = VALID_MASTERCARD.number.slice(-4);
       await expect(
         subscriptionManagement.paymentInformation.cardInfoAndLastFour
       ).toContainText(lastFour);

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
@@ -3,9 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
+import {
+  CAVE_JOHNSON_CREDIT_CARD,
+  TEST_USER_CREDIT_CARD,
+} from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
-import { LoginPage } from '../../../pages/login';
+import { Coupon } from '../../../pages/products';
+import { SubscriptionManagementPage } from '../../../pages/products/subscriptionManagement';
+import { SettingsPage } from '../../../pages/settings';
+import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('payment', () => {
@@ -16,39 +23,60 @@ test.describe('severity-2 #smoke', () => {
     test('update mode of payment for stripe', async ({
       target,
       page,
-      pages: { relier, subscribe, login, settings, subscriptionManagement },
+      pages: { relier, subscribe, settings, signinReact },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe6Month();
 
       // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
+      await subscribe.addCouponCode(Coupon.AUTO_10_PERCENT_FOREVER);
 
       //Subscribe successfully
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
 
-      //Login to FxA account
-      await login.goto();
-      await login.clickSignIn();
-      const subscriptionPage = await settings.clickPaidSubscriptions();
-      subscriptionManagement.page = subscriptionPage;
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
 
+      //Signin to FxA account
+      await signinReact.goto();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+      const newPage = await settings.clickPaidSubscriptions();
+      const subscriptionManagement = new SubscriptionManagementPage(
+        newPage,
+        target
+      );
+      await subscriptionManagement.ChangePaymentInformationButton.click();
       //Change stripe card information
-      await subscriptionManagement.changeStripeCardDetails();
+      await subscriptionManagement.paymentInformation.fillOutCreditCardInfo(
+        TEST_USER_CREDIT_CARD
+      );
+      await subscriptionManagement.paymentInformation.updateButton.click();
 
       //Verify that the card info is updated
-      expect(await subscriptionManagement.getCardInfo()).toContain('4444');
+      const lastFour = TEST_USER_CREDIT_CARD.number.slice(-4);
+      await expect(
+        subscriptionManagement.paymentInformation.cardInfoAndLastFour
+      ).toContainText(lastFour);
     });
   });
 });
@@ -56,15 +84,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
+import { VALID_VISA } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
@@ -48,9 +48,7 @@ test.describe('severity-2 #smoke', () => {
 
       //Subscribe successfully with Stripe
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -3,9 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
+import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
-import { LoginPage } from '../../../pages/login';
+import { Coupon } from '../../../pages/products';
+import { SubscriptionManagementPage } from '../../../pages/products/subscriptionManagement';
+import { SettingsPage } from '../../../pages/settings';
+import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('resubscription test', () => {
@@ -16,41 +20,56 @@ test.describe('severity-2 #smoke', () => {
     test('resubscribe successfully with the same coupon after canceling for stripe', async ({
       target,
       page,
-      pages: { relier, subscribe, login, settings, subscriptionManagement },
+      pages: { relier, subscribe, settings, signinReact },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe6Month();
 
       // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
+      await subscribe.addCouponCode(Coupon.AUTO_10_PERCENT_FOREVER);
 
       // Verify the coupon is applied successfully
       await expect(subscribe.promoCodeAppliedHeading).toBeVisible();
 
-      const total = await subscribe.getTotalPrice();
+      const total = await subscribe.totalPrice.textContent();
 
       //Subscribe successfully with Stripe
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
 
-      //Login to FxA account
-      await login.goto();
-      await login.clickSignIn();
-      const subscriptionPage = await settings.clickPaidSubscriptions();
-      subscriptionManagement.page = subscriptionPage;
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
+      //Signin to FxA account
+      await signinReact.goto();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+      const newPage = await settings.clickPaidSubscriptions();
+      const subscriptionManagement = new SubscriptionManagementPage(
+        newPage,
+        target
+      );
 
       //Verify no coupon details are visible
-      expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
+      await expect(subscriptionManagement.subscriptionDetails).not.toHaveText(
         'Promo'
       );
 
@@ -59,12 +78,11 @@ test.describe('severity-2 #smoke', () => {
       await subscriptionManagement.resubscribe();
 
       //Verify that the resubscription has the same coupon applied
-      expect(await subscriptionManagement.getResubscriptionPrice()).toEqual(
-        total
-      );
-
+      const resubscriptionPrice =
+        await subscriptionManagement.resubscriptionPrice.textContent();
+      expect(resubscriptionPrice).toEqual(total);
       //Verify no coupon details are visible
-      expect(await subscriptionManagement.subscriptionDetails()).not.toContain(
+      await expect(subscriptionManagement.subscriptionDetails).not.toHaveText(
         'Promo'
       );
     });
@@ -74,15 +92,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -4,7 +4,7 @@
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { MetricsObserver } from '../../../lib/metrics';
-import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
+import { VALID_VISA } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
@@ -50,9 +50,7 @@ test.describe('severity-2 #smoke', () => {
 
       //Subscribe successfully with Stripe
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -4,16 +4,19 @@
 
 import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { MetricsObserver } from '../../../lib/metrics';
+import { CAVE_JOHNSON_CREDIT_CARD } from '../../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../../lib/targets/base';
 import { TestAccountTracker } from '../../../lib/testAccountTracker';
-import { LoginPage } from '../../../pages/login';
+import { Coupon } from '../../../pages/products';
+import { SettingsPage } from '../../../pages/settings';
+import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('ui functionality', () => {
     test('verify plan change funnel metrics & coupon feature not available when changing plans', async ({
       target,
       page,
-      pages: { relier, subscribe, login },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
@@ -22,7 +25,13 @@ test.describe('severity-2 #smoke', () => {
       );
       test.slow();
 
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       const metricsObserver = new MetricsObserver(subscribe);
       metricsObserver.startTracking();
@@ -31,35 +40,36 @@ test.describe('severity-2 #smoke', () => {
       await relier.clickSubscribe6Month();
 
       // Verify discount section is displayed
-      expect(await subscribe.discountTextbox()).toBe(true);
+      await expect(subscribe.promoCodeHeading).toBeVisible();
 
       // 'auto10pforever' is a 10% forever discount coupon for a 6mo plan
-      await subscribe.addCouponCode('auto10pforever');
+      await subscribe.addCouponCode(Coupon.AUTO_10_PERCENT_FOREVER);
 
       // Verify the coupon is applied successfully
       await expect(subscribe.promoCodeAppliedHeading).toBeVisible();
 
       //Subscribe successfully with Stripe
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
-      await relier.goto();
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
 
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
+      await relier.goto();
       //Change the plan
       await relier.clickSubscribe12Month();
 
       //Verify Discount section is not displayed
-      expect(await subscribe.planUpgradeDetails()).not.toContain('Promo');
+      await expect(subscribe.planUpgradeDetails).not.toContainText('Promo');
 
       //Submit the changes
-      await subscribe.clickConfirmPlanChange();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.clickPayNow();
 
       //Verify the subscription is successful
-      expect(await subscribe.isSubscriptionSuccess()).toBe(true);
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
 
       // check conversion funnel metrics
       const expectedEventTypes = [
@@ -92,15 +102,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -4,10 +4,7 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { MetricsObserver } from '../../lib/metrics';
-import {
-  BAD_CAVE_JOHNSON_CREDIT_CARD,
-  CAVE_JOHNSON_CREDIT_CARD,
-} from '../../lib/paymentArtifacts';
+import { INVALID_VISA, VALID_VISA } from '../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
@@ -43,9 +40,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
 
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
@@ -87,17 +82,13 @@ test.describe('severity-2 #smoke', () => {
       await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
 
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        BAD_CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(INVALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionErrorHeading).toBeVisible();
 
       await subscribe.tryAgainButton.click();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
@@ -345,17 +336,13 @@ test.describe('severity-2 #smoke', () => {
       await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
 
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        BAD_CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(INVALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionErrorHeading).toBeVisible();
 
       await subscribe.tryAgainButton.click();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -2,11 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { MetricsObserver } from '../../lib/metrics';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { Page, expect, test } from '../../lib/fixtures/standard';
+import { MetricsObserver } from '../../lib/metrics';
+import {
+  BAD_CAVE_JOHNSON_CREDIT_CARD,
+  CAVE_JOHNSON_CREDIT_CARD,
+} from '../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { LoginPage } from '../../pages/login';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { SettingsPage } from '../../pages/settings';
+import { SigninReactPage } from '../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('subscription', () => {
@@ -17,56 +22,94 @@ test.describe('severity-2 #smoke', () => {
     test('subscribe with credit card and login to product', async ({
       target,
       page,
-      pages: { relier, login, subscribe },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe();
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+
+      await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
+
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.submit();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+
       expect(await relier.isPro()).toBe(true);
     });
 
     test('subscribe with credit card after initial failed subscription & verify existing user checkout funnel metrics', async ({
       target,
       page,
-      pages: { relier, login, subscribe },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
-
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
       const metricsObserver = new MetricsObserver(subscribe);
       metricsObserver.startTracking();
 
       await relier.goto();
       await relier.clickSubscribe();
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setFailedCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.clickTryAgain();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+
+      await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
+
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        BAD_CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionErrorHeading).toBeVisible();
+
+      await subscribe.tryAgainButton.click();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
       await relier.goto();
       await relier.clickEmailFirst();
-      await login.submit();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+
       expect(await relier.isPro()).toBe(true);
 
       // check conversion funnel metrics
@@ -105,18 +148,27 @@ test.describe('severity-2 #smoke', () => {
     test('subscribe with paypal opens popup', async ({
       target,
       page,
-      pages: { relier, subscribe, login },
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe();
-      await subscribe.setConfirmPaymentCheckbox();
+
+      await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
+
+      await subscribe.confirmPaymentCheckbox.check();
       const paypalPopup = await subscribe.clickPayPal();
       expect(
         await paypalPopup.title(),
@@ -132,14 +184,21 @@ test.describe('severity-2 #smoke', () => {
 
     test('Metrics disabled: existing user checkout URL to not have flow params', async ({
       target,
-      pages: { settings, relier, page, login },
+      page,
+      pages: { relier, settings, signinReact },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       // Go to settings page and verify the Data Collection toggle switch is visible
       await settings.goto();
@@ -158,14 +217,21 @@ test.describe('severity-2 #smoke', () => {
 
     test('Existing user checkout URL to have flow params', async ({
       target,
-      pages: { settings, relier, page, login },
+      page,
+      pages: { relier, settings, signinReact },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       // Go to settings page and verify the Data Collection toggle switch is visible
       await settings.goto();
@@ -183,14 +249,21 @@ test.describe('severity-2 #smoke', () => {
 
     test('New user checkout URL to have flow params', async ({
       target,
-      pages: { settings, relier, page, login },
+      page,
+      pages: { relier, settings, signinReact },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await settings.goto();
       await settings.signOut();
@@ -201,14 +274,21 @@ test.describe('severity-2 #smoke', () => {
 
     test('New user checkout URL to have flow params with cache cleared', async ({
       target,
-      pages: { settings, login, relier, page },
+      page,
+      pages: { relier, settings, signinReact, login },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
       );
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await settings.goto();
       await settings.signOut();
@@ -220,15 +300,22 @@ test.describe('severity-2 #smoke', () => {
 
     test('New user checkout URL to have RP-provided flow params, acquisition params & verify funnel metrics', async ({
       target,
-      pages: { settings, relier, page, login, subscribe },
+      page,
+      pages: { relier, settings, signinReact, subscribe },
       testAccountTracker,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
       );
-
-      await signInAccount(target, page, login, testAccountTracker);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
+      const email = testAccountTracker.generateEmail();
 
       await settings.goto();
       await settings.signOut();
@@ -252,15 +339,26 @@ test.describe('severity-2 #smoke', () => {
       expect(rpFlowParamsAfter).toStrictEqual(rpFlowParamsBefore);
 
       // subscribe, failing first then succeeding
-      await subscribe.setEmailAndConfirmNewUser();
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setFailedCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.clickTryAgain();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
+      await subscribe.emailTextbox.fill(email);
+      await subscribe.confirmEmailTextbox.fill(email);
+
+      await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
+
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        BAD_CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionErrorHeading).toBeVisible();
+
+      await subscribe.tryAgainButton.click();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
 
       // check acquisition metrics
       const acquisitionParamsAfter =
@@ -304,15 +402,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -4,7 +4,7 @@
 
 import { SettingsPage } from '../..//pages/settings';
 import { Page, expect, test } from '../../lib/fixtures/standard';
-import { CAVE_JOHNSON_CREDIT_CARD } from '../../lib/paymentArtifacts';
+import { VALID_VISA } from '../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SubscriptionManagementPage } from '../../pages/products/subscriptionManagement';
@@ -83,9 +83,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
 
       await subscribe.confirmPaymentCheckbox.check();
-      await subscribe.paymentInformation.fillOutCreditCardInfo(
-        CAVE_JOHNSON_CREDIT_CARD
-      );
+      await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
@@ -109,9 +107,9 @@ test.describe('severity-2 #smoke', () => {
       await subscriptionManagement.contactsupportButton.click();
 
       await subscriptionSupport.fillOutSupportForm(
-        'One, Two, Three Done...PRO',
+        target.subscriptionConfig.name,
         Topic.PAYMENT_AND_BILLING,
-        App.Desktop,
+        App.DESKTOP,
         'Test Support',
         'Testing Support Form'
       );

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -2,23 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { SettingsPage } from '../..//pages/settings';
 import { Page, expect, test } from '../../lib/fixtures/standard';
+import { CAVE_JOHNSON_CREDIT_CARD } from '../../lib/paymentArtifacts';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
-import { LoginPage } from '../../pages/login';
+import { SubscriptionManagementPage } from '../../pages/products/subscriptionManagement';
+import {
+  App,
+  SubscriptionSupportPage,
+  Topic,
+} from '../../pages/products/support';
+import { SigninReactPage } from '../../pages/signinReact';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('support form without valid session', () => {
     test('go to support form, redirects to index', async ({
       page,
       target,
-      pages: { login },
+      pages: { login, settings },
     }) => {
       await login.clearCache();
-      await page.goto(`${target.contentServerUrl}/support`, {
-        waitUntil: 'load',
-      });
-      expect(await login.waitForEmailHeader()).toBe(true);
+      await page.goto(`${target.contentServerUrl}/support`);
+
+      await expect(settings.settingsHeading).toBeVisible();
     });
   });
 
@@ -26,16 +33,21 @@ test.describe('severity-1 #smoke', () => {
     test('go to support form, redirects to subscription management, then back to settings', async ({
       page,
       target,
-      pages: { login },
+      pages: { settings, signinReact },
       testAccountTracker,
     }) => {
       test.slow();
-      await signInAccount(target, page, login, testAccountTracker);
-      await page.goto(`${target.contentServerUrl}/support`, {
-        waitUntil: 'load',
-      });
-      await page.waitForURL(/settings/);
-      expect(await login.isUserLoggedIn()).toBe(true);
+      await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
+      await page.goto(`${target.contentServerUrl}/support`);
+
+      await expect(page).toHaveURL(/settings/);
+      await expect(settings.settingsHeading).toBeVisible();
     });
   });
 });
@@ -48,7 +60,7 @@ test.describe('severity-2 #smoke', () => {
     test('go to support form, cancel, redirects to subscription management', async ({
       target,
       page,
-      pages: { login, relier, subscribe, settings, subscriptionManagement },
+      pages: { relier, subscribe, settings, signinReact },
       testAccountTracker,
     }, { project }) => {
       test.skip(
@@ -57,26 +69,56 @@ test.describe('severity-2 #smoke', () => {
       );
       test.slow();
 
-      await signInAccount(target, page, login, testAccountTracker);
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signinReact,
+        testAccountTracker
+      );
 
       await relier.goto();
       await relier.clickSubscribe();
-      await subscribe.setConfirmPaymentCheckbox();
-      await subscribe.setFullName();
-      await subscribe.setCreditCardInfo();
-      await subscribe.clickPayNow();
-      await subscribe.submit();
 
-      //Login to FxA account
-      await login.goto();
-      await login.clickSignIn();
-      const subscriptionPage = await settings.clickPaidSubscriptions();
-      subscriptionManagement.page = subscriptionPage;
-      await subscriptionManagement.fillSupportForm();
-      await subscriptionManagement.cancelSupportForm();
+      await expect(subscribe.setupSubscriptionFormHeading).toBeVisible();
+
+      await subscribe.confirmPaymentCheckbox.check();
+      await subscribe.paymentInformation.fillOutCreditCardInfo(
+        CAVE_JOHNSON_CREDIT_CARD
+      );
+      await subscribe.paymentInformation.clickPayNow();
+
+      await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
+
+      //Signin to FxA account
+      await signinReact.goto();
+
+      await expect(signinReact.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
+
+      await signinReact.signInButton.click();
+      const newPage = await settings.clickPaidSubscriptions();
+      const subscriptionManagement = new SubscriptionManagementPage(
+        newPage,
+        target
+      );
+      const subscriptionSupport = new SubscriptionSupportPage(newPage, target);
+
+      await expect(subscriptionManagement.subscriptiontHeading).toBeVisible();
+
+      await subscriptionManagement.contactsupportButton.click();
+
+      await subscriptionSupport.fillOutSupportForm(
+        'One, Two, Three Done...PRO',
+        Topic.PAYMENT_AND_BILLING,
+        App.Desktop,
+        'Test Support',
+        'Testing Support Form'
+      );
+      await subscriptionSupport.cancelButton.click();
 
       //Verify it redirects back to the subscription management page
-      expect(await subscriptionManagement.subscriptiontHeader()).toBe(true);
+      await expect(subscriptionManagement.subscriptiontHeading).toBeVisible();
     });
   });
 });
@@ -84,15 +126,17 @@ test.describe('severity-2 #smoke', () => {
 async function signInAccount(
   target: BaseTarget,
   page: Page,
-  login: LoginPage,
+  settings: SettingsPage,
+  signinReact: SigninReactPage,
   testAccountTracker: TestAccountTracker
 ): Promise<Credentials> {
   const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
-  await login.fillOutEmailFirstSignIn(credentials.email, credentials.password);
+  await signinReact.fillOutEmailFirstForm(credentials.email);
+  await signinReact.fillOutPasswordForm(credentials.password);
 
-  //Verify logged in on Settings page
-  expect(await login.isUserLoggedIn()).toBe(true);
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
 
   return credentials;
 }


### PR DESCRIPTION
## Because

- we need to improve resilience in the subscription functional tests

## This pull request

- refactor the SubscribePage and SubscriptionManagement Page to use built-in locators
- use signinReact over login POM
- update the subscription-tests to use auto-awaiting asserts

## Issue that this pull request solves

Closes: # FXA-9729

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
