### PR TITLE
fix(settings): Should not be able to navigate back during password reset

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
 import base32Decode from 'base32-decode';
 
 import { decryptRecoveryKeyData } from 'fxa-auth-client/lib/recoveryKey';
@@ -17,6 +17,7 @@ import {
 } from './interfaces';
 
 import AccountRecoveryConfirmKey from '.';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 const AccountRecoveryConfirmKeyContainer = ({
   serviceName,
@@ -26,7 +27,7 @@ const AccountRecoveryConfirmKeyContainer = ({
   const account = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
-  const navigate = useNavigate();
+  const navigate = useNavigateWithQuery();
 
   const {
     accountResetToken: previousAccountResetToken,
@@ -65,7 +66,7 @@ const AccountRecoveryConfirmKeyContainer = ({
       uid
     );
 
-    navigate(`/account_recovery_reset_password${window.location.search}`, {
+    navigate('/account_recovery_reset_password', {
       state: {
         accountResetToken: fetchedAccountResetToken,
         email,
@@ -74,6 +75,7 @@ const AccountRecoveryConfirmKeyContainer = ({
         kB,
         recoveryKeyId,
       },
+      replace: true,
     });
   };
 

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/container.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
 
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import {
@@ -22,6 +22,7 @@ import GleanMetrics from '../../../lib/glean';
 import firefox from '../../../lib/channels/firefox';
 import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import { useState } from 'react';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 // This component is used for both /complete_reset_password and /account_recovery_reset_password routes
 // for easier maintenance
@@ -36,15 +37,13 @@ const CompleteResetPasswordContainer = ({
   const account = useAccount();
   const config = useConfig();
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigate();
+  const navigate = useNavigateWithQuery();
   const location = useLocation();
 
   const [errorMessage, setErrorMessage] = useState('');
 
-  const searchParams = location.search;
-
   if (!location.state) {
-    navigate(`/reset_password${searchParams}`);
+    navigate('/reset_password', { replace: true });
   }
 
   const {
@@ -67,11 +66,11 @@ const CompleteResetPasswordContainer = ({
   const isResetWithoutRecoveryKey = !!(code && token);
 
   const handleNavigationWithRecoveryKey = () => {
-    navigate(`/reset_password_with_recovery_key_verified${searchParams}`);
+    navigate('/reset_password_with_recovery_key_verified');
   };
 
   const handleNavigationWithoutRecoveryKey = () => {
-    navigate(`/reset_password_verified${searchParams}`, {
+    navigate('/reset_password_verified', {
       replace: true,
     });
   };
@@ -176,14 +175,13 @@ const CompleteResetPasswordContainer = ({
 
   // handle the case where we don't have all data required
   if (!(hasConfirmedRecoveryKey || isResetWithoutRecoveryKey)) {
-    navigate(`/reset_password${searchParams}`);
+    navigate('/reset_password', { replace: true });
   }
   return (
     <CompleteResetPassword
       {...{
         email,
         errorMessage,
-        searchParams,
         submitNewPassword,
         hasConfirmedRecoveryKey,
       }}

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.tsx
@@ -18,7 +18,7 @@ import {
   CompleteResetPasswordProps,
 } from './interfaces';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { Link } from '@reach/router';
+import { Link, useLocation } from '@reach/router';
 
 const CompleteResetPassword = ({
   email,
@@ -26,8 +26,9 @@ const CompleteResetPassword = ({
   hasConfirmedRecoveryKey,
   locationState,
   submitNewPassword,
-  searchParams,
 }: CompleteResetPasswordProps) => {
+  const location = useLocation();
+
   useEffect(() => {
     hasConfirmedRecoveryKey
       ? GleanMetrics.resetPassword.recoveryKeyCreatePasswordView()
@@ -72,7 +73,7 @@ const CompleteResetPassword = ({
               {/* TODO add metrics to measure if users see and click on this link */}
               <FtlMsg id="complete-reset-password-recovery-key-link">
                 <Link
-                  to={`/account_recovery_confirm_key${searchParams}`}
+                  to={`/account_recovery_confirm_key${location.search}`}
                   state={locationState}
                   className="link-white underline-offset-4"
                 >

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/interfaces.ts
@@ -41,7 +41,6 @@ export interface CompleteResetPasswordProps {
   locationState: CompleteResetPasswordLocationState;
   submitNewPassword: (newPassword: string) => Promise<void>;
   hasConfirmedRecoveryKey?: boolean;
-  searchParams?: string;
 }
 
 export type AccountResetData = {

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useState } from 'react';
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps, useLocation } from '@reach/router';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import ConfirmResetPassword from '.';
@@ -12,6 +12,7 @@ import {
   RecoveryKeyCheckResult,
 } from './interfaces';
 import { ResendStatus } from '../../../lib/types';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
@@ -21,7 +22,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const navigate = useNavigate();
+  const navigate = useNavigateWithQuery();
   let location = useLocation();
 
   const { email, metricsContext } =
@@ -42,7 +43,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
     recoveryKeyExists?: boolean
   ) => {
     if (recoveryKeyExists === true) {
-      navigate(`/account_recovery_confirm_key${location.search}`, {
+      navigate('/account_recovery_confirm_key', {
         state: {
           code,
           email,
@@ -52,9 +53,10 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
           token,
           uid,
         },
+        replace: true,
       });
     } else {
-      navigate(`/complete_reset_password${location.search}`, {
+      navigate('/complete_reset_password', {
         state: {
           code,
           email,
@@ -64,6 +66,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
           token,
           uid,
         },
+        replace: true,
       });
     }
   };

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/container.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
 import React, { useState } from 'react';
 import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
@@ -10,6 +10,7 @@ import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import { ResetPasswordContainerProps } from './interfaces';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import ResetPassword from '.';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 const ResetPasswordContainer = ({
   flowQueryParams = {},
@@ -17,10 +18,7 @@ const ResetPasswordContainer = ({
 }: ResetPasswordContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const searchParams = location.search;
+  const navigate = useNavigateWithQuery();
 
   const [errorMessage, setErrorMessage] = useState<string>('');
 
@@ -41,7 +39,7 @@ const ResetPasswordContainer = ({
     };
     try {
       await authClient.passwordForgotSendOtp(email, options);
-      navigate(`/confirm_reset_password${searchParams}`, {
+      navigate('/confirm_reset_password', {
         state: { email, metricsContext },
       });
     } catch (err) {


### PR DESCRIPTION
## Because

* Once password reset steps are completed (confirming code, setting new password), clicking back should only return to the beginning of the reset password flow, not to the previous step that cannot be repeated

## This pull request

* Set {replace:true} for navigation within password reset flow when steps are successfully completed
* Do not use {replace:true} when navigating between account_recovery_confirm_key and complete_reset_password (choosing to use a recovery key or not)

## Issue that this pull request solves

Closes: #FXA-9731

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
