### PR TITLE
docs(functional-tests): update functional test documentation and fixme/skip annotations

### DIFF
--- a/packages/functional-tests/README.md
+++ b/packages/functional-tests/README.md
@@ -47,19 +47,17 @@ npx playwright codegen localhost:3030
 
 ## Fixtures
 
-We have a standard [fixture](https://playwright.dev/docs/test-fixtures) for the most common kind of tests.
+We have a standard [fixture](https://playwright.dev/docs/test-fixtures) module for the most common functions needed in tests.
 
-Its job is to:
+Its job is to make the following functionalities available:
 
-- Connect to the target environment
-- Create and verify an account for each test
-- Create the POMs
-- Destroy the account after each test
+- target: connect to the target environment
+- pages & syncBrowserPages: create the POMs
+- testAccountTracker: create and destroy accounts
 
-Use this fixture in test files like so:
+Make these fixtures available in test files by declaring the following:
 
 ```ts
-// tests/example.spec.ts
 import { test } from '../lib/fixtures/standard';
 ```
 
@@ -130,84 +128,4 @@ We record traces for failed tests locally and in CI. On CircleCI they are in the
 
 ## Avoiding Race condition while writing tests
 
-1. Use `waitFor` functions: Playwright provides `waitFor` functions to wait for specific conditions to be met, such as an element to appear or be visible, or an attribute to change. Use these functions instead of hard-coding time delays in your tests.
-
-Example:
-
-```ts
-async showError() {
-  const error = this.page.locator('#error');
-  await error.waitFor({ state: 'visible' });
-  return error.isVisible();
-}
-```
-
-2. Use `waitForUrl` and/or `waitForNavigation`: Use the `waitForUrl` or `waitForNavigation` function to wait for page navigation to complete before continuing with the test.
-
-Example:
-
-```ts
-async clickForgotPassword() {
-  await this.page.locator(selectors.LINK_RESET_PASSWORD).click();
-  await this.page.waitForURL(/reset_password/);
-}
-```
-
-```ts
-async performNavigation() {
-  const waitForNavigation = this.page.waitForNavigation();
-  await this.page.locator('button[id=navigate]').click();
-  return waitForNavigation;
-}
-```
-
-3. Use unique selectors: Use unique selectors to identify elements on the page to avoid confusion or ambiguity in selecting the correct element.
-
-Example:
-
-```ts
-this.page.getByRole('link', { name: 'name1' });
-```
-
-```ts
-this.page.locator('[data-testid="change"]');
-```
-
-```ts
-this.page.locator('#id');
-```
-
-```ts
-this.page.locator('.class');
-```
-
-4. Use `locator().action()` : Use `page.locator().click()` to wait for an element to appear before interacting with it.
-
-Example:
-
-```ts
-performClick() {
-  return this.page.locator('button[id=Save]').click();
-}
-```
-
-5. Use `Promise.all`: Use `Promise.all` to execute multiple asynchronous tasks simultaneously and wait for them to complete before continuing with the test.
-
-Example:
-
-```ts
-async signOut() {
-  await Promise.all([
-    this.page.locator('#logout').click(),
-    this.page.waitForResponse(/\/api\/logout/),
-  ]);
-}
-```
-
-6. Use `fixtures` to set up and tear down the test environment or run a test in a particular environment etc.
-
-7. Use `test.slow()` to mark the test as slow and triple the test timeout.
-
-8. When writing tests that use Firefox Sync, use the `syncBrowserPages` fixture. This fixture creates a new browser and a new browser context to avoid any Sync data being shared between tests. After your test is complete, the fixture will ensure that the browser is closed to free up memory.
-
-By following these best practices, you can minimize the likelihood of race conditions in your Playwright tests and ensure more reliable and consistent test results.
+See related [Ecosystem Docs](https://mozilla.github.io/ecosystem-platform/reference/functional-testing#avoiding-race-condition-while-writing-tests)

--- a/packages/functional-tests/tests/react-conversion/oauthResetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPasswordRecoveryKey.spec.ts
@@ -14,7 +14,7 @@ test.describe('severity-1 #smoke', () => {
   test.describe('oauth reset password with recovery key react', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/react-conversion/oauthResetPasswordScopeKeys.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPasswordScopeKeys.spec.ts
@@ -15,7 +15,7 @@ test.describe('severity-1 #smoke', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/react-conversion/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPasswordSyncMobile.spec.ts
@@ -16,7 +16,7 @@ test.describe('severity-1 #smoke', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
       const config = await configPage.getConfig();
       test.skip(config.showReactApp.resetPasswordRoutes !== true);
-      test.fixme(
+      test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -9,37 +9,6 @@ test.describe('Firefox Desktop Sync v3 email first', () => {
     test.slow();
   });
 
-  test('open directly to /signup page, refresh on the /signup page', async ({
-    pages: { configPage },
-    target,
-    syncBrowserPages: { page, login },
-    testAccountTracker,
-  }) => {
-    const config = await configPage.getConfig();
-    test.fixme(
-      config.showReactApp.signUpRoutes === true,
-      'Not currently supported in React Signup FXA-8973'
-    );
-
-    const { email } = testAccountTracker.generateSyncAccountDetails();
-
-    await page.goto(
-      `${target.contentServerUrl}/signup?context=fx_desktop_v3&service=sync&action=email`,
-      { waitUntil: 'load' }
-    );
-    await login.setEmail(email);
-    await login.submit();
-
-    // Verify user is redirected to the set password page
-    await expect(login.signUpPasswordHeader).toBeVisible();
-
-    //Refresh the page
-    await page.reload();
-
-    // refresh sends the user back to the first step
-    await login.waitForEmailHeader();
-  });
-
   test('open directly to /signin page, refresh on the /signin page', async ({
     target,
     syncBrowserPages: { page, login },


### PR DESCRIPTION
## Because

- we want to classify test.skip and test.fixme consistently

## This pull request

- updates functional-test documentation
- updates some test.fixme annotations to test.skip annotations 
- removes `open directly to /signup page, refresh on the /signup page`

## Issue that this pull request solves

Closes: # FXA-9740

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

Relates to https://github.com/mozilla/ecosystem-platform/pull/536
