### PR TITLE
fix(settings): Ensure disabled button is read by screen readers

### DIFF
--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -64,7 +64,7 @@ const Banner = ({
     >
       {dismissible ? (
         <>
-          <div className="grow ltr:pl-5 rtl:pr-5">{children}</div>
+          <div className="grow ps-5">{children}</div>
           <FtlMsg id="banner-dismiss-button" attrs={{ ariaLabel: true }}>
             <button
               type="button"

--- a/packages/fxa-settings/src/components/FormVerifyTotp/en.ftl
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/en.ftl
@@ -1,5 +1,0 @@
-## FormVerifyTotp
-
-# When focused on the button, screen reader will read the action and entire number that will be submitted
-form-verify-code-submit-button =
-  .aria-label = Submit { $codeValue }

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
@@ -22,7 +22,7 @@ describe('FormVerifyTotp component', () => {
       renderWithLocalizationProvider(<Subject />);
       const button = screen.getByRole('button');
       expect(button).toHaveTextContent('Submit');
-      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('is enabled when numbers are typed into all inputs', async () => {
@@ -30,7 +30,7 @@ describe('FormVerifyTotp component', () => {
       renderWithLocalizationProvider(<Subject />);
       const button = screen.getByRole('button');
       expect(button).toHaveTextContent('Submit');
-      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'true');
 
       expect(
         screen.getByRole('textbox', { name: 'Digit 1 of 6' })
@@ -45,7 +45,7 @@ describe('FormVerifyTotp component', () => {
           )
         );
       }
-      expect(button).toBeEnabled();
+      expect(button).toHaveAttribute('aria-disabled', 'false');
     });
 
     it('is enabled when numbers are pasted into all inputs', async () => {
@@ -53,33 +53,14 @@ describe('FormVerifyTotp component', () => {
       renderWithLocalizationProvider(<Subject />);
       const button = screen.getByRole('button');
       expect(button).toHaveTextContent('Submit');
-      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'true');
 
       await waitFor(() => {
         user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }));
         user.paste('123456');
       });
 
-      expect(button).toBeEnabled();
-    });
-  });
-
-  describe('errors', () => {
-    it('are cleared when typing in input', async () => {
-      const user = userEvent.setup();
-      renderWithLocalizationProvider(
-        <Subject initialErrorMessage="Something went wrong" />
-      );
-
-      expect(screen.getByText('Something went wrong')).toBeVisible();
-
-      await waitFor(() =>
-        user.type(screen.getByRole('textbox', { name: 'Digit 1 of 6' }), '1')
-      );
-
-      expect(
-        screen.queryByText('Something went wrong')
-      ).not.toBeInTheDocument();
+      expect(button).toHaveAttribute('aria-disabled', 'false');
     });
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
@@ -98,11 +98,11 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
         recoveryKeyExists
       );
     } catch (error) {
-      const localizerErrorMessage = getLocalizedErrorMessage(
+      const localizedErrorMessage = getLocalizedErrorMessage(
         ftlMsgResolver,
         error
       );
-      setErrorMessage(localizerErrorMessage);
+      setErrorMessage(localizedErrorMessage);
     }
   };
 

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/en.ftl
@@ -22,5 +22,5 @@ confirm-reset-password-otp-submit-button = Continue
 # Button to request a new reset password confirmation code
 confirm-reset-password-otp-resend-code-button = Resend code
 
-# LInk to cancel the password reset and sign in with a different account
+# Link to cancel the password reset and sign in with a different account
 confirm-reset-password-otp-different-account-link = Use a different account

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.test.tsx
@@ -36,7 +36,7 @@ describe('ConfirmResetPassword', () => {
     const buttons = await screen.findAllByRole('button');
     expect(buttons).toHaveLength(2);
     expect(buttons[0]).toHaveTextContent('Continue');
-    expect(buttons[0]).toBeDisabled();
+    expect(buttons[0]).toHaveAttribute('aria-disabled', 'true');
     expect(buttons[1]).toHaveTextContent('Resend code');
 
     const links = await screen.findAllByRole('link');
@@ -58,9 +58,9 @@ describe('ConfirmResetPassword', () => {
 
     // name here is the accessible name from aria-label
     const submitButton = screen.getByRole('button', {
-      name: 'Submit 12345678',
+      name: 'Continue',
     });
-    expect(submitButton).toBeEnabled();
+    expect(submitButton).toHaveAttribute('aria-disabled', 'false');
 
     await waitFor(() => user.click(submitButton));
     expect(mockVerifyCode).toHaveBeenCalledTimes(1);
@@ -83,5 +83,32 @@ describe('ConfirmResetPassword', () => {
         'Email re-sent. Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
       )
     ).toBeVisible();
+  });
+
+  describe('errors', () => {
+    it('can display error passed in by the container', () => {
+      renderWithLocalizationProvider(
+        <Subject initialErrorMessage="Something went wrong" />
+      );
+
+      expect(screen.getByText('Something went wrong')).toBeVisible();
+    });
+
+    it('clears the error when input is modified', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(
+        <Subject initialErrorMessage="Something went wrong" />
+      );
+
+      expect(screen.getByText('Something went wrong')).toBeVisible();
+
+      await waitFor(() =>
+        user.type(screen.getByRole('textbox', { name: 'Digit 1 of 8' }), '1')
+      );
+
+      expect(
+        screen.queryByText('Something went wrong')
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
@@ -10,7 +10,10 @@ import { RouteComponentProps } from '@reach/router';
 import { useFtlMsgResolver } from '../../../models';
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { ResendEmailSuccessBanner } from '../../../components/Banner';
+import Banner, {
+  BannerType,
+  ResendEmailSuccessBanner,
+} from '../../../components/Banner';
 import { ResendStatus } from '../../../lib/types';
 import { EmailCodeImage } from '../../../components/images';
 
@@ -64,6 +67,7 @@ const ConfirmResetPassword = ({
         </p>
       </FtlMsg>
       {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}
+      {errorMessage && <Banner type={BannerType.error}>{errorMessage}</Banner>}
       <FormVerifyTotp
         codeLength={8}
         {...{

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/mocks.tsx
@@ -15,9 +15,10 @@ const mockResendCode = () => Promise.resolve(true);
 export const Subject = ({
   resendCode = mockResendCode,
   verifyCode = mockVerifyCode,
-}: Partial<ConfirmResetPasswordProps>) => {
+  initialErrorMessage = '',
+}: Partial<ConfirmResetPasswordProps> & { initialErrorMessage?: string }) => {
   const email = MOCK_EMAIL;
-  const [errorMessage, setErrorMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState(initialErrorMessage);
   const [resendStatus, setResendStatus] = useState(ResendStatus['not sent']);
   const searchParams = '';
 


### PR DESCRIPTION
## Because

* When a button is 'disabled' is cannot be focused or read by screen readers
* The "Continue" button on the confirm reset password screen was not read by screen-readers
* The "Continue" button is not disabled when there is a code error

## This pull request

* Use aria-disabled instead of disabled
* Disable the input if there is an error message on screen - error is cleared by editing the code input

## Issue that this pull request solves

Closes: #FXA-9711, FXA-9724

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
