### PR TITLE
fix(customs): apply password reset OTP limit only to OTP reqs

### DIFF
--- a/packages/fxa-customs-server/test/local/email_record_tests.js
+++ b/packages/fxa-customs-server/test/local/email_record_tests.js
@@ -182,9 +182,6 @@ test('retryAfter works', function (t) {
   t.equal(er.retryAfter(), 0, 'just expired blocks can be retried immediately');
   er.rl = 6000;
   t.equal(er.retryAfter(), 1, 'unexpired blocks can be retried in a bit');
-  t.equal(er.retryAfter(10000), 6, 'optional rate limit interval');
-  er.bk = 6000;
-  t.equal(er.retryAfter(10000, 20000), 16, 'optional block interval');
 
   delete er.rl;
   delete er.bk;

--- a/packages/fxa-customs-server/test/local/ip_record_tests.js
+++ b/packages/fxa-customs-server/test/local/ip_record_tests.js
@@ -106,29 +106,6 @@ test('retryAfter block works', function (t) {
   t.end();
 });
 
-test('retryAfter rate limiting and blocking with optional intervals', function (t) {
-  const ir = simpleIpRecord();
-  t.equal(ir.retryAfter(), 0, 'unblocked records can be retried now');
-  ir.rl = 240 * 1000;
-  t.equal(
-    ir.retryAfter(),
-    1,
-    'unblocked records can be retried after default interval'
-  );
-  t.equal(
-    ir.retryAfter(5000),
-    5,
-    'unblocked records can be retried after given rate limited interval'
-  );
-  ir.bk = ir.rl;
-  t.equal(
-    ir.retryAfter(5000, 8000),
-    8,
-    'unblocked records can be retried after given blocked interval'
-  );
-  t.end();
-});
-
 test('parse works', function (t) {
   var ir = simpleIpRecord();
   t.equal(ir.shouldBlock(), false, 'original object is not blocked');


### PR DESCRIPTION
Because:
 - we want the rate limit for requesting password reset OTPs applied only to the OTP request action

This commit:
 - reverts changes that used the existing rate limit property in email and ip records
 - reverts changes to retryAfter to allow optional arguments to adjust the rate limit / block duration
 - updates the password reset OTP request action handling so that it's self-contained, and won't affect other actions' rate limiting
