### PR TITLE
fix(settings): Use different account link redirects to signin with cached account

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
@@ -28,8 +28,6 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
   const { email, metricsContext } =
     (location.state as ConfirmResetPasswordLocationState) || {};
 
-  const searchParams = location.search;
-
   const handleNavigation = (
     code: string,
     emailToHashWith: string,
@@ -39,7 +37,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
     recoveryKeyExists?: boolean
   ) => {
     if (recoveryKeyExists === true) {
-      navigate(`/account_recovery_confirm_key${searchParams}`, {
+      navigate(`/account_recovery_confirm_key${location.search}`, {
         state: {
           code,
           email,
@@ -51,7 +49,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
         },
       });
     } else {
-      navigate(`/complete_reset_password${searchParams}`, {
+      navigate(`/complete_reset_password${location.search}`, {
         state: {
           code,
           email,
@@ -123,7 +121,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
   };
 
   if (!email) {
-    navigate(`/reset_password${searchParams}`);
+    navigate(`/reset_password${location.search}`);
     return <LoadingSpinner fullScreen />;
   }
 
@@ -134,7 +132,6 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
         errorMessage,
         resendCode,
         resendStatus,
-        searchParams,
         setErrorMessage,
         setResendStatus,
         verifyCode,

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
@@ -6,10 +6,10 @@ import React from 'react';
 import AppLayout from '../../../components/AppLayout';
 import FormVerifyTotp from '../../../components/FormVerifyTotp';
 import { ConfirmResetPasswordProps } from './interfaces';
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
 import { useFtlMsgResolver } from '../../../models';
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import { ResendEmailSuccessBanner } from '../../../components/Banner';
 import { ResendStatus } from '../../../lib/types';
 import { EmailCodeImage } from '../../../components/images';
@@ -19,12 +19,12 @@ const ConfirmResetPassword = ({
   errorMessage,
   resendCode,
   resendStatus,
-  searchParams,
   setErrorMessage,
   setResendStatus,
   verifyCode,
 }: ConfirmResetPasswordProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
+  const location = useLocation();
 
   const localizedInputGroupLabel = ftlMsgResolver.getMsg(
     'confirm-reset-password-otp-input-group-label',
@@ -82,7 +82,26 @@ const ConfirmResetPassword = ({
           </button>
         </FtlMsg>
         <FtlMsg id="confirm-reset-password-otp-different-account-link">
-          <a href={`/${searchParams}`} className="link-blue">
+          <a
+            href="/"
+            className="text-sm link-blue"
+            onClick={(e) => {
+              e.preventDefault();
+              const params = new URLSearchParams(location.search);
+              // Tell content-server to stay on index and prefill the email
+              params.set('prefillEmail', email);
+              // Passing back the 'email' param causes various behaviors in
+              // content-server since it marks the email as "coming from a RP".
+              // Also remove other params that are passed when coming
+              // from content-server to Backbone, see Signup container component
+              // for more info.
+              params.delete('email');
+              params.delete('hasLinkedAccount');
+              params.delete('hasPassword');
+              params.delete('showReactApp');
+              hardNavigate(`/?${params.toString()}`);
+            }}
+          >
             Use a different account
           </a>
         </FtlMsg>

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/interfaces.ts
@@ -20,7 +20,6 @@ export type ConfirmResetPasswordProps = {
   errorMessage: string;
   resendCode: () => Promise<boolean>;
   resendStatus: ResendStatus;
-  searchParams: string;
   setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
   setResendStatus: React.Dispatch<React.SetStateAction<ResendStatus>>;
   verifyCode: (code: string) => Promise<void>;

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/mocks.tsx
@@ -19,7 +19,6 @@ export const Subject = ({
   const email = MOCK_EMAIL;
   const [errorMessage, setErrorMessage] = useState('');
   const [resendStatus, setResendStatus] = useState(ResendStatus['not sent']);
-  const searchParams = '';
 
   return (
     <LocationProvider>
@@ -29,7 +28,6 @@ export const Subject = ({
           errorMessage,
           resendCode,
           resendStatus,
-          searchParams,
           setErrorMessage,
           setResendStatus,
           verifyCode,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Link, RouteComponentProps, useLocation } from '@reach/router';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
 import { logViewEvent } from '../../../lib/metrics';
 import { TwoFactorAuthImage } from '../../../components/images';
@@ -175,7 +175,26 @@ export const SigninTotpCode = ({
       <div className="mt-5 link-blue text-sm flex justify-between">
         <FtlMsg id="signin-totp-code-other-account-link">
           {/* TODO in FXA-8636 replace with Link component once index reactified */}
-          <a href={`/${location.search}`} className="text-start">
+          <a
+            href="/"
+            className="text-sm link-blue"
+            onClick={(e) => {
+              e.preventDefault();
+              const params = new URLSearchParams(location.search);
+              // Tell content-server to stay on index and prefill the email
+              params.set('prefillEmail', email);
+              // Passing back the 'email' param causes various behaviors in
+              // content-server since it marks the email as "coming from a RP".
+              // Also remove other params that are passed when coming
+              // from content-server to Backbone, see Signup container component
+              // for more info.
+              params.delete('email');
+              params.delete('hasLinkedAccount');
+              params.delete('hasPassword');
+              params.delete('showReactApp');
+              hardNavigate(`/?${params.toString()}`);
+            }}
+          >
             Use a different account
           </a>
         </FtlMsg>


### PR DESCRIPTION
## Because

* When clicking on "Use a different account" link, should not redirect to signin with a cached account
* Should be able to edit email to use
 
## This pull request

* Reuse the click handling from signin page for "use different account" links on ConfirmResetPassword and SigninTotpCode

## Issue that this pull request solves

Closes: #FXA-9717

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
